### PR TITLE
Use pydantic to instantiate all dicts

### DIFF
--- a/ert_gui/model/node.py
+++ b/ert_gui/model/node.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from ert_shared.ensemble_evaluator.entity.snapshot import Snapshot
+from ert_shared.ensemble_evaluator.entity.snapshot import Snapshot, SnapshotDict
 from ert_shared.ensemble_evaluator.entity import identifiers as ids
 
 
@@ -37,8 +37,9 @@ class Node:
 
 def snapshot_to_tree(snapshot: Snapshot, iter_: int) -> Node:
     iter_node = Node(iter_, {ids.STATUS: snapshot.get_status()}, NodeType.ITER)
-    for real_id in sorted(snapshot.get_reals(), key=int):
-        real = snapshot.get_reals()[real_id]
+    snapshot_d = SnapshotDict(**snapshot.to_dict())
+    for real_id in sorted(snapshot_d.reals, key=int):
+        real = snapshot_d.reals[real_id]
         real_node = Node(
             real_id,
             {ids.STATUS: real.status, ids.ACTIVE: real.active},
@@ -56,7 +57,7 @@ def snapshot_to_tree(snapshot: Snapshot, iter_: int) -> Node:
                 for job_id in sorted(step.jobs, key=int):
                     job = step.jobs[job_id]
                     job_dict = dict(job)
-                    job_dict[ids.DATA] = dict(job[ids.DATA])
+                    job_dict[ids.DATA] = job.data
                     job_node = Node(job_id, job_dict, NodeType.JOB)
                     step_node.add_child(job_node)
     return iter_node

--- a/ert_gui/model/snapshot.py
+++ b/ert_gui/model/snapshot.py
@@ -3,7 +3,11 @@ import logging
 import ert_shared.status.entity.state as state
 from ert_gui.model.node import Node, NodeType, snapshot_to_tree
 from ert_shared.ensemble_evaluator.entity import identifiers as ids
-from ert_shared.ensemble_evaluator.entity.snapshot import PartialSnapshot, Snapshot
+from ert_shared.ensemble_evaluator.entity.snapshot import (
+    PartialSnapshot,
+    Snapshot,
+    SnapshotDict,
+)
 from ert_shared.status.utils import byte_with_unit
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, QVariant
 from qtpy.QtGui import QColor
@@ -69,80 +73,80 @@ class SnapshotModel(QAbstractItemModel):
         self.root = Node(None, {}, NodeType.ROOT)
 
     def _add_partial_snapshot(self, partial: PartialSnapshot, iter_: int):
-        partial_d = partial.to_dict()
+        partial_dict = partial.to_dict()
+        partial_s = SnapshotDict(**partial_dict)
         if iter_ not in self.root.children:
             logger.debug("no full snapshot yet, bailing")
             return
         iter_index = self.index(iter_, 0, QModelIndex())
         iter_node = self.root.children[iter_]
-        if ids.REALS not in partial_d:
+        if not partial_s.reals:
             logger.debug(f"no realizations in partial for iter {iter_}")
             return
-        for real_id in sorted(partial_d[ids.REALS], key=int):
-            real = partial_d[ids.REALS][real_id]
+        for real_id in sorted(partial_s.reals, key=int):
+            real = partial_s.reals[real_id]
             real_node = iter_node.children[real_id]
-            if real.get(ids.STATUS):
-                real_node.data[ids.STATUS] = real.get(ids.STATUS)
+            if real.status:
+                real_node.data[ids.STATUS] = real.status
 
             real_index = self.index(real_node.row(), 0, iter_index)
             real_index_bottom_right = self.index(
                 real_node.row(), self.columnCount(iter_index) - 1, iter_index
             )
 
-            if ids.STAGES not in real:
+            if not real.stages:
                 continue
 
             # TODO: sort stages, but wait till after https://github.com/equinor/ert/issues/1220 ?
-            for stage_id, stage in real[ids.STAGES].items():
+            for stage_id, stage in real.stages.items():
                 stage_node = real_node.children[stage_id]
 
-                if stage.get(ids.STATUS):
-                    stage_node.data[ids.STATUS] = stage.get(ids.STATUS)
+                if stage.status:
+                    stage_node.data[ids.STATUS] = stage.status
 
                 stage_index = self.index(stage_node.row(), 0, real_index)
                 stage_index_bottom_right = self.index(
                     stage_node.row(), self.columnCount(real_index) - 1, real_index
                 )
 
-                if ids.STEPS not in stage:
+                if not stage.steps:
                     continue
 
                 # TODO: sort steps, but wait till after https://github.com/equinor/ert/issues/1220 ?
-                for step_id, step in stage[ids.STEPS].items():
+                for step_id, step in stage.steps.items():
                     step_node = stage_node.children[step_id]
-                    if step.get(ids.STATUS):
-                        step_node.data[ids.STATUS] = step.get(ids.STATUS)
+                    if step.status:
+                        step_node.data[ids.STATUS] = step.status
 
                     step_index = self.index(step_node.row(), 0, stage_index)
                     step_index_bottom_right = self.index(
                         step_node.row(), self.columnCount(stage_index) - 1, stage_index
                     )
 
-                    if ids.JOBS not in step:
+                    if not step.jobs:
                         continue
 
-                    for job_id in sorted(step[ids.JOBS], key=int):
-                        job = step[ids.JOBS][job_id]
+                    for job_id in sorted(step.jobs, key=int):
+                        job = step.jobs[job_id]
                         job_node = step_node.children[job_id]
-                        for attr in (
-                            ids.STATUS,
-                            ids.START_TIME,
-                            ids.END_TIME,
-                            ids.STDOUT,
-                            ids.STDERR,
-                        ):
-                            if attr in job:
-                                job_node.data[attr] = job[attr]
+
+                        if job.status:
+                            job_node.data[ids.STATUS] = job.status
+                        if job.start_time:
+                            job_node.data[ids.START_TIME] = job.start_time
+                        if job.end_time:
+                            job_node.data[ids.END_TIME] = job.end_time
+                        if job.stdout:
+                            job_node.data[ids.STDOUT] = job.stdout
+                        if job.stderr:
+                            job_node.data[ids.STDERR] = job.stderr
 
                         # Errors may be unset as the queue restarts the job
-                        job_node.data[ids.ERROR] = job.get(ids.ERROR, "")
+                        job_node.data[ids.ERROR] = job.error if job.error else ""
 
                         for attr in (ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE):
-                            if attr not in job.get(ids.DATA, {}):
-                                continue
-                            job_node.data[ids.DATA][attr] = job.get(ids.DATA, {}).get(
-                                attr
-                            )
+                            if job.data and attr in job.data:
+                                job_node.data[ids.DATA][attr] = job.data.get(attr)
 
                         job_index = self.index(job_node.row(), 0, step_index)
                         job_index_bottom_right = self.index(

--- a/ert_shared/ensemble_evaluator/entity/snapshot.py
+++ b/ert_shared/ensemble_evaluator/entity/snapshot.py
@@ -2,7 +2,7 @@ import copy
 import datetime
 import typing
 from collections import defaultdict
-from typing import Dict, List, Optional, Any
+from typing import Dict, Iterable, Optional, Any
 
 import pyrsistent
 from dateutil.parser import parse
@@ -63,104 +63,73 @@ class PartialSnapshot:
         self._snapshot = copy.copy(snapshot) if snapshot else None
 
     def update_status(self, status):
-        self._apply_update({ids.STATUS: status})
+        self._apply_update(SnapshotDict(status=status))
 
     def update_real(
         self,
         real_id,
-        active=None,
-        start_time=None,
-        end_time=None,
-        status=None,
+        real,
     ):
-        real = {}
-        if active is not None:
-            real[ids.ACTIVE] = active
-        if start_time is not None:
-            real[ids.START_TIME] = start_time
-        if end_time is not None:
-            real[ids.END_TIME] = end_time
-        if status is not None:
-            real[ids.STATUS] = status
-
-        self._apply_update({ids.REALS: {real_id: real}})
+        self._apply_update(SnapshotDict(reals={real_id: real}))
 
     def update_stage(
         self,
         real_id,
         stage_id,
-        status=None,
-        start_time=None,
-        end_time=None,
+        stage,
     ):
-        stage = {}
-
-        if status is not None:
-            stage[ids.STATUS] = status
-        if start_time is not None:
-            stage[ids.START_TIME] = start_time
-        if end_time is not None:
-            stage[ids.END_TIME] = end_time
-
-        self._apply_update({ids.REALS: {real_id: {ids.STAGES: {stage_id: stage}}}})
-        if (
-            self._snapshot.get_real(real_id)[ids.STATUS]
-            != state.REALIZATION_STATE_FAILED
-        ):
-            if status in [
+        self._apply_update(
+            SnapshotDict(reals={real_id: Realization(stages={stage_id: stage})})
+        )
+        if self._snapshot.get_real(real_id).status != state.REALIZATION_STATE_FAILED:
+            if stage.status in [
                 state.REALIZATION_STATE_FAILED,
                 state.REALIZATION_STATE_PENDING,
                 state.REALIZATION_STATE_RUNNING,
             ]:
-                self.update_real(real_id, status=status)
+                self.update_real(real_id, Realization(status=stage.status))
             elif (
-                status == state.REALIZATION_STATE_FINISHED
+                stage.status == state.REALIZATION_STATE_FINISHED
                 and self._snapshot.all_stages_finished(real_id)
             ):
-                self.update_real(real_id, status=status)
+                self.update_real(real_id, Realization(status=stage.status))
 
     def _apply_update(self, update):
         if self._snapshot is None:
             raise UnsupportedOperationException(
                 f"trying to mutate {self.__class__} without providing a snapshot is not supported"
             )
-        self._data = recursive_update(self._data, update, check_key=False)
-        self._snapshot.merge(update)
+        dictionary = update.dict(
+            exclude_unset=True, exclude_none=True, exclude_defaults=True
+        )
+        self._data = recursive_update(self._data, dictionary, check_key=False)
+        self._snapshot.merge(dictionary)
 
-    def update_step(
-        self, real_id, stage_id, step_id, status=None, start_time=None, end_time=None
-    ):
-        step = {}
-
-        if status is not None:
-            step[ids.STATUS] = status
-        if start_time is not None:
-            step[ids.START_TIME] = start_time
-        if end_time is not None:
-            step[ids.END_TIME] = end_time
-
+    def update_step(self, real_id, stage_id, step_id, step):
         self._apply_update(
-            {
-                ids.REALS: {
-                    real_id: {ids.STAGES: {stage_id: {ids.STEPS: {step_id: step}}}}
+            SnapshotDict(
+                reals={
+                    real_id: Realization(
+                        stages={stage_id: Stage(steps={step_id: step})}
+                    )
                 }
-            }
+            )
         )
         if (
-            self._snapshot.get_stage(real_id, stage_id)[ids.STATUS]
+            self._snapshot.get_stage(real_id, stage_id).status
             != state.REALIZATION_STATE_FAILED
         ):
-            if status in [
+            if step.status in [
                 state.REALIZATION_STATE_FAILED,
                 state.REALIZATION_STATE_PENDING,
                 state.REALIZATION_STATE_RUNNING,
             ]:
-                self.update_stage(real_id, stage_id, status)
+                self.update_stage(real_id, stage_id, Stage(status=step.status))
             elif (
-                status == state.STEP_STATE_SUCCESS
+                step.status == state.STEP_STATE_SUCCESS
                 and self._snapshot.all_steps_finished(real_id, stage_id)
             ):
-                self.update_stage(real_id, stage_id, status)
+                self.update_stage(real_id, stage_id, Stage(status=step.status))
 
     def update_job(
         self,
@@ -168,41 +137,19 @@ class PartialSnapshot:
         stage_id,
         step_id,
         job_id,
-        status=None,
-        data=None,
-        start_time=None,
-        end_time=None,
-        error=None,
-        stdout=None,
-        stderr=None,
+        job,
     ):
-        job = {}
-
-        if status is not None:
-            job[ids.STATUS] = status
-        if start_time is not None:
-            job[ids.START_TIME] = start_time
-        if end_time is not None:
-            job[ids.END_TIME] = end_time
-        if data is not None:
-            job[ids.DATA] = data
-        if error is not None:
-            job[ids.ERROR] = error
-        if stdout is not None:
-            job[ids.STDOUT] = stdout
-        if stderr is not None:
-            job[ids.STDERR] = stderr
 
         self._apply_update(
-            {
-                ids.REALS: {
-                    real_id: {
-                        ids.STAGES: {
-                            stage_id: {ids.STEPS: {step_id: {ids.JOBS: {job_id: job}}}}
+            SnapshotDict(
+                reals={
+                    real_id: Realization(
+                        stages={
+                            stage_id: Stage(steps={step_id: Step(jobs={job_id: job})})
                         }
-                    }
+                    )
                 }
-            }
+            )
         )
 
     def to_dict(self):
@@ -228,9 +175,11 @@ class PartialSnapshot:
             self.update_stage(
                 get_real_id(e_source),
                 get_stage_id(e_source),
-                status=status,
-                start_time=start_time,
-                end_time=end_time,
+                stage=Stage(
+                    status=status,
+                    start_time=start_time,
+                    end_time=end_time,
+                ),
             )
         elif e_type in ids.EVGROUP_FM_STEP:
             start_time = None
@@ -244,9 +193,11 @@ class PartialSnapshot:
                 get_real_id(e_source),
                 get_stage_id(e_source),
                 get_step_id(e_source),
-                status=status,
-                start_time=start_time,
-                end_time=end_time,
+                step=Step(
+                    status=status,
+                    start_time=start_time,
+                    end_time=end_time,
+                ),
             )
             if e_type == ids.EVTYPE_FM_STEP_START and event.data:
                 for job_id, job in event.data.get(ids.JOBS, {}).items():
@@ -255,8 +206,10 @@ class PartialSnapshot:
                         get_stage_id(e_source),
                         get_step_id(e_source),
                         job_id,
-                        stdout=job[ids.STDOUT],
-                        stderr=job[ids.STDERR],
+                        job=Job(
+                            stdout=job[ids.STDOUT],
+                            stderr=job[ids.STDERR],
+                        ),
                     )
 
         elif e_type in ids.EVGROUP_FM_JOB:
@@ -272,13 +225,15 @@ class PartialSnapshot:
                 get_stage_id(e_source),
                 get_step_id(e_source),
                 get_job_id(e_source),
-                status=status,
-                start_time=start_time,
-                end_time=end_time,
-                data=event.data if e_type == ids.EVTYPE_FM_JOB_RUNNING else None,
-                error=event.data.get(ids.FM_STDERR)
-                if e_type == ids.EVTYPE_FM_JOB_FAILURE
-                else None,
+                job=Job(
+                    status=status,
+                    start_time=start_time,
+                    end_time=end_time,
+                    data=event.data if e_type == ids.EVTYPE_FM_JOB_RUNNING else None,
+                    error=event.data.get(ids.FM_STDERR)
+                    if e_type == ids.EVTYPE_FM_JOB_FAILURE
+                    else None,
+                ),
             )
         elif e_type in ids.EVGROUP_ENSEMBLE:
             self.update_status(_ENSEMBLE_TYPE_EVENT_TO_STATUS[e_type])
@@ -306,30 +261,30 @@ class Snapshot:
         return self._data[ids.STATUS]
 
     def get_reals(self):
-        return self._data[ids.REALS]
+        return SnapshotDict(**self._data).reals
 
     def get_real(self, real_id):
         if real_id not in self._data[ids.REALS]:
             raise ValueError(f"No realization with id {real_id}")
-        return self._data[ids.REALS][real_id]
+        return Realization(**self._data[ids.REALS][real_id])
 
     def get_stage(self, real_id, stage_id):
         real = self.get_real(real_id)
-        stages = real[ids.STAGES]
+        stages = real.stages
         if stage_id not in stages:
             raise ValueError(f"No stage with id {stage_id} in {real_id}")
         return stages[stage_id]
 
     def get_step(self, real_id, stage_id, step_id):
         stage = self.get_stage(real_id, stage_id)
-        steps = stage[ids.STEPS]
+        steps = stage.steps
         if step_id not in steps:
             raise ValueError(f"No step with id {step_id} in {stage_id}")
         return steps[step_id]
 
     def get_job(self, real_id, stage_id, step_id, job_id):
         step = self.get_step(real_id, stage_id, step_id)
-        jobs = step[ids.JOBS]
+        jobs = step.jobs
         if job_id not in jobs:
             raise ValueError(f"No job with id {job_id} in {step_id}")
         return jobs[job_id]
@@ -337,22 +292,20 @@ class Snapshot:
     def all_stages_finished(self, real_id):
         real = self.get_real(real_id)
         return all(
-            stage[ids.STATUS] == state.STAGE_STATE_SUCCESS
-            for stage in real[ids.STAGES].values()
+            stage.status == state.STAGE_STATE_SUCCESS for stage in real.stages.values()
         )
 
     def all_steps_finished(self, real_id, stage_id):
         stage = self.get_stage(real_id, stage_id)
         return all(
-            step[ids.STATUS] == state.STEP_STATE_SUCCESS
-            for step in stage[ids.STEPS].values()
+            step.status == state.STEP_STATE_SUCCESS for step in stage.steps.values()
         )
 
     def get_successful_realizations(self):
         return len(
             [
                 real
-                for real in self.to_dict()[ids.REALS].values()
+                for real in self._data[ids.REALS].values()
                 if real[ids.STATUS] == state.REALIZATION_STATE_FINISHED
             ]
         )
@@ -364,67 +317,66 @@ class Snapshot:
         return states
 
 
-class _JobDetails(BaseModel):
+class JobDetails(BaseModel):
     job_id: str
     name: str
 
 
-class _ForwardModel(BaseModel):
-    step_definitions: Dict[str, Dict[str, List[_JobDetails]]]
+class ForwardModel(BaseModel):
+    step_definitions: Dict[str, Dict[str, Iterable[JobDetails]]]
 
 
-class _Job(BaseModel):
-    status: str
+class Job(BaseModel):
+    status: Optional[str]
     start_time: Optional[datetime.datetime]
     end_time: Optional[datetime.datetime]
-    data: Dict
-    name: str
+    data: Optional[Dict]
+    name: Optional[str]
     error: Optional[str]
     stdout: Optional[str]
     stderr: Optional[str]
 
 
-class _Step(BaseModel):
-    status: str
+class Step(BaseModel):
+    status: Optional[str]
     start_time: Optional[datetime.datetime]
     end_time: Optional[datetime.datetime]
-    jobs: Dict[str, _Job] = {}
+    jobs: Optional[Dict[str, Job]] = {}
 
 
-class _Stage(BaseModel):
-    status: str
+class Stage(BaseModel):
+    status: Optional[str]
     start_time: Optional[datetime.datetime]
     end_time: Optional[datetime.datetime]
-    steps: Dict[str, _Step] = {}
+    steps: Optional[Dict[str, Step]] = {}
 
 
-class _Realization(BaseModel):
-    status: str
-    active: bool
+class Realization(BaseModel):
+    status: Optional[str]
+    active: Optional[bool]
     start_time: Optional[datetime.datetime]
     end_time: Optional[datetime.datetime]
-    stages: Dict[str, _Stage] = {}
-    status: str
+    stages: Optional[Dict[str, Stage]] = {}
 
 
-class _SnapshotDict(BaseModel):
-    status: str
-    reals: Dict[str, _Realization] = {}
-    forward_model: _ForwardModel
-    metadata: Dict[str, Any] = {}
+class SnapshotDict(BaseModel):
+    status: Optional[str]
+    reals: Optional[Dict[str, Realization]] = {}
+    forward_model: Optional[ForwardModel]
+    metadata: Optional[Dict[str, Any]]
 
 
 class SnapshotBuilder(BaseModel):
-    stages: Dict[str, _Stage] = {}
-    forward_model: _ForwardModel = _ForwardModel(step_definitions={})
+    stages: Dict[str, Stage] = {}
+    forward_model: ForwardModel = ForwardModel(step_definitions={})
     metadata: Dict[str, Any] = {}
 
     def build(self, real_ids, status, start_time=None, end_time=None):
-        top = _SnapshotDict(
+        top = SnapshotDict(
             status=status, forward_model=self.forward_model, metadata=self.metadata
         )
         for r_id in real_ids:
-            top.reals[r_id] = _Realization(
+            top.reals[r_id] = Realization(
                 active=True,
                 stages=self.stages,
                 start_time=start_time,
@@ -434,7 +386,7 @@ class SnapshotBuilder(BaseModel):
         return Snapshot(top.dict())
 
     def add_stage(self, stage_id, status, start_time=None, end_time=None):
-        self.stages[stage_id] = _Stage(
+        self.stages[stage_id] = Stage(
             status=status,
             start_time=start_time,
             end_time=end_time,
@@ -443,7 +395,7 @@ class SnapshotBuilder(BaseModel):
 
     def add_step(self, stage_id, step_id, status, start_time=None, end_time=None):
         stage = self.stages[stage_id]
-        stage.steps[step_id] = _Step(
+        stage.steps[step_id] = Step(
             status=status, start_time=start_time, end_time=end_time
         )
         return self
@@ -463,7 +415,7 @@ class SnapshotBuilder(BaseModel):
     ):
         stage = self.stages[stage_id]
         step = stage.steps[step_id]
-        step.jobs[job_id] = _Job(
+        step.jobs[job_id] = Job(
             status=status,
             data=data,
             start_time=start_time,
@@ -477,7 +429,7 @@ class SnapshotBuilder(BaseModel):
         if step_id not in self.forward_model.step_definitions[stage_id]:
             self.forward_model.step_definitions[stage_id][step_id] = []
         self.forward_model.step_definitions[stage_id][step_id].append(
-            _JobDetails(job_id=job_id, name=name)
+            JobDetails(job_id=job_id, name=name)
         )
         return self
 

--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -14,12 +14,12 @@ from ert_shared.ensemble_evaluator.entity import serialization
 from ert_shared.ensemble_evaluator.entity.snapshot import (
     PartialSnapshot,
     Snapshot,
-    _ForwardModel,
-    _Job,
-    _Realization,
-    _SnapshotDict,
-    _Stage,
-    _Step,
+    ForwardModel,
+    Job,
+    Realization,
+    SnapshotDict,
+    Stage,
+    Step,
 )
 from ert_shared.status.entity.state import (
     ENSEMBLE_STATE_CANCELLED,
@@ -66,36 +66,30 @@ class EnsembleEvaluator:
     def create_snapshot(ensemble):
         reals = {}
         for real in ensemble.get_active_reals():
-            reals[str(real.get_iens())] = _Realization(
+            reals[str(real.get_iens())] = Realization(
                 active=True,
-                start_time=None,
-                end_time=None,
                 status=REALIZATION_STATE_WAITING,
             )
             for stage in real.get_stages():
-                reals[str(real.get_iens())].stages[str(stage.get_id())] = _Stage(
+                reals[str(real.get_iens())].stages[str(stage.get_id())] = Stage(
                     status=STAGE_STATE_UNKNOWN,
-                    start_time=None,
-                    end_time=None,
                 )
                 for step in stage.get_steps():
                     reals[str(real.get_iens())].stages[str(stage.get_id())].steps[
                         str(step.get_id())
-                    ] = _Step(status=STEP_STATE_START, start_time=None, end_time=None)
+                    ] = Step(status=STEP_STATE_START)
                     for job in step.get_jobs():
                         reals[str(real.get_iens())].stages[str(stage.get_id())].steps[
                             str(step.get_id())
-                        ].jobs[str(job.get_id())] = _Job(
+                        ].jobs[str(job.get_id())] = Job(
                             status=JOB_STATE_START,
                             data={},
-                            start_time=None,
-                            end_time=None,
                             name=job.get_name(),
                         )
-        top = _SnapshotDict(
+        top = SnapshotDict(
             reals=reals,
             status=ENSEMBLE_STATE_STARTED,
-            forward_model=_ForwardModel(step_definitions={}),
+            forward_model=ForwardModel(step_definitions={}),
             metadata=ensemble.get_metadata(),
         )
 

--- a/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
+++ b/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
@@ -264,6 +264,7 @@ class PrefectEnsemble(_Ensemble):
         self._eval_proc.start()
 
     def _evaluate(self, dispatch_url, ee_id):
+        asyncio.set_event_loop(asyncio.get_event_loop())
         try:
             with Client(dispatch_url) as c:
                 event = CloudEvent(

--- a/ert_shared/status/utils.py
+++ b/ert_shared/status/utils.py
@@ -35,7 +35,7 @@ def tracker_progress(tracker) -> float:
     done_reals = 0
     if current_iter in tracker._iter_snapshot:
         for real in tracker._iter_snapshot[current_iter].get_reals().values():
-            if real[ids.STATUS] == state.REALIZATION_STATE_FINISHED:
+            if real.status == state.REALIZATION_STATE_FINISHED:
                 done_reals += 1
     total_reals = len(tracker._iter_snapshot[0].get_reals())
     return _calculate_progress(

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -7,9 +7,9 @@ from ert_shared.status.entity.state import (
 )
 from ert_shared.ensemble_evaluator.entity.snapshot import (
     Snapshot,
-    _SnapshotDict,
-    _ForwardModel,
-    _Realization,
+    SnapshotDict,
+    ForwardModel,
+    Realization,
 )
 import unittest
 
@@ -30,10 +30,10 @@ class MonitorTest(unittest.TestCase):
 
     def test_legends(self):
         monitor = Monitor(out=StringIO())
-        sd = _SnapshotDict(status="", forward_model=_ForwardModel(step_definitions={}))
+        sd = SnapshotDict(status="", forward_model=ForwardModel(step_definitions={}))
         for i in range(0, 100):
             status = REALIZATION_STATE_FINISHED if i < 10 else REALIZATION_STATE_RUNNING
-            sd.reals[i] = _Realization(status=status, active=True)
+            sd.reals[i] = Realization(status=status, active=True)
         monitor._snapshot = Snapshot(sd.dict())
         legends = monitor._get_legends()
 
@@ -69,10 +69,10 @@ class MonitorTest(unittest.TestCase):
     def test_print_progress(self):
         out = StringIO()
         monitor = Monitor(out=out)
-        sd = _SnapshotDict(status="", forward_model=_ForwardModel(step_definitions={}))
+        sd = SnapshotDict(status="", forward_model=ForwardModel(step_definitions={}))
         for i in range(0, 100):
             status = REALIZATION_STATE_FINISHED if i < 50 else REALIZATION_STATE_WAITING
-            sd.reals[i] = _Realization(status=status, active=True)
+            sd.reals[i] = Realization(status=status, active=True)
         monitor._snapshot = Snapshot(sd.dict())
         monitor._start_time = datetime.now()
         general_event = _UpdateEvent(

--- a/tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -146,7 +146,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
                 {"current_memory_usage": 1000},
             )
             snapshot = Snapshot(next(events).data)
-            assert snapshot.get_job("0", "0", "0", "0")["status"] == JOB_STATE_RUNNING
+            assert snapshot.get_job("0", "0", "0", "0").status == JOB_STATE_RUNNING
 
             # second dispatcher informs that job 0 is running
             send_dispatch_event(
@@ -157,7 +157,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
                 {"current_memory_usage": 1000},
             )
             snapshot = Snapshot(next(events).data)
-            assert snapshot.get_job("1", "0", "0", "0")["status"] == JOB_STATE_RUNNING
+            assert snapshot.get_job("1", "0", "0", "0").status == JOB_STATE_RUNNING
 
             # second dispatcher informs that job 0 is done
             send_dispatch_event(
@@ -168,19 +168,15 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
                 {"current_memory_usage": 1000},
             )
             snapshot = Snapshot(next(events).data)
-            assert snapshot.get_job("1", "0", "0", "0")["status"] == JOB_STATE_FINISHED
+            assert snapshot.get_job("1", "0", "0", "0").status == JOB_STATE_FINISHED
 
             # a second monitor connects
             with ee_monitor.create(host, port) as monitor2:
                 events2 = monitor2.track()
                 snapshot = Snapshot(next(events2).data)
                 assert snapshot.get_status() == ENSEMBLE_STATE_STARTED
-                assert (
-                    snapshot.get_job("0", "0", "0", "0")["status"] == JOB_STATE_RUNNING
-                )
-                assert (
-                    snapshot.get_job("1", "0", "0", "0")["status"] == JOB_STATE_FINISHED
-                )
+                assert snapshot.get_job("0", "0", "0", "0").status == JOB_STATE_RUNNING
+                assert snapshot.get_job("1", "0", "0", "0").status == JOB_STATE_FINISHED
 
                 # one monitor requests that server exit
                 monitor.signal_cancel()

--- a/tests/ensemble_evaluator/test_entity.py
+++ b/tests/ensemble_evaluator/test_entity.py
@@ -1,26 +1,13 @@
 from datetime import datetime
+import dateutil.parser
 
 import pytest
 from ert_shared.ensemble_evaluator.entity import command, tool
 from ert_shared.ensemble_evaluator.entity.snapshot import (
     PartialSnapshot,
-    Snapshot,
     SnapshotBuilder,
+    Job,
 )
-
-
-def _dict_equal(d1, d2):
-    if set(d1.keys()) != set(d2.keys()):
-        return False
-
-    for k in d1:
-        if type(d1[k]) is dict:
-            if not _dict_equal(d1[k], d2[k]):
-                return False
-        else:
-            if d1[k] != d2[k]:
-                return False
-    return True
 
 
 _REALIZATION_INDEXES = ["0", "1", "3", "4", "5", "9"]
@@ -83,70 +70,74 @@ def test_snapshot_merge():
         stage_id="0",
         step_id="0",
         job_id="0",
-        status="Finished",
-        start_time=datetime(year=2020, month=10, day=27).isoformat(),
-        end_time=datetime(year=2020, month=10, day=28).isoformat(),
-        data={"memory": 1000},
+        job=Job(
+            status="Finished",
+            start_time=datetime(year=2020, month=10, day=27),
+            end_time=datetime(year=2020, month=10, day=28),
+            data={"memory": 1000},
+        ),
     )
     update_event.update_job(
         real_id="1",
         stage_id="0",
         step_id="0",
         job_id="1",
-        status="Running",
-        start_time=datetime(year=2020, month=10, day=27).isoformat(),
+        job=Job(
+            status="Running",
+            start_time=datetime(year=2020, month=10, day=27),
+        ),
     )
     update_event.update_job(
         real_id="9",
         stage_id="0",
         step_id="0",
         job_id="0",
-        status="Running",
-        start_time=datetime(year=2020, month=10, day=27).isoformat(),
+        job=Job(
+            status="Running",
+            start_time=datetime(year=2020, month=10, day=27),
+        ),
     )
 
     snapshot.merge_event(update_event)
 
     assert snapshot.get_status() == "running"
 
-    assert _dict_equal(
-        snapshot.get_job(real_id="1", stage_id="0", step_id="0", job_id="0"),
-        {
-            "status": "Finished",
-            "start_time": "2020-10-27T00:00:00",
-            "end_time": "2020-10-28T00:00:00",
-            "data": {"memory": 1000},
-            "error": None,
-            "name": "job0",
-            "stderr": None,
-            "stdout": None,
-        },
+    assert snapshot.get_job(real_id="1", stage_id="0", step_id="0", job_id="0") == Job(
+        status="Finished",
+        start_time=datetime(year=2020, month=10, day=27),
+        end_time=datetime(year=2020, month=10, day=28),
+        data={"memory": 1000},
+        error=None,
+        name="job0",
+        stderr=None,
+        stdout=None,
     )
-    assert snapshot.get_job(real_id="1", stage_id="0", step_id="0", job_id="1") == {
-        "status": "Running",
-        "start_time": "2020-10-27T00:00:00",
-        "end_time": None,
-        "data": {},
-        "error": None,
-        "name": "job1",
-        "stderr": None,
-        "stdout": None,
-    }
+
+    assert snapshot.get_job(real_id="1", stage_id="0", step_id="0", job_id="1") == Job(
+        status="Running",
+        start_time=datetime(year=2020, month=10, day=27),
+        end_time=None,
+        data={},
+        error=None,
+        name="job1",
+        stderr=None,
+        stdout=None,
+    )
 
     assert (
-        snapshot.get_job(real_id="9", stage_id="0", step_id="0", job_id="0")["status"]
+        snapshot.get_job(real_id="9", stage_id="0", step_id="0", job_id="0").status
         == "Running"
     )
-    assert snapshot.get_job(real_id="9", stage_id="0", step_id="0", job_id="0") == {
-        "status": "Running",
-        "start_time": "2020-10-27T00:00:00",
-        "end_time": None,
-        "data": {},
-        "error": None,
-        "name": "job0",
-        "stderr": None,
-        "stdout": None,
-    }
+    assert snapshot.get_job(real_id="9", stage_id="0", step_id="0", job_id="0") == Job(
+        status="Running",
+        start_time=datetime(year=2020, month=10, day=27),
+        end_time=None,
+        data={},
+        error=None,
+        name="job0",
+        stderr=None,
+        stdout=None,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/gui/models/conftest.py
+++ b/tests/gui/models/conftest.py
@@ -12,12 +12,12 @@ import pytest
 from ert_shared.ensemble_evaluator.entity.snapshot import (
     PartialSnapshot,
     Snapshot,
-    _ForwardModel,
-    _Job,
-    _Realization,
-    _SnapshotDict,
-    _Stage,
-    _Step,
+    ForwardModel,
+    Job,
+    Realization,
+    SnapshotDict,
+    Stage,
+    Step,
 )
 import copy
 import datetime
@@ -25,24 +25,24 @@ import datetime
 
 def partial_snapshot(snapshot) -> PartialSnapshot:
     partial = PartialSnapshot(snapshot)
-    partial.update_real("0", status=JOB_STATE_FINISHED)
-    partial.update_job("0", "0", "0", "0", status=JOB_STATE_FINISHED)
+    partial.update_real("0", Realization(status=JOB_STATE_FINISHED))
+    partial.update_job("0", "0", "0", "0", Job(status=JOB_STATE_FINISHED))
     return partial
 
 
 @pytest.fixture()
 def full_snapshot() -> Snapshot:
-    real = _Realization(
+    real = Realization(
         status=REALIZATION_STATE_UNKNOWN,
         active=True,
         stages={
-            "0": _Stage(
+            "0": Stage(
                 status="",
                 steps={
-                    "0": _Step(
+                    "0": Step(
                         status="",
                         jobs={
-                            "0": _Job(
+                            "0": Job(
                                 start_time=datetime.datetime.now(),
                                 end_time=datetime.datetime.now(),
                                 name="poly_eval",
@@ -55,7 +55,7 @@ def full_snapshot() -> Snapshot:
                                     MAX_MEMORY_USAGE: "312",
                                 },
                             ),
-                            "1": _Job(
+                            "1": Job(
                                 start_time=datetime.datetime.now(),
                                 end_time=datetime.datetime.now(),
                                 name="poly_postval",
@@ -74,10 +74,10 @@ def full_snapshot() -> Snapshot:
             )
         },
     )
-    snapshot = _SnapshotDict(
+    snapshot = SnapshotDict(
         status=ENSEMBLE_STATE_STARTED,
         reals={},
-        forward_model=_ForwardModel(step_definitions={}),
+        forward_model=ForwardModel(step_definitions={}),
     )
     for i in range(0, 100):
         snapshot.reals[str(i)] = copy.deepcopy(real)

--- a/tests/gui/models/test_job_list_model.py
+++ b/tests/gui/models/test_job_list_model.py
@@ -3,7 +3,7 @@ import ert_shared.ensemble_evaluator.entity.identifiers as ids
 from ert_gui.model.job_list import JobListProxyModel
 from ert_gui.model.node import NodeType
 from ert_gui.model.snapshot import COLUMNS, SnapshotModel
-from ert_shared.ensemble_evaluator.entity.snapshot import PartialSnapshot
+from ert_shared.ensemble_evaluator.entity.snapshot import PartialSnapshot, Job
 from ert_shared.status.entity.state import JOB_STATE_FAILURE, JOB_STATE_START
 from PyQt5.QtCore import QModelIndex
 from pytestqt.qt_compat import qt_api
@@ -62,9 +62,11 @@ def test_changes(full_snapshot):
         "0",
         "0",
         "0",
-        status=JOB_STATE_FAILURE,
-        start_time=start_time,
-        end_time=end_time,
+        job=Job(
+            status=JOB_STATE_FAILURE,
+            start_time=start_time,
+            end_time=end_time,
+        ),
     )
     source_model._add_partial_snapshot(partial, 0)
     assert model.index(0, _id_to_col(ids.START_TIME), QModelIndex()).data() == str(
@@ -95,7 +97,7 @@ def test_no_cross_talk(full_snapshot):
 
     # Test that changes to iter=1 does not bleed into iter=0
     partial = PartialSnapshot(full_snapshot)
-    partial.update_job("0", "0", "0", "0", status=JOB_STATE_FAILURE)
+    partial.update_job("0", "0", "0", "0", job=Job(status=JOB_STATE_FAILURE))
     source_model._add_partial_snapshot(partial, 1)
     assert (
         model.index(0, _id_to_col(ids.STATUS), QModelIndex()).data() == JOB_STATE_START

--- a/tests/gui/models/test_progress_proxy.py
+++ b/tests/gui/models/test_progress_proxy.py
@@ -3,7 +3,7 @@ from ert_shared.status.entity.state import (
     REALIZATION_STATE_FINISHED,
     REALIZATION_STATE_UNKNOWN,
 )
-from ert_shared.ensemble_evaluator.entity.snapshot import PartialSnapshot
+from ert_shared.ensemble_evaluator.entity.snapshot import PartialSnapshot, Realization
 from PyQt5.QtCore import QModelIndex
 from ert_gui.model.progress_proxy import ProgressProxyModel
 from tests.gui.models.conftest import partial_snapshot
@@ -48,7 +48,7 @@ def test_progression(full_snapshot):
     }
 
     partial = PartialSnapshot(full_snapshot)
-    partial.update_real("0", status=REALIZATION_STATE_FINISHED)
+    partial.update_real("0", Realization(status=REALIZATION_STATE_FINISHED))
     source_model._add_partial_snapshot(partial, 0)
 
     assert model.data(model.index(0, 0, QModelIndex()), ProgressRole) == {

--- a/tests/gui/models/test_real_list_model.py
+++ b/tests/gui/models/test_real_list_model.py
@@ -1,5 +1,6 @@
 from PyQt5.QtCore import QModelIndex
 from ert_gui.model.real_list import RealListModel
+from ert_shared.ensemble_evaluator.entity.snapshot import Realization
 from tests.gui.models.conftest import partial_snapshot
 from ert_gui.model.snapshot import NodeRole, SnapshotModel
 from pytestqt.qt_compat import qt_api
@@ -53,7 +54,7 @@ def test_change_iter(full_snapshot):
     model.setIter(1)
 
     partial = partial_snapshot(full_snapshot)
-    partial.update_real("0", status=REALIZATION_STATE_FINISHED)
+    partial.update_real("0", Realization(status=REALIZATION_STATE_FINISHED))
     source_model._add_partial_snapshot(partial, 1)
 
     assert (

--- a/tests/status/test_evaluator_tracker.py
+++ b/tests/status/test_evaluator_tracker.py
@@ -11,6 +11,7 @@ import ert_shared.ensemble_evaluator.entity.identifiers as ids
 from ert_shared.ensemble_evaluator.entity.snapshot import (
     PartialSnapshot,
     SnapshotBuilder,
+    Step,
 )
 
 from ert_shared.status.entity import state
@@ -43,8 +44,8 @@ def mock_ee_monitor(*args):
     )
 
     update = PartialSnapshot(snapshot)
-    update.update_step("0", "0", "0", state.STEP_STATE_SUCCESS)
-    update.update_step("1", "0", "0", state.STEP_STATE_SUCCESS)
+    update.update_step("0", "0", "0", step=Step(status=state.STEP_STATE_SUCCESS))
+    update.update_step("1", "0", "0", step=Step(status=state.STEP_STATE_SUCCESS))
 
     events = [
         MockCloudEvent(

--- a/tests/status/test_legacy_tracker.py
+++ b/tests/status/test_legacy_tracker.py
@@ -132,16 +132,16 @@ def test_tracking(cmd_line_arguments, num_successful, num_iters, tmpdir, source_
             assert len(snapshot.get_reals()) == num_successful
             for real_id, real in snapshot.get_reals().items():
                 assert (
-                    real["status"] == REALIZATION_STATE_FINISHED
+                    real.status == REALIZATION_STATE_FINISHED
                 ), f"iter:{iter_} real:{real_id} was not finished"
 
-                poly = real["stages"]["0"]["steps"]["0"]["jobs"]["0"]
-                poly2 = real["stages"]["0"]["steps"]["0"]["jobs"]["1"]
-                assert poly["name"] == "poly_eval"
+                poly = real.stages["0"].steps["0"].jobs["0"]
+                poly2 = real.stages["0"].steps["0"].jobs["1"]
+                assert poly.name == "poly_eval"
                 assert (
-                    poly["status"] == JOB_STATE_FINISHED
+                    poly.status == JOB_STATE_FINISHED
                 ), f"real {real_id}/{poly['name']} was not finished"
-                assert poly2["name"] == "poly_eval2"
+                assert poly2.name == "poly_eval2"
                 assert (
-                    poly2["status"] == JOB_STATE_FINISHED
+                    poly2.status == JOB_STATE_FINISHED
                 ), f"real {real_id}/{poly['name']} was not finished"


### PR DESCRIPTION
In order to make it easier to find the places where the snapshot is interacted, we can make sure to use the pydantic classses every place we access it.

Also includes a fix for #1459, which was causing a Bad file descriptor Exception due to a corrupt loop instance after forking in the prefect ensemle.