### PR TITLE
Remove all refs to enkf_main obj in ERT

### DIFF
--- a/ert_gui/ertnotifier.py
+++ b/ert_gui/ertnotifier.py
@@ -6,7 +6,7 @@ except ImportError:
   from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 
 from res.enkf import EnKFMain
-from ert_shared import ERT
+from ert_shared import ERT, EnkfFacade
 
 class ErtNotifier(QObject):
     ertChanged = pyqtSignal()
@@ -48,6 +48,7 @@ class ErtNotifier(QObject):
         self._ert = None
         os.execl(python_executable, python_executable, ert_gui_main, config_file)
 
-def configureErtNotifier(ert, config_file):    
+def configureErtNotifier(ert, config_file):
     notifier = ErtNotifier(ert, config_file)
-    ERT.adapt(notifier)    
+    facade = EnkfFacade(ert)
+    ERT.adapt(notifier, facade)

--- a/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
+++ b/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
@@ -46,7 +46,7 @@ class AnalysisModuleVariablesModel(object):
     @classmethod
     def getVariableNames(cls, analysis_module_name):
         """ @rtype: list of str """
-        analysis_module = ERT.ert.analysisConfig().getModule(analysis_module_name)
+        analysis_module = ERT.enkf_facade.get_analysis_module(analysis_module_name)
         assert isinstance(analysis_module, AnalysisModule)
         items = []
         for name in cls._VARIABLE_NAMES:
@@ -83,13 +83,12 @@ class AnalysisModuleVariablesModel(object):
 
     @classmethod
     def setVariableValue(cls, analysis_module_name, name, value):
-        analysis_module = ERT.ert.analysisConfig().getModule(analysis_module_name)
-        result = analysis_module.setVar(name, str(value))
+        ERT.enkf_facade.set_variable_value(analysis_module_name, name, value)
 
     @classmethod
     def getVariableValue(cls, analysis_module_name, name):
         """ @rtype: int or float or bool or str """
-        analysis_module = ERT.ert.analysisConfig().getModule(analysis_module_name)
+        analysis_module = ERT.enkf_facade.get_analysis_module(analysis_module_name)
         variable_type = cls.getVariableType(name)
         if variable_type == float:
             return analysis_module.getDouble(name)

--- a/ert_gui/ertwidgets/models/ertsummary.py
+++ b/ert_gui/ertwidgets/models/ertsummary.py
@@ -6,27 +6,27 @@ class ErtSummary(object):
 
     def getForwardModels(self):
         """ @rtype: list of str """
-        forward_model  = ERT.ert.getModelConfig().getForwardModel()
+        forward_model  = ERT.enkf_facade.get_forward_model()
         return [job for job in forward_model.joblist()]
 
     def getParameters(self):
         """ @rtype: list of str """
-        parameters = ERT.ert.ensembleConfig().getKeylistFromVarType(EnkfVarType.PARAMETER)
+        parameters = ERT.enkf_facade.get_keylist_from_var_type(EnkfVarType.PARAMETER)
         return sorted([parameter for parameter in parameters], key=lambda k : k.lower())
 
 
     def getObservations(self):
         """ @rtype: list of str """
-        gen_obs = ERT.ert.getObservations().getTypedKeylist(EnkfObservationImplementationType.GEN_OBS)
+        gen_obs = ERT.enkf_facade.get_typed_keylist(EnkfObservationImplementationType.GEN_OBS)
 
 
-        summary_obs = ERT.ert.getObservations().getTypedKeylist(EnkfObservationImplementationType.SUMMARY_OBS)
+        summary_obs = ERT.enkf_facade.get_typed_keylist(EnkfObservationImplementationType.SUMMARY_OBS)
 
         keys = []
         summary_keys_count = {}
         summary_keys = []
         for key in summary_obs:
-            data_key = ERT.ert.getObservations()[key].getDataKey()
+            data_key = ERT.enkf_facade.get_observations_data_key(key)
 
             if not data_key in summary_keys_count:
                 summary_keys_count[data_key] = 1

--- a/ert_gui/ertwidgets/models/targetcasemodel.py
+++ b/ert_gui/ertwidgets/models/targetcasemodel.py
@@ -21,8 +21,8 @@ class TargetCaseModel(ValueModel):
     def getDefaultValue(self):
         """ @rtype: str """
         if self._format_mode:
-            if ERT.ert.analysisConfig().getAnalysisIterConfig().caseFormatSet():
-                return ERT.ert.analysisConfig().getAnalysisIterConfig().getCaseFormat()
+            if ERT.enkf_facade.is_case_format_set():
+                return ERT.enkf_facade.get_case_format()
             else:
                 case_name = getCurrentCaseName()
                 return "%s_%%d" % case_name

--- a/ert_gui/plottery/plot_config_factory.py
+++ b/ert_gui/plottery/plot_config_factory.py
@@ -1,29 +1,29 @@
 from ert_gui.plottery import PlotConfig
+from ert_shared import ERT
 
 
 class PlotConfigFactory(object):
 
     @classmethod
-    def createPlotConfigForKey(cls, ert, key):
+    def createPlotConfigForKey(cls, key):
         """
         @type ert: res.enkf.enkf_main.EnKFMain
         @param key: str
         @return: PlotConfig
         """
         plot_config = PlotConfig(plot_settings=None , title = key)
-        return PlotConfigFactory.updatePlotConfigForKey(ert, key, plot_config)
+        return PlotConfigFactory.updatePlotConfigForKey(key, plot_config)
 
 
     @classmethod
-    def updatePlotConfigForKey(cls, ert, key, plot_config):
+    def updatePlotConfigForKey(cls, key, plot_config):
         """
         @type ert: res.enkf.enkf_main.EnKFMain
         @param key: str
         @return: PlotConfig
         """
-        key_manager = ert.getKeyManager()
         # The styling of statistics changes based on the nature of the data
-        if key_manager.isSummaryKey(key) or key_manager.isGenDataKey(key):
+        if ERT.enkf_facade.is_summary_key(key) or ERT.enkf_facade.is_gen_data_key(key):
             mean_style = plot_config.getStatisticsStyle("mean")
             mean_style.line_style = "-"
             plot_config.setStatisticsStyle("mean", mean_style)

--- a/ert_gui/plottery/plot_context.py
+++ b/ert_gui/plottery/plot_context.py
@@ -11,13 +11,12 @@ class PlotContext(object):
     DEPTH_AXIS = "DEPTH"
     AXIS_TYPES = [UNKNOWN_AXIS, COUNT_AXIS, DATE_AXIS, DENSITY_AXIS, DEPTH_AXIS, INDEX_AXIS, VALUE_AXIS]
 
-    def __init__(self, ert, figure, plot_config, cases, key, data_gatherer):
+    def __init__(self, figure, plot_config, cases, key, data_gatherer):
         super(PlotContext, self).__init__()
         self._data_gatherer = data_gatherer
         self._key = key
         self._cases = cases
-        self._figure = figure
-        self._ert = ert
+        self._figure = figure        
         self._plot_config = plot_config
 
         self._date_support_active = True
@@ -30,11 +29,7 @@ class PlotContext(object):
 
     def plotConfig(self):
         """ :rtype: PlotConfig """
-        return self._plot_config
-
-    def ert(self):
-        """ :rtype: res.enkf.EnKFMain"""
-        return self._ert
+        return self._plot_config   
 
     def cases(self):
         """ :rtype: list of str """

--- a/ert_gui/plottery/plots/ccsp.py
+++ b/ert_gui/plottery/plots/ccsp.py
@@ -4,8 +4,7 @@ from .plot_tools import PlotTools
 import pandas as pd
 
 def plotCrossCaseStatistics(plot_context):
-    """ @type plot_context: ert_gui.plottery.PlotContext """
-    ert = plot_context.ert()
+    """ @type plot_context: ert_gui.plottery.PlotContext """    
     key = plot_context.key()
     config = plot_context.plotConfig()
     axes = plot_context.figure().add_subplot(111)
