### PR TITLE
Remove appending of job index for stdout and stderr files

### DIFF
--- a/ert_gui/simulation/detailed_progress.py
+++ b/ert_gui/simulation/detailed_progress.py
@@ -153,7 +153,7 @@ class SingleProgressModel(QAbstractTableModel):
     def get_file_name(self, index):
         col = self.get_column_name(index.column())
         if col == 'stdout' or col == 'stderr':
-            return self.model_data[index.row()][index.column()] + "." + str(index.row())
+            return self.model_data[index.row()][index.column()]
         return ''
 
     @staticmethod


### PR DESCRIPTION
Due to [this change](https://github.com/equinor/libres/commit/f4551b3696d1d265cd74bf4d369deccf2006a4b4) in libres the stdout and stderr files could not be loaded from the GUI. 