### PR TITLE
Init active realizations list with currently runnable realizations

### DIFF
--- a/ert_gui/ertwidgets/models/ertmodel.py
+++ b/ert_gui/ertwidgets/models/ertmodel.py
@@ -43,6 +43,26 @@ def getHistoryLength():
     return ERT.ert.getHistoryLength()
 
 
+def get_runnable_realizations_mask(casename):
+    """ Return the list of IDs corresponding to realizations that can be run.
+
+    A realization is considered "runnable" if its status is any other than
+    STATE_PARENT_FAILED. In that case, ERT does not know why that realization
+    failed, so it does not even know whether the parameter set for that
+    realization is sane or not.
+    If the requested case does not exist, an empty list is returned
+    """
+    fsm = ERT.ert.getEnkfFsManager()
+    if not fsm.caseExists(casename):
+        return []
+    sm = fsm.getStateMapForCase(casename)
+    runnable_flag = RealizationStateEnum.STATE_UNDEFINED | \
+                    RealizationStateEnum.STATE_INITIALIZED | \
+                    RealizationStateEnum.STATE_LOAD_FAILURE | \
+                    RealizationStateEnum.STATE_HAS_DATA
+    return sm.createMask(runnable_flag)
+
+
 @showWaitCursorWhileWaiting
 def selectOrCreateNewCase(case_name):
     if getCurrentCaseName() != case_name:

--- a/ert_gui/ertwidgets/stringbox.py
+++ b/ert_gui/ertwidgets/stringbox.py
@@ -14,12 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details. 
 
-import sys
-
 from ErtQt.Qt import QPalette, QLineEdit
 
 from ert_gui.ertwidgets import ValidationSupport, addHelpToWidget
-from ert_gui.ertwidgets.models.valuemodel import ValueModel
 
 
 class StringBox(QLineEdit):
@@ -27,7 +24,7 @@ class StringBox(QLineEdit):
 
     def __init__(self, model, help_link="", default_string="", continuous_update=False):
         """
-        :type model: ValueModel
+        :type model: ert_gui.ertwidgets.models.valuemodel.ValueModel
         :type help_link: str
         :type default_string: str
         :type continuous_update: bool
@@ -87,6 +84,10 @@ class StringBox(QLineEdit):
             text = ""
 
         self.setText(str(text))
+
+    @property
+    def model(self):
+        return self._model
 
     def setValidator(self, validator):
         self._validator = validator

--- a/tests/gui/models/test_active_realizations_model.py
+++ b/tests/gui/models/test_active_realizations_model.py
@@ -1,0 +1,28 @@
+from tests import ErtTest
+
+from ert_gui.ertwidgets.models.activerealizationsmodel import mask_to_rangestring
+
+class ActiveRealizationsModelTest(ErtTest):
+
+    def testMaskToRangeConversion(self):
+        cases = (
+            ([0, 1, 0, 1, 1, 1, 0], "1, 3-5"),
+            ([0, 1, 0, 1, 1, 1, 1], "1, 3-6"),
+            ([0, 1, 0, 1, 0, 1, 0], "1, 3, 5"),
+            ([1, 1, 0, 0, 1, 1, 1, 0, 1], "0-1, 4-6, 8"),
+            ([1, 1, 1, 1, 1, 1, 1], "0-6"),
+            ([0, 0, 0, 0, 0, 0, 0], ""),
+            ([True, False, True, True], "0, 2-3"),
+            ([], ""),
+            )
+        def nospaces(s):
+            return "".join(s.split())
+        for mask, expected in cases:
+            rngstr = mask_to_rangestring(mask)
+            self.assertEqual(
+                nospaces(rngstr),
+                nospaces(expected),
+                msg=("Mask {} was converted to {} which is different from the "
+                     "expected range {}"
+                     ).format(mask, rngstr, expected)
+                )


### PR DESCRIPTION
This change affects only the EnsembleExperiment and the EnsembleSmoother
execution modes, and is effective only when running through the GUI.
When one of these modes is selected, the `Active realizations` field is
automatically filled with the runnable realizations available for the
current case. If a new case is selected, the field is updated.

There is a small breaking change in behavior. If the `Active
realizations` field is manually edited, the change is lost if the user
selects a different mode or case and then comes back to the starting
mode or case. I expect this to be irrelevant for most use cases, but I
can be wrong, please let me know if this has to be adjusted.

A realization is considered "runnable" if its status is any other than
STATE_PARENT_FAILED. In that case, ERT does not know why that
realization failed, so it does not even know whether the parameter set
for that realization is sane or not.
