### PR TITLE
Depend on libres 2.6.0

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.6.b2
+export LIBRES_VERSION=2.6.0


### PR DESCRIPTION
**Issue**
Requirement for 2019.12 release


**Approach**
Bump `libres` dep to `2.6.0`
