### PR TITLE
Separate sampling and running experiments

### DIFF
--- a/ert3/__init__.py
+++ b/ert3/__init__.py
@@ -3,6 +3,7 @@ import ert3.storage
 import ert3.evaluator
 import ert3.engine
 import ert3.workspace
+import ert3.stats
 
 
 _WORKSPACE_DATA_ROOT = ".ert"

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -24,6 +24,17 @@ def _build_argparser():
     export_parser = subparsers.add_parser("export", help="Export experiment")
     export_parser.add_argument("experiment_name", help="Name of the experiment")
 
+    sample_parser = subparsers.add_parser(
+        "sample", help="Sample parameter distribution"
+    )
+    sample_parser.add_argument(
+        "parameter_group", help="Name of the distribution group in parameters.yml"
+    )
+    sample_parser.add_argument("sample_name", help="Name of the sampling")
+    sample_parser.add_argument(
+        "ensemble_size", type=int, help="Size of ensemble of variables"
+    )
+
     return parser
 
 
@@ -48,4 +59,9 @@ def main():
         return
     if args.sub_cmd == "export":
         ert3.engine.export(workspace, args.experiment_name)
+        return
+    if args.sub_cmd == "sample":
+        ert3.engine.sample(
+            workspace, args.parameter_group, args.sample_name, args.ensemble_size
+        )
         return

--- a/ert3/engine/__init__.py
+++ b/ert3/engine/__init__.py
@@ -1,2 +1,3 @@
 from ert3.engine._run import run
 from ert3.engine._export import export
+from ert3.engine._sample import sample

--- a/ert3/engine/_sample.py
+++ b/ert3/engine/_sample.py
@@ -1,0 +1,32 @@
+import ert3
+
+import yaml
+
+
+def sample(workspace, parameter_group_name, sample_name, ensemble_size):
+    with open(workspace / "parameters.yml") as f:
+        parameters = yaml.safe_load(f)
+
+    parameter_group = None
+    for ps in parameters:
+        if ps["name"] == parameter_group_name:
+            parameter_group = ps
+
+    if parameter_group is None:
+        raise ValueError(f"No parameter group found named: {parameter_group_name}")
+
+    dist_config = parameter_group["distribution"]
+    if dist_config["type"] == "gaussian":
+        distribution = ert3.stats.Gaussian(
+            dist_config["input"]["mean"],
+            dist_config["input"]["std"],
+            index=parameter_group["variables"],
+        )
+    else:
+        raise ValueError("Unknown distribution type: {}".format(dist_config["type"]))
+
+    ert3.storage.add_variables(
+        workspace,
+        sample_name,
+        [distribution.sample() for _ in range(ensemble_size)],
+    )

--- a/ert3/stats/__init__.py
+++ b/ert3/stats/__init__.py
@@ -1,0 +1,1 @@
+from ert3.stats._stats import Gaussian

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -26,4 +26,4 @@ class Gaussian:
         if self._index is None:
             return sample
         else:
-            return {idx: val for idx, val in zip(self._index, sample)}
+            return {idx: float(val) for idx, val in zip(self._index, sample)}

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -1,0 +1,29 @@
+import scipy.stats
+
+
+class Gaussian:
+    def __init__(self, mean, std, *, size=None, index=None):
+        self._mean = mean
+        self._std = std
+
+        if size is None and index is None:
+            raise ValueError(
+                "Cannot create gaussian distribution with neither size nor index"
+            )
+        if size is not None and index is not None:
+            raise ValueError(
+                "Cannot create gaussian distribution with both size and index"
+            )
+
+        if size is not None:
+            self._size = size
+        else:
+            self._size = len(tuple(index))
+        self._index = index
+
+    def sample(self):
+        sample = scipy.stats.norm.rvs(loc=self._mean, scale=self._std, size=self._size)
+        if self._index is None:
+            return sample
+        else:
+            return {idx: val for idx, val in zip(self._index, sample)}

--- a/ert3/storage/__init__.py
+++ b/ert3/storage/__init__.py
@@ -5,3 +5,5 @@ from ert3.storage._storage import add_input_data
 from ert3.storage._storage import get_input_data
 from ert3.storage._storage import add_output_data
 from ert3.storage._storage import get_output_data
