### PR TITLE
Reduce ee complexity

### DIFF
--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -2,6 +2,8 @@ version: 1
 formatters:
   simple:
     format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+  simple_with_threading:
+    format: '%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s'
 handlers:
   console:
     class: logging.StreamHandler
@@ -21,7 +23,7 @@ handlers:
   eefile:
     class: logging.FileHandler
     level: DEBUG
-    formatter: simple
+    formatter: simple_with_threading
     filename: ee-log.txt
 loggers:
   ert_shared.storage:
@@ -30,6 +32,10 @@ loggers:
     propagate: no
   ert_shared.ensemble_evaluator:
     level: DEBUG
+    handlers: [eefile]
+    propagate: no
+  websockets.server:
+    level: ERROR
     handlers: [eefile]
     propagate: no
 root:

--- a/ert_shared/ensemble_evaluator/monitor.py
+++ b/ert_shared/ensemble_evaluator/monitor.py
@@ -23,6 +23,9 @@ class _Monitor:
         self._receive_future = None
         self._event_index = 1
 
+    def get_base_uri(self):
+        return self._base_uri
+
     def event_index(self):
         index = self._event_index
         self._event_index += 1

--- a/ert_shared/ensemble_evaluator/nfs_adaptor.py
+++ b/ert_shared/ensemble_evaluator/nfs_adaptor.py
@@ -1,22 +1,32 @@
-import asyncio
-import os.path
 import aiofiles
+import asyncio
+import logging
+import os.path
 import websockets
+
 from ert_shared.ensemble_evaluator.entity.identifiers import (
     EVTYPE_FM_STEP_FAILURE,
     EVTYPE_FM_STEP_SUCCESS,
 )
 from ert_shared.ensemble_evaluator.ws_util import wait
 
+logger = logging.getLogger(__name__)
 
-async def _wait_for_filepath(filepath):
-    while not os.path.isfile(filepath):
-        await asyncio.sleep(0.5)
+
+async def _wait_for_filepath(filepath, attempts_between_report=4):
+    attempts = 0
+    while True:
+        if os.path.isfile(filepath):
+            return
+        await asyncio.sleep(2)
+        if attempts != 0 and attempts % attempts_between_report == 0:
+            logger.info(f"Could not find {filepath} after {attempts} attempts")
+        attempts += 1
 
 
 async def nfs_adaptor(log_file, ws_url):
-    await _wait_for_filepath(log_file)
     await wait(ws_url, 25)
+    await _wait_for_filepath(log_file)
     async with websockets.connect(ws_url) as websocket:
         async with aiofiles.open(str(log_file), "r") as f:
             line = None

--- a/ert_shared/ensemble_evaluator/ws_util.py
+++ b/ert_shared/ensemble_evaluator/ws_util.py
@@ -22,4 +22,4 @@ async def wait(url, max_retries):
             logger.info(f"{__name__} failed to connect ({retries}/{max_retries}: {e}")
             await asyncio.sleep(0.2 + 5 * retries)
             retries += 1
-    raise ConnectionRefusedError(f"could not connect to {url} after {retries}")
+    raise ConnectionRefusedError(f"Could not connect to {url} after {retries} retries")

--- a/ert_shared/tracker/evaluator.py
+++ b/ert_shared/tracker/evaluator.py
@@ -1,3 +1,5 @@
+from asyncio.tasks import wait_for
+from ert_shared.ensemble_evaluator.ws_util import wait_for_ws
 import logging
 from queue import Empty
 import threading
@@ -70,6 +72,7 @@ class EvaluatorTracker:
                                 time.sleep(5)
                                 drainer_logger.debug("connecting to new monitor...")
                                 monitor = create_ee_monitor(host, port)
+                                wait_for_ws(monitor.get_base_uri(), max_retries=2)
                                 drainer_logger.debug("connected")
                                 break
                             except ConnectionRefusedError as e:

--- a/tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -126,7 +126,6 @@ def send_dispatch_event(client, event_type, source, event_id, data):
 
 def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
     asyncio.set_event_loop(asyncio.new_event_loop())
-    asyncio.get_event_loop()
     monitor = evaluator.run()
     events = monitor.track()
 

--- a/tests/ensemble_evaluator/test_nfs_adoptor_integration.py
+++ b/tests/ensemble_evaluator/test_nfs_adoptor_integration.py
@@ -48,10 +48,9 @@ async def test_append_to_file(tmpdir, unused_tcp_port, event_loop):
     host = "localhost"
     port = unused_tcp_port
     log_file = Path(tmpdir) / "log"
-    loop = asyncio.get_event_loop()
-    adaptor_task = loop.create_task(nfs_adaptor(log_file, f"ws://{host}:{port}"))
-    mock_ws_task = loop.create_task(mock_ws(host, port))
-    mock_writer_task = loop.create_task(mock_writer(log_file))
+    adaptor_task = event_loop.create_task(nfs_adaptor(log_file, f"ws://{host}:{port}"))
+    mock_ws_task = event_loop.create_task(mock_ws(host, port))
+    mock_writer_task = event_loop.create_task(mock_writer(log_file))
     await asyncio.wait(
         (adaptor_task, mock_ws_task, mock_writer_task),
         timeout=2,


### PR DESCRIPTION
Resolves #1117 

Reduce evaluator complexity and improve error handling

This is done by
 - logging websocket errors since they include uncaught exceptions
   happening inside the handlers
 - logging for EE now includes thread information
 - inline function definitions are extracted