### PR TITLE
Change initial type to iterable in BaseRunModel

### DIFF
--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -46,11 +46,11 @@ class BaseRunModel(object):
         self._queue_config = queue_config
         self._job_queue = None
         self.realization_progress = {}
-        self.initial_realizations_mask = None
-        self.completed_realizations_mask = None
+        self.initial_realizations_mask = []
+        self.completed_realizations_mask = []
         self.support_restart = True
         self._run_context = None
-        self._last_run_iteration = -1;
+        self._last_run_iteration = -1
         self.reset( )
 
     def ert(self):


### PR DESCRIPTION
**Task**
The `update_realizations_view` fails with `TypeError: 'NoneType' object is not iterable` 
solves #271

**Approach**
The mask that will be assigned to completed_realizations_mask is an
interable.  Change the initial value such that functions using the
parameter can safely use `__iter__` methods

**Pre un-WIP checklist**
- [x] Equinor tests pass locally
