### PR TITLE
Remove ERT_SHARE_PATH

### DIFF
--- a/docs/rst/manual/changes/index.rst
+++ b/docs/rst/manual/changes/index.rst
@@ -100,14 +100,11 @@ presented with the following overview.
       ERT can be accessed through a GUI or CLI interface. Include one of the
       following arguments to change between the interfaces. Note that different
       entry points may require different additional arguments. See the help
-      section for each interface for more details. DEPRECATION WARNING: Text
-      User Interface and Shell Interface are to be removed in ERT > 2.4!
+      section for each interface for more details.  
 
       {gui,text,shell,cli}  Available entry points
         gui                 Graphical User Interface - opens up an independent
-                            window for the user to interact with ERT.
-        text                Text user interface. Deprecated! Use CLI instead.
-        shell               Shell interface. Deprecated! Use CLI instead.
+                            window for the user to interact with ERT.        
         cli                 Command Line Interface - provides a user interface in
                             the terminal.
 
@@ -120,13 +117,6 @@ ERT command line interface
 The **cli** option listed above is new and will run *ERT* as a command line
 interface with no further interaction after initialization. This will be the
 supported command line interface of *ERT* in the future.
-
-The shell and text interfaces are deprecated
-######################################################
-Furthermore, the **text** and **shell** options are deprecated and **cli** will be
-the only option supported terminal option in the future. Hence, if you are
-using the text or shell interface of *ERT* and the current **cli** does not
-fit your needs, please contact us with a feature request!
 
 Forward model monitoring
 ######################################################

--- a/ert_gui/bin/ert
+++ b/ert_gui/bin/ert
@@ -2,10 +2,6 @@
 import sys
 import os
 from argparse import ArgumentParser, ArgumentTypeError
-import pkg_resources
-
-ERT_ROOT = pkg_resources.working_set.by_key['ensemble-reservoir-tool'].location
-ERT_SHARE_PATH = os.path.realpath(os.path.join(ERT_ROOT, '../../../share/ert'))
 
 def valid_file(fname):
     if not os.path.isfile(fname):
@@ -19,17 +15,6 @@ def runExec(executable , args):
 
 def runGui( args ):
     runExec("python", ["-m", "ert_gui.gert_main"] + [args.config])
-
-
-def runTui( args ):
-    os.environ["ERT_UI_MODE"] = "tui"
-    exec_path = os.path.join(os.path.dirname(__file__), "ert_tui")
-    runExec(exec_path,  [args.config])
-
-
-def runShell( args ):
-    exec_path = os.path.join(os.path.dirname(__file__), "ertshell")
-    runExec(exec_path,  [args.config])
 
 
 def runCli( args ):
@@ -53,9 +38,7 @@ def ert_parser():
                     'one of the following arguments to change between the '
                     'interfaces. Note that different entry points may require '
                     'different additional arguments. See the help section for '
-                    'each interface for more details. DEPRECATION WARNING: '
-                    'Text User Interface and Shell Interface are to be removed in '
-                    'ERT > 2.4!',
+                    'each interface for more details. ',
         help="Available entry points")
 
 
@@ -65,24 +48,7 @@ def ert_parser():
             description='Graphical User Interface')
     gui_parser.add_argument('config', type=valid_file,
             help="Ert configuration file")
-    gui_parser.set_defaults(func=runGui)
-
-
-    tui_parser = subparsers.add_parser('text',
-            help='Text user interface. Deprecated! Use CLI instead.',
-            description='Text user interface. Deprecated! Use CLI instead.')
-    tui_parser.add_argument('config', type=valid_file,
-            help="Ert configuration file")
-    tui_parser.set_defaults(func=runTui)
-
-
-    shell_parser = subparsers.add_parser('shell',
-            help='Shell interface. Deprecated! Use CLI instead.',
-            description='Shell interface. Deprecated! Use CLI instead.')
-    shell_parser.add_argument('config', type=valid_file,
-            help="Ert configuration file")
-    shell_parser.set_defaults(func=runShell)
-
+    gui_parser.set_defaults(func=runGui)    
 
     cli_parser = subparsers.add_parser('cli',
             help='Command Line Interface - provides a user interface in the terminal.',
@@ -109,7 +75,4 @@ def main():
 
 
 if __name__ == '__main__':
-    os.environ["ERT_SHARE_PATH"] = ERT_SHARE_PATH
-    os.environ["ERT_UI_MODE"] = "gui"
-    os.environ["ERT_ROOT"] = ERT_ROOT
     main()


### PR DESCRIPTION
Remove ERT_SHARE_PATH

Cleanup - removed cli and shell entrypoints as they have been forgotten

Relates to https://github.com/equinor/ert-statoil/pull/148
