### PR TITLE
Log ert_shared.storage messages to stderr

### DIFF
--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -5,9 +5,9 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: WARNING
+    level: INFO
     formatter: simple
-    stream: ext://sys.stdout
+    stream: ext://sys.stderr
   file:
     class: logging.FileHandler
     level: DEBUG
@@ -21,7 +21,7 @@ handlers:
 loggers:
   ert_shared.storage:
     level: DEBUG
-    handlers: [apifile]
+    handlers: [console, apifile]
     propagate: no
 root:
   level: DEBUG


### PR DESCRIPTION
Resolves: #1011 

The WARNING loglevel is more restrictive than INFO, as such Werkzeug's
INFO message about the server's URL did get printed.