### PR TITLE
Fix Python 3.8 deprecation warnings

### DIFF
--- a/ert_gui/ert_splash.py
+++ b/ert_gui/ert_splash.py
@@ -20,8 +20,8 @@ class ErtSplash(QSplashScreen):
         screen = desktop.screenGeometry(desktop.primaryScreen()).size()
 
         screen_width, screen_height = screen.width(), screen.height()
-        x = screen_width / 2 - splash_width / 2
-        y = screen_height / 2 - splash_height / 2
+        x = screen_width // 2 - splash_width // 2
+        y = screen_height // 2 - splash_height // 2
         self.setGeometry(x, y, splash_width, splash_height)
 
 
@@ -63,7 +63,7 @@ class ErtSplash(QSplashScreen):
             aspect = float(image_width) / float(image_height)
 
         scaled_height = h - 2 * margin
-        scaled_width = scaled_height * aspect
+        scaled_width = round(scaled_height * aspect)
 
         painter.drawRect(margin, margin, scaled_width, scaled_height)
         painter.drawPixmap(margin, margin, scaled_width, scaled_height, self.splash_image)
@@ -80,16 +80,16 @@ class ErtSplash(QSplashScreen):
         font.setStyleHint(QFont.Serif)
         font.setPixelSize(text_size)
         painter.setFont(font)
-        painter.drawText(text_x, margin + top_offset, text_area_width, text_size, Qt.AlignHCenter | Qt.AlignCenter, self.ert)
+        painter.drawText(text_x, margin + top_offset, text_area_width, text_size, int(Qt.AlignHCenter | Qt.AlignCenter), self.ert)
 
         top_offset += text_size + 2 * margin
         text_size = 25
         font.setPixelSize(text_size)
         painter.setFont(font)
-        painter.drawText(text_x, top_offset, text_area_width, text_size, Qt.AlignHCenter | Qt.AlignCenter, self.ert_title)
+        painter.drawText(text_x, top_offset, text_area_width, text_size, int(Qt.AlignHCenter | Qt.AlignCenter), self.ert_title)
 
         top_offset += text_size + 4 * margin
         text_size = 20
         font.setPixelSize(text_size)
         painter.setFont(font)
-        painter.drawText(text_x, top_offset, text_area_width, text_size, Qt.AlignHCenter | Qt.AlignCenter, self.version)
+        painter.drawText(text_x, top_offset, text_area_width, text_size, int(Qt.AlignHCenter | Qt.AlignCenter), self.version)

--- a/ert_gui/simulation/detailed_progress.py
+++ b/ert_gui/simulation/detailed_progress.py
@@ -84,8 +84,8 @@ class DetailedProgress(QFrame):
         self.grid_height = math.ceil(math.sqrt(nr_realizations / aspect_ratio))
         self.grid_width = math.ceil(self.grid_height * aspect_ratio)
         sub_grid_size = math.ceil(math.sqrt(fm_size))
-        cell_height = height / self.grid_height
-        cell_width = width / self.grid_width
+        cell_height = height // self.grid_height
+        cell_width = width // self.grid_width
 
         foreground_image = QImage(self.grid_width * sub_grid_size, self.grid_height * sub_grid_size,
                                   QImage.Format_ARGB32)
@@ -103,7 +103,7 @@ class DetailedProgress(QFrame):
 
             painter.setPen(QColor(80, 80, 80))
             painter.drawText(x * cell_width, y * cell_height, cell_width, cell_height,
-                             Qt.AlignHCenter | Qt.AlignVCenter, str(iens))
+                             int(Qt.AlignHCenter | Qt.AlignVCenter), str(iens))
 
             if iens == self.selected_realization:
                 pen = QPen(QColor(240, 240, 240))
@@ -117,8 +117,8 @@ class DetailedProgress(QFrame):
             thickness = 4
             pen.setWidth(thickness)
             painter.setPen(pen)
-            painter.drawRect((x * cell_width) + (thickness / 2),
-                             (y * cell_height) + (thickness / 2),
+            painter.drawRect((x * cell_width) + (thickness // 2),
+                             (y * cell_height) + (thickness // 2),
                              cell_width - (thickness - 1),
                              cell_height - (thickness - 1))
 
@@ -177,7 +177,7 @@ class SingleProgressModel(QAbstractTableModel):
 
         if role == Qt.BackgroundColorRole:
             color = QColor(*self.state_colors[status])
-            color.setAlpha(color.alpha() / 2)
+            color.setAlpha(round(color.alpha() / 2))
             if col == 'stdout' or col == 'stderr':
                 color = QColor(100,100,100,100) # make items stand out
             return color


### PR DESCRIPTION
> Implicit conversion to integers using \_\_int\_\_ is deprecated, and may be removed in a future version of Python.

This PR fixes this with a combination of integer division where that is applicable and explicit integer conversion for Qt Enums