### PR TITLE
Provide subparser for each entry

### DIFF
--- a/bin/ert.in
+++ b/bin/ert.in
@@ -17,32 +17,29 @@ def runExec(executable , args):
 
 
 def runGui( args ):
-    runExec("python", ["-m", "ert_gui.gert_main"] + args.config)
+    runExec("python", ["-m", "ert_gui.gert_main"] + [args.config])
 
 
 def runTui( args ):
     os.environ["ERT_UI_MODE"] = "tui"
-    runExec("ert_tui",  args.config)
+    exec_path = os.path.join(os.path.dirname(__file__), "ert_tui")
+    runExec(exec_path,  [args.config])
 
 
 def runShell( args ):
-    runExec("ertshell",  args.config)
+    exec_path = os.path.join(os.path.dirname(__file__), "ertshell")
+    runExec(exec_path,  [args.config])
 
 
 def runCli( args ):
-    runExec("ert_cli", [args.config, args.algorithm, args.target_case])
+    exec_path = os.path.join(os.path.dirname(__file__), "ert_cli")
+    runExec(exec_path, [args.config, args.algorithm, args.target_case])
 
 
-#################################################################
-runDefault = runGui
+def ert_parser():
+    parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
 
-os.environ["ERT_SHARE_PATH"] = ERT_SHARE_PATH
-os.environ["ERT_UI_MODE"] = "gui"
-os.environ["ERT_ROOT"] = ERT_ROOT
-
-parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
-
-subparsers = parser.add_subparsers(
+    subparsers = parser.add_subparsers(
         title="Available user entries",
         description='ERT can be accessed through various interfaces. Include '
                     'one of the following arguments to change between the '
@@ -52,43 +49,54 @@ subparsers = parser.add_subparsers(
         help="Available entry points")
 
 
-gui_parser = subparsers.add_parser('gui',
-        help='Graphical User Interface - opens up an independent window for '
-            'the user to interact with ERT.',
-        description='Graphical User Interface')
-gui_parser.add_argument('config', type=valid_file,
-        help="Ert configuration file")
-gui_parser.set_defaults(func=runGui)
+    gui_parser = subparsers.add_parser('gui',
+            help='Graphical User Interface - opens up an independent window for '
+                'the user to interact with ERT.',
+            description='Graphical User Interface')
+    gui_parser.add_argument('config', type=valid_file,
+            help="Ert configuration file")
+    gui_parser.set_defaults(func=runGui)
 
 
-tui_parser = subparsers.add_parser('tui',
-        help='Text user interface - provides a user interface in the terminal.'
-        ' Allows the user to interact within the terminal window ',
-        description='Text user interface')
-tui_parser.add_argument('config', type=valid_file,
-        help="Ert configuration file")
-tui_parser.set_defaults(func=runTui)
+    tui_parser = subparsers.add_parser('text',
+            help='Text user interface - provides a user interface in the terminal.'
+            ' Allows the user to interact within the terminal window ',
+            description='Text user interface')
+    tui_parser.add_argument('config', type=valid_file,
+            help="Ert configuration file")
+    tui_parser.set_defaults(func=runTui)
 
 
-shell_parser = subparsers.add_parser('shell',
-        help='Shell interface - provides a user interface in the terminal.',
-        description='Shell interface')
-shell_parser.add_argument('config', type=valid_file,
-        help="Ert configuration file")
-shell_parser.set_defaults(func=runShell)
+    shell_parser = subparsers.add_parser('shell',
+            help='Shell interface - provides a user interface in the terminal.',
+            description='Shell interface')
+    shell_parser.add_argument('config', type=valid_file,
+            help="Ert configuration file")
+    shell_parser.set_defaults(func=runShell)
 
 
-cli_parser = subparsers.add_parser('cli',
-        description="Command Line Interface",
-        help="command line help")
-cli_parser.add_argument('config', type=valid_file,
-        help="Ert configuration file")
-cli_parser.add_argument("--algorithm", type=str, required=True,
-        choices=["Test-run", "Ensemble Smoother", "Ensemble Experiment"],
-        help="The available algorithms")
-cli_parser.add_argument("--target-case", type=str, default="default",
-        help="The target filesystem to store results")
-cli_parser.set_defaults(func=runCli)
+    cli_parser = subparsers.add_parser('cli',
+            description="Command Line Interface",
+            help="command line help")
+    cli_parser.add_argument('config', type=valid_file,
+            help="Ert configuration file")
+    cli_parser.add_argument("--algorithm", type=str, required=True,
+            choices=["Test-run", "Ensemble Smoother", "Ensemble Experiment"],
+            help="The available algorithms")
+    cli_parser.add_argument("--target-case", type=str, default="default",
+            help="The target filesystem to store results")
+    cli_parser.set_defaults(func=runCli)
+    return parser
 
-args = parser.parse_args(sys.argv[1:])
-args.func(args)
+
+def main():
+    parser = ert_parser()
+    args = parser.parse_args(sys.argv[1:])
+    args.func(args)
+
+
+if __name__ == '__main__':
+    os.environ["ERT_SHARE_PATH"] = ERT_SHARE_PATH
+    os.environ["ERT_UI_MODE"] = "gui"
+    os.environ["ERT_ROOT"] = ERT_ROOT
+    main()

--- a/bin/ert.in
+++ b/bin/ert.in
@@ -1,47 +1,36 @@
 #!/usr/bin/env python
 import sys
 import os
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 
 ERT_ROOT = "${ERT_ROOT}"
 ERT_SHARE_PATH = "%s/share/ert" % ERT_ROOT
 
-def ensureConfig(func):
-
-    def runWrapper(args):
-        if len(args) == 0:
-            sys.exit("Must have config file argument")
-
-        if os.path.isfile( args[0] ):
-            return func( args )
-        else:
-            sys.exit("Config file:%s not found" % args[0])
-
-    return runWrapper
+def valid_file(fname):
+    if not os.path.isfile(fname):
+        raise ArgumentTypeError("File was not found: {}".format(fname))
+    return fname
 
 
 def runExec(executable , args):
     os.execvp(executable, [executable] + args)
 
 
-@ensureConfig
 def runGui( args ):
-    runExec("python", ["-m", "ert_gui.gert_main"] + args)
+    runExec("python", ["-m", "ert_gui.gert_main"] + args.config)
 
 
-@ensureConfig
 def runTui( args ):
     os.environ["ERT_UI_MODE"] = "tui"
-    runExec("ert_tui",  args)
+    runExec("ert_tui",  args.config)
 
 
 def runShell( args ):
-    runExec("ertshell",  args)
+    runExec("ertshell",  args.config)
 
 
-@ensureConfig
 def runCli( args ):
-    runExec("ert_cli", args)
+    runExec("ert_cli", [args.config, args.algorithm, args.target_case])
 
 
 #################################################################
@@ -51,23 +40,55 @@ os.environ["ERT_SHARE_PATH"] = ERT_SHARE_PATH
 os.environ["ERT_UI_MODE"] = "gui"
 os.environ["ERT_ROOT"] = ERT_ROOT
 
-parser = ArgumentParser()
-mode = parser.add_mutually_exclusive_group( required = False )
-mode.add_argument("--gui" , dest = "gui" , action = "store_true" , default = False)
-mode.add_argument("--text" , dest = "tui" , action = "store_true" , default = False)
-mode.add_argument("--shell" , dest = "shell" , action = "store_true" , default = False)
-mode.add_argument("--cli" , dest = "cli" , action = "store_true" , default = False)
+parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
 
-options, args = parser.parse_known_args( args = sys.argv[1:] )
+subparsers = parser.add_subparsers(
+        title="Available user entries",
+        description='ERT can be accessed through various interfaces. Include '
+                    'one of the following arguments to change between the '
+                    'interfaces. Note that different entry points may require'
+                    'different additional arguments. See the help section for '
+                    'each interface for more details',
+        help="Available entry points")
 
-if options.gui:
-    runGui( args )
-elif options.tui:
-    runTui(args)
-elif options.shell:
-    runShell( args )
-elif options.cli:
-    runCli(args)
-else:
-    runDefault(args)
 
+gui_parser = subparsers.add_parser('gui',
+        help='Graphical User Interface - opens up an independent window for '
+            'the user to interact with ERT.',
+        description='Graphical User Interface')
+gui_parser.add_argument('config', type=valid_file,
+        help="Ert configuration file")
+gui_parser.set_defaults(func=runGui)
+
+
+tui_parser = subparsers.add_parser('tui',
+        help='Text user interface - provides a user interface in the terminal.'
+        ' Allows the user to interact within the terminal window ',
+        description='Text user interface')
+tui_parser.add_argument('config', type=valid_file,
+        help="Ert configuration file")
+tui_parser.set_defaults(func=runTui)
+
+
+shell_parser = subparsers.add_parser('shell',
+        help='Shell interface - provides a user interface in the terminal.',
+        description='Shell interface')
+shell_parser.add_argument('config', type=valid_file,
+        help="Ert configuration file")
+shell_parser.set_defaults(func=runShell)
+
+
+cli_parser = subparsers.add_parser('cli',
+        description="Command Line Interface",
+        help="command line help")
+cli_parser.add_argument('config', type=valid_file,
+        help="Ert configuration file")
+cli_parser.add_argument("--algorithm", type=str, required=True,
+        choices=["Test-run", "Ensemble Smoother", "Ensemble Experiment"],
+        help="The available algorithms")
+cli_parser.add_argument("--target-case", type=str, default="default",
+        help="The target filesystem to store results")
+cli_parser.set_defaults(func=runCli)
+
+args = parser.parse_args(sys.argv[1:])
+args.func(args)

--- a/python/python/bin/ert_cli
+++ b/python/python/bin/ert_cli
@@ -10,7 +10,7 @@ from res.util import ResLog
 import argparse
 
 
-def setup_fs(ert, target="default_smoother_update"):
+def setup_fs(ert, target="default"):
     fs_manager = ert.getEnkfFsManager()
 
     src_fs = fs_manager.getCurrentFileSystem()
@@ -21,20 +21,6 @@ def setup_fs(ert, target="default_smoother_update"):
 
 def resconfig(config_file):
     return ResConfig(user_config_file=config_file)
-
-
-def args_parser():
-    parser = argparse.ArgumentParser(
-        description="ERT - Ensemble based Reservoir Tool")
-    parser.add_argument("config_file", metavar="config-file", type=str,
-                        help="The ert configuration file")
-    parser.add_argument("--algorithm", type=str, choices=["Test-run",
-                                                          "Ensemble Smoother",
-                                                          "Ensemble Experiment"],
-                        help="")
-    parser.add_argument("--target-case", type=str, default="default",
-                        help="The target filesystem to store results")
-    return parser
 
 
 def _test_run(ert):
@@ -78,8 +64,8 @@ def _experiment_run(ert):
     _run_ensemble_experiment(ert, run_context, sim_runner)
 
 
-def _ensemble_smoother_run(ert):
-    source_fs, target_fs = setup_fs(ert)
+def _ensemble_smoother_run(ert, target_case):
+    source_fs, target_fs = setup_fs(ert, target_case)
 
     model_config = ert.getModelConfig()
     subst_list = ert.getDataKW()
@@ -145,18 +131,21 @@ def _assert_minium_realizations_success(ert, num_successful_realizations):
 
 
 def main():
-    parser = args_parser()
-    args = parser.parse_args()
+    # The ert_cli script should be called from ert.in. The arguments are parsed and verified in ert.in
+    if len(sys.argv) < 3:
+        raise AssertionError("Required arguments are missing, the config-file, "
+                             "algorithm and target case must be provided")
+    config_file, algorithm, target_case = sys.argv[1:]
 
-    config = resconfig(args.config_file)
+    config = resconfig(config_file)
     ert = EnKFMain(config)
 
-    if args.algorithm == "Test-run":
+    if algorithm == "Test-run":
         _test_run(ert)
-    if args.algorithm == "Ensemble Experiment":
+    if algorithm == "Ensemble Experiment":
         _experiment_run(ert)
-    if args.algorithm == "Ensemble Smoother":
-        _ensemble_smoother_run(ert)
+    if algorithm == "Ensemble Smoother":
+        _ensemble_smoother_run(ert, target_case)
 
 
 if __name__ == '__main__':

--- a/python/tests/global/test_cli.py
+++ b/python/tests/global/test_cli.py
@@ -7,5 +7,5 @@ class EntryPointTest(ErtTest):
     def test_single_realization(self):
         config_file = self.createTestPath('local/poly_example/poly.ert')
         exec_path = os.path.join(self.SOURCE_ROOT, "python/python/bin/ert_cli")
-        ok = subprocess.call([exec_path, config_file, "--algorithm=Test-run"])
+        ok = subprocess.call([exec_path, config_file, "Test-run", "default"])
         assert ok == 0


### PR DESCRIPTION
**Task**

The previous setup would not allow the user to access the help
information for any other parser than the one in ert.in. This was
especially important for the cli mode, which required additional
arguments other than just the config file. 

**Approach**
Now each mode has it's own subparser that may be set up to suit each need.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps
