### PR TITLE
Add a failure event and use it in the prefect and legacy ensemble evaluators

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -123,7 +123,7 @@ def _fetch_results(ee_config, ensemble, stages_config):
 def _run(ensemble_evaluator):
     monitor = ensemble_evaluator.run()
     for event in monitor.track():
-        if event.data is not None and event.data.get("status") == "Stopped":
+        if event.data is not None and event.data.get("status") in ["Stopped", "Failed"]:
             monitor.signal_done()
 
 

--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -34,6 +34,10 @@ loggers:
     level: DEBUG
     handlers: [eefile]
     propagate: no
+  ert_shared.ensemble_evaluator.prefect_ensemble:
+    level: DEBUG
+    handlers: [eefile]
+    propagate: no
   websockets.server:
     level: ERROR
     handlers: [eefile]

--- a/ert_shared/ensemble_evaluator/entity/identifiers.py
+++ b/ert_shared/ensemble_evaluator/entity/identifiers.py
@@ -86,11 +86,13 @@ FM_JOB_ATTR_CURRENT_MEMORY_USAGE = "current_memory_usage"
 EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
 EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
 EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"
+EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.exception"
 
 EVGROUP_ENSEMBLE = {
     EVTYPE_ENSEMBLE_STARTED,
     EVTYPE_ENSEMBLE_STOPPED,
     EVTYPE_ENSEMBLE_CANCELLED,
+    EVTYPE_ENSEMBLE_FAILED,
 }
 
 STATUS_QUEUE_STATE = {

--- a/ert_shared/ensemble_evaluator/entity/snapshot.py
+++ b/ert_shared/ensemble_evaluator/entity/snapshot.py
@@ -33,6 +33,7 @@ _ENSEMBLE_TYPE_EVENT_TO_STATUS = {
     ids.EVTYPE_ENSEMBLE_STARTED: "Starting",
     ids.EVTYPE_ENSEMBLE_STOPPED: "Stopped",
     ids.EVTYPE_ENSEMBLE_CANCELLED: "Cancelled",
+    ids.EVTYPE_ENSEMBLE_FAILED: "Failed",
 }
 
 

--- a/tests/ensemble_evaluator/conftest.py
+++ b/tests/ensemble_evaluator/conftest.py
@@ -130,7 +130,7 @@ def _dump_ext_job(ext_job, index):
         "stderr": f"{index}.stderr",
         "stdin": ext_job.get_stdin_file(),
         "license_path": ext_job.get_license_path(),
-        "environment": {},
+        "environment": None,
         "exec_env": {},
         "max_running": ext_job.get_max_running(),
         "max_running_minutes": ext_job.get_max_running_minutes(),

--- a/tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import pytest
 import ert_shared.ensemble_evaluator.entity.identifiers as identifiers
 from pathlib import Path
@@ -24,9 +25,10 @@ def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
                     identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
                     identifiers.EVTYPE_EE_SNAPSHOT,
                 )
-                and e.data.get("status") == "Stopped"
+                and e.data.get("status") in ["Failed", "Stopped"]
             ):
                 monitor.signal_done()
+        assert evaluator._snapshot.get_status() == "Stopped"
         assert evaluator.get_successful_realizations() == num_reals
 
 
@@ -52,3 +54,30 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_b
                 cancel = False
 
         assert evaluator._snapshot.get_status() == "Cancelled"
+
+
+@pytest.mark.timeout(60)
+def test_run_legacy_ensemble_exception(tmpdir, unused_tcp_port, make_ensemble_builder):
+    num_reals = 2
+    conf_file = Path(tmpdir / CONFIG_FILE)
+    with tmpdir.as_cwd():
+        with open(conf_file, "w") as f:
+            f.write(f'port: "{unused_tcp_port}"\n')
+
+        ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
+        config = load_config(conf_file)
+        evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
+
+        with patch.object(ensemble, "_run_path_list", side_effect=RuntimeError()):
+            monitor = evaluator.run()
+            for e in monitor.track():
+                if (
+                    e["type"]
+                    in (
+                        identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                        identifiers.EVTYPE_EE_SNAPSHOT,
+                    )
+                    and e.data.get("status") in ["Failed", "Stopped"]
+                ):
+                    monitor.signal_done()
+            assert evaluator._snapshot.get_status() == "Failed"


### PR DESCRIPTION
**Issue**
Resolves #1301 


**Approach**
A new event for failures has been added, and this is send when an exception is caught. The status is the set to "Failed".

This approach is not completely satisfactory, since the exception is not reported. I will look in to adding at least logging.

In general this issue points to a problem: we do not have decent error handling across threads, sub-processes and asyncio event loops in place. This needs to be discussed and most likely addressed in a separate issue.

**Edit:**
I have update this request, the approach is now to log the error, and then send a `Failed` status event. However, I am not sure if that is needed, maybe it should just be a `Stopped` status. This depends on how a `Failed` status wold be handled by the rest of the program, is it reported?

**Edit 2**: I am not truly happy with this approach, since there is still the potential to crash in the without sending a Failed event in the exception handler. Then the program may again seem to hang indefinitely. But solving that will require more nasty tricks to track the status of the sub-process that is used to run the ensemble. This is something to be discussed, hence I am putting this up for review.