### PR TITLE
ert3: Add uniform distribution

### DIFF
--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -34,6 +34,12 @@ def sample_record(workspace, parameter_group_name, record_name, ensemble_size):
             dist_config["input"]["std"],
             index=parameter_group["variables"],
         )
+    elif dist_config["type"] == "uniform":
+        distribution = ert3.stats.Uniform(
+            dist_config["input"]["lower_bound"],
+            dist_config["input"]["upper_bound"],
+            index=parameter_group["variables"],
+        )
     else:
         raise ValueError("Unknown distribution type: {}".format(dist_config["type"]))
 

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -1,20 +1,6 @@
 import ert3
 
-import random
 import yaml
-
-
-def _generate_coefficients():
-    return [
-        {
-            "coefficients": {
-                "a": random.gauss(0, 1),
-                "b": random.gauss(0, 1),
-                "c": random.gauss(0, 1),
-            }
-        }
-        for _ in range(1000)
-    ]
 
 
 def _persist_variables(

--- a/ert3/stats/__init__.py
+++ b/ert3/stats/__init__.py
@@ -1,1 +1,2 @@
 from ert3.stats._stats import Gaussian
+from ert3.stats._stats import Uniform

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -27,3 +27,34 @@ class Gaussian:
             return sample
         else:
             return {idx: float(val) for idx, val in zip(self._index, sample)}
+
+
+class Uniform:
+    def __init__(self, lower_bound, upper_bound, *, size=None, index=None):
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+        self._scale = upper_bound - lower_bound
+
+        if size is None and index is None:
+            raise ValueError(
+                "Cannot create uniform distribution with neither size nor index"
+            )
+        if size is not None and index is not None:
+            raise ValueError(
+                "Cannot create uniform distribution with both size and index"
+            )
+
+        if size is not None:
+            self._size = size
+        else:
+            self._size = len(tuple(index))
+        self._index = index
+
+    def sample(self):
+        sample = scipy.stats.uniform.rvs(
+            loc=self._lower_bound, scale=self._scale, size=self._size
+        )
+        if self._index is None:
+            return sample
+        else:
+            return {idx: float(val) for idx, val in zip(self._index, sample)}

--- a/examples/polynomial/parameters.yml
+++ b/examples/polynomial/parameters.yml
@@ -7,3 +7,12 @@
       mean: 0
       std: 1
   variables: ["a", "b", "c"]
+-
+  name: uniform_coefficients
+  type: stochastic
+  distribution:
+    type: uniform
+    input:
+      lower_bound: 0
+      upper_bound: 1
+  variables: ["a", "b", "c"]

--- a/examples/polynomial/presampled_uniform_evaluation/ensemble.yml
+++ b/examples/polynomial/presampled_uniform_evaluation/ensemble.yml
@@ -1,0 +1,11 @@
+size: 1000
+
+input:
+  -
+    source: storage.uniform_coefficients0
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/presampled_uniform_evaluation/experiment.yml
+++ b/examples/polynomial/presampled_uniform_evaluation/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/polynomial/uniform_evaluation/ensemble.yml
+++ b/examples/polynomial/uniform_evaluation/ensemble.yml
@@ -1,0 +1,11 @@
+size: 1001
+
+input:
+  -
+    source: stochastic.uniform_coefficients
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/uniform_evaluation/experiment.yml
+++ b/examples/polynomial/uniform_evaluation/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/tests/ert3/stats/test_distributions.py
+++ b/tests/ert3/stats/test_distributions.py
@@ -66,3 +66,64 @@ def test_gaussian_distribution_invalid():
     err_msg_both = "Cannot create gaussian distribution with both size and index"
     with pytest.raises(ValueError, match=err_msg_both):
         ert3.stats.Gaussian(0, 1, size=10, index=list(range(10)))
+
+
+@flaky.flaky(max_runs=3, min_passes=2)
+@pytest.mark.parametrize(
+    ("size", "lower_bound", "upper_bound"),
+    (
+        (10000, 0, 1),
+        (20000, 10, 20),
+    ),
+)
+def test_uniform_distribution(size, lower_bound, upper_bound):
+    uniform = ert3.stats.Uniform(lower_bound, upper_bound, size=size)
+
+    prev_samples = set()
+    for _ in range(10):
+        sample = uniform.sample()
+
+        assert len(sample) == size
+
+        assert tuple(sample) not in prev_samples
+        prev_samples.add(tuple(sample))
+
+        assert sample.min() == approx(lower_bound)
+        assert sample.mean() == approx((lower_bound + upper_bound) / 2)
+        assert sample.max() == approx(upper_bound)
+
+
+@flaky.flaky(max_runs=3, min_passes=2)
+@pytest.mark.parametrize(
+    ("index", "lower_bound", "upper_bound"),
+    (
+        (("a", "b", "c"), 0, 1),
+        (tuple("a" * i for i in range(1, 10)), 2, 5),
+    ),
+)
+def test_uniform_distribution_index(index, lower_bound, upper_bound):
+    uniform = ert3.stats.Uniform(lower_bound, upper_bound, index=index)
+
+    samples = {idx: [] for idx in index}
+    for i in range(1000):
+        sample = uniform.sample()
+        assert sorted(sample.keys()) == sorted(index)
+
+        for key in index:
+            samples[key].append(sample[key])
+
+    for key in index:
+        s = np.array(samples[key])
+        assert s.min() == approx(lower_bound)
+        assert s.mean() == approx((lower_bound + upper_bound) / 2)
+        assert s.max() == approx(upper_bound)
+
+
+def test_uniform_distribution_invalid():
+    err_msg_neither = "Cannot create uniform distribution with neither size nor index"
+    with pytest.raises(ValueError, match=err_msg_neither):
+        ert3.stats.Uniform(0, 1)
+
+    err_msg_both = "Cannot create uniform distribution with both size and index"
+    with pytest.raises(ValueError, match=err_msg_both):
+        ert3.stats.Uniform(0, 1, size=10, index=list(range(10)))

--- a/tests/ert3/stats/test_distributions.py
+++ b/tests/ert3/stats/test_distributions.py
@@ -38,7 +38,7 @@ def test_gaussian_distribution(size, mean, std):
     ("index", "mean", "std"),
     (
         (("a", "b", "c"), 0, 1),
-        (("a" * i for i in range(1, 10)), 2, 5),
+        (tuple("a" * i for i in range(1, 10)), 2, 5),
     ),
 )
 def test_gaussian_distribution_index(index, mean, std):


### PR DESCRIPTION
**Issue**
Resolves #1218 


**Approach**
ert3: add uniform distribution to the stat module

also, increase tolerance in tests of distributions to reduce occasionally fails
