### PR TITLE
Clear global state before closing GUI

### DIFF
--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -9,6 +9,8 @@ from ErtQt import QT5
 
 from ert_gui.about_dialog import AboutDialog
 
+import ert_shared
+
 
 class GertMainWindow(QMainWindow):
     def __init__(self):
@@ -88,6 +90,7 @@ class GertMainWindow(QMainWindow):
 
     def __quit(self):
         self.__saveSettings()
+        self._clear_global_state()
         qApp.quit()
 
 
@@ -97,10 +100,14 @@ class GertMainWindow(QMainWindow):
         settings.setValue("windowState", self.saveState())
 
 
+    def _clear_global_state(self):
+        ert_shared.clear_global_state()
+
     def closeEvent(self, event):
         #Use QT settings saving mechanism
         #settings stored in ~/.config/Equinor/ErtGui.conf
         self.__saveSettings()
+        self._clear_global_state()
         QMainWindow.closeEvent(self, event)
 
 

--- a/ert_shared/__init__.py
+++ b/ert_shared/__init__.py
@@ -1,1 +1,16 @@
 from .ert_adapter import ERT
+
+def clear_global_state():
+    """Deletes the global ERT instance shared as a global variable in the
+    ert_shared module. This is due to an exception that arrises when closing
+    the ERT application when modules, Python objects and C-objects are removed.
+    Over time the singleton instance of ERT should disappear and this function
+    should be removed.
+    """
+    global ERT
+    if ERT is None:
+        return
+
+    ERT._implementation = None
+    ERT._enkf_facade = None
+    ERT = None


### PR DESCRIPTION
Resolves: #534 

Since the removal of the `C`-code in the repo the following exception has been occurring when closing the GUI:

```
Exception TypeError: 'super() argument 1 must be type, not None' in <bound method EnkfFsManager.__del__ of EnkfFsManager() at 0x40a8fa0> ignored
Exception AttributeError: "'NoneType' object has no attribute 'PY2'" in <object repr() failed> ignored
```

This PR fixes this problem by clearing the global state in `ert_shared` before the application and the GUI is closed down.
