### PR TITLE
Improve FileView usability and responsiveness

### DIFF
--- a/ert_gui/tools/file/__init__.py
+++ b/ert_gui/tools/file/__init__.py
@@ -1,0 +1,4 @@
+from .file_update_worker import FileUpdateWorker
+from .file_model import FileModel
+from .file_view import FileView
+from .file_dialog import FileDialog

--- a/ert_gui/tools/file/file_dialog.py
+++ b/ert_gui/tools/file/file_dialog.py
@@ -1,0 +1,67 @@
+from qtpy.QtCore import QThread, Slot
+from qtpy.QtWidgets import QDialog, QMessageBox, QDialogButtonBox, QVBoxLayout
+
+from .file_model import FileModel
+from .file_view import FileView
+from .file_update_worker import FileUpdateWorker
+
+
+class FileDialog(QDialog):
+    def __init__(self, file_name, job_name, job_number, realization, iteration, parent=None):
+        super(FileDialog, self).__init__(parent)
+
+        self.setWindowTitle("{} # {} Realization: {} Iteration: {}" \
+                            .format(job_name, job_number, realization, iteration))
+
+        self._file_name = file_name
+        try:
+            self._file = open(file_name, "r")
+        except OSError as error:
+            self._mb = QMessageBox(QMessageBox.Critical, "Error opening file", error.strerror, QMessageBox.Ok, self)
+            self._mb.finished.connect(self.accept)
+            self._mb.show()
+            return
+
+        self._model = FileModel()
+        self._view = FileView()
+        self._view.setModel(self._model)
+
+        self._init_layout()
+        self._init_thread()
+
+        self.show()
+
+    @Slot()
+    def _stop_thread(self):
+        self._thread.quit()
+        self._thread.wait()
+
+    def _init_layout(self):
+        self.setMinimumWidth(400)
+        self.setMinimumHeight(200)
+
+        dialog_buttons = QDialogButtonBox(QDialogButtonBox.Ok)
+        self._follow = dialog_buttons.addButton("Follow", QDialogButtonBox.ActionRole)
+        self._copy_all = dialog_buttons.addButton("Copy All", QDialogButtonBox.ActionRole)
+        dialog_buttons.accepted.connect(self.accept)
+
+        self._follow.setCheckable(True)
+        self._follow.toggled.connect(self._view.enable_follow_mode)
+        self._copy_all.clicked.connect(self._model.copy_all)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._view)
+        layout.addWidget(dialog_buttons)
+
+    def _init_thread(self):
+        self._thread = QThread()
+
+        self._worker = FileUpdateWorker(self._file)
+        self._worker.moveToThread(self._thread)
+        self._worker.read.connect(self._model.append_text)
+
+        self._thread.started.connect(self._worker.setup)
+        self._thread.finished.connect(self._worker.stop)
+        self._thread.finished.connect(self._worker.deleteLater)
+        self.finished.connect(self._stop_thread)
+        self._thread.start()

--- a/ert_gui/tools/file/file_model.py
+++ b/ert_gui/tools/file/file_model.py
@@ -1,0 +1,48 @@
+from qtpy.QtCore import Slot, Qt, QAbstractListModel, QModelIndex
+from qtpy.QtGui import QClipboard
+from qtpy.QtWidgets import QApplication
+
+
+class FileModel(QAbstractListModel):
+    def __init__(self, parent=None):
+        super(FileModel, self).__init__(parent)
+        self._rows = []
+        self._new_line = True
+
+    def rowCount(self, parent):
+        """
+        Overloaded Qt function. Return the number of rows in this model.
+        :type parent: QModelIndex
+        """
+        return len(self._rows)
+
+    def data(self, index, role=Qt.DisplayRole):
+        """
+        Overloaded Qt function. Return data for index.
+        :type index: QModelIndex
+        """
+        if not index.isValid() or index.row() >= len(self._rows):
+            return
+
+        line = self._rows[index.row()]
+        if role == Qt.DisplayRole:
+            return line
+
+    @Slot(str)
+    def append_text(self, text):
+        if not self._new_line:
+            text = self._rows[-1] + text
+        self._new_line = text[-2] == "\n"
+
+        rows = text.splitlines(False)
+        first = len(self._rows)
+        last = first + len(rows)
+
+        self.beginInsertRows(QModelIndex(), first, last)
+        self._rows.extend(rows)
+        self.endInsertRows()
+
+    @Slot()
+    def copy_all(self):
+        """Copy the entire document into clipboard"""
+        QApplication.clipboard().setText("\n".join(self._rows), QClipboard.Clipboard)

