### PR TITLE
GUI: Warn user for invalid target run analysis

### DIFF
--- a/ert_gui/tools/run_analysis/run_analysis_tool.py
+++ b/ert_gui/tools/run_analysis/run_analysis_tool.py
@@ -56,6 +56,10 @@ class RunAnalysisTool(Tool):
         target = self._run_widget.target_case()
         source = self._run_widget.source_case()
 
+        if len(target) == 0:
+            self._report_empty_target()
+            return
+
         success = analyse(target, source)
 
         msg = QMessageBox()
@@ -74,3 +78,11 @@ class RunAnalysisTool(Tool):
 
         ert_shared.ERT.ertChanged.emit()
         self._dialog.accept()
+
+    def _report_empty_target(self):
+        msg = QMessageBox()
+        msg.setWindowTitle("Invalid Target")
+        msg.setIcon(QMessageBox.Warning)
+        msg.setText("Target case can not be empty")
+        msg.setStandardButtons(QMessageBox.Ok)
+        msg.exec_()


### PR DESCRIPTION
**Issue**
Resolves #832 


**Approach**
Apparently  `fs_manager.getFileSystem` will provide `storage` as the name if the string is empty. I think the best approach here is to just validate that the target is not empty, as soon as possible.