### PR TITLE
Bump libres to 2.6.1

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.6.0
+export LIBRES_VERSION=2.6.1


### PR DESCRIPTION
**Issue**
Part of the `2019.12` release


**Approach**
Cherry pick of 6dedeae4b07f49a6bbb9341c42f5643bc60a64cb
