### PR TITLE
Move detail progress monitor to run_dialog

### DIFF
--- a/python/python/ert_gui/simulation/__init__.py
+++ b/python/python/ert_gui/simulation/__init__.py
@@ -1,6 +1,6 @@
 from .progress import Progress
 from .simple_progress import SimpleProgress
-from .detailed_progress import DetailedProgressDialog
+from .detailed_progress import DetailedProgressWidget
 from .run_dialog import RunDialog
 from .simulation_config_panel import SimulationConfigPanel
 from .single_test_run_panel import SingleTestRunPanel

--- a/python/python/ert_gui/simulation/detailed_progress.py
+++ b/python/python/ert_gui/simulation/detailed_progress.py
@@ -266,9 +266,9 @@ class FileViewer(QDialog):
         self.show()
 
 
-class DetailedProgressDialog(QWidget):
+class DetailedProgressWidget(QWidget):
     def __init__(self, parent, state_colors):
-        super(DetailedProgressDialog, self).__init__(parent)
+        super(DetailedProgressWidget, self).__init__(parent)
         self.setWindowTitle("Realization Progress")
         layout = QGridLayout(self)
 

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -264,10 +264,10 @@ class BaseRunModel(object):
         self.updateDetailedProgress()
 
         if self._run_context and self._run_context.get_iter() in self.realization_progress:
-            return self.realization_progress[self._run_context.get_iter()], self._run_context.get_iter()
+            return self.realization_progress, self._run_context.get_iter()
 
         elif self._last_run_iteration in self.realization_progress:
-            return self.realization_progress[self._last_run_iteration], self._last_run_iteration
+            return self.realization_progress, self._last_run_iteration
 
         else:
             return {},-1

--- a/python/python/ert_gui/simulation/run_dialog.py
+++ b/python/python/ert_gui/simulation/run_dialog.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 from ert_gui.ertwidgets import resourceMovie, Legend
-from ert_gui.simulation import Progress, SimpleProgress, DetailedProgressDialog
+from ert_gui.simulation import Progress, SimpleProgress, DetailedProgressWidget
 from ert_gui.simulation.models import BaseRunModel, SimulationsTracker
 from ert_gui.tools.plot.plot_tool import PlotTool
 
@@ -39,7 +39,8 @@ from ecl.util.util import BoolVector
 class RunDialog(QDialog):
 
     def __init__(self, run_model, parent):
-        QDialog.__init__(self, None)
+        QDialog.__init__(self, parent)
+        self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setModal(True)
         self.setWindowModality(Qt.WindowModal)
@@ -122,7 +123,7 @@ class RunDialog(QDialog):
         button_widget_container = QWidget()
         button_widget_container.setLayout(button_layout)
 
-        self.detailed_progress = DetailedProgressDialog(self, self.state_colors)
+        self.detailed_progress = DetailedProgressWidget(self, self.state_colors)
         self.detailed_progress.setVisible(False)
         self.dummy_widget_container = QWidget() #Used to keep the other widgets from stretching
 

--- a/python/python/ert_gui/simulation/run_dialog.py
+++ b/python/python/ert_gui/simulation/run_dialog.py
@@ -192,7 +192,7 @@ class RunDialog(QDialog):
             if self._run_model.hasRunFailed():
                 error = self._run_model.getFailMessage()
                 QMessageBox.critical(self, "Simulations failed!", "The simulation failed with the following error:\n\n%s" % error)
-                self.reject()
+                
             return True
         return False
 


### PR DESCRIPTION
Add support investigating past iterations

**Task**
Upgrade realizations view after simulation finished to the forward model monitoring widget. 
Add support to show multiple iterations in the monitoring widget
Allow users to debug if the run fails completely

Resolves #280 