### PR TITLE
Backport bugfix manual load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,15 +80,11 @@ before_install:
     - pip install --upgrade -r requirements.txt
     # Checkout libres - need libecl version
     - source .libres_version
-    - git clone https://github.com/equinor/libres
+    - git clone --branch $LIBRES_VERSION --depth 1 https://github.com/equinor/libres
     - pushd libres
-    - git checkout tags/$LIBRES_VERSION
     - source .libecl_version
     - popd
-    - git clone https://github.com/equinor/libecl
-    - pushd libecl
-    - git checkout tags/$LIBECL_VERSION
-    - popd
+    - git clone --branch $LIBECL_VERSION --depth 1 https://github.com/equinor/libecl
 
 install:
   # For now we have to make install libecl.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 set( ERT_VERSION_MAJOR 2 )   # Remember to update release notes whenever
 set( ERT_VERSION_MINOR 5 )   # you change the ERT_VERSION_MINOR or MAJOR
-set( ERT_VERSION_MICRO 2 ) # with "new in Ert Version X.X.X"!
+set( ERT_VERSION_MICRO 3 ) # with "new in Ert Version X.X.X"!
 
 # If the micro version is not integer, that should be interpreted as a
 # development version leading towards version MAJOR.MINOR.0

--- a/python/python/ert_gui/ertwidgets/models/all_cases_model.py
+++ b/python/python/ert_gui/ertwidgets/models/all_cases_model.py
@@ -15,7 +15,7 @@ class AllCasesModel(QAbstractItemModel):
         self.__data = []
 
     def index(self, row, column, parent=None, *args, **kwargs):
-        return self.createIndex(row, column, parent)
+        return self.createIndex(row, column)
 
     def parent(self, index=None):
         return QModelIndex()

--- a/python/python/ert_gui/tools/load_results/load_results_model.py
+++ b/python/python/ert_gui/tools/load_results/load_results_model.py
@@ -67,7 +67,7 @@ class LoadResultsModel(object):
         iteration = 0
         valid_directory = True
         while valid_directory:
-            formatted = run_path % (0, iteration)
+            formatted = run_path % (0, iteration + 1)
             valid_directory = os.path.exists(formatted)
             if valid_directory:
                 iteration += 1

--- a/python/python/ert_gui/tools/plot/data_type_keys_list_model.py
+++ b/python/python/ert_gui/tools/plot/data_type_keys_list_model.py
@@ -27,7 +27,7 @@ class DataTypeKeysListModel(QAbstractItemModel):
         return self.__ert.getKeyManager()
 
     def index(self, row, column, parent=None, *args, **kwargs):
-        return self.createIndex(row, column, parent)
+        return self.createIndex(row, column)
 
     def parent(self, index=None):
         return QModelIndex()


### PR DESCRIPTION
The parent in the createIndex function from QAbstractItemModel refers to a
datamodel, not a GUI component. Setting it incorrectly results in ASSERT
failure in the QAbstractItemView::setModel.

Fixed a minor bug with defaults for iteration number as well

solves: #381 