### PR TITLE
Adopting ert3 to the prefect ensemble

### DIFF
--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -48,17 +48,6 @@ def _load_input_records(ensemble, workspace_root, experiment_name):
     return records
 
 
-def _create_forward_model(stages_config, ensemble):
-    # For now we only allow one stage with one function
-    # So will fail quite hard if these constraints are not met
-    # TODO: Allow different stages and removing asserts.
-    assert len(ensemble.forward_model.stages) == 1
-    assert len(stages_config) == 1
-    forward_model = stages_config.step_from_key(ensemble.forward_model.stages[0]).script
-    assert len(forward_model) == 1
-    return forward_model[0]
-
-
 def run(ensemble, stages_config, workspace_root, experiment_name):
     if ert3.workspace.experiment_have_run(workspace_root, experiment_name):
         raise ValueError(f"Experiment {experiment_name} have been carried out.")
@@ -67,8 +56,8 @@ def run(ensemble, stages_config, workspace_root, experiment_name):
 
     input_records = _load_input_records(ensemble, workspace_root, experiment_name)
     ert3.storage.add_input_data(workspace_root, experiment_name, input_records)
-    func = _create_forward_model(stages_config, ensemble)
+
     response = ert3.evaluator.evaluate(
-        input_records, func, ensemble.forward_model.driver
+        workspace_root, experiment_name, input_records, ensemble, stages_config
     )
     ert3.storage.add_output_data(workspace_root, experiment_name, response)

--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -1,18 +1,139 @@
+import json
+import os
+import pathlib
+
 from ert_shared.ensemble_evaluator import config as evaluator_config
-from ert_shared.ensemble_evaluator.entity.function_ensemble import (
-    create_function_ensemble,
-)
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
+from ert_shared.ensemble_evaluator.prefect_ensemble.prefect_ensemble import (
+    PrefectEnsemble,
+    storage_driver_factory,
+)
+
+import ert3
 
 
-def evaluate(inputs, fun, executor):
-    ensemble = create_function_ensemble(fun=fun, inputs=inputs, executor=executor)
+def _create_evaluator_tmp_dir(workspace_root, evaluation_name):
+    return (
+        pathlib.Path(workspace_root)
+        / ert3._WORKSPACE_DATA_ROOT
+        / "tmp"
+        / evaluation_name
+    )
+
+
+def _assert_single_stage_forward_model(stages_config, ensemble):
+    # The current implementation only support one stage as the forward model
+    # and hence we fail if multiple are provided
+    assert len(ensemble.forward_model.stages) == 1
+
+
+def _prepare_input(ee_config, stages_config, inputs, evaluation_tmp_dir):
+    tmp_input_folder = evaluation_tmp_dir / "prep_input_files"
+    os.makedirs(tmp_input_folder)
+    ee_storage = storage_driver_factory(ee_config["storage"], tmp_input_folder)
+    record2location = {input.record: input.location for input in stages_config[0].input}
+    input_files = {iens: () for iens in range(ee_config["realizations"])}
+    for iens, realization_inputs in enumerate(inputs):
+        for name, value in realization_inputs.items():
+            filename = record2location[name]
+            with open(tmp_input_folder / filename, "w") as f:
+                json.dump(value, f)
+            input_files[iens] += (ee_storage.store(filename, iens),)
+    return input_files
+
+
+def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records):
+    _assert_single_stage_forward_model(stages_config, ensemble)
+
+    stage_name = ensemble.forward_model.stages[0]
+    step_name = stage_name + "-only_step"
+    stage = stages_config.step_from_key(stage_name)
+
+    command_scripts = [cmd.location for cmd in stage.transportable_commands]
+    output_files = [out.location for out in stage.output]
+
+    cmd_name2script = {cmd.name: cmd.location for cmd in stage.transportable_commands}
+    jobs = [
+        {
+            "name": cmd[0],
+            "executable": cmd_name2script[cmd[0]],
+            "args": tuple(cmd[1:]),
+        }
+        for cmd in [elem.split() for elem in stage.script]
+    ]
+
+    ee_config = {
+        "stages": [
+            {
+                "name": stage_name,
+                "steps": [
+                    {
+                        "name": step_name,
+                        "resources": command_scripts,
+                        "parameter": [],
+                        "inputs": [],
+                        "outputs": output_files,
+                        "jobs": jobs,
+                    }
+                ],
+            }
+        ],
+        "realizations": ensemble.size,
+        "max_running": 10000,
+        "max_retries": 0,
+        "run_path": str(evaluation_tmp_dir / "my_output"),
+        "executor": ensemble.forward_model.driver,
+        "storage": {
+            "type": "shared_disk",
+            "storage_path": str(evaluation_tmp_dir / ".my_storage"),
+        },
+    }
+
+    ee_config["input_files"] = _prepare_input(
+        ee_config, stages_config, input_records, evaluation_tmp_dir
+    )
+
+    return ee_config
+
+
+def _fetch_results(ee_config, ensemble, stages_config):
+    _assert_single_stage_forward_model(stages_config, ensemble)
+
+    results = []
+    ee_storage = storage_driver_factory(ee_config["storage"], ee_config["run_path"])
+    for iens in range(ee_config["realizations"]):
+        spath = pathlib.Path(ee_storage.get_storage_path(iens))
+        realization_results = {}
+
+        stage_name = ensemble.forward_model.stages[0]
+        stage = stages_config.step_from_key(stage_name)
+        for output_elem in stage.output:
+            with open(spath / output_elem.location) as f:
+                realization_results[output_elem.record] = json.load(f)
+        results.append(realization_results)
+    return results
+
+
+def _run(ensemble_evaluator):
+    monitor = ensemble_evaluator.run()
+    for event in monitor.track():
+        if event.data is not None and event.data.get("status") == "Stopped":
+            monitor.signal_done()
+
+
+def evaluate(
+    workspace_root, evaluation_name, input_records, ensemble_config, stages_config
+):
+    evaluation_tmp_dir = _create_evaluator_tmp_dir(workspace_root, evaluation_name)
+
+    ee_config = _build_ee_config(
+        evaluation_tmp_dir, ensemble_config, stages_config, input_records
+    )
+    ensemble = PrefectEnsemble(ee_config)
 
     config = evaluator_config.load_config()
     ee = EnsembleEvaluator(ensemble=ensemble, config=config)
