### PR TITLE
Use FastAPI's APIKey* security

### DIFF
--- a/ert_shared/storage/app.py
+++ b/ert_shared/storage/app.py
@@ -2,14 +2,14 @@ import os
 import sys
 import json
 from typing import Any
-from fastapi import FastAPI, Request, status
+from fastapi import Depends, FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import Response
 from fastapi.security import HTTPBasic
 
 from ert_shared.storage import json_schema as js
-from ert_shared.storage.db import ERT_STORAGE
+from ert_shared.storage.db import ERT_STORAGE, security_token
 from ert_shared.storage.endpoints import router
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -55,30 +55,6 @@ async def shutdown_database():
     ERT_STORAGE.shutdown()
 
 
-@app.middleware("http")
-async def check_authorization(request: Request, call_next):
-    api_token = os.getenv("ERT_AUTHTOKEN")
-    if not api_token:
-        return await call_next(request)
-
-    try:
-        credentials = await security(request)
-    except HTTPException as e:
-        # HTTPBasic throws an HTTPException when it can't validate. However,
-        # we're a middleware and not an endpoint and as such the exception
-        # handlers don't trigger. Do it manually
-        return await http_exception_handler(request, e)
-
-    if not (credentials.username == "__token__" and credentials.password == api_token):
-        return JSONResponse(
-            {"detail": "Invalid credentials"},
-            status_code=status.HTTP_403_FORBIDDEN,
-            headers={"WWW-Authenticate": "Basic"},
-        )
-
-    return await call_next(request)
-
-
 @app.exception_handler(NoResultFound)
 async def sqlalchemy_exception_handler(request: Request, exc: NoResultFound):
     """Automatically catch and convert an SQLAlchemy NoResultFound exception (when
@@ -94,7 +70,11 @@ async def root():
     return {}
 
 
-@app.get("/healthcheck", response_model=js.Healthcheck)
+@app.get(
+    "/healthcheck",
+    dependencies=[Depends(security_token)],
+    response_model=js.Healthcheck,
+)
 async def healthcheck():
     from datetime import datetime
 

--- a/ert_shared/storage/command.py
+++ b/ert_shared/storage/command.py
@@ -28,3 +28,8 @@ def add_parser_options(ap):
         action="store_true",
         default=os.environ.get("ERT_STORAGE_DEBUG", False),
     )
+    ap.add_argument(
+        "--insecure",
+        action="store_true",
+        default=False,
+    )

--- a/ert_shared/storage/command.py
+++ b/ert_shared/storage/command.py
@@ -23,4 +23,8 @@ def add_parser_options(ap):
     ap.add_argument(
         "--host", type=str, default=os.environ.get("ERT_STORAGE_HOST", "127.0.0.1")
     )
-    ap.add_argument("--debug", action="store_true", default=False)
+    ap.add_argument(
+        "--debug",
+        action="store_true",
+        default=os.environ.get("ERT_STORAGE_DEBUG", False),
+    )

--- a/ert_shared/storage/connection.py
+++ b/ert_shared/storage/connection.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 import getpass
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from pathlib import Path
 
 
@@ -38,10 +38,11 @@ def get_info(project_path: Union[str, Path] = None) -> Dict[str, str]:
     with path.open() as f:
         info = json.load(f)
 
-    auth = ("__token__", info["authtoken"])
     for baseurl in info["urls"]:
         try:
-            resp = requests.get(f"{baseurl}/healthcheck", auth=auth)
+            resp = requests.get(
+                f"{baseurl}/healthcheck", headers={"X-Token": info["token"]}
+            )
             if resp.status_code == 200:
                 break
         except requests.ConnectionError:
@@ -49,7 +50,7 @@ def get_info(project_path: Union[str, Path] = None) -> Dict[str, str]:
     else:
         raise RuntimeError(f"None of the URLs provided by {path} are valid")
 
-    return {"baseurl": baseurl, "auth": auth}
+    return {"baseurl": baseurl, "token": info["token"]}
 
 
 def set_global_info(project_path: Union[str, Path]):

--- a/ert_shared/storage/db.py
+++ b/ert_shared/storage/db.py
@@ -5,7 +5,7 @@ import asyncio
 import atexit
 import getpass
 from typing import Generator
-from fastapi import Depends
+from fastapi import Depends, Security
 from pathlib import Path
 from shutil import copy2, move
 
@@ -16,6 +16,8 @@ from sqlalchemy.engine.url import make_url
 import alembic
 from alembic.config import Config
 from alembic import script, migration
+
+from ert_shared.storage.security import security_token
 
 
 class ErtStorage:
@@ -173,7 +175,7 @@ def _tmp_db_path(real_db_path: str) -> Path:
     return db_path / f"ert_storage.db"
 
 
-async def get_db() -> Generator[Session, None, None]:
+async def get_db(*, _=Depends(security_token)) -> Generator[Session, None, None]:
     sess = ERT_STORAGE.Session()
     try:
         yield sess

--- a/ert_shared/storage/main.py
+++ b/ert_shared/storage/main.py
@@ -87,6 +87,13 @@ def run_server(args=None, debug=False):
     if args is None:
         args = parse_args()
 
+    if args.insecure:
+        print("Starting ERT Storage server WITHOUT SECURITY")
+        os.environ["ERT_STORAGE_INSECURE"] = "1"
+    elif "ERT_STORAGE_INSECURE" in os.environ:
+        # Unset just in case the user sets it deliberately
+        del os.environ["ERT_STORAGE_INSECURE"]
+
     if "ERT_STORAGE_TOKEN" in os.environ:
         token = os.environ["ERT_STORAGE_TOKEN"]
     elif not args.debug:

--- a/ert_shared/storage/requests.py
+++ b/ert_shared/storage/requests.py
@@ -1,0 +1,67 @@
+from typing import Any, Optional
+from pathlib import Path
+import requests
+
+from ert_shared.storage.connection import get_info
+
+
+_conn_info: Optional[dict] = None
+
+
+def connect(project_path: Optional[Path] = None) -> None:
+    """
+    Initialise the Requests instance to connect to the project's storage
+    """
+    global _conn_info
+    _conn_info = get_info(project_path)
+
+
+def request(method: str, path: str, **kwargs) -> requests.Response:
+    if _conn_info is None:
+        raise ValueError("A connection to ERT Storage wasn't initialized")
+
+    headers = kwargs.setdefault("headers", {})
+    headers["X-Token"] = _conn_info["token"]
+    if method not in {"get", "head"}:
+        headers.setdefault("Content-Type", "application/json")
+    return requests.request(method, f"{_conn_info['baseurl']}/{path}", **kwargs)
+
+
+def get(path: str, params: Optional[dict] = None, **kwargs) -> requests.Response:
+    """Sends a GET request using the requests library"""
+    kwargs.setdefault("allow_redirects", True)
+    return request("get", path, params=params, **kwargs)
+
+
+def options(path: str, **kwargs) -> requests.Response:
+    """Sends an OPTIONS request using the requests library"""
+    kwargs.setdefault("allow_redirects", True)
+    return request("options", path, **kwargs)
+
+
+def head(path: str, **kwargs) -> requests.Response:
+    """Sends a HEAD request using the requests library"""
+    kwargs.setdefault("allow_redirects", False)
+    return request("head", path, **kwargs)
+
+
+def post(
+    path: str, data: Optional[Any] = None, json: Optional[Any] = None, **kwargs
+) -> requests.Response:
+    """Sends a POST request using the requests library"""
+    return request("post", path, data=data, json=json, **kwargs)
+
+
+def put(path: str, data: Optional[Any] = None, **kwargs) -> requests.Response:
+    """Sends a PUT request using the requests library"""
+    return request("put", path, data=data, **kwargs)
+
+
+def patch(path: str, data: Optional[Any] = None, **kwargs) -> requests.Response:
+    """Sends a PATCH request using the requests library"""
+    return request("patch", path, data=data, **kwargs)
+
+
+def delete(path: str, **kwargs) -> requests.Response:
+    """Sends a DELETE request using the requests library"""
+    return request("delete", path, **kwargs)

--- a/ert_shared/storage/security.py
+++ b/ert_shared/storage/security.py
@@ -3,9 +3,9 @@ from fastapi import Security, HTTPException, status
 from fastapi.security import APIKeyCookie, APIKeyHeader, APIKeyQuery
 
 
-_security_cookie = APIKeyCookie(name="X-ERT-Storage-Token", auto_error=False)
-_security_header = APIKeyHeader(name="X-Token", auto_error=False)
-_security_query = APIKeyQuery(name="_token", auto_error=False)
+_security_cookie = APIKeyCookie(name="ERT-Storage-Token", auto_error=False)
+_security_header = APIKeyHeader(name="Token", auto_error=False)
+_security_query = APIKeyQuery(name="token", auto_error=False)
 
 
 async def security_token(

--- a/ert_shared/storage/security.py
+++ b/ert_shared/storage/security.py
@@ -1,0 +1,39 @@
+import os
+from fastapi import Security, HTTPException, status
+from fastapi.security import APIKeyCookie, APIKeyHeader, APIKeyQuery
+
+
+_security_cookie = APIKeyCookie(name="X-ERT-Storage-Token", auto_error=False)
+_security_header = APIKeyHeader(name="X-Token", auto_error=False)
+_security_query = APIKeyQuery(name="_token", auto_error=False)
+
+
+async def security_token(
+    *,
+    cookie_token: str = Security(_security_cookie),
+    header_token: str = Security(_security_header),
+    query_token: str = Security(_security_query),
+) -> None:
+    if not any((cookie_token, header_token, query_token)):
+        # HTTP 401 is when the user didn't attempt to authorize themselves
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized"
+        )
+
+    real_token = os.getenv("ERT_STORAGE_TOKEN")
+    for token in cookie_token, header_token, query_token:
+        if token == real_token:
+            return
+    # HTTP 403 is when the user has authorized themselves, but aren't allowed to
+    # access this resource
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token")
+
+
+if "ERT_STORAGE_TOKEN" not in os.environ:
+
+    async def security_token():
+        """
+        This is a dummy function that doesn't depend on the APIKey*. This is done so
+        that FastAPI doesn't produce an OpenAPI document that incorrectly states
+        that there is security enabled.
+        """

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -17,6 +17,7 @@ def db_factory(tmp_path_factory):
 
     sess = ErtStorage()
     sess.initialize(project_path=tmp_path, testing=True)
+    sess.Session.path = tmp_path
 
     def override_get_db():
         try:

--- a/tests/storage/test_requests.py
+++ b/tests/storage/test_requests.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from pathlib import Path
+from ert_shared.storage import requests
+from ert_shared.storage.server_monitor import ServerMonitor
+
+
+@pytest.fixture(scope="module")
+def server(request, db_populated):
+    cwd = os.getcwd()
+    path = db_populated.path
+    os.chdir(path)
+
+    server_ = ServerMonitor()
+    server_.start()
+    request.addfinalizer(lambda: server_.shutdown())
+
+    server_.fetch_connection_info()
+    yield server_
+
+    os.chdir(cwd)
+
+
+def test_connect(server):
+    with pytest.raises(ValueError) as exc:
+        requests.get("healthcheck")
+    assert "wasn't initialized" in str(exc.value)
+
+    requests.connect(Path.cwd())
+    resp = requests.get("healthcheck")
+    assert resp.status_code == 200

--- a/tests/storage/test_server_monitor.py
+++ b/tests/storage/test_server_monitor.py
@@ -141,7 +141,7 @@ def test_integration(request, tmpdir):
 
         resp = requests.get(
             f"{server.fetch_url()}/healthcheck",
-            headers={"X-Token": server.fetch_token()},
+            headers={"Token": server.fetch_token()},
         )
         assert "date" in resp.json()
 
@@ -149,14 +149,14 @@ def test_integration(request, tmpdir):
         conn_info = connection.get_info()
         requests.get(
             conn_info["baseurl"] + "/healthcheck",
-            headers={"X-Token": conn_info["token"]},
+            headers={"Token": conn_info["token"]},
         )
 
         # Use local connection info
         conn_info = connection.get_info(str(tmpdir))
         requests.get(
             conn_info["baseurl"] + "/healthcheck",
-            headers={"X-Toekn": conn_info["token"]},
+            headers={"Toekn": conn_info["token"]},
         )
 
         server.shutdown()
@@ -181,6 +181,6 @@ def test_integration_auth(request, tmpdir):
 
         # Invalid auth
         resp = requests.get(
-            f"{server.fetch_url()}/healthcheck", headers={"X-Token": "invalid-token"}
+            f"{server.fetch_url()}/healthcheck", headers={"Token": "invalid-token"}
         )
         assert resp.status_code == 403


### PR DESCRIPTION
Replace our semi-homegrown solution with FastAPI's solution. This has the positive effect of letting Swagger in on the secret that we have secrets:

![bilde](https://user-images.githubusercontent.com/2150728/106488375-f2c74000-64b3-11eb-82ce-259cf37cea85.png)

Resolves: #1355 