### PR TITLE
Rewrite monitor as context manager

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -11,6 +11,9 @@ from ert_shared.ensemble_evaluator.prefect_ensemble.prefect_ensemble import (
 
 import ert3
 
+_EVTYPE_SNAPSHOT_STOPPED = "Stopped"
+_EVTYPE_SNAPSHOT_FAILED = "Failed"
+
 
 def _create_evaluator_tmp_dir(workspace_root, evaluation_name):
     return (
@@ -121,10 +124,13 @@ def _fetch_results(ee_config, ensemble, stages_config):
 
 
 def _run(ensemble_evaluator):
-    monitor = ensemble_evaluator.run()
-    for event in monitor.track():
-        if event.data is not None and event.data.get("status") in ["Stopped", "Failed"]:
-            monitor.signal_done()
+    with ensemble_evaluator.run() as monitor:
+        for event in monitor.track():
+            if event.data is not None and event.data.get("status") in [
+                _EVTYPE_SNAPSHOT_STOPPED,
+                _EVTYPE_SNAPSHOT_FAILED,
+            ]:
+                monitor.signal_done()
 
 
 def evaluate(

--- a/ert_shared/ensemble_evaluator/entity/identifiers.py
+++ b/ert_shared/ensemble_evaluator/entity/identifiers.py
@@ -86,7 +86,7 @@ FM_JOB_ATTR_CURRENT_MEMORY_USAGE = "current_memory_usage"
 EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
 EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
 EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"
-EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.exception"
+EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.failed"
 
 EVGROUP_ENSEMBLE = {
     EVTYPE_ENSEMBLE_STARTED,

--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -260,7 +260,7 @@ class EnsembleEvaluator:
         return self._snapshot.get_successful_realizations()
 
     def run_and_get_successful_realizations(self):
-        mon = self.run()
-        for _ in mon.track():
-            pass
+        with self.run() as mon:
+            for _ in mon.track():
+                pass
         return self.get_successful_realizations()

--- a/tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -12,17 +12,10 @@ def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
         config = EvaluatorServerConfig(unused_tcp_port)
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
-        monitor = evaluator.run()
-        for e in monitor.track():
-            if (
-                e["type"]
-                in (
-                    identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                    identifiers.EVTYPE_EE_SNAPSHOT,
-                )
-                and e.data.get("status") in ["Failed", "Stopped"]
-            ):
-                monitor.signal_done()
+        with evaluator.run() as monitor:
+            for e in monitor.track():
+                if e.data is not None and e.data.get("status") in ["Failed", "Stopped"]:
+                    monitor.signal_done()
         assert evaluator._snapshot.get_status() == "Stopped"
         assert evaluator.get_successful_realizations() == num_reals
 
@@ -36,12 +29,12 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_b
 
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
 
-        mon = evaluator.run()
-        cancel = True
-        for _ in mon.track():
-            if cancel:
-                mon.signal_cancel()
-                cancel = False
+        with evaluator.run() as mon:
+            cancel = True
+            for _ in mon.track():
+                if cancel:
+                    mon.signal_cancel()
+                    cancel = False
 
         assert evaluator._snapshot.get_status() == "Cancelled"
 
@@ -55,15 +48,11 @@ def test_run_legacy_ensemble_exception(tmpdir, unused_tcp_port, make_ensemble_bu
         evaluator = EnsembleEvaluator(ensemble, config, ee_id="1")
 
         with patch.object(ensemble, "_run_path_list", side_effect=RuntimeError()):
-            monitor = evaluator.run()
-            for e in monitor.track():
-                if (
-                    e["type"]
-                    in (
-                        identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                        identifiers.EVTYPE_EE_SNAPSHOT,
-                    )
-                    and e.data.get("status") in ["Failed", "Stopped"]
-                ):
-                    monitor.signal_done()
+            with evaluator.run() as monitor:
+                for e in monitor.track():
+                    if e.data is not None and e.data.get("status") in [
+                        "Failed",
+                        "Stopped",
+                    ]:
+                        monitor.signal_done()
             assert evaluator._snapshot.get_status() == "Failed"


### PR DESCRIPTION
**Issue**
Resolves #1332 

**Approach**
- Rewrite the `_drain_monitor` function to make it suitable for use with a context manager
- Add `__enter__` and `__exit__` methods to the monitor class that start and stop the event loop
- Rewrite every usage of the monitor to use a context manager
