### PR TITLE
Use matplotlib's Qt5 backend rather than Qt4

### DIFF
--- a/ert_gui/tools/plot/plot_widget.py
+++ b/ert_gui/tools/plot/plot_widget.py
@@ -5,7 +5,7 @@ from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QAction
 
 from matplotlib.figure import Figure
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas, NavigationToolbar2QT
+from matplotlib.backends.backend_qt5agg import FigureCanvas, NavigationToolbar2QT
 
 from ert_gui.ertwidgets import resourceIcon
 


### PR DESCRIPTION
The Qt5 backend provides the same classes as Qt4, so it is a drop-in
replacement. According to the documentation page below, 'FigureCanvas'
is an alias of 'FigureCanvasQTAgg', so the import 'as' is unnecessary.

https://doc.ebichu.cc/matplotlib/api/backend_qt5agg_api.html
