### PR TITLE
Unify code paths with and without monitoring

### DIFF
--- a/tests/cli/test_integration.py
+++ b/tests/cli/test_integration.py
@@ -109,6 +109,33 @@ def test_ensemble_evaluator(tmpdir, source_root):
         run_cli(parsed)
         FeatureToggling.reset()
 
+def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+
+    with tmpdir.as_cwd():
+        parser = ArgumentParser(prog="test_main")
+        parsed = ert_parser(
+            parser,
+            [
+                ENSEMBLE_SMOOTHER_MODE,
+                "--enable-ensemble-evaluator",
+                "--disable-monitoring",
+                "--target-case",
+                "poly_runpath_file",
+                "--realizations",
+                "1,2,4,8,16,32,64",
+                "poly_example/poly.ert",
+            ],
+        )
+        FeatureToggling.update_from_args(parsed)
+
+        assert FeatureToggling.is_enabled("ensemble-evaluator") is True
+
+        run_cli(parsed)
+        FeatureToggling.reset()
 
 def test_cli_test_run(tmpdir, source_root, mock_cli_run):
     shutil.copytree(


### PR DESCRIPTION
The code paths for running with and without monitoring differed
substantially. These code paths have now been unified by running
the same tracker/monitor code, but instead redirecting to devnull when
running without monitoring.

This also resolves an issue where the ensemble evaluator would not
be shutdown when running without monitoring.
