### PR TITLE
New documentation front page

### DIFF
--- a/docs/rst/manual/changes/index.rst
+++ b/docs/rst/manual/changes/index.rst
@@ -424,7 +424,7 @@ C++:
 
 Well:
 
- - Get well rates from restart files [`8 <https://github.com/Equinor/libecl/pull/8/>`__,`20 <https://github.com/Equinor/res/pull/20/>`__].
+ - Get well rates from restart files [`8 <https://github.com/Equinor/libecl/pull/8/>`__, `20 <https://github.com/Equinor/res/pull/20/>`__].
  - Test if file exists before load [`111 <https://github.com/Equinor/libecl/pull/111/>`__].
  - Fix some warnings [`169 <https://github.com/Equinor/libecl/pull/169/>`__]
 

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -82,7 +82,7 @@ numfig = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'bizstyle'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/rst/manual/interfaces/index.rst
+++ b/docs/rst/manual/interfaces/index.rst
@@ -1,5 +1,5 @@
-Interfaces
-==========
+Running ERT
+===========
 
 Graphical User Interface (GUI)
 ------------------------------

--- a/docs/rst/manual/manual.rst
+++ b/docs/rst/manual/manual.rst
@@ -1,34 +1,94 @@
-.. ERT documentation master file, created by
-   sphinx-quickstart on Thu Sep  6 12:18:15 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 
 Welcome to ERT's documentation!
 ===============================
 
+ERT (Ensemble based Reservoir Tool) is a tool for model updating (history matching) using ensemble methods.
+ERT is primarily developed for use with reservoir models, but the tool can be used in any area dealing
+with model updates and uncertainty estimation.
+
+Launching ERT
+-------------
+
+The most common way to launch ERT is using the graphical user interface (GUI).
+Given that you have a ERT configuration file you want to run, the program is launched as follows:
+
+.. code-block:: bash
+
+   ert gui config.ert
+
+To see the full documentation of the available commands and how to run the command line interface (CLI),
+see :doc:`interfaces/index`.
+
+.. toctree::
+   :hidden:
+
+   self
+
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :hidden:
+   :caption: Getting started:
+
+   interfaces/index
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Theory:
 
    introduction/index
-   interfaces/index
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Data types and observations:
+
    data_types/index
    forward_model/index
+   observations/index
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Workflows:
+
    workflows/index
    workflows/built_in
-   observations/index
-   eclipse/index
-   update/index
-   scripting/index   
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Configuration:
+
    site-configuration/index
    keywords/index
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Advanced:
+
+   eclipse/index
+   update/index
+   scripting/index
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Releases:
+
    changes/index
 
-          
 
-Indices and tables
-==================
+.. Indices and tables
+   ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   * :ref:`genindex`
+   * :ref:`modindex`
+   * :ref:`search`

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ matplotlib<3
 scipy
 pyyaml
 sphinx-argparse
+sphinx_rtd_theme


### PR DESCRIPTION
**Issue**
Resolves #443 


**Approach**
Create a new front page for the documentation and change the theme to "read-the-docs"-theme

Test link: file:///scratch/ert/sonso/docs/manual.html