### PR TITLE
Re-instantiating run model

### DIFF
--- a/python/python/ert_gui/plottery/plot_config.py
+++ b/python/python/ert_gui/plottery/plot_config.py
@@ -28,7 +28,7 @@ class PlotConfig(object):
 
         self._limits = PlotLimits()
 
-        self._default_style = PlotStyle(name="Default", color=None, alpha=0.8)
+        self._default_style = PlotStyle(name="Default", color=None, marker=".", alpha=0.8)
 
         self._refcase_style = PlotStyle(name="Refcase", alpha=0.8, line_style="--", marker="", width=2.0,
                                         enabled=self._plot_settings["SHOW_REFCASE"])

--- a/python/python/ert_gui/simulation/ensemble_experiment_panel.py
+++ b/python/python/ert_gui/simulation/ensemble_experiment_panel.py
@@ -8,7 +8,7 @@ except ImportError:
 from ert_gui.ertwidgets import addHelpToWidget
 from ert_gui.ertwidgets.caseselector import CaseSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
-from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath
 from ert_gui.ertwidgets.stringbox import StringBox
 from ert_gui.ide.keywords.definitions import RangeStringArgument
 from ert_gui.simulation.models import EnsembleExperiment

--- a/python/python/ert_gui/simulation/ensemble_experiment_panel.py
+++ b/python/python/ert_gui/simulation/ensemble_experiment_panel.py
@@ -18,7 +18,7 @@ from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
 class EnsembleExperimentPanel(SimulationConfigPanel):
 
     def __init__(self):
-        SimulationConfigPanel.__init__(self, EnsembleExperiment( getQueueConfig( ) ))
+        SimulationConfigPanel.__init__(self, EnsembleExperiment)
 
         layout = QFormLayout()
 

--- a/python/python/ert_gui/simulation/ensemble_smoother_panel.py
+++ b/python/python/ert_gui/simulation/ensemble_smoother_panel.py
@@ -8,7 +8,7 @@ except ImportError:
 from ert_gui.ertwidgets import addHelpToWidget, AnalysisModuleSelector
 from ert_gui.ertwidgets.caseselector import CaseSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
-from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath
 from ert_gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert_gui.ertwidgets.stringbox import StringBox
 from ert_gui.ide.keywords.definitions import RangeStringArgument, ProperNameArgument

--- a/python/python/ert_gui/simulation/ensemble_smoother_panel.py
+++ b/python/python/ert_gui/simulation/ensemble_smoother_panel.py
@@ -18,7 +18,7 @@ from ert_gui.simulation.models import EnsembleSmoother
 
 class EnsembleSmootherPanel(SimulationConfigPanel):
     def __init__(self):
-        SimulationConfigPanel.__init__(self, EnsembleSmoother( getQueueConfig( ) ))
+        SimulationConfigPanel.__init__(self, EnsembleSmoother)
 
         layout = QFormLayout()
 

--- a/python/python/ert_gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/python/python/ert_gui/simulation/iterated_ensemble_smoother_panel.py
@@ -8,7 +8,7 @@ except ImportError:
 
 from ert_gui.ertwidgets import addHelpToWidget, AnalysisModuleSelector, CaseSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
-from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, setNumberOfIterations, getNumberOfIterations, getQueueConfig
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, setNumberOfIterations, getNumberOfIterations
 from ert_gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert_gui.ertwidgets.stringbox import StringBox
 from ert_gui.ide.keywords.definitions import RangeStringArgument, ProperNameFormatArgument

--- a/python/python/ert_gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/python/python/ert_gui/simulation/iterated_ensemble_smoother_panel.py
@@ -18,7 +18,7 @@ from ert_gui.simulation.models import IteratedEnsembleSmoother
 
 class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
     def __init__(self):
-        SimulationConfigPanel.__init__(self, IteratedEnsembleSmoother( getQueueConfig( )))
+        SimulationConfigPanel.__init__(self, IteratedEnsembleSmoother)
 
         layout = QFormLayout()
 

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -31,9 +31,8 @@ class ErtRunError(Exception):
 
 class BaseRunModel(object):
 
