### PR TITLE
Fix websoket url

### DIFF
--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -30,7 +30,7 @@ def load_config(config_path=CONFIG_FILE):
         return {
             "host": host,
             "port": port,
-            "url": f"{host}:{port}",
-            "client_url": f"{host}:{port}/{CLIENT_URI}",
-            "dispatch_url": f"{host}:{port}/{DISPATCH_URI}",
+            "url": f"ws://{host}:{port}",
+            "client_url": f"ws://{host}:{port}/{CLIENT_URI}",
+            "dispatch_url": f"ws://{host}:{port}/{DISPATCH_URI}",
         }

--- a/tests/ensemble_evaluator/test_config.py
+++ b/tests/ensemble_evaluator/test_config.py
@@ -19,9 +19,9 @@ def test_load_config(tmpdir, host, port):
     expected_config = {
         "host": expected_host,
         "port": expected_port,
-        "url": f"{expected_host}:{expected_port}",
-        "client_url": f"{expected_host}:{expected_port}/{CLIENT_URI}",
-        "dispatch_url": f"{expected_host}:{expected_port}/{DISPATCH_URI}",
+        "url": f"ws://{expected_host}:{expected_port}",
+        "client_url": f"ws://{expected_host}:{expected_port}/{CLIENT_URI}",
+        "dispatch_url": f"ws://{expected_host}:{expected_port}/{DISPATCH_URI}",
     }
 
     if host is not None:


### PR DESCRIPTION
**Issue**

Managed to mess up the default websoket URL now it does not contain the initial "ws://"

This PR fixes that.
