### PR TITLE
Check for Qt version instead of python version where appropriate

### DIFF
--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -1,11 +1,11 @@
 import functools
 import os
 import pkg_resources
-import sys
 import webbrowser
 import yaml
 
 from ErtQt.Qt import QSettings, Qt, QMainWindow, qApp, QWidget, QVBoxLayout, QDockWidget, QAction, QToolButton
+from ErtQt import QT5
 
 from ert_gui.about_dialog import AboutDialog
 
@@ -105,14 +105,13 @@ class GertMainWindow(QMainWindow):
 
 
     def __fetchSettings(self):
-        py3 = sys.version_info[0] == 3
         settings = QSettings("Equinor", "Ert-Gui")
         geo = settings.value("geometry")
         if geo:
-            self.restoreGeometry(geo if py3 else geo.toByteArray())
+            self.restoreGeometry(geo if QT5 else geo.toByteArray())
         wnd = settings.value("windowState")
         if wnd:
-            self.restoreState   (wnd if py3 else wnd.toByteArray())
+            self.restoreState   (wnd if QT5 else wnd.toByteArray())
 
 
     def setWidget(self, widget):

--- a/ert_gui/tools/plot/style_chooser.py
+++ b/ert_gui/tools/plot/style_chooser.py
@@ -1,9 +1,6 @@
 import sys
 
-try:
-  from PyQt4.QtGui import QWidget, QHBoxLayout, QComboBox, QDoubleSpinBox, QLabel, QHBoxLayout
-except ImportError:
-  from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QDoubleSpinBox, QLabel, QHBoxLayout
+from ErtQt.Qt import QWidget, QHBoxLayout, QComboBox, QDoubleSpinBox, QLabel, QHBoxLayout
 
 from ert_gui.plottery import PlotStyle
 
@@ -136,7 +133,8 @@ class StyleChooser(QWidget):
         thickness = float(self.thickness_spinner.value())
         size = float(self.size_spinner.value())
 
-        if sys.version_info[0] == 2:
+        from ErtQt import QT4
+        if QT4:
             self._style.line_style = str(line_style.toString())
             self._style.marker = str(marker_style.toString())
         else:

--- a/ert_gui/tools/plot/widgets/clearable_line_edit.py
+++ b/ert_gui/tools/plot/widgets/clearable_line_edit.py
@@ -1,13 +1,13 @@
 import sys
 
-try:
-  from PyQt4.QtCore import QString, QSize, Qt
-  from PyQt4.QtGui import QPushButton, QColor, QLineEdit, QStyle
-except ImportError:
-  from PyQt5.QtCore import QSize, Qt
-  from PyQt5.QtWidgets import QPushButton, QLineEdit, QStyle
-  from PyQt5.QtGui import QColor
-
+from ErtQt.Qt import (
+    QColor,
+    QLineEdit,
+    QPushButton,
+    QSize,
+    QStyle,
+    Qt,
+    )
 
 from ert_gui.ertwidgets import resourceIcon
 
@@ -100,7 +100,9 @@ class ClearableLineEdit(QLineEdit):
 
     def text(self):
         if self._placeholder_active:
-            if sys.version_info[0] == 2:
+            from ErtQt import QT4
+            if QT4:
+                from ErtQt.Qt import QString
                 return QString("")
             else:
                 return ""


### PR DESCRIPTION
**Issue**
Ert gui has several issues if you have python 2 with qt5
There was an implicit assumption that Python2 comes with Qt4, while Python 3 comes with Qt5. This is not necessarily true

**Approach**
We explicitly check the Qt version when we need different code for different Qt versions
I have tried fixing some of these issue using `ErtQt`, but there are some limitations:
- In PyQt5 there is no `QString`. I could not come up with a simple solution for using PyQt4 without QString (except building a huge wrapper around PyQt4, which is probably overkill) 
- The api of `QSettings` in PyQt5 is kind of mysterious, The returned type can change a lot, sometimes it is automatically guessed, sometimes it returns a `QVariant` 