-    def __init__(self, name, queue_config, phase_count=1):
+    def __init__(self, queue_config, phase_count=1):
         super(BaseRunModel, self).__init__()
-        self._name = name
         self._phase = 0
         self._phase_count = phase_count
         self._phase_update_count = 0

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -294,6 +294,3 @@ class BaseRunModel(object):
 
     def count_active_realizations(self, run_context):
         return sum(run_context.get_mask( ))
-
-    def __str__(self):
-        return self._name

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -1,8 +1,5 @@
 from res.enkf.enums import HookRuntime
 from res.enkf import ErtRunContext
-from res.util import ResLog
-
-from res.simulator import SimulationContext
 
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
 from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
@@ -10,7 +7,7 @@ from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, 
 class EnsembleExperiment(BaseRunModel):
 
     def __init__(self):
-        super(EnsembleExperiment, self).__init__("Ensemble Experiment" , getQueueConfig())
+        super(EnsembleExperiment, self).__init__(getQueueConfig())
 
     def runSimulations__(self, arguments, run_msg):
 
@@ -64,5 +61,5 @@ class EnsembleExperiment(BaseRunModel):
         return run_context
 
     @classmethod
-    def __repr__(cls):
+    def name(cls):
         return "Ensemble Experiment"

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -5,11 +5,12 @@ from res.util import ResLog
 from res.simulator import SimulationContext
 
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
 class EnsembleExperiment(BaseRunModel):
 
-    def __init__(self, queue_config):
-        super(EnsembleExperiment, self).__init__("Ensemble Experiment" , queue_config)
+    def __init__(self):
+        super(EnsembleExperiment, self).__init__("Ensemble Experiment" , getQueueConfig())
 
     def runSimulations__(self, arguments, run_msg):
 
@@ -61,3 +62,7 @@ class EnsembleExperiment(BaseRunModel):
         self._run_context = run_context
         self._last_run_iteration = run_context.get_iter()
         return run_context
+
+    @classmethod
+    def __repr__(cls):
+        return "Ensemble Experiment"

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -1,4 +1,3 @@
-from res.enkf.enums import EnkfInitModeEnum
 from res.enkf.enums import HookRuntime
 from res.enkf.enums import RealizationStateEnum
 from res.enkf import ErtRunContext
@@ -8,7 +7,7 @@ from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, 
 class EnsembleSmoother(BaseRunModel):
 
     def __init__(self):
-        super(EnsembleSmoother, self).__init__("Ensemble Smoother", getQueueConfig() , phase_count=2)
+        super(EnsembleSmoother, self).__init__(getQueueConfig() , phase_count=2)
         self.support_restart = False
 
     def setAnalysisModule(self, module_name):
@@ -99,5 +98,5 @@ class EnsembleSmoother(BaseRunModel):
         return run_context
 
     @classmethod
-    def __repr__(cls):
+    def name(cls):
         return "Ensemble Smoother"

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -3,12 +3,12 @@ from res.enkf.enums import HookRuntime
 from res.enkf.enums import RealizationStateEnum
 from res.enkf import ErtRunContext
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
-
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
 class EnsembleSmoother(BaseRunModel):
 
-    def __init__(self, queue_config):
-        super(EnsembleSmoother, self).__init__("Ensemble Smoother", queue_config , phase_count=2)
+    def __init__(self):
+        super(EnsembleSmoother, self).__init__("Ensemble Smoother", getQueueConfig() , phase_count=2)
         self.support_restart = False
 
     def setAnalysisModule(self, module_name):
@@ -98,4 +98,6 @@ class EnsembleSmoother(BaseRunModel):
         self._last_run_iteration = run_context.get_iter()
         return run_context
 
-
+    @classmethod
+    def __repr__(cls):
+        return "Ensemble Smoother"

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -2,12 +2,12 @@ from res.enkf.enums import EnkfInitModeEnum, HookRuntime
 from res.enkf import ErtRunContext
 from ert_gui.ertwidgets.models.ertmodel import getNumberOfIterations
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
-
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
 class IteratedEnsembleSmoother(BaseRunModel):
 
