### PR TITLE
Don't set SimulationPanel to be RunDialog's parent

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -20,7 +20,7 @@ class RunDialog(QDialog):
 
     simulation_done = pyqtSignal(bool, str)
 
-    def __init__(self, config_file, run_model, arguments, parent):
+    def __init__(self, config_file, run_model, arguments, parent=None):
         QDialog.__init__(self, parent)
         self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -111,7 +111,7 @@ class SimulationPanel(QWidget):
         if start_simulations == QMessageBox.Yes:
             run_model = self.getCurrentSimulationModel()
             arguments = self.getSimulationArguments()
-            dialog = RunDialog(self._config_file, run_model(), arguments, self)
+            dialog = RunDialog(self._config_file, run_model(), arguments)
             dialog.startSimulation()
             dialog.exec_()
 


### PR DESCRIPTION
#575 was caused by Qt4 accessing some invalid memory when sending a delete event to RunDialog during Python's exit GC cleanup. We haven't figured out what specifically is causing the invalid deallocation of the object, since it could be either Qt4 or Python 2.7 (error doesn't happen on Py3+Qt5). However, not assigning a parent to RunDialog seems to have solved the problem.