### PR TITLE
Include queue status in detailed FM monitor

### DIFF
--- a/ert_gui/simulation/detailed_progress.py
+++ b/ert_gui/simulation/detailed_progress.py
@@ -101,7 +101,7 @@ class DetailedProgress(QFrame):
         foreground_image = QImage(self.grid_width*sub_grid_size, self.grid_height*sub_grid_size, QImage.Format_ARGB32)
         foreground_image.fill(QColor(0, 0, 0, 0))
 
-        for index, (iens, progress, state) in enumerate(self._current_progress):
+        for index, (iens, progress, _) in enumerate(self._current_progress):
             y = int(iens / self.grid_width)
             x = int(iens - (y * self.grid_width))
             self.draw_window(x * sub_grid_size, y * sub_grid_size, progress, foreground_image)

--- a/ert_gui/simulation/models/base_run_model.py
+++ b/ert_gui/simulation/models/base_run_model.py
@@ -186,14 +186,13 @@ class BaseRunModel(object):
         """ @rtype: dict of (JobStatusType, int) """
         queue_status = {}
 
-        if self._job_queue.isRunning():
-            for job_number in range(len(self._job_queue)):
-                status = self._job_queue.getJobStatus(job_number)
+        for job_number in range(len(self._job_queue)):
+            status = self._job_queue.getJobStatus(job_number)
 
-                if not status in queue_status:
-                    queue_status[status] = 0
+            if not status in queue_status:
+                queue_status[status] = 0
 
-                queue_status[status] += 1
+            queue_status[status] += 1
 
 
         return queue_status

--- a/ert_gui/simulation/models/ensemble_experiment.py
+++ b/ert_gui/simulation/models/ensemble_experiment.py
@@ -30,7 +30,6 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
         self.setPhase(1, "Simulations completed.") # done...
-        self._job_queue = None
 
         return run_context
 

--- a/ert_gui/simulation/models/ensemble_smoother.py
+++ b/ert_gui/simulation/models/ensemble_smoother.py
@@ -68,7 +68,6 @@ class EnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
 
         self.setPhase(2, "Simulations completed.")
-        self.__job_queue = None
 
         return prior_context
 

--- a/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -35,8 +35,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
-        self._job_queue = None
-
 
 
     def createTargetCaseFileSystem(self, phase, target_case_format):

--- a/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -113,7 +113,6 @@ class MultipleDataAssimilation(BaseRunModel):
         phase_string = "Post processing for iteration: %d" % iteration
         self.setPhaseName(phase_string, indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows(HookRuntime.POST_SIMULATION)
-        self._job_queue = None
         return num_successful_realizations
 
 

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -197,14 +197,15 @@ class RunDialog(QDialog):
             return True
         return False
 
-    def updateProgress(self, recount=True):
+    def updateProgress(self):
+
         total_count = self._run_model.getQueueSize()
         queue_status = self._run_model.getQueueStatus()
         states = self.simulations_tracker.getStates()
-        if recount:
-            for state in states:
-                state.count = 0
-                state.total_count = total_count
+
+        for state in states:
+            state.count = 0
+            state.total_count = total_count
 
         for state in states:
             for queue_state in queue_status:
@@ -220,7 +221,7 @@ class RunDialog(QDialog):
         if self.checkIfRunFinished():
             self.total_progress.setProgress(self._run_model.getProgress())
             self.detailed_progress.set_progress(*self._run_model.getDetailedProgress())
-            self.updateProgress(False)
+            self.updateProgress()
             return
 
         self.total_progress.setProgress(self._run_model.getProgress())


### PR DESCRIPTION
In order to meet the expectation that a finished FM in the detailed progress view should be  match the finished in the progress overview, we include the information from the queue driver. 

