### PR TITLE
Storage: Remove 'realization' table

### DIFF
--- a/ert_shared/storage/database_schema.py
+++ b/ert_shared/storage/database_schema.py
@@ -31,6 +31,7 @@ class Ensemble(Entity):
     project_id = sa.Column(sa.Integer, sa.ForeignKey("project.id"), nullable=True)
     project = relationship("Project", back_populates="ensembles")
     time_created = sa.Column(sa.DateTime, server_default=func.now())
+    num_realizations = sa.Column(sa.Integer, nullable=False)
 
     children = relationship(
         "Update",
@@ -41,7 +42,6 @@ class Ensemble(Entity):
         uselist=False,
         foreign_keys="[Update.ensemble_result_id]",
     )
-    realizations = relationship("Realization", back_populates="ensemble")
     response_definitions = relationship(
         "ResponseDefinition",
         back_populates="ensemble",
@@ -77,22 +77,6 @@ class Update(Entity):
     )
 
 
-class Realization(Entity):
-    __tablename__ = "realization"
-    __table_args__ = (
-        UniqueConstraint(
-            "index", "ensemble_id", name="uq_realization_index_ensemble_id"
-        ),
-    )
-
-    id = sa.Column(sa.Integer, primary_key=True)
-    index = sa.Column(sa.Integer, nullable=False)
-    ensemble_id = sa.Column(sa.Integer, sa.ForeignKey("ensemble.id"), nullable=False)
-
-    ensemble = relationship("Ensemble", back_populates="realizations")
-    responses = relationship("Response", back_populates="realization")
-
-
 class ResponseDefinition(Entity):
     __tablename__ = "response_definition"
     __table_args__ = (
@@ -118,22 +102,19 @@ class Response(Entity):
     __tablename__ = "response"
     __table_args__ = (
         UniqueConstraint(
-            "realization_id",
             "response_definition_id",
-            name="uq_response_realization_id_reponse_defition_id",
+            "index",
+            name="uq_response_definition_id_index",
         ),
     )
 
     id = sa.Column(sa.Integer, primary_key=True)
     values = sa.Column(sa.PickleType)
-    realization_id = sa.Column(
-        sa.Integer, sa.ForeignKey("realization.id"), nullable=False
-    )
+    index = sa.Column(sa.Integer, nullable=False)
     response_definition_id = sa.Column(
         sa.Integer, sa.ForeignKey("response_definition.id"), nullable=False
     )
 
-    realization = relationship("Realization", back_populates="responses")
     response_definition = relationship("ResponseDefinition", back_populates="responses")
     misfits = relationship("Misfit", back_populates="response")
 

--- a/ert_shared/storage/endpoints/realizations.py
+++ b/ert_shared/storage/endpoints/realizations.py
@@ -9,10 +9,6 @@ router = APIRouter()
 
 @router.get("/ensembles/{ensemble_id}/realizations/{index}")
 async def read_item(*, db: Session = Db(), ensemble_id: int, index: int):
-    realization = (
-        db.query(ds.Realization).filter_by(ensemble_id=ensemble_id, index=index).one()
-    )
-
     response_definitions = db.query(ds.ResponseDefinition).filter_by(
         ensemble_id=ensemble_id
     )
@@ -21,9 +17,7 @@ async def read_item(*, db: Session = Db(), ensemble_id: int, index: int):
             "name": resp_def.name,
             "response": (
                 db.query(ds.Response)
-                .filter_by(
-                    response_definition_id=resp_def.id, realization_id=realization.id
-                )
+                .filter_by(response_definition_id=resp_def.id, index=index)
                 .one()
             ),
         }