@@ -35,7 +34,7 @@ def plotCrossCaseStatistics(plot_context):
     }
     for case_index, case in enumerate(case_list):
         case_indexes.append(case_index)
-        data = plot_context.dataGatherer().gatherData(ert, case, key)
+        data = plot_context.dataGatherer().gatherData(case, key)
         std_dev_factor = config.getStandardDeviationFactor()
 
         if not data.empty:

--- a/ert_gui/plottery/plots/distribution.py
+++ b/ert_gui/plottery/plots/distribution.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 def plotDistribution(plot_context):
     """ @type plot_context: ert_gui.plottery.PlotContext """
-    ert = plot_context.ert()
     key = plot_context.key()
     config = plot_context.plotConfig()
     axes = plot_context.figure().add_subplot(111)
@@ -22,7 +21,7 @@ def plotDistribution(plot_context):
     previous_data = None
     for case_index, case in enumerate(case_list):
         case_indexes.append(case_index)
-        data = plot_context.dataGatherer().gatherData(ert, case, key)
+        data = plot_context.dataGatherer().gatherData(case, key)
 
         if not data.empty:
             _plotDistribution(axes, config, data, case, case_index, previous_data)

--- a/ert_gui/plottery/plots/ensemble.py
+++ b/ert_gui/plottery/plots/ensemble.py
@@ -7,7 +7,6 @@ def plotEnsemble(plot_context):
     """
     @type plot_context: ert_gui.plottery.PlotContext
     """
-    ert = plot_context.ert()
     key = plot_context.key()
     config = plot_context.plotConfig()
     """:type: ert_gui.plottery.PlotConfig """
@@ -20,7 +19,7 @@ def plotEnsemble(plot_context):
     plot_context.x_axis = plot_context.DATE_AXIS
 
     for case in case_list:
-        data = plot_context.dataGatherer().gatherData(ert, case, key)
+        data = plot_context.dataGatherer().gatherData(case, key)
         if not data.empty:
             if not data.index.is_all_dates:
                 plot_context.deactivateDateSupport()

--- a/ert_gui/plottery/plots/gaussian_kde.py
+++ b/ert_gui/plottery/plots/gaussian_kde.py
@@ -8,7 +8,6 @@ def plotGaussianKDE(plot_context):
     """
     @type plot_context: ert_gui.plottery.PlotContext
     """
-    ert = plot_context.ert()
     key = plot_context.key()
     config = plot_context.plotConfig()
     axes = plot_context.figure().add_subplot(111)
@@ -24,7 +23,7 @@ def plotGaussianKDE(plot_context):
 
     case_list = plot_context.cases()
     for case in case_list:
-        data = plot_context.dataGatherer().gatherData(ert, case, key)
+        data = plot_context.dataGatherer().gatherData(case, key)
 
         if not data.empty and data.nunique() > 1:
             _plotGaussianKDE(axes, config, data, case)

--- a/ert_gui/plottery/plots/histogram.py
+++ b/ert_gui/plottery/plots/histogram.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 def plotHistogram(plot_context):
     """ @type plot_context: ert_gui.plottery.PlotContext """
-    ert = plot_context.ert()
     key = plot_context.key()
     config = plot_context.plotConfig()
 
@@ -34,7 +33,7 @@ def plotHistogram(plot_context):
     max_element_count = 0
     categorical = False
     for case in case_list:
-        data[case] = plot_context.dataGatherer().gatherData(ert, case, key)
+        data[case] = plot_context.dataGatherer().gatherData(case, key)
 
         if data[case].dtype == "object":
             try:

--- a/ert_gui/plottery/plots/history.py
+++ b/ert_gui/plottery/plots/history.py
@@ -1,5 +1,4 @@
 def plotHistory(plot_context, axes):
-    ert = plot_context.ert()
     key = plot_context.key()
 
     if len(plot_context.cases()) == 0:
@@ -11,7 +10,7 @@ def plotHistory(plot_context, axes):
     data_gatherer = plot_context.dataGatherer()
 
     if config.isHistoryEnabled() and data_gatherer.hasHistoryGatherFunction():
-        history_data = data_gatherer.gatherHistoryData(ert, case, key)
+        history_data = data_gatherer.gatherHistoryData(case, key)
 
         if not history_data.empty:
             _plotHistory(axes, config, history_data)

--- a/ert_gui/plottery/plots/observations.py
+++ b/ert_gui/plottery/plots/observations.py
@@ -1,7 +1,6 @@
 import math
 
 def plotObservations(plot_context, axes):
-    ert = plot_context.ert()
     key = plot_context.key()
     config = plot_context.plotConfig()
     case_list = plot_context.cases()
@@ -9,7 +8,7 @@ def plotObservations(plot_context, axes):
 
     if config.isObservationsEnabled() and data_gatherer.hasObservationGatherFunction():
         if len(case_list) > 0:
-            observation_data = data_gatherer.gatherObservationData(ert, case_list[0], key)
+            observation_data = data_gatherer.gatherObservationData(case_list[0], key)
 
             if not observation_data.empty:
                 _plotObservations(axes, config, observation_data, value_column=key)

--- a/ert_gui/plottery/plots/plot_tools.py
+++ b/ert_gui/plottery/plots/plot_tools.py
@@ -1,3 +1,5 @@
+from ert_shared import ERT
+
 class PlotTools(object):
     @staticmethod
     def showGrid(axes, plot_context):
@@ -93,7 +95,6 @@ class PlotTools(object):
 
     @staticmethod
     def __setupLabels(plot_context, default_x_label, default_y_label):
-        ert = plot_context.ert()
         key = plot_context.key()
         config = plot_context.plotConfig()
 
@@ -103,7 +104,7 @@ class PlotTools(object):
         if config.yLabel() is None:
             config.setYLabel(default_y_label)
 
-            if ert.eclConfig().hasRefcase() and key in ert.eclConfig().getRefcase():
-                unit = ert.eclConfig().getRefcase().unit(key)
+            if ERT.enkf_facade.have_refcase() and key in ERT.enkf_facade.get_refcase():
+                unit = ERT.enkf_facade.get_refcase().unit(key)
                 if unit != "":
                     config.setYLabel(unit)

--- a/ert_gui/plottery/plots/refcase.py
+++ b/ert_gui/plottery/plots/refcase.py
@@ -1,11 +1,10 @@
 def plotRefcase(plot_context, axes):
-   ert = plot_context.ert()
    key = plot_context.key()
    config = plot_context.plotConfig()
    data_gatherer = plot_context.dataGatherer()
 
    if config.isRefcaseEnabled() and data_gatherer.hasRefcaseGatherFunction():
-       refcase_data = data_gatherer.gatherRefcaseData(ert, key)
+       refcase_data = data_gatherer.gatherRefcaseData(key)
 
        if not refcase_data.empty:
            _plotRefcase(axes, config, refcase_data)

--- a/ert_gui/plottery/plots/statistics.py
+++ b/ert_gui/plottery/plots/statistics.py
@@ -7,8 +7,7 @@ from .plot_tools import PlotTools
 
 
 def plotStatistics(plot_context):
-    """ @type plot_context: ert_gui.plottery.PlotContext """
-    ert = plot_context.ert()
+    """ @type plot_context: ert_gui.plottery.PlotContext """    
     key = plot_context.key()
     config = plot_context.plotConfig()
     """:type: ert_gui.plotter.PlotConfig """
@@ -20,7 +19,7 @@ def plotStatistics(plot_context):
 
     case_list = plot_context.cases()
     for case in case_list:
-        data = plot_context.dataGatherer().gatherData(ert, case, key)
+        data = plot_context.dataGatherer().gatherData(case, key)
 
         if not data.empty:
             if not data.index.is_all_dates:

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -49,10 +49,6 @@ class RunDialog(QDialog):
         assert isinstance(run_model, BaseRunModel)
         self._run_model = run_model
 
-        ert = None
-        if isinstance(run_model, BaseRunModel):
-            ert = run_model.ert()
-
         self.simulations_tracker = SimulationsTracker()
         states = self.simulations_tracker.getStates()
         self.state_colors = {state.name: state.color for state in states}
