### PR TITLE
Ert3 reservoir example

### DIFF
--- a/.github/workflows/run_spe1_demo.yml
+++ b/.github/workflows/run_spe1_demo.yml
@@ -1,0 +1,46 @@
+name: Run SPE1 demo
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6]
+        os: [ubuntu-18.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Flow Simulator
+      run: |
+        sudo apt-get update
+        sudo apt-get install software-properties-common
+        sudo apt-add-repository ppa:opm/ppa
+        sudo apt-get update
+        sudo apt-get install mpi-default-bin
+        sudo apt-get install libopm-simulators-bin
+
+    - name: Install ERT
+      run: |
+        pip install .
+
+    - name: Install spe1 dependencies
+      run: |
+        pip install ecl2df
+
+    - name: Run spe1 demo
+      run: |
+        pushd examples/spe1
+        ./run_demo
+        popd

--- a/examples/spe1/README.md
+++ b/examples/spe1/README.md
@@ -1,0 +1,122 @@
+## A reservoir example based on SPE1
+
+The motivation of this example is to have a plain and simple reservoir setup
+that highlights the features of ert3 in a reservoir context.
+
+#### Requirements
+
+ - ert3: In Equinor you can fetch an installation via Komodo, but
+   in general a `pip install ert` should suffice.
+ - flow: A functioning installation of OPM Flow with a binary named `flow`.
+ - `SPE1_WORKSPACE_ROOT` defined as the workspace root. This is only a temporary
+   workaround. Running `export SPE1_WORKSPAE_ROOT=$(pwd)` in the root should
+   suffice in bash.
+ - ecl2df: In addition to the ERT dependencies the job `summary2json` utilises
+   ecl2df. It can be installed via `pip install ecl2df`.
+
+### Overview of the workspace
+
+#### Parameters
+The available parameterizations of the model resides within
+[parameters.yml](parameters.yml). In general a parameter group is given a name,
+which can be referenced later in experiments, a distribution (`uniform` or
+`gauss`) and a list of variables that are drawn from the distribution.
+
+#### Stages
+The forward model in ert3 is a stage and is described in
+[stages.yml](stages.yml). Currently the only available stage is a unix step,
+which gets input data as files on disk, runs a script and then is to produce
+output data in files on disk again.
+
+Each stage is given a name and is in addition to:
+ - direct input records into files,
+ - point to files which are to be loaded as output,
+ - give commands that can be transported to the compute side and
+ - a script that is to be executed.
+When the script starts it can assume the input data to be present in the
+specified files and when it finishes it should have produced the expected data
+in the specified output files.
+
+Note that the motivation for keeping both stages and parameters in the global workspace
+is so that experiments can share them.
+
+#### The datafile
+The datafile is based on an example from [OPM test
+data](https://github.com/OPM/opm-tests/blob/master/spe1/SPE1CASE2.DATA). It is
+written as a Jinja2 template and resides in `resources/SPE1CASE2.DATA.jinja2`.
+
+The datafile aims at simulating a reservoir for 10 years with two wells named
+`PROD` and `INJ`.
+
+The template is templated by the following parameters:
+ - `field_properties.porosity`: The uniform porosity of the model
+ - `field_properties.x_mid_permability`: The permeability of the middle layer of
+   cells in X direction and
+ - `wells.delay`: The delay (must be between 1 and 365 days) before the wells
+   are opened.
+
+### The experiments
+
+#### Layout
+Each experiment is a folder within within the `experiments` folder. The name of
+the folder is the name of the experiment and each folder is expected to contain
+two files, namely `experiment.yml` and `ensemble.yml`.
+
+#### Initialising
+A workspace is only a collection of files until it is initialised as a
+workspace. This is a one-time operation carried out from the root of the
+workspace running the command `ert3 init`.
+
+#### Evaluation
+The first experiment of the workspace is the evaluation experiment. It runs an
+evaluation of the model described in the respective `ensembles.yml`. The
+`experiment.yml` is the file indicating that the experiment is indeed an
+evaluation. The `ensemble.yml` describes the size of the ensemble, maps data
+sources to input records and specifies the stage that is the forward model
+together with the queue system that is to be used. Notice in particular that by
+`stochastic.field_properties` one is pointing at the parameter group named
+`field_properties` in `parameters.yml`.
+
+The experiment can be executed by `ert3 run evaluation`. And the data can
+afterwards be exported using `ert3 export evaluation`, that will put the data
+in the file `experiments/evaluation/data.json`.
+
+#### Design of experiment
+The next experiment in the workspace carries out a design of experiment. The
+important differences to notice is that there are two files named
+`field_properties.json` and `wells.json` containing the parameter values chosen
+for the experiment. Both of these can be loaded via the `ert3 record load`
+command. Use `ert3 record load --help` for assistance or look at the `run_demo`
+script in the workspace root. Two important things to notice is that the length
+of the list of records in each of the files must align with the size of the
+ensemble configured. Furthermore, the input records are now fetched via
+`storage.designed_field_properties`. Indicating that the records come from
+storage. The name of the record given when loading it must be the same as the
+one referred to in the ensemble.
+
+#### Sensitivity analysis
+The last experiment is a sensitivity study. Again it refers to distributions
+from the `parameters.yml` and uses the distributions to design the different
+realisations. An important difference is that the ensemble size is no longer
+configured by the user, but dictated by the algorithm. There are also some
+differences in the `experiment.yml`, but those are hopefully self-explaining.
+
+### Some additional notes
+ERT3 is highly experimental software in the sense that we aim at moving fast.
+Natural features that is lacking is among others:
+ - inspect records and experiments in the cli,
+ - delete records and experiment runs,
+ - monitor ongoing experiments,
+ - visualize experiment results,
+ - fetch experiment results via an API and
+ - cross configuration file validation (each file is validated in isolation, but not
+   towards each other).
+
+The first two points are currently resolved by deleting the `.ert` folder in
+the workspace and starting over. Monitoring is currently via extensive output
+in the terminal. Results can fetched via the export command.
+
+Notice that the `.ert` folder is to contain data that the user should not
+inspect, assume to be present nor change directly. It currently contains the
+runpath, but remember that this will not be available over time. So we should
+mature other means for debugging, etc.

--- a/examples/spe1/bash.py
+++ b/examples/spe1/bash.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# TODO: This script is a hack in its entirety to run shell commands. The reason
+# is that the prefect evaluator and hence ert3 currently runs all commands
+# within the unix step with "python3 cmd <args>". Over time this script should
+# disappear...
+
 import subprocess
 import sys
 

--- a/examples/spe1/bash.py
+++ b/examples/spe1/bash.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+
+cmd = list(sys.argv[1:])
+subprocess.run(" ".join(cmd), shell=True, check=True)

--- a/examples/spe1/experiments/doe/ensemble.yml
+++ b/examples/spe1/experiments/doe/ensemble.yml
@@ -1,0 +1,15 @@
+size: 10
+
+input:
+  -
+    source: storage.designed_field_properties
+    record: field_properties
+  -
+    source: storage.designed_wells
+    record: wells
+
+
+forward_model:
+  driver: local
+  stages:
+    - simulate_SPE1

--- a/examples/spe1/experiments/doe/experiment.yml
+++ b/examples/spe1/experiments/doe/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/spe1/experiments/doe/field_properties.json
+++ b/examples/spe1/experiments/doe/field_properties.json
@@ -1,0 +1,12 @@
+[
+    {"porosity": 0.2, "x_mid_permability": 0.5},
+    {"porosity": 0.21, "x_mid_permability": 0.6},
+    {"porosity": 0.22, "x_mid_permability": 0.7},
+    {"porosity": 0.23, "x_mid_permability": 0.4},
+    {"porosity": 0.24, "x_mid_permability": 0.5},
+    {"porosity": 0.25, "x_mid_permability": 0.4},
+    {"porosity": 0.26, "x_mid_permability": 0.7},
+    {"porosity": 0.27, "x_mid_permability": 0.6},
+    {"porosity": 0.28, "x_mid_permability": 0.5},
+    {"porosity": 0.29, "x_mid_permability": 0.4}
+]

--- a/examples/spe1/experiments/doe/wells.json
+++ b/examples/spe1/experiments/doe/wells.json
@@ -1,0 +1,12 @@
+[
+    {"delay": 10},
+    {"delay": 1},
+    {"delay": 2},
+    {"delay": 3},
+    {"delay": 4},
+    {"delay": 5},
+    {"delay": 6},
+    {"delay": 7},
+    {"delay": 8},
+    {"delay": 9}
+]

--- a/examples/spe1/experiments/evaluation/ensemble.yml
+++ b/examples/spe1/experiments/evaluation/ensemble.yml
@@ -1,0 +1,11 @@
+size: 10
+
+input:
+  -
+    source: stochastic.field_properties
+    record: field_properties
+
+forward_model:
+  driver: local
+  stages:
+    - simulate_SPE1

--- a/examples/spe1/experiments/evaluation/ensemble.yml
+++ b/examples/spe1/experiments/evaluation/ensemble.yml
@@ -4,6 +4,10 @@ input:
   -
     source: stochastic.field_properties
     record: field_properties
+  -
+    source: stochastic.wells_no_delay
+    record: wells
+
 
 forward_model:
   driver: local

--- a/examples/spe1/experiments/evaluation/experiment.yml
+++ b/examples/spe1/experiments/evaluation/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/spe1/experiments/sensitivity/ensemble.yml
+++ b/examples/spe1/experiments/sensitivity/ensemble.yml
@@ -1,0 +1,13 @@
+input:
+  -
+    source: stochastic.field_properties
+    record: field_properties
+  -
+    source: stochastic.wells
+    record: wells
+
+
+forward_model:
+  driver: local
+  stages:
+    - simulate_SPE1

--- a/examples/spe1/experiments/sensitivity/experiment.yml
+++ b/examples/spe1/experiments/sensitivity/experiment.yml
@@ -1,0 +1,2 @@
+type: sensitivity
+algorithm: one-at-a-time

--- a/examples/spe1/parameters.yml
+++ b/examples/spe1/parameters.yml
@@ -1,0 +1,9 @@
+-
+  name: field_properties
+  type: stochastic
+  distribution:
+    type: uniform
+    input:
+      lower_bound: 0.1
+      upper_bound: 0.9
+  variables: ["porosity"]

--- a/examples/spe1/parameters.yml
+++ b/examples/spe1/parameters.yml
@@ -16,3 +16,12 @@
       lower_bound: 1
       upper_bound: 1
   variables: ["delay"]
+-
+  name: wells
+  type: stochastic
+  distribution:
+    type: uniform
+    input:
+      lower_bound: 1
+      upper_bound: 365
+  variables: ["delay"]

--- a/examples/spe1/parameters.yml
+++ b/examples/spe1/parameters.yml
@@ -6,4 +6,13 @@
     input:
       lower_bound: 0.1
       upper_bound: 0.9
-  variables: ["porosity"]
+  variables: ["porosity", "x_mid_permability"]
+-
+  name: wells_no_delay
+  type: stochastic
+  distribution:
+    type: uniform
+    input:
+      lower_bound: 1
+      upper_bound: 1
+  variables: ["delay"]

--- a/examples/spe1/render.py
+++ b/examples/spe1/render.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import pathlib
+import res
+import subprocess
+import sys
+
+
+def _locate_template_render_exec():
+    return (
+        pathlib.Path(res.__file__).parent.parent.parent.parent.parent
+        / "share"
+        / "ert"
+        / "forward-models"
+        / "templating"
+        / "script"
+        / "template_render"
+    )
+
+
+render_exec = _locate_template_render_exec()
+args = tuple(sys.argv[1:])
+subprocess.run(" ".join((str(render_exec),) + args), shell=True, check=True)

--- a/examples/spe1/render.py
+++ b/examples/spe1/render.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+
+
+# TODO: This script is a hack in its entirety to get hold the template_render
+# job from libres. Over time this script should disappear...
+
+
 import pathlib
 import res
 import subprocess

--- a/examples/spe1/resources/SPE1CASE2.DATA.jinja2
+++ b/examples/spe1/resources/SPE1CASE2.DATA.jinja2
@@ -1,0 +1,436 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015 Statoil
+
+-- This simulation is based on the data given in
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 2 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 2
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+
+FIELD
+
+START
+   1 'JAN' 2015 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+-- 	   - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+-- 	   - there must be two wells in a group as there are two wells in total
+   2 1 1 2 /
+
+UNIFOUT
+
+GRID
+
+-- The INIT keyword is used to request an .INIT file. The .INIT file
+-- is written before the simulation actually starts, and contains grid
+-- properties and saturation tables as inferred from the input
+-- deck. There are no other keywords which can be used to configure
+-- exactly what is written to the .INIT file.
+INIT
+
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX
+-- There are in total 300 cells with length 1000ft in x-direction
+   	300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction
+	300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+	100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+	100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+    300*{{field_properties.porosity}} /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+	100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+-- 	277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+    	4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+	14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+--   	     - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--   	     - generated from the Corey-type approx. formula
+--	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: oil relative permeability when only oil and water are present
+--	     - we will use the same values as in column 3 in SGOF.
+-- 	       This is not really correct, but since only the first 
+--	       two values are of importance, this does not really matter
+-- Column 4: corresponding water-oil capillary pressure (psi) 
+
+0.12	0    		 	1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+-- 	     - stated to be zero in Odeh's paper
+
+-- Values in column 1-3 are taken from table 3 in Odeh's paper:
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0
+0.88	0.984	0.000	0 /
+--1.00	1.0	0.000	0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+-- 	   		 must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+      	53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - in Odeh's paper the units are said to be given in rb per bbl,
+-- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper
+--	       are given in rb per scf, not rb per bbl. This will be in
+--	       agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100
+	9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490
+	9014.7	1.7370	0.6310 /
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above.
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Odeh's table 1 says that initial reservoir pressure is
+-- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+-- 	   - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+	8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher
+---than the bubble point presssure of 4014.7psia, meaning that there is no
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------
+
+-- 1a) Oil rate vs time
+FOPR
+-- Field Oil Production Rate
+
+-- 1b) GOR vs time
+WGOR
+-- Well Gas-Oil Ratio
+   'PROD'
+/
+-- Using FGOR instead of WGOR:PROD results in the same graph
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 10 3 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+1  1  2 /
+1  1  3 /
+10 1  1 /
+10 1  2 /
+10 1  3 /
+10 10 1 /
+10 10 2 /
+10 10 3 /
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+  'INJ'
+  'PROD'
+/
+WGIR
+  'INJ'
+  'PROD'
+/
+WGIT
+  'INJ'
+  'PROD'
+/
+WGPR
+  'INJ'
+  'PROD'
+/
+WGPT
+  'INJ'
+  'PROD'
+/
+WOIR
+  'INJ'
+  'PROD'
+/
+WOIT
+  'INJ'
+  'PROD'
+/
+WOPR
+  'INJ'
+  'PROD'
+/
+WOPT
+  'INJ'
+  'PROD'
+/
+WWIR
+  'INJ'
+  'PROD'
+/
+WWIT
+  'INJ'
+  'PROD'
+/
+WWPR
+  'INJ'
+  'PROD'
+/
+WWPT
+  'INJ'
+  'PROD'
+/
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'RS' 'WELLS' /
+
+RPTRST
+	'BASIC=1' /
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+--DRSDT
+-- 0 /
+-- Since this is Case 2, the two lines above have been commented out.
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'PROD'	'G1'	10	10	8400	'OIL' /
+	'INJ'	'G1'	1	1	8335	'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'PROD'	10	10	3	3	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2
+-- Item 9 is the well bore internal diameter,
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+
+TSTEP
+--Advance the simulater once a month for TEN years:
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31 /
+
+--Advance the simulator once a year for TEN years:
+--10*365 /
+
+END

