### PR TITLE
Sensitivity analysis

### DIFF
--- a/ert3/__init__.py
+++ b/ert3/__init__.py
@@ -6,5 +6,7 @@ import ert3.workspace
 import ert3.stats
 import ert3.config
 import ert3.exceptions
+import ert3.algorithms
+
 
 _WORKSPACE_DATA_ROOT = ".ert"

--- a/ert3/algorithms/__init__.py
+++ b/ert3/algorithms/__init__.py
@@ -1,0 +1,1 @@
+from ert3.algorithms._sensitivity import one_at_the_time

--- a/ert3/algorithms/_sensitivity.py
+++ b/ert3/algorithms/_sensitivity.py
@@ -1,0 +1,30 @@
+def _build_base_records(groups, parameters):
+    return {group_name: parameters[group_name].ppf(0.5) for group_name in groups}
+
+
+def one_at_the_time(parameters):
+    if len(parameters) == 0:
+        raise ValueError("Cannot study the sensitivity of no variables")
+
+    # The lower extremal value of the analysis. Each variable will after turn
+    # be explored as ppf(tail) and ppf(1-tail) as the two extremal values.
+    tail = (1 - 0.99) / 2
+
+    evaluations = []
+    for group_name, dist in parameters.items():
+        lower = dist.ppf(tail)
+        upper = dist.ppf(1 - tail)
+        const_records = set(parameters.keys())
+        const_records.remove(group_name)
+
+        for idx in dist.index:
+            for lim_val in (lower, upper):
+                records = _build_base_records(const_records, parameters)
+
+                rec_values = dist.ppf(0.5)
+                rec_values[idx] = lim_val[idx]
+                records[group_name] = rec_values
+
+                evaluations.append(records)
+
+    return evaluations

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -1,2 +1,3 @@
 from ert3.config._ensemble_config import load_ensemble_config
 from ert3.config._stages_config import load_stages_config
+from ert3.config._experiment_config import load_experiment_config

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from typing_extensions import Literal
 from pydantic.dataclasses import dataclass
 from pydantic import BaseModel
@@ -25,7 +25,7 @@ class Input(_EnsembleConfig):
 class EnsembleConfig(_EnsembleConfig):
     forward_model: ForwardModel
     input: List[Input]
-    size: int
+    size: Optional[int] = None
 
 
 def load_ensemble_config(config_dict):

--- a/ert3/config/_experiment_config.py
+++ b/ert3/config/_experiment_config.py
@@ -1,0 +1,37 @@
+from typing import List, Optional
+from typing_extensions import Literal
+from pydantic.dataclasses import dataclass
+from pydantic import root_validator, BaseModel
+
+
+class _ExperimentConfig(BaseModel):
+    validate_all = True
+    validate_assignment = True
+    extra = "forbid"
+    allow_mutation = False
+    arbitrary_types_allowed = True
+
+
+class ExperimentConfig(_ExperimentConfig):
+    type: Literal["evaluation", "sensitivity"]
+    algorithm: Optional[Literal["one-at-a-time"]]
+
+    @root_validator
+    def command_defined(cls, experiment):
+        type_ = experiment.get("type")
+        algorithm = experiment.get("algorithm")
+
+        if type_ == "evaluation":
+            if algorithm != None:
+                raise ValueError("Did not expect algorithm for evaluation experiment")
+        elif type_ == "sensitivity":
+            if algorithm == None:
+                raise ValueError("Expected an algorithm for sensitivity experiments")
+        else:
+            raise ValueError(f"Unexpected experiment type: {type_}")
+
+        return experiment
+
+
+def load_experiment_config(config_dict):
+    return ExperimentConfig(**config_dict)

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -65,7 +65,14 @@ def _run(workspace, args):
     ert3.workspace.assert_experiment_exists(workspace, args.experiment_name)
     ensemble = _load_ensemble_config(workspace, args.experiment_name)
     stages_config = _load_stages_config(workspace)
-    ert3.engine.run(ensemble, stages_config, workspace, args.experiment_name)
+    experiment_config = _load_experiment_config(workspace, args.experiment_name)
+    ert3.engine.run(
+        ensemble,
+        stages_config,
+        experiment_config,
+        workspace,
+        args.experiment_name,
+    )
 
 
 def _export(workspace, args):
