### PR TITLE
cli to support all models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user.*
 .idea
 .vscode
+.pytest_cache
 python/lib64
 /libenkf/src/.faultlist
 /develbranch/libenkf/src/.faultlist

--- a/ert_gui/__init__.py
+++ b/ert_gui/__init__.py
@@ -22,5 +22,6 @@ try:
 except ImportError:
     __version__ = '0.0.0'
 
-from .ertnotifier import ERT
+from .ert_adapter import ERT
 from .ertnotifier import configureErtNotifier
+from .cli import run_cli

--- a/ert_gui/ert_adapter.py
+++ b/ert_gui/ert_adapter.py
@@ -1,0 +1,24 @@
+class ErtAdapter():
+
+    def adapt(self, implementation):
+        self._implementation = implementation
+    
+    @property
+    def ertChanged(self):
+        return self._implementation.ertChanged
+
+    @property
+    def ert(self):
+        return self._implementation.ert
+
+    @property
+    def config_file(self):
+        return self._implementation.config_file
+    
+    def emitErtChange(self):
+        self._implementation.emitErtChange()
+
+    def reloadERT(self, config_file):
+        self._implementation.reloadERT(config_file)
+
+ERT = ErtAdapter()

--- a/ert_gui/ertnotifier.py
+++ b/ert_gui/ertnotifier.py
@@ -6,7 +6,7 @@ except ImportError:
   from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 
 from res.enkf import EnKFMain
-
+from ert_gui import ERT
 
 class ErtNotifier(QObject):
     ertChanged = pyqtSignal()
@@ -48,10 +48,6 @@ class ErtNotifier(QObject):
         self._ert = None
         os.execl(python_executable, python_executable, ert_gui_main, config_file)
 
-
-ERT = ErtNotifier(None, None)
-""" @type: ErtNotifier """
-
-def configureErtNotifier(ert, config_file):
-    ERT._ert = ert
-    ERT._config_file = config_file
+def configureErtNotifier(ert, config_file):    
+    notifier = ErtNotifier(ert, config_file)
+    ERT.adapt(notifier)    

--- a/ert_gui/main.py
+++ b/ert_gui/main.py
@@ -2,6 +2,10 @@
 import os
 import sys
 from argparse import ArgumentParser, ArgumentTypeError
+from ert_gui import run_cli
+from ert_gui import ERT
+from ert_gui.ide.keywords.definitions import RangeStringArgument, ProperNameFormatArgument, NumberListStringArgument
+from ert_gui.simulation.models.multiple_data_assimilation import MultipleDataAssimilation
 
 
 def valid_file(fname):
@@ -10,29 +14,59 @@ def valid_file(fname):
     return fname
 
 
-def runExec(executable, args):
-    os.execvp(executable, [executable] + args)
+def valid_realizations(user_input):
+    validator = RangeStringArgument()
+    validated = validator.validate(user_input)
+    if validated.failed():
+        raise ArgumentTypeError(
+            "Defined realizations is not of correct format: {}".format(user_input))
+    return user_input
+
+
+def valid_weights(user_input):
+    validator = NumberListStringArgument()
+    validated = validator.validate(user_input)
+    if validated.failed():
+        raise ArgumentTypeError(
+            "Defined weights is not of correct format: {}".format(user_input))
+
+    return user_input
+
+
+def valid_name_format(user_input):
+    validator = ProperNameFormatArgument()
+    validated = validator.validate(user_input)
+    if validated.failed():
+        raise ArgumentTypeError(
+            "Defined name is not of correct format: {}".format(user_input))
+    return user_input
+
+
+def valid_name_format_not_default(user_input):
+    if user_input == 'default':
+        msg = "Target file system and source file system can not be the same. "\
+              "They were both: <default>."
+        raise ArgumentTypeError(msg)
+    valid_name_format(user_input)
+    return user_input
+
+
+def range_limited_int(user_input):
+    try:
+        i = int(user_input)
+    except ValueError:
+        raise ArgumentTypeError("Must be a int")
+    if 0 < i < 100:
+        return i
+    raise ArgumentTypeError("Range must be in range 1 - 99")
 
 
 def runGui(args):