-    def __init__(self, queue_config):
-        super(IteratedEnsembleSmoother, self).__init__("Iterated Ensemble Smoother", queue_config , phase_count=2)
+    def __init__(self):
+        super(IteratedEnsembleSmoother, self).__init__("Iterated Ensemble Smoother", getQueueConfig() , phase_count=2)
         self.support_restart = False
 
     def setAnalysisModule(self, module_name):
@@ -126,5 +126,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self._last_run_iteration = run_context.get_iter()
         return run_context
 
-
-
+    @classmethod
+    def __repr__(cls):
+        return "Iterated Ensemble Smoother"

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -127,5 +127,5 @@ class IteratedEnsembleSmoother(BaseRunModel):
         return run_context
 
     @classmethod
-    def __repr__(cls):
+    def name(cls):
         return "Iterated Ensemble Smoother"

--- a/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -13,7 +13,6 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from res.enkf.enums import EnkfInitModeEnum
 from res.enkf.enums import HookRuntime
 from res.enkf.enums import RealizationStateEnum
 from res.enkf import ErtRunContext
@@ -28,7 +27,7 @@ class MultipleDataAssimilation(BaseRunModel):
     default_weights = "3, 2, 1"
 
     def __init__(self):
-        super(MultipleDataAssimilation, self).__init__("Multiple Data Assimilation (ES MDA)", getQueueConfig() , phase_count=2)
+        super(MultipleDataAssimilation, self).__init__(getQueueConfig() , phase_count=2)
         self.weights = MultipleDataAssimilation.default_weights
 
     def setAnalysisModule(self, module_name):
@@ -180,5 +179,5 @@ class MultipleDataAssimilation(BaseRunModel):
         return run_context
 
     @classmethod
-    def __repr__(cls):
-        return "Muiltiple Data Assimilation"
+    def name(cls):
+        return "Multiple Data Assimilation (ES MDA)"

--- a/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -19,24 +19,17 @@ from res.enkf.enums import RealizationStateEnum
 from res.enkf import ErtRunContext
 
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
-
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
 class MultipleDataAssimilation(BaseRunModel):
     """
     Run Multiple Data Assimilation (MDA) Ensemble Smoother with custom weights.
     """
+    default_weights = "3, 2, 1"
 
-    def __init__(self, queue_config):
-        super(MultipleDataAssimilation, self).__init__("Multiple Data Assimilation (ES MDA)", queue_config , phase_count=2)
-        self.weights = "3, 2, 1" # default value
-
-    def getWeights(self):
-        return self.weights
-
-    def setWeights(self, weights):
-        str_weights = str(weights)
-        print("Weights changed: %s" % str_weights)
-        self.weights = str_weights
+    def __init__(self):
+        super(MultipleDataAssimilation, self).__init__("Multiple Data Assimilation (ES MDA)", getQueueConfig() , phase_count=2)
+        self.weights = MultipleDataAssimilation.default_weights
 
     def setAnalysisModule(self, module_name):
         module_load_success = self.ert().analysisConfig().selectModule(module_name)
@@ -47,7 +40,7 @@ class MultipleDataAssimilation(BaseRunModel):
     def runSimulations(self, arguments):
         context = self.create_context(arguments, 0, None)
         self.checkMinimumActiveRealizations(context)
-        weights = self.parseWeights(self.weights)
+        weights = self.parseWeights(arguments['weights'])
         iteration_count = len(weights)
 
         self.setAnalysisModule(arguments["analysis_module"])
@@ -185,3 +178,7 @@ class MultipleDataAssimilation(BaseRunModel):
         self._run_context = run_context
         self._last_run_iteration = run_context.get_iter()
         return run_context
+
+    @classmethod
+    def __repr__(cls):
+        return "Muiltiple Data Assimilation"

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -1,6 +1,4 @@
-from ecl.util.util import BoolVector
-from res.enkf.enums import HookRuntime
-from res.enkf import ErtRunContext
+
 from ert_gui.simulation.models import BaseRunModel, ErtRunError, EnsembleExperiment
 from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
