### PR TITLE
Fix condition for is_forward_model_finished

### DIFF
--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -229,7 +229,7 @@ class BaseRunModel(object):
 
     @staticmethod
     def is_forward_model_finished(progress):
-        return any((job.status == 'Failure' for job in progress))
+        return not (any((job.status != 'Success' for job in progress)))
 
 
     def updateDetailedProgress(self):


### PR DESCRIPTION
As forward models are restarted the test should only say finished if all jobs are successful