### PR TITLE
Only run style for one python version

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We are running style with three different python versions, might be overkill as these are unlikely to be different.