### PR TITLE
Fix sphinx warnings when building the documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,4 @@ script:
   - echo $PYTHONPATH
   - pip install . --prefix=$INSTALL_DIR
   - python setup.py test
-  - sphinx-build -n -v -E ./docs/rst/manual ./tmp/ert_docs # Add also -W when all the warnings have been addressed
+  - sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs

--- a/docs/rst/manual/cases/index.rst
+++ b/docs/rst/manual/cases/index.rst
@@ -1,3 +1,0 @@
-The ERT storage system - cases
-==============================
-

--- a/docs/rst/manual/changes/index.rst
+++ b/docs/rst/manual/changes/index.rst
@@ -178,16 +178,16 @@ job name will be deprecated in the future.
 PR: 162 - 257
 
 New functionality:
-  - Unified ERT binary `[165] https://github.com/equinor/ert/pull/165`
-  - Restart failed realizations `[206, 209] https://github.com/equinor/ert/pull/206`
-  - Forward model monitoring in GUI `[252] https://github.com/equinor/ert/pull/252`
+  - Unified ERT binary `[165] <https://github.com/equinor/ert/pull/165>`__
+  - Restart failed realizations `[206, 209] <https://github.com/equinor/ert/pull/206>`__
+  - Forward model monitoring in GUI `[252] <https://github.com/equinor/ert/pull/252>`__
 
 Improvement:
-  - Print warning if decimal point is not `.` `[212] https://github.com/equinor/ert/pull/212`
-  - Fixed bug such that initial realization mask contains all `[213] https://github.com/equinor/ert/pull/213`
-  - Fixed bug in iterated smoother gui `[215] https://github.com/equinor/ert/pull/215`
-  - Always display advanced settings `[216] https://github.com/equinor/ert/pull/216`
-  - Change default plot size to emphasize discrete data `[243] https://github.com/equinor/ert/pull/243`
+  - Print warning if decimal point is not `.` `[212] <https://github.com/equinor/ert/pull/212>`__
+  - Fixed bug such that initial realization mask contains all `[213] <https://github.com/equinor/ert/pull/213>`__
+  - Fixed bug in iterated smoother gui `[215] <https://github.com/equinor/ert/pull/215>`__
+  - Always display advanced settings `[216] <https://github.com/equinor/ert/pull/216>`__
+  - Change default plot size to emphasize discrete data `[243] <https://github.com/equinor/ert/pull/243>`__
 
 Others:
   - Continued to move documentation into the manual.
@@ -199,7 +199,7 @@ Others:
 PR: 114 - 126
 
 New functionality:
-  - Forward model for dynamic porevolume geertsma `[114] https://github.com/equinor/ert-statoil/pull/114`
+  - Forward model for dynamic porevolume geertsma `[114] <https://github.com/equinor/ert-statoil/pull/114>`__
 
 Improvements:
   - Eclipse version should be passed to job ECLIPSE_100 / ECLIPSE_300 as an argument
@@ -213,23 +213,23 @@ Others:
 PR: 411 - 517
 
 New functionality:
- - Job description can set environment vars `[431] https://github.com/equinor/libres/pull/431/files`
- - Experimental dump of parameters to runpath as json `[436] https://github.com/equinor/libres/pull/436`
- - Jinja based rendering forward model `[443] https://github.com/equinor/libres/pull/443/files`
- - New config keyword NUM_CPU to override eclipse PARALLEL keyword `[455] https://github.com/equinor/libres/pull/455/files`
- - Expose the algorithm iteration number as magic string <ITER> `[515] https://github.com/equinor/libres/pull/515`
+ - Job description can set environment vars `[431] <https://github.com/equinor/libres/pull/431/files>`__
+ - Experimental dump of parameters to runpath as json `[436] <https://github.com/equinor/libres/pull/436>`__
+ - Jinja based rendering forward model `[443] <https://github.com/equinor/libres/pull/443/files>`__
+ - New config keyword NUM_CPU to override eclipse PARALLEL keyword `[455] <https://github.com/equinor/libres/pull/455/files>`__
+ - Expose the algorithm iteration number as magic string <ITER> `[515] <https://github.com/equinor/libres/pull/515>`__
 
 Improvements:
- - Fix bug in default standard deviation calculations `[513] https://github.com/equinor/libres/pull/513`
- - Start scan for active observations at report step 0, instead of 1 `[439] https://github.com/equinor/libres/pull/439`
- - Bug fixes in linear algebra code `[435] https://github.com/equinor/libres/pull/435`
- - Improved job killing capabilities of local queue `[488] https://github.com/equinor/libres/pull/488`
+ - Fix bug in default standard deviation calculations `[513] <https://github.com/equinor/libres/pull/513>`__
+ - Start scan for active observations at report step 0, instead of 1 `[439] <https://github.com/equinor/libres/pull/439>`__
+ - Bug fixes in linear algebra code `[435] <https://github.com/equinor/libres/pull/435>`__
+ - Improved job killing capabilities of local queue `[488] <https://github.com/equinor/libres/pull/488>`__
 
 Others:
  - Various improvements to code due to now being a C++ project
- - Removed traces of WPRO and the RPCServer `[428] https://github.com/equinor/libres/pull/428`
- - CAREFUL_COPY moved to libres `[424] https://github.com/equinor/libres/pull/424`
- - Split simulator configuration into multiple files `[477] https://github.com/equinor/libres/pull/477`
+ - Removed traces of WPRO and the RPCServer `[428] <https://github.com/equinor/libres/pull/428>`__
+ - CAREFUL_COPY moved to libres `[424] <https://github.com/equinor/libres/pull/424>`__
+ - Split simulator configuration into multiple files `[477] <https://github.com/equinor/libres/pull/477>`__
 
 
 2.4 libecl
@@ -237,21 +237,21 @@ Others:
 PR: 506 - 579
 
 New functionality:
- - Ability to compute geertsma based on dynamic porevolume `[530] https://github.com/equinor/libecl/pull/530?`
- - Support for Intersect NNC format `[533] https://github.com/equinor/libecl/pull/533`
- - Support for extrapolation when resampling `[534] https://github.com/equinor/libecl/pull/534`
- - Ability to load summary data from .csv-files `[536] https://github.com/equinor/libecl/pull/536`
- - Identify region-to-region variables `[551] https://github.com/equinor/libecl/pull/551`
+ - Ability to compute geertsma based on dynamic porevolume `[530] <https://github.com/equinor/libecl/pull/530>`__
+ - Support for Intersect NNC format `[533] <https://github.com/equinor/libecl/pull/533>`__
+ - Support for extrapolation when resampling `[534] <https://github.com/equinor/libecl/pull/534>`__
+ - Ability to load summary data from .csv-files `[536] <https://github.com/equinor/libecl/pull/536>`__
+ - Identify region-to-region variables `[551] <https://github.com/equinor/libecl/pull/551>`__
 
 Improvements:
- - Load LGR info when loading well info `[529] https://github.com/equinor/libecl/pull/529`
- - Do not fail if restart file is missing icon `[549] https://github.com/equinor/libecl/pull/549`
+ - Load LGR info when loading well info `[529] <https://github.com/equinor/libecl/pull/529>`__
+ - Do not fail if restart file is missing icon `[549] <https://github.com/equinor/libecl/pull/549>`__
 
 Others:
  - Various improvements to code due to now being a C++ project.
  - Improved documentation for Windows users
  - Improved Python 3 testing
- - Revert fortio changes to increase reading speed `[567] https://github.com/equinor/libecl/pull/567`
+ - Revert fortio changes to increase reading speed `[567] <https://github.com/equinor/libecl/pull/567>`__
 
 
 Version 2.3
@@ -264,12 +264,12 @@ PR: 67 - 162
 
 2.3 libres
 ~~~~~~~~~~
-PR: 105 - 411 
+PR: 105 - 411
 
 
 2.3 libecl
 ~~~~~~~~~~
-PR: 170 - 506 
+PR: 170 - 506
 
 
 
@@ -281,34 +281,34 @@ Version 2.2
 ~~~~~~~~~~~~~~~~~~~~
 
 Version 2.2.1 September 2017 PR: 1 - 66
-Cherry-picked: `70 <https://github.com/Equinor/ert/pull/70/>`_
+Cherry-picked: `70 <https://github.com/Equinor/ert/pull/70/>`__
 
 Misc:
 
