### PR TITLE
Add testkomodo.sh

### DIFF
--- a/Jenkinsfile-komodo
+++ b/Jenkinsfile-komodo
@@ -1,0 +1,17 @@
+pipeline {
+    agent { label 'si-build' }
+    stages {
+        stage('checkout komodo tag') {
+            steps {
+                sh 'sh checkout_komodo_tag.sh'
+            }
+        }
+	stage('run tests') {
+            steps {
+                sh 'sh testkomodo.sh'
+            }
+        }
+    }
+}
+
+

--- a/checkout_komodo_tag.sh
+++ b/checkout_komodo_tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source /project/res/komodo/$KOMODO_VERSION/enable
+
+GIT=/prog/sdpsoft/bin/git
+
+# find and check out the code that was used to build libres for this komodo relase
+echo "checkout tag from komodo"
+EV=$(cat /project/res/komodo/$KOMODO_VERSION/$KOMODO_RELEASE | grep "ert:" -A2 | grep "version:")
+EV=($EV)    # split the string "version: vX.X.X"
+EV=${EV[1]} # extract the version
+echo "Using Ert version $EV"
+$GIT checkout $EV
+

--- a/testkomodo.sh
+++ b/testkomodo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source /project/res/komodo/$KOMODO_VERSION/enable
+ENV=testenv
+rm -rf testenv
+mkdir $ENV
+python -m virtualenv --system-site-packages $ENV
+source $ENV/bin/activate
+python -m pip install mock
+
+#ensure that we are not using code from git, but rather from komodo
+ls|grep -xFv tests|grep -xFv testkomodo.sh|grep -xFv testenv|grep -xFv test-data|xargs rm -r
+
+ls
+
+echo "running pytest"
+python -m pytest


### PR DESCRIPTION
Partial solution to #387

Reviewer:

- The build script in the Jenkins job [ert-komodo-run](https://ci.equinor.com/be/view/SCOUT/job/ert-komodo-run/) first sources komodo, checks out the corresponding git tag, and then runs the testkomodo.sh script.
- The Jenkins build is currently running this code on my fork mortalisk/ert on master branch. After merge this must be switched to use equinor/ert in the jenkins build.
