### PR TITLE
[WIP] Remove pyqt dependency for cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,3 +101,5 @@ script:
   - pip install . --prefix=$INSTALL_DIR
   - python setup.py test
   - sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
+  - conda remove pyqt -y
+  - ert --help

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -5,7 +5,6 @@ import sys
 import re
 from argparse import ArgumentParser, ArgumentTypeError
 from ert_shared.cli.main import run_cli
-from ert_gui.gert_main import run_gui
 from ert_gui.ide.keywords.definitions import (
     RangeStringArgument,
     ProperNameArgument,
@@ -83,6 +82,11 @@ def range_limited_int(user_input):
     raise ArgumentTypeError("Range must be in range 1 - 99")
 
 
+def run_gui_wrapper(args):
+    from ert_gui.gert_main import run_gui
+    run_gui(args)
+
+
 def get_ert_parser(parser=None):
     if parser is None:
         parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
@@ -106,7 +110,7 @@ def get_ert_parser(parser=None):
         description="Opens an independent graphical user interface for "
         "the user to interact with ERT.",
     )
-    gui_parser.set_defaults(func=run_gui)
+    gui_parser.set_defaults(func=run_gui_wrapper)
     gui_parser.add_argument("config", type=valid_file, help=config_help)
     gui_parser.add_argument(
         "--verbose", action="store_true", help="Show verbose output", default=False

--- a/tests/all/test_main.py
+++ b/tests/all/test_main.py
@@ -11,7 +11,7 @@ class MainTest(unittest.TestCase):
     def test_argparse_exec_gui(self):
         parser = ArgumentParser(prog="test_main")
         parsed = ert_parser(parser, ['gui', 'test-data/local/poly_example/poly.ert'])
-        self.assertEquals(parsed.func.__name__, "run_gui")
+        self.assertEquals(parsed.func.__name__, "run_gui_wrapper")
 
     def test_argparse_exec_test_run_valid_case(self):
         parser = ArgumentParser(prog="test_main")


### PR DESCRIPTION
**Issue**
Resolves #552 


**Approach**
Import from ert_gui only when the gui is actually going to run

Add "test" for PyQt dependency for the CLi by removing PyQt from Conda and running `ert --help` at the end of the travis run. 