### PR TITLE
Add pre_first_update hook

### DIFF
--- a/docs/rst/manual/reference/configuration/keywords.rst
+++ b/docs/rst/manual/reference/configuration/keywords.rst
@@ -2163,8 +2163,11 @@ Keywords related to plotting
     points in ERTs flow of execution where you can hook in a workflow,
     before the simulations start, :code:`PRE_SIMULATION`; after all
     the simulations have completed, :code:`POST_SIMULATION`; before the
-    update step, :code:`PRE_UPDATE` and after the update step,
-    :code:`POST_UPDATE`.  The :code:`POST_SIMULATION` hook is
+    update step, :code:`PRE_UPDATE`; :code:`POST_UPDATE`; after the update
+    step and :code:`PRE_FIRST_UPDATE` only before the first update.
+    :code:`PRE_FIRST_UPDATE` will run before :code:`PRE_UPDATE`.
+    For non iterative algorithms, :code:`PRE_FIRST_UPDATE` is equal to
+    :code:`PRE_UPDATE`. The :code:`POST_SIMULATION` hook is
     typically used to trigger QC workflows:
 
     ::

--- a/ert_shared/models/ensemble_smoother.py
+++ b/ert_shared/models/ensemble_smoother.py
@@ -40,7 +40,7 @@ class EnsembleSmoother(BaseRunModel):
         EnkfSimulationRunner.runWorkflows(HookRuntime.POST_SIMULATION, ert=ERT.ert )
 
         self.setPhaseName("Analyzing...")
-
+        EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_FIRST_UPDATE, ert=ERT.ert)
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_UPDATE, ert=ERT.ert )
         es_update = self.ert().getESUpdate( )
         success = es_update.smootherUpdate( prior_context )

--- a/ert_shared/models/iterated_ensemble_smoother.py
+++ b/ert_shared/models/iterated_ensemble_smoother.py
@@ -79,7 +79,11 @@ class IteratedEnsembleSmoother(BaseRunModel):
         previous_ensemble_name = None
         while current_iter < ERT.enkf_facade.get_number_of_iterations() and num_retries < num_retries_per_iteration:
             pre_analysis_iter_num = analysis_module.getInt("ITER")
-            self.analyzeStep( run_context )
+            # We run the PRE_FIRST_UPDATE hook here because the current_iter is explicitly available, versus
+            # in the run_context inside analyzeStep
+            if current_iter == 0:
+                EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_FIRST_UPDATE, ert=ERT.ert)
+            self.analyzeStep(run_context)
             current_iter = analysis_module.getInt("ITER")
 
             analysis_success = current_iter > pre_analysis_iter_num

--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -65,7 +65,8 @@ class MultipleDataAssimilation(BaseRunModel):
             is_first_iteration = iteration == 0
             run_context = self.create_context( arguments , iteration,  initialize_mask_from_arguments=is_first_iteration)
             self._simulateAndPostProcess(run_context, arguments)
-
+            if is_first_iteration:
+                EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_FIRST_UPDATE, ert=ERT.ert)
             EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_UPDATE, ert=ERT.ert)
             self.update(run_context , weight)
             EnkfSimulationRunner.runWorkflows(HookRuntime.POST_UPDATE, ert=ERT.ert)

