### PR TITLE
WIP: Use a context manager with Monitor

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -122,9 +122,8 @@ def _fetch_results(ee_config, ensemble, stages_config):
 
 def _run(ensemble_evaluator):
     monitor = ensemble_evaluator.run()
-    for event in monitor.track():
-        if event.data is not None and event.data.get("status") in ["Stopped", "Failed"]:
-            monitor.signal_done()
+    for _ in monitor.track():
+        pass
 
 
 def evaluate(

--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -95,6 +95,7 @@ class EnsembleEvaluator:
                 event
             )
             await self._send_snapshot_update(snapshot_mutate_event)
+            self._stop()
 
     @_dispatch.register_event_handler(identifiers.EVTYPE_ENSEMBLE_STARTED)
     async def _ensemble_started_handler(self, event):
@@ -120,6 +121,7 @@ class EnsembleEvaluator:
                 event
             )
             await self._send_snapshot_update(snapshot_mutate_event)
+            self._stop()
 
     async def _send_snapshot_update(self, snapshot_mutate_event):
         self._snapshot.merge_event(snapshot_mutate_event)
@@ -189,10 +191,7 @@ class EnsembleEvaluator:
             async for msg in websocket:
                 event = from_json(msg)
                 await self._dispatch.handle_event(self, event)
-                if event["type"] in [
-                    identifiers.EVTYPE_ENSEMBLE_STOPPED,
-                    identifiers.EVTYPE_ENSEMBLE_FAILED,
-                ]:
+                if event["type"] != identifiers.EVTYPE_ENSEMBLE_STARTED:
                     return
 
     async def connection_handler(self, websocket, path):

--- a/ert_shared/tracker/evaluator.py
+++ b/ert_shared/tracker/evaluator.py
@@ -46,64 +46,50 @@ class EvaluatorTracker:
 
     def _drain_monitor(self):
         drainer_logger = logging.getLogger("ert_shared.ensemble_evaluator.drainer")
-        monitor = create_ee_monitor(self._monitor_host, self._monitor_port)
-        while monitor:
-            try:
-                for event in monitor.track():
-                    if event["type"] == ids.EVTYPE_EE_SNAPSHOT:
-                        iter_ = event.data["metadata"]["iter"]
-                        with self._state_mutex:
-                            self._realization_progress[
-                                iter_
-                            ] = self._snapshot_to_realization_progress(event.data)
-                            self._work_queue.put(None)
-                            if event.data.get("status") == _EVTYPE_SNAPSHOT_STOPPED:
-                                drainer_logger.debug(
-                                    "observed evaluation stopped event, signal done"
-                                )
-                                monitor.signal_done()
-                    elif event["type"] == ids.EVTYPE_EE_SNAPSHOT_UPDATE:
-                        with self._state_mutex:
-                            self._updates.append(event.data)
-                            self._work_queue.put(None)
-                            if event.data.get("status") == _EVTYPE_SNAPSHOT_CANCELLED:
-                                drainer_logger.debug(
-                                    "observed evaluation cancelled event, return"
-                                )
-                                return
-                            if event.data.get("status") == _EVTYPE_SNAPSHOT_STOPPED:
-                                drainer_logger.debug(
-                                    "observed evaluation stopped event, signal done"
-                                )
-                                monitor.signal_done()
-                    elif event["type"] == ids.EVTYPE_EE_TERMINATED:
-                        drainer_logger.debug("got terminator event")
-                        while True:
-                            if self._model.isFinished():
-                                drainer_logger.debug(
-                                    "observed that model was finished, waiting tasks completion..."
-                                )
-                                self._work_queue.join()
-                                drainer_logger.debug("tasks complete")
-                                return
-                            try:
-                                time.sleep(5)
-                                drainer_logger.debug("connecting to new monitor...")
-                                monitor = create_ee_monitor(
-                                    self._monitor_host, self._monitor_port
-                                )
-                                wait_for_ws(monitor.get_base_uri(), max_retries=2)
-                                drainer_logger.debug("connected")
-                                break
-                            except ConnectionRefusedError as e:
-                                drainer_logger.debug(f"connection refused: {e}")
-                                pass
+        try:
+            while not self._model.isFinished():
+                drainer_logger.debug("connecting to new monitor...")
+                with create_ee_monitor(
+                    self._monitor_host, self._monitor_port
+                ) as monitor:
+                    wait_for_ws(monitor.get_base_uri(), max_retries=2)
+                    drainer_logger.debug("connected")
 
-            except ConnectionRefusedError as e:
-                if self._model.isFinished():
-                    return
-                else:
-                    raise e
+                    for event in monitor.track():
+                        if event["type"] == ids.EVTYPE_EE_SNAPSHOT:
+                            iter_ = event.data["metadata"]["iter"]
+                            with self._state_mutex:
+                                self._realization_progress[
+                                    iter_
+                                ] = self._snapshot_to_realization_progress(event.data)
+                                self._work_queue.put(None)
+                        elif event["type"] == ids.EVTYPE_EE_SNAPSHOT_UPDATE:
+                            with self._state_mutex:
+                                self._updates.append(event.data)
+                                self._work_queue.put(None)
+                                if (
+                                    event.data.get("status")
+                                    == _EVTYPE_SNAPSHOT_CANCELLED
+                                ):
+                                    drainer_logger.debug(
+                                        "observed evaluation cancelled event, return"
+                                    )
+                                    return
+                        elif event["type"] == ids.EVTYPE_EE_TERMINATED:
+                            drainer_logger.debug("got terminator event")
+
+                time.sleep(5)
+            else:
+                drainer_logger.debug(
+                    "observed that model was finished, waiting tasks completion..."
+                )
+                self._work_queue.join()
+                drainer_logger.debug("tasks complete")
+        except ConnectionRefusedError as e:
+            if self._model.isFinished():
+                return
+            else:
+                raise e
 
     def _get_most_recent_snapshot(self):
         iter_ = self._get_current_iter()


### PR DESCRIPTION
**Issue**
Resolves #1332 


**Approach**
Turned the monitor into a context manager. This required some rewriting of code, including the evaluator tracker, but the result seems simpler. It still remains to be seen if the event handling is done properly, but that appears to be an issue that was already present in the master branch, and that is already under discussion. When that is resolved this code may need to change again.