### PR TITLE
Removed extra __init__() argument

### DIFF
--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -7,7 +7,7 @@ from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath, 
 class IteratedEnsembleSmoother(BaseRunModel):
 
     def __init__(self):
-        super(IteratedEnsembleSmoother, self).__init__("Iterated Ensemble Smoother", getQueueConfig() , phase_count=2)
+        super(IteratedEnsembleSmoother, self).__init__(getQueueConfig() , phase_count=2)
         self.support_restart = False
 
     def setAnalysisModule(self, module_name):


### PR DESCRIPTION
**Task**
This is a fix to the issue described here: #264. The actual bug was probably introduced here: https://github.com/equinor/ert/commit/5639fc7fa4987683dff0e73b8037766be93bb1bb

**Approach**
The fix is just to remove an extra string argument when calling the `BaseRunModel.__init__()` method.