--- a/examples/spe1/resources/SPE1CASE2.DATA.jinja2
+++ b/examples/spe1/resources/SPE1CASE2.DATA.jinja2
@@ -92,7 +92,7 @@ PORO
 
 PERMX
 -- The layers have perm. 500mD, 50mD and 200mD, respectively.
-	100*500 100*50 100*200 /
+	100*500 100*{{100 * field_properties.x_mid_permability}} 100*200 /
 
 PERMY
 -- Equal to PERMX
@@ -381,6 +381,9 @@ RPTRST
 -- if DRSDT is set to 0, GOR cannot rise and free gas does not
 -- dissolve in undersaturated oil -> constant bubble point pressure
 
+TSTEP
+{{wells.delay|default(0)}} /
+
 WELSPECS
 -- Item #: 1	 2	3	4	5	 6
 	'PROD'	'G1'	10	10	8400	'OIL' /
@@ -427,10 +430,13 @@ TSTEP
 31 28 31 30 31 30 31 31 30 31 30 31
 31 28 31 30 31 30 31 31 30 31 30 31
 31 28 31 30 31 30 31 31 30 31 30 31
-31 28 31 30 31 30 31 31 30 31 30 31
 31 28 31 30 31 30 31 31 30 31 30 31 /
 
 --Advance the simulator once a year for TEN years:
 --10*365 /
