### PR TITLE
Append ERT config name to the titles of windows.

### DIFF
--- a/ert_gui/ertplot.py
+++ b/ert_gui/ertplot.py
@@ -59,7 +59,7 @@ def main(argv):
     ert = EnKFMain(res_config, strict=strict, verbose=False)
     configureErtNotifier(ert, config_file)
 
-    window = PlotWindow(ert, None)
+    window = PlotWindow(config_file, ert, None)
 
     sleep_time = 2 - (time.time() - now)
 

--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -118,16 +118,14 @@ def _check_locale():
 
 
 def _setup_main_window(config_file, ert):
-    window = GertMainWindow()
-    window.setWidget(SimulationPanel())
-    window.setWindowTitle("ERT - {}".format(config_file))
+    window = GertMainWindow(config_file)
+    window.setWidget(SimulationPanel(config_file))
     plugin_handler = PluginHandler(ert, ert.getWorkflowList().getPluginJobs(), window)
     help_tool = HelpTool("ERT", window)
-    window.addDock(
-        "Configuration Summary", SummaryPanel(), area=Qt.BottomDockWidgetArea
-    )
-    window.addTool(IdeTool(os.path.basename(config_file), help_tool))
-    window.addTool(PlotTool())
+
+    window.addDock("Configuration Summary", SummaryPanel(), area=Qt.BottomDockWidgetArea)
+    window.addTool(IdeTool(config_file, help_tool))
+    window.addTool(PlotTool(config_file))
     window.addTool(ExportTool())
     window.addTool(WorkflowsTool())
     window.addTool(ManageCasesTool())

--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -16,13 +16,13 @@ import ert_shared
 
 
 class GertMainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, config_file):
         QMainWindow.__init__(self)
 
         self.tools = {}
 
         self.resize(300, 700)
-        self.setWindowTitle('ERT')
+        self.setWindowTitle('ERT - {}'.format(config_file))
 
         self.__main_widget = None
 

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -28,7 +28,6 @@ except ImportError:
                                  QWidget)
     from PyQt5.QtGui import QColor, QStandardItemModel, QStandardItem
 
-
 from ert_gui.ertwidgets import resourceMovie, Legend
 from ert_gui.simulation import Progress, SimpleProgress, DetailedProgressWidget
 from ert_shared.models import BaseRunModel, SimulationsTracker
@@ -38,13 +37,13 @@ from ecl.util.util import BoolVector
 
 class RunDialog(QDialog):
 
-    def __init__(self, run_model, parent):
+    def __init__(self, config_file, run_model, parent):
         QDialog.__init__(self, parent)
         self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setModal(True)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Simulations")
+        self.setWindowTitle("Simulations - {}".format(config_file))
 
         assert isinstance(run_model, BaseRunModel)
         self._run_model = run_model
@@ -86,7 +85,7 @@ class RunDialog(QDialog):
 
         self.running_time = QLabel("")
 
-        self.plot_tool = PlotTool()
+        self.plot_tool = PlotTool(config_file)
         self.plot_tool.setParent(None)
         self.plot_button = QPushButton(self.plot_tool.getName())
         self.plot_button.clicked.connect(self.plot_tool.trigger)

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -26,8 +26,9 @@ from collections import OrderedDict
 
 class SimulationPanel(QWidget):
 
-    def __init__(self):
+    def __init__(self, config_file):
         QWidget.__init__(self)
+        self._config_file = config_file
 
         layout = QVBoxLayout()
 
@@ -110,7 +111,7 @@ class SimulationPanel(QWidget):
         if start_simulations == QMessageBox.Yes:
             run_model = self.getCurrentSimulationModel()
             arguments = self.getSimulationArguments()
-            dialog = RunDialog(run_model(), self)
+            dialog = RunDialog(self._config_file, run_model(), self)
             dialog.startSimulation( arguments )
             dialog.exec_()
 

--- a/ert_gui/tools/ide/configuration_panel.py
+++ b/ert_gui/tools/ide/configuration_panel.py
@@ -19,7 +19,7 @@ class ConfigurationPanel(QWidget):
 
     reloadApplication = pyqtSignal(str)
 
-    def __init__(self, config_file_path, help_tool):
+    def __init__(self, config_file, help_tool):
         QWidget.__init__(self)
 
         layout = QVBoxLayout()
@@ -58,9 +58,9 @@ class ConfigurationPanel(QWidget):
         self.ide_panel = IdePanel()
         layout.addWidget(self.ide_panel, 1)
 
-        self.config_file_path = config_file_path
+        self.config_file = config_file
 
-        with open(config_file_path) as f:
+        with open(config_file) as f:
             config_file_text = f.read()
 
         self.highlighter = KeywordHighlighter(self.ide_panel.document())
