### PR TITLE
Add source package to workflow docs

### DIFF
--- a/ert_shared/plugins/plugin_manager.py
+++ b/ert_shared/plugins/plugin_manager.py
@@ -244,6 +244,7 @@ class ErtPluginManager(pluggy.PluginManager):
                 "examples": workflow.examples,
                 "config_file": workflow.config_path,
                 "parser": workflow.parser,
+                "source_package": workflow.source_package,
             }
             for workflow in workflow_config._workflows
         }

--- a/ert_shared/plugins/workflow_config.py
+++ b/ert_shared/plugins/workflow_config.py
@@ -54,6 +54,7 @@ class WorkflowConfig(object):
         self.func = ertscript_class
         self.name = self._get_func_name(ertscript_class, name)
         self.function_dir = os.path.abspath(inspect.getfile(ertscript_class))
+        self.source_package = self._get_source_package(self.func)
         self.config_path = self._write_workflow_config(tmpdir)
         self._description = ertscript_class.__doc__ if ertscript_class.__doc__ else ""
         self._examples = None
@@ -102,3 +103,8 @@ class WorkflowConfig(object):
             f_out.write("INTERNAL      True\n")
             f_out.write("SCRIPT        {}".format(self.function_dir))
         return file_path
+
+    @staticmethod
+    def _get_source_package(module):
+        base, _, _ = module.__module__.partition(".")
+        return base


### PR DESCRIPTION
At the moment, the source package for the workflow jobs only show as missing. This extracts the source package from the module and adds that to the documentation.