@@ -9,7 +7,7 @@ class SingleTestRun(EnsembleExperiment):
     def __init__(self):
         queue_config = getQueueConfig()
         local_queue_config = queue_config.create_local_copy()
-        super(EnsembleExperiment, self).__init__("Single realization test-run" , local_queue_config)
+        super(EnsembleExperiment, self).__init__( local_queue_config)
 
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         #Should only have one successful realization
@@ -20,5 +18,5 @@ class SingleTestRun(EnsembleExperiment):
         return self.runSimulations__( arguments  , "Running single realisation test ...")
 
     @classmethod
-    def __repr__(cls):
+    def name(cls):
         return "Single realization test-run"

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -2,11 +2,14 @@ from ecl.util.util import BoolVector
 from res.enkf.enums import HookRuntime
 from res.enkf import ErtRunContext
 from ert_gui.simulation.models import BaseRunModel, ErtRunError, EnsembleExperiment
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
 
 class SingleTestRun(EnsembleExperiment):
 
-    def __init__(self, queue_config):
-        super(EnsembleExperiment, self).__init__("Single realization test-run" , queue_config)
+    def __init__(self):
+        queue_config = getQueueConfig()
+        local_queue_config = queue_config.create_local_copy()
+        super(EnsembleExperiment, self).__init__("Single realization test-run" , local_queue_config)
 
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         #Should only have one successful realization
@@ -15,3 +18,7 @@ class SingleTestRun(EnsembleExperiment):
 
     def runSimulations(self, arguments):
         return self.runSimulations__( arguments  , "Running single realisation test ...")
+
+    @classmethod
+    def __repr__(cls):
+        return "Single realization test-run"

--- a/python/python/ert_gui/simulation/multiple_data_assimilation_panel.py
+++ b/python/python/ert_gui/simulation/multiple_data_assimilation_panel.py
@@ -34,7 +34,7 @@ from ert_gui.simulation.models import MultipleDataAssimilation
 
 class MultipleDataAssimilationPanel(SimulationConfigPanel):
     def __init__(self):
-        SimulationConfigPanel.__init__(self, MultipleDataAssimilation( getQueueConfig() ))
+        SimulationConfigPanel.__init__(self, MultipleDataAssimilation)
 
         layout = QFormLayout()
 
@@ -54,6 +54,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         self._target_case_format_field.setValidator(ProperNameFormatArgument())
         layout.addRow("Target case format:", self._target_case_format_field)
 
+        self.weights = MultipleDataAssimilation.default_weights
         self._createInputForWeights(layout)
 
         self._analysis_module_selector = AnalysisModuleSelector(iterable=False, help_link="config/analysis/analysis_module")
@@ -72,13 +73,15 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
 
         self.setLayout(layout)
 
+
+
     def _createInputForWeights(self, layout):
-        relative_iteration_weights_model = ValueModel(self.getSimulationModel().getWeights())
+        relative_iteration_weights_model = ValueModel( self.weights)
         self._relative_iteration_weights_box = StringBox(relative_iteration_weights_model, help_link="config/simulation/iteration_weights", continuous_update=True)
         self._relative_iteration_weights_box.setValidator(NumberListStringArgument())
         layout.addRow("Relative Weights:", self._relative_iteration_weights_box)
 
-        relative_iteration_weights_model.valueChanged.connect(self.getSimulationModel().setWeights)
+        relative_iteration_weights_model.valueChanged.connect(self.setWeights)
 
         normalized_weights_model = ValueModel()
         normalized_weights_widget = ActiveLabel(normalized_weights_model, help_link="config/simulation/iteration_weights")
@@ -103,7 +106,13 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
     def getSimulationArguments(self):
         arguments = {"active_realizations": self._active_realizations_model.getActiveRealizationsMask(),
                      "target_case": self._target_case_format_model.getValue(),
-                     "analysis_module": self._analysis_module_selector.getSelectedAnalysisModuleName()
+                     "analysis_module": self._analysis_module_selector.getSelectedAnalysisModuleName(),
+                     "weights": self.weights
                      }
         return arguments
 
+
+    def setWeights(self, weights):
+        str_weights = str(weights)
+        print("Weights changed: %s" % str_weights)
+        self.weights = str_weights

