### PR TITLE
Rename algorithm to mode

### DIFF
--- a/bin/ert.in
+++ b/bin/ert.in
@@ -81,9 +81,9 @@ def ert_parser():
             description="Command Line Interface")
     cli_parser.add_argument('config', type=valid_file,
             help="Ert configuration file")
-    cli_parser.add_argument("--algorithm", type=str, required=True,
-            choices=["Test-run", "Ensemble Smoother", "Ensemble Experiment"],
-            help="The available algorithms")
+    cli_parser.add_argument("--mode", type=str, required=True,
+            choices=["test_run", "ensemble_experiment", "ensemble_smoother"],
+            help="The available modes")
     cli_parser.add_argument("--target-case", type=str, default="default",
             help="The target filesystem to store results")
     cli_parser.set_defaults(func=runCli)

--- a/python/python/bin/ert_cli
+++ b/python/python/bin/ert_cli
@@ -134,17 +134,17 @@ def main():
     # The ert_cli script should be called from ert.in. The arguments are parsed and verified in ert.in
     if len(sys.argv) < 3:
         raise AssertionError("Required arguments are missing, the config-file, "
-                             "algorithm and target case must be provided")
-    config_file, algorithm, target_case = sys.argv[1:]
+                             "mode and target case must be provided")
+    config_file, mode, target_case = sys.argv[1:]
 
     config = resconfig(config_file)
     ert = EnKFMain(config)
 
-    if algorithm == "Test-run":
+    if mode == "test_run":
         _test_run(ert)
-    if algorithm == "Ensemble Experiment":
+    if mode == "ensemble_experiment":
         _experiment_run(ert)
-    if algorithm == "Ensemble Smoother":
+    if mode == "ensemble_smoother":
         _ensemble_smoother_run(ert, target_case)
 
 

--- a/python/tests/global/test_cli.py
+++ b/python/tests/global/test_cli.py
@@ -7,5 +7,5 @@ class EntryPointTest(ErtTest):
     def test_single_realization(self):
         config_file = self.createTestPath('local/poly_example/poly.ert')
         exec_path = os.path.join(self.SOURCE_ROOT, "python/python/bin/ert_cli")
-        ok = subprocess.call([exec_path, config_file, "Test-run", "default"])
+        ok = subprocess.call([exec_path, config_file, "test_run", "default"])
         assert ok == 0


### PR DESCRIPTION
Whitespace in arguments removed

**Task**
resolves #269

**Approach**
Removed whitespace and renamed `algorithm` to `mode`

**Pre un-WIP checklist**
- [x] Equinor tests pass locally
