### PR TITLE
Bump libres to 2.6.6

### DIFF
--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,1 @@
-export LIBRES_VERSION=2.6.5
+export LIBRES_VERSION=2.6.6


### PR DESCRIPTION
Part of the 2019.12 release