--- a/python/python/ert_gui/simulation/multiple_data_assimilation_panel.py
+++ b/python/python/ert_gui/simulation/multiple_data_assimilation_panel.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from ert_gui.ertwidgets import addHelpToWidget, CaseSelector, ActiveLabel, AnalysisModuleSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
-from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath
 from ert_gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert_gui.ertwidgets.models.valuemodel import ValueModel
 from ert_gui.ertwidgets.stringbox import StringBox

--- a/python/python/ert_gui/simulation/simulation_panel.py
+++ b/python/python/ert_gui/simulation/simulation_panel.py
@@ -74,7 +74,7 @@ class SimulationPanel(QWidget):
         self._simulation_stack.addWidget(panel)
         simulation_model = panel.getSimulationModel()
         self._simulation_widgets[simulation_model] = panel
-        self._simulation_mode_combo.addItem(simulation_model.__repr__(),simulation_model)
+        self._simulation_mode_combo.addItem(simulation_model.name(),simulation_model)
         panel.simulationConfigurationChanged.connect(self.validationStatusChanged)
 
 

--- a/python/python/ert_gui/simulation/simulation_panel.py
+++ b/python/python/ert_gui/simulation/simulation_panel.py
@@ -74,7 +74,7 @@ class SimulationPanel(QWidget):
         self._simulation_stack.addWidget(panel)
         simulation_model = panel.getSimulationModel()
         self._simulation_widgets[simulation_model] = panel
-        self._simulation_mode_combo.addItem(str(simulation_model), simulation_model)
+        self._simulation_mode_combo.addItem(simulation_model.__repr__(),simulation_model)
         panel.simulationConfigurationChanged.connect(self.validationStatusChanged)
 
 
@@ -104,7 +104,7 @@ class SimulationPanel(QWidget):
         if start_simulations == QMessageBox.Yes:
             run_model = self.getCurrentSimulationModel()
             arguments = self.getSimulationArguments()
-            dialog = RunDialog(run_model, self)
+            dialog = RunDialog(run_model(), self)
             dialog.startSimulation( arguments )
             dialog.exec_()
 

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -20,9 +20,8 @@ from ecl.util.util import BoolVector
 class SingleTestRunPanel(SimulationConfigPanel):
 
     def __init__(self):
-        queue_config = getQueueConfig( )
-        local_queue_config = queue_config.create_local_copy( )
-        SimulationConfigPanel.__init__(self, SingleTestRun( local_queue_config ))
+
+        SimulationConfigPanel.__init__(self, SingleTestRun)
         
         layout = QFormLayout()
 

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -1,4 +1,4 @@
-import sys
+
 
 try:
   from PyQt4.QtGui import QFormLayout, QLabel
@@ -9,10 +9,7 @@ except ImportError:
 from ert_gui.ertwidgets import addHelpToWidget
 from ert_gui.ertwidgets.caseselector import CaseSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
-from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, getQueueConfig
-from ert_gui.ertwidgets.stringbox import StringBox
-from ert_gui.ide.keywords.definitions import RangeStringArgument
-from ert_gui.simulation.models import EnsembleExperiment
+from ert_gui.ertwidgets.models.ertmodel import  getRunPath
 from ert_gui.simulation.models import SingleTestRun
 from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
 from ecl.util.util import BoolVector

--- a/python/tests/gui/models/test_base_run_model.py
+++ b/python/tests/gui/models/test_base_run_model.py
@@ -11,6 +11,6 @@ class BaseRunModelTest(ErtTest):
         with ErtTestContext('kjell', config_file) as work_area:
             ert = work_area.getErt()
             configureErtNotifier(ert, config_file)
-            brm = BaseRunModel('kjell' ,ert.get_queue_config( ))
+            brm = BaseRunModel(ert.get_queue_config( ))
             self.assertFalse(brm.isQueueRunning())
             self.assertTrue(brm.getProgress() >= 0)


### PR DESCRIPTION
Run models were instantiated only at startup, which left several of object properties not reset. 

Now the run model is created when running the ensemble. 

Resolves issue #248 
