### PR TITLE
Remove upper version limit matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "flask",
         "gunicorn",
         "jinja2",
-        "matplotlib < 3.2",
+        "matplotlib",
         "numpy",
         "pandas",
         "pluggy",


### PR DESCRIPTION
**Issue**
"Resolves" #717


**Approach**
Remove `<3.2`.
