### PR TITLE
Load config close to ensemble evaluator evaluation

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -2,7 +2,7 @@ import json
 import os
 import pathlib
 
-from ert_shared.ensemble_evaluator import config as evaluator_config
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert_shared.ensemble_evaluator.prefect_ensemble.prefect_ensemble import (
     PrefectEnsemble,
@@ -137,7 +137,7 @@ def evaluate(
     )
     ensemble = PrefectEnsemble(ee_config)
 
-    config = evaluator_config.load_config()
+    config = EvaluatorServerConfig()
     ee = EnsembleEvaluator(ensemble=ensemble, config=config)
     _run(ee)
 

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -36,7 +36,9 @@ class RunDialog(QDialog):
         self.simulations_tracker = create_tracker(
             run_model, qtimer_cls=QTimer,
             event_handler=self._on_tracker_event,
-            num_realizations=self._simulations_argments["active_realizations"].count())
+            num_realizations=self._simulations_argments["active_realizations"].count(),
+            ee_config=self._simulations_argments.get("ee_config", None)
+        )
 
         self._ticker = QTimer(self)
         self._ticker.timeout.connect(self._on_ticker)

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -21,12 +21,17 @@ from ert_gui.simulation import IteratedEnsembleSmootherPanel, MultipleDataAssimi
 from ert_gui.simulation import RunDialog
 from ert_shared.feature_toggling import FeatureToggling
 from collections import OrderedDict
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 
 
 class SimulationPanel(QWidget):
     def __init__(self, config_file):
         QWidget.__init__(self)
         self._config_file = config_file
+        self._ee_config = None
+        if FeatureToggling.is_enabled("prefect") or FeatureToggling.is_enabled("ensemble-evaluator"):
+            self._ee_config = EvaluatorServerConfig()
+
         self.setObjectName("Simulation_panel")
         layout = QVBoxLayout()
 
@@ -98,7 +103,10 @@ class SimulationPanel(QWidget):
     def getSimulationArguments(self):
         """ @rtype: dict[str,object]"""
         simulation_widget = self._simulation_widgets[self.getCurrentSimulationModel()]
-        return simulation_widget.getSimulationArguments()
+        args = simulation_widget.getSimulationArguments()
+        if self._ee_config is not None:
+            args.update({"ee_config": self._ee_config})
+        return args
 
     def runSimulation(self):
         case_name = getCurrentCaseName()

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -6,8 +6,7 @@ import threading
 
 from ert_shared import ERT
 from ert_shared import clear_global_state
-from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
-from ert_shared.ensemble_evaluator.monitor import create as create_ee_monitor
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.feature_toggling import FeatureToggling
 from ert_shared.cli.model_factory import create_model
 from ert_shared.cli.monitor import Monitor
@@ -59,6 +58,11 @@ MIN_REALIZATIONS 1
         )
         _clear_and_exit(msg)
 
+    ee_config = None
+    if FeatureToggling.is_enabled("prefect") or FeatureToggling.is_enabled("ensemble-evaluator"):
+        ee_config = EvaluatorServerConfig()
+        argument.update({"ee_config": ee_config})
+
     thread = threading.Thread(
         name="ert_cli_simulation_thread",
         target=model.startSimulations,
@@ -66,7 +70,7 @@ MIN_REALIZATIONS 1
     )
     thread.start()
 
-    tracker = create_tracker(model, detailed_interval=0)
+    tracker = create_tracker(model, detailed_interval=0, ee_config=ee_config)
 
     out = open(os.devnull, 'w') if args.disable_monitoring else sys.stdout
     monitor = Monitor(out=out, color_always=args.color_always)

--- a/ert_shared/ensemble_evaluator/entity/ensemble_base.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble_base.py
@@ -1,8 +1,6 @@
 import asyncio
-import threading
 import websockets
 
-from ert_shared.ensemble_evaluator.config import load_config
 
 from cloudevents.http import to_json
 

--- a/ert_shared/ensemble_evaluator/entity/ensemble_legacy.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble_legacy.py
@@ -53,14 +53,14 @@ class _LegacyEnsemble(_Ensemble):
     def evaluate(self, config, ee_id):
         self._config = config
         self._ee_id = ee_id
