### PR TITLE
Set auto-servernum on xvfb-run jenkins test

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -43,4 +43,7 @@ if [[ ${RELEASE_NAME} =~ py27$  ]]
 then
     export PYTEST_QT_API=pyqt4v2
 fi
-xvfb-run python -m pytest
+# The existence of a running xvfb process will produce
+# a lock file for the default server and kill the run
+# Allow xvfb to find a new server
+xvfb-run --auto-servernum python -m pytest


### PR DESCRIPTION
**Issue**
Issue where xvfb-run will kill itself. `/usr/bin/xvfb-run: line 186: kill: (14231) - No such process`
The problem is slightly hidden and stems from an existing `/tmp/.X99-lock`

**Approach**
Allow xvfb-run to search for an available display other than the default.