### PR TITLE
Fix sensitivity record passing

### DIFF
--- a/.github/workflows/run_polynomial_demo.yml
+++ b/.github/workflows/run_polynomial_demo.yml
@@ -1,0 +1,33 @@
+name: Run polynomial demo 
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install ERT
+      run: |
+        pip install .
+
+    - name: Run polynomial demo
+      run: |
+        pushd examples/polynomial
+        ./run_demo
+        popd

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,5 +1,10 @@
 from typing import List, Optional
-from typing_extensions import Literal
+try:
+    # Will only work from Python 3.8
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from pydantic.dataclasses import dataclass
 from pydantic import BaseModel
 

--- a/ert3/config/_experiment_config.py
+++ b/ert3/config/_experiment_config.py
@@ -1,5 +1,9 @@
 from typing import List, Optional
-from typing_extensions import Literal
+try:
+    # Will only work from Python 3.8
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 from pydantic.dataclasses import dataclass
 from pydantic import root_validator, BaseModel
 

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -69,7 +69,7 @@ def _load_ensemble_parameters(ensemble, workspace):
         assert len(record_source) == 2
         assert record_source[0] == "stochastic"
         parameter_group_name = record_source[1]
-        ensemble_parameters[parameter_group_name] = parameters[parameter_group_name]
+        ensemble_parameters[record_name] = parameters[parameter_group_name]
     return ensemble_parameters
 
 

--- a/examples/polynomial/experiments/uniform_evaluation/ensemble.yml
+++ b/examples/polynomial/experiments/uniform_evaluation/ensemble.yml
@@ -1,0 +1,11 @@
+size: 10
+
+input:
+  -
+    source: stochastic.uniform_coefficients
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/experiments/uniform_evaluation/experiment.yml
+++ b/examples/polynomial/experiments/uniform_evaluation/experiment.yml
@@ -1,0 +1,1 @@
+type: evaluation

--- a/examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
+++ b/examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
@@ -1,0 +1,9 @@
+input:
+  -
+    source: stochastic.uniform_coefficients
+    record: coefficients
+
+forward_model:
+  driver: local
+  stages:
+    - evaluate_polynomial

--- a/examples/polynomial/experiments/uniform_sensitivity/experiment.yml
+++ b/examples/polynomial/experiments/uniform_sensitivity/experiment.yml
@@ -1,0 +1,2 @@
+type: sensitivity
+algorithm: one-at-a-time

--- a/examples/polynomial/run_demo
+++ b/examples/polynomial/run_demo
@@ -6,9 +6,15 @@ ert3 init
 ert3 run evaluation
 ert3 export evaluation
 
+ert3 run uniform_evaluation
+ert3 export uniform_evaluation
+
 ert3 record load designed_coefficients experiments/doe/coefficients_record.json
 ert3 run doe
 ert3 export doe
 
 ert3 run sensitivity
 ert3 export sensitivity
+
+ert3 run uniform_sensitivity
+ert3 export uniform_sensitivity

--- a/examples/polynomial/run_demo
+++ b/examples/polynomial/run_demo
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+ert3 init
+
+ert3 run evaluation
+ert3 export evaluation
+
+ert3 record load designed_coefficients experiments/doe/coefficients_record.json
+ert3 run doe
+ert3 export doe
+
+ert3 run sensitivity
+ert3 export sensitivity

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "scipy",
         "semeio",
         "sqlalchemy",
+        "typing-extensions; python_version < '3.8'",
         "websockets",
         "python-dateutil",
         "async_generator",


### PR DESCRIPTION
**Issue**
During https://github.com/equinor/ert/pull/1410 and reintroduction on `flake8` a bug was found via

```
ert3/engine/_run.py:67:9: F841 local variable 'record_name' is assigned to but never used
```

Now, this implies that the name of the record passed to the forward model was not the name specified in `ensemble.yml`, but the one dictated in `parameters.yml`. A consequence of this is that one could not carry out a sensitivity analysis experiment where one changed the parameterisation from `coefficients` to `uniform_coefficients` because the record would be named `uniform_coefficients`, not `coefficients` as dictated by the `ensemble`.


**Approach**
- Inspired by the recent work in #1391 I added a `run_demo` script in the workspace and make a CI pipeline that executes it,
- then I added two new experiments, namely `uniform_evaluation` and `uniform_sensitivity` to pick up the bug above and
- last we patch the problem.

The last two commits should be squashed after review.

**Note**
We should write extensive unit tests for both the cli and the engine mocking the underlying infrastructure to catch errors like this. But I find this easier to address in one unified lift and right now I believe that formalising `records` and storage integration is more important payback. Created an issue: #1411 in addition to already existing #1338.