### PR TITLE
Storage: Move database to /tmp while using it

### DIFF
--- a/ert_shared/storage/app.py
+++ b/ert_shared/storage/app.py
@@ -39,6 +39,11 @@ async def prepare_database():
     ERT_STORAGE.initialize()
 
 
+@app.on_event("shutdown")
+async def shutdown_database():
+    ERT_STORAGE.shutdown()
+
+
 @app.middleware("http")
 async def check_authorization(request: Request, call_next):
     api_token = os.getenv("ERT_AUTHTOKEN")

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -14,10 +14,9 @@ def db_factory(tmp_path_factory):
     """
 
     tmp_path = tmp_path_factory.mktemp("database")
-    url = f"sqlite:///{tmp_path}/ert_storage.db"
 
     sess = ErtStorage()
-    sess.initialize(url=url, testing=True)
+    sess.initialize(project_path=tmp_path, testing=True)
 
     def override_get_db():
         try:

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -14,6 +14,7 @@ def test_initialize_from_scratch(tmpdir):
         storage = ErtStorage()
         assert not os.path.isfile(storage._db_file_name)
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         assert os.path.isfile(storage._db_file_name)
 
 
@@ -35,9 +36,11 @@ def test_db_backup_before_upgrade(tmpdir):
     with tmpdir.as_cwd():
         storage = ErtStorage()
         storage.initialize(script_location=script_location, revision="11d6bbf0a926")
+        storage.shutdown()
         initial_revision = storage._db_revision()
 
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         last_revision = storage._db_revision()
 
         assert initial_revision != last_revision
@@ -53,11 +56,13 @@ def test_ert_too_old_with_backup(tmpdir):
         script_location = str(Path(__file__).parent / "migrations_stable")
         storage = ErtStorage()
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         stable_revision = storage._db_revision()
 
         # Switch to testing and upgrade database
         script_location = str(Path(__file__).parent / "migrations_testing")
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         testing_revision = storage._db_revision()
 
         assert stable_revision != testing_revision
@@ -79,11 +84,13 @@ def test_ert_too_old_without_backup(tmpdir):
         script_location = str(Path(__file__).parent / "migrations_testing")
         storage = ErtStorage()
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         testing_revision = storage._db_revision()
 
         # Switch to bleeding and upgrade database
         script_location = str(Path(__file__).parent / "migrations_bleeding")
         storage.initialize(script_location=script_location)
+        storage.shutdown()
         bleeding_revision = storage._db_revision()
 
         assert testing_revision != bleeding_revision


### PR DESCRIPTION
This is a hack in order to avoid the latency from NFS. In the future
this will be done properly by having a separate centralised database
server to which ERT will connect to and thus we won't be on NFS anymore.

Resolves: #1309 