+
+TSTEP
+{{365 - wells.delay|default(0)}} /
+
 
 END

--- a/examples/spe1/run_demo
+++ b/examples/spe1/run_demo
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+export SPE1_WORKSPACE_ROOT=$(pwd)
+
+ert3 init
+ert3 run evaluation
+ert3 export evaluation

--- a/examples/spe1/run_demo
+++ b/examples/spe1/run_demo
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
+
+
+# Note: This script runs the experiments in the workspace one after each other.
+# It is mainly kept around for CI purposes...
+
+
 set -e
 
+# TODO: This is a hack because of the lack of blob records. Hence, we currently
+# copy the datafile to the compute nodes and this environment variable makes
+# the workspace transportable.
 export SPE1_WORKSPACE_ROOT=$(pwd)
 
 ert3 init

--- a/examples/spe1/run_demo
+++ b/examples/spe1/run_demo
@@ -4,5 +4,11 @@ set -e
 export SPE1_WORKSPACE_ROOT=$(pwd)
 
 ert3 init
+
 ert3 run evaluation
 ert3 export evaluation
+
+ert3 record load designed_field_properties experiments/doe/field_properties.json
+ert3 record load designed_wells experiments/doe/wells.json
+ert3 run doe
+ert3 export doe

--- a/examples/spe1/run_demo
+++ b/examples/spe1/run_demo
@@ -12,3 +12,6 @@ ert3 record load designed_field_properties experiments/doe/field_properties.json
 ert3 record load designed_wells experiments/doe/wells.json
 ert3 run doe
 ert3 export doe