@@ -130,3 +137,8 @@ def _load_ensemble_config(workspace, experiment_name):
 def _load_stages_config(workspace):
     with open(workspace / "stages.yml") as f:
         return ert3.config.load_stages_config(yaml.safe_load(f))
+
+
+def _load_experiment_config(workspace, experiment_name):
+    with open(workspace / experiment_name / "experiment.yml") as f:
+        return ert3.config.load_experiment_config(yaml.safe_load(f))

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -1,4 +1,5 @@
 import ert3
+from ert3.engine import _utils
 
 import json
 import yaml
@@ -16,32 +17,11 @@ def load_record(workspace, record_name, record_file):
 
 
 def sample_record(workspace, parameter_group_name, record_name, ensemble_size):
-    with open(workspace / "parameters.yml") as f:
-        parameters = yaml.safe_load(f)
+    parameters = _utils.load_parameters(workspace)
 
-    parameter_group = None
-    for ps in parameters:
-        if ps["name"] == parameter_group_name:
-            parameter_group = ps
-
-    if parameter_group is None:
+    if parameter_group_name not in parameters:
         raise ValueError(f"No parameter group found named: {parameter_group_name}")
-
-    dist_config = parameter_group["distribution"]
-    if dist_config["type"] == "gaussian":
-        distribution = ert3.stats.Gaussian(
-            dist_config["input"]["mean"],
-            dist_config["input"]["std"],
-            index=parameter_group["variables"],
-        )
-    elif dist_config["type"] == "uniform":
-        distribution = ert3.stats.Uniform(
-            dist_config["input"]["lower_bound"],
-            dist_config["input"]["upper_bound"],
-            index=parameter_group["variables"],
-        )
-    else:
-        raise ValueError("Unknown distribution type: {}".format(dist_config["type"]))
+    distribution = parameters[parameter_group_name]
 
     ert3.storage.add_variables(
         workspace,

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -1,4 +1,5 @@
 import ert3
+from ert3.engine import _utils
 
 
 def _persist_variables(
@@ -33,7 +34,6 @@ def _add_record(records, record_name, record):
 
 
 def _load_input_records(ensemble, workspace_root, experiment_name):
-
     records = [{} for _ in range(ensemble.size)]
     for input_record in ensemble.input:
         record_name = input_record.record
@@ -48,16 +48,53 @@ def _load_input_records(ensemble, workspace_root, experiment_name):
     return records
 
 
-def run(ensemble, stages_config, workspace_root, experiment_name):
+def _prepare_experiment(workspace_root, experiment_name):
     if ert3.workspace.experiment_have_run(workspace_root, experiment_name):
         raise ValueError(f"Experiment {experiment_name} have been carried out.")
-
     ert3.storage.init_experiment(workspace_root, experiment_name)
 
+
+def _prepare_evaluation(ensemble, workspace_root, experiment_name):
     input_records = _load_input_records(ensemble, workspace_root, experiment_name)
     ert3.storage.add_input_data(workspace_root, experiment_name, input_records)
 
+
+def _load_ensemble_parameters(ensemble, workspace):
+    parameters = _utils.load_parameters(workspace)
+
+    ensemble_parameters = {}
+    for input_record in ensemble.input:
+        record_name = input_record.record
+        record_source = input_record.source.split(".")
+        assert len(record_source) == 2
+        assert record_source[0] == "stochastic"
+        parameter_group_name = record_source[1]
+        ensemble_parameters[parameter_group_name] = parameters[parameter_group_name]
+    return ensemble_parameters
+
+
+def _prepare_sensitivity(ensemble, workspace_root, experiment_name):
+    parameters = _load_ensemble_parameters(ensemble, workspace_root)
+    input_records = ert3.algorithms.one_at_the_time(parameters)
+    ert3.storage.add_input_data(workspace_root, experiment_name, input_records)
+
+
+def _evaluate(ensemble, stages_config, workspace_root, experiment_name):
+    input_records = ert3.storage.get_input_data(workspace_root, experiment_name)
     response = ert3.evaluator.evaluate(
         workspace_root, experiment_name, input_records, ensemble, stages_config
     )
     ert3.storage.add_output_data(workspace_root, experiment_name, response)
+
+
+def run(ensemble, stages_config, experiment_config, workspace_root, experiment_name):
+    _prepare_experiment(workspace_root, experiment_name)
+
+    if experiment_config.type == "evaluation":
+        _prepare_evaluation(ensemble, workspace_root, experiment_name)
+    elif experiment_config.type == "sensitivity":
+        _prepare_sensitivity(ensemble, workspace_root, experiment_name)
+    else:
+        raise ValueError(f"Unknown experiment type {experiment_config.type}")
+
+    _evaluate(ensemble, stages_config, workspace_root, experiment_name)

--- a/ert3/engine/_utils.py
+++ b/ert3/engine/_utils.py
@@ -1,0 +1,36 @@
+import ert3
+import yaml
+
+
+# TODO: This entire file should be replaced by a pydantic schema!
+# This is a hack, but at least it lives in isolation, with a plan to get
+# rid of it...
+
+
+def load_parameters(workspace):
+    with open(workspace / "parameters.yml") as f:
+        parameter_config = yaml.safe_load(f)
+
+    parameters = {}
+    for parameter_group in parameter_config:
+        dist_config = parameter_group["distribution"]
+        if dist_config["type"] == "gaussian":
+            distribution = ert3.stats.Gaussian(
+                dist_config["input"]["mean"],
+                dist_config["input"]["std"],
+                index=parameter_group["variables"],
+            )
+        elif dist_config["type"] == "uniform":
+            distribution = ert3.stats.Uniform(
+                dist_config["input"]["lower_bound"],
+                dist_config["input"]["upper_bound"],
+                index=parameter_group["variables"],
+            )
+        else:
+            raise ValueError(
+                "Unknown distribution type: {}".format(dist_config["type"])
+            )
+
+        parameters[parameter_group["name"]] = distribution
+
+    return parameters

--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -45,6 +45,12 @@ def _prepare_input(ee_config, stages_config, inputs, evaluation_tmp_dir):
 def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records):
     _assert_single_stage_forward_model(stages_config, ensemble)
 
+    if ensemble.size != None:
+        ensemble_size = ensemble.size
+    else:
+        ensemble_size = len(input_records)
+    assert len(input_records) == ensemble_size
+
     stage_name = ensemble.forward_model.stages[0]
     step_name = stage_name + "-only_step"
     stage = stages_config.step_from_key(stage_name)
@@ -78,7 +84,7 @@ def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records)
                 ],
             }
         ],
