### PR TITLE
Prevent run dialog from closing on simulation failure

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -193,7 +193,7 @@ class RunDialog(QDialog):
             if self._run_model.hasRunFailed():
                 error = self._run_model.getFailMessage()
                 QMessageBox.critical(self, "Simulations failed!", "The simulation failed with the following error:\n\n%s" % error)
-                self.reject()
+                
             return True
         return False
 


### PR DESCRIPTION
This allows users to debug after failed run
resolves #280 