@@ -90,7 +86,7 @@ class RunDialog(QDialog):
         self.plot_tool.setParent(None)
         self.plot_button = QPushButton(self.plot_tool.getName())
         self.plot_button.clicked.connect(self.plot_tool.trigger)
-        self.plot_button.setEnabled(ert is not None)
+        self.plot_button.setEnabled(True)
 
         self.kill_button = QPushButton("Kill simulations")
         self.done_button = QPushButton("Done")

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -69,7 +69,7 @@ class SimulationPanel(QWidget):
 
         self.addSimulationConfigPanel(SingleTestRunPanel())
         self.addSimulationConfigPanel(EnsembleExperimentPanel())
-        if(ERT.ert.have_observations()):
+        if(ERT.enkf_facade.have_observations()):
             self.addSimulationConfigPanel(EnsembleSmootherPanel())
             self.addSimulationConfigPanel(MultipleDataAssimilationPanel())
             self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel())

--- a/ert_gui/tools/export/export_keyword_model.py
+++ b/ert_gui/tools/export/export_keyword_model.py
@@ -26,7 +26,7 @@ class ExportKeywordModel(object):
         self.__gen_param = None
 
     def getKeylistFromImplType(self, ert_impl_type):
-        return sorted(ERT.ert.ensembleConfig().getKeylistFromImplType(ert_impl_type))
+        return sorted(ERT.enkf_facade.get_keylist_from_impl_type(ert_impl_type))
 
     def isDynamicPlot(self, key):
         vtype = self.getVarType(key)
@@ -36,17 +36,17 @@ class ExportKeywordModel(object):
         return self.getVarType(key) == EnkfVarType.DYNAMIC_STATE
 
     def getVarType(self, key):
-        config_node = ERT.ert.ensembleConfig().getNode(key)
+        config_node = ERT.enkf_facade.get_node(key)
         variable_type = config_node.getVariableType()
         return variable_type
 
     def getImplementationType(self, key):
-        config_node = ERT.ert.ensembleConfig().getNode(key)
+        config_node = ERT.enkf_facade.get_node(key)
         return config_node.getImplementationType()
 
     def getGenKwKeyWords(self):
         if self.__gen_kw is None:
-            self.__gen_kw = [key for key in ERT.ert.ensembleConfig().getKeylistFromImplType(ErtImplType.GEN_KW)]
+            self.__gen_kw = [key for key in ERT.enkf_facade.get_keylist_from_impl_type(ErtImplType.GEN_KW)]
 
         return self.__gen_kw
 
@@ -54,13 +54,13 @@ class ExportKeywordModel(object):
         if self.__gen_data is None:
             gen_data_list = []
             gen_param_list = []
-            for key in ERT.ert.ensembleConfig().getKeylistFromImplType(ErtImplType.GEN_DATA):
+            for key in ERT.enkf_facade.get_keylist_from_impl_type(ErtImplType.GEN_DATA):
                 if self.getVarType(key) == EnkfVarType.PARAMETER:
                     gen_param_list.append(key)
                     continue
-                if ERT.ert.ensembleConfig().getNode(key).getDataModelConfig().getOutputFormat() is not None:
+                if ERT.enkf_facade.get_node_output_format(key) is not None:
                     gen_data_list.append(key)
-                elif ERT.ert.ensembleConfig().getNode(key).getDataModelConfig().getInputFormat() is not None:
+                elif ERT.enkf_facade.get_node_input_format(key) is not None:
                     gen_data_list.append(key)
             self.__gen_data = gen_data_list
             self.__gen_param = gen_param_list
@@ -104,9 +104,9 @@ class ExportKeywordModel(object):
 
     def getGenDataReportSteps(self, key):
         gen_data_list = []
-        obs_keys = ERT.ert.ensembleConfig().getNode(key).getObservationKeys()
+        obs_keys = ERT.enkf_facade.get_observation_keys(key)
         for obs_key in obs_keys:
-            obs_vector = ERT.ert.getObservations()[obs_key]
+            obs_vector = ERT.enkf_facade.get_observations(obs_key)
             for report_step in obs_vector.getStepList():
                 gen_data_list.append(str(report_step))
 

