### PR TITLE
Use pathlib throughout the prefect ensemble code

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -81,11 +81,11 @@ def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records)
         "realizations": ensemble.size,
         "max_running": 10000,
         "max_retries": 0,
-        "run_path": str(evaluation_tmp_dir / "my_output"),
+        "run_path": evaluation_tmp_dir / "my_output",
         "executor": ensemble.forward_model.driver,
         "storage": {
             "type": "shared_disk",
-            "storage_path": str(evaluation_tmp_dir / ".my_storage"),
+            "storage_path": evaluation_tmp_dir / ".my_storage",
         },
     }
 

--- a/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
+++ b/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
@@ -6,6 +6,7 @@ import multiprocessing
 import signal
 import threading
 import asyncio
+from pathlib import Path
 from datetime import timedelta
 from functools import partial
 from cloudevents.http import to_json, CloudEvent
@@ -88,9 +89,9 @@ def gen_coef(parameters, real, config):
             for element in elements:
                 start, end = element["args"]
                 data[element["name"]] = uniform(start, end)
-        os.makedirs(f"coeff", exist_ok=True)
-        file_name = f"coeffs.json"
-        file_path = os.path.join("coeff", file_name)
+        Path("coeff").mkdir(exist_ok=True)
+        file_name = "coeffs.json"
+        file_path = Path("coeff") / file_name
         with open(file_path, "w") as f:
             json.dump(data, f)
         paths[iens] = (storage.store(file_name, iens),)

--- a/tests/ensemble_evaluator/test_prefect_storage.py
+++ b/tests/ensemble_evaluator/test_prefect_storage.py
@@ -1,12 +1,12 @@
+from pathlib import Path
 import pytest
 from ert_shared.ensemble_evaluator.prefect_ensemble.storage_driver import (
     storage_driver_factory,
 )
-import os
 
 
 def test_storage_driver(tmpdir):
-    storage_path = ".my_storage_test_path"
+    storage_path = Path(".my_storage_test_path")
     test_config = {"type": "shared_disk", "storage_path": storage_path}
 
     with tmpdir.as_cwd():
@@ -20,29 +20,57 @@ def test_storage_driver(tmpdir):
 
         # Check storage path
         global_storage_path = storage.get_storage_path(None)
-        expected_global_storage_path = os.path.join(storage_path, "global")
+        expected_global_storage_path = storage_path / "global"
         assert expected_global_storage_path == global_storage_path
 
         storage_path_iens_1 = storage.get_storage_path(1)
-        expected_storage_path = os.path.join(storage_path, "1")
+        expected_storage_path = storage_path / "1"
         assert expected_storage_path == storage_path_iens_1
 
         # Store global file
         global_resource_uri = storage.store(file_name)
-        expected_uri = os.path.join(storage_path, "global", file_name)
+        expected_uri = storage_path / "global" / file_name
         assert expected_uri == global_resource_uri
-        assert os.path.isfile(global_resource_uri)
+        assert global_resource_uri.is_file()
 
         # Store file for realization 1
         real_resource = storage.store(file_name, 1)
-        expected_uri = os.path.join(storage_path, "1", file_name)
+        expected_uri = storage_path / "1" / file_name
         assert expected_uri == real_resource
-        assert os.path.isfile(real_resource)
+        assert real_resource.is_file()
 
         # Retrieve resource from global storage
         storage.retrieve(global_resource_uri, target="global_resource")
-        assert os.path.isfile("global_resource")
+        assert Path("global_resource").is_file()
 
         # Retrieve resource from realization storage
         storage.retrieve(real_resource, target="realization_resource")
-        assert os.path.isfile("realization_resource")
+        assert Path("realization_resource").is_file()
+
+        # Retrieve non-existing file
+        file_uri = global_storage_path / "foo"
+        assert not file_uri.is_file()
+        with pytest.raises(
+            ValueError, match=f"Storage does not contain file: {file_uri}"
+        ):
+            storage.retrieve(file_uri)
+
+        # Retrieve a file that is not in storage, but exists outside of it.
+        file_uri = Path("foo.txt")
+        with open(file_uri, "w") as f:
+            f.write("bar")
+        assert file_uri.is_file()
+        with pytest.raises(
+            ValueError, match=f"Storage does not contain file: {file_uri}"
+        ):
+            storage.retrieve(file_uri)
+
+        # Retrieve an existing file that is not in storage using a relative uri.
+        file_uri = storage_path / ".." / "foo.txt"
+        with open(file_uri, "w") as f:
+            f.write("bar")
+        assert file_uri.is_file()
+        with pytest.raises(
+            ValueError, match=f"Storage does not contain file: {file_uri}"
+        ):
+            storage.retrieve(file_uri)


### PR DESCRIPTION
**Issue**
We prefer to use `pathlib` over `os.path` in new code.

Resolves #1303 


**Approach**
- Replace usage of `os.path` with `Path` in all prefect ensemble files.
- Add a small test.