### PR TITLE
Do not run test_gui_load on jenkins

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -52,4 +52,4 @@ fi
 # The existence of a running xvfb process will produce
 # a lock file for the default server and kill the run
 # Allow xvfb to find a new server
-xvfb-run --auto-servernum python -m pytest
+ xvfb-run --auto-servernum python -m pytest -k "not test_gui_load"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 black ; python_version >= '3.6'
-pytest
+pytest<6
 pytest-qt
 mock ; python_version >= '3'
 mock<4; python_version < '3'


### PR DESCRIPTION
The test_gui_load test is flaky and results in segfaults.
See: #893

