### PR TITLE
Add base distribution

### DIFF
--- a/ert3/stats/__init__.py
+++ b/ert3/stats/__init__.py
@@ -1,2 +1,3 @@
+from ert3.stats._stats import Distribution
 from ert3.stats._stats import Gaussian
 from ert3.stats._stats import Uniform

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -2,85 +2,84 @@ import numpy as np
 import scipy.stats
 
 
-class Gaussian:
+class Distribution:
+    def __init__(self, *, size, index, rvs, ppf):
+        if size is None and index is None:
+            raise ValueError(
+                "Cannot create distribution with neither size nor index"
+            )
+        if size is not None and index is not None:
+            raise ValueError(
+                "Cannot create distribution with both size and index"
+            )
+
+        if size is not None:
+            self._size = size
+            self._as_array = True
+            self._index = tuple(range(self._size))
+        else:
+            self._size = len(tuple(index))
+            self._as_array = False
+            self._index = tuple(index)
+
+        self._raw_rvs = rvs
+        self._raw_ppf = ppf
+
+    @property
+    def index(self):
+        return self._index
+
+    def _add_index(self, x):
+        if self._as_array:
+            return x 
+        else:
+            return {idx: float(val) for idx, val in zip(self.index, x)}
+
+    def sample(self):
+        return self._add_index(self._raw_rvs(self._size))
+
+    def ppf(self, x):
+        x = np.full(self._size, x)
+        result = self._raw_ppf(x)
+        return self._add_index(result)
+
+
+class Gaussian(Distribution):
     def __init__(self, mean, std, *, size=None, index=None):
         self._mean = mean
         self._std = std
 
-        if size is None and index is None:
-            raise ValueError(
-                "Cannot create gaussian distribution with neither size nor index"
-            )
-        if size is not None and index is not None:
-            raise ValueError(
-                "Cannot create gaussian distribution with both size and index"
-            )
+        rvs = lambda size: scipy.stats.norm.rvs(
+            loc=self._mean, scale=self._std, size=size
+        )
+        ppf = lambda x: scipy.stats.norm.ppf(
+            x, loc=self._mean, scale=self._std
+        )
 
-        self._index = index
-        if size is not None:
-            self._size = size
-        else:
-            self._size = len(tuple(index))
-            self._index = tuple(index)
-
-    def sample(self):
-        sample = scipy.stats.norm.rvs(loc=self._mean, scale=self._std, size=self._size)
-        if self._index is None:
-            return sample
-        else:
-            return {idx: float(val) for idx, val in zip(self._index, sample)}
-
-    def ppf(self, x):
-        x = np.full(self._size, x)
-        result = scipy.stats.norm.ppf(x, loc=self._mean, scale=self._std)
-        if self._index is None:
-            return result
-        else:
-            return {idx: float(val) for idx, val in zip(self._index, result)}
-
-    @property
-    def index(self):
-        return self._index if self._index is not None else tuple(range(self._size))
+        super().__init__(
+            size=size,
+            index=index,
+            rvs=rvs,
+            ppf=ppf,
+        )
 
 
-class Uniform:
+class Uniform(Distribution):
     def __init__(self, lower_bound, upper_bound, *, size=None, index=None):
         self._lower_bound = lower_bound
         self._upper_bound = upper_bound
         self._scale = upper_bound - lower_bound
 
-        if size is None and index is None:
-            raise ValueError(
-                "Cannot create uniform distribution with neither size nor index"
-            )
-        if size is not None and index is not None:
-            raise ValueError(
-                "Cannot create uniform distribution with both size and index"
-            )
-
-        if size is not None:
-            self._size = size
-        else:
-            self._size = len(tuple(index))
-        self._index = index
-
-    def sample(self):
-        sample = scipy.stats.uniform.rvs(
+        rvs = lambda size: scipy.stats.uniform.rvs(
             loc=self._lower_bound, scale=self._scale, size=self._size
         )
-        if self._index is None:
-            return sample
-        else:
-            return {idx: float(val) for idx, val in zip(self._index, sample)}
+        ppf = lambda x: scipy.stats.uniform.ppf(
+            x, loc=self._lower_bound, scale=self._scale
+        )
 
-    def ppf(self, x):
-        x = np.full(self._size, x)
-        result = scipy.stats.uniform.ppf(x, loc=self._lower_bound, scale=self._scale)
-        if self._index is None:
-            return result
-        else:
-            return {idx: float(val) for idx, val in zip(self._index, result)}
-
-    @property
-    def index(self):
-        return self._index if self._index is not None else tuple(range(self._size))
+        super().__init__(
+            size=size,
+            index=index,
+            rvs=rvs,
+            ppf=ppf,
+        )

--- a/tests/ert3/stats/test_distributions.py
+++ b/tests/ert3/stats/test_distributions.py
@@ -62,11 +62,11 @@ def test_gaussian_distribution_index(index, mean, std):
 
 
 def test_gaussian_distribution_invalid():
-    err_msg_neither = "Cannot create gaussian distribution with neither size nor index"
+    err_msg_neither = "Cannot create distribution with neither size nor index"
     with pytest.raises(ValueError, match=err_msg_neither):
         ert3.stats.Gaussian(0, 1)
 
-    err_msg_both = "Cannot create gaussian distribution with both size and index"
+    err_msg_both = "Cannot create distribution with both size and index"
     with pytest.raises(ValueError, match=err_msg_both):
         ert3.stats.Gaussian(0, 1, size=10, index=list(range(10)))
 
@@ -123,11 +123,11 @@ def test_uniform_distribution_index(index, lower_bound, upper_bound):
 
 
 def test_uniform_distribution_invalid():
-    err_msg_neither = "Cannot create uniform distribution with neither size nor index"
+    err_msg_neither = "Cannot create distribution with neither size nor index"
     with pytest.raises(ValueError, match=err_msg_neither):
         ert3.stats.Uniform(0, 1)
 
-    err_msg_both = "Cannot create uniform distribution with both size and index"
+    err_msg_both = "Cannot create distribution with both size and index"
     with pytest.raises(ValueError, match=err_msg_both):
         ert3.stats.Uniform(0, 1, size=10, index=list(range(10)))
 


### PR DESCRIPTION
To prepare for type annotations of distributions and the sensitivity analysis algorithm I've created a base implementation for the two current (and future) distributions. This was also a nice opportunity to get rid of some duplicate code.

**Note**
This was to be a pure refactor, but the current tests verify that the name of the distributions was part of the error message on wrong initialisation. I don't really see the point as the stack trace will give this information anyway (as this is really an internal error). Due to this I changed the test. However, I can of course fetch the class name, lowercase it and add it to the error message if wanted...