### PR TITLE
Add pipeline for deploying to PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,64 +1,83 @@
 name: Python package
 
-on: [pull_request]
+on: [push, pull_request]
 
 env:
-  INSTALL_DIR: ${{ github.workspace }}/install
   ERT_SHOW_BACKTRACE: 1
 
 jobs:
   build:
-
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest]
-        include:
-        - python-version: 3.6
-          os: macos-latest
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install Ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install liblapack-dev valgrind clang cmake cmake-data xvfb libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3
-    - name: Setup environment
-      run: |
-        echo "${{ env.INSTALL_DIR}}/bin" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64" >> $GITHUB_ENV
-        echo "DYLD_LIBRARY_PATH=${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64" >> $GITHUB_ENV
-        echo "PYTHONPATH=${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/site-packages:${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/dist-packages" >> $GITHUB_ENV
+        sudo apt-get install xvfb libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3
+
     - name: Install ERT and dependencies
       run: |
-        source .libres_version
-        git clone --branch $LIBRES_VERSION --depth 1 https://github.com/equinor/libres
-        pushd libres
-        source .libecl_version
-        popd
-        git clone --branch $LIBECL_VERSION --depth 1 https://github.com/equinor/libecl
-        bash .build_install.sh libecl
-        bash .build_install.sh libres
         pip install -r dev-requirements.txt
         pip install .
-        pip list
+
     - name: Test Ubuntu
       if: matrix.os == 'ubuntu-latest'
       run: |
-        xvfb-run  -s "-screen 0 640x480x24" --auto-servernum python -m pytest -sv tests
+        xvfb-run  -s "-screen 0 640x480x24" --auto-servernum python -m pytest -sv
+
     - name: Test MacOS
       if: matrix.os == 'macos-latest'
       run: |
-        python -m pytest -sv tests
+        python -m pytest -sv
+
     - name: Test docs and CLI
       run: |
         sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
         pip uninstall -y PyQt5
         ert --help
+
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    # If this is a tagged release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Build wheel
+      run: |
+        pip install --upgrade pip wheel setuptools
+        pip wheel . --no-deps -w dist
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        user: statoil-travis
+        password: ${{ secrets.pypi_password }}

--- a/.libres_version
+++ b/.libres_version
@@ -1,1 +1,0 @@
-export LIBRES_VERSION=7.0.0b3

--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@ reservoir models. ERT was originally devised as tool to do model updating
 updating is the Ensemble Smoother (ES).
 
 
+``` sh
+$ pip install ert
+$ ert --help
+```
+
+or, for the latest development version:
+
+``` sh
+$ pip install git+https://github.com/equinor/ert.git@master
+$ ert --help
+```
+
+
 The `ert` program is based on three different repositories:
 
-1. [libecl](https://github.com/Equinor/libecl) which contains utilities to read and write Eclipse files.
+1. [ecl](https://github.com/Equinor/ecl) which contains utilities to read and write Eclipse files.
 
 2. [libres](https://github.com/Equinor/libres) utilities to manage reservoir data, and algorithms do actually do model updating.
 
@@ -17,42 +30,23 @@ The `ert` program is based on three different repositories:
 
 ERT is now Python 3 only. The last Python 2 compatible release is [2.14](https://github.com/equinor/ert/tree/version-2.14)
 
-##  Building ert
+## Developing
 
-#### 1. Build and install [libecl](https://github.com/Equinor/libecl) and [libres](https://github.com/Equinor/libres). 
-When configuring `libecl` and
-`libres` you should used the option `-DCMAKE_INSTALL_PREFIX` to tell ``cmake``
-where to install. The value passed to `CMAKE_INSTALL_PREFIX` will be needed when
-running pip install in point 4, below. For now let us assume that the prefix
-`/local/ert/install` was used.
+ERT is pure Python software. To start developing, install it in editable mode:
 
-
-#### 2. Update environment variables 
-To ensure that the build system correctly finds the `ecl` Python package you
-need to set the environment variables `PYTHONPATH` and `LD_LIBRARY_PATH` to
-include the `libecl` installation:
-  
 ```
-bash% export LD_LIBRARY_PATH=/local/ert/install/lib64:$LD_LIBRARY_PATH
-bash% export PYTHONPATH=/local/ert/install/lib/python2.7/site-packages:$PYTHONPATH
+$ git clone https://github.com/equinor/ert
+$ cd ert
+$ pip install -e .
 ```
 
-Observe that path components `lib64` and `lib/python*.*/site-packages` will
-depend on your Python version and which Linux distribution you are using. The
-example given here is for RedHat based distributions.
-
-
-#### 3. Pip install Ert
- 
+Additional development packages must be installed to run the test suite:
 ```
-pip install . --prefix=/local/ert/install
+$ pip install -r dev-requirements.txt
+$ pytest tests/
 ```
 
-When this process if over you will have a binary executable `ert` installed in
-`/local/ert/install/bin/ert`. 
-
-
-#### 4. Try your new `ert` installation
+## Example usage
 
 To actually get ert to work at your site you need to configure details about
 your system; at the very least this means you must configure where your

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -24,7 +24,7 @@ project = u'ERT'
 copyright = u'Equinor'
 author = u'Joakim Hove'
 
-dist_version = get_distribution('ensemble-reservoir-tool').version
+dist_version = get_distribution('ert').version
 
 # The short X.Y version
 version = u'.'.join(dist_version.split('.')[:2])

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ extra_files = package_files("ert_gui/resources/")
 logging_configuration = package_files("ert_logging/")
 
 setup(
-    name="Ensemble Reservoir Tool",
+    name="ert",
+    author="Equinor ASA",
+    author_email="fg_sib-scout@equinor.com",
     use_scm_version={"root": ".", "write_to": "ert_shared/version.py"},
     scripts=["ert_shared/bin/ert"],
     packages=find_packages(exclude=["tests*"]),
@@ -25,6 +27,7 @@ setup(
     license="Open Source",
     long_description=open("README.md").read(),
     install_requires=[
+        "equinor-libres",
         "ansicolors==1.1.8",
         "console-progressbar==1.1.2",
         "decorator",

--- a/tests/storage/test_server_monitor.py
+++ b/tests/storage/test_server_monitor.py
@@ -32,7 +32,7 @@ def server(request, monkeypatch, tmp_path: Path):
     path.write_text(script)
     path.chmod(0o755)
     monkeypatch.setattr(ServerMonitor, "EXEC_ARGS", [str(path)])
-    monkeypatch.setattr(ServerMonitor, "TIMEOUT", 1)
+    monkeypatch.setattr(ServerMonitor, "TIMEOUT", 5)
 
     proc = ServerMonitor()
     proc.start()


### PR DESCRIPTION
**Issue**
Resolves #687 

**Approach**
Uses `equinor-libres` from PyPI.

It's possible to test the wheel using a test run where I uploaded the wheel as a artifact rather than to pypi. Download and extract `Python wheel.zip`, then do `pip install ./ert-*.whl`. ERT should be working (in theory).

https://github.com/equinor/ert/actions/runs/345376584