+
+ert3 run sensitivity
+ert3 export sensitivity

--- a/examples/spe1/stages.yml
+++ b/examples/spe1/stages.yml
@@ -1,0 +1,32 @@
+-
+  name: simulate_SPE1
+
+  input:
+    -
+      record: field_properties
+      location: field_properties.json
+
+  output:
+    -
+      record: summary
+      location: summary.json
+
+  transportable_commands:
+    -
+      name: bash
+      location: bash.py
+    -
+      name: summary2json
+      location: summary2json.py
+    -
+      name: render
+      location: render.py
+
+  script:
+    # TODO: The following cp should not be present, instead files should be
+    # transfered as opaque data
+    - bash cp ${SPE1_WORKSPACE_ROOT}/resources/SPE1CASE2.DATA.jinja2 SPE1CASE2.DATA.jinja2
+    - bash echo "{}" > parameters.json
+    - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json -o SPE1CASE2.DATA
+    - bash flow SPE1CASE2
+    - summary2json --datafile SPE1CASE2.DATA --output summary.json

--- a/examples/spe1/stages.yml
+++ b/examples/spe1/stages.yml
@@ -27,9 +27,13 @@
 
   script:
     # TODO: The following cp should not be present, instead files should be
-    # transfered as opaque data
+    # transfered as blob records.
     - bash cp ${SPE1_WORKSPACE_ROOT}/resources/SPE1CASE2.DATA.jinja2 SPE1CASE2.DATA.jinja2
