### PR TITLE
Ert3 test runtime

### DIFF
--- a/examples/polynomial/evaluation/ensemble.yml
+++ b/examples/polynomial/evaluation/ensemble.yml
@@ -1,4 +1,4 @@
-size: 1001
+size: 10
 
 input:
   -

--- a/examples/polynomial/presampled_evaluation/ensemble.yml
+++ b/examples/polynomial/presampled_evaluation/ensemble.yml
@@ -1,4 +1,4 @@
-size: 1000
+size: 10
 
 input:
   -

--- a/examples/polynomial/presampled_evaluation_big/ensemble.yml
+++ b/examples/polynomial/presampled_evaluation_big/ensemble.yml
@@ -1,0 +1,11 @@
+size: 1000
+
+input:
+  -
+    source: storage.coefficients0
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/presampled_evaluation_big/experiment.yml
+++ b/examples/polynomial/presampled_evaluation_big/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/polynomial/presampled_uniform_evaluation/ensemble.yml
+++ b/examples/polynomial/presampled_uniform_evaluation/ensemble.yml
@@ -1,4 +1,4 @@
-size: 1000
+size: 10
 
 input:
   -

--- a/examples/polynomial/presampled_uniform_evaluation_big/ensemble.yml
+++ b/examples/polynomial/presampled_uniform_evaluation_big/ensemble.yml
@@ -1,0 +1,11 @@
+size: 1000
+
+input:
+  -
+    source: storage.uniform_coefficients0
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/presampled_uniform_evaluation_big/experiment.yml
+++ b/examples/polynomial/presampled_uniform_evaluation_big/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/polynomial/uniform_evaluation/ensemble.yml
+++ b/examples/polynomial/uniform_evaluation/ensemble.yml
@@ -1,4 +1,4 @@
-size: 1001
+size: 10
 
 input:
   -

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -213,28 +213,6 @@ def _assert_poly_output(config, export_data):
             assert coeff["a"] * x ** 2 + coeff["b"] * x + coeff["c"] == pytest.approx(y)
 
 
-def _assert_parameter_statistics(config, export_data):
-    for input_data in config["ensemble"]["input"]:
-        record = input_data["record"]
-        source = input_data["source"]
-
-        for p in config["parameters"]:
-            if p["type"] + "." + p["name"] == source:
-                parameter = p
-                break
-
-        assert parameter["distribution"]["type"] == "gaussian"
-        mean = parameter["distribution"]["input"]["mean"]
-        std = parameter["distribution"]["input"]["std"]
-
-        for variable in parameter["variables"]:
-            values = np.array(
-                [realisation["input"][record][variable] for realisation in export_data]
-            )
-            assert mean == pytest.approx(sum(values) / len(values), abs=0.1)
-            assert std == pytest.approx(np.std(values), abs=0.1)
-
-
 def _assert_export(workspace, experiment_name):
     with open(workspace / experiment_name / "data.json") as f:
         export_data = json.load(f)
@@ -248,56 +226,7 @@ def _assert_export(workspace, experiment_name):
     # evaluates a * x^2 + b * x + c. If not, this will fail miserably!
     _assert_poly_output(config, export_data)
 
-    # Note: This might fail (but with rather low probability) as it computes
-    # the mean and std of the sampled parameter values and compares it to the
-    # theoretical distribution.
-    _assert_parameter_statistics(config, export_data)
 
