### PR TITLE
Fail with exit code when simulations fail.

### DIFF
--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import logging
 import os
+import sys
 import threading
 
 from ert_shared import ERT
@@ -28,6 +29,8 @@ def run_cli(args):
 
     if args.disable_monitoring:
         model.startSimulations(argument)
+        if model.hasRunFailed():
+            sys.exit(model.getFailMessage())
     else:
         thread = threading.Thread(
             name="ert_cli_simulation_thread",
@@ -46,3 +49,6 @@ def run_cli(args):
             model.killAllSimulations()
 
         thread.join()
+
+        if model.hasRunFailed():
+            sys.exit(1)  # the monitor has already reported the error message


### PR DESCRIPTION
**Issue**
(No issue created)


**Approach**
For monitoring, exit with `1`, for non-monitoring exit with a message.