### PR TITLE
Change regexp patterns to raw string

### DIFF
--- a/ert_gui/ide/keywords/configuration_line_parser.py
+++ b/ert_gui/ide/keywords/configuration_line_parser.py
@@ -3,9 +3,9 @@ from ert_gui.ide.keywords.data import Argument, Keyword
 
 
 class ConfigurationLineParser(object):
-    COMMENT_PATTERN = re.compile(".*?(--.*)")
-    KEYWORD_PATTERN = re.compile("^\s*([A-Z_]+)(\s|--)?")
-    ARGUMENT_PATTERN = re.compile('\s+?(\S+)\s*?')
+    COMMENT_PATTERN = re.compile(r".*?(--.*)")
+    KEYWORD_PATTERN = re.compile(r"^\s*([A-Z_]+)(\s|--)?")
+    ARGUMENT_PATTERN = re.compile(r'\s+?(\S+)\s*?')
 
     def __init__(self):
         super(ConfigurationLineParser, self).__init__()

--- a/ert_gui/ide/keywords/definitions/float_argument.py
+++ b/ert_gui/ide/keywords/definitions/float_argument.py
@@ -7,7 +7,7 @@ class FloatArgument(ArgumentDefinition):
     NOT_FLOAT = "The argument must be a float."
     NOT_IN_RANGE = "The argument is not in range: %s"
 
-    pattern  = re.compile("^[\S]+$")
+    pattern  = re.compile(r"^[\S]+$")
 
     def __init__(self, from_value=None, to_value=None, **kwargs):
         super(FloatArgument, self).__init__(**kwargs)

--- a/ert_gui/ide/keywords/definitions/number_list_string_argument.py
+++ b/ert_gui/ide/keywords/definitions/number_list_string_argument.py
@@ -7,7 +7,7 @@ class NumberListStringArgument(ArgumentDefinition):
     NOT_A_VALID_NUMBER_LIST_STRING = "The input should be of the type: <b><pre>\n\t23,5.5,11,1.01,3\n</pre></b>i.e. numeric values separated by commas."
     VALUE_NOT_A_NUMBER = "The value: '%s' is not a number."
 
-    PATTERN = re.compile("^[0-9\.\-+, \t]+$")
+    PATTERN = re.compile(r"^[0-9\.\-+, \t]+$")
 
     def __init__(self, **kwargs):
         super(NumberListStringArgument, self).__init__(**kwargs)

--- a/ert_gui/ide/keywords/definitions/path_argument.py
+++ b/ert_gui/ide/keywords/definitions/path_argument.py
@@ -8,8 +8,8 @@ class PathArgument(ArgumentDefinition):
     NOT_A_VALID_PATH = "The argument must be a valid path."
     PATH_DOES_NOT_EXIST = "The argument must be a valid path that exists."
 
-    PATTERN = re.compile("^[\S]+$")
-    PATTERN_WITH_SPACE = re.compile("^[\S| ]+$")
+    PATTERN = re.compile(r"^[\S]+$")
+    PATTERN_WITH_SPACE = re.compile(r"^[\S| ]+$")
 
     DEFINES = {}
 

--- a/ert_gui/ide/keywords/definitions/percent_argument.py
+++ b/ert_gui/ide/keywords/definitions/percent_argument.py
@@ -7,7 +7,7 @@ class PercentArgument(ArgumentDefinition):
     NOT_PERCENT = "The argument must be a number followed by % - no space allowed."
     NOT_IN_RANGE = "The argument is not in range: %s"
 
-    pattern = re.compile("^-?[0-9]+(\.[0-9]+)?\%$")
+    pattern = re.compile(r"^-?[0-9]+(\.[0-9]+)?\%$")
 
     def __init__(self, from_value, to_value, **kwargs):
         super(PercentArgument, self).__init__(**kwargs)

--- a/ert_gui/ide/keywords/definitions/proper_name_argument.py
+++ b/ert_gui/ide/keywords/definitions/proper_name_argument.py
@@ -15,7 +15,7 @@ class ProperNameArgument(ArgumentDefinition):
                        "</ul>"
 
 
-    PATTERN = re.compile("^[A-Za-z0-9_\-.<>]+$")
+    PATTERN = re.compile(r"^[A-Za-z0-9_\-.<>]+$")
 
 
     def __init__(self, **kwargs):

--- a/ert_gui/ide/keywords/definitions/proper_name_format_argument.py
+++ b/ert_gui/ide/keywords/definitions/proper_name_format_argument.py
@@ -15,7 +15,7 @@ class ProperNameFormatArgument(ArgumentDefinition):
                        "</ul>"
 
 
