### PR TITLE
Type hinting

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,31 @@
+name: Type checking
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python-version: ['3.8']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install ERT and dependencies
+      run: |
+        pip install .
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install mypy
+    - name: Run mypy
+      run: |
+        mypy ert3
+    - name: Run strict mypy
+      run: |
+        mypy ert3 --config-file .mypy-strict.ini

--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -1,0 +1,34 @@
+[mypy]
+
+[mypy-ert3.storage.*]
+ignore_errors = True
+
+[mypy-ert3.console.*]
+ignore_errors = True
+
+[mypy-ert3.engine.*]
+ignore_errors = True
+
+[mypy-ert3.evaluator.*]
+ignore_errors = True
+
+[mypy-ert3.stats.*]
+ignore_errors = True
+
+[mypy-ert3.workspace.*]
+ignore_errors = True
+
+[mypy-ert3.config.*]
+ignore_errors = True
+
+[mypy-ert3.algorithms.*]
+ignore_errors = True
+
+[mypy-ert3.data.*]
+ignore_errors = True
+
+[mypy-ert3.exceptions.*]
+ignore_errors = True
+
+[mypy-ert_shared.*]
+ignore_errors = True

--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -1,7 +1,7 @@
 [mypy]
 
 [mypy-ert3.storage.*]
-ignore_errors = True
+strict = True
 
 [mypy-ert3.console.*]
 ignore_errors = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+[mypy-ert_shared.*]
+ignore_errors = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Build status](https://github.com/equinor/ert/actions/workflows/build.yml/badge.svg)
 ![Code style](https://github.com/equinor/ert/actions/workflows/style.yml/badge.svg)
+![Type Hinting](https://github.com/equinor/ert/actions/workflows/style.yml/typing.svg)
 ![ERT2 test data setups](https://github.com/equinor/ert/actions/workflows/run_ert2_test_data_setups.yml/badge.svg)
 ![ERT3 polynomial demo](https://github.com/equinor/ert/actions/workflows/run_polynomial_demo.yml/badge.svg)
 ![ERT3 SPE1 demo](https://github.com/equinor/ert/actions/workflows/run_spe1_demo.yml/badge.svg)

--- a/ert3/__init__.py
+++ b/ert3/__init__.py
@@ -1,13 +1,13 @@
-import ert3.console
+import ert3.data
+import ert3.workspace
 import ert3.storage
 import ert3.evaluator
-import ert3.engine
-import ert3.workspace
+import ert3.exceptions
 import ert3.stats
 import ert3.config
-import ert3.exceptions
 import ert3.algorithms
-import ert3.data
+import ert3.engine
+import ert3.console
 
 
 _WORKSPACE_DATA_ROOT = ".ert"

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -1,3 +1,3 @@
-from ert3.config._ensemble_config import load_ensemble_config
-from ert3.config._stages_config import load_stages_config
-from ert3.config._experiment_config import load_experiment_config
+from ert3.config._ensemble_config import load_ensemble_config, EnsembleConfig
+from ert3.config._stages_config import load_stages_config, StagesConfig
+from ert3.config._experiment_config import load_experiment_config, ExperimentConfig

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,9 +1,10 @@
 from typing import List, Optional
 
-try:
-    # Will only work from Python 3.8
+import sys
+
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
 
 from pydantic.dataclasses import dataclass

--- a/ert3/config/_experiment_config.py
+++ b/ert3/config/_experiment_config.py
@@ -1,10 +1,12 @@
 from typing import List, Optional
 
-try:
-    # Will only work from Python 3.8
+import sys
+
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
+
 from pydantic.dataclasses import dataclass
 from pydantic import root_validator, BaseModel
 

--- a/ert3/config/_stages_config.py
+++ b/ert3/config/_stages_config.py
@@ -2,10 +2,11 @@ import importlib
 import os
 from typing import List, Callable, Optional
 
-try:
-    # Will only work from Python 3.8
+import sys
+
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
 
 from pydantic import root_validator, validator, FilePath, BaseModel

--- a/ert3/data/__init__.py
+++ b/ert3/data/__init__.py
@@ -1,3 +1,5 @@
 from ert3.data._record import Record
 from ert3.data._record import EnsembleRecord
 from ert3.data._record import MultiEnsembleRecord
+
+__all__ = ("Record", "EnsembleRecord", "MultiEnsembleRecord")

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -26,7 +26,7 @@ def _prepare_export(workspace_root, experiment_name, parameter_names, response_n
     return data
 
 
-def export(workspace_root, experiment_name):
+def export(workspace_root: Path, experiment_name: str) -> None:
     experiment_root = (
         Path(workspace_root) / ert3.workspace.EXPERIMENTS_BASE / experiment_name
     )

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -1,11 +1,13 @@
 import ert3
 from ert3.engine import _utils
 
+from pathlib import Path
 import json
+from typing import Optional, TextIO
 import yaml
 
 
-def load_record(workspace, record_name, record_file):
+def load_record(workspace: Path, record_name: str, record_file: TextIO) -> None:
     raw_ensrecord = json.load(record_file)
 
     record_file.close()
@@ -21,8 +23,12 @@ def load_record(workspace, record_name, record_file):
 
 
 def sample_record(
-    workspace, parameter_group_name, record_name, ensemble_size, experiment_name=None
-):
+    workspace: Path,
+    parameter_group_name: str,
+    record_name: str,
+    ensemble_size: int,
+    experiment_name: Optional[str] = None,
+) -> None:
     parameters = _utils.load_parameters(workspace)
 
     if parameter_group_name not in parameters:

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -50,13 +50,6 @@ def _prepare_evaluation(ensemble, workspace_root, experiment_name):
             record_name, record_source, ensemble.size, experiment_name, workspace_root
         )
 
-        ensemble_record = ert3.storage.get_ensemble_record(
-            workspace=workspace_root,
-            experiment_name=experiment_name,
-            record_name=record_name,
-        )
-        parameters[record_name] = ensemble_record
-
 
 def _load_ensemble_parameters(ensemble, workspace):
     parameters = _utils.load_parameters(workspace)


### PR DESCRIPTION
**Issue**
Resolves #1348

**Notes**
- This PR introduces type hinting for the two central submodules `ert3.storage` and `ert3.engine`. More can come later...
- The type hinting in `ert_shared` is currently not consistent. I have chosen to ignore the errors (see the `.mypy`-files). A separate issue should be created for this.
- Some of the type hinting is rather verbose. For instance `ensemble: ert3.config.EnsembleConfig,`. It can be discussed whether we instead should import `EnsembleConfig`.