### PR TITLE
Add check for observations when performing model update

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.6.a2
+export LIBRES_VERSION=2.6.a3

--- a/ert_gui/bin/ert_cli
+++ b/ert_gui/bin/ert_cli
@@ -8,6 +8,7 @@ import res
 from res.util import ResLog
 
 import argparse
+import logging
 
 
 def setup_fs(ert, target="default"):
@@ -139,6 +140,10 @@ def main():
 
     config = resconfig(config_file)
     ert = EnKFMain(config)
+
+    if not ert._real_enkf_main().have_observations() and mode == 'ensemble_smoother':
+        logging.error("No observations loaded. Unable to perform model update.")
+        return 
 
     if mode == "test_run":
         _test_run(ert)

--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -113,10 +113,10 @@ import sys
 
 try:
   from PyQt4.QtCore import Qt, QLocale
-  from PyQt4.QtGui import QApplication, QFileDialog
+  from PyQt4.QtGui import QApplication, QFileDialog, QMessageBox
 except ImportError:
   from PyQt5.QtCore import Qt, QLocale
-  from PyQt5.QtWidgets import QApplication, QFileDialog
+  from PyQt5.QtWidgets import QApplication, QFileDialog, QMessageBox
 
 
 from ert_gui.ert_splash import ErtSplash
@@ -265,9 +265,13 @@ def main(argv):
     window.activateWindow()
     window.raise_()
     ResLog.log(3, "Versions: ecl:%s    res:%s    ert:%s" % (ecl.__version__, res.__version__, ert_gui.__version__))
+    
+    if not ert._real_enkf_main().have_observations():
+        em = QMessageBox.warning(window, "Warning!", "No observations loaded. Model update algorithms disabled!")
+        
+    
     finished_code = app.exec_()
     sys.exit(finished_code)
-
 
 
 if __name__ == "__main__":

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -69,9 +69,10 @@ class SimulationPanel(QWidget):
 
         self.addSimulationConfigPanel(SingleTestRunPanel())
         self.addSimulationConfigPanel(EnsembleExperimentPanel())
-        self.addSimulationConfigPanel(EnsembleSmootherPanel())
-        self.addSimulationConfigPanel(MultipleDataAssimilationPanel())
-        self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel())
+        if(ERT.ert.have_observations()):
+            self.addSimulationConfigPanel(EnsembleSmootherPanel())
+            self.addSimulationConfigPanel(MultipleDataAssimilationPanel())
+            self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel())
 
         self.setLayout(layout)
 


### PR DESCRIPTION
resolves equinor/libres#610
requires equinor/libres#623

Add a check to see if observations are loaded. If not, do not run model update algorithms