-    PATTERN = re.compile("^[A-Za-z0-9_\-.<>]*(%d)[A-Za-z0-9_\-.<>]*$")
+    PATTERN = re.compile(r"^[A-Za-z0-9_\-.<>]*(%d)[A-Za-z0-9_\-.<>]*$")
 
 
     def __init__(self, **kwargs):

--- a/ert_gui/ide/keywords/definitions/proper_name_format_string_argument.py
+++ b/ert_gui/ide/keywords/definitions/proper_name_format_string_argument.py
@@ -18,7 +18,7 @@ class ProperNameFormatStringArgument(ArgumentDefinition):
                        "</ul>"
 
 
-    PATTERN = re.compile("^[A-Za-z0-9_\-.<>]*(%s)[A-Za-z0-9_\-.<>]*$")
+    PATTERN = re.compile(r"^[A-Za-z0-9_\-.<>]*(%s)[A-Za-z0-9_\-.<>]*$")
 
 
     def __init__(self, **kwargs):

--- a/ert_gui/ide/keywords/definitions/range_string_argument.py
+++ b/ert_gui/ide/keywords/definitions/range_string_argument.py
@@ -7,10 +7,9 @@ class RangeStringArgument(ArgumentDefinition):
     NOT_A_VALID_RANGE_STRING = "The input should be of the type: <b><pre>\n\t1,3-5,9,17\n</pre></b>i.e. integer values separated by commas, and dashes to represent ranges."
     VALUE_NOT_IN_RANGE = "A value must be in the range from 0 to %d."
 
-
-    PATTERN = re.compile("^[0-9\-, \t]+$")
-    RANGE_PATTERN = re.compile("^[ \t]*([0-9]+)[ \t]*-[ \t]*([0-9]+)[ \t]*$")
-    NUMBER_PATTERN = re.compile("^[ \t]*([0-9]+)[ \t]*$")
+    PATTERN = re.compile(r"^[0-9\-, \t]+$")
+    RANGE_PATTERN = re.compile(r"^[ \t]*([0-9]+)[ \t]*-[ \t]*([0-9]+)[ \t]*$")
+    NUMBER_PATTERN = re.compile(r"^[ \t]*([0-9]+)[ \t]*$")
 
 
     def __init__(self, max_value=None, **kwargs):

--- a/ert_gui/ide/keywords/definitions/string_argument.py
+++ b/ert_gui/ide/keywords/definitions/string_argument.py
@@ -6,8 +6,8 @@ class StringArgument(ArgumentDefinition):
 
     NOT_A_VALID_STRING = "The argument must be a valid string."
 
-    PATTERN = re.compile("^[\S]+$")
-    PATTERN_WITH_SPACE = re.compile("^[\S| ]+$")
+    PATTERN = re.compile(r"^[\S]+$")
+    PATTERN_WITH_SPACE = re.compile(r"^[\S| ]+$")
 
 
     def __init__(self, allow_space=False, **kwargs):

--- a/ert_gui/tools/ide/configuration_panel.py
+++ b/ert_gui/tools/ide/configuration_panel.py
@@ -121,7 +121,7 @@ class ConfigurationPanel(QWidget):
         print("Start!")
 
     def parseDefines(self, text):
-        pattern = re.compile("[ \t]*DEFINE[ \t]*(\S+)[ \t]*(\S+)")
+        pattern = re.compile(r"[ \t]*DEFINE[ \t]*(\S+)[ \t]*(\S+)")
 
         match = re.findall(pattern, text)
 

--- a/ert_gui/tools/ide/ide_panel.py
+++ b/ert_gui/tools/ide/ide_panel.py
@@ -162,7 +162,7 @@ class IdePanel(QPlainTextEdit):
 
             cursor_pos = text_cursor.positionInBlock()
             pos = cursor_pos
-            pattern = u"[\s\u2029\u2028]"
+            pattern = u"[\\s\u2029\u2028]"
             while pos >= block_start:
                 text_cursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor)
                 text = text_cursor.selectedText()


### PR DESCRIPTION
**Issue**
Deprication warning. Python 3 defaults to unicode strings which means that the \ is interpreted as an escape character and not a literal. (Related to #407 ) 


**Approach**
Explicitly using a raw string means the backslash is interpreted as a literal backslash for both python 2 and 3. (Python 2 uses byte strings by defaults and not unicode) 