-    runExec("python", ["-m", "ert_gui.gert_main"] + [args.config])
+    os.execvp("python", ["python"] +
+              ["-m", "ert_gui.gert_main"] + [args.config])
 
 
-def runCli(args):
-    runExec("python", ["-m", "ert_gui.cli"] +
-            [args.config, args.mode, args.target_case])
-
-
-def validate_cli_args(parser, args):
-    if args.mode == "ensemble_smoother" and args.target_case == "default":
-        msg = "Target file system and source file system can not be the same. "\
-              "They were both: <default>. Please set using --target-case on "\
-              "the command line."
-        parser.error(msg)
-
-
-def ert_parser():
-    parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
+def ert_parser(parser, args):
 
     subparsers = parser.add_subparsers(
         title="Available user entries",
@@ -41,37 +75,103 @@ def ert_parser():
                     'interfaces. Note that different entry points may require '
                     'different additional arguments. See the help section for '
                     'each interface for more details.',
-        help="Available entry points",
-        dest="interface")
+        help="Available entry points", dest="mode")
 
-    gui_parser = subparsers.add_parser('gui',
-                                       help='Graphical User Interface - opens up an independent window for '
-                                       'the user to interact with ERT.',
-                                       description='Graphical User Interface')
-    gui_parser.add_argument('config', type=valid_file,
-                            help="Ert configuration file")
+    parser.add_argument('config', type=valid_file,
+                        help="Ert configuration file")
+
+    # gui_parser
+    gui_parser = subparsers.add_parser('gui', help='opens up an independent graphical user interface for '
+                                       'the user to interact with ERT.')
     gui_parser.set_defaults(func=runGui)
 
