### PR TITLE
Move and update installed workflow doc

### DIFF
--- a/docs/rst/manual/reference/index.rst
+++ b/docs/rst/manual/reference/index.rst
@@ -6,6 +6,5 @@
    configuration/index
    forward_models
    workflows/index
-   workflow_jobs
    queue
    configuration_file

--- a/docs/rst/manual/reference/workflow_jobs.rst
+++ b/docs/rst/manual/reference/workflow_jobs.rst
@@ -1,4 +1,0 @@
-
-.. ert_workflow_jobs::
-
-    These are the workflows installed in your ERT environment.

--- a/docs/rst/manual/reference/workflows/added_workflow_jobs.rst
+++ b/docs/rst/manual/reference/workflows/added_workflow_jobs.rst
@@ -1,0 +1,7 @@
+
+.. ert_workflow_jobs::
+
+    These are the workflow jobs installed in your ERT environment.
+    To use them in the configuration file they must be included in a
+    workflow and loaded in the configuration file as shown in
+    :ref:`Configure Workflows <complete_workflows_chapter>`

--- a/docs/rst/manual/reference/workflows/complete_workflows.rst
+++ b/docs/rst/manual/reference/workflows/complete_workflows.rst
@@ -1,3 +1,5 @@
+.. _complete_workflows_chapter:
+
 Complete Workflows
 ==================
 

--- a/docs/rst/manual/reference/workflows/index.rst
+++ b/docs/rst/manual/reference/workflows/index.rst
@@ -32,3 +32,4 @@ can be of two fundamentally different types - *external* and *internal*.
    configuring_jobs
    complete_workflows
    built_in
+   added_workflow_jobs


### PR DESCRIPTION
While working on a workflow issue, I thought that it would be nice just to add what is necessary to run the workflows (it wasn't as clear as I would like it to be). I might add an example (unless it's covered in the other chapter) perhaps demonstrating how arguments can be passed along (which very often is the part that is documented in the workflow_jobs description)