-        "realizations": ensemble.size,
+        "realizations": ensemble_size,
         "max_running": 10000,
         "max_retries": 0,
         "run_path": str(evaluation_tmp_dir / "my_output"),

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy.stats
 
 
@@ -15,11 +16,12 @@ class Gaussian:
                 "Cannot create gaussian distribution with both size and index"
             )
 
+        self._index = index
         if size is not None:
             self._size = size
         else:
             self._size = len(tuple(index))
-        self._index = index
+            self._index = tuple(index)
 
     def sample(self):
         sample = scipy.stats.norm.rvs(loc=self._mean, scale=self._std, size=self._size)
@@ -27,6 +29,18 @@ class Gaussian:
             return sample
         else:
             return {idx: float(val) for idx, val in zip(self._index, sample)}
+
+    def ppf(self, x):
+        x = np.full(self._size, x)
+        result = scipy.stats.norm.ppf(x, loc=self._mean, scale=self._std)
+        if self._index is None:
+            return result
+        else:
+            return {idx: float(val) for idx, val in zip(self._index, result)}
+
+    @property
+    def index(self):
+        return self._index if self._index is not None else tuple(range(self._size))
 
 
 class Uniform:
@@ -58,3 +72,15 @@ class Uniform:
             return sample
         else:
             return {idx: float(val) for idx, val in zip(self._index, sample)}