--- a/ert_gui/tools/load_results/load_results_model.py
+++ b/ert_gui/tools/load_results/load_results_model.py
@@ -28,13 +28,12 @@ class LoadResultsModel(object):
         @type iteration: int
         @rtype int: number of loaded realisations
         """
-        fs = ERT.ert.getEnkfFsManager().getFileSystem(selected_case)
-        return ERT.ert.loadFromForwardModel(realisations, iteration, fs)
+        return ERT.enkf_facade.load_results(selected_case, realisations, iteration)
 
     @staticmethod
     def isValidRunPath():
         """ @rtype: bool """
-        run_path = ERT.ert.getModelConfig().getRunpathAsString()
+        run_path = ERT.enkf_facade.get_runpath_as_string()
         try:
             result = run_path % (0, 0)
             return True
@@ -52,13 +51,13 @@ class LoadResultsModel(object):
     @staticmethod
     def getCurrentRunPath():
         """ @rtype: str """
-        return ERT.ert.getModelConfig().getRunpathAsString()
+        return ERT.enkf_facade.get_runpath_as_string()
 
 
     @staticmethod
     def getIterationCount():
         """ @rtype: int """
-        run_path = ERT.ert.getModelConfig().getRunpathAsString()
+        run_path = ERT.enkf_facade.get_runpath_as_string()
         try:
             results = run_path % (0, 0)
         except TypeError:

--- a/ert_gui/tools/plot/customize/customize_plot_dialog.py
+++ b/ert_gui/tools/plot/customize/customize_plot_dialog.py
@@ -176,13 +176,6 @@ class CustomizePlotDialog(QDialog):
         QDialog.__init__(self, parent)
         self.setWindowTitle(title)
 
-        self._ert = ERT.ert
-
-        """:type: res.enkf.enkf_main.EnKFMain"""
-
-        self.key_manager = self._ert.getKeyManager()
-        """:type: res.enkf.key_manager.KeyManager """
-
         self.current_key = key
 
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
@@ -262,7 +255,7 @@ class CustomizePlotDialog(QDialog):
         self.setLayout(layout)
 
     def initiateCopyStyleToDialog(self):
-        all_other_keys = [k for k in self.key_manager.allDataTypeKeys() if k != self.current_key]
+        all_other_keys = ERT.enkf_facade.get_all_other_data_type_keys(self.current_key)
         dialog = CopyStyleToDialog(self, self.current_key, all_other_keys)
         if dialog.exec_():
             self.copySettingsToOthers.emit(dialog.getSelectedKeys())

--- a/ert_gui/tools/plot/data_type_keys_list_model.py
+++ b/ert_gui/tools/plot/data_type_keys_list_model.py
@@ -1,5 +1,3 @@
-import sys
-
 try:
   from PyQt4.QtCore import QAbstractItemModel, QModelIndex, Qt, QVariant
   from PyQt4.QtGui import QColor
@@ -8,6 +6,7 @@ except ImportError:
   from PyQt5.QtGui import QColor
 
 from ert_gui.ertwidgets import resourceIcon
+from ert_shared import ERT
 
 
 class DataTypeKeysListModel(QAbstractItemModel):
@@ -15,16 +14,9 @@ class DataTypeKeysListModel(QAbstractItemModel):
     HAS_OBSERVATIONS = QColor(237, 218, 116)
     GROUP_ITEM = QColor(64, 64, 64)
 
-    def __init__(self, ert):
-        """
-        @type ert: res.enkf.EnKFMain
-        """
-        QAbstractItemModel.__init__(self)
-        self.__ert = ert
-        self.__icon = resourceIcon("ide/small/bullet_star")
-
-    def keyManager(self):
-        return self.__ert.getKeyManager()
+    def __init__(self):
+        QAbstractItemModel.__init__(self)        
+        self.__icon = resourceIcon("ide/small/bullet_star")    
 
     def index(self, row, column, parent=None, *args, **kwargs):
         return self.createIndex(row, column)
@@ -33,7 +25,7 @@ class DataTypeKeysListModel(QAbstractItemModel):
         return QModelIndex()
 
     def rowCount(self, parent=None, *args, **kwargs):
-        return len(self.keyManager().allDataTypeKeys())
+        return len(ERT.enkf_facade.get_all_data_type_keys())
 
     def columnCount(self, QModelIndex_parent=None, *args, **kwargs):
         return 1
@@ -42,14 +34,14 @@ class DataTypeKeysListModel(QAbstractItemModel):
         assert isinstance(index, QModelIndex)
 
         if index.isValid():
-            items = self.keyManager().allDataTypeKeys()
+            items = ERT.enkf_facade.get_all_data_type_keys()
             row = index.row()
             item = items[row]
 
             if role == Qt.DisplayRole:
                 return item
             elif role == Qt.BackgroundRole:
-                if self.keyManager().isKeyWithObservations(item):
+                if ERT.enkf_facade.is_key_with_observations(item):                
                     return self.HAS_OBSERVATIONS
 
         return QVariant()
@@ -59,25 +51,25 @@ class DataTypeKeysListModel(QAbstractItemModel):
 
         if index.isValid():
             row = index.row()
-            return self.keyManager().allDataTypeKeys()[row]
+            return ERT.enkf_facade.get_data_type_key(row)
 
         return None
 
 
     def isSummaryKey(self, key):
-        return self.keyManager().isSummaryKey(key)
+        return ERT.enkf_facade.is_summary_key(key)
 
     def isBlockKey(self, key):
         return False
 
     def isGenKWKey(self, key):
-        return self.keyManager().isGenKwKey(key)
+        return ERT.enkf_facade.is_gen_kw_key(key)
 
     def isGenDataKey(self, key):
-        return self.keyManager().isGenDataKey(key)
+        return ERT.enkf_facade.is_gen_data_key(key)
 
     def isCustomKwKey(self, key):
-        return self.keyManager().isCustomKwKey(key)
+        return ERT.enkf_facade.is_custom_kw_key(key)
 
     def isCustomPcaKey(self, key):
         return False

--- a/ert_gui/tools/plot/filterable_kw_list_model.py
+++ b/ert_gui/tools/plot/filterable_kw_list_model.py
@@ -1,18 +1,17 @@
 from ert_gui.ertwidgets.models.selectable_list_model import SelectableListModel
-
+from ert_shared import ERT
 
 class FilterableKwListModel(SelectableListModel):
     """
     Adds ERT - plotting keyword specific filtering functionality to the general SelectableListModel
     """
-    def __init__(self, ert, selectable_keys):
+    def __init__(self, selectable_keys):
         SelectableListModel.__init__(self, selectable_keys)
-        self._ert = ert
         self._show_summary_keys = True
         self._show_gen_kw_keys = True
         self._show_gen_data_keys = True
         self._show_custom_kw_keys = True
-        
+
     def getList(self):
         filtered_list = []
         for item in self._items:
@@ -27,20 +26,17 @@ class FilterableKwListModel(SelectableListModel):
 
         return filtered_list
 
-    def keyManager(self):
-        return self._ert.getKeyManager()
-
     def isSummaryKey(self, key):
-        return self.keyManager().isSummaryKey(key)
+        return ERT.enkf_facade.is_summary_key(key)
 
     def isGenKWKey(self, key):
-        return self.keyManager().isGenKwKey(key)
+        return ERT.enkf_facade.is_gen_kw_key(key)
 
     def isGenDataKey(self, key):
-        return self.keyManager().isGenDataKey(key)
+        return ERT.enkf_facade.is_gen_data_key(key)
 
     def isCustomKwKey(self, key):
-        return self.keyManager().isCustomKwKey(key)
+        return ERT.enkf_facade.is_custom_kw_key(key)
 
     def setShowSummaryKeys(self, visible):
         self._show_summary_keys = visible

--- a/ert_gui/tools/plot/plot_window.py
+++ b/ert_gui/tools/plot/plot_window.py
@@ -29,12 +29,6 @@ class PlotWindow(QMainWindow):
     def __init__(self, parent):
         QMainWindow.__init__(self, parent)
 
-        self._ert = ERT.ert
-        """:type: res.enkf.enkf_main.EnKFMain"""
-
-        key_manager = self._ert.getKeyManager()
-        """:type: res.enkf.key_manager.KeyManager """
-
         self.setMinimumWidth(850)
         self.setMinimumHeight(650)
 
@@ -44,7 +38,7 @@ class PlotWindow(QMainWindow):
         self._plot_customizer = PlotCustomizer(self)
 
         def plotConfigCreator(key):
-            return PlotConfigFactory.createPlotConfigForKey(self._ert, key)
+            return PlotConfigFactory.createPlotConfigForKey(key)
 
         self._plot_customizer.setPlotConfigCreator(plotConfigCreator)
         self._plot_customizer.settingsChanged.connect(self.keySelected)
@@ -67,10 +61,10 @@ class PlotWindow(QMainWindow):
         self._data_gatherers = []
         """:type: list of PlotDataGatherer """
 
-        summary_gatherer = self.createDataGatherer(PDG.gatherSummaryData, key_manager.isSummaryKey, refcaseGatherFunc=PDG.gatherSummaryRefcaseData, observationGatherFunc=PDG.gatherSummaryObservationData, historyGatherFunc=PDG.gatherSummaryHistoryData)
-        gen_data_gatherer = self.createDataGatherer(PDG.gatherGenDataData, key_manager.isGenDataKey, observationGatherFunc=PDG.gatherGenDataObservationData)
-        gen_kw_gatherer = self.createDataGatherer(PDG.gatherGenKwData, key_manager.isGenKwKey)
-        custom_kw_gatherer = self.createDataGatherer(PDG.gatherCustomKwData, key_manager.isCustomKwKey)
+        summary_gatherer = self.createDataGatherer(PDG.gatherSummaryData, ERT.enkf_facade.is_summary_key, refcaseGatherFunc=PDG.gatherSummaryRefcaseData, observationGatherFunc=PDG.gatherSummaryObservationData, historyGatherFunc=PDG.gatherSummaryHistoryData)
+        gen_data_gatherer = self.createDataGatherer(PDG.gatherGenDataData, ERT.enkf_facade.is_gen_data_key, observationGatherFunc=PDG.gatherGenDataObservationData)
+        gen_kw_gatherer = self.createDataGatherer(PDG.gatherGenKwData, ERT.enkf_facade.is_gen_kw_key)
+        custom_kw_gatherer = self.createDataGatherer(PDG.gatherCustomKwData, ERT.enkf_facade.is_custom_kw_key)
 
 
         self.addPlotWidget(ENSEMBLE, plots.plotEnsemble, [summary_gatherer, gen_data_gatherer])
@@ -81,7 +75,7 @@ class PlotWindow(QMainWindow):
         self.addPlotWidget(CROSS_CASE_STATISTICS, plots.plotCrossCaseStatistics, [gen_kw_gatherer, custom_kw_gatherer])
 
 
-        data_types_key_model = DataTypeKeysListModel(self._ert)
+        data_types_key_model = DataTypeKeysListModel()
 
         self._data_type_keys_widget = DataTypeKeysWidget(data_types_key_model)
         self._data_type_keys_widget.dataTypeKeySelected.connect(self.keySelected)
@@ -119,13 +113,11 @@ class PlotWindow(QMainWindow):
     def _updateCustomizer(self, plot_widget):
         """ @type plot_widget: PlotWidget """
         key = self.getSelectedKey()
-        key_manager = self._ert.getKeyManager()
-
         index_type = PlotContext.UNKNOWN_AXIS
 
-        if key_manager.isGenDataKey(key):
+        if ERT.enkf_facade.is_gen_data_key(key):
             index_type = PlotContext.INDEX_AXIS
-        elif key_manager.isSummaryKey(key):
+        elif ERT.enkf_facade.is_summary_key(key):
             index_type = PlotContext.DATE_AXIS
 
         x_axis_type = PlotContext.UNKNOWN_AXIS
@@ -157,7 +149,7 @@ class PlotWindow(QMainWindow):
         data_gatherer = self.getDataGathererForKey(key)
         plot_config = PlotConfig.createCopy(self._plot_customizer.getPlotConfig())
         plot_config.setTitle(key)
-        return PlotContext(self._ert, figure, plot_config, cases, key, data_gatherer)
+        return PlotContext(figure, plot_config, cases, key, data_gatherer)
 
     def getDataGathererForKey(self, key):
         """ @rtype: PlotDataGatherer """

--- a/ert_gui/tools/plot/widgets/copy_style_to_dialog.py
+++ b/ert_gui/tools/plot/widgets/copy_style_to_dialog.py
@@ -23,11 +23,6 @@ class CopyStyleToDialog(QDialog):
 
         layout = QFormLayout(self)
 
-        self._ert = ERT.ert
-        """:type: res.enkf.enkf_main.EnKFMain"""
-
-        self.model = self._ert
-
         self._filter_popup = FilterPopup(self)
         self._filter_popup.filterSettingsChanged.connect(self.filterSettingsChanged)
 
@@ -35,7 +30,7 @@ class CopyStyleToDialog(QDialog):
         filter_popup_button.setIcon(resourceIcon("ide/cog_edit.png"))
         filter_popup_button.clicked.connect(self._filter_popup.show)
 
-        self._list_model = FilterableKwListModel(self._ert, selectable_keys)
+        self._list_model = FilterableKwListModel(selectable_keys)
         self._list_model.unselectAll()
 
         self._cl = CheckList(self._list_model, custom_filter_button=filter_popup_button)

--- a/ert_gui/tools/run_analysis/run_analysis_tool.py
+++ b/ert_gui/tools/run_analysis/run_analysis_tool.py
@@ -13,17 +13,13 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import ert_shared
-
 try:
     from PyQt4.QtGui import QMessageBox
 except ImportError:
     from PyQt5.QtWidgets import QMessageBox
 
+from ert_shared import ERT
 from res.enkf import ErtRunContext
-
-
-from res.enkf import ESUpdate
 from ert_gui.ertwidgets import resourceIcon
 from ert_gui.ertwidgets.closabledialog import ClosableDialog
 from ert_gui.tools import Tool
@@ -33,14 +29,11 @@ from ert_gui.tools.run_analysis import RunAnalysisPanel
 def analyse(target, source):
     """Runs analysis using target and source cases. Returns whether or not
     the analysis was successful."""
-    ert = ert_shared.ERT.ert
-    fs_manager = ert.getEnkfFsManager()
-    es_update = ESUpdate(ert)
 
-    target_fs = fs_manager.getFileSystem(target)
-    source_fs = fs_manager.getFileSystem(source)
+    target_fs = ERT.enkf_facade.get_file_system(target)
+    source_fs = ERT.enkf_facade.get_file_system(source)
     run_context = ErtRunContext.ensemble_smoother_update(source_fs, target_fs,)
-    return es_update.smootherUpdate(run_context)
+    return ERT.enkf_facade.smoother_update(run_context)
 
 
 class RunAnalysisTool(Tool):
@@ -77,5 +70,5 @@ class RunAnalysisTool(Tool):
             msg.exec_()
             return
 
-        ert_shared.ERT.ertChanged.emit()
+        ERT.ertChanged.emit()
         self._dialog.accept()

--- a/ert_gui/tools/run_analysis/run_analysis_tool.py
+++ b/ert_gui/tools/run_analysis/run_analysis_tool.py
@@ -70,5 +70,5 @@ class RunAnalysisTool(Tool):
             msg.exec_()
             return
 
-        ERT.ertChanged.emit()
+        ERT.emitErtChange()
         self._dialog.accept()

--- a/ert_shared/__init__.py
+++ b/ert_shared/__init__.py
@@ -1,2 +1,3 @@
 from .ert_adapter import ERT
+from .enkf_facade import EnkfFacade
 from .cli import run_cli

--- a/ert_shared/cli.py
+++ b/ert_shared/cli.py
@@ -57,7 +57,7 @@ def _setup_ensemble_experiment(args):
 def _setup_ensemble_smoother(args):
     model = EnsembleSmoother()
     iterable = False
-    active_name = ERT.ert.analysisConfig().activeModuleName()
+    active_name = ERT.enkf_facade.get_active_module_name()
     modules = ERT.enkf_facade.get_analysis_module_names(iterable=iterable)
     simulations_argument = {
         "active_realizations": _realizations(args),
@@ -70,7 +70,7 @@ def _setup_ensemble_smoother(args):
 def _setup_multiple_data_assimilation(args):
     model = MultipleDataAssimilation()
     iterable = False
-    active_name = ERT.ert.analysisConfig().activeModuleName()
+    active_name = ERT.enkf_facade.get_active_module_name()
     modules = ERT.enkf_facade.get_analysis_module_names(iterable=iterable)
     simulations_argument = {
         "active_realizations": _realizations(args),
@@ -121,9 +121,8 @@ def _target_case_name(args, format_mode=False):
         case_name = ERT.enkf_facade.get_current_case_name()
         return "{}_smoother_update".format(case_name)
 
-    aic = ERT.ert.analysisConfig().getAnalysisIterConfig()
-    if aic.caseFormatSet():
-        return aic.getCaseFormat()
+    if ERT.enkf_facade.is_case_format_set():
+        return ERT.enkf_facade.get_case_format()
 
     case_name = ERT.enkf_facade.get_current_case_name()
     return "{}_%d".format(case_name)

--- a/ert_shared/cli.py
+++ b/ert_shared/cli.py
@@ -5,7 +5,7 @@ from argparse import ArgumentTypeError
 from ecl.util.util import BoolVector
 from res.enkf import EnKFMain, ResConfig
 
-from ert_shared import ERT
+from ert_shared import ERT, EnkfFacade
 from ert_gui.ide.keywords.definitions import RangeStringArgument
 from .models.ensemble_experiment import EnsembleExperiment
 from .models.ensemble_smoother import EnsembleSmoother
@@ -19,7 +19,8 @@ def run_cli(args):
     os.chdir(res_config.config_path)
     ert = EnKFMain(res_config, strict=True, verbose=args.verbose)
     notifier = ErtCliNotifier(ert, args.config)
-    ERT.adapt(notifier)
+    facade = EnkfFacade(ert)
+    ERT.adapt(notifier, facade)
 
     # Setup model
     if args.mode == 'test_run':

--- a/ert_shared/enkf_facade.py
+++ b/ert_shared/enkf_facade.py
@@ -1,11 +1,24 @@
 from res.analysis.analysis_module import AnalysisModule
 from res.analysis.enums.analysis_module_options_enum import AnalysisModuleOptionsEnum
+from res.enkf import ErtRunContext
+
 
 class EnkfFacade():
     """Facade to untangle ENKF Main funcs inside ERT."""
 
     def __init__(self, enkf_main):
         self._enkf_main = enkf_main
+
+    def get_all_cases(self):
+        fs_manager = self._enkf_main.getEnkfFsManager()
+        case_list = fs_manager.getCaseList()
+        return [str(case) for case in case_list if not fs_manager.isCaseHidden(case)]
+
+    def get_active_module_name(self):
+        return self._enkf_main.analysisConfig().activeModuleName()
+
+    def get_analysis_module(self, module_name):
+        return self._enkf_main.analysisConfig().getModule(module_name)
 
     def get_analysis_module_names(self, iterable=False):
         modules = self.get_analysis_modules(iterable)
@@ -16,22 +29,136 @@ class EnkfFacade():
 
         modules = []
         for module_name in module_names:
-            module = self._enkf_main.analysisConfig().getModule(module_name)
-            module_is_iterable = module.checkOption(AnalysisModuleOptionsEnum.ANALYSIS_ITERABLE)
+            module = self.get_analysis_module(module_name)
+            module_is_iterable = module.checkOption(
+                AnalysisModuleOptionsEnum.ANALYSIS_ITERABLE)
 
             if iterable == module_is_iterable:
                 modules.append(module)
 
         return sorted(modules, key=AnalysisModule.getName)
 
-    def get_ensemble_size(self):
-        return self._enkf_main.getEnsembleSize()
+    def get_case_format(self):
+        return self._enkf_main.analysisConfig().getAnalysisIterConfig().getCaseFormat()
+
+    def get_config_node(self, keyword):
+        return self._enkf_main.ensembleConfig()[keyword]
 
     def get_current_case_name(self):
         return str(self._enkf_main.getEnkfFsManager().getCurrentFileSystem().getCaseName())
 
-    def get_queue_config(self):
-        return self._enkf_main.get_queue_config()
+    def get_ensemble_size(self):
+        return self._enkf_main.getEnsembleSize()
+
+    def get_file_system(self, selected_case):
+        return self._enkf_main.getEnkfFsManager().getFileSystem(selected_case)
+
+    def get_forward_model(self):
+        return self._enkf_main.getModelConfig().getForwardModel()
+
+    def get_history_length(self):
+        return self._enkf_main.getHistoryLength()
+
+    def get_keylist_from_impl_type(self, impl_type):
+        return self._enkf_main.ensembleConfig().getKeylistFromImplType(impl_type)
+
+    def get_keylist_from_var_type(self, var_type):
+        return self._enkf_main.ensembleConfig().getKeylistFromVarType(var_type)
+
+    def get_node(self, keyword):
+        return self._enkf_main.ensembleConfig().getNode(keyword)
+
+    def get_node_input_format(self, keyword):
+        return self.get_node(keyword).getDataModelConfig().getInputFormat()
+
+    def get_node_output_format(self, keyword):
+        return self.get_node(keyword).getDataModelConfig().getOutputFormat()
 
     def get_number_of_iterations(self):
         return self._enkf_main.analysisConfig().getAnalysisIterConfig().getNumIterations()
+
+    def get_observations(self, key):
+        return self._enkf_main.getObservations()[key]
+
+    def get_observations_data_key(self, key):
+        return self._enkf_main.getObservations()[key].getDataKey()
+
+    def get_observation_keys(self, key):
+        return self.get_node(key).getObservationKeys()
+
+    def get_other_keys(self, current_key):
+        key_manager = self._enkf_main.getKeyManager()
+        return [k for k in key_manager.allDataTypeKeys() if k != current_key]
+
+    def get_queue_config(self):
+        return self._enkf_main.get_queue_config()
+
+    def get_runpath_as_string(self):
+        return self._enkf_main.getModelConfig().getRunpathAsString()
+
+    def get_runpath_format(self):
+        return self._enkf_main.getModelConfig().getRunpathFormat()
+
+    def get_state_map(self, case):
+        return self._enkf_main.getEnkfFsManager().getStateMapForCase(case)
+
+    def get_typed_keylist(self, enkf_observation_impl_type):
+        return self._enkf_main.getObservations().getTypedKeylist(enkf_observation_impl_type)
+
+    def get_workflow_list(self):
+        return self._enkf_main.getWorkflowList()
+
+    def have_observations(self):
+        return self._enkf_main.have_observations()
+
+    def is_case_initialized(self, case_name):
+        return self._enkf_main.getEnkfFsManager().isCaseInitialized(case_name)
+
+    def is_case_format_set(self):
+        return self._enkf_main.analysisConfig().getAnalysisIterConfig().caseFormatSet()
+
+    def is_case_running(self, case):
+        return self._enkf_main.getEnkfFsManager().isCaseRunning(case)
+
+    def is_custom_kw_key(self, key):
+        return self._enkf_main.getKeyManager().isCustomKwKey(key)
+
+    def is_gen_data_key(self, key):
+        return self._enkf_main.getKeyManager().isGenDataKey(key)
+
+    def is_gen_kw_key(self, key):
+        return self._enkf_main.getKeyManager().isGenKwKey(key)
+
+    def is_summary_key(self, key):
+        return self._enkf_main.getKeyManager().isSummaryKey(key)
+
+    def initialize_from_existing_case(self, source_case, source_report_step, member_mask, selected_parameters):
+        file_system_manager = self._enkf_main.getEnkfFsManager()
+        file_system_manager.customInitializeCurrentFromExistingCase(source_case, source_report_step, member_mask,
+                                                                    selected_parameters)
+
+    def initialize_from_scratch(self, mask, selected_parameters):
+        current_file_system = self._enkf_main.getEnkfFsManager().getCurrentFileSystem()
+        run_context = ErtRunContext.case_init(current_file_system, mask)
+        self._enkf_main.getEnkfFsManager().initializeFromScratch(
+            selected_parameters, run_context)
+
+    def load_results(self, selected_case, realisations, iteration):
+        file_system = self.get_file_system(selected_case)
+        return self._enkf_main.loadFromForwardModel(realisations, iteration, file_system)
+
+    def set_number_of_iterations(self, iteration_count):
+        self._enkf_main.analysisConfig().getAnalysisIterConfig(
+        ).setNumIterations(iteration_count)
+
+    def set_variable_value(self, analysis_module_name, name, value):
+        analysis_module = self.get_analysis_module(analysis_module_name)
+        analysis_module.setVar(name, str(value))
+
+    def switch_file_system(self, case_name):
+        file_system = self.get_file_system(case_name)
+        self._enkf_main.getEnkfFsManager().switchFileSystem(file_system)
+
+    def try_load_node(self, selected_case, node, node_id):
+        file_system = self.get_file_system(selected_case)
+        return node.tryLoad(file_system, node_id)

--- a/ert_shared/enkf_facade.py
+++ b/ert_shared/enkf_facade.py
@@ -1,7 +1,7 @@
 from res.analysis.analysis_module import AnalysisModule
 from res.analysis.enums.analysis_module_options_enum import AnalysisModuleOptionsEnum
 from res.enkf import ErtRunContext
-
+from ert_shared.models import ErtRunError
 
 class EnkfFacade():
     """Facade to untangle ENKF Main funcs inside ERT."""
@@ -13,6 +13,13 @@ class EnkfFacade():
         fs_manager = self._enkf_main.getEnkfFsManager()
         case_list = fs_manager.getCaseList()
         return [str(case) for case in case_list if not fs_manager.isCaseHidden(case)]
+
+    def get_all_data_type_keys(self):
+        return self._enkf_main.getKeyManager().allDataTypeKeys()
+
+    def get_all_other_data_type_keys(self, current_key):
+        key_manager = self._enkf_main.getKeyManager()
+        return [k for k in key_manager.allDataTypeKeys() if k != current_key]
 
     def get_active_module_name(self):
         return self._enkf_main.analysisConfig().activeModuleName()
@@ -47,6 +54,18 @@ class EnkfFacade():
     def get_current_case_name(self):
         return str(self._enkf_main.getEnkfFsManager().getCurrentFileSystem().getCaseName())
 
+    def get_current_file_system(self):
+        return self._enkf_main.getEnkfFsManager().getCurrentFileSystem()
+
+    def get_custom_kw_keys(self):
+        return self._enkf_main.getKeyManager().customKwKeys()
+    
+    def get_data_kw(self):
+        return self._enkf_main.getDataKW()
+    
+    def get_data_type_key(self, key):
+        return self._enkf_main.getKeyManager().allDataTypeKeys()[key]
+
     def get_ensemble_size(self):
         return self._enkf_main.getEnsembleSize()
 
@@ -55,9 +74,15 @@ class EnkfFacade():
 
     def get_forward_model(self):
         return self._enkf_main.getModelConfig().getForwardModel()
+    
+    def get_gen_kw_keys(self):
+        return self._enkf_main.getKeyManager().genKwKeys()
 
     def get_history_length(self):
         return self._enkf_main.getHistoryLength()
+
+    def get_jobname_format(self):
+        return self._enkf_main.getModelConfig().getJobnameFormat()
 
     def get_keylist_from_impl_type(self, impl_type):
         return self._enkf_main.ensembleConfig().getKeylistFromImplType(impl_type)
@@ -77,8 +102,15 @@ class EnkfFacade():
     def get_number_of_iterations(self):
         return self._enkf_main.analysisConfig().getAnalysisIterConfig().getNumIterations()
 
+    def get_number_of_retries(self):
+        analysis_config = self._enkf_main.analysisConfig()
+        analysis_iter_config = analysis_config.getAnalysisIterConfig()
+        return analysis_iter_config.getNumRetries()
+
     def get_observations(self, key):
-        return self._enkf_main.getObservations()[key]
+        if key:
+            return self._enkf_main.getObservations()[key]
+        return self._enkf_main.getObservations()
 
     def get_observations_data_key(self, key):
         return self._enkf_main.getObservations()[key].getDataKey()
@@ -86,12 +118,11 @@ class EnkfFacade():
     def get_observation_keys(self, key):
         return self.get_node(key).getObservationKeys()
 
-    def get_other_keys(self, current_key):
-        key_manager = self._enkf_main.getKeyManager()
-        return [k for k in key_manager.allDataTypeKeys() if k != current_key]
-
     def get_queue_config(self):
         return self._enkf_main.get_queue_config()
+
+    def get_refcase(self):
+        return self._enkf_main.eclConfig().getRefcase()
 
     def get_runpath_as_string(self):
         return self._enkf_main.getModelConfig().getRunpathAsString()
@@ -102,15 +133,30 @@ class EnkfFacade():
     def get_state_map(self, case):
         return self._enkf_main.getEnkfFsManager().getStateMapForCase(case)
 
+    def get_summary_keys(self):
+        return self._enkf_main.getKeyManager().summaryKeys()
+
+    def get_summary_keys_with_observation(self):
+        return self._enkf_main.getKeyManager().summaryKeysWithObservations()
+
     def get_typed_keylist(self, enkf_observation_impl_type):
         return self._enkf_main.getObservations().getTypedKeylist(enkf_observation_impl_type)
 
     def get_workflow_list(self):
         return self._enkf_main.getWorkflowList()
 
+    def create_runpath(self, run_context):
+        self._enkf_main.getEnkfSimulationRunner().createRunPath(run_context)
+
+    def have_enough_realizations(self, successful_realizations, ensemble_size):
+        return self._enkf_main.analysisConfig().haveEnoughRealisations(successful_realizations, ensemble_size)
+
     def have_observations(self):
         return self._enkf_main.have_observations()
 
+    def have_refcase(self):
+        return self._enkf_main.eclConfig().hasRefcase()
+    
     def is_case_initialized(self, case_name):
         return self._enkf_main.getEnkfFsManager().isCaseInitialized(case_name)
 
@@ -128,6 +174,9 @@ class EnkfFacade():
 
     def is_gen_kw_key(self, key):
         return self._enkf_main.getKeyManager().isGenKwKey(key)
+
+    def is_key_with_observations(self, key):
+        return self._enkf_main.getKeyManager().isKeyWithObservations(key)
 
     def is_summary_key(self, key):
         return self._enkf_main.getKeyManager().isSummaryKey(key)
@@ -147,6 +196,26 @@ class EnkfFacade():
         file_system = self.get_file_system(selected_case)
         return self._enkf_main.loadFromForwardModel(realisations, iteration, file_system)
 
+    def run_ensemble_experiment(self, job_queue, run_context):
+        return self._enkf_main.getEnkfSimulationRunner().runEnsembleExperiment(job_queue, run_context)
+
+    def run_simple_step(self, job_queue, run_context):
+        return self._enkf_main.getEnkfSimulationRunner().runSimpleStep(job_queue, run_context)
+
+    def run_workflows(self, runtime):
+        self._enkf_main.getEnkfSimulationRunner().runWorkflows(runtime)
+
+    def set_analysis_module(self, module_name):
+        module_load_success = self._enkf_main.analysisConfig().selectModule(module_name)
+
+        if not module_load_success:
+            raise ErtRunError("Unable to load analysis module '%s'!" % module_name)
+
+        return self._enkf_main.analysisConfig().getModule(module_name)
+
+    def set_case_format(self, target_case_format):
+        self._enkf_main.analysisConfig().getAnalysisIterConfig().setCaseFormat(target_case_format)
+
     def set_number_of_iterations(self, iteration_count):
         self._enkf_main.analysisConfig().getAnalysisIterConfig(
         ).setNumIterations(iteration_count)
@@ -154,6 +223,12 @@ class EnkfFacade():
     def set_variable_value(self, analysis_module_name, name, value):
         analysis_module = self.get_analysis_module(analysis_module_name)
         analysis_module.setVar(name, str(value))
+
+    def smoother_update(self, prior_context, weight=None):
+        es_update = self._enkf_main.getESUpdate()
+        if weight:
+            es_update.setGlobalStdScaling(weight)
+        return es_update.smootherUpdate(prior_context)
 
     def switch_file_system(self, case_name):
         file_system = self.get_file_system(case_name)

--- a/ert_shared/ert_adapter.py
+++ b/ert_shared/ert_adapter.py
@@ -1,5 +1,3 @@
-from .enkf_facade import EnkfFacade
-
 class ErtAdapter():
     """The adapter object is the global ERT variable used all
     over the place in the application, and is added due to legacy
