### PR TITLE
Register storage server system-wide

### DIFF
--- a/ert_shared/storage/connection.py
+++ b/ert_shared/storage/connection.py
@@ -1,0 +1,60 @@
+import os
+import json
+import requests
+import getpass
+from typing import Dict, Union
+from pathlib import Path
+
+
+def _json_path(project_path: Union[str, Path] = None) -> Path:
+    """Return a path to `storage_server.json`. If `project_path` is None, look for
+    any storage server running on the machine.
+
+    """
+
+    if project_path is None:
+        if "XDG_RUNTIME_DIR" in os.environ:
+            project_path = Path(os.environ["XDG_RUNTIME_DIR"]) / "ert"
+            project_path.mkdir(exist_ok=True)
+        else:
+            project_path = Path(f"/tmp/ert-{getpass.getuser()}")
+            project_path.mkdir(mode=0o700, exist_ok=True)
+
+    project_path = Path(project_path)
+    return project_path / "storage_server.json"
+
+
+def get_info(project_path: Union[str, Path] = None) -> Dict[str, str]:
+    """Return a dictionary containing `auth`, a tuple of (username, password) and
+    `baseurl`, the URL that the server responds to. If `project_path` is None,
+    look for any storage_server running on the machine.
+
+    """
+
+    path = _json_path(project_path)
+    if not path.is_file():
+        raise RuntimeError(f"{path} is not a file")
+
+    with path.open() as f:
+        info = json.load(f)
+
+    auth = ("__token__", info["authtoken"])
+    for baseurl in info["urls"]:
+        try:
+            resp = requests.get(f"{baseurl}/healthcheck", auth=auth)
+            if resp.status_code == 200:
+                break
+        except requests.ConnectionError:
+            pass
+    else:
+        raise RuntimeError(f"None of the URLs provided by {path} are valid")
+
+    return {"baseurl": baseurl, "auth": auth}
+
+
+def set_global_info(project_path: Union[str, Path]):
+    """Set `project_path` to be this user's default system-wide ERT project"""
+    path = _json_path()
+    if path.is_symlink():
+        path.unlink()
+    path.symlink_to(_json_path(project_path))

--- a/ert_shared/storage/http_server.py
+++ b/ert_shared/storage/http_server.py
@@ -13,6 +13,7 @@ from flask import Response, request, abort, jsonify
 from gunicorn.app.base import BaseApplication
 from subprocess import Popen, PIPE
 from ert_shared import ERT_STORAGE
+from ert_shared.storage import connection
 from ert_shared.storage.rdb_api import RdbApi
 from ert_shared.storage.blob_api import BlobApi
 from contextlib import contextmanager
@@ -72,10 +73,8 @@ class FlaskWrapper:
 
             @app.before_request
             def check_auth():
-                print(request.environ)
                 if request.authorization is None:
                     abort(401)
-                print(request.authorization, self.authtoken)
                 un = request.authorization["username"]
                 pw = request.authorization["password"]
                 if un != "__token__" or pw != self.authtoken:
@@ -339,6 +338,7 @@ class Application(BaseApplication):
 
         if self.lockfile:
             self.lockfile.write_text(connection_info)
+            connection.set_global_info(os.getcwd())
 
         fd = os.environ.get("ERT_COMM_FD")
         if fd is not None:


### PR DESCRIPTION
Create a directory `/run/user/{UID}/ert` on Linux and `/tmp/ert-{Username}` everywhere else. This directory will contain a symlink to `storage_server.json` of the last started storage server.