- - Using res_config changes from libres `[16] <https://github.com/Equinor/ert/pull/16/>`_
- - files moved from libecl to libres: `[51] <https://github.com/Equinor/ert/pull/51>`_
- - replaced ert.enkf with res.enkf `[56] <https://github.com/Equinor/ert/pull/56/>`_
- - Created ErtVersion: [`61 <https://github.com/Equinor/ert/pull/61/>`_, `66 <https://github.com/Equinor/ert/pull/66/>`_].
- - Using res_config: [`62 <https://github.com/Equinor/ert/pull/62/>`_]
- - Removed dead workflow files: `[64] <https://github.com/Equinor/ert/pull/64/>`_
+ - Using res_config changes from libres `[16] <https://github.com/Equinor/ert/pull/16/>`__
+ - files moved from libecl to libres: `[51] <https://github.com/Equinor/ert/pull/51>`__
+ - replaced ert.enkf with res.enkf `[56] <https://github.com/Equinor/ert/pull/56/>`__
+ - Created ErtVersion: [`61 <https://github.com/Equinor/ert/pull/61/>`__, `66 <https://github.com/Equinor/ert/pull/66/>`__].
+ - Using res_config: [`62 <https://github.com/Equinor/ert/pull/62/>`__]
+ - Removed dead workflow files: `[64] <https://github.com/Equinor/ert/pull/64/>`__
 
 Build and testing:
 
- - Cleanup after repo split [`1 <https://github.com/Equinor/ert/pull/1/>`_, `2 <https://github.com/Equinor/ert/pull/2/>`_, `3 <https://github.com/Equinor/ert/pull/3/>`_ , `4 <https://github.com/Equinor/ert/pull/4/>`_, `5 <https://github.com/Equinor/ert/pull/5/>`_ , `6 <https://github.com/Equinor/ert/pull/6/>`_]
- - Added test_install functionality [`7 <https://github.com/Equinor/ert/pull/7/>`_]
+ - Cleanup after repo split [`1 <https://github.com/Equinor/ert/pull/1/>`__, `2 <https://github.com/Equinor/ert/pull/2/>`__, `3 <https://github.com/Equinor/ert/pull/3/>`__ , `4 <https://github.com/Equinor/ert/pull/4/>`__, `5 <https://github.com/Equinor/ert/pull/5/>`__ , `6 <https://github.com/Equinor/ert/pull/6/>`__]
+ - Added test_install functionality [`7 <https://github.com/Equinor/ert/pull/7/>`__]
  - Added travis build script for libecl+libres+ert:
-   [`15 <https://github.com/Equinor/ert/pull/15/>`_, `17 <https://github.com/Equinor/ert/pull/17/>`_, `18 <https://github.com/Equinor/ert/pull/18/>`_, `19 <https://github.com/Equinor/ert/pull/19/>`_, `21 <https://github.com/Equinor/ert/pull/21/>`_, `26 <https://github.com/Equinor/ert/pull/26/>`_, `27 <https://github.com/Equinor/ert/pull/27/>`_, `39, <https://github.com/Equinor/ert/pull/39/>`_ `52 <https://github.com/Equinor/ert/pull/52/>`_-`55 <https://github.com/Equinor/ert/pull/55/>`_, `63 <https://github.com/Equinor/ert/pull/63/>`_]
+   [`15 <https://github.com/Equinor/ert/pull/15/>`__, `17 <https://github.com/Equinor/ert/pull/17/>`__, `18 <https://github.com/Equinor/ert/pull/18/>`__, `19 <https://github.com/Equinor/ert/pull/19/>`__, `21 <https://github.com/Equinor/ert/pull/21/>`__, `26 <https://github.com/Equinor/ert/pull/26/>`__, `27 <https://github.com/Equinor/ert/pull/27/>`__, `39, <https://github.com/Equinor/ert/pull/39/>`__ `52 <https://github.com/Equinor/ert/pull/52/>`__-`55 <https://github.com/Equinor/ert/pull/55/>`__, `63 <https://github.com/Equinor/ert/pull/63/>`__]
 
- - MacOS build error: [`28 <https://github.com/Equinor/ert/pull/28/>`_].
- - Created simple gui_test bin/gui_test [`32 <https://github.com/Equinor/ert/pull/32/>`_]
- - cmake - create symlink: [`41 <https://github.com/Equinor/ert/pull/41/>`_, `42 <https://github.com/Equinor/ert/pull/42/>`_, `43 <https://github.com/Equinor/ert/pull/43/>`_]
- - Initial Python3 testing [`58 <https://github.com/Equinor/ert/pull/58/>`_, `60 <https://github.com/Equinor/ert/pull/60/>`_].
+ - MacOS build error: [`28 <https://github.com/Equinor/ert/pull/28/>`__].
+ - Created simple gui_test bin/gui_test [`32 <https://github.com/Equinor/ert/pull/32/>`__]
+ - cmake - create symlink: [`41 <https://github.com/Equinor/ert/pull/41/>`__, `42 <https://github.com/Equinor/ert/pull/42/>`__, `43 <https://github.com/Equinor/ert/pull/43/>`__]
+ - Initial Python3 testing [`58 <https://github.com/Equinor/ert/pull/58/>`__, `60 <https://github.com/Equinor/ert/pull/60/>`__].
 
 
 Queue and running:
 
- - Added base run model - gui model updates: [`20 <https://github.com/Equinor/ert/pull/20/>`_].
- - Added single simulation pretest running [`33 <https://github.com/Equinor/ert/pull/33/>`_, `36 <https://github.com/Equinor/ert/pull/36/>`_, `50 <https://github.com/Equinor/ert/pull/50/>`_, `67 <https://github.com/Equinor/ert/pull/67/>`_].
+ - Added base run model - gui model updates: [`20 <https://github.com/Equinor/ert/pull/20/>`__].
+ - Added single simulation pretest running [`33 <https://github.com/Equinor/ert/pull/33/>`__, `36 <https://github.com/Equinor/ert/pull/36/>`__, `50 <https://github.com/Equinor/ert/pull/50/>`__, `67 <https://github.com/Equinor/ert/pull/67/>`__].
  - Add run_id to simulation batches.
 
 
@@ -316,29 +316,29 @@ Queue and running:
 ~~~~~~~~~~~
 
 Version 2.2.9 September 2017 PR: 1 - 104
-Cherry-picks: [`106 <https://github.com/Equinor/res/pull/106/>`_, `108 <https://github.com/Equinor/res/pull/108/>`_, `110 <https://github.com/Equinor/res/pull/110/>`_, `118 <https://github.com/Equinor/res/pull/118/>`_, `121 <https://github.com/Equinor/res/pull/121/>`_, `122 <https://github.com/Equinor/res/pull/122/>`_, `123 <https://github.com/Equinor/res/pull/123/>`_, `127 <https://github.com/Equinor/res/pull/127/>`_]
+Cherry-picks: [`106 <https://github.com/Equinor/res/pull/106/>`__, `108 <https://github.com/Equinor/res/pull/108/>`__, `110 <https://github.com/Equinor/res/pull/110/>`__, `118 <https://github.com/Equinor/res/pull/118/>`__, `121 <https://github.com/Equinor/res/pull/121/>`__, `122 <https://github.com/Equinor/res/pull/122/>`__, `123 <https://github.com/Equinor/res/pull/123/>`__, `127 <https://github.com/Equinor/res/pull/127/>`__]
 
 Misc:
 
- - implement legacy from ert.xxx [`1, <https://github.com/Equinor/res/pull/1/>`_ `20, <https://github.com/Equinor/res/pull/20/>`_ `21, <https://github.com/Equinor/res/pull/21/>`_ `22 <https://github.com/Equinor/res/pull/22/>`_]
- - Setting up libres_util and moving ert_log there [`13 <https://github.com/Equinor/res/pull/13/>`_, `44 <https://github.com/Equinor/res/pull/44/>`_, `48 <https://github.com/Equinor/res/pull/48/>`_].
+ - implement legacy from ert.xxx [`1, <https://github.com/Equinor/res/pull/1/>`__ `20, <https://github.com/Equinor/res/pull/20/>`__ `21, <https://github.com/Equinor/res/pull/21/>`__ `22 <https://github.com/Equinor/res/pull/22/>`__]
+ - Setting up libres_util and moving ert_log there [`13 <https://github.com/Equinor/res/pull/13/>`__, `44 <https://github.com/Equinor/res/pull/44/>`__, `48 <https://github.com/Equinor/res/pull/48/>`__].
  - Added subst_list + block_fs functionality to res_util - moved from
