### PR TITLE
Revert "Revert default case name for MDA"

### DIFF
--- a/ert_gui/simulation/multiple_data_assimilation_panel.py
+++ b/ert_gui/simulation/multiple_data_assimilation_panel.py
@@ -49,7 +49,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         addHelpToWidget(number_of_realizations_label, "config/ensemble/num_realizations")
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
-        self._target_case_format_model = TargetCaseModel(format_mode=False)
+        self._target_case_format_model = TargetCaseModel(format_mode=True)
         self._target_case_format_field = StringBox(self._target_case_format_model, "config/simulation/target_case_format")
         self._target_case_format_field.setValidator(ProperNameFormatArgument())
         layout.addRow("Target case format:", self._target_case_format_field)

--- a/ert_shared/cli/model_factory.py
+++ b/ert_shared/cli/model_factory.py
@@ -64,7 +64,7 @@ def _setup_multiple_data_assimilation(args):
     modules = ERT.enkf_facade.get_analysis_module_names(iterable=iterable)
     simulations_argument = {
         "active_realizations": _realizations(args),
-        "target_case": _target_case_name(args, format_mode=False),
+        "target_case": _target_case_name(args, format_mode=True),
         "analysis_module": _get_analysis_module_name(active_name, modules, iterable=iterable),
         "weights": args.weights
     }


### PR DESCRIPTION
Reverts equinor/ert#548

It seems the discussion in https://github.com/equinor/ert/issues/537 is not yet complete, and that this PR causes a regression in the MDA panel where the default case format lacks a formatting verb.