+from ert3.storage._storage import add_variables
+from ert3.storage._storage import get_variables

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -80,7 +80,9 @@ def _add_data(workspace, experiment_name, data_type, data, required_types=()):
 
     for req in required_types:
         if req not in storage[experiment_name]:
-            raise KeyError(f"Cannot add {data_type} data to experiment without {req} data")
+            raise KeyError(
+                f"Cannot add {data_type} data to experiment without {req} data"
+            )
 
     storage[experiment_name][data_type] = data
 

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -6,6 +6,7 @@ import os
 
 
 _STORAGE_FILE = "storage.yaml"
+_VARIABLES = "__variables__"
 
 
 def _generate_storage_location(workspace):
@@ -29,6 +30,8 @@ def init(workspace):
 
     with open(storage_location, "w") as f:
         yaml.dump({}, f)
+
+    init_experiment(workspace, _VARIABLES)
 
 
 def init_experiment(workspace, experiment_name):
@@ -54,7 +57,9 @@ def get_experiment_names(workspace):
     with open(storage_location) as f:
         storage = yaml.safe_load(f)
 
-    return storage.keys()
+    experiment_names = set(storage.keys())
+    experiment_names.remove(_VARIABLES)
+    return experiment_names
 
 
 def _add_data(workspace, experiment_name, data_type, data, required_types=()):
@@ -121,3 +126,11 @@ def get_input_data(workspace, experiment_name):
 
 def get_output_data(workspace, experiment_name):
     return _get_data(workspace, experiment_name, "output")
+
+
+def add_variables(workspace, var_name, data):
+    _add_data(workspace, _VARIABLES, var_name, data)
+
+
+def get_variables(workspace, var_name):
+    return _get_data(workspace, _VARIABLES, var_name)

--- a/ert3/workspace/__init__.py
+++ b/ert3/workspace/__init__.py
@@ -1,4 +1,4 @@
 from ert3.workspace._workspace import initialize
-from ert3.workspace._workspace import load 
+from ert3.workspace._workspace import load
 from ert3.workspace._workspace import experiment_have_run
 from ert3.workspace._workspace import assert_experiment_exists

--- a/examples/polynomial/presampled_evaluation/ensemble.yml
+++ b/examples/polynomial/presampled_evaluation/ensemble.yml
@@ -1,0 +1,11 @@
+size: 1000
+
+input:
+  -
+    source: storage.coefficients0
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/presampled_evaluation/experiment.yml
+++ b/examples/polynomial/presampled_evaluation/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/tests/ert3/stats/test_distributions.py
+++ b/tests/ert3/stats/test_distributions.py
@@ -17,7 +17,7 @@ def test_gaussian_distribution(size, mean, std):
     prev_samples = set()
     for _ in range(10):
         sample = gauss.sample()
-        
+
         assert len(sample) == size
 
         assert tuple(sample) not in prev_samples
@@ -31,7 +31,7 @@ def test_gaussian_distribution(size, mean, std):
     ("index", "mean", "std"),
     (
         (("a", "b", "c"), 0, 1),
-        (("a"*i for i in range(1, 10)), 2, 5),
+        (("a" * i for i in range(1, 10)), 2, 5),
     ),
 )
 def test_gaussian_distribution_index(index, mean, std):

--- a/tests/ert3/stats/test_distributions.py
+++ b/tests/ert3/stats/test_distributions.py
@@ -1,0 +1,61 @@
+import ert3
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("size", "mean", "std"),
+    (
+        (10000, 0, 1),
+        (20000, 10, 10),
+    ),
+)
+def test_gaussian_distribution(size, mean, std):
+    gauss = ert3.stats.Gaussian(mean, std, size=size)
+
+    prev_samples = set()
+    for _ in range(10):
+        sample = gauss.sample()
+        
+        assert len(sample) == size
+
+        assert tuple(sample) not in prev_samples
+        prev_samples.add(tuple(sample))
+
+        assert sample.mean() == pytest.approx(mean, abs=0.2)
+        assert sample.std() == pytest.approx(std, abs=0.2)
+
+
+@pytest.mark.parametrize(
+    ("index", "mean", "std"),
+    (
+        (("a", "b", "c"), 0, 1),
+        (("a"*i for i in range(1, 10)), 2, 5),
+    ),
+)
+def test_gaussian_distribution_index(index, mean, std):
+    gauss = ert3.stats.Gaussian(mean, std, index=index)
+
+    samples = {idx: [] for idx in index}
+    for i in range(1000):
+        sample = gauss.sample()
+        assert sorted(sample.keys()) == sorted(index)
+
+        for key in index:
+            samples[key].append(sample[key])
+
+    for key in index:
+        s = np.array(samples[key])
+        assert s.mean() == pytest.approx(mean, abs=0.2)
+        assert s.std() == pytest.approx(std, abs=0.2)
+
+
+def test_gaussian_distribution_invalid():
+    err_msg_neither = "Cannot create gaussian distribution with neither size nor index"
+    with pytest.raises(ValueError, match=err_msg_neither):
+        ert3.stats.Gaussian(0, 1)
+
+    err_msg_both = "Cannot create gaussian distribution with both size and index"
+    with pytest.raises(ValueError, match=err_msg_both):
+        ert3.stats.Gaussian(0, 1, size=10, index=list(range(10)))