-   libecl [`27 <https://github.com/Equinor/res/pull/27/>`_, `68 <https://github.com/Equinor/res/pull/68/>`_, `74 <https://github.com/Equinor/res/pull/74/>`_].
- - Do not generate parameters.txt if no GEN_KW is specified.[`89 <https://github.com/Equinor/res/pull/89/>`_]
- - Started using RES_VERSION [`91 <https://github.com/Equinor/res/pull/91/>`_].
- - CONFIG_PATH subtitution settings - bug fixed[`43 <https://github.com/Equinor/res/pull/43/>`_, `96 <https://github.com/Equinor/res/pull/96/>`_].
- - Will load summary if GEN_DATA is present [`123 <https://github.com/Equinor/res/pull/123/>`_, `127 <https://github.com/Equinor/res/pull/127/>`_]
+   libecl [`27 <https://github.com/Equinor/res/pull/27/>`__, `68 <https://github.com/Equinor/res/pull/68/>`__, `74 <https://github.com/Equinor/res/pull/74/>`__].
+ - Do not generate parameters.txt if no GEN_KW is specified.[`89 <https://github.com/Equinor/res/pull/89/>`__]
+ - Started using RES_VERSION [`91 <https://github.com/Equinor/res/pull/91/>`__].
+ - CONFIG_PATH subtitution settings - bug fixed[`43 <https://github.com/Equinor/res/pull/43/>`__, `96 <https://github.com/Equinor/res/pull/96/>`__].
+ - Will load summary if GEN_DATA is present [`123 <https://github.com/Equinor/res/pull/123/>`__, `127 <https://github.com/Equinor/res/pull/127/>`__]
 
 
 Build and test fixes:
 
- - Simple functionality to do post-install testing[`3 <https://github.com/Equinor/res/pull/3/>`_]
- - Use libecl as cmake target[`6 <https://github.com/Equinor/res/pull/6/>`_,`15 <https://github.com/Equinor/res/pull/15/>`_]
- - removed stale binaries [`7 <https://github.com/Equinor/res/pull/7/>`_, `9 <https://github.com/Equinor/res/pull/9/>`_]
- - travis will build all repositories [`23 <https://github.com/Equinor/res/pull/23/>`_].
- - Travis + OSX [`69 <https://github.com/Equinor/res/pull/69/>`_, `72 <https://github.com/Equinor/res/pull/72/>`_]
- - Remove equinor specific settings from build sytem [`38 <https://github.com/Equinor/res/pull/38/>`_].
- - Travis split for parallell builds [`79 <https://github.com/Equinor/res/pull/79/>`_].
+ - Simple functionality to do post-install testing[`3 <https://github.com/Equinor/res/pull/3/>`__]
+ - Use libecl as cmake target[`6 <https://github.com/Equinor/res/pull/6/>`__,`15 <https://github.com/Equinor/res/pull/15/>`__]
+ - removed stale binaries [`7 <https://github.com/Equinor/res/pull/7/>`__, `9 <https://github.com/Equinor/res/pull/9/>`__]
+ - travis will build all repositories [`23 <https://github.com/Equinor/res/pull/23/>`__].
+ - Travis + OSX [`69 <https://github.com/Equinor/res/pull/69/>`__, `72 <https://github.com/Equinor/res/pull/72/>`__]
+ - Remove equinor specific settings from build sytem [`38 <https://github.com/Equinor/res/pull/38/>`__].
+ - Travis split for parallell builds [`79 <https://github.com/Equinor/res/pull/79/>`__].
 
 
 Config refactor:
@@ -349,35 +349,35 @@ Config refactor:
   change is that a new configuration object - res_config has been
   created ,which holds all the configuration subobjects:
 
-    [`10 <https://github.com/Equinor/res/pull/10/>`_, `14 <https://github.com/Equinor/res/pull/14/>`_, `35 <https://github.com/Equinor/res/pull/35/>`_, `39 <https://github.com/Equinor/res/pull/39/>`_, `45 <https://github.com/Equinor/res/pull/45/>`_, `52 <https://github.com/Equinor/res/pull/52/>`_, `54 <https://github.com/Equinor/res/pull/54/>`_, `58 <https://github.com/Equinor/res/pull/58/>`_-`62 <https://github.com/Equinor/res/pull/62/>`_, `66 <https://github.com/Equinor/res/pull/66/>`_, `75 <https://github.com/Equinor/res/pull/75/>`_]
+    [`10 <https://github.com/Equinor/res/pull/10/>`__, `14 <https://github.com/Equinor/res/pull/14/>`__, `35 <https://github.com/Equinor/res/pull/35/>`__, `39 <https://github.com/Equinor/res/pull/39/>`__, `45 <https://github.com/Equinor/res/pull/45/>`__, `52 <https://github.com/Equinor/res/pull/52/>`__, `54 <https://github.com/Equinor/res/pull/54/>`__, `58 <https://github.com/Equinor/res/pull/58/>`__-`62 <https://github.com/Equinor/res/pull/62/>`__, `66 <https://github.com/Equinor/res/pull/66/>`__, `75 <https://github.com/Equinor/res/pull/75/>`__]
 
 
 Queue layer:
 
- - Improved logging [`17 <https://github.com/Equinor/res/pull/17/>`_, `37 <https://github.com/Equinor/res/pull/37/>`_].
- - Funcionality to create a queue_config object copy [`36 <https://github.com/Equinor/res/pull/36/>`_].
+ - Improved logging [`17 <https://github.com/Equinor/res/pull/17/>`__, `37 <https://github.com/Equinor/res/pull/37/>`__].
+ - Funcionality to create a queue_config object copy [`36 <https://github.com/Equinor/res/pull/36/>`__].
 
  As part of this development cycle the job_dispatch script has been
  included in the libres distribution. There are many PR's related to
  this script:
 
-    [`28 <https://github.com/Equinor/res/pull/28/>`_, `40 <https://github.com/Equinor/res/pull/40/>`_, `41 <https://github.com/Equinor/res/pull/1/>`_, `51 <https://github.com/Equinor/res/pull/51/>`_, `53 <https://github.com/Equinor/res/pull/53/>`_, `63 <https://github.com/Equinor/res/pull/63/>`_, `64 <https://github.com/Equinor/res/pull/64/>`_, `83 <https://github.com/Equinor/res/pull/83/>`_, `84 <https://github.com/Equinor/res/pull/84/>`_, `85 <https://github.com/Equinor/res/pull/85/>`_, `93 <https://github.com/Equinor/res/pull/93/>`_, `94 <https://github.com/Equinor/res/pull/94/>`_, `95 <https://github.com/Equinor/res/pull/95/>`_, `97 <https://github.com/Equinor/res/pull/97/>`_-`99 <https://github.com/Equinor/res/pull/99/>`_,
-     `101 <https://github.com/Equinor/res/pull/101/>`_, `103 <https://github.com/Equinor/res/pull/103/>`_, `108 <https://github.com/Equinor/res/pull/108/>`_, `110 <https://github.com/Equinor/res/pull/110/>`_]
+    [`28 <https://github.com/Equinor/res/pull/28/>`__, `40 <https://github.com/Equinor/res/pull/40/>`__, `41 <https://github.com/Equinor/res/pull/1/>`__, `51 <https://github.com/Equinor/res/pull/51/>`__, `53 <https://github.com/Equinor/res/pull/53/>`__, `63 <https://github.com/Equinor/res/pull/63/>`__, `64 <https://github.com/Equinor/res/pull/64/>`__, `83 <https://github.com/Equinor/res/pull/83/>`__, `84 <https://github.com/Equinor/res/pull/84/>`__, `85 <https://github.com/Equinor/res/pull/85/>`__, `93 <https://github.com/Equinor/res/pull/93/>`__, `94 <https://github.com/Equinor/res/pull/94/>`__, `95 <https://github.com/Equinor/res/pull/95/>`__, `97 <https://github.com/Equinor/res/pull/97/>`__-`99 <https://github.com/Equinor/res/pull/99/>`__,
+     `101 <https://github.com/Equinor/res/pull/101/>`__, `103 <https://github.com/Equinor/res/pull/103/>`__, `108 <https://github.com/Equinor/res/pull/108/>`__, `110 <https://github.com/Equinor/res/pull/110/>`__]
 
  - Create a common run_id for one batch of simulations, and generally
    treat one batch of simulations as one unit, in a better way than
-   previously: [`42 <https://github.com/Equinor/res/pull/42/>`_, `67 <https://github.com/Equinor/res/pull/67/>`_]
+   previously: [`42 <https://github.com/Equinor/res/pull/42/>`__, `67 <https://github.com/Equinor/res/pull/67/>`__]
 
