### PR TITLE
Fix plotting with no cases available

### DIFF
--- a/ert_gui/plottery/plots/histogram.py
+++ b/ert_gui/plottery/plots/histogram.py
@@ -18,6 +18,11 @@ def plotHistogram(figure, plot_context, case_to_data_map, _observation_data):
     config = plot_context.plotConfig()
 
     case_list = plot_context.cases()
+    if not case_list:
+        dummy_case_name = "default"
+        case_list = [dummy_case_name]
+        case_to_data_map = {dummy_case_name: pd.DataFrame()}
+
     case_count = len(case_list)
 
     plot_context.x_axis = plot_context.VALUE_AXIS

--- a/ert_gui/plottery/plots/histogram.py
+++ b/ert_gui/plottery/plots/histogram.py
@@ -39,7 +39,7 @@ def plotHistogram(figure, plot_context, case_to_data_map, _observation_data):
     categorical = False
     for case, datas in case_to_data_map.items():
         if datas.empty:
-            data[case] = pd.Series()
+            data[case] = pd.Series(dtype="float64")
             continue
 
         data[case] = datas[0]

--- a/ert_gui/tools/plot/plot_window.py
+++ b/ert_gui/tools/plot/plot_window.py
@@ -98,7 +98,7 @@ class PlotWindow(QMainWindow):
                 case_to_data_map = {
                     case: self._api.data_for_key(case, key) for case in cases
                 }
-                if len(key_def["observations"]) > 0:
+                if len(key_def["observations"]) > 0 and cases:
                     observations = self._api.observations_for_obs_keys(
                         cases[0], key_def["observations"]
                     )


### PR DESCRIPTION
**Issue**
Resolves #1143 


**Approach**
Parts of the plotting code expects there to be at least one case
available (specifically the histogram plot for parameters and the
statistics plot for the responses). However, when a case is running
it's not included in the case list sent to the plotting (most likely
since the fs is locked, and reading from it could cause problems).

This commit fixes this by adding a dummy empty case for the
historgram plot, and by guarding direct indexing in the case list for
the response plot. An interesting side effect for the latter is that the
observations will not be plotted during simulations, while they can
be if you open the plot window immidiatly after starting ERT.