+    # TODO: This is a hack because render currently expects there to be a
+    # "parameters.json" from ert2.
     - bash echo "{}" > parameters.json
     - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json wells.json -o SPE1CASE2.DATA
+    # TODO: When executables can be ran directly, the `bash` prefix should be
+    # removed.
     - bash flow SPE1CASE2
     - summary2json --datafile SPE1CASE2.DATA --output summary.json

--- a/examples/spe1/stages.yml
+++ b/examples/spe1/stages.yml
@@ -5,6 +5,9 @@
     -
       record: field_properties
       location: field_properties.json
+    -
+      record: wells
+      location: wells.json
 
   output:
     -
@@ -27,6 +30,6 @@
     # transfered as opaque data
     - bash cp ${SPE1_WORKSPACE_ROOT}/resources/SPE1CASE2.DATA.jinja2 SPE1CASE2.DATA.jinja2
     - bash echo "{}" > parameters.json
-    - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json -o SPE1CASE2.DATA
+    - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json wells.json -o SPE1CASE2.DATA
     - bash flow SPE1CASE2
     - summary2json --datafile SPE1CASE2.DATA --output summary.json

--- a/examples/spe1/summary2json.py
+++ b/examples/spe1/summary2json.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import argparse
+import ecl2df
+import json
+import sys
+import pathlib
+
+
+def _build_arg_parser():
+    arg_parser = argparse.ArgumentParser(
+        description="Exports summary data as JSON",
+    )
+    arg_parser.add_argument(
+        "--datafile",
+        type=pathlib.Path,
+        required=True,
+        help="Path to datafile"
+    )
+    arg_parser.add_argument(
+        "--output",
+        type=argparse.FileType('w'),
+        required=True,
+        help="Path to the output file"
+    )
+    return arg_parser
+
+
+def _load_summary(datafile):
+    if not datafile.is_file():
+        sys.exit(f"{datafile} is not an existing file")
+    eclfiles = ecl2df.EclFiles(datafile)
+    ecl2df.summary.df(eclfiles)
+    return ecl2df.summary.df(eclfiles)
+
+
+def _summary2json(sdf):
+    s = {}
+    s["DATE"] = [date.isoformat() for date in sdf.index]
+    for key in sdf.columns:
+        s[key] = list(map(float, sdf[key]))
+    return s
+
+
+if __name__ == "__main__":
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    summary_data = _load_summary(args.datafile)
+    json_summary = _summary2json(summary_data)
+    json.dump(json_summary, args.output)


### PR DESCRIPTION
**Issue**
Resolves #1337 

**Approach**
Fetched a `SPE1` case from `opm-data`. Will try to get it to run with a forward model consisting of:
- template injection into deck
- run flow
- extract summary data and dump it as JSON (as that is the only supported data as of now)

**Notes (should probably be turned into issues)**
- All jobs in a `unix_script` is executed with `python job job_args` which makes anything but Python scripts kind of awkward...
- I would like to put all scripts into a folder like `<workspace>/src/bin`, but that currently fails with an exception from Prefect storage if attempted (but it might be the consumption in `ert3` that is the problem!).
- Fetching resources is really awkward right now. Ie we have to copy the datafile using the disk...
- ~Start running a poly case demo also during CI~
- Launch a discussion on the compute environment for the unix step. In the end we would like to be able to run on top of a `komodo_env` internally, but this should not leak into ERT.
- Start writing some ert3 documentation?

**Todo (should be resolved in this PR)**
- [x] Increase the parameter space
- [x] Set up a sensitivity experiment for the parameter space
- [x] Set up a design of experiment
- [x] Set up a sensitivity experiment for the drill dates of the wells