### PR TITLE
Leave parent default QAbstractItemModel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,15 +82,11 @@ before_install:
     - pip install --upgrade -r requirements.txt
     # Checkout libres - need libecl version
     - source .libres_version
-    - git clone https://github.com/equinor/libres
+    - git clone --branch $LIBRES_VERSION --depth 1 https://github.com/equinor/libres
     - pushd libres
-    - git checkout tags/$LIBRES_VERSION
     - source .libecl_version
     - popd
-    - git clone https://github.com/equinor/libecl
-    - pushd libecl
-    - git checkout tags/$LIBECL_VERSION
-    - popd
+    - git clone --branch $LIBECL_VERSION --depth 1 https://github.com/equinor/libecl
 
 install:
   # For now we have to make install libecl.

--- a/ert_gui/ertwidgets/models/all_cases_model.py
+++ b/ert_gui/ertwidgets/models/all_cases_model.py
@@ -15,7 +15,7 @@ class AllCasesModel(QAbstractItemModel):
         self.__data = []
 
     def index(self, row, column, parent=None, *args, **kwargs):
-        return self.createIndex(row, column, parent)
+        return self.createIndex(row, column)
 
     def parent(self, index=None):
         return QModelIndex()

--- a/ert_gui/tools/load_results/load_results_model.py
+++ b/ert_gui/tools/load_results/load_results_model.py
@@ -67,7 +67,7 @@ class LoadResultsModel(object):
         iteration = 0
         valid_directory = True
         while valid_directory:
-            formatted = run_path % (0, iteration)
+            formatted = run_path % (0, iteration + 1)
             valid_directory = os.path.exists(formatted)
             if valid_directory:
                 iteration += 1

--- a/ert_gui/tools/plot/data_type_keys_list_model.py
+++ b/ert_gui/tools/plot/data_type_keys_list_model.py
@@ -27,7 +27,7 @@ class DataTypeKeysListModel(QAbstractItemModel):
         return self.__ert.getKeyManager()
 
     def index(self, row, column, parent=None, *args, **kwargs):
-        return self.createIndex(row, column, parent)
+        return self.createIndex(row, column)
 
     def parent(self, index=None):
         return QModelIndex()


### PR DESCRIPTION
The parent in the createIndex function from QAbstractItemModel refers to a
datamodel, not a GUI component. Setting it incorrectly results in ASSERT
failure in the QAbstractItemView::setModel.

Fixed a minor bug with defaults for iteration number as well

