### PR TITLE
Add support for unknown status of submitted realizations

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.6.a3
+export LIBRES_VERSION=2.6.a4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 
 osx_image: xcode8.3
 sudo: false
-dist: trusty
+dist: xenial
 
 env:
   global:
@@ -40,15 +40,11 @@ addons:
     packages:
       - liblapack-dev
       - valgrind
-      - gcc-4.8
-      - g++-4.8
       - clang
       - cmake
       - cmake-data
 
 before_install:
-    - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
-
     - if [[ $PYTHON_VERSION == 2.7 ]]; then
         export TRAVIS_PYTHON_VERSION="2.7";
       else
@@ -74,7 +70,8 @@ before_install:
     - export CONDA_HOME="$HOME/miniconda"
     - export PATH="$CONDA_HOME/bin:$PATH"
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        conda create -n ert_env pyqt=4.11.4 python=2.7 --yes;
+        conda config --set restore_free_channel true;        
+        conda create -n ert_env pyqt=4.11.3 python=2.7 --yes;
       else
         conda create -n ert_env pyqt python=$TRAVIS_PYTHON_VERSION --yes;
       fi

--- a/ert_gui/simulation/models/simulations_tracker.py
+++ b/ert_gui/simulation/models/simulations_tracker.py
@@ -5,7 +5,7 @@ class SimulationStateStatus(object):
     COLOR_PENDING = (190,174,212)
     COLOR_RUNNING = (255,255,153)
     COLOR_FAILED  = (255, 200, 200)
-
+    COLOR_UNKNOWN  = (128, 128, 128)
     COLOR_FINISHED   = (127,201,127)
     COLOR_NOT_ACTIVE  = (255, 255, 255)
 
@@ -67,8 +67,11 @@ class SimulationsTracker(object):
         done_flag  = JobStatusType.JOB_QUEUE_DONE | JobStatusType.JOB_QUEUE_SUCCESS
         done_state = SimulationStateStatus("Finished", done_flag, SimulationStateStatus.COLOR_FINISHED)
 
-        self.states = [done_state, failed_state, running_state, pending_state, waiting_state]
-        self.custom_states = [done_state, failed_state, running_state, pending_state, waiting_state]
+        unknown_flag  = JobStatusType.JOB_QUEUE_UNKNOWN
+        unknown_state = SimulationStateStatus("Unknown", unknown_flag, SimulationStateStatus.COLOR_UNKNOWN)
+
+        self.states = [done_state, failed_state, unknown_state, running_state, pending_state, waiting_state]
+        self.custom_states = [done_state, failed_state, running_state, unknown_state, pending_state, waiting_state]
         self.__checkForUnusedEnums()
 
     def getStates(self):

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -33,7 +33,7 @@ from ert_gui.ertwidgets import resourceMovie, Legend
 from ert_gui.simulation import Progress, SimpleProgress, DetailedProgressWidget
 from ert_gui.simulation.models import BaseRunModel, SimulationsTracker
 from ert_gui.tools.plot.plot_tool import PlotTool
-
+from res.job_queue import JobStatusType
 from ecl.util.util import BoolVector
 
 class RunDialog(QDialog):
@@ -270,7 +270,11 @@ class RunDialog(QDialog):
 
 
     def killJobs(self):
-        kill_job = QMessageBox.question(self, "Kill simulations?", "Are you sure you want to kill the currently running simulations?", QMessageBox.Yes | QMessageBox.No )
+
+        msg =  "Are you sure you want to kill the currently running simulations?"
+        if self._run_model.getQueueStatus().get(JobStatusType.JOB_QUEUE_UNKNOWN, 0) > 0:
+            msg += "\n\nKilling a simulation with unknown status will not kill the realizations already submitted!"
+        kill_job = QMessageBox.question(self, "Kill simulations?",msg, QMessageBox.Yes | QMessageBox.No )
 
         if kill_job == QMessageBox.Yes:
             if self._run_model.killAllSimulations():


### PR DESCRIPTION
bump libres version

Warns users to not kill simulations where the status is unknown

Resolves #386 