--- a/ert_gui/tools/file/file_update_worker.py
+++ b/ert_gui/tools/file/file_update_worker.py
@@ -1,0 +1,37 @@
+from qtpy.QtCore import Signal, Slot, QObject, QTimer
+
+
+class FileUpdateWorker(QObject):
+    POLL_TIMER_MS = 1000
+    POLL_BUFFER_SIZE = 2**16  # 16KiB
+    INIT_BUFFER_SIZE = 2**20  #  1MiB
+
+    read = Signal(str)
+
+    def __init__(self, file, parent=None):
+        super(FileUpdateWorker, self).__init__(parent)
+        self._file = file
+        self._timer = None
+
+    @Slot()
+    def stop(self):
+        self._file.close()
+        self._timer.stop()
+
+    @Slot()
+    def setup(self):
+        text = self._file.read(self.INIT_BUFFER_SIZE)
+        self._send_text(text)
+
+        self._timer = QTimer()
+        self._timer.timeout.connect(self._poll_file)
+        self._timer.start(self.POLL_TIMER_MS)
+
+    @Slot()
+    def _poll_file(self):
+        text = self._file.read(self.POLL_BUFFER_SIZE)
+        self._send_text(text)
+
+    def _send_text(self, text):
+        if len(text) > 0:
+            self.read.emit(text)

