### PR TITLE
Make es_mda run correctly from cli

### DIFF
--- a/ert_gui/cli.py
+++ b/ert_gui/cli.py
@@ -13,8 +13,6 @@ from ert_gui.ide.keywords.definitions import (NumberListStringArgument,
                                               RangeStringArgument)
 from ert_gui.simulation.models.ensemble_experiment import EnsembleExperiment
 from ert_gui.simulation.models.ensemble_smoother import EnsembleSmoother
-from ert_gui.simulation.models.iterated_ensemble_smoother import \
-    IteratedEnsembleSmoother
 from ert_gui.simulation.models.multiple_data_assimilation import \
     MultipleDataAssimilation
 from ert_gui.simulation.models.single_test_run import SingleTestRun
@@ -36,9 +34,7 @@ def run_cli(args):
     elif args.mode == 'ensemble_smoother':
         model, argument = _setup_ensemble_smoother(args)
     elif args.mode == 'es_mda':
-        model, argument = _setup_multiple_data_assimilation(args)
-    elif args.mode == 'iterated_ensemble_smoother':
-        model, argument = _setup_iterated_ensemble_smoother(args)
+        model, argument = _setup_multiple_data_assimilation(args)    
     else:
         raise NotImplementedError(
             "Run type not supported {}".format(args.mode))
@@ -65,40 +61,27 @@ def _setup_ensemble_experiment(args):
 
 def _setup_ensemble_smoother(args):
     model = EnsembleSmoother()
-
+    iterable = False
+    active_name = ERT.ert.analysisConfig().activeModuleName()
+    modules = ertmodel.getAnalysisModuleNames(iterable=iterable)
     simulations_argument = {
         "active_realizations": _realizations(args),
-        "target_case": _target_case_name(args, format_mode=False)
+        "target_case": _target_case_name(args, format_mode=False),
+        "analysis_module": _get_analysis_module_name(active_name, modules, iterable=iterable),
     }
     return model, simulations_argument
 
 
 def _setup_multiple_data_assimilation(args):
     model = MultipleDataAssimilation()
-    iterable = True
+    iterable = False
     active_name = ERT.ert.analysisConfig().activeModuleName()
     modules = ertmodel.getAnalysisModuleNames(iterable=iterable)
     simulations_argument = {
         "active_realizations": _realizations(args),
         "target_case": _target_case_name(args, format_mode=True),
-        "analysis_module": _get_analysis_module_name(active_name, modules, iterable=False),
+        "analysis_module": _get_analysis_module_name(active_name, modules, iterable=iterable),
         "weights": args.weights
-    }
-    return model, simulations_argument
-
-
-def _setup_iterated_ensemble_smoother(args):
-    if args.iterations is not None:
-        ertmodel.setNumberOfIterations(args.iterations)
-
-    model = IteratedEnsembleSmoother()
-    iterable = True
-    active_name = ERT.ert.analysisConfig().activeModuleName()
-    modules = ertmodel.getAnalysisModuleNames(iterable=iterable)
-    simulations_argument = {
-        "active_realizations": _realizations(args),
-        "target_case": _target_case_name(args, format_mode=True),
-        "analysis_module": _get_analysis_module_name(active_name, modules, iterable=iterable)
     }
     return model, simulations_argument
 

--- a/ert_gui/main.py
+++ b/ert_gui/main.py
@@ -140,29 +140,7 @@ def ert_parser(parser, args):
                                help="Example Custom Relative Weights: '8,4,2,1'. This means Multiple Data "
                                "Assimilation Ensemble Smoother will half the weight applied to the "
                                "Observation Errors from one iteration to the next across 4 iterations.")
-    es_mda_parser.set_defaults(func=run_cli)
-
-    # iterative_ensemble_smoother_parser
-    iterative_ensemble_smoother_parser = subparsers.add_parser('iterated_ensemble_smoother',
-                                                               help="run simulations in cli while performing multiple updates on "
-                                                               "the parameters by using the iterated ensemble smoother algorithm")
-    iterative_ensemble_smoother_parser.add_argument('--target-case', type=valid_name_format,
-                                                    help="The iterated_ensemble_smoother creates multiple cases for the different "
-                                                    "iterations. The case names will follow the specified format. "
-                                                    "For example, 'Target case format: iter_%%d' will generate "
-                                                    "cases with the names iter_0, iter_1, iter_2, iter_3, ....")
-    iterative_ensemble_smoother_parser.add_argument('--iterations', type=range_limited_int, default=4,
-                                                    help="Specify the number of times to perform updates/iterations. "
-                                                    "In general, the more updates the better, however, this could be time consuming. "
-                                                    "The default value is 4.")
-    iterative_ensemble_smoother_parser.add_argument('--verbose', action='store_true',
-                                                    help="Show verbose output", default=False)
-    iterative_ensemble_smoother_parser.add_argument('--realizations', type=valid_realizations,
-                                                    help="These are the realizations that will be used to perform simulations."
-                                                    "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
-                                                    "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
-                                                    "while realizations 10,11, 12,...,49 will be excluded")
-    iterative_ensemble_smoother_parser.set_defaults(func=run_cli)
+    es_mda_parser.set_defaults(func=run_cli)    
 
     return parser.parse_args(args)
 

