### PR TITLE
Remove Qt.WindowCancelButtonHint

### DIFF
--- a/ert_gui/about_dialog.py
+++ b/ert_gui/about_dialog.py
@@ -40,7 +40,6 @@ class AboutDialog(QDialog):
         self.setFixedSize(QSize(600, 480))
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowCancelButtonHint)
 
         main_layout = QVBoxLayout()
 

--- a/ert_gui/ertwidgets/closabledialog.py
+++ b/ert_gui/ertwidgets/closabledialog.py
@@ -28,7 +28,6 @@ class ClosableDialog(QDialog):
         self.setModal(True)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowCancelButtonHint)
 
 
         layout = QVBoxLayout()

--- a/ert_gui/tools/plot/customize/customize_plot_dialog.py
+++ b/ert_gui/tools/plot/customize/customize_plot_dialog.py
@@ -187,7 +187,6 @@ class CustomizePlotDialog(QDialog):
 
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowCancelButtonHint)
 
         self._tab_map = {}
         self._tab_order = []

--- a/ert_gui/tools/plugins/process_job_dialog.py
+++ b/ert_gui/tools/plugins/process_job_dialog.py
@@ -28,7 +28,6 @@ class ProcessJobDialog(QDialog):
         self.setModal(True)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowCancelButtonHint)
 
         layout = QVBoxLayout()
         layout.setSizeConstraint(QLayout.SetFixedSize)

--- a/ert_gui/tools/workflows/workflow_dialog.py
+++ b/ert_gui/tools/workflows/workflow_dialog.py
@@ -19,7 +19,6 @@ class WorkflowDialog(QDialog):
         self.setModal(True)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowCancelButtonHint)
 
 
         layout = QVBoxLayout()


### PR DESCRIPTION
**Task**
Fix gui crashing in Python 3/ PyQt5. Fixes #412 

**Approach**
Removing Qt.WindowCancelButtonHint as it has been removed from qtbase in PyQt>=5. (See https://code.qt.io/cgit/qt/qtbase.git/commit/?id=2be25273e1fc81c5a9e5124f1444100bdb3d458a) 

**Pre un-WIP checklist**
- [x] Equinor tests pass locally
