### PR TITLE
Improve storage development workflow

### DIFF
--- a/ert_shared/storage/db.py
+++ b/ert_shared/storage/db.py
@@ -43,21 +43,21 @@ class ErtStorage:
         if testing:
             database_file = project_file
             self._url = make_url(f"sqlite:///{project_path / self._db_file_name}")
-
-            self._engine = create_engine(
-                self._url, connect_args={"check_same_thread": False}
-            )
-            self.Session = sessionmaker(
-                bind=self._engine, autocommit=False, autoflush=False
-            )
         else:
             database_file = _tmp_db_path(project_path)
             if project_file.is_file():
                 copy2(project_file, database_file)
             self._url = make_url(f"sqlite:///{database_file}")
 
-            self._engine = create_engine(self._url)
-            self.Session = sessionmaker(bind=self._engine)
+        # As per FastAPI docs
+        # https://fastapi.tiangolo.com/tutorial/sql-databases/#create-the-sqlalchemy-engine
+        self._engine = create_engine(
+            self._url, connect_args={"check_same_thread": False}
+        )
+        # https://fastapi.tiangolo.com/tutorial/sql-databases/#create-a-sessionlocal-class
+        self.Session = sessionmaker(
+            bind=self._engine, autocommit=False, autoflush=False
+        )
 
         self.database_file = database_file
         self.project_file = project_file

--- a/ert_shared/storage/server_monitor.py
+++ b/ert_shared/storage/server_monitor.py
@@ -75,13 +75,6 @@ class ServerMonitor(threading.Thread):
 
         try:
             self._connection_info = json.loads(comm_buf.getvalue())
-
-            curl = f"curl -u '__token__:{self._connection_info['authtoken']}' {self._connection_info['urls'][0]}/ensembles"
-
-            print("Storage server is ready to accept requests. Listening on:")
-            for url in self._connection_info["urls"]:
-                print(f"  {url}")
-            print(f"\nUse `{curl}` to test")
         except json.JSONDecodeError:
             self._connection_info = ServerBootFail()
         except Exception as e:


### PR DESCRIPTION
- Improve the `--debug` option. It disables security and enables FastAPI
debug mode. Also improve the output to the user.

- Connect to the database in the way that is documented by FastAPI.

- Default to host `0.0.0.0` rather than `127.0.0.1`. In the future we'll
want to default on a public repository to be `127.0.0.1`, but while we
have no way to set a separate default for RGS users, we should default
to `0.0.0.0` to make ERT Storage work across RGS nodes.