### PR TITLE
clear_global_state() outside of Qt

### DIFF
--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -70,7 +70,7 @@ class GertMainWindow(QMainWindow):
 
     def __createMenu(self):
         file_menu = self.menuBar().addMenu("&File")
-        file_menu.addAction("Close", self.__quit)
+        file_menu.addAction("Close", self.close)
         self.__view_menu = self.menuBar().addMenu("&View")
         self.__help_menu = self.menuBar().addMenu("&Help")
         """:type: QMenu"""
@@ -93,12 +93,6 @@ class GertMainWindow(QMainWindow):
             help_link_item = self.__help_menu.addAction(menu_label)
             help_link_item.setMenuRole(QAction.ApplicationSpecificRole)
             help_link_item.triggered.connect(functools.partial(webbrowser.open, link))
-
-
-    def __quit(self):
-        self.__saveSettings()
-        self._clear_global_state()
-        qApp.quit()
 
 
     def __saveSettings(self):

--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -12,8 +12,6 @@ from ErtQt import QT5
 from ert_gui.about_dialog import AboutDialog
 from ert_shared.plugins import ErtPluginManager
 
-import ert_shared
-
 
 class GertMainWindow(QMainWindow):
     def __init__(self, config_file):
@@ -101,14 +99,10 @@ class GertMainWindow(QMainWindow):
         settings.setValue("windowState", self.saveState())
 
 
-    def _clear_global_state(self):
-        ert_shared.clear_global_state()
-
     def closeEvent(self, event):
         #Use QT settings saving mechanism
         #settings stored in ~/.config/Equinor/ErtGui.conf
         self.__saveSettings()
-        self._clear_global_state()
         QMainWindow.closeEvent(self, event)
 
 

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 import re
 from argparse import ArgumentParser, ArgumentTypeError
+from ert_shared import clear_global_state
 from ert_shared.cli.main import run_cli
 from ert_gui.gert_main import run_gui
 from ert_gui.ide.keywords.definitions import (
@@ -237,6 +238,8 @@ def main():
 
     with ErtPluginContext():
         args.func(args)
+
+    clear_global_state()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Turns out this wasn't being caused by `cwrap` or `libres` (!), but a Python 2.7 quirk where class names are set to `None` before their member functions are done running, when used in global variables.

```python
class A(object):
    def __del__(self):
        print(A)
a = A()
```
Will print `None` in 2 and the expected `<class '__main__.A'>` in 3. Fun stuff.

#555 is resolved by moving the `clear_global_state` outside of Qt, so that any Qt widgets may be destroyed before the `ERT` object is set to `None`.

I also did some minor clean-up for the 'Close' menu button.