--- a/tests/ert3/storage/test_storage.py
+++ b/tests/ert3/storage/test_storage.py
@@ -224,3 +224,29 @@ def test_get_output_data_no_output_data(tmpdir, experiment_name):
         KeyError, match=f"No output data for experiment: {experiment_name}"
     ):
         ert3.storage.get_output_data(tmpdir, experiment_name)
+
+
+def test_add_sample_not_initialised(tmpdir):
+    with pytest.raises(ValueError, match="Storage is not initialized"):
+        ert3.storage.add_variables(tmpdir, "some_sample", [1, 2, 3])
+
+
+def test_add_sample_twice(tmpdir):
+    ert3.storage.init(tmpdir)
+
+    ert3.storage.add_variables(tmpdir, "some_sample", [1, 2, 3])
+    with pytest.raises(KeyError):
+        ert3.storage.add_variables(tmpdir, "some_sample", [1, 2, 3])
+
+
+def test_add_and_get_samples(tmpdir):
+    ert3.storage.init(tmpdir)
+
+    sample1 = [1, 2, 3.0]
+    ert3.storage.add_variables(tmpdir, "sample1", sample1)
+
+    sample2 = {i*"key": 1.5 * i for i in range(1, 10)}
+    ert3.storage.add_variables(tmpdir, "sample2", sample2)
+
+    assert ert3.storage.get_variables(tmpdir, "sample1") == sample1
+    assert ert3.storage.get_variables(tmpdir, "sample2") == sample2

--- a/tests/ert3/storage/test_storage.py
+++ b/tests/ert3/storage/test_storage.py
@@ -245,7 +245,7 @@ def test_add_and_get_samples(tmpdir):
     sample1 = [1, 2, 3.0]
     ert3.storage.add_variables(tmpdir, "sample1", sample1)
 
-    sample2 = {i*"key": 1.5 * i for i in range(1, 10)}
+    sample2 = {i * "key": 1.5 * i for i in range(1, 10)}
     ert3.storage.add_variables(tmpdir, "sample2", sample2)
 
     assert ert3.storage.get_variables(tmpdir, "sample1") == sample1


### PR DESCRIPTION
Resolves: #1193 

**Intent**
The original intent of this PR was to do some groundwork prior to implementing algorithms by separating the logic for sampling input and running an experiment (#playground). As a result I ended up resolving making the sampling of distributions configurable.

One can now run `evaluations` with input records either being a pre-sampled or sampled during the experiment. One can pre-sample by using the command `ert3 sample` and point at a pre-sampled record by using `storage.<sample_name>` when configuring the input of the forward model. See `examples/evaluation/presampled_evaluation` for an example. Furthermore, `run` now utilises the same sampling method as above, meaning that it now reads from the configuration and dumps a sampling to `storage`, that is afterwards read again in the same fashion independently of whether the record was pre-sampled or sampled during the experiment. Sampling during experiment is configured as before with `stochastic.<parameter_group_name>`.

**Approach**
I've created a module `ert3.stats` with a single distribution `Gaussian` that can sample the parameters. Afterwards I extended storage to be able to store variable sets, such that samplings can be stored. Then I implemented a `ert3 sample` command. Last, I made `run` utilise the same sampling and always load input records from storage. The commits in this PR reflects these 4 steps.

**Note**
This is a continuation of the work in #1198. I suggest we try to merge that PR first...