### PR TITLE
Use is_active to identify active realisation members

### DIFF
--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -212,8 +212,8 @@ class BaseRunModel(object):
         iteration = self._run_context.get_iter()
         if iteration not in self.realization_progress:
             self.realization_progress[iteration] = {}
-        for run_arg in self._run_context:
-            if not run_arg:
+        for idx, run_arg in enumerate(self._run_context):
+            if not self._run_context.is_active(idx):
                 continue
             try:
                 # will throw if not yet submitted (is in a limbo state)


### PR DESCRIPTION
In https://github.com/equinor/libres/pull/822 we stop returning `None` for inactive ensemble members, use `is_active` to check this instead.

I tested this locally by running an extension of the poly case. Added it in a separate commit. I doubt we have a test or case that has failing realisations, so could be worth keeping around. And possibly even add to our test suite as an end to end test?