### PR TITLE
Expose active observations in API

### DIFF
--- a/ert_shared/storage/storage_api.py
+++ b/ert_shared/storage/storage_api.py
@@ -183,6 +183,9 @@ class StorageApi(object):
                             "key_indexes" :     {
                                 "data_ref" : <key_indexes_ref>
                             }
+                            "active_mask" : {
+                                "data_ref" : <active_mask_ref>
+                            }
                         }
                     }
                 ]
@@ -220,7 +223,8 @@ class StorageApi(object):
             }
             if len(observation_links) > 0:
                 return_schema["observations"] = [
-                    self._obs_to_json(link.observation) for link in observation_links
+                    self._obs_to_json(link.observation, link.active_ref)
+                    for link in observation_links
                 ]
 
         return return_schema
@@ -366,7 +370,7 @@ class StorageApi(object):
             )
         return return_schema
 
-    def _obs_to_json(self, obs):
+    def _obs_to_json(self, obs, active_ref=None):
         data = {
             "name": obs.name,
             "data": {
@@ -376,6 +380,8 @@ class StorageApi(object):
                 "key_indexes": {"data_ref": obs.key_indexes_ref},
             },
         }
+        if active_ref is not None:
+            data["data"]["active_mask"] = {"data_ref": active_ref}
 
         attrs = obs.get_attributes()
         if len(attrs) > 0:

--- a/tests/storage/test_flask.py
+++ b/tests/storage/test_flask.py
@@ -56,6 +56,7 @@ def test_observation(test_client):
     resp = test_client.get("/ensembles/1")
     ens = json.loads(resp.data)
     expected = {
+        ("active_mask", "True,False"),
         ("data_indexes", "2,3"),
         ("key_indexes", "0,3"),
         ("std", "1,3"),

--- a/tests/storage/test_storage_api.py
+++ b/tests/storage/test_storage_api.py
@@ -14,7 +14,7 @@ def test_response(populated_db):
         schema = api.response(1, "response_one", None)
         assert len(schema["realizations"]) == 2
         assert len(schema["observations"]) == 1
-        assert len(schema["observations"][0]["data"]) == 4
+        assert len(schema["observations"][0]["data"]) == 5
         print("############### RESPONSE ###############")
         pprint.pprint(schema)
 


### PR DESCRIPTION
**Issue**
Resolves #779 

With the approach in this PR there will only be a reference to the active mask when you query the response endpoint, and not when you query the observations endpoint. This is because when you query the observation endpoint no ensemble is specified, hence it's not possible to make a connection to a specific active mask.