+    _run(ee)
 
-    ee.run()
-    ensemble.join()
-    ee.stop()
-
-    return ensemble.results()
+    results = _fetch_results(ee_config, ensemble_config, stages_config)
+    return results

--- a/ert3/evaluator/poly.py
+++ b/ert3/evaluator/poly.py
@@ -1,7 +1,0 @@
-def polynomial(coefficients, x_range=tuple(range(10))):
-    return {
-        "polynomial_output": [
-            coefficients["a"] * (x ** 2) + coefficients["b"] * x + coefficients["c"]
-            for x in x_range
-        ]
-    }

--- a/examples/polynomial/poly.py
+++ b/examples/polynomial/poly.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import argparse
+import json
+import sys
+
+
+def _build_arg_parser():
+    arg_parser = argparse.ArgumentParser(
+        description="Computes the result of a second degree polynomial",
+    )
+    arg_parser.add_argument(
+        "--coefficients",
+        type=argparse.FileType('r'),
+        required=True,
+        help="Path to file containing the coefficients"
+    )
+    arg_parser.add_argument(
+        "--output",
+        type=argparse.FileType('w'),
+        required=True,
+        help="Path to the output file"
+    )
+    return arg_parser
+
+
+def _evaluate_polynomial(coefficients):
+    a, b, c = coefficients["a"], coefficients["b"], coefficients["c"]
+    x_range = tuple(range(10))
+    return tuple(a * x**2 + b * x + c for x in x_range)
+
+
+def _main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    coefficients = json.load(args.coefficients)
+    result = _evaluate_polynomial(coefficients)
+    json.dump(result, args.output)
+
+
+if __name__ == "__main__":
+    _main()

--- a/examples/polynomial/stages.yml
+++ b/examples/polynomial/stages.yml
@@ -1,13 +1,20 @@
 -
   name: evaluate_polynomial
-  environment: polynomial
+
   input:
     -
       record: coefficients
       location: coefficients.json
+
   output:
     -
       record: polynomial_output
       location: output.json
+
+  transportable_commands:
+    -
+      name: poly
+      location: poly.py
+
   script:
-    - ert3.evaluator.poly:polynomial
+    - poly --coefficients coefficients.json --output output.json

--- a/tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert3/engine/integration/test_engine.py
@@ -74,12 +74,18 @@ def stages_config():
     config_list = [
         {
             "name": "evaluate_polynomial",
-            "environment": "polynomial",
             "input": [{"record": "coefficients", "location": "coefficients.json"}],
             "output": [{"record": "polynomial_output", "location": "output.json"}],
-            "script": ["ert3.evaluator.poly:polynomial"],
+            "script": ["poly --coefficients coefficients.json --output output.json"],
+            "transportable_commands": [
+                {
+                    "name": "poly",
+                    "location": "poly.py",
+                }
+            ],
         }
     ]
+    shutil.copy2(_EXAMPLES_ROOT / "polynomial" / "poly.py", "poly.py")
     yield ert3.config.load_stages_config(config_list)
 
 


### PR DESCRIPTION
The goal of this PR is to make the tests of the `ert3-prefect-ensemble` pass again.

As one can see from the changes in `examples/polynomial/stages.yml` I've changed the configuration from being able to configure a Python function as the forward model to the forward model being a single `unix_step`. The remainder of the PR consists of:
- updating configuration code and tests according to be above change and
- to configure the `EnsembleEvaluator` according to the user configuration.

While doing so I've tried to keep the changes to a minimum. Due to this it is only possible to configure the forward model as a single stage, and stages cannot be built on top of other stages. Implying that the forward model will be a single `unix_step`.