### PR TITLE
Fix extraction.py's create_update

### DIFF
--- a/ert_shared/storage/json_schema/misfit.py
+++ b/ert_shared/storage/json_schema/misfit.py
@@ -9,7 +9,7 @@ class MisfitBase(BaseModel):
 class MisfitCreate(MisfitBase):
     observation_key: str
     response_definition_key: str
-    active: Optional[List[float]] = None
+    active: Optional[List[bool]] = None
     realizations: Mapping[int, float]
 
 


### PR DESCRIPTION
When refactoring for FastAPI, the create_update function was incorrectly
transferred. The lack of ensemble updates came from a bug where a
function was inlined naively, causing an early return.

The usage of the term 'misfit' is incorrect but I've chosen not to touch
it. It should rather be called an update or a synonym thereof.