--- a/tests/cli/test_model_hook_order.py
+++ b/tests/cli/test_model_hook_order.py
@@ -1,0 +1,124 @@
+from ert_shared.models import (
+    EnsembleSmoother,
+    MultipleDataAssimilation,
+    IteratedEnsembleSmoother,
+)
+import inspect
+
+from unittest.mock import MagicMock, call
+from res.enkf.enums import HookRuntime
+
+EXPECTED_CALL_ORDER = [
+    HookRuntime.PRE_SIMULATION,
+    HookRuntime.POST_SIMULATION,
+    HookRuntime.PRE_FIRST_UPDATE,
+    HookRuntime.PRE_UPDATE,
+    HookRuntime.POST_UPDATE,
+    HookRuntime.PRE_SIMULATION,
+    HookRuntime.POST_SIMULATION,
+]
+
+
+def test_hook_call_order_ensemble_smoother(monkeypatch):
+    """
+    The goal of this test is to assert that the hook call order is the same
+    across different models.
+    """
+    test_class = EnsembleSmoother
+    mock_parent = MagicMock()
+    mock_sim_runner = MagicMock()
+    mock_parent.runWorkflows = mock_sim_runner
+    ERT_mock = MagicMock()
+    test_module = inspect.getmodule(test_class)
+    monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
+    monkeypatch.setattr(test_module, "ERT", ERT_mock)
+    test_class.runSimulations(MagicMock(), ERT_mock)
+
+    expected_calls = [
+        call(expected_call, ert=ERT_mock.ert) for expected_call in EXPECTED_CALL_ORDER
+    ]
+    assert mock_sim_runner.mock_calls == expected_calls
+
+
+def test_hook_call_order_es_mda(monkeypatch):
+    """
+    The goal of this test is to assert that the hook call order is the same
+    across different models.
+    """
+    test_class = MultipleDataAssimilation
+    minimum_args = {
+        "start_iteration": 0,
+        "weights": [1],
+        "analysis_module": "some_module",
+    }
+    mock_sim_runner = MagicMock()
+    mock_parent = MagicMock()
+    mock_parent.runWorkflows = mock_sim_runner
+    ERT_mock = MagicMock()
+
+    test_module = inspect.getmodule(test_class)
+    monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
+    monkeypatch.setattr(test_module, "ERT", ERT_mock)
+
+    test_class = test_class()
+    test_class.create_context = MagicMock()
+    test_class.checkMinimumActiveRealizations = MagicMock()
+    test_class.parseWeights = MagicMock(return_value=[1])
+    test_class.setAnalysisModule = MagicMock()
+    test_class.ert = MagicMock()
+
+    sim_runner_mock = MagicMock()
+    sim_runner_mock.runSimpleStep.return_value = 1
+    test_class.ert.return_value.getEnkfSimulationRunner = sim_runner_mock
+
+    test_class.runSimulations(minimum_args)
+
+    expected_calls = [
+        call(expected_call, ert=ERT_mock.ert) for expected_call in EXPECTED_CALL_ORDER
+    ]
+    assert mock_sim_runner.mock_calls == expected_calls
+
+
+def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
+    """
+    The goal of this test is to assert that the hook call order is the same
+    across different models.
+    """
+    test_class = IteratedEnsembleSmoother
+    minimum_args = MagicMock()
+    mock_sim_runner = MagicMock()
+    mock_parent = MagicMock()
+    mock_parent.runWorkflows = mock_sim_runner
+
+    ERT_mock = MagicMock()
+    ERT_mock.enkf_facade.get_number_of_iterations.return_value = 1
+
+    test_module = inspect.getmodule(test_class)
+    monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
+    monkeypatch.setattr(test_module, "ERT", ERT_mock)
+
+    test_class = test_class()
+    test_class.create_context = MagicMock()
+    test_class.checkMinimumActiveRealizations = MagicMock()
+    test_class.parseWeights = MagicMock(return_value=[1])
+    test_class.setAnalysisModule = MagicMock()
+    test_class.ert = MagicMock()
+
+    analysis_config = MagicMock()
+    analysis_config.getAnalysisIterConfig.return_value.getNumRetries.return_value = 1
+    test_class.ert.return_value.analysisConfig.return_value = analysis_config
+
+    simple_step_mock = MagicMock()
+    simple_step_mock.runSimpleStep.return_value = 1
+    test_class.ert.return_value.getEnkfSimulationRunner.return_value = simple_step_mock
+
+    test_class.setAnalysisModule = MagicMock()
+    test_class.setAnalysisModule.return_value.getInt.return_value = 1
+    test_class.setPhase = MagicMock()
+
+    test_class.runSimulations(minimum_args)
+
+    expected_calls = [
+        call(expected_call, ert=ERT_mock.ert) for expected_call in EXPECTED_CALL_ORDER
+    ]
+    assert mock_sim_runner.mock_calls == expected_calls


### PR DESCRIPTION
This will add the PRE_FIRST_UPDATE hook which will run before the first
analysis is performed. This is only relevant for iterative algorithms,
for non iterative algorithms this hook equals the PRE_ANALYSIS hook.

Blocked by: https://github.com/equinor/libres/pull/1023

Closes: https://github.com/equinor/semeio/issues/58