### PR TITLE
Fix wrongly spelled parameter name in rdb_api get_response_data

### DIFF
--- a/ert_shared/storage/rdb_api.py
+++ b/ert_shared/storage/rdb_api.py
@@ -91,7 +91,7 @@ class RdbApi:
     def get_response_data(self, name, ensemble_name):
         """Load lightweight "bundle" objects using the ORM."""
 
-        bundle = Bundle("response", Response.id, Response.values, Realization.index)
+        bundle = Bundle("response", Response.id, Response.values_ref, Realization.index)
         ensemble = self.get_ensemble(ensemble_name)
         response_definition = self._get_response_definition(
             name=name, ensemble_id=ensemble.id

--- a/tests/storage/test_rdb_api.py
+++ b/tests/storage/test_rdb_api.py
@@ -340,6 +340,18 @@ def test_add_prior(db_connection):
         assert prior.id is not None
 
 
+def test_get_response_data(db_info):
+    populated_db, _ = db_info
+    rdb_connection = connections.get_rdb_connection(populated_db)
+    with RdbApi(connection=rdb_connection) as rdb_api:
+        responses = rdb_api.get_response_data(
+            name="response_one", ensemble_name="ensemble_name"
+        )
+        ids = [resp.values_ref for resp in responses]
+        assert ids is not None
+        assert ids == [18, 23]
+
+
 def test_get_response_bundle(db_info):
     populated_db, db_lookup = db_info
     rdb_connection = connections.get_rdb_connection(populated_db)


### PR DESCRIPTION
Found an error / wrongly spelled param in a function. Fixed and created test for it. 