- - Added PPU (Paay Per Use) code to LSF driver [`71 <https://github.com/Equinor/res/pull/71/>`_].
- - Workflow job PRE_SIMULATION_COPY [`73 <https://github.com/Equinor/res/pull/73/>`_, `88 <https://github.com/Equinor/res/pull/88/>`_].
- - Allow to unset QUEUE_OPTION [`87 <https://github.com/Equinor/res/pull/87/>`_].
- - Jobs failing due to dead nodes are restarted [`100 <https://github.com/Equinor/res/pull/100/>`_].
+ - Added PPU (Paay Per Use) code to LSF driver [`71 <https://github.com/Equinor/res/pull/71/>`__].
+ - Workflow job PRE_SIMULATION_COPY [`73 <https://github.com/Equinor/res/pull/73/>`__, `88 <https://github.com/Equinor/res/pull/88/>`__].
+ - Allow to unset QUEUE_OPTION [`87 <https://github.com/Equinor/res/pull/87/>`__].
+ - Jobs failing due to dead nodes are restarted [`100 <https://github.com/Equinor/res/pull/100/>`__].
 
 
 Documentation:
 
-  - Formatting bugs: [`49 <https://github.com/Equinor/res/pull/49/>`_, `50 <https://github.com/Equinor/res/pull/50/>`_]
-  - Removed doxygen + build rst [`29 <https://github.com/Equinor/res/pull/29/>`_]
+  - Formatting bugs: [`49 <https://github.com/Equinor/res/pull/49/>`__, `50 <https://github.com/Equinor/res/pull/50/>`__]
+  - Removed doxygen + build rst [`29 <https://github.com/Equinor/res/pull/29/>`__]
 
 2.2: libecl
 ~~~~~~~~~~~
@@ -387,65 +387,65 @@ Open PR: 108, 145
 
 Grid:
 
- - Extracted implementation ecl_nnc_geometry [`1 <https://github.com/Equinor/libecl/pull/1/>`_, `66 <https://github.com/Equinor/libecl/pull/66/>`_, `75 <https://github.com/Equinor/libecl/pull/75/>`_, `78 <https://github.com/Equinor/libecl/pull/78/>`_, `80 <https://github.com/Equinor/libecl/pull/80/>`_, `109 <https://github.com/Equinor/libecl/pull/109/>`_].
- - Fix bug in cell_contains for mirrored grid [`51 <https://github.com/Equinor/libecl/pull/51/>`_, `53 <https://github.com/Equinor/libecl/pull/53/>`_].
- - Extract subgrid from grid [`56 <https://github.com/Equinor/libecl/pull/56/>`_].
- - Expose mapaxes [`63 <https://github.com/Equinor/libecl/pull/63/>`_, `64 <https://github.com/Equinor/libecl/pull/64/>`_].
- - grid.get_lgr - numbered lookup [`83 <https://github.com/Equinor/libecl/pull/83/>`_]
- - Added NUMRES values to EGRID header [`125 <https://github.com/Equinor/libecl/pull/125/>`_].
+ - Extracted implementation ecl_nnc_geometry [`1 <https://github.com/Equinor/libecl/pull/1/>`__, `66 <https://github.com/Equinor/libecl/pull/66/>`__, `75 <https://github.com/Equinor/libecl/pull/75/>`__, `78 <https://github.com/Equinor/libecl/pull/78/>`__, `80 <https://github.com/Equinor/libecl/pull/80/>`__, `109 <https://github.com/Equinor/libecl/pull/109/>`__].
+ - Fix bug in cell_contains for mirrored grid [`51 <https://github.com/Equinor/libecl/pull/51/>`__, `53 <https://github.com/Equinor/libecl/pull/53/>`__].
+ - Extract subgrid from grid [`56 <https://github.com/Equinor/libecl/pull/56/>`__].
+ - Expose mapaxes [`63 <https://github.com/Equinor/libecl/pull/63/>`__, `64 <https://github.com/Equinor/libecl/pull/64/>`__].
+ - grid.get_lgr - numbered lookup [`83 <https://github.com/Equinor/libecl/pull/83/>`__]
+ - Added NUMRES values to EGRID header [`125 <https://github.com/Equinor/libecl/pull/125/>`__].
 
 Build & testing:
 
- - Removed warnings - added pylint [`4 <https://github.com/Equinor/libecl/pull/4/>`_, `5 <https://github.com/Equinor/libecl/pull/5/>`_, `6 <https://github.com/Equinor/libecl/pull/6/>`_, `10 <https://github.com/Equinor/libecl/pull/10/>`_, `11 <https://github.com/Equinor/libecl/pull/11/>`_, `12 <https://github.com/Equinor/libecl/pull/12/>`_]
- - Accept any Python 2.7.x version [`17 <https://github.com/Equinor/libecl/pull/17/>`_, `18 <https://github.com/Equinor/libecl/pull/18/>`_]
- - Remove ERT testing & building [`3 <https://github.com/Equinor/libecl/pull/3/>`_, `19 <https://github.com/Equinor/libecl/pull/19/>`_]
- - Changes to Python/cmake machinery [`25 <https://github.com/Equinor/libecl/pull/25/>`_, `30 <https://github.com/Equinor/libecl/pull/3/>`_, `31 <https://github.com/Equinor/libecl/pull/31/>`_, `32 <https://github.com/Equinor/libecl/pull/32/>`_, `49 <https://github.com/Equinor/libecl/pull/49/>`_, `52 <https://github.com/Equinor/libecl/pull/52/>`_, `62 <https://github.com/Equinor/libecl/pull/62/>`_].
- - Added cmake config file [`33 <https://github.com/Equinor/libecl/pull/33/>`_, `44 <https://github.com/Equinor/libecl/pull/44/>`_, `45 <https://github.com/Equinor/libecl/pull/45/>`_, `47 <https://github.com/Equinor/libecl/pull/47/>`_].
- - Only *one* library [`54 <https://github.com/Equinor/libecl/pull/54/>`_, `55 <https://github.com/Equinor/libecl/pull/55/>`_, `58 <https://github.com/Equinor/libecl/pull/58/>`_, `69 <https://github.com/Equinor/libecl/pull/69/>`_, `73 <https://github.com/Equinor/libecl/pull/73/>`_, `77 <https://github.com/Equinor/libecl/pull/77/>`_, `91 <https://github.com/Equinor/libecl/pull/91/>`_, `133 <https://github.com/Equinor/libecl/pull/133/>`_]
- - Removed stale binaries [`59 <https://github.com/Equinor/libecl/pull/59/>`_].
- - Require cmake >= 2.8.12 [`67 <https://github.com/Equinor/libecl/pull/67/>`_].
- - Fix build on OSX [`87 <https://github.com/Equinor/libecl/pull/87/>`_, `88 <https://github.com/Equinor/libecl/pull/88/>`_, `95 <https://github.com/Equinor/libecl/pull/95/>`_, `103 <https://github.com/Equinor/libecl/pull/103/>`_].
- - Fix broken behavior with internal test data [`97 <https://github.com/Equinor/libecl/pull/97/>`_].
- - Travis - compile with -Werror [`122 <https://github.com/Equinor/libecl/pull/122/>`_, `123 <https://github.com/Equinor/libecl/pull/123/>`_, `127 <https://github.com/Equinor/libecl/pull/127/>`_, `130 <https://github.com/Equinor/libecl/pull/130/>`_]
- - Started to support Python3 syntax [`150 <https://github.com/Equinor/libecl/pull/150/>`_, `161 <https://github.com/Equinor/libecl/pull/161/>`_]
- - Add support for paralell builds on Travis [`149 <https://github.com/Equinor/libecl/pull/149/>`_]
+ - Removed warnings - added pylint [`4 <https://github.com/Equinor/libecl/pull/4/>`__, `5 <https://github.com/Equinor/libecl/pull/5/>`__, `6 <https://github.com/Equinor/libecl/pull/6/>`__, `10 <https://github.com/Equinor/libecl/pull/10/>`__, `11 <https://github.com/Equinor/libecl/pull/11/>`__, `12 <https://github.com/Equinor/libecl/pull/12/>`__]
+ - Accept any Python 2.7.x version [`17 <https://github.com/Equinor/libecl/pull/17/>`__, `18 <https://github.com/Equinor/libecl/pull/18/>`__]
+ - Remove ERT testing & building [`3 <https://github.com/Equinor/libecl/pull/3/>`__, `19 <https://github.com/Equinor/libecl/pull/19/>`__]
+ - Changes to Python/cmake machinery [`25 <https://github.com/Equinor/libecl/pull/25/>`__, `30 <https://github.com/Equinor/libecl/pull/3/>`__, `31 <https://github.com/Equinor/libecl/pull/31/>`__, `32 <https://github.com/Equinor/libecl/pull/32/>`__, `49 <https://github.com/Equinor/libecl/pull/49/>`__, `52 <https://github.com/Equinor/libecl/pull/52/>`__, `62 <https://github.com/Equinor/libecl/pull/62/>`__].
+ - Added cmake config file [`33 <https://github.com/Equinor/libecl/pull/33/>`__, `44 <https://github.com/Equinor/libecl/pull/44/>`__, `45 <https://github.com/Equinor/libecl/pull/45/>`__, `47 <https://github.com/Equinor/libecl/pull/47/>`__].
+ - Only *one* library [`54 <https://github.com/Equinor/libecl/pull/54/>`__, `55 <https://github.com/Equinor/libecl/pull/55/>`__, `58 <https://github.com/Equinor/libecl/pull/58/>`__, `69 <https://github.com/Equinor/libecl/pull/69/>`__, `73 <https://github.com/Equinor/libecl/pull/73/>`__, `77 <https://github.com/Equinor/libecl/pull/77/>`__, `91 <https://github.com/Equinor/libecl/pull/91/>`__, `133 <https://github.com/Equinor/libecl/pull/133/>`__]
+ - Removed stale binaries [`59 <https://github.com/Equinor/libecl/pull/59/>`__].
+ - Require cmake >= 2.8.12 [`67 <https://github.com/Equinor/libecl/pull/67/>`__].
+ - Fix build on OSX [`87 <https://github.com/Equinor/libecl/pull/87/>`__, `88 <https://github.com/Equinor/libecl/pull/88/>`__, `95 <https://github.com/Equinor/libecl/pull/95/>`__, `103 <https://github.com/Equinor/libecl/pull/103/>`__].
+ - Fix broken behavior with internal test data [`97 <https://github.com/Equinor/libecl/pull/97/>`__].
+ - Travis - compile with -Werror [`122 <https://github.com/Equinor/libecl/pull/122/>`__, `123 <https://github.com/Equinor/libecl/pull/123/>`__, `127 <https://github.com/Equinor/libecl/pull/127/>`__, `130 <https://github.com/Equinor/libecl/pull/130/>`__]
+ - Started to support Python3 syntax [`150 <https://github.com/Equinor/libecl/pull/150/>`__, `161 <https://github.com/Equinor/libecl/pull/161/>`__]
+ - Add support for paralell builds on Travis [`149 <https://github.com/Equinor/libecl/pull/149/>`__]
 
 libecl now fully supports OSX. On Travis it is compiled with
 -Werror=all which should protect against future warnings.
 
 C++:
 
