### PR TITLE
Set ECL_SKIP_SIGNAL in testkomodo.sh

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -9,6 +9,10 @@ GCC_VERSION=7.3.0 CMAKE_VERSION=3.10.2 source ${SDPSOFT}/env.sh
 
 GIT=${SDPSOFT}/bin/git
 
+# Killing ert spawn an eternal loop. Issue occurs when tests segfault.
+# See ert/issues/705, libecl/issues/694 and libecl/pull/700
+export ECL_SKIP_SIGNAL=1
+
 if [[ -z "${sha1// }" ]]; then
     # this is not a PR build, the komodo everest verison is checked out
     EV=$(cat ${RELEASE_PATH}/${RELEASE_NAME} | grep "${PROJECT}:" -A2 | grep "version:")


### PR DESCRIPTION
Python will end up in an eternal loop if a test segfaults.
We set the ECL_SKIP_SIGNAL to prevent that from occuring.
It will of course not fix any test.