+
+    def ppf(self, x):
+        x = np.full(self._size, x)
+        result = scipy.stats.uniform.ppf(x, loc=self._lower_bound, scale=self._scale)
+        if self._index is None:
+            return result
+        else:
+            return {idx: float(val) for idx, val in zip(self._index, result)}
+
+    @property
+    def index(self):
+        return self._index if self._index is not None else tuple(range(self._size))

--- a/examples/polynomial/sensitivity/ensemble.yml
+++ b/examples/polynomial/sensitivity/ensemble.yml
@@ -1,0 +1,9 @@
+input:
+  -
+    source: stochastic.coefficients
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/sensitivity/experiment.yml
+++ b/examples/polynomial/sensitivity/experiment.yml
@@ -1,0 +1,2 @@
+type: sensitivity
+algorithm: one-at-a-time

--- a/tests/ert3/algorithms/test_one_at_the_time.py
+++ b/tests/ert3/algorithms/test_one_at_the_time.py
@@ -1,0 +1,176 @@
+import pytest
+
+import ert3
+
+
+# The inverse cumulative normal distribution function evaluated at 0.995
+CNORM_INV = 2.57582930
+
+# The inverse cumulative uniform distribution function evaluated at 0.995
+CUNI_INV = 0.005
+
+
+def test_no_parameters():
+    with pytest.raises(ValueError):
+        ert3.algorithms.one_at_the_time([])
+
+
+@pytest.mark.parametrize(
+    ("distribution", "a", "b", "sens_low", "sens_high"),
+    (
+        (ert3.stats.Gaussian, 0, 1, -CNORM_INV, CNORM_INV),
+        (ert3.stats.Uniform, 0, 1, CUNI_INV, 1 - CUNI_INV),
+    ),
+)
+def test_single_parameter(distribution, a, b, sens_low, sens_high):
+    single_dist = distribution(a, b, size=1)
+    evaluations = ert3.algorithms.one_at_the_time({"single": single_dist})
+
+    assert 2 == len(evaluations)
+    for idx, parameter_value in enumerate([sens_low, sens_high]):
+        evali = evaluations[idx]
+        assert ["single"] == list(evali.keys())
+        assert 1 == len(evali["single"])
+        for val in evali["single"]:
+            assert parameter_value == pytest.approx(val)
+
+
+def test_parameter_array():
+    size = 10
+    gauss_array = ert3.stats.Gaussian(0, 1, size=size)
+    evaluations = ert3.algorithms.one_at_the_time({"array": gauss_array})
+
+    assert 2 * size == len(evaluations)
+    for eidx, evali in enumerate(evaluations):
+        parameter_value = -CNORM_INV if eidx % 2 == 0 else CNORM_INV
+        assert ["array"] == list(evali.keys())
+        assert size == len(evali["array"])
+        for vidx, val in enumerate(evali["array"]):
+            expected_value = parameter_value if vidx == eidx // 2 else 0
+            assert expected_value == pytest.approx(val)
+
+
+def test_parameter_index():
+    index = ["a" * i + str(i) for i in range(5)]
+    gauss_index = ert3.stats.Gaussian(0, 1, index=index)
+    evaluations = ert3.algorithms.one_at_the_time({"indexed_gauss": gauss_index})
+
+    assert 2 * len(index) == len(evaluations)
+    for eidx, evali in enumerate(evaluations):
+        parameter_value = -CNORM_INV if eidx % 2 == 0 else CNORM_INV
+        assert ["indexed_gauss"] == list(evali.keys())
+        assert sorted(index) == sorted(evali["indexed_gauss"].keys())
+        for kidx, key in enumerate(index):
+            expected_value = parameter_value if kidx == eidx // 2 else 0
+            assert expected_value == pytest.approx(evali["indexed_gauss"][key])
+
+
+def test_multi_parameter_singletons():
+    expected_evaluations = [
+        {"a": [-CNORM_INV], "b": [0]},
+        {"a": [CNORM_INV], "b": [0]},
+        {"a": [0], "b": [-CNORM_INV]},
+        {"a": [0], "b": [CNORM_INV]},
+    ]
+
+    records = {
+        "a": ert3.stats.Gaussian(0, 1, size=1),
+        "b": ert3.stats.Gaussian(0, 1, size=1),
+    }
+    evaluations = ert3.algorithms.one_at_the_time(records)
+
+    assert len(expected_evaluations) == len(evaluations)
+    for expected, result in zip(expected_evaluations, evaluations):
+        assert expected.keys() == result.keys()
+        for key in expected.keys():
+            assert len(expected[key]) == len(result[key])
+            for e, r in zip(expected[key], result[key]):
+                assert e == pytest.approx(r)
+
+
+def test_multi_parameter_doubles():
+    expected_evaluations = [
+        {"a": [-CNORM_INV, 0], "b": [0, 0]},
+        {"a": [CNORM_INV, 0], "b": [0, 0]},
+        {"a": [0, -CNORM_INV], "b": [0, 0]},
+        {"a": [0, CNORM_INV], "b": [0, 0]},
+        {"a": [0, 0], "b": [-CNORM_INV, 0]},
+        {"a": [0, 0], "b": [CNORM_INV, 0]},
+        {"a": [0, 0], "b": [0, -CNORM_INV]},
+        {"a": [0, 0], "b": [0, CNORM_INV]},
+    ]
+
+    records = {
+        "a": ert3.stats.Gaussian(0, 1, size=2),
+        "b": ert3.stats.Gaussian(0, 1, size=2),
+    }
+    evaluations = ert3.algorithms.one_at_the_time(records)
+
+    assert len(expected_evaluations) == len(evaluations)
+    for expected, result in zip(expected_evaluations, evaluations):
+        assert expected.keys() == result.keys()
+        for key in expected.keys():
+            assert len(expected[key]) == len(result[key])
+            for e, r in zip(expected[key], result[key]):
+                assert e == pytest.approx(r)
+
+
+def test_uni_and_norm():
+    expected_evaluations = [
+        {"a": [-CNORM_INV, 0], "b": [0.5, 0.5]},
+        {"a": [CNORM_INV, 0], "b": [0.5, 0.5]},
+        {"a": [0, -CNORM_INV], "b": [0.5, 0.5]},
+        {"a": [0, CNORM_INV], "b": [0.5, 0.5]},
+        {"a": [0, 0], "b": [CUNI_INV, 0.5]},
+        {"a": [0, 0], "b": [1 - CUNI_INV, 0.5]},
+        {"a": [0, 0], "b": [0.5, CUNI_INV]},
+        {"a": [0, 0], "b": [0.5, 1 - CUNI_INV]},
+    ]
+
+    records = {
+        "a": ert3.stats.Gaussian(0, 1, size=2),
+        "b": ert3.stats.Uniform(0, 1, size=2),
+    }
+    evaluations = ert3.algorithms.one_at_the_time(records)
+
+    assert len(expected_evaluations) == len(evaluations)
+    for expected, result in zip(expected_evaluations, evaluations):
+        assert expected.keys() == result.keys()
+
+        for key in expected.keys():
+            assert len(expected[key]) == len(result[key])
+            for e, r in zip(expected[key], result[key]):
+                assert e == pytest.approx(r)
+
+
+def test_multi_parameter_groups():
+    records = {}
+
+    size = 10
+    records["array"] = ert3.stats.Gaussian(0, 1, size=size)
+
+    index = ["a" * i + str(i) for i in range(5)]
+    records["indexed"] = ert3.stats.Gaussian(0, 1, index=index)
+
+    evaluations = ert3.algorithms.one_at_the_time(records)
+
+    assert 2 * (size + len(index)) == len(evaluations)
+    for eidx, evali in enumerate(evaluations):
+        parameter_value = -CNORM_INV if eidx % 2 == 0 else CNORM_INV
+        assert ["array", "indexed"] == sorted(evali.keys())
+
+        assert size == len(evali["array"])
+        for vidx, val in enumerate(evali["array"]):
+            expected_value = (
+                parameter_value if eidx < 2 * size and vidx == eidx // 2 else 0
+            )
+            assert expected_value == pytest.approx(val)
+
+        assert sorted(index) == sorted(evali["indexed"].keys())
+        for kidx, key in enumerate(index):
+            expected_value = (
+                parameter_value
+                if eidx >= 2 * size and kidx == (eidx - 2 * size) // 2
+                else 0
+            )
+            assert expected_value == pytest.approx(evali["indexed"][key])