@@ -15,9 +13,9 @@ class ErtAdapter():
         self._implementation = None
         self._enkf_facade = None
 
-    def adapt(self, implementation):
+    def adapt(self, implementation, enkf_facade):
         self._implementation = implementation
-        self._enkf_facade = EnkfFacade(implementation.ert)
+        self._enkf_facade = enkf_facade
 
     @property
     def enkf_facade(self):

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -3,7 +3,7 @@ from res.job_queue import JobStatusType
 from res.job_queue import ForwardModelStatus
 from res.util import ResLog
 from ecl.util.util import BoolVector
-import ert_shared
+from ert_shared import ERT
 
 # A method decorated with the @job_queue decorator implements the following logic:
 #
@@ -282,13 +282,13 @@ class BaseRunModel(object):
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed! All realizations failed!")
-        elif not ert_shared.ERT.enkf_facade.have_enough_realizations(num_successful_realizations, self._ensemble_size):
+        elif not ERT.enkf_facade.have_enough_realizations(num_successful_realizations, self._ensemble_size):
             raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
                               "Check ERT log file '%s' or simulation folder for details." % ResLog.getFilename())
 
     def checkMinimumActiveRealizations(self, run_context):
         active_realizations = self.count_active_realizations( run_context )
-        if not ert_shared.ERT.enkf_facade.have_enough_realizations(active_realizations, self._ensemble_size):
+        if not ERT.enkf_facade.have_enough_realizations(active_realizations, self._ensemble_size):
             raise ErtRunError("Number of active realizations is less than the specified MIN_REALIZATIONS in the config file")
 
     def count_active_realizations(self, run_context):

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -3,7 +3,7 @@ from res.job_queue import JobStatusType
 from res.job_queue import ForwardModelStatus
 from res.util import ResLog
 from ecl.util.util import BoolVector
