### PR TITLE
Validate target file system at startup

### DIFF
--- a/bin/ert.in
+++ b/bin/ert.in
@@ -36,6 +36,13 @@ def runCli( args ):
     runExec(exec_path, [args.config, args.mode, args.target_case])
 
 
+def validate_cli_args(parser, args):
+    if args.mode == "ensemble_smoother" and args.target_case == "default":
+        msg = "Target file system and source file system can not be the same. "\
+              "They were both: <default>. Please set using --target-case on "\
+              "the command line."
+        parser.error(msg)
+
 def ert_parser():
     parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
 
@@ -93,6 +100,10 @@ def ert_parser():
 def main():
     parser = ert_parser()
     args = parser.parse_args(sys.argv[1:])
+
+    if args.func.func_name == "runCli":
+        validate_cli_args(parser, args)
+
     args.func(args)
 
 

--- a/bin/ert.in
+++ b/bin/ert.in
@@ -33,7 +33,7 @@ def runShell( args ):
 
 def runCli( args ):
     exec_path = os.path.join(os.path.dirname(__file__), "ert_cli")
-    runExec(exec_path, [args.config, args.algorithm, args.target_case])
+    runExec(exec_path, [args.config, args.mode, args.target_case])
 
 
 def ert_parser():


### PR DESCRIPTION
**Task**
Validate target file system early 

resolves #270

**Approach**
Does a minor validation of the specified target-case. The subparser isn't that flexible yet, and currently it is only possible to select `default` as simulation case - thus running multiple ensemble experiments after another while changing sim case isn't possible. When we're adding sim_case as well on the input we could improve upon this.

However, I believe using the parser for error handling is the, currently, best way of doing this.

This pr has merge conflicts with #281 

**Pre un-WIP checklist**
- [x] Equinor tests pass locally
