### PR TITLE
Add missing qt5 QPA deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,16 @@ addons:
       - clang
       - cmake
       - cmake-data
+      - libxcb-image0
+      - libxcb-icccm4
+      - libxcb-keysyms1
+      - libxcb-randr0
+      - libxcb-render0
+      - libxcb-render-util0
+      - libxcb-shape0
+      - libxcb-shm0
+      - libxcb-xfixes0
+      - libxcb-xinerama0
 
 before_install:
     - if [[ $PYTHON_VERSION == 2.7 ]]; then


### PR DESCRIPTION
**Issue**
Resolves CI failures for ERT on travis


**Approach**
Added missing debians containing the qpa plugin deps