-
-def _assert_uniform_parameter_statistics(config, export_data):
-    for input_data in config["ensemble"]["input"]:
-        record = input_data["record"]
-        source = input_data["source"]
-
-        for p in config["parameters"]:
-            if p["type"] + "." + p["name"] == source:
-                parameter = p
-                break
-
-        assert parameter["distribution"]["type"] == "uniform"
-        lower_bound = parameter["distribution"]["input"]["lower_bound"]
-        upper_bound = parameter["distribution"]["input"]["upper_bound"]
-        mean = (lower_bound + upper_bound) / 2
-
-        for variable in parameter["variables"]:
-            values = np.array(
-                [realisation["input"][record][variable] for realisation in export_data]
-            )
-            assert lower_bound == pytest.approx(min(values), abs=0.1)
-            assert upper_bound == pytest.approx(max(values), abs=0.1)
-            assert mean == pytest.approx(sum(values) / len(values), abs=0.1)
-
-
-def _assert_uniform_export(workspace, experiment_name):
-    with open(workspace / experiment_name / "data.json") as f:
-        export_data = json.load(f)
-
-    config = _load_experiment_config(workspace, experiment_name)
-    _assert_ensemble_size(config, export_data)
-    _assert_input_records(config, export_data)
-    _assert_output_records(config, export_data)
-
-    # Note: This test assumes the forward model in the setup indeed
-    # evaluates a * x^2 + b * x + c. If not, this will fail miserably!
-    _assert_poly_output(config, export_data)
-
-    # Note: This might fail (but with rather low probability) as it computes
-    # the mean and std of the sampled parameter values and compares it to the
-    # theoretical distribution.
-    _assert_uniform_parameter_statistics(config, export_data)
-
-
-@flaky.flaky(max_runs=3, min_passes=2)
 def test_cli_export_polynomial_evaluation(tmpdir):
     workspace = tmpdir / _POLY_WORKSPACE_NAME
     shutil.copytree(_POLY_WORKSPACE, workspace)
@@ -318,7 +247,6 @@ def test_cli_export_polynomial_evaluation(tmpdir):
     _assert_export(workspace, "evaluation")
 
 
-@flaky.flaky(max_runs=3, min_passes=2)
 def test_cli_export_uniform_polynomial_evaluation(tmpdir):
     workspace = tmpdir / _POLY_WORKSPACE_NAME
     shutil.copytree(_POLY_WORKSPACE, workspace)
@@ -336,7 +264,7 @@ def test_cli_export_uniform_polynomial_evaluation(tmpdir):
     with unittest.mock.patch.object(sys, "argv", args):
         ert3.console.main()
 
-    _assert_uniform_export(workspace, "uniform_evaluation")
+    _assert_export(workspace, "uniform_evaluation")
 
 
 def _assert_distribution(workspace, experiment, distribution, coefficients):

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -368,12 +368,12 @@ def test_cli_run_presampled(tmpdir):
     with unittest.mock.patch.object(sys, "argv", args):
         ert3.console.main()
 
-    args = ["ert3", "record", "sample", "coefficients", "coefficients0", "1000"]
+    args = ["ert3", "record", "sample", "coefficients", "coefficients0", "10"]
     with unittest.mock.patch.object(sys, "argv", args):
         ert3.console.main()
 
     coeff0 = ert3.storage.get_variables(workspace, "coefficients0")
-    assert 1000 == len(coeff0)
+    assert 10 == len(coeff0)
     for real_coeff in coeff0:
         assert sorted(("a", "b", "c")) == sorted(real_coeff.keys())
         for val in real_coeff.values():
@@ -414,13 +414,13 @@ def test_cli_run_uniform_presampled(tmpdir):
         "sample",
         "uniform_coefficients",
         "uniform_coefficients0",
-        "1000",
+        "10",
     ]
     with unittest.mock.patch.object(sys, "argv", args):
         ert3.console.main()
 
     uniform_coeff0 = ert3.storage.get_variables(workspace, "uniform_coefficients0")
-    assert 1000 == len(uniform_coeff0)
+    assert 10 == len(uniform_coeff0)
     for real_coeff in uniform_coeff0:
         assert sorted(("a", "b", "c")) == sorted(real_coeff.keys())
         for val in real_coeff.values():


### PR DESCRIPTION
**Issue**
Resolves #1204 

Reduces local runtime of `pytest -k ert3` from ~410s to ~80s

**Approach**

- the distribution testing is now done for the samples from a pre-sampled record of size 1000 (no need to run experiment)
- the distribution tests are removed from the export polynomial tests that also runs the experiment 
- ensemble size is now reduced to 10 from 1000 for all tests that does not test the distributions

This is done by reusing existing patterns in the tests. Other improvements of distribution testing is left to #1231 
