### PR TITLE
Fix regression -- ERT GUI not able to reload config

### DIFF
--- a/ert_gui/ertnotifier.py
+++ b/ert_gui/ertnotifier.py
@@ -46,7 +46,7 @@ class ErtNotifier(QObject):
         ert_gui_main = sys.argv[0]
 
         self._ert = None
-        os.execl(python_executable, python_executable, ert_gui_main, config_file)
+        os.execl(python_executable, python_executable, ert_gui_main, 'gui', config_file)
 
 def configureErtNotifier(ert, config_file):    
     notifier = ErtNotifier(ert, config_file)


### PR DESCRIPTION
Previously, `ert_shared.main` would do a `python -m ert_gui.gert_main {CONFIG}`, so that when `ert_gui.ertnotifier.ErtAdapter.reloadErt` did it's own `execve`, the stars would align and `python` started the `main` in `ert_gui` instead of `ert_shared`.

f014337fd76867ea2816c1dcca45076aeb259290 changed this, so now `reloadErt` would restart from `ert_shared`'s `main`.

This PR fixes this by adding a `gui` argument to `reloadErt`'s `execl`.