-    cli_parser = subparsers.add_parser('cli',
-                                       help='Command Line Interface - provides a user interface in the terminal.',
-                                       description="Command Line Interface")
-    cli_parser.add_argument('config', type=valid_file,
-                            help="Ert configuration file")
-    cli_parser.add_argument("--mode", type=str, required=True,
-                            choices=["test_run", "ensemble_experiment",
-                                     "ensemble_smoother"],
-                            help="The available modes")
-    cli_parser.add_argument("--target-case", type=str, default="default",
-                            help="The target filesystem to store results")
-    cli_parser.set_defaults(func=runCli)
-    return parser
+    # test_run_parser
+    test_run_parser = subparsers.add_parser(
+        'test_run', help="run 'test_run' in cli")
+    test_run_parser.add_argument('--verbose', action='store_true',
+                                 help="Show verbose output", default=False)
+    test_run_parser.set_defaults(func=run_cli)
+
+    # ensemble_experiment_parser
+    ensemble_experiment_parser = subparsers.add_parser('ensemble_experiment',
+                                                       help="run simulations in cli without performing any updates on the parameters.",
+                                                       description='')
+    ensemble_experiment_parser.add_argument('--verbose', action='store_true',
+                                            help="Show verbose output", default=False)
+    ensemble_experiment_parser.add_argument('--realizations', type=valid_realizations,
+                                            help="These are the realizations that will be used to perform simulations."
+                                            "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
+                                            "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+                                            "while realizations 10,11, 12,...,49 will be excluded")
+    ensemble_experiment_parser.set_defaults(func=run_cli)
+
+    # ensemble_smoother_parser
+    ensemble_smoother_parser = subparsers.add_parser('ensemble_smoother',
+                                                     help="run simulations in cli while performing one update on the "
+                                                     "parameters by using the ensemble smoother algorithm")
+    ensemble_smoother_parser.add_argument('--target-case', type=valid_name_format_not_default, required=True,
+                                          help="This is the name of the case where the results for the "
+                                          "updated parameters will be stored")
+    ensemble_smoother_parser.add_argument('--verbose', action='store_true',
+                                          help="Show verbose output", default=False)
+    ensemble_smoother_parser.add_argument('--realizations', type=valid_realizations,
+                                          help="These are the realizations that will be used to perform simulations."
+                                          "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
+                                          "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+                                          "while realizations 10,11, 12,...,49 will be excluded")
+    ensemble_smoother_parser.set_defaults(func=run_cli)
+
+    # es_mda_parser
+    es_mda_parser = subparsers.add_parser('es_mda',
+                                          help="run 'es_mda' in cli")
+    es_mda_parser.add_argument('--target-case', type=valid_name_format,
+                               help="The es_mda creates multiple cases for the different "
+                               "iterations. The case names will follow the specified format. "
+                               "For example, 'Target case format: iter_%%d' will generate "
+                               "cases with the names iter_0, iter_1, iter_2, iter_3, ....")
+    es_mda_parser.add_argument('--verbose', action='store_true',
+                               help="Show verbose output", default=False)
+    es_mda_parser.add_argument('--realizations', type=valid_realizations,
+                               help="These are the realizations that will be used to perform simulations."
+                               "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
+                               "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+                               "while realizations 10,11, 12,...,49 will be excluded")
+    es_mda_parser.add_argument('--weights', type=valid_weights, default=MultipleDataAssimilation.default_weights,
+                               help="Example Custom Relative Weights: '8,4,2,1'. This means Multiple Data "
+                               "Assimilation Ensemble Smoother will half the weight applied to the "
+                               "Observation Errors from one iteration to the next across 4 iterations.")
+    es_mda_parser.set_defaults(func=run_cli)
+
+    # iterative_ensemble_smoother_parser
+    iterative_ensemble_smoother_parser = subparsers.add_parser('iterated_ensemble_smoother',
+                                                               help="run simulations in cli while performing multiple updates on "
+                                                               "the parameters by using the iterated ensemble smoother algorithm")
+    iterative_ensemble_smoother_parser.add_argument('--target-case', type=valid_name_format,
+                                                    help="The iterated_ensemble_smoother creates multiple cases for the different "
+                                                    "iterations. The case names will follow the specified format. "
+                                                    "For example, 'Target case format: iter_%%d' will generate "
+                                                    "cases with the names iter_0, iter_1, iter_2, iter_3, ....")
+    iterative_ensemble_smoother_parser.add_argument('--iterations', type=range_limited_int, default=4,
+                                                    help="Specify the number of times to perform updates/iterations. "
+                                                    "In general, the more updates the better, however, this could be time consuming. "
+                                                    "The default value is 4.")
+    iterative_ensemble_smoother_parser.add_argument('--verbose', action='store_true',
+                                                    help="Show verbose output", default=False)
+    iterative_ensemble_smoother_parser.add_argument('--realizations', type=valid_realizations,
+                                                    help="These are the realizations that will be used to perform simulations."
+                                                    "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
+                                                    "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+                                                    "while realizations 10,11, 12,...,49 will be excluded")
+    iterative_ensemble_smoother_parser.set_defaults(func=run_cli)
+
+    return parser.parse_args(args)
 
 
 def main():
-    parser = ert_parser()
-    args = parser.parse_args(sys.argv[1:])
-
-    if args.interface == "cli":
-        validate_cli_args(parser, args)
-
+    parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
+    args = ert_parser(parser, sys.argv[1:])
     args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ert_gui/simulation/models/ensemble_experiment.py
+++ b/ert_gui/simulation/models/ensemble_experiment.py
@@ -24,7 +24,7 @@ class EnsembleExperiment(BaseRunModel):
 
         num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(self._job_queue, run_context)
 
-        num_successful_realizations += arguments['prev_successful_realizations']
+        num_successful_realizations += arguments.get('prev_successful_realizations', 0)
         self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)

--- a/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -107,7 +107,7 @@ class MultipleDataAssimilation(BaseRunModel):
         self.setPhaseName(phase_string, indeterminate=False)
         num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(self._job_queue, run_context)
 
-        num_successful_realizations += arguments['prev_successful_realizations']
+        num_successful_realizations += arguments.get('prev_successful_realizations', 0)
         self.checkHaveSufficientRealizations(num_successful_realizations)
 
         phase_string = "Post processing for iteration: %d" % iteration

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -170,9 +170,6 @@ class RunDialog(QDialog):
     def startSimulation(self, arguments):
 
         self._simulations_argments = arguments
-
-        if not 'prev_successful_realizations' in self._simulations_argments:
-            self._simulations_argments['prev_successful_realizations'] = 0
         self._run_model.reset()
 
         def run():
@@ -337,6 +334,7 @@ class RunDialog(QDialog):
             self.done_button.setVisible(False)
             active_realizations = self.create_mask_from_failed_realizations()
             self._simulations_argments['active_realizations'] = active_realizations
+            self._simulations_argments['prev_successful_realizations'] = self._simulations_argments.get('prev_successful_realizations', 0)
             self._simulations_argments['prev_successful_realizations'] += self.count_successful_realizations()
             self.startSimulation(self._simulations_argments)
 

--- a/tests/global/test_cli.py
+++ b/tests/global/test_cli.py
@@ -2,14 +2,120 @@ from tests import ErtTest
 from res.test import ErtTestContext
 import os
 import subprocess
+from res.enkf import EnKFMain, ResConfig
+from ecl.util.util import BoolVector
+from ert_gui import cli
+from ert_gui import ERT
+from ert_gui.cli import ErtCliNotifier
+from argparse import Namespace
 
 
 class EntryPointTest(ErtTest):
-    def test_single_realization(self):
+
+    def test_custom_target_case_name(self):
         config_file = self.createTestPath('local/poly_example/poly.ert')
-        exec_path = os.path.join(self.SOURCE_ROOT, "ert_gui/bin/ert")
-        try:
-            subprocess.check_call([exec_path, "cli", config_file, "--mode", "test_run",
-                                   "--target-case", "default"])
-        except subprocess.CalledProcessError as e:
-            self.fail("%s: %s" % (e.__class__.__name__, e))
+        with ErtTestContext('test_custom_target_case_name', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            custom_name = "test"
+            args = Namespace(target_case=custom_name)
+            res = cli._target_case_name(args)
+            self.assertEqual(custom_name, res)
+
+    def test_default_target_case_name(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_default_target_case_name', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            args = Namespace(target_case=None)
+            res = cli._target_case_name(args)
+            self.assertEqual("default_smoother_update", res)
+
+    def test_default_target_case_name_format_mode(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_default_target_case_name_format_mode', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            args = Namespace(target_case=None)
+            res = cli._target_case_name(args, format_mode=True)
+            self.assertEqual("default_%d", res)
+
+    def test_default_realizations(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_default_realizations', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            args = Namespace(realizations=None)
+            res = cli._realizations(args)
+            ensemble_size = ERT.ert.getEnsembleSize()
+            mask = BoolVector(default_value=False, initial_size=ensemble_size)
+            mask.updateActiveMask("0-99")
+            self.assertEqual(mask, res)
+
+    def test_custom_realizations(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_custom_realizations', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            args = Namespace(realizations="0-4,7,8")
+            res = cli._realizations(args)
+            ensemble_size = ERT.ert.getEnsembleSize()
+            mask = BoolVector(default_value=False, initial_size=ensemble_size)
+            mask.updateActiveMask("0-4,7,8")
+            self.assertEqual(mask, res)
+
+    def test_analysis_module_name_iterable(self):
+
+        active_name = "STD_ENKF"
+        modules = ["RML_ENKF"]
+        name = cli._get_analysis_module_name(
+            active_name, modules, iterable=True)
+
+        self.assertEqual(name, "RML_ENKF")
+
+    def test_analysis_module_name_not_iterable(self):
+
+        active_name = "STD_ENKF"
+        modules = ['BOOTSTRAP_ENKF', 'CV_ENKF', 'FWD_STEP_ENKF',
+                   'NULL_ENKF', 'SQRT_ENKF', 'STD_ENKF']
+        name = cli._get_analysis_module_name(
+            active_name, modules, iterable=True)
+
+        self.assertEqual(name, "STD_ENKF")
+
+    def test_analysis_module_name_in_module(self):
+
+        active_name = "STD_ENKF"
+        modules = ['STD_ENKF']
+        name = cli._get_analysis_module_name(
+            active_name, modules, iterable=True)
+
+        self.assertEqual(name, "STD_ENKF")
+
+    def test_analysis_module_items_in_module(self):
+
+        active_name = "FOO"
+        modules = ["BAR"]
+        name = cli._get_analysis_module_name(
+            active_name, modules, iterable=True)
+
+        self.assertEqual(name, "BAR")
+
+    def test_analysis_module_no_hit(self):
+
+        active_name = "FOO"
+        modules = []
+        name = cli._get_analysis_module_name(
+            active_name, modules, iterable=True)
+
+        self.assertIsNone(name)


### PR DESCRIPTION
The issue was originally just to support spec of realizations through cli as it is in GUI. Was soon extended to remove already developed entry-points in ert_cli and substitute with models used by GUI and by that reuse code. 

Restructured the argparse a bit - removed the 'cli' keyword and run the different modes on same level as 'gui'. Refactored the tests removing mocking. 

Depending on #410 
Resolves #359 