- - Removed use of deignated initializers [`7 <https://github.com/Equinor/libecl/pull/7/>`_].
- - Memory leak in EclFilename.cpp [`14 <https://github.com/Equinor/libecl/pull/14/>`_].
- - Guarantee C linkage for ecl_data_type [`65 <https://github.com/Equinor/libecl/pull/65/>`_].
- - New smspec overload [`89 <https://github.com/Equinor/libecl/pull/89/>`_].
- - Use -std=c++0x if -std=c++11 is unavailable [`118 <https://github.com/Equinor/libecl/pull/118/>`_]
- - Make all of (previous( libutil compile with C++ [`162 <https://github.com/Equinor/libecl/pull/162/>`_]
+ - Removed use of deignated initializers [`7 <https://github.com/Equinor/libecl/pull/7/>`__].
+ - Memory leak in EclFilename.cpp [`14 <https://github.com/Equinor/libecl/pull/14/>`__].
+ - Guarantee C linkage for ecl_data_type [`65 <https://github.com/Equinor/libecl/pull/65/>`__].
+ - New smspec overload [`89 <https://github.com/Equinor/libecl/pull/89/>`__].
+ - Use -std=c++0x if -std=c++11 is unavailable [`118 <https://github.com/Equinor/libecl/pull/118/>`__]
+ - Make all of (previous( libutil compile with C++ [`162 <https://github.com/Equinor/libecl/pull/162/>`__]
 
 Well:
 
- - Get well rates from restart files [`8 <https://github.com/Equinor/libecl/pull/8/>`_,`20 <https://github.com/Equinor/res/pull/20/>`_].
- - Test if file exists before load [`111 <https://github.com/Equinor/libecl/pull/111/>`_].
- - Fix some warnings [`169 <https://github.com/Equinor/libecl/pull/169/>`_]
+ - Get well rates from restart files [`8 <https://github.com/Equinor/libecl/pull/8/>`__,`20 <https://github.com/Equinor/res/pull/20/>`__].
+ - Test if file exists before load [`111 <https://github.com/Equinor/libecl/pull/111/>`__].
+ - Fix some warnings [`169 <https://github.com/Equinor/libecl/pull/169/>`__]
 
 Core:
 
- - Support for variable length strings in binary eclipse files [`13 <https://github.com/Equinor/libecl/pull/13/>`_, `146 <https://github.com/Equinor/libecl/pull/146/>`_].
- - Renamed root package ert -> ecl [`21 <https://github.com/Equinor/libecl/pull/21/>`_]
- - Load INTERSECT summary files with NAMES instead WGNAMES [`34 <https://github.com/Equinor/libecl/pull/34/>`_ - `39 <https://github.com/Equinor/libecl/pull/39/>`_].
- - Possible memory leak: [`61 <https://github.com/Equinor/libecl/pull/61/>`_]
- - Refactored binary time search in __get_index_from_sim_time() [`113 <https://github.com/Equinor/libecl/pull/113/>`_]
- - Possible to mark fortio writer as "failed" - will unlink on close [`119 <https://github.com/Equinor/libecl/pull/119/>`_].
- - Allow keywords of more than 8 characters [`120 <https://github.com/Equinor/libecl/pull/120/>`_, `124 <https://github.com/Equinor/libecl/pull/124/>`_].
- - ecl_sum writer: Should write RESTART keyword [`129 <https://github.com/Equinor/libecl/pull/129/>`_, `131 <https://github.com/Equinor/libecl/pull/131/>`_]
- - Made EclVersion class [`160 <https://github.com/Equinor/libecl/pull/160/>`_]
- - Functionality to dump an index file for binary files: [`155 <https://github.com/Equinor/libecl/pull/155/>`_, `159 <https://github.com/Equinor/libecl/pull/159/>`_, `163 <https://github.com/Equinor/libecl/pull/163/>`_, `166 <https://github.com/Equinor/libecl/pull/166/>`_, `167 <https://github.com/Equinor/libecl/pull/167/>`_]
+ - Support for variable length strings in binary eclipse files [`13 <https://github.com/Equinor/libecl/pull/13/>`__, `146 <https://github.com/Equinor/libecl/pull/146/>`__].
+ - Renamed root package ert -> ecl [`21 <https://github.com/Equinor/libecl/pull/21/>`__]
+ - Load INTERSECT summary files with NAMES instead WGNAMES [`34 <https://github.com/Equinor/libecl/pull/34/>`__ - `39 <https://github.com/Equinor/libecl/pull/39/>`__].
+ - Possible memory leak: [`61 <https://github.com/Equinor/libecl/pull/61/>`__]
+ - Refactored binary time search in __get_index_from_sim_time() [`113 <https://github.com/Equinor/libecl/pull/113/>`__]
+ - Possible to mark fortio writer as "failed" - will unlink on close [`119 <https://github.com/Equinor/libecl/pull/119/>`__].
+ - Allow keywords of more than 8 characters [`120 <https://github.com/Equinor/libecl/pull/120/>`__, `124 <https://github.com/Equinor/libecl/pull/124/>`__].
+ - ecl_sum writer: Should write RESTART keyword [`129 <https://github.com/Equinor/libecl/pull/129/>`__, `131 <https://github.com/Equinor/libecl/pull/131/>`__]
+ - Made EclVersion class [`160 <https://github.com/Equinor/libecl/pull/160/>`__]
+ - Functionality to dump an index file for binary files: [`155 <https://github.com/Equinor/libecl/pull/155/>`__, `159 <https://github.com/Equinor/libecl/pull/159/>`__, `163 <https://github.com/Equinor/libecl/pull/163/>`__, `166 <https://github.com/Equinor/libecl/pull/166/>`__, `167 <https://github.com/Equinor/libecl/pull/167/>`__]
 
 Misc:
 
- - Added legacy pacakge ert/ [`48 <https://github.com/Equinor/libecl/pull/48/>`_, `99 <https://github.com/Equinor/libecl/pull/99/>`_]
- - Improved logging - adding enums for og levels [`90 <https://github.com/Equinor/libecl/pull/90/>`_, `140 <https://github.com/Equinor/libecl/pull/140/>`_, `141 <https://github.com/Equinor/libecl/pull/141/>`_]
- - Refactored to use snake_case instead of CamelCase [`144 <https://github.com/Equinor/libecl/pull/144/>`_, `145 <https://github.com/Equinor/libecl/pull/145/>`_]
+ - Added legacy pacakge ert/ [`48 <https://github.com/Equinor/libecl/pull/48/>`__, `99 <https://github.com/Equinor/libecl/pull/99/>`__]
+ - Improved logging - adding enums for og levels [`90 <https://github.com/Equinor/libecl/pull/90/>`__, `140 <https://github.com/Equinor/libecl/pull/140/>`__, `141 <https://github.com/Equinor/libecl/pull/141/>`__]
+ - Refactored to use snake_case instead of CamelCase [`144 <https://github.com/Equinor/libecl/pull/144/>`__, `145 <https://github.com/Equinor/libecl/pull/145/>`__]
 
 
 -----------------------------------------------------------------

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -75,6 +75,7 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+numfig = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/rst/manual/data_types/index.rst
+++ b/docs/rst/manual/data_types/index.rst
@@ -122,6 +122,7 @@ keyword are here :ref:`prior distributions available in ERT
 
 The prior - it is really a *transformation*
 ...........................................
+.. _prior_distributions:
 
 The Ensemble Smoother method, which ERT uses for updating of parameters, works
 with normally distributed variables. So internally in ERT the interplay between

--- a/docs/rst/manual/introduction/index.rst
+++ b/docs/rst/manual/introduction/index.rst
@@ -75,6 +75,7 @@ magnitude as the uncertainty in the data. The assumption is then that if this mo
 predictions, it will be unbiased and give a realistic estimate of the future uncertainty (see
 illustration in figure :numref:`ensemble`).
 
+.. _ensemble:
 .. figure:: images/bpr.jpg
    :scale: 20%
 

--- a/docs/rst/manual/keywords/index.rst
+++ b/docs/rst/manual/keywords/index.rst
@@ -68,7 +68,7 @@ Keyword name                                                        	Required by
 :ref:`DATA_KW <data_kw>`                                            	NO                                          				Replace strings in ECLIPSE .DATA files
 :ref:`DBASE_TYPE <dbase_type>`                                      	NO                    			BLOCK_FS         	     	Which 'database' system should be used for storage
 :ref:`DEFINE <define>`                                              	NO                                          				Define keywords with config scope
-:ref:`DELETE_RUNPATH <delete_runpath>`                              	NO                                          				Explicitly tell ert to delete the runpath when a job is complete 
+:ref:`DELETE_RUNPATH <delete_runpath>`                              	NO                                          				Explicitly tell ERT to delete the runpath when a job is complete 
 :ref:`ECLBASE <eclbase>`	                                    	YES\*					        			Define a name for the ECLIPSE simulations. \*Either JOBNAME or ECLBASE must be specified
 :ref:`END_DATE <end_date>`                                          	NO                                          				You can tell ERT how lon the simulations should be - for error check
 :ref:`ENKF_ALPHA <enkf_alpha>`                                      	NO                    			1.50                  		Parameter controlling outlier behaviour in EnKF algorithm
@@ -114,7 +114,7 @@ Keyword name                                                        	Required by
 :ref:`LSF_RESOURCES <lsf_resources>` 				    	NO 
 :ref:`LSF_SERVER <lsf_server>` 					    	NO 									Set server used when submitting LSF jobs. 
 :ref:`MAX_ITER_COUNT <max_iter_count>` 				    	NO 									Maximal number of iterations - iterated ensemble smoother. 
-:ref:`MAX_RESAMPLE <max_resample>`				    	NO 					1		 		How many times should ert resample & retry a simulation.
+:ref:`MAX_RESAMPLE <max_resample>`				    	NO 					1		 		How many times should ERT resample & retry a simulation.
 :ref:`MAX_RUNNING_RSH <max_running_rsh>` 				NO 									The maximum number of running jobs when using RSH queue system. 
 :ref:`MAX_RUNTIME <max_runtime>` 					NO 					0 				Set the maximum runtime in seconds for a realization. 
 :ref:`MAX_SUBMIT <max_submit>` 						NO 					2 				How many times should the queue system retry a simulation. 
@@ -320,11 +320,11 @@ possible to do with ERT.
 .. _delete_runpath:
 .. topic:: DELETE_RUNPATH
 
-	When the ert application is running it creates directories for
+	When the ERT application is running it creates directories for
 	the forward model simulations, one for each realization. When
-	the simulations are done, ert will load the results into the
+	the simulations are done, ERT will load the results into the
 	internal database. By default the realization folders will be
-	left intact after ert has loaded the results, but using the
+	left intact after ERT has loaded the results, but using the
 	keyword DELETE_RUNPATH you can request to have (some of) the
 	directories deleted after results have been loaded.
 
@@ -438,10 +438,10 @@ possible to do with ERT.
 .. _refcase:
 .. topic:: REFCASE
 
-	With the REFCASE key you can supply ert with a reference case which can be
+	With the REFCASE key you can supply ERT with a reference case which can be
 	used for observations (see HISTORY_SOURCE), if you want to use wildcards with
 	the SUMMARY keyword you also must supply a REFCASE keyword. The REFCASE
-	keyword should just point to an existing ECLIPSE data file; ert will then look
+	keyword should just point to an existing ECLIPSE data file; ERT will then look
 	up and load the corresponding summary results.
 
 	*Example:*
@@ -549,7 +549,7 @@ possible to do with ERT.
 	external script in some way or another were all the realisations are located in
 	the filesystem. Since the number of realisations can be quite high this will
 	easily overflow the commandline buffer; the solution which is used is therefor
-	to let ert write a reagular file which looks like this::
+	to let ERT write a reagular file which looks like this::
 	
   	        0   /path/to/realisation0   CASE0   iter
   		1   /path/to/realisation1   CASE1   iter
@@ -726,7 +726,7 @@ list of available priors.
 
 	INIT_TRANSFORM:LOG To ensure that the variables which were initially
 	log-normal distributed are transformed to normal distribution when they are
-	loaded into ert.
+	loaded into ERT.
 
 	OUTPUT_TRANSFORM:EXP To ensure that the variables are reexponentiated to be
 	log-normal distributed before going out to Eclipse.
@@ -960,7 +960,7 @@ list of available priors.
 		GEN_KW  MY-FAULTS   MULTFLT.tmpl   MULTFLT.INC   MULTFLT.txt    INIT_FILES:priors/multflt/faults%d
 
 	In the example above you must prepare files priors/multflt/faults0,
-	priors/multflt/faults1, ... priors/multflt/faultsn which ert will load when
+	priors/multflt/faults1, ... priors/multflt/faultsn which ERT will load when
 	you initialize the case. The format of the GEN_KW input files can be of two
 	varieties:
 
@@ -1083,7 +1083,7 @@ list of available priors.
 		SURFACE TOP   OUTPUT_FILE:surf.irap   INIT_FILES:Surfaces/surf%d.irap   BASE_SURFACE:Surfaces/surf0.irap 
 
 	The first argument, TOP in the example above, is the identifier you want to
-	use for this surface in ert. The OUTPUT_FILE key is the name of surface file
+	use for this surface in ERT. The OUTPUT_FILE key is the name of surface file
 	which ERT will generate for you, INIT_FILES points to a list of files which
 	are used to initialize, and BASE_SURFACE must point to one existing surface
 	file. When loading the surfaces ERT will check that all the headers are
@@ -1508,7 +1508,7 @@ matrix expressions, and no knowledge of the innards of the ERT program are
 required. Some more details of how modules work can be found here modules.txt.
 In principle a module is 'just' a shared library following some conventions, and
 if you are sufficiently savvy with gcc you can build them manually, but along
-with the ert installation you should have utility script ert_module which can be
+with the ERT installation you should have utility script ert_module which can be
 used to build a module; just write ert_module without any arguments to get a
 brief usage description.
 
@@ -1685,7 +1685,7 @@ Keywords related to running the forward model
 
 	::
 
-		-- Tell ert to use the LSF cluster.
+		-- Tell ERT to use the LSF cluster.
 		QUEUE_SYSTEM LSF
 
 	The QUEUE_SYSTEM keyword is optional, and usually defaults to LSF (this is
@@ -1700,10 +1700,10 @@ alternative with most options. The most important options are related to how ert
 should submit jobs to the LSF system. Essentially there are two methods ERT can
 use when submitting jobs to the LSF system:
 
-#. Workstations which have direct access to LSF ert can submit directly with
+#. Workstations which have direct access to LSF ERT can submit directly with
    no further configuration. This is the preferred solution, but unfortunately not
    very common.
-#. Alternatively ert can issue shell commands to bsub/bjobs/bkill to submit
+#. Alternatively ERT can issue shell commands to bsub/bjobs/bkill to submit
    jobs. These shell commands can be issued on the current workstation, or
    alternatively on a remote workstation using ssh.
 
@@ -1726,7 +1726,7 @@ The main switch between alternatives 1 and 2 above is the LSF_SERVER option.
 
 	ert will use ssh to submit your jobs using shell commands on the server
 	be-grid01. For this to work you must have passwordless ssh to the server
-	be-grid01. If you give the special server name LOCAL ert will submit using
+	be-grid01. If you give the special server name LOCAL ERT will submit using
 	shell commands on the current workstation.
 
 	**bsub/bjobs/bkill options**
@@ -1749,7 +1749,7 @@ The main switch between alternatives 1 and 2 above is the LSF_SERVER option.
 		QUEUE_OPTION  LSF     BJOBS_CMD   /path/to/my/bjobs
 		QUEUE_OPTION  LSF     BSUB_CMD    /path/to/my/bsub
 
-	In this example we tell ert to submit jobs from the workstation be-grid01
+	In this example we tell ERT to submit jobs from the workstation be-grid01
 	using custom binaries for bsub and bjobs.
 
 	*Example 2*
@@ -1775,11 +1775,11 @@ Configuring TORQUE access
 .. _configuring_torque_access:
 
 The TORQUE system is the only available system on some clusters. The most
-important options are related to how ert should submit jobs to the TORQUE
+important options are related to how ERT should submit jobs to the TORQUE
 system.
 
 * Currently, the TORQUE option only works when the machine you are logged into
-  have direct access to the queue system. ert then submits directly with no
+  have direct access to the queue system. ERT then submits directly with no
   further configuration.
 
 The most basic invocation is in other words:
@@ -1790,9 +1790,9 @@ The most basic invocation is in other words:
 
 **qsub/qstat/qdel options**
 
-By default ert will use the shell commands qsub,qstat and qdel to interact with
+By default ERT will use the shell commands qsub,qstat and qdel to interact with
 the queue system, i.e. whatever binaries are first in your PATH will be used.
-For fine grained control of the shell based submission you can tell ert which
+For fine grained control of the shell based submission you can tell ERT which
 programs to use:
 
 ::
@@ -1802,7 +1802,7 @@ programs to use:
 	QUEUE_OPTION TORQUE QSTAT_CMD /path/to/my/qstat 
 	QUEUE_OPTION TORQUE QDEL_CMD /path/to/my/qdel 
 
-In this example we tell ert to submit jobs using custom binaries for bsub and
+In this example we tell ERT to submit jobs using custom binaries for bsub and
 bjobs.
 
 **Name of queue**
@@ -1838,7 +1838,7 @@ QUEUE_SYSTEM.
 **Queue options controlling number of nodes and CPUs**
 
 When using TORQUE, you must specify how many nodes a single job is should to
-use, and how many CPUs per node. The default setup in ert will use one node and
+use, and how many CPUs per node. The default setup in ERT will use one node and
 one CPU. These options are called NUM_NODES and NUM_CPUS_PER_NODE.
 
 If the numbers specified is higher than supported by the cluster (i.e. use 32
@@ -1971,15 +1971,15 @@ Keywords related to plotting
 .. topic:: PLOT_ERRORBAR_MAX
 
 	When plotting summary vectors for which observations have been 'installed'
-	with the OBS_CONFIG keyword, ert will plot the observed values. If you have
-	less than PLOT_ERRORBAR_MAX observations ert will use errorbars to show the
+	with the OBS_CONFIG keyword, ERT will plot the observed values. If you have
+	less than PLOT_ERRORBAR_MAX observations ERT will use errorbars to show the
 	observed values, otherwise it will use two dashed lines indicating +/- one
 	standard deviation. This option is only meaningful when PLOT_PLOT_ERRORBAR is
 	activated.
 
 	To ensure that you always get errorbars you can set PLOT_ERRORBAR_MAX to a
 	very large value, on the other hand setting PLOT_ERRORBAR_MAX to 0 will ensure
-	that ert always plots observation uncertainty using dashed lines of +/- one
+	that ERT always plots observation uncertainty using dashed lines of +/- one
 	standard deviation.
 
 	The setting here will also affect the output when you are using the TEXT
@@ -2182,9 +2182,9 @@ instance, and are not applied to the shell.
 .. topic:: UMASK
 
         The `umask` is a concept used by Linux to control the permissions on
-        newly created files. By default the files created by ert will have the
+        newly created files. By default the files created by ERT will have the
         default permissions of your account, but by using the keyword `UMASK`
-        you can alter the permissions of files created by ert.
+        you can alter the permissions of files created by ERT.
 
         To determine the initial permissions on newly created files start with
         the initial permissions `-rw-rw-rw-` (octal 0666) for files and
@@ -2208,9 +2208,9 @@ instance, and are not applied to the shell.
            UMASK 0
 
         No permissions are removed, i.e. everyone can do everything with the
-        files and directories created by ert.
+        files and directories created by ERT.
 
-        The umask setting in ert is passed on to the forward model, and should
+        The umask setting in ERT is passed on to the forward model, and should
         apply to the files/directories created by the forward model also.
         However - the executables in the forward model can in principle set it's
         own umask setting or alter permissions in another way - so there is no

--- a/docs/rst/manual/keywords/index.rst
+++ b/docs/rst/manual/keywords/index.rst
@@ -69,7 +69,7 @@ Keyword name                                                        	Required by
 :ref:`DBASE_TYPE <dbase_type>`                                      	NO                    			BLOCK_FS         	     	Which 'database' system should be used for storage
 :ref:`DEFINE <define>`                                              	NO                                          				Define keywords with config scope
 :ref:`DELETE_RUNPATH <delete_runpath>`                              	NO                                          				Explicitly tell ert to delete the runpath when a job is complete 
-:ref:`ECLBASE <eclbase>`	                                    	YES*					        			Define a name for the ECLIPSE simulations. *Either JOBNAME or ECLBASE must be specified
+:ref:`ECLBASE <eclbase>`	                                    	YES\*					        			Define a name for the ECLIPSE simulations. \*Either JOBNAME or ECLBASE must be specified
 :ref:`END_DATE <end_date>`                                          	NO                                          				You can tell ERT how lon the simulations should be - for error check
 :ref:`ENKF_ALPHA <enkf_alpha>`                                      	NO                    			1.50                  		Parameter controlling outlier behaviour in EnKF algorithm
 :ref:`ENKF_BOOTSTRAP <enkf_bootstrap>`                              	NO                    			FALSE                 		Should we bootstrap the Kalman gain estimate
@@ -101,7 +101,7 @@ Keyword name                                                        	Required by
 :ref:`ITER_CASE <iter_Case>`                                        	NO                    			IES%d         	        	Case name format - iterated ensemble smoother
 :ref:`ITER_COUNT <iter_count>`                                      	NO                    			4             	        	Number of iterations - iterated ensemble smoother 
 :ref:`ITER_RETRY_COUNT <iter_retry_count>`                          	NO                    			4         	            	Number of retries for a iteration - iterated ensemble smoother 
-:ref:`JOBNAME <jobname>`                                            	YES*                                          				Name used for simulation files. *Either JOBNAME or ECLBASE must be specified.
+:ref:`JOBNAME <jobname>`                                            	YES\*                                          				Name used for simulation files. \*Either JOBNAME or ECLBASE must be specified.
 :ref:`JOB_SCRIPT <job_script>`                                      	NO                                          				Python script managing the forward model. 
 :ref:`LOAD_SEED <load_seed>`                                        	NO                                          				Load random seed from given file.
 :ref:`LOAD_WORKFLOW <load_workflow>` 				    	NO                             						Load a workflow into ERT. 
@@ -1177,8 +1177,8 @@ Keywords controlling the ES algorithm
 .. _enkf_alpha:
 .. topic:: ENKF_ALPHA
 
-        See the sub keyword :code:`OVERLAP_LIMIT` under the :code:`UPDATE_SETTINGS`keyword.           
-	
+	See the sub keyword :code:`OVERLAP_LIMIT` under the :code:`UPDATE_SETTINGS` keyword.
+
 .. _enkf_bootstrap:
 .. topic:: ENKF_BOOTSTRAP
 
@@ -1388,7 +1388,7 @@ Keywords controlling the ES algorithm
 
         The :code:`UPDATE_SETTINGS` keyword is a *super-keyword* which can be used to
 	control parameters which apply to the Ensemble Smoother update algorithm. The
-	:code:`UPDATE_SETTINGS`currently supports the two subkeywords:
+	:code:`UPDATE_SETTINGS` currently supports the two subkeywords:
 
    	OVERLAP_LIMIT Scaling factor used when detecting outliers. Increasing this
         factor means that more observations will potentially be included in the
@@ -1401,7 +1401,7 @@ Keywords controlling the ES algorithm
 
 	::
 
-		|d^o_i - \bar{d}_i| > \mathrm{ENKF\_ALPHA} \left(s_{d_i} + \sigma_{d^o_i}\right), 
+		|d^o_i - \bar{d}_i| > \mathrm{ENKF\_ALPHA} \left(s_{d_i} + \sigma_{d^o_i}\right)
 
 	where \textstyle\boldsymbol{d}^o is the vector of observed data,
 	\textstyle\boldsymbol{\bar{d}} is the average of the forcasted data ensemble,
@@ -1661,7 +1661,8 @@ Keywords related to running the forward model
 
 .. _queue_option:
 .. topic:: QUEUE_OPTION
-        Keyword used to set options for a queue (LSF, RSH, TORQUE, LOCAL), such like queue 
+
+	Keyword used to set options for a queue (LSF, RSH, TORQUE, LOCAL), such like queue
 
 .. _queue_system:
 .. topic:: QUEUE_SYSTEM

--- a/docs/rst/manual/keywords/index.rst
+++ b/docs/rst/manual/keywords/index.rst
@@ -2229,3 +2229,205 @@ instance, and are not applied to the shell.
          - Owner(7) can execute(1), write(2) and read(4).
          - Group(5) can execute(1) and read(4).
          - Others(2) can read(4)
+
+Undocumented keywords
+---------------------------------
+.. _undocumented_keywords:
+
+.. _case_table:
+.. topic:: CASE_TABLE
+
+        CASE_TABLE is not documented yet.
+
+
+.. _container:
+.. topic:: CONTAINER
+
+        CONTAINER is not documented yet.
+
+
+.. _dbase_type:
+.. topic:: DBASE_TYPE
+
+        DBASE_TYPE is not documented yet.
+
+
+.. _enkf_cross_validation:
+.. topic:: ENKF_CROSS_VALIDATION
+
+        ENKF_CROSS_VALIDATION is not documented yet.
+
+
+.. _enkf_kernel_param:
+.. topic:: ENKF_KERNEL_PARAM
+
+        ENKF_KERNEL_PARAM is not documented yet.
+
+
+.. _gen_kw_tag_format:
+.. topic:: GEN_KW_TAG_FORMAT
+
+        GEN_KW_TAG_FORMAT is not documented yet.
+
+
+.. _gen_kw_export_file:
+.. topic:: GEN_KW_EXPORT_FILE
+
+        GEN_KW_EXPORT_FILE is not documented yet.
+
+
+.. _ignore_schedule:
+.. topic:: IGNORE_SCHEDULE
+
+        IGNORE_SCHEDULE is not documented yet.
+
+
+.. _iter_case:
+.. topic:: ITER_CASE
+
+        ITER_CASE is not documented yet.
+
+
+.. _iter_count:
+.. topic:: ITER_COUNT
+
+        ITER_COUNT is not documented yet.
+
+
+.. _iter_retry_count:
+.. topic:: ITER_RETRY_COUNT
+
+        ITER_RETRY_COUNT is not documented yet.
+
+
+.. _load_seed:
+.. topic:: LOAD_SEED
+
+        LOAD_SEED is not documented yet.
+
+
+.. _load_workflow:
+.. topic:: LOAD_WORKFLOW
+
+        LOAD_WORKFLOW is not documented yet.
+
+
+.. _load_workflow_job:
+.. topic:: LOAD_WORKFLOW_JOB
+
+        LOAD_WORKFLOW_JOB is not documented yet.
+
+
+.. _licence_path:
+.. topic:: LICENCE_PATH
+
+        LICENCE_PATH is not documented yet.
+
+
+.. _load_config:
+.. topic:: LOAD_CONFIG
+
+        LOAD_CONFIG is not documented yet.
+
+
+.. _log_file:
+.. topic:: LOG_FILE
+
+        LOG_FILE is not documented yet.
+
+
+.. _log_level:
+.. topic:: LOG_LEVEL
+
+        LOG_LEVEL is not documented yet.
+
+
+.. _lsf_resources:
+.. topic:: LSF_RESOURCES
+
+        LSF_RESOURCES is not documented yet.
+
+
+.. _max_iter_count:
+.. topic:: MAX_ITER_COUNT
+
+        MAX_ITER_COUNT is not documented yet.
+
+
+.. _max_resample:
+.. topic:: MAX_RESAMPLE
+
+        MAX_RESAMPLE is not documented yet.
+
+
+.. _max_submit:
+.. topic:: MAX_SUBMIT
+
+        MAX_SUBMIT is not documented yet.
+
+
+.. _pre_clear_runpath:
+.. topic:: PRE_CLEAR_RUNPATH
+
+        PRE_CLEAR_RUNPATH is not documented yet.
+
+
+.. _refcase_list:
+.. topic:: REFCASE_LIST
+
+        REFCASE_LIST is not documented yet.
+
+
+.. _rerun_path:
+.. topic:: RERUN_PATH
+
+        RERUN_PATH is not documented yet.
+
+
+.. _rerun_start:
+.. topic:: RERUN_START
+
+        RERUN_START is not documented yet.
+
+
+.. _run_template:
+.. topic:: RUN_TEMPLATE
+
+        RUN_TEMPLATE is not documented yet.
+
+
+.. _simulation_job:
+.. topic:: SIMULATION_JOB
+
+        SIMULATION_JOB is not documented yet.
+
+
+.. _single_node_update:
+.. topic:: SINGLE_NODE_UPDATE
+
+        SINGLE_NODE_UPDATE is not documented yet.
+
+
+.. _store_seed:
+.. topic:: STORE_SEED
+
+        STORE_SEED is not documented yet.
+
+
+.. _torque_queue:
+.. topic:: TORQUE_QUEUE
+
+        TORQUE_QUEUE is not documented yet.
+
+
+.. _workflow_job_directory:
+.. topic:: WORKFLOW_JOB_DIRECTORY
+
+        WORKFLOW_JOB_DIRECTORY is not documented yet.
+
+
+.. _prior_distributions:
+.. topic:: PRIOR_DISTRIBUTIONS
+
+        PRIOR_DISTRIBUTIONS is not documented yet.
+

--- a/docs/rst/manual/observations/index.rst
+++ b/docs/rst/manual/observations/index.rst
@@ -306,11 +306,11 @@ file, containing an error covariance matrix. The file should contain
 the elements of the matrix as formatted numbers; newline formatting is
 allowed but not necessary. Since the matrix should by construction be
 symmetric there is no difference between column-major and row-major
-order! The covariance matrix
+order! The covariance matrix::
 
-     [ 1      0.75  -0.25]
-C =  [ 0.75   1.25  -0.50] 
-     [-0.25  -0.50   0.85]
+         [ 1      0.75  -0.25]
+    C =  [ 0.75   1.25  -0.50]
+         [-0.25  -0.50   0.85]
 
 Can be represented by the file::
 

--- a/docs/rst/manual/workflows/index.rst
+++ b/docs/rst/manual/workflows/index.rst
@@ -57,6 +57,7 @@ function as exported is quite simple, but it requires changes to the
 core code and a new version must be installed.
 
 .. _ert_script:
+
 Run a Python Script
 ...................
 
@@ -295,10 +296,10 @@ argument which will be used as name for the workflow. Alternatively
 you can load a workflow interactively.
 
 
+.. _hook_workflow:
+
 Automatically run workflows : HOOK_WORKFLOW
 -------------------------------------------
-.. _hook_workflow:
-.. topic:: HOOK_WORKFLOW
 
 With the keyword :code:`HOOK_WORKFLOW` you can configure workflow
 'hooks'; meaning workflows which will be run automatically at certain


### PR DESCRIPTION
**Issue**
Resolves #459 


**Approach**
Fixes all sphinx warnings except those related to undefined labels in the keyword table (pointing to keywords that have not been documented). See #392 and #433.
