### PR TITLE
setup.py: Invalid kwarg `tests_suite` -> valid `test_suite`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
                     ],
     zip_safe=False,
     tests_require=['pytest', 'mock'],
-    tests_suite=['tests'],
+    test_suite='tests',
     setup_requires=["pytest-runner", 'setuptools_scm'],
 )


### PR DESCRIPTION
There isn't an kwarg called `tests_suite` in setuptools, which gets ignored with
a warning: `UserWarning: Unknown distribution option: 'tests_suite'`

This causes setuptools to look for tests in _all_ python files, not just those
residing in the `tests` directory.

We solve this problem by changing `tests_suite` to `test_suite`, which is the
correct name.