-        wait_for_ws(self._config.get("url"))
+        wait_for_ws(self._config.url)
         self._evaluate_thread = threading.Thread(target=self._evaluate)
         self._evaluate_thread.start()
 
     def _evaluate(self):
         asyncio.set_event_loop(asyncio.new_event_loop())
 
-        dispatch_url = self._config.get("dispatch_url")
+        dispatch_url = self._config.dispatch_uri
 
         try:
             out_cloudevent = CloudEvent(
@@ -105,7 +105,7 @@ class _LegacyEnsemble(_Ensemble):
                     )
                 ]
 
-            queue_adaptor = QueueAdaptor(self._job_queue, self._config, self._ee_id)
+            queue_adaptor = QueueAdaptor(self._job_queue, dispatch_url, self._ee_id)
             futures.append(
                 queue_adaptor.execute_queue(
                     threading.BoundedSemaphore(value=CONCURRENT_INTERNALIZATION),
@@ -174,6 +174,6 @@ class _LegacyEnsemble(_Ensemble):
         )
         loop = asyncio.new_event_loop()
         loop.run_until_complete(
-            self.send_cloudevent(self._config.get("dispatch_url"), out_cloudevent)
+            self.send_cloudevent(self._config.dispatch_uri, out_cloudevent)
         )
         loop.close()

--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -205,8 +205,7 @@ class EnsembleEvaluator:
     async def evaluator_server(self, done):
         async with websockets.serve(
             self.connection_handler,
-            self._config.get("host"),
-            self._config.get("port"),
+            sock=self._config.get_socket(),
             max_queue=500,
             max_size=2 ** 26,
         ):
@@ -247,7 +246,7 @@ class EnsembleEvaluator:
     def run(self):
         self._ws_thread.start()
         self._ensemble.evaluate(self._config, self._ee_id)
-        return ee_monitor.create(self._config.get("host"), self._config.get("port"))
+        return ee_monitor.create(self._config.host, self._config.port)
 
     def _stop(self):
         if not self._done.done():

--- a/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
+++ b/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
@@ -57,7 +57,7 @@ def _get_executor(name="local"):
             "use_stdin": True,
             "n_workers": 2,
             "silence_logs": "debug",
-            "scheduler_options": {"port": find_open_port(lower=51820, upper=51840)},
+            "scheduler_options": {"port": find_open_port()},
         }
         return DaskExecutor(
             cluster_class="dask_jobqueue.LSFCluster",
@@ -247,7 +247,7 @@ class PrefectEnsemble(_Ensemble):
         return flow
 
     def evaluate(self, config, ee_id):
-        self._ee_dispach_url = config.get("dispatch_url")
+        self._ee_dispach_url = config.dispatch_uri
         self._ee_id = ee_id
         self._eval_proc = multiprocessing.Process(
             target=self._evaluate,

--- a/ert_shared/ensemble_evaluator/queue_adaptor.py
+++ b/ert_shared/ensemble_evaluator/queue_adaptor.py
@@ -45,8 +45,8 @@ def _queue_state_event_type(state):
 
 
 class QueueAdaptor:
-    def __init__(self, queue, config, ee_id):
-        self._ws_url = config.get("dispatch_url")
+    def __init__(self, queue, url, ee_id):
+        self._ws_url = url
         self._ee_id = ee_id
         self._queue = queue
 

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -5,7 +5,7 @@ import uuid
 
 from ecl.util.util import BoolVector
 from ert_shared import ERT
-from ert_shared.ensemble_evaluator.config import load_config
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.entity.ensemble import (
     create_ensemble_builder_from_legacy,
 )
@@ -315,7 +315,7 @@ class BaseRunModel(object):
     def count_active_realizations(self, run_context):
         return sum(run_context.get_mask())
 
-    def run_ensemble_evaluator(self, run_context):
+    def run_ensemble_evaluator(self, run_context, ee_config):
         if run_context.get_step():
             self.ert().eclConfig().assert_restart()
 
@@ -336,7 +336,6 @@ class BaseRunModel(object):
         ).build()
 
         self.ert().initRun(run_context)
-
         return EnsembleEvaluator(
-            ensemble, load_config(), ee_id=str(uuid.uuid1()).split("-")[0]
+            ensemble, ee_config, ee_id=str(uuid.uuid1()).split("-")[0]
         ).run_and_get_successful_realizations()

--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -27,7 +27,8 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhaseName(run_msg, indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            num_successful_realizations = self.run_ensemble_evaluator(run_context)
+            ee_config = arguments["ee_config"]
+            num_successful_realizations = self.run_ensemble_evaluator(run_context, ee_config)
         else:
             self._job_queue = self._queue_config.create_job_queue()
             num_successful_realizations = (

--- a/ert_shared/models/ensemble_prefect_experiment.py
+++ b/ert_shared/models/ensemble_prefect_experiment.py
@@ -1,11 +1,10 @@
-import os
 import yaml
 from ert_shared.ensemble_evaluator.prefect_ensemble.prefect_ensemble import (
     PrefectEnsemble,
 )
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 import time
-from ert_shared.ensemble_evaluator.config import load_config
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 import uuid
 
 
@@ -31,7 +30,7 @@ class EnsemblePrefectExperiment:
             config = yaml.safe_load(f)
         ensemble = PrefectEnsemble(config)
 
-        ee_config = load_config()
+        ee_config = arg["ee_config"]
         ee_id = str(uuid.uuid1()).split("-")[0]
         ee = EnsembleEvaluator(ensemble, ee_config, ee_id=ee_id)
         ee.run_and_get_successful_realizations()

--- a/ert_shared/models/ensemble_smoother.py
+++ b/ert_shared/models/ensemble_smoother.py
@@ -40,7 +40,8 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhaseName("Running forecast...", indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            num_successful_realizations = self.run_ensemble_evaluator(prior_context)
+            ee_config = arguments["ee_config"]
+            num_successful_realizations = self.run_ensemble_evaluator(prior_context, ee_config)
         else:
             self._job_queue = self._queue_config.create_job_queue()
             num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(self._job_queue, prior_context)
@@ -81,7 +82,8 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhaseName("Running forecast...", indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            num_successful_realizations = self.run_ensemble_evaluator(rerun_context)
+            ee_config = arguments["ee_config"]
+            num_successful_realizations = self.run_ensemble_evaluator(rerun_context, ee_config)
         else:
             self._job_queue = self._queue_config.create_job_queue()
             num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(self._job_queue, rerun_context)

--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -125,7 +125,8 @@ class MultipleDataAssimilation(BaseRunModel):
         self.setPhaseName(phase_string, indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            num_successful_realizations = self.run_ensemble_evaluator(run_context)
+            ee_config = arguments["ee_config"]
+            num_successful_realizations = self.run_ensemble_evaluator(run_context, ee_config)
         else:
             self._job_queue = self._queue_config.create_job_queue()
             num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(self._job_queue, run_context)

--- a/ert_shared/tracker/factory.py
+++ b/ert_shared/tracker/factory.py
@@ -1,10 +1,6 @@
-from ert_shared.tracker.evaluator import EvaluatorTracker
 from ert_shared.tracker.blocking import BlockingTracker
 from ert_shared.tracker.qt import QTimerTracker
 from ert_shared.tracker.utils import scale_intervals
-from ert_shared.ensemble_evaluator.monitor import create as create_ee_monitor
-from ert_shared.ensemble_evaluator.config import load_config
-from ert_shared.feature_toggling import FeatureToggling
 
 
 def create_tracker(
@@ -14,6 +10,7 @@ def create_tracker(
     qtimer_cls=None,
     event_handler=None,
     num_realizations=None,
+    ee_config=None,
 ):
     """Creates a tracker tracking a @model. The provided model
     is updated in two tiers: @general_interval, @detailed_interval.
@@ -32,12 +29,8 @@ def create_tracker(
     if num_realizations is not None:
         general_interval, detailed_interval = scale_intervals(num_realizations)
 
-    ee_config = load_config()
     ee_monitor_connection_details = (
-        (ee_config.get("host"), ee_config.get("port"))
-        if FeatureToggling.is_enabled("ensemble-evaluator")
-        or FeatureToggling.is_enabled("prefect")
-        else None
+        (ee_config.host, ee_config.port) if ee_config is not None else None
     )
 
     if qtimer_cls:

--- a/tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -1,9 +1,16 @@
+import websockets
+import pytest
+import asyncio
+import threading
+import json
+from unittest.mock import Mock
 from cloudevents.http import to_json
 from cloudevents.http.event import CloudEvent
 from ert_shared.ensemble_evaluator.evaluator import (
     EnsembleEvaluator,
     ee_monitor,
 )
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.entity.ensemble import (
     create_ensemble_builder,
     create_realization_builder,
@@ -11,27 +18,13 @@ from ert_shared.ensemble_evaluator.entity.ensemble import (
     create_step_builder,
     create_legacy_job_builder,
 )
-from ert_shared.ensemble_evaluator.entity.snapshot import SnapshotBuilder
 import ert_shared.ensemble_evaluator.entity.identifiers as identifiers
 from ert_shared.ensemble_evaluator.entity.snapshot import Snapshot
-from ert_shared.ensemble_evaluator.config import load_config
-import websockets
-import pytest
-import asyncio
-import threading
-from unittest.mock import Mock
 
 
 @pytest.fixture
 def ee_config(unused_tcp_port):
-    default_url = f"ws://localhost:{unused_tcp_port}"
-    return {
-        "host": "localhost",
-        "port": unused_tcp_port,
-        "url": default_url,
-        "client_url": f"{default_url}/client",
-        "dispatch_url": f"{default_url}/dispatch",
-    }
+    return EvaluatorServerConfig(unused_tcp_port)
 
 
 @pytest.fixture
@@ -123,8 +116,8 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
     monitor = evaluator.run()
     events = monitor.track()
 
-    host = evaluator._config.get("host")
-    port = evaluator._config.get("port")
+    host = evaluator._config.host
+    port = evaluator._config.port
 
     # first snapshot before any event occurs
     snapshot_event = next(events)

--- a/tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,21 +1,16 @@
 from unittest.mock import patch
 import pytest
 import ert_shared.ensemble_evaluator.entity.identifiers as identifiers
-from pathlib import Path
-from ert_shared.ensemble_evaluator.config import CONFIG_FILE, load_config
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 
 
 @pytest.mark.timeout(60)
 def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 2
-    conf_file = Path(tmpdir / CONFIG_FILE)
     with tmpdir.as_cwd():
-        with open(conf_file, "w") as f:
-            f.write(f'port: "{unused_tcp_port}"\n')
-
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
-        config = load_config(conf_file)
+        config = EvaluatorServerConfig(unused_tcp_port)
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
         monitor = evaluator.run()
         for e in monitor.track():
@@ -35,14 +30,9 @@ def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
 @pytest.mark.timeout(60)
 def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 10
-    conf_file = Path(tmpdir / CONFIG_FILE)
-
     with tmpdir.as_cwd():
-        with open(conf_file, "w") as f:
-            f.write(f'port: "{unused_tcp_port}"\n')
-
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
-        config = load_config(conf_file)
+        config = EvaluatorServerConfig(unused_tcp_port)
 
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
 
@@ -59,13 +49,9 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_b
 @pytest.mark.timeout(60)
 def test_run_legacy_ensemble_exception(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 2
-    conf_file = Path(tmpdir / CONFIG_FILE)
     with tmpdir.as_cwd():
-        with open(conf_file, "w") as f:
-            f.write(f'port: "{unused_tcp_port}"\n')
-
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
-        config = load_config(conf_file)
+        config = EvaluatorServerConfig(unused_tcp_port)
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
 
         with patch.object(ensemble, "_run_path_list", side_effect=RuntimeError()):

--- a/tests/ensemble_evaluator/test_queue_adaptor_integration.py
+++ b/tests/ensemble_evaluator/test_queue_adaptor_integration.py
@@ -46,7 +46,7 @@ async def test_happy_path(
         queue.add_ee_stage(real.get_stages()[0])
     queue.submit_complete()
 
-    adaptor = QueueAdaptor(queue, {"dispatch_url": url}, "ee_id_123")
+    adaptor = QueueAdaptor(queue, url, "ee_id_123")
 
     execute_task = asyncio.get_event_loop().create_task(
         adaptor.execute_queue(threading.BoundedSemaphore(value=10), None)


### PR DESCRIPTION
**Issue**
Resolves #1358


**Approach**
Find open port closer to ensemble evaluation and bind the socket associated with the port. Reuse the socket once the socket is closed for starting the ensemble evaluator server.  