### PR TITLE
API server SIGTERM when parent process ends

### DIFF
--- a/ert_shared/storage/http_server.py
+++ b/ert_shared/storage/http_server.py
@@ -358,6 +358,33 @@ def parse_args():
     return ap.parse_args()
 
 
+def terminate_on_parent_death():
+    """Quit the server when the parent does a SIGABRT or is otherwise destroyed.
+    This functionality has existed on Linux for a good while, but it isn't
+    exposed in the Python standard library. Use ctypes to hook into the
+    functionality.
+    """
+    if sys.platform != "linux" or "ERT_COMM_FD" not in os.environ:
+        return
+
+    from ctypes import CDLL, c_int, c_ulong
+    import signal
+
+    lib = CDLL(None)
+
+    # from <sys/prctl.h>
+    # int prctl(int option, ...)
+    prctl = lib.prctl
+    prctl.restype = c_int
+    prctl.argtypes = (c_int, c_ulong)
+
+    # from <linux/prctl.h>
+    PR_SET_PDEATHSIG = 1
+
+    # connect parent death signal to our SIGTERM
+    prctl(PR_SET_PDEATHSIG, signal.SIGTERM)
+
+
 def run_server(args=None):
     if args is None:
         args = parse_args()
@@ -373,6 +400,7 @@ def run_server(args=None):
         if lock.exists():
             raise RuntimeError("storage_server.json already exists")
 
+    terminate_on_parent_death()
     Application(wrapper, lock).run()
 
 


### PR DESCRIPTION
Use Linux-specific functionality to signal SIGTERM on parent process death

Test this by:
1. `ert gui --enable-new-storage poly.ert`
2. `ps ax | grep ert`
3. Find the ert GUI in the list. Notice API server processes.
4. `kill -9 [ert PID]`
5. `ps ax | grep ert` should not contain server processes