--- a/tests/ert3/config/test_experiment_config.py
+++ b/tests/ert3/config/test_experiment_config.py
@@ -1,0 +1,54 @@
+import pydantic
+import pytest
+
+import ert3
+
+
+def test_valid_evaluation():
+    raw_config = {"type": "evaluation"}
+    experiment_config = ert3.config.load_experiment_config(raw_config)
+    assert experiment_config.type == "evaluation"
+    assert experiment_config.algorithm == None
+
+
+def test_valid_sensitivity():
+    raw_config = {"type": "sensitivity", "algorithm": "one-at-a-time"}
+    experiment_config = ert3.config.load_experiment_config(raw_config)
+    assert experiment_config.type == "sensitivity"
+    assert experiment_config.algorithm == "one-at-a-time"
+
+
+def test_unknown_experiment_type():
+    raw_config = {"type": "unknown_experiment_type"}
+    with pytest.raises(
+        pydantic.error_wrappers.ValidationError,
+        match="unexpected value; permitted: 'evaluation', 'sensitivity' \(",
+    ):
+        ert3.config.load_experiment_config(raw_config)
+
+
+def test_evaluation_and_algorithm():
+    raw_config = {"type": "evaluation", "algorithm": "one-at-a-time"}
+    with pytest.raises(
+        pydantic.error_wrappers.ValidationError,
+        match="Did not expect algorithm for evaluation experiment",
+    ):
+        ert3.config.load_experiment_config(raw_config)
+
+
+def test_sensitivity_and_no_algorithm():
+    raw_config = {"type": "sensitivity"}
+    with pytest.raises(
+        pydantic.error_wrappers.ValidationError,
+        match="Expected an algorithm for sensitivity experiments",
+    ):
+        ert3.config.load_experiment_config(raw_config)
+
+
+def test_unkown_sensitivity_algorithm():
+    raw_config = {"type": "sensitivity", "algorithm": "unknown_algorithm"}
+    with pytest.raises(
+        pydantic.error_wrappers.ValidationError,
+        match="unexpected value; permitted: 'one-at-a-time' \(",
+    ):
+        experiment_config = ert3.config.load_experiment_config(raw_config)