--- a/ert_gui/tools/file/file_view.py
+++ b/ert_gui/tools/file/file_view.py
@@ -1,0 +1,165 @@
+from bisect import bisect_left, bisect_right
+
+from builtins import range
+
+from qtpy.QtCore import QModelIndex, QPoint, QRect, QSize, Slot
+from qtpy.QtGui import QFont, QFontDatabase, QPainter, QPalette, QRegion
+from qtpy.QtWidgets import QAbstractItemView, QStyle, QStyleOptionViewItem
+
+
+class FileView(QAbstractItemView):
+    def __init__(self, parent=None):
+        super(FileView, self).__init__(parent)
+        self.setSelectionMode(self.NoSelection)
+        self._line_offsets = [0]
+        self._line_sizes = []
+        self._size = QSize()
+        self._force_follow = False
+
+        self._init_font()
+
+    def paintEvent(self, event):
+        painter = QPainter(self.viewport())
+
+        view_rect = self._translate(event.rect())
+        if view_rect.y() < 0:
+            rect = QRect()
+            rect.setHeight(self.viewport().height() + view_rect.y())
+            rect.setWidth(self.viewport().width())
+
+            brush = self.palette().brush(QPalette.Disabled, QPalette.Window)
+            painter.fillRect(rect, brush)
+
+        for index in self._intersecting_rows(view_rect):
+            option = self._style_option(index)
+            delegate = self.itemDelegate(index)
+            delegate.paint(painter, option, index)
+
+    def setSelection(self, _rect, _flags):
+        """setSelection is a pure virtual member function of QAbstractItemView"""
+
+    def scrollTo(self, _index, _hint):
+        """scrollTo is a pure virtual member function of QAbstractItemView"""
+
+    def indexAt(self, point):
+        """indexAt is a pure virtual member function of QAbstractItemView"""
+        return self.model().index(self._resolve_row(point), 0)
+
+    def moveCursor(self, _action, _modifiers):
+        """moveCursor is a pure virtual member function of QAbstractItemView"""
+        return QModelIndex()
+
+    def visualRect(self, index):
+        """visualRect is a pure virtual member function of QAbstractItemView"""
+        if index.row() < 0 or index.row() >= len(self._line_sizes):
+            return QRect()
+        point = QPoint(-self.horizontalOffset(), self._line_offsets[index.row()] - self.verticalOffset())
+        return QRect(point, self._line_sizes[index.row()])
+
+    def visualRegionForSelection(self, _selection):
+        """visualRegionForSelection is a pure virtual member function of QAbstractItemView"""
+        return QRegion()
+
+    def horizontalOffset(self):
+        """horizontalOffset is a pure virtual member function of QAbstractItemView"""
+        return self.horizontalScrollBar().value()
+
+    def verticalOffset(self):
+        """verticalOffset is a pure virtual member function of QAbstractItemView"""
+        if self._force_follow:
+            return self._size.height() - self.viewport().height()
+        else:
+            return self.verticalScrollBar().value()
+
+    def isIndexHidden(self, _index):
+        """isIndexHidden is a pure virtual member function of QAbstractItemView"""
+        return False
+
+    @Slot(QModelIndex, int, int)
+    def rowsInserted(self, parent, first, last):
+        """rowsInserted is an overriden slot of QAbstractItemView"""
+        if first != len(self._line_sizes):
+            raise NotImplementedError("FileView can only be appended to")
+        model = self.model()
+
+        follow = self._force_follow or self.verticalOffset() == self.verticalScrollBar().maximum()
+
+        for idx in range(first, last):
+            end = self._size.height()
+            index = model.index(idx, 0)
+
+            option = self._style_option(index)
+            delegate = self.itemDelegate(index)
+            size = delegate.sizeHint(option, index)
+
+            self._line_sizes.append(size)
+            self._line_offsets.append(end + size.height())
+            self._size.setWidth(max(size.width(), self._size.width()))
+            self._size.setHeight(end + size.height())
+        self.updateGeometries()
+
+        if follow:
+            self.verticalScrollBar().setValue(self.verticalScrollBar().maximum())
+        self.viewport().update()
+
+    @Slot()
+    def updateGeometries(self):
+        """updateGeometries is an overridden slot of QAbstractItemView"""
+        horizontal_max = self._size.width() - self.viewport().width()
+        self.horizontalScrollBar().setRange(0, horizontal_max)
+
+        if self._force_follow:
+            self.verticalScrollBar().setRange(0, 0)
+        else:
+            vertical_max = self._size.height() - self.viewport().height()
+            self.verticalScrollBar().setRange(0, vertical_max)
+
+        QAbstractItemView.updateGeometries(self)
+
+    @Slot(bool)
+    def enable_follow_mode(self, follow=True):
+        """Enables or disabled follow mode, as in tail -f"""
+        self._force_follow = follow
+        self.updateGeometries()
+        self.verticalScrollBar().setValue(self.verticalScrollBar().maximum())
+        self.viewport().update()
+
+    def _intersecting_rows(self, rect):
+        """Get rows that intersect with rect"""
+        model = self.model()
+        first = max(0, bisect_left(self._line_offsets, rect.top()) - 1)
+        last = min(len(self._line_sizes), bisect_right(self._line_offsets, rect.bottom()))
+
+        return [model.index(row, 0) for row in range(first, last)]
+
+    def _resolve_row(self, point):
+        """Get row that is at point"""
+        y = point.y() + self.verticalOffset()
+        return max(0, bisect_left(self._line_offsets, y) - 1)
+
+    def _init_font(self):
+        # There isn't a standard way of getting the system default monospace
+        # font in Qt4 (it was introduced in Qt5.2). If QFontDatabase.FixedFont
+        # exists, then we can assume that this functionality exists and ask for
+        # the correct font directly. Otherwise we ask for a font that doesn't
+        # exist and specify our requirements. Qt then finds an existing font
+        # that best matches our parameters.
+        if hasattr(QFontDatabase, "systemFont") and hasattr(QFontDatabase, "FixedFont"):
+            font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        else:
+            font = QFont("")
+            font.setFixedPitch(True)
+            font.setStyleHint(QFont.Monospace)
+        self.setFont(font)
+
+    def _style_option(self, index):
+        """Get default style option for index"""
+        option = QStyleOptionViewItem()
+        option.font = self.font()
+        option.rect = self.visualRect(index)
+        option.state = QStyle.State_Enabled
+        return option
+
+    def _translate(self, rect):
+        """Translate rect from viewport to document coordinates"""
+        return rect.translated(self.horizontalOffset(), self.verticalOffset())


### PR DESCRIPTION
Addresses first half of #532 by improving on ERT's `FileViewer`. In particular, it does the following:

- Instead of re-reading the file, it keeps its handle open.
- Appends the text to QPlainTextEdit instead of setting it.
- Polls the file every 50ms instead of 1000ms.
- Follows the output when scrollbar is at the bottom. (`tail -f`)
- Uses a monospace font with no word-wrapping.
- Displays the current open file path.

Tested with Python 2.7 + Qt4 and Python 3.6 + Qt5.