### PR TITLE
Fix default plot style with one data-point

### DIFF
--- a/python/python/ert_gui/plottery/plot_config.py
+++ b/python/python/ert_gui/plottery/plot_config.py
@@ -28,7 +28,7 @@ class PlotConfig(object):
 
         self._limits = PlotLimits()
 
-        self._default_style = PlotStyle(name="Default", color=None, marker=".", alpha=0.8)
+        self._default_style = PlotStyle(name="Default", color=None, marker="", alpha=0.8)
 
         self._refcase_style = PlotStyle(name="Refcase", alpha=0.8, line_style="--", marker="", width=2.0,
                                         enabled=self._plot_settings["SHOW_REFCASE"])

--- a/python/python/ert_gui/plottery/plots/ensemble.py
+++ b/python/python/ert_gui/plottery/plots/ensemble.py
@@ -47,6 +47,9 @@ def _plotLines(axes, plot_config, data, ensemble_label, is_date_supported):
 
     style = plot_config.defaultStyle()
 
+    if len(data) == 1 and style.marker == '':
+        style.marker = '.'
+
     if is_date_supported:
         lines = axes.plot_date(x=data.index.values, y=data, color=style.color, alpha=style.alpha, marker=style.marker, linestyle=style.line_style, linewidth=style.width, markersize=style.size)
     else:


### PR DESCRIPTION
Changes default plot style to point for data with one data-point if marker is set to 'off'.

Resolves #276 

