### PR TITLE
Set setup.py long_description type to markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     include_package_data=True,
     license="Open Source",
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     install_requires=[
         "equinor-libres",
         "ansicolors==1.1.8",


### PR DESCRIPTION
PyPI requires that long_description is renderable on their website and defaults to reStructuredText if no type is given.