-from ert_shared import ERT
+import ert_shared
 
 # A method decorated with the @job_queue decorator implements the following logic:
 #
@@ -52,10 +52,6 @@ class BaseRunModel(object):
         self._run_context = None
         self._last_run_iteration = -1
         self.reset( )
-
-    def ert(self):
-        """ @rtype: res.enkf.EnKFMain"""
-        return ERT.ert
 
     @property
     def _ensemble_size(self):
@@ -286,13 +282,13 @@ class BaseRunModel(object):
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed! All realizations failed!")
-        elif not self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self._ensemble_size):
+        elif not ert_shared.ERT.enkf_facade.have_enough_realizations(num_successful_realizations, self._ensemble_size):
             raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
                               "Check ERT log file '%s' or simulation folder for details." % ResLog.getFilename())
 
     def checkMinimumActiveRealizations(self, run_context):
         active_realizations = self.count_active_realizations( run_context )
-        if not self.ert().analysisConfig().haveEnoughRealisations(active_realizations, self._ensemble_size):
+        if not ert_shared.ERT.enkf_facade.have_enough_realizations(active_realizations, self._ensemble_size):
             raise ErtRunError("Number of active realizations is less than the specified MIN_REALIZATIONS in the config file")
 
     def count_active_realizations(self, run_context):

