### PR TITLE
Added tui / shell deprecation warnings

### DIFF
--- a/bin/ert.in
+++ b/bin/ert.in
@@ -41,11 +41,13 @@ def ert_parser():
 
     subparsers = parser.add_subparsers(
         title="Available user entries",
-        description='ERT can be accessed through various interfaces. Include '
+        description='ERT can be accessed through a GUI or CLI interface. Include '
                     'one of the following arguments to change between the '
-                    'interfaces. Note that different entry points may require'
+                    'interfaces. Note that different entry points may require '
                     'different additional arguments. See the help section for '
-                    'each interface for more details',
+                    'each interface for more details. DEPRECATION WARNING: '
+                    'Text User Interface and Shell Interface are to be removed in '
+                    'ERT > 2.4!',
         help="Available entry points")
 
 
@@ -59,25 +61,24 @@ def ert_parser():
 
 
     tui_parser = subparsers.add_parser('text',
-            help='Text user interface - provides a user interface in the terminal.'
-            ' Allows the user to interact within the terminal window ',
-            description='Text user interface')
+            help='Text user interface. Deprecated! Use CLI instead.',
+            description='Text user interface. Deprecated! Use CLI instead.')
     tui_parser.add_argument('config', type=valid_file,
             help="Ert configuration file")
     tui_parser.set_defaults(func=runTui)
 
 
     shell_parser = subparsers.add_parser('shell',
-            help='Shell interface - provides a user interface in the terminal.',
-            description='Shell interface')
+            help='Shell interface. Deprecated! Use CLI instead.',
+            description='Shell interface. Deprecated! Use CLI instead.')
     shell_parser.add_argument('config', type=valid_file,
             help="Ert configuration file")
     shell_parser.set_defaults(func=runShell)
 
 
     cli_parser = subparsers.add_parser('cli',
-            description="Command Line Interface",
-            help="command line help")
+            help='Command Line Interface - provides a user interface in the terminal.',
+            description="Command Line Interface")
     cli_parser.add_argument('config', type=valid_file,
             help="Ert configuration file")
     cli_parser.add_argument("--algorithm", type=str, required=True,

--- a/libert/applications/ert_tui/main.cpp
+++ b/libert/applications/ert_tui/main.cpp
@@ -119,6 +119,7 @@ void parse_workflows(int argc, char ** argv, stringlist_type * workflows) {
 int main (int argc, char ** argv) {
   text_splash();
   printf("\n");
+  printf("DEPRECATION WARNING: ERT tui is to be removed in ERT > 2.4.\n");
   printf("Documentation : %s \n","http://ert.nr.no");
   printf("git commit    : %s \n",ert_version_get_git_commit( ));
   printf("compile time  : %s \n",ert_version_get_build_time( ));

--- a/python/python/ert_gui/shell/ertshell.py
+++ b/python/python/ert_gui/shell/ertshell.py
@@ -43,11 +43,11 @@ class ErtShell(Cmd):
             "\n" \
             "Interactive shell for working with ERT.\n" \
             "\n" \
+            "-- DEPRECATION WARNING: ERT shell is to be removed in ERT > 2.4.\n" \
             "-- Type help for a list of supported commands.\n" \
             "-- Type exit or press Ctrl+D to end the shell session.\n" \
             "-- Press Tab for auto completion.\n" \
             "-- Arrow up/down for history.\n"
-
 
     def __init__(self, forget_history=False):
         Cmd.__init__(self)


### PR DESCRIPTION
Added deprecation warnings on all entrypoints using tui and shell
stating this functionality will be removed in ERT > 2.4.

Resolves #255 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#
* Statoil/libecl#