--- a/tests/global/test_cli.py
+++ b/tests/global/test_cli.py
@@ -8,6 +8,11 @@ from ert_gui import cli
 from ert_gui import ERT
 from ert_gui.cli import ErtCliNotifier
 from argparse import Namespace
+from ert_gui.simulation.models.ensemble_experiment import EnsembleExperiment
+from ert_gui.simulation.models.ensemble_smoother import EnsembleSmoother
+from ert_gui.simulation.models.multiple_data_assimilation import \
+    MultipleDataAssimilation
+from ert_gui.simulation.models.single_test_run import SingleTestRun
 
 
 class EntryPointTest(ErtTest):
@@ -73,6 +78,61 @@ class EntryPointTest(ErtTest):
             mask = BoolVector(default_value=False, initial_size=ensemble_size)
             mask.updateActiveMask("0-4,7,8")
             self.assertEqual(mask, res)
+
+    def test_setup_single_test_run(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_single_test_run', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            model, argument = cli._setup_single_test_run()
+            self.assertTrue(isinstance(model, SingleTestRun))
+            self.assertEquals(1, len(argument.keys()))
+            self.assertTrue("active_realizations" in argument)
+
+    def test_setup_ensemble_experiment(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_single_test_run', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+
+            model, argument = cli._setup_single_test_run()
+            self.assertTrue(isinstance(model, EnsembleExperiment))
+            self.assertEquals(1, len(argument.keys()))
+            self.assertTrue("active_realizations" in argument)
+
+    def test_setup_ensemble_smoother(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_single_test_run', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+            args = Namespace(realizations="0-4,7,8", target_case="test_case")
+
+            model, argument = cli._setup_ensemble_smoother(args)
+            self.assertTrue(isinstance(model, EnsembleSmoother))
+            self.assertEquals(3, len(argument.keys()))
+            self.assertTrue("active_realizations" in argument)
+            self.assertTrue("target_case" in argument)
+            self.assertTrue("analysis_module" in argument)
+
+    def test_setup_multiple_data_assimilation(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('test_single_test_run', config_file) as work_area:
+            ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            ERT.adapt(notifier)
+            args = Namespace(realizations="0-4,7,8", weights="6,4,2", target_case="test_case")
+
+            model, argument = cli._setup_multiple_data_assimilation(args)
+            self.assertTrue(isinstance(model, MultipleDataAssimilation))
+            self.assertEquals(4, len(argument.keys()))
+            self.assertTrue("active_realizations" in argument)
+            self.assertTrue("target_case" in argument)
+            self.assertTrue("analysis_module" in argument)
+            self.assertTrue("weights" in argument)
 
     def test_analysis_module_name_iterable(self):
 

--- a/tests/global/test_main.py
+++ b/tests/global/test_main.py
@@ -85,40 +85,7 @@ class MainTest(unittest.TestCase):
             parsed.config, "test-data/local/poly_example/poly.ert")        
         self.assertEquals(parsed.weights, "3, 2, 1")
         self.assertEquals(parsed.func.__name__, "run_cli")
-        self.assertFalse(parsed.verbose)
-
-    def test_argparse_exec_iterated_ensemble_smoother_valid_case(self):
-        parser = ArgumentParser(prog="test_main")
-        parsed = ert_parser(parser, ['iterated_ensemble_smoother',  "--iterations", "40",
-                                     'test-data/local/poly_example/poly.ert'])
-        self.assertEquals(parsed.mode, "iterated_ensemble_smoother")
-        self.assertEquals(
-            parsed.config, "test-data/local/poly_example/poly.ert")
-        self.assertEquals(parsed.iterations, 40)
-        self.assertEquals(parsed.func.__name__, "run_cli")
-        self.assertFalse(parsed.verbose)
-
-    def test_argparse_exec_iterated_ensemble_smoother_default_iterations(self):
-        parser = ArgumentParser(prog="test_main")
-        parsed = ert_parser(parser, [
-                            'iterated_ensemble_smoother', 'test-data/local/poly_example/poly.ert'])
-        self.assertEquals(parsed.mode, "iterated_ensemble_smoother")
-        self.assertEquals(
-            parsed.config, "test-data/local/poly_example/poly.ert")
-        self.assertEquals(parsed.iterations, 4)
-        self.assertEquals(parsed.func.__name__, "run_cli")
-        self.assertFalse(parsed.verbose)
-
-    def test_argparse_exec_iterated_ensemble_smoother_faulty_iterations(self):
-        parser = ArgumentParser(prog="test_main")
-        with self.assertRaises(SystemExit):
-            ert_parser(parser, ['iterated_ensemble_smoother', "--iterations", "100"
-                                'test-data/local/poly_example/poly.ert'])
-
-        with self.assertRaises(SystemExit):
-            ert_parser(parser, ['iterated_ensemble_smoother', "--iterations", "0",
-                                'test-data/local/poly_example/poly.ert'])
-
+        self.assertFalse(parsed.verbose)    
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed bug where i had mixed up use of variable setting iterable to False and by that not retrieved a list of valid analysis modules.

Added analysis module to ensemble_smoother.

Removed Iterated Ensemble Smoother as it has known bugs and is deprecated as is. Not going to add support for it in CLI.
