### PR TITLE
Add obs to plot new api

### DIFF
--- a/tests/excluded_files_black.py
+++ b/tests/excluded_files_black.py
@@ -116,7 +116,6 @@ def get_files_excluded_from_black(root):
         "ert_gui/tools/plot/plot_api.py",
         "ert_gui/tools/plot/customize/customize_plot_dialog.py",
         "ert_gui/tools/plot/widgets/copy_style_to_dialog.py",
-        "ert_gui/tools/plot/storage_client.py",
         "ert_gui/tools/plot/widgets/clearable_line_edit.py",
         "ert_gui/tools/plot/widgets/custom_date_edit.py",
         "ert_gui/tools/plugins/plugin.py",

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -77,10 +77,38 @@ def populated_db(tmpdir):
         observation_id=observation.id, response_definition_id=response_definition.id
     )
 
-    repository.add_response_definition(
+    observation_one = repository.add_observation(
+        name="observation_two_first",
+        key_indexes_ref=add_blob(["2000-01-01 20:01:01"]),
+        data_indexes_ref=add_blob([4]),
+        values_ref=add_blob([10.3]),
+        stds_ref=add_blob([2]),
+    )
+
+    observation_two = repository.add_observation(
+        name="observation_two_second",
+        key_indexes_ref=add_blob(["2000-01-02 20:01:01"]),
+        data_indexes_ref=add_blob([5]),
+        values_ref=add_blob([10.4]),
+        stds_ref=add_blob([2.5]),
+    )
+
+    response_two_definition = repository.add_response_definition(
         name="response_two",
         indexes_ref=add_blob(["2000-01-01 20:01:01", "2000-01-02 20:01:01"]),
         ensemble_name=ensemble.name,
+    )
+
+    repository.flush()
+
+    repository._add_observation_response_definition_link(
+        observation_id=observation_one.id,
+        response_definition_id=response_two_definition.id,
+    )
+
+    repository._add_observation_response_definition_link(
+        observation_id=observation_two.id,
+        response_definition_id=response_two_definition.id,
     )
 
     repository.add_parameter_definition("A", "G", "ensemble_name")


### PR DESCRIPTION
**Issue**
Resolves #799

**Approach**

I am not sure if the approach in `all_data_type_keys` is correct here. The return value in the old API for `observation` was a list of strings.

The `observation` in a response contains the data refs necessary for `observations_for_obs_keys`
and including that in the data information makes the data collection later much easier. Otherwise one would need to iterate over all the responses later in order to find the one with the same name.

On the other hand, including the data structure from `response` means leaking information about the HTTP API in structures in the rest of the code and significantly changes the structure of the result this function provides. If this class is the only one going to use any of that information anyway, then it might not matter. If not, we would need to handle different backends other places in the gui, and that is not acceptable in my mind. I have not searched for usage of the data from `all_data_type_keys` yet, so unsure if there are any consequences

Depends on #801