### PR TITLE
Proper pkg resources usage fix 419

### DIFF
--- a/ert_gui/ertwidgets/__init__.py
+++ b/ert_gui/ertwidgets/__init__.py
@@ -1,8 +1,8 @@
 import sys
 
+from pkg_resources import resource_filename
 from ErtQt.Qt import Qt, QCursor, QApplication, QIcon, QPixmap, QMovie
 
-img_prefix = ""
 
 def addHelpToWidget(widget, link):
     original_enter_event = widget.enterEvent
@@ -34,7 +34,7 @@ def showWaitCursorWhileWaiting(func):
 def resourceIcon(name):
     """Load an image as an icon"""
     # print("Icon used: %s" % name)
-    return QIcon(img_prefix + name)
+    return QIcon(resource_filename("ert_gui", "resources/gui/img/" + name))
 
 
 def resourceStateIcon(on, off):
@@ -47,12 +47,12 @@ def resourceStateIcon(on, off):
 
 def resourceImage(name):
     """Load an image as a Pixmap"""
-    return QPixmap(img_prefix + name)
+    return QPixmap(resource_filename("ert_gui", "resources/gui/img/" + name))
 
 
 def resourceMovie(name):
     """ @rtype: QMovie """
-    movie = QMovie(img_prefix + name)
+    movie = QMovie(resource_filename("ert_gui", "resources/gui/img/" + name))
     movie.start()
     return movie
 

--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -144,11 +144,6 @@ import ecl
 import sys
 import time
 
-import pkg_resources
-
-pkg_dir = os.path.join(pkg_resources.working_set.by_key['ensemble-reservoir-tool'].location, 'ert_gui')
-ert_gui.ertwidgets.img_prefix = os.path.join(pkg_dir, "resources/gui/img/")
-
 
 def main(argv):
     app = QApplication(argv)  # Early so that QT is initialized before other imports
@@ -193,7 +188,6 @@ def main(argv):
         config_file = argv[1]
 
     help_center = HelpCenter("ERT")
-    help_center.setHelpLinkPrefix(os.path.join(pkg_dir, "resources", "gui", "help"))
     help_center.setHelpMessageLink("welcome_to_ert")
 
     strict = True
@@ -276,5 +270,3 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv)
-
-

--- a/ert_gui/tools/help/help_window.py
+++ b/ert_gui/tools/help/help_window.py
@@ -27,7 +27,6 @@ class HelpWindow(QMainWindow):
     def __init__(self, help_center_name, parent=None):
         QMainWindow.__init__(self, parent, Qt.WindowStaysOnTopHint)
         palette = self.palette()
-        palette.setColor(self.backgroundRole(), QColor(255, 255, 224))
         self.setPalette(palette)
         self.setAutoFillBackground(True)
         self.setMinimumWidth(300)
@@ -91,4 +90,3 @@ class HelpWindow(QMainWindow):
     def closeEvent(self, event):
         self.hide()
         event.ignore()
-

--- a/ert_gui/tools/help_center.py
+++ b/ert_gui/tools/help_center.py
@@ -1,4 +1,4 @@
-import os
+from pkg_resources import resource_string
 
 
 class HelpCenter(object):
@@ -12,12 +12,10 @@ class HelpCenter(object):
         super(HelpCenter, self).__init__()
         self.__name = name
         self.__listeners = []
-        self.__help_prefix = ""
         self.__current_help_link = ""
         self.__help_messages = {}
 
         HelpCenter.__help_centers[name] = self
-
 
     def setHelpMessageLink(self, help_link):
         self.__current_help_link = help_link
@@ -44,21 +42,12 @@ class HelpCenter(object):
         help_link = self.__current_help_link
         listener.setHelpMessage(help_link, self.__help_messages[help_link])
 
-
-    # The setHelpLinkPrefix should be set to point to a directory
-    # containing (directories) with html help files. In the current
-    # implementation this variable is set from the gert_main.py script.
-    def setHelpLinkPrefix(self, prefix):
-        self.__help_prefix = prefix
-
     def getTemplate(self):
-        path = self.__help_prefix + "template.html"
-        if os.path.exists(path) and os.path.isfile(path):
-            f = open(path, 'r')
-            template = f.read()
-            f.close()
-            return template
-        else:
+        try:
+            return resource_string(
+                "ert_gui", "resources/gui/help/template.html"
+            ).decode("utf-8")
+        except IOError:
             return "<html>%s</html>"
 
     def resolveHelpLink(self, help_link):
@@ -71,27 +60,12 @@ class HelpCenter(object):
         #    if label.strip() == "":
         #        raise AssertionError("NOOOOOOOOOOOOOOOOOOOOO!!!!!!!!!!!!")
 
-        path = os.path.join(self.__help_prefix, help_link + ".html")
-        if os.path.exists(path) and os.path.isfile(path):
-            f = open(path, 'r')
-            help = f.read()
-            f.close()
-            return self.getTemplate() % help
-        else:
-            # This code automatically creates empty help files
-            #        sys.stderr.write("Missing help file: '%s'\n" % label)
-            #        if not label == "" and not label.find("/") == -1:
-            #            sys.stderr.write("Creating help file: '%s'\n" % label)
-            #            directory, filename = os.path.split(path)
-            #
-            #            if not os.path.exists(directory):
-            #                os.makedirs(directory)
-            #
-            #            file_object = open(path, "w")
-            #            file_object.write(label)
-            #            file_object.close()
+        try:
+            return self.getTemplate() % resource_string(
+                "ert_gui", "resources/gui/help/{}.html".format(help_link)
+            ).decode("utf-8")
+        except IOError:
             return None
-
 
     @classmethod
     def getHelpCenter(cls, name):


### PR DESCRIPTION
**Issue**
Resolves #419 


**Approach**
http://peak.telecommunity.com/DevCenter/PythonEggs#accessing-package-resources

Note: For resources passed to `PyQt` classes, these must be properly included using the QT resources system \[[1](https://www.riverbankcomputing.com/static/Docs/PyQt4/resources.html), [2](https://doc.qt.io/qt-5/resources.html)\]. For now they are passed as file paths using `resource_filename`.

Unless we really need speed _and_ zip-safe packaging, utilizing the QT resources system might be overkill.