@@ -33,13 +27,13 @@ async def read_item(*, db: Session = Db(), ensemble_id: int, index: int):
     parameters = [
         {
             "name": param.name,
-            "value": param.values[realization.index],
+            "value": param.values[index],
         }
         for param in db.query(ds.Parameter).filter_by(ensemble_id=ensemble_id)
     ]
 
     return_schema = {
-        "name": realization.index,
+        "name": index,
         "responses": [
             {"name": res["name"], "data": res["response"].values} for res in responses
         ],

--- a/ert_shared/storage/migrations/versions/22487ba09fe3_remove_realizations.py
+++ b/ert_shared/storage/migrations/versions/22487ba09fe3_remove_realizations.py
@@ -1,0 +1,94 @@
+"""Remove Realizations
+
+Revision ID: 22487ba09fe3
+Revises: dbe9b8d6288b
+Create Date: 2021-01-28 09:48:22.892822
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.ext.declarative import declarative_base
+
+
+# revision identifiers, used by Alembic.
+revision = "22487ba09fe3"
+down_revision = "dbe9b8d6288b"
+branch_labels = None
+depends_on = None
+
+
+Base = declarative_base()
+
+
+class Ensemble(Base):
+    __tablename__ = "ensemble"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    num_realizations = sa.Column(sa.Integer, nullable=False)
+
+
+class Realization(Base):
+    __tablename__ = "realization"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    index = sa.Column(sa.Integer, nullable=False)
+    ensemble_id = sa.Column(sa.Integer, sa.ForeignKey("ensemble.id"), nullable=False)
+
+
+class Response(Base):
+    __tablename__ = "response"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    index = sa.Column(sa.Integer, nullable=False)
+    realization_id = sa.Column(
+        sa.Integer, sa.ForeignKey("realization.id"), nullable=False
+    )
+
+
+def upgrade():
+    session = orm.Session(bind=op.get_bind())
+
+    # 1. Add column to ensemble, response
+    op.add_column(
+        "ensemble", sa.Column("num_realizations", sa.Integer(), nullable=True)
+    )
+    op.add_column("response", sa.Column("index", sa.Integer(), nullable=True))
+
+    # 2. Count ensembles' realizations, copy index from realizations to responses
+    for ens in session.query(Ensemble):
+        ens.num_realizations = (
+            session.query(Realization).filter_by(ensemble_id=ens.id).count()
+        )
+    session.commit()
+
+    for resp in session.query(Response):
+        resp.index = (
+            session.query(Realization.index)
+            .filter_by(id=resp.realization_id)
+            .one()
+            .index
+        )
+    session.commit()
+
+    # 3. Finalise
+    with op.batch_alter_table("response") as bop:
+        bop.drop_constraint(
+            "uq_response_realization_id_reponse_defition_id", type_="unique"
+        )
+        bop.create_unique_constraint(
+            "uq_response_definition_id_index",
+            ["response_definition_id", "index"],
+        )
+        bop.drop_column("realization_id")
+    op.drop_table("realization")
+
+    # 4. Set nullable
+    with op.batch_alter_table("ensemble") as bop:
+        bop.alter_column("num_realizations", existing_type=sa.Integer(), nullable=False)
+    with op.batch_alter_table("response") as bop:
+        bop.alter_column("index", existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade():
+    sys.exit("Cannot downgrade")

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -71,7 +71,7 @@ def db_populated(db_factory):
     db.add(prior_a)
 
     ######## add ensemble ########
-    ensemble = ds.Ensemble(name="ensemble_name", priors=priors)
+    ensemble = ds.Ensemble(name="ensemble_name", priors=priors, num_realizations=2)
     db.add(ensemble)
 
     ######## add parameteredefinitionss ########
@@ -188,15 +188,12 @@ def db_populated(db_factory):
         ]
     )
 
-    ######## add realizations ########
-    realization_0 = ds.Realization(index=0, ensemble=ensemble)
-    realization_1 = ds.Realization(index=1, ensemble=ensemble)
-
-    def add_data(realization):
+    ######## add responses ########
+    def add_data(index):
         response_one = ds.Response(
             response_definition=response_definition_one,
             values=[11.1, 11.2, 9.9, 9.3],
-            realization=realization,
+            index=index,
         )
         db.add(response_one)
         db.add(
@@ -211,12 +208,12 @@ def db_populated(db_factory):
             ds.Response(
                 response_definition=response_definition_two,
                 values=[12.1, 12.2, 11.1, 11.2, 9.9, 9.3],
-                realization=realization,
+                index=index,
             )
         )
 
-    add_data(realization_0)
-    add_data(realization_1)
+    add_data(0)
+    add_data(1)
 
     db.commit()
     db.close()

--- a/tests/storage/test_read_api.py
+++ b/tests/storage/test_read_api.py
@@ -8,8 +8,8 @@ def test_api(app_client):
     for ens in ensembles["ensembles"]:
         ensemble = app_client.get(p.ensemble(ens["id"])).json()
 
-        for real in ensemble["realizations"]:
-            realization = app_client.get(p.realization(ens["id"], real["index"])).json()
+        for real in range(ensemble["realizations"]):
+            realization = app_client.get(p.realization(ens["id"], real)).json()
 
             for response in realization["responses"]:
                 assert response["data"] is not None

--- a/tests/storage/test_write_api.py
+++ b/tests/storage/test_write_api.py
@@ -334,10 +334,9 @@ def test_responses(app_client, mock_ert):
 
     response_0 = (
         app_client.db.query(ds.Response.values)
+        .filter_by(index=0)
         .join(ds.Response.response_definition)
         .filter_by(ensemble_id=ens_resp["id"], name="POLY_RES")
-        .join(ds.Response.realization)
-        .filter_by(index=0)
         .one()
     )
     response_values = response_0.values


### PR DESCRIPTION
The Realization table complicates databases, so we remove it. This PR may also fix issue with incorrect misfits due to a typo.