### PR TITLE
Ensure py2 QString conversion through py3 str

### DIFF
--- a/ert_gui/tools/ide/configuration_panel.py
+++ b/ert_gui/tools/ide/configuration_panel.py
@@ -1,3 +1,4 @@
+from builtins import str
 import re
 import shutil
 import six
@@ -89,7 +90,7 @@ class ConfigurationPanel(QWidget):
         shutil.copyfile(self.config_file, backup_path)
 
         with open(self.config_file, "w") as f:
-            f.write(self.ide_panel.getText())
+            f.write(str(self.ide_panel.getText()))
 
         message = "To make your changes current, a reload of the configuration file is required. Would you like to reload now?"
         result = QMessageBox.information(self, "Reload required!", message, QMessageBox.Yes | QMessageBox.No)


### PR DESCRIPTION
**Issue**
Resolves test failure seen in e.g. https://ci.equinor.com/komodo/job/komodo-test-ert/539/console but also locally with py2+qt4

**Approach**
It seems implicit conversion between `QString` and `unicode` failed for Python2 on RH. Not sure why. It is resolved by importing a smarter `str`.
