### PR TITLE
Minor fixups

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -160,6 +160,8 @@ class RunDialog(QDialog):
         self.__update_timer.timeout.connect(self.updateRunStatus)
         self._simulations_argments = {}
 
+    def reject(self):
+        return
 
     def closeEvent(self, QCloseEvent):
         if not self.checkIfRunFinished():

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -92,7 +92,7 @@ class BaseRunModel(object):
 
     @job_queue(None)
     def killAllSimulations(self):
-        self._job_queue.killAllJobs()
+        self._job_queue.kill_all_jobs()
 
 
     @job_queue(False)


### PR DESCRIPTION
Make base_run_model use the current libres api for killing jobs
prevent run_dialog for closing on esc by overwriting the reject function for QDialog