@@ -85,17 +85,17 @@ class ConfigurationPanel(QWidget):
 
 
     def save(self):
-        backup_path = "%s.backup" % self.config_file_path
-        shutil.copyfile(self.config_file_path, backup_path)
+        backup_path = "%s.backup" % self.config_file
+        shutil.copyfile(self.config_file, backup_path)
 
-        with open(self.config_file_path, "w") as f:
+        with open(self.config_file, "w") as f:
             f.write(self.ide_panel.getText())
 
         message = "To make your changes current, a reload of the configuration file is required. Would you like to reload now?"
         result = QMessageBox.information(self, "Reload required!", message, QMessageBox.Yes | QMessageBox.No)
 
         if result == QMessageBox.Yes:
-            self.reload(self.config_file_path)
+            self.reload(self.config_file)
 
 
     def saveAs(self):

--- a/ert_gui/tools/ide/ide_tool.py
+++ b/ert_gui/tools/ide/ide_tool.py
@@ -1,3 +1,5 @@
+from os.path import basename
+
 from weakref import ref
 
 from ert_shared import ERT
@@ -7,16 +9,17 @@ from ert_gui.tools.ide import IdeWindow
 
 
 class IdeTool(Tool):
-    def __init__(self, path, help_tool):
+    def __init__(self, config_file, help_tool):
         super(IdeTool, self).__init__("Configure", "tools/ide", resourceIcon("ide/widgets"))
 
         self.ide_window = None
-        self.path = path
+        self.config_file = config_file
+        self.path = basename(config_file)
         self.help_tool = help_tool
 
     def trigger(self):
         if self.ide_window is None:
-            self.ide_window = ref(IdeWindow(self.path, self.parent(), self.help_tool))
+            self.ide_window = ref(IdeWindow(self.config_file, self.parent(), self.help_tool))
             self.ide_window().reloadTriggered.connect(ERT.reloadERT)
 
         self.ide_window().show()

--- a/ert_gui/tools/ide/ide_window.py
+++ b/ert_gui/tools/ide/ide_window.py
@@ -13,7 +13,7 @@ from ert_gui.tools.ide.configuration_panel import ConfigurationPanel
 class IdeWindow(QMainWindow):
     reloadTriggered = pyqtSignal(str)
 
-    def __init__(self, path, parent, help_tool):
+    def __init__(self, config_file, parent, help_tool):
         QMainWindow.__init__(self, parent)
 
         self.resize(900, 900)
@@ -21,10 +21,10 @@ class IdeWindow(QMainWindow):
         self.__position = None
         self.__geometry = None
 
-        self.__configuration_panel = ConfigurationPanel(path, help_tool)
+        self.__configuration_panel = ConfigurationPanel(config_file, help_tool)
         self.__configuration_panel.reloadApplication.connect(self.reloadTriggered)
         self.setCentralWidget(self.__configuration_panel)
-        self.setWindowTitle("Configuration")
+        self.setWindowTitle("Configuration - {}".format(config_file))
         self.activateWindow()
 
 

--- a/ert_gui/tools/plot/plot_tool.py
+++ b/ert_gui/tools/plot/plot_tool.py
@@ -4,11 +4,12 @@ from ert_gui.tools.plot import PlotWindow
 
 
 class PlotTool(Tool):
-    def __init__(self):
+    def __init__(self, config_file):
         super(PlotTool, self).__init__("Create Plot", "tools/plot", resourceIcon("ide/chart_curve_add"))
+        self._config_file = config_file
 
     def trigger(self):
-        plot_window = PlotWindow(self.parent())
+        plot_window = PlotWindow(self._config_file, self.parent())
         plot_window.show()
 
 

--- a/ert_gui/tools/plot/plot_window.py
+++ b/ert_gui/tools/plot/plot_window.py
@@ -26,7 +26,7 @@ STATISTICS = "Statistics"
 class PlotWindow(QMainWindow):
 
 
-    def __init__(self, parent):
+    def __init__(self, config_file, parent):
         QMainWindow.__init__(self, parent)
 
         self._ert = ERT.ert
@@ -38,7 +38,7 @@ class PlotWindow(QMainWindow):
         self.setMinimumWidth(850)
         self.setMinimumHeight(650)
 
-        self.setWindowTitle("Plotting")
+        self.setWindowTitle("Plotting - {}".format(config_file))
         self.activateWindow()
 
         self._plot_customizer = PlotCustomizer(self)


### PR DESCRIPTION
Resolves #535 

The following windows now show the config name:
- Configuration
- Simulations
- Plotting

Uses the `ERT` singleton to get `config_name`, which might not be the best of practices.

An alternative is to give `config_name` to `GertMainWindow`, and then have each relevant window get it by using `parent.window().config_name`.