--- a/tests/ert3/engine/integration/conftest.py
+++ b/tests/ert3/engine/integration/conftest.py
@@ -115,3 +115,21 @@ def assert_distribution(
 
         else:
             raise ValueError(f"Unknown distribution {distribution}")
+
+
+def assert_sensitivity_oat_export(
+    workspace, experiment_name, ensemble_config, stages_config
+):
+    with open(workspace / experiment_name / "data.json") as f:
+        export_data = json.load(f)
+
+    num_input_coeffs = 3
+    assert 2 * num_input_coeffs == len(export_data)
+
+    config = load_experiment_config(workspace, ensemble_config, stages_config)
+    assert_input_records(config, export_data)
+    assert_output_records(config, export_data)
+
+    # Note: This test assumes the forward model in the setup indeed
+    # evaluates a * x^2 + b * x + c. If not, this will fail miserably!
+    assert_poly_output(export_data)


### PR DESCRIPTION
Resolves #1329

**Overview**
This PR consists of three commits: the first introduces necessary functionality to the distributions, the second implements the one-at-the-time sensitivity algorithm and the last exposes that algorithm as the capability of running sensitivity studies with ert3.

**Notes on the algorithm**
The oat algorithm implemented in the second commit takes the following approach; for each of the parameters try to move it to a low and high extreme while keeping the other parameters as its expected value. There are multiple possibilities for configuring the algorithm, but that can be addressed in later work as I have tried to keep the PR as small as possible.

**Historic development**
This branch is a continuation of #1248 on top of `master`.
> Aiming at implementing a minimalistic version of sensitivity analysis based on OAT. See https://en.wikipedia.org/wiki/Sensitivity_analysis#One-at-a-time_(OAT)