### PR TITLE
Remove enkf plot_config staff from ert

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.5.a2
+export LIBRES_VERSION=2.6.a2

--- a/ert_gui/plottery/plot_config.py
+++ b/ert_gui/plottery/plot_config.py
@@ -7,11 +7,12 @@ class PlotConfig(object):
     # The plot_settings input argument is an internalisation of the (quite few) plot
     # policy settings which can be set in the configuration file.
     
-    def __init__(self, plot_settings, title="Unnamed", x_label=None, y_label=None):
+    def __init__(self, plot_settings=None, title="Unnamed", x_label=None, y_label=None):
         self._title = title
         self._plot_settings = plot_settings
         if self._plot_settings is None:
-            raise ValueError('PlotConfig needs a non-None plot settings.')
+            self._plot_settings = {'SHOW_REFCASE': True, 'SHOW_HISTORY': True}
+
         self._line_color_cycle_colors = ["#000000"]
         self._line_color_cycle = itertools.cycle(self._line_color_cycle_colors) #Black
         # Blueish, Greenlike, Beigeoid, Pinkness, Orangy-Brown

--- a/ert_gui/plottery/plot_config_factory.py
+++ b/ert_gui/plottery/plot_config_factory.py
@@ -10,7 +10,7 @@ class PlotConfigFactory(object):
         @param key: str
         @return: PlotConfig
         """
-        plot_config = PlotConfig(ert.plotConfig() , title = key)
+        plot_config = PlotConfig(plot_settings=None , title = key)
         return PlotConfigFactory.updatePlotConfigForKey(ert, key, plot_config)
 
 

--- a/ert_gui/shell/plot_settings.py
+++ b/ert_gui/shell/plot_settings.py
@@ -1,5 +1,4 @@
 from res.enkf.enkf_fs_manager import naturalSortKey
-from res.enkf import PlotSettings as ErtPlotSettings
 from ert_gui.plottery.plot_config import PlotConfig
 from ert_gui.shell import assertConfigLoaded, ErtShellCollection
 from ert_gui.shell.libshell import autoCompleteList, boolValidator, pathCompleter, splitArguments
@@ -21,12 +20,8 @@ class PlotSettings(ErtShellCollection):
         super(PlotSettings, self).__init__("plot_settings", parent)
         
         self.__cases = None
-        if self.ert():
-            ert_ps = self.ert().plotConfig( )
-        else:
-            ert_ps = ErtPlotSettings( )
 
-        self.__plot_config = PlotConfig( ert_ps )
+        self.__plot_config = PlotConfig()
         self.shellContext()["plot_settings"] = self
 
         self.addShellFunction(name="current",
@@ -42,15 +37,6 @@ class PlotSettings(ErtShellCollection):
                               completer=PlotSettings.completeSelect,
                               help_arguments="[case_1..case_n]",
                               help_message="Select one or more cases as default plot sources. Empty resets to current case.")
-
-        self.addShellProperty(name="path",
-                              getter=PlotSettings.getPath,
-                              setter=PlotSettings.setPath,
-                              validator=plotPathValidator,
-                              completer=pathCompleter,
-                              help_arguments="[path]",
-                              help_message="Show or set the plot output path",
-                              pretty_attribute="Plot output path")
 
         self.addShellProperty(name="title",
                               getter=PlotConfig.title,
@@ -165,14 +151,6 @@ class PlotSettings(ErtShellCollection):
         all_case_list = fs_manager.getCaseList()
         all_case_list = [case for case in all_case_list if not case.startswith(".")]
         return all_case_list
-
-    @assertConfigLoaded
-    def getPath(self):
-        return self.ert().plotConfig().getPath()
-
-    @assertConfigLoaded
-    def setPath(self, path):
-        self.ert().plotConfig().setPath(path)
 
     def resetTitle(self, line):
         self.plotConfig().setTitle(None)

--- a/ert_gui/tools/plot/customize/customize_plot_dialog.py
+++ b/ert_gui/tools/plot/customize/customize_plot_dialog.py
@@ -20,13 +20,17 @@ class PlotCustomizer(QObject):
 
     settingsChanged = pyqtSignal()
 
-    def __init__(self, parent, default_plot_settings):
+    def __init__(self, parent, default_plot_settings=None):
         super(PlotCustomizer, self).__init__()
 
         self._plot_config_key = None
         self._previous_key = None
         self.default_plot_settings = default_plot_settings
-        self._plot_configs = {None: PlotConfigHistory("No_Key_Selected", PlotConfig(default_plot_settings, title=None))}
+        self._plot_configs = {
+            None: PlotConfigHistory(
+                "No_Key_Selected",
+                PlotConfig(plot_settings=default_plot_settings, title=None))
+        }
 
         self._plotConfigCreator = self._defaultPlotConfigCreator
 

--- a/ert_gui/tools/plot/plot_window.py
+++ b/ert_gui/tools/plot/plot_window.py
@@ -41,7 +41,7 @@ class PlotWindow(QMainWindow):
         self.setWindowTitle("Plotting")
         self.activateWindow()
 
-        self._plot_customizer = PlotCustomizer(self, self._ert.plotConfig())
+        self._plot_customizer = PlotCustomizer(self)
 
         def plotConfigCreator(key):
             return PlotConfigFactory.createPlotConfigForKey(self._ert, key)

--- a/tests/gui/ertshell/test_ertshell_plot_settings.py
+++ b/tests/gui/ertshell/test_ertshell_plot_settings.py
@@ -43,8 +43,6 @@ class ErtShellPlotSettingsTest(ErtTest):
             self.checkBoolProperties(shell, "plot_settings refcase", plot_config.isRefcaseEnabled)
             self.checkBoolProperties(shell, "plot_settings observations", plot_config.isObservationsEnabled)
 
-            self.checkStringProperties(shell, "plot_settings path", shell.shellContext()["plot_settings"].getPath, allow_multiple_arguments=False)
-
             default_plot_cases = shell.shellContext()["plot_settings"].getCurrentPlotCases()
             self.assertTrue(shell.invokeCommand("plot_settings current"))
             self.assertTrue(shell.invokeCommand("plot_settings select test_run default"))

--- a/tests/gui/plottery/test_plot_config_history.py
+++ b/tests/gui/plottery/test_plot_config_history.py
@@ -1,13 +1,11 @@
 from tests import ErtTest
-from res.enkf import PlotSettings
 from ert_gui.plottery import PlotConfig, PlotConfigHistory
 
 
 class PlotConfigHistoryTest(ErtTest):
 
     def test_plot_config_history(self):
-        ps = PlotSettings( )
-        test_pc = PlotConfig(ps , title = "test_1")
+        test_pc = PlotConfig(title = "test_1")
         history = PlotConfigHistory("test", test_pc)
 
         self.assertEqual(history.getPlotConfig().title(), test_pc.title())
@@ -16,7 +14,7 @@ class PlotConfigHistoryTest(ErtTest):
         self.assertFalse(history.isUndoPossible())
         self.assertFalse(history.isRedoPossible())
 
-        history.applyChanges(PlotConfig(ps, title = "test_2"))
+        history.applyChanges(PlotConfig(title = "test_2"))
         self.assertTrue(history.isUndoPossible())
         self.assertFalse(history.isRedoPossible())
         self.assertEqual(history.getPlotConfig().title(), "test_2")

--- a/tests/gui/plottery/test_plot_style.py
+++ b/tests/gui/plottery/test_plot_style.py
@@ -1,7 +1,6 @@
 import datetime
 
 from tests import ErtTest
-from res.enkf import PlotSettings
 from ert_gui.plottery import PlotStyle, PlotConfig, PlotLimits
 
 
@@ -80,8 +79,7 @@ class PlotStyleTest(ErtTest):
 
 
     def test_plot_config(self):
-        ps = PlotSettings( )
-        plot_config = PlotConfig(ps , "Golden Sample", x_label="x", y_label="y")
+        plot_config = PlotConfig(title="Golden Sample", x_label="x", y_label="y")
 
         limits = PlotLimits()
         limits.count_limits = 1, 2
@@ -111,7 +109,7 @@ class PlotStyleTest(ErtTest):
         plot_config.setStatisticsStyle("p33-p67", style)
         plot_config.setStatisticsStyle("std", style)
 
-        copy_of_plot_config = PlotConfig(ps , "Copy of Golden Sample")
+        copy_of_plot_config = PlotConfig(title="Copy of Golden Sample")
         copy_of_plot_config.copyConfigFrom(plot_config)
 
         self.assertEqual(plot_config.isLegendEnabled(), copy_of_plot_config.isLegendEnabled())
@@ -141,7 +139,7 @@ class PlotStyleTest(ErtTest):
         plot_config.currentColor()  # cycle state will not be copied
         plot_config.nextColor()
 
-        copy_of_plot_config = PlotConfig(ps, "Another Copy of Golden Sample")
+        copy_of_plot_config = PlotConfig(title="Another Copy of Golden Sample")
         copy_of_plot_config.copyConfigFrom(plot_config)
 
         self.assertEqual(plot_config.refcaseStyle(), copy_of_plot_config.refcaseStyle())


### PR DESCRIPTION
**Task**
_Short description of the task_
PlotConfig has been remove from libres 
here: https://github.com/equinor/libres/pull/560
We need to update PlotSettings and fix tests to work without enkf plot_config

**Pre un-WIP checklist**
- [ ] Equinor tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Equinor/libres#
* Equinor/libecl#
