### PR TITLE
Use forkserver as strategy with multiprocessing

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -102,7 +102,7 @@ def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records)
         "stages": stages,
         "realizations": ensemble_size,
         "max_running": 10000,
-        "max_retries": 1,
+        "max_retries": 0,
         "run_path": evaluation_tmp_dir / "my_output",
         "executor": ensemble.forward_model.driver,
         "storage": {

--- a/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
+++ b/ert_shared/ensemble_evaluator/prefect_ensemble/prefect_ensemble.py
@@ -255,7 +255,8 @@ class PrefectEnsemble(_Ensemble):
     def evaluate(self, config, ee_id):
         self._ee_dispach_url = config.dispatch_uri
         self._ee_id = ee_id
-        self._eval_proc = multiprocessing.Process(
+        mp_ctx = multiprocessing.get_context(method="forkserver")
+        self._eval_proc = mp_ctx.Process(
             target=self._evaluate,
             args=(self._ee_dispach_url, ee_id),
         )

--- a/tests/ensemble_evaluator/test_prefect_ensemble.py
+++ b/tests/ensemble_evaluator/test_prefect_ensemble.py
@@ -455,11 +455,11 @@ def test_on_task_failure(unused_tcp_port):
         assert expected_step_failed_messages == len(fail_step_messages)
 
 
+def dummy_get_flow(*args, **kwargs):
+    raise RuntimeError()
+
+
 @pytest.mark.timeout(60)
-@pytest.mark.skipif(
-    sys.platform.startswith("darwin"),
-    reason="On darwin patching is unreliable since processes may use 'spawn'.",
-)
 def test_run_prefect_ensemble_exception(unused_tcp_port, coefficients):
     with tmp(os.path.join(SOURCE_DIR, "test-data/local/prefect_test_case")):
         config = parse_config("config.yml")
@@ -477,12 +477,12 @@ def test_run_prefect_ensemble_exception(unused_tcp_port, coefficients):
         ensemble = PrefectEnsemble(config)
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
 
-        with patch.object(ensemble, "get_flow", side_effect=RuntimeError()):
-            with evaluator.run() as mon:
-                for event in mon.track():
-                    if event.data is not None and event.data.get("status") in [
-                        "Failed",
-                        "Stopped",
-                    ]:
-                        mon.signal_done()
-            assert evaluator._snapshot.get_status() == "Failed"
+        ensemble.get_flow = dummy_get_flow
+        with evaluator.run() as mon:
+            for event in mon.track():
+                if event.data is not None and event.data.get("status") in [
+                    "Failed",
+                    "Stopped",
+                ]:
+                    mon.signal_done()
+        assert evaluator._snapshot.get_status() == "Failed"


### PR DESCRIPTION
Use `forkserver` as strategy when using multiprocessing in the prefect ensemble.