### PR TITLE
WIP: Add python 3.5 support ert entry point

### DIFF
--- a/ert_gui/bin/ert
+++ b/ert_gui/bin/ert
@@ -56,8 +56,9 @@ def ert_parser():
                     'each interface for more details. DEPRECATION WARNING: '
                     'Text User Interface and Shell Interface are to be removed in '
                     'ERT > 2.4!',
-        help="Available entry points")
-
+        help="Available entry points",
+        dest="{gui,text,shell,cli}")
+    subparsers.required = True
 
     gui_parser = subparsers.add_parser('gui',
             help='Graphical User Interface - opens up an independent window for '

--- a/tests/global/test_cli.py
+++ b/tests/global/test_cli.py
@@ -9,3 +9,11 @@ class EntryPointTest(ErtTest):
         exec_path = os.path.join(self.SOURCE_ROOT, "ert_gui/bin/ert_cli")
         ok = subprocess.call([exec_path, config_file, "test_run", "default"])
         assert ok == 0
+
+    def test_ert_no_arguments(self):
+        exec_path = os.path.join(self.SOURCE_ROOT, "bin/ert.in")
+        proc = subprocess.Popen(exec_path, stderr=subprocess.PIPE)
+        _, err = proc.communicate()
+
+        assert("ert.in: error" in str(err))
+


### PR DESCRIPTION
Subparsers was no longer required after update, forced them to be required

resolves #323 

**Pre un-WIP checklist**
- [ ] Equinor tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Equinor/libres#
* Equinor/libecl#
