### PR TITLE
Storage: Allow NaNs to be returned

### DIFF
--- a/ert_shared/storage/app.py
+++ b/ert_shared/storage/app.py
@@ -1,9 +1,11 @@
 import os
 import sys
+import json
+from typing import Any
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.exception_handlers import http_exception_handler
-from fastapi.responses import JSONResponse
+from fastapi.responses import Response
 from fastapi.security import HTTPBasic
 
 from ert_shared.storage import json_schema as js
@@ -13,7 +15,22 @@ from ert_shared.storage.endpoints import router
 from sqlalchemy.orm.exc import NoResultFound
 
 
-app = FastAPI(name="ERT Storage API", debug=True)
+class JSONResponse(Response):
+    """A replacement for Starlette's JSONResponse that permits NaNs."""
+
+    media_type = "application/json"
+
+    def render(self, content: Any) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=True,
+            indent=None,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
+app = FastAPI(name="ERT Storage API", debug=True, default_response_class=JSONResponse)
 security = HTTPBasic()
 
 

--- a/tests/storage/test_fastapi.py
+++ b/tests/storage/test_fastapi.py
@@ -1,0 +1,31 @@
+import math
+from pydantic import BaseModel
+
+from ert_shared.storage.app import app
+
+
+class _NanModel(BaseModel):
+    value: float
+
+
+@app.get("/test_nan_json")
+async def _nan_json():
+    return math.nan
+
+
+@app.get("/test_nan_pydantic", response_model=_NanModel)
+async def _nan_pydantic():
+    return _NanModel(value=math.nan)
+
+
+def test_nan(app_client):
+    """
+    The JSONResponse as found in Starlette explicitly disallows NaNs when
+    encoding. Both the direct return of JSON-able objects and Pydantic use
+    JSONResponse.
+    """
+    resp = app_client.get("/test_nan_json")
+    assert math.isnan(resp.json())
+
+    resp = app_client.get("/test_nan_pydantic")
+    assert math.isnan(resp.json()["value"])


### PR DESCRIPTION
Starlette (and therefore FastAPI) explicitly disables float nans when using the `JSONResponse` object, which is the default one used by FastAPI. We replace the default with our own copy that has `allow_nan=True`.

Resolves: #1284 