### PR TITLE
Move creation of loop into JM

### DIFF
--- a/ert_shared/ensemble_evaluator/queue_adaptor.py
+++ b/ert_shared/ensemble_evaluator/queue_adaptor.py
@@ -19,6 +19,7 @@ class JobQueueManagerAdaptor(JobQueueManager):
 
     def __init__(self, queue, queue_evaluators=None):
         super().__init__(queue, queue_evaluators)
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self._ws_url = self.ws_url
         self._changes_queue = asyncio.Queue()
         wait_for_ws(self._ws_url)

--- a/tests/ensemble_evaluator/test_queue_adaptor_integration.py
+++ b/tests/ensemble_evaluator/test_queue_adaptor_integration.py
@@ -25,7 +25,6 @@ async def mock_ws(host, port):
 
 
 def mock_queue_mutator(host, port):
-    asyncio.set_event_loop(asyncio.new_event_loop())
     mock_queue = Mock(
         job_list=[Mock(status=Mock(value=4), callback_arguments=[Mock(iens=0)])]
     )


### PR DESCRIPTION
I'm not actually sure why this ever worked in my local testing. The event loop is local to the JM, and the JM is put on a thread, which doesn't have one initially…