--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -17,18 +17,18 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(0, "Running simulations...", indeterminate=False)
 
         self.setPhaseName("Pre processing...", indeterminate=True)
-        self.ert().getEnkfSimulationRunner().createRunPath( run_context )
-        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+        ERT.enkf_facade.create_runpath(run_context)
+        ERT.enkf_facade.run_workflows(HookRuntime.PRE_SIMULATION)
 
         self.setPhaseName( run_msg, indeterminate=False)
 
-        num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(self._job_queue, run_context)
+        num_successful_realizations = ERT.enkf_facade.run_ensemble_experiment(self._job_queue, run_context)
 
         num_successful_realizations += arguments.get('prev_successful_realizations', 0)
         self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
-        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
+        ERT.enkf_facade.run_workflows(HookRuntime.POST_SIMULATION)
         self.setPhase(1, "Simulations completed.") # done...
 
         return run_context
@@ -39,13 +39,11 @@ class EnsembleExperiment(BaseRunModel):
 
 
     def create_context(self, arguments):
-        fs_manager = self.ert().getEnkfFsManager()
-        result_fs = fs_manager.getCurrentFileSystem( )
+        result_fs = ERT.enkf_facade.get_current_file_system()
 
-        model_config = self.ert().getModelConfig( )
-        runpath_fmt = model_config.getRunpathFormat( )
-        jobname_fmt = model_config.getJobnameFormat( )
-        subst_list = self.ert().getDataKW( )
+        runpath_fmt = ERT.enkf_facade.get_runpath_format()
+        jobname_fmt = ERT.enkf_facade.get_jobname_format()
+        subst_list = ERT.enkf_facade.get_data_kw()
         itr = 0
         mask = arguments["active_realizations"]
 

--- a/tests/global/test_cli.py
+++ b/tests/global/test_cli.py
@@ -1,8 +1,5 @@
 from tests import ErtTest
 from res.test import ErtTestContext
-import os
-import subprocess
-from res.enkf import EnKFMain, ResConfig
 from ecl.util.util import BoolVector
 from ert_shared import cli
 from ert_shared import ERT
@@ -60,7 +57,7 @@ class EntryPointTest(ErtTest):
 
             args = Namespace(realizations=None)
             res = cli._realizations(args)
-            ensemble_size = ERT.ert.getEnsembleSize()
+            ensemble_size = ERT.enkf_facade.get_ensemble_size()
             mask = BoolVector(default_value=False, initial_size=ensemble_size)
             mask.updateActiveMask("0-99")
             self.assertEqual(mask, res)
@@ -74,7 +71,7 @@ class EntryPointTest(ErtTest):
 
             args = Namespace(realizations="0-4,7,8")
             res = cli._realizations(args)
-            ensemble_size = ERT.ert.getEnsembleSize()
+            ensemble_size = ERT.enkf_facade.get_ensemble_size()
             mask = BoolVector(default_value=False, initial_size=ensemble_size)
             mask.updateActiveMask("0-4,7,8")
             self.assertEqual(mask, res)

--- a/tests/global/test_cli.py
+++ b/tests/global/test_cli.py
@@ -1,8 +1,7 @@
 from tests import ErtTest
 from res.test import ErtTestContext
 from ecl.util.util import BoolVector
-from ert_shared import cli
-from ert_shared import ERT
+from ert_shared import ERT, cli, EnkfFacade
 from ert_shared.cli import ErtCliNotifier
 from argparse import Namespace
 from ert_shared.models.ensemble_experiment import EnsembleExperiment
@@ -19,7 +18,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_custom_target_case_name', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             custom_name = "test"
             args = Namespace(target_case=custom_name)
@@ -31,7 +31,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_default_target_case_name', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             args = Namespace(target_case=None)
             res = cli._target_case_name(args)
@@ -42,7 +43,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_default_target_case_name_format_mode', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             args = Namespace(target_case=None)
             res = cli._target_case_name(args, format_mode=True)
@@ -53,7 +55,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_default_realizations', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             args = Namespace(realizations=None)
             res = cli._realizations(args)
@@ -67,7 +70,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_custom_realizations', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             args = Namespace(realizations="0-4,7,8")
             res = cli._realizations(args)
@@ -81,7 +85,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_single_test_run', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             model, argument = cli._setup_single_test_run()
             self.assertTrue(isinstance(model, SingleTestRun))
@@ -93,7 +98,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_single_test_run', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
 
             model, argument = cli._setup_single_test_run()
             self.assertTrue(isinstance(model, EnsembleExperiment))
@@ -105,7 +111,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_single_test_run', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
             args = Namespace(realizations="0-4,7,8", target_case="test_case")
 
             model, argument = cli._setup_ensemble_smoother(args)
@@ -120,7 +127,8 @@ class EntryPointTest(ErtTest):
         with ErtTestContext('test_single_test_run', config_file) as work_area:
             ert = work_area.getErt()
             notifier = ErtCliNotifier(ert, config_file)
-            ERT.adapt(notifier)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
             args = Namespace(realizations="0-4,7,8", weights="6,4,2", target_case="test_case")
 
             model, argument = cli._setup_multiple_data_assimilation(args)

--- a/tests/gui/plottery/test_plot_data_gatherer.py
+++ b/tests/gui/plottery/test_plot_data_gatherer.py
@@ -6,6 +6,8 @@ import pandas as pd
 from tests import ErtTest
 from res.test import ErtTestContext
 from ert_gui.plottery.plot_data_gatherer import PlotDataGatherer
+from ert_shared import ERT, EnkfFacade
+from ert_shared.cli import ErtCliNotifier
 
 
 class PlotGatherTest(ErtTest):
@@ -14,8 +16,12 @@ class PlotGatherTest(ErtTest):
         config_file = self.createTestPath(os.path.join("local", "snake_oil", "snake_oil.ert"))
         with ErtTestContext('SummaryRefcaseData', config_file) as work_area:
             ert = work_area.getErt()
+            notifier = ErtCliNotifier(ert, config_file)
+            facade = EnkfFacade(ert)
+            ERT.adapt(notifier, facade)
+
             key = "WOPRH:OP1"
-            result_data = PlotDataGatherer.gatherSummaryRefcaseData(ert, key)
+            result_data = PlotDataGatherer.gatherSummaryRefcaseData(key)
 
             expected_data = [
                 (0, datetime.date(2010,1,2),       1.03836009657e-05),
@@ -32,7 +38,7 @@ class PlotGatherTest(ErtTest):
 
             key = "not_a_key"
 
-            result_data = PlotDataGatherer.gatherSummaryRefcaseData(ert, key)
+            result_data = PlotDataGatherer.gatherSummaryRefcaseData(key)
             expected_data = pd.DataFrame()
 
             pd.testing.assert_frame_equal(result_data, expected_data, check_exact=True)


### PR DESCRIPTION
With this PR i've tried loosen up on the strong dependency towards enkf_main making full use of the enkf_facade interface. Instead of passing around the global ERT.ert (enkf_main) object, i've just used the global one. The enkf_facade is still leaking some objects out into ERT unfortunately, but my hope is that this is a good start and will make it easier moving implementation details into the facade as we go... This PR is big enough i feel and thus do not want to start refactoring more logic and move to the facade ( which probably should be done in the future )

Benefit of having all enkf_main code and implementation details in a facade will make our life easier as we go on with refactoring of the enkf_main implementation. In ERT we'll just need to make adjustments one place. 