### PR TITLE
Return empty list in create_observations when no obs are available

### DIFF
--- a/ert_shared/storage/extraction.py
+++ b/ert_shared/storage/extraction.py
@@ -98,7 +98,7 @@ def create_observations(ert) -> List[js.ObservationCreate]:
     keys = [ert.get_observation_key(i) for i, _ in enumerate(ert.get_observations())]
 
     if len(keys) == 0:
-        return
+        return []
 
     data = MeasuredData(ert, keys)
     data.remove_inactive_observations()
@@ -123,12 +123,12 @@ def create_observations(ert) -> List[js.ObservationCreate]:
 def _extract_active_observations(ert):
     update_step = ert.get_update_step()
     if len(update_step) == 0:
-        return
+        return {}
 
     ministep = update_step[-1]
     obs_data = ministep.get_obs_data()
     if obs_data is None:
-        return
+        return {}
 
     active_obs = {}
     for block_num in range(obs_data.get_num_blocks()):

--- a/tests/storage/test_write_api.py
+++ b/tests/storage/test_write_api.py
@@ -144,18 +144,19 @@ class MockFacade:
 
     def __init__(self):
         self.enkf_main = None
+        self.observations = {
+            "POLY_OBS": MockObservation("POLY_OBS", "POLY_RES"),
+            "TEST_OBS": MockObservation("TEST_OBS", "TEST_RES"),
+        }
 
     def get_observations(self):
-        return [
-            MockObservation("POLY_OBS", "POLY_RES"),
-            MockObservation("TEST_OBS", "TEST_RES"),
-        ]
+        return self.observations.values()
 
     def get_ensemble_size(self):
         return 5
 
     def get_observation_key(self, i):
-        return ["POLY_OBS", "TEST_OBS"][i]
+        return list(self.observations.keys())[i]
 
     def get_current_case_name(self):
         return self.ENSEMBLE_NAME
@@ -255,6 +256,10 @@ def test_create_observations(app_client, mock_ert):
     assert test_obs.data_indices == [3, 6, 9]
     assert test_obs.values == [6, 12, 18]
     assert test_obs.errors == [0.1, 0.2, 0.3]
+
+    mock_ert.observations = {}
+    obs = extraction.create_observations(mock_ert)
+    assert obs == []
 
 
 def test_ensemble_return(app_client, mock_ert):


### PR DESCRIPTION
Fix failure when extracting data to new storage and no observations present