### PR TITLE
Python 2: Use io.open to save ERT config

### DIFF
--- a/ert_gui/tools/ide/configuration_panel.py
+++ b/ert_gui/tools/ide/configuration_panel.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+import six
 
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QToolBar, QMessageBox, QSizePolicy, QFileDialog
@@ -8,6 +9,10 @@ from ert_gui.ertwidgets import SearchBox, resourceIcon
 from ert_gui.ide.highlighter import KeywordHighlighter
 from ert_shared.ide.keywords.definitions.path_argument import PathArgument
 from ert_gui.tools.ide import IdePanel
+
+
+if six.PY2:
+    from io import open
 
 
 class ConfigurationPanel(QWidget):

--- a/ert_gui/tools/ide/ide_panel.py
+++ b/ert_gui/tools/ide/ide_panel.py
@@ -36,7 +36,7 @@ class IdePanel(QPlainTextEdit):
         text_cursor = self.textCursor()
         user_data = text_cursor.block().userData()
 
-        if user_data is not None:
+        if user_data is not None and hasattr(user_data, "configuration_line"):
             configuration_line = user_data.configuration_line
 
             if configuration_line.keyword().hasKeywordDefinition():

--- a/tests/gui/tools/ide/test_configuration_panel.py
+++ b/tests/gui/tools/ide/test_configuration_panel.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import io
+from qtpy.QtWidgets import QAction, QMessageBox
+from ert_gui.tools.ide import ConfigurationPanel
+
+
+UNICODE_TEXT = u"""ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+ᛋᚳᛖᚪᛚ᛫ᚦᛖᚪᚻ᛫ᛗᚪᚾᚾᚪ᛫ᚷᛖᚻᚹᛦᛚᚳ᛫ᛗᛁᚳᛚᚢᚾ᛫ᚻᛦᛏ᛫ᛞᚫᛚᚪᚾ
+ᚷᛁᚠ᛫ᚻᛖ᛫ᚹᛁᛚᛖ᛫ᚠᚩᚱ᛫ᛞᚱᛁᚻᛏᚾᛖ᛫ᛞᚩᛗᛖᛋ᛫ᚻᛚᛇᛏᚪᚾ᛬"""
+
+
+class MockHelpTool(object):
+    def getAction(self):
+        return QAction(None)
+
+
+def test_init(qtbot):
+    """Initialise a ConfigurationPanel"""
+    w = ConfigurationPanel(__file__, MockHelpTool())
+    qtbot.addWidget(w)
+
+    w.close()
+
+
+def test_load_unicode(tmpdir, qtbot):
+    """Attempt to open a config that contains unicode characters."""
+    with tmpdir.as_cwd():
+        with io.open("poly.ert", "w") as f:
+            f.write(UNICODE_TEXT)
+
+        w = ConfigurationPanel("poly.ert", MockHelpTool())
+        qtbot.addWidget(w)
+
+        assert w.ide_panel.getText() == UNICODE_TEXT
+
+
+def test_save_unicode(tmpdir, qtbot, monkeypatch):
+    """Attempt to save config that contains unicode characters. This is an issue
+    that exists in Python 2's implementation of `open`, which supports only
+    ASCII (Latin-1) encoding.
+
+    """
+
+    @staticmethod
+    def information(*args, **kwargs):
+        return QMessageBox.No
+
+    monkeypatch.setattr(QMessageBox, "information", information)
+
+    with tmpdir.as_cwd():
+        with io.open("poly.ert", "w") as f:
+            f.write(u"Hello World\n")
+
+        widget = ConfigurationPanel("poly.ert", MockHelpTool())
+        qtbot.addWidget(widget)
+
+        widget.ide_panel.setPlainText(UNICODE_TEXT)
+        widget.save()
+
+        with io.open("poly.ert") as f:
+            assert f.read() == UNICODE_TEXT


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/6048085/writing-unicode-text-to-a-text-file

As far as I understand, Python 2's `open` will by default try to convert `unicode` (which I verified is what `self.ide_panel.getText()` returns) into Latin-1 or `ascii`. We use `io.open`, which in Python 3 is the same as the builtin `open`.

**Issue**
Resolves #885 