### PR TITLE
Avoid unnecessary stack trace during `ert vis`

### DIFF
--- a/ert_shared/plugins/__init__.py
+++ b/ert_shared/plugins/__init__.py
@@ -1,30 +1,18 @@
 import os
+import sys
 from .plugin_manager import ErtPluginContext, ErtPluginManager
 from .visualization_plugin_handler import (
     VisualizationPluginHandler,
     PluginHandlerException,
 )
-from ert_shared.storage.connection import get_info, get_project_id
-from ert_shared.storage.server_monitor import ServerMonitor
+from ert_shared.storage.connection import autostart
 
 
 def launch_visualization_plugin(args):
-
-    # Try to use project specified in args (Defaults to cwd)
     try:
-        get_info(args.project)
-        os.environ["ERT_PROJECT_IDENTIFIER"] = os.path.realpath(args.project)
-    except RuntimeError as e:
-        # Try to use "registered" ert server
-        try:
-            path = get_project_id()
-            os.environ["ERT_PROJECT_IDENTIFIER"] = str(path.absolute())
-        except RuntimeError as e:
-            # try to start ert api
-            monitor = ServerMonitor.get_instance()
-            monitor.start()
-            monitor.fetch_connection_info()
-            os.environ["ERT_PROJECT_IDENTIFIER"] = os.path.realpath(os.getcwd())
+        os.environ["ERT_PROJECT_IDENTIFIER"] = autostart(args.project)
+    except RuntimeError:
+        sys.exit("Failed to connect to ERT Storage server")
 
     pm = ErtPluginManager()
     handler = VisualizationPluginHandler()

--- a/ert_shared/storage/app.py
+++ b/ert_shared/storage/app.py
@@ -36,7 +36,18 @@ security = HTTPBasic()
 
 @app.on_event("startup")
 async def prepare_database():
-    ERT_STORAGE.initialize()
+    try:
+        ERT_STORAGE.initialize()
+    except SystemExit as exc:
+        # SystemExit is caught by Startlette, which prints a stack trace. This
+        # is not what we want. We want a clean exit. As such, we use os._exit,
+        # which doesn't clean up very well after itself, but it should be fine
+        # here.
+        if isinstance(exc.code, str):
+            print(exc.code, file=sys.stderr)
+        elif isinstance(exc.code, int):
+            os._exit(exc.code)
+        os._exit(1)
 
 
 @app.on_event("shutdown")

--- a/ert_shared/storage/connection.py
+++ b/ert_shared/storage/connection.py
@@ -71,3 +71,27 @@ def get_project_id() -> Path:
     if json_path.exists():
         return json_path.resolve().parent
     raise RuntimeError("No ert storage server found!")
+
+
+def autostart(project_path: str = None) -> str:
+    from .server_monitor import ServerMonitor
+
+    # Try to use project specified in args (Defaults to cwd)
+    try:
+        get_info(project_path)
+        return os.path.realpath(project_path)
+    except RuntimeError:
+        pass
+
+    # Try to use globally registered ERT Storage
+    try:
+        path = get_project_id()
+        return str(path.absolute())
+    except RuntimeError:
+        pass
+
+    # Try to start ERT Storage
+    monitor = ServerMonitor.get_instance()
+    monitor.start()
+    monitor.fetch_connection_info()
+    return os.path.realpath(os.getcwd())

--- a/ert_shared/storage/db.py
+++ b/ert_shared/storage/db.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import textwrap
 import asyncio
 import atexit
@@ -97,7 +98,7 @@ class ErtStorage:
             )
 
         elif database_exists and self._revision_position(current_revision) == -1:
-            raise Exception(self._error_msg(self._revisions(index=0)))
+            sys.exit(self._error_msg(self._revisions(index=0)))
 
         with self._engine.begin() as connection:
             self._cfg.attributes["connection"] = connection

--- a/ert_shared/storage/server_monitor.py
+++ b/ert_shared/storage/server_monitor.py
@@ -15,6 +15,10 @@ def empty(arr):
     return len(arr) == 0
 
 
+class ServerBootFail(RuntimeError):
+    pass
+
+
 class ServerMonitor(threading.Thread):
     EXEC_ARGS = [sys.executable, "-m", "ert_shared.storage"]
     TIMEOUT = 20  # Wait 20s for the server to start before panicking
@@ -78,6 +82,8 @@ class ServerMonitor(threading.Thread):
             for url in self._connection_info["urls"]:
                 print(f"  {url}")
             print(f"\nUse `{curl}` to test")
+        except json.JSONDecodeError:
+            self._connection_info = ServerBootFail()
         except Exception as e:
             self._connection_info = e
 

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -73,7 +73,7 @@ def test_ert_too_old_with_backup(tmpdir):
 
         # Switch back to stable. Database is now too new
         script_location = str(Path(__file__).parent / "migrations_stable")
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(SystemExit) as excinfo:
             storage.initialize(script_location=script_location)
         assert storage._error_msg(stable_revision) in str(excinfo.value)
 
@@ -101,6 +101,6 @@ def test_ert_too_old_without_backup(tmpdir):
 
         # Switch back to stable. Database is now too new and no backup for stable
         script_location = str(Path(__file__).parent / "migrations_stable")
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(SystemExit) as excinfo:
             storage.initialize(script_location=script_location)
         assert storage._error_msg("rev-for-test-purpose") in str(excinfo.value)

--- a/tests/storage/test_server_monitor.py
+++ b/tests/storage/test_server_monitor.py
@@ -1,10 +1,13 @@
 import pytest
 import signal
 import requests
-from json import JSONDecodeError
 from textwrap import dedent
 from pathlib import Path
-from ert_shared.storage.server_monitor import ServerMonitor, TimeoutError
+from ert_shared.storage.server_monitor import (
+    ServerBootFail,
+    ServerMonitor,
+    TimeoutError,
+)
 from ert_shared.storage import connection
 
 
@@ -81,7 +84,7 @@ os.write(fd, b"This isn't valid json (I hope)")
 """
 )
 def test_authtoken_wrong_json(server):
-    with pytest.raises(JSONDecodeError):
+    with pytest.raises(ServerBootFail):
         server.fetch_connection_info()
 
 


### PR DESCRIPTION
When the ERT Storage server fails to start, ert vis would print out a
too intricate stack trace. This is not what we want. ERT Storage already
prints out a human-readable error message on how to solve the user's
problem, so with these changes we avoid bombarding the user with scary
printouts.

Resolves: #1306 
