### PR TITLE
Add ert3 status command

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = F401,E711,W503
+ignore = F401,E711,W503,E203
 max-line-length = 88

--- a/ert3/console/__init__.py
+++ b/ert3/console/__init__.py
@@ -1,1 +1,2 @@
 from ert3.console._console import main
+from ert3.console._status import status

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -48,6 +48,10 @@ def _build_record_argparser(subparsers):
     )
 
 
+def _build_status_argparser(subparsers):
+    subparsers.add_parser("status", help="Report the status of all experiments")
+
+
 def _build_argparser():
     parser = argparse.ArgumentParser(description=_ERT3_DESCRIPTION)
     subparsers = parser.add_subparsers(dest="sub_cmd", help="ert3 commands")
@@ -56,6 +60,7 @@ def _build_argparser():
     _build_run_argparser(subparsers)
     _build_export_argparser(subparsers)
     _build_record_argparser(subparsers)
+    _build_status_argparser(subparsers)
 
     return parser
 
@@ -94,6 +99,11 @@ def _record(workspace, args):
         )
 
 
+def _status(workspace, args):
+    assert args.sub_cmd == "status"
+    ert3.console.status(workspace)
+
+
 def main():
     try:
         _main()
@@ -125,6 +135,8 @@ def _main():
         _export(workspace, args)
     elif args.sub_cmd == "record":
         _record(workspace, args)
+    elif args.sub_cmd == "status":
+        _status(workspace, args)
     else:
         raise NotImplementedError(f"No implementation to handle command {args.sub_cmd}")
 

--- a/ert3/console/_status.py
+++ b/ert3/console/_status.py
@@ -1,0 +1,22 @@
+import ert3
+
+
+def status(workspace_root):
+    experiments = ert3.workspace.get_experiment_names(workspace_root)
+    done = ert3.storage.get_experiment_names(workspace=workspace_root)
+    pending = [experiment for experiment in experiments if experiment not in done]
+
+    if done:
+        print("Experiments that have run already:")
+        for experiment in done:
+            print(f"  {experiment}")
+
+    if pending:
+        if done:
+            print()
+        print("Experiments that can be run:")
+        for experiment in pending:
+            print(f"  {experiment}")
+
+    if not done and not pending:
+        print("No experiments present in this workspace")

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -32,7 +32,7 @@ def export(workspace_root: Path, experiment_name: str) -> None:
     )
     ert3.workspace.assert_experiment_exists(workspace_root, experiment_name)
 
-    if not ert3.workspace.experiment_have_run(workspace_root, experiment_name):
+    if not ert3.workspace.experiment_has_run(workspace_root, experiment_name):
         raise ValueError("Cannot export experiment that has not been carried out")
 
     parameter_names = set(

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -9,7 +9,7 @@ def _prepare_experiment(
     experiment_name: str,
     ensemble: ert3.config.EnsembleConfig,
 ):
-    if ert3.workspace.experiment_have_run(workspace_root, experiment_name):
+    if ert3.workspace.experiment_has_run(workspace_root, experiment_name):
         raise ValueError(f"Experiment {experiment_name} have been carried out.")
 
     parameter_names = [elem.record for elem in ensemble.input]

--- a/ert3/exceptions/__init__.py
+++ b/ert3/exceptions/__init__.py
@@ -1,2 +1,3 @@
 from ert3.exceptions._exceptions import ErtError
 from ert3.exceptions._exceptions import IllegalWorkspaceOperation
+from ert3.exceptions._exceptions import IllegalWorkspaceState

--- a/ert3/exceptions/_exceptions.py
+++ b/ert3/exceptions/_exceptions.py
@@ -7,3 +7,8 @@ class ErtError(Exception):
 class IllegalWorkspaceOperation(ErtError):
     def __init__(self, message):
         self.message = "{}".format(message)
+
+
+class IllegalWorkspaceState(ErtError):
+    def __init__(self, message):
+        self.message = "{}".format(message)

--- a/ert3/workspace/__init__.py
+++ b/ert3/workspace/__init__.py
@@ -1,6 +1,7 @@
 from ert3.workspace._workspace import initialize
 from ert3.workspace._workspace import load
-from ert3.workspace._workspace import experiment_have_run
+from ert3.workspace._workspace import get_experiment_names
+from ert3.workspace._workspace import experiment_has_run
 from ert3.workspace._workspace import assert_experiment_exists
 
 EXPERIMENTS_BASE = "experiments"

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -24,7 +24,20 @@ def assert_experiment_exists(workspace_root, experiment_name):
         )
 
 
-def experiment_have_run(workspace_root, experiment_name):
+def get_experiment_names(workspace_root):
+    experiment_base = Path(workspace_root) / ert3.workspace.EXPERIMENTS_BASE
+    if not experiment_base.is_dir():
+        raise ert3.exceptions.IllegalWorkspaceState(
+            f"the workspace {workspace_root} cannot access experiments"
+        )
+    return {
+        experiment.name
+        for experiment in experiment_base.iterdir()
+        if experiment.is_dir()
+    }
+
+
+def experiment_has_run(workspace_root, experiment_name):
     experiments = ert3.storage.get_experiment_names(workspace=workspace_root)
     return experiment_name in experiments
 

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -28,8 +28,11 @@ def test_cli_no_init(tmpdir, args):
     workspace.chdir()
 
     with patch.object(sys, "argv", args):
-        with pytest.raises(SystemExit, match="Not inside an ERT workspace"):
-            ert3.console.main()
+        with pytest.raises(
+            ert3.exceptions.IllegalWorkspaceOperation,
+            match="Not inside an ERT workspace",
+        ):
+            ert3.console._console._main()
 
 
 def test_cli_no_args(tmpdir):
@@ -62,8 +65,11 @@ def test_cli_init_twice(tmpdir):
         ert3.console.main()
 
     with patch.object(sys, "argv", args):
-        with pytest.raises(SystemExit, match="Already inside an ERT workspace"):
-            ert3.console.main()
+        with pytest.raises(
+            ert3.exceptions.IllegalWorkspaceOperation,
+            match="Already inside an ERT workspace",
+        ):
+            ert3.console._console._main()
 
 
 def test_cli_init_subfolder(tmpdir):
@@ -80,8 +86,11 @@ def test_cli_init_subfolder(tmpdir):
     subfolder.chdir()
 
     with patch.object(sys, "argv", args):
-        with pytest.raises(SystemExit, match="Already inside an ERT workspace"):
-            ert3.console.main()
+        with pytest.raises(
+            ert3.exceptions.IllegalWorkspaceOperation,
+            match="Already inside an ERT workspace",
+        ):
+            ert3.console._console._main()
 
 
 def test_cli_run_invalid_experiment(tmpdir):
@@ -96,9 +105,10 @@ def test_cli_run_invalid_experiment(tmpdir):
     args = ["ert3", "run", "this-is-not-an-experiment"]
     with patch.object(sys, "argv", args):
         with pytest.raises(
-            SystemExit, match="this-is-not-an-experiment is not an experiment"
+            ert3.exceptions.IllegalWorkspaceOperation,
+            match="this-is-not-an-experiment is not an experiment",
         ):
-            ert3.console.main()
+            ert3.console._console._main()
 
 
 def test_cli_record_load_not_existing_file(tmpdir):
@@ -119,7 +129,7 @@ def test_cli_record_load_not_existing_file(tmpdir):
     ]
     with patch.object(sys, "argv", args):
         with pytest.raises(SystemExit):
-            ert3.console.main()
+            ert3.console._console._main()
 
 
 def _assert_done_or_pending(captured, experiments, done_indices):
@@ -245,6 +255,7 @@ def test_cli_status_no_experiments_root(tmpdir):
     args = ["ert3", "status"]
     with patch.object(sys, "argv", args):
         with pytest.raises(
-            SystemExit, match=f"the workspace {workspace} cannot access experiments"
+            ert3.exceptions.IllegalWorkspaceState,
+            match=f"the workspace {workspace} cannot access experiments",
         ):
-            ert3.console.main()
+            ert3.console._console._main()

--- a/tests/ert3/workspace/test_workspace.py
+++ b/tests/ert3/workspace/test_workspace.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+import ert3
+
+
+def test_workspace_initialize(tmpdir):
+    ert3.workspace.initialize(tmpdir)
+
+    assert (Path(tmpdir) / ert3._WORKSPACE_DATA_ROOT).is_dir()
+
+    with pytest.raises(
+        ert3.exceptions.IllegalWorkspaceOperation,
+        match="Already inside an ERT workspace.",
+    ):
+        ert3.workspace.initialize(tmpdir)
+
+
+def test_workspace_load(tmpdir):
+    assert ert3.workspace.load(tmpdir) is None
+    assert ert3.workspace.load(tmpdir / "foo") is None
+    ert3.workspace.initialize(tmpdir)
+    assert ert3.workspace.load(tmpdir) == tmpdir
+    assert ert3.workspace.load(tmpdir / "foo") == tmpdir
+
+
+def test_workspace_assert_experiment_exists(tmpdir):
+    experiments_dir = Path(tmpdir) / ert3.workspace.EXPERIMENTS_BASE
+    with pytest.raises(
+        ert3.exceptions.IllegalWorkspaceState,
+        match=f"the workspace {tmpdir} cannot access experiments",
+    ):
+        ert3.workspace.get_experiment_names(tmpdir)
+
+    ert3.workspace.initialize(tmpdir)
+    Path(experiments_dir / "test1").mkdir(parents=True)
+
+    ert3.workspace.assert_experiment_exists(tmpdir, "test1")
+
+    with pytest.raises(
+        ert3.exceptions.IllegalWorkspaceOperation,
+        match=f"test2 is not an experiment within the workspace {tmpdir}",
+    ):
+        ert3.workspace.assert_experiment_exists(tmpdir, "test2")
+
+
+def test_workspace_assert_get_experiment_names(tmpdir):
+    experiments_dir = Path(tmpdir) / ert3.workspace.EXPERIMENTS_BASE
+    with pytest.raises(
+        ert3.exceptions.IllegalWorkspaceState,
+        match=f"the workspace {tmpdir} cannot access experiments",
+    ):
+        ert3.workspace.get_experiment_names(tmpdir)
+
+    ert3.workspace.initialize(tmpdir)
+    Path(experiments_dir / "test1").mkdir(parents=True)
+    Path(experiments_dir / "test2").mkdir(parents=True)
+
+    assert ert3.workspace.get_experiment_names(tmpdir) == {"test1", "test2"}
+
+
+def test_workspace_experiment_has_run(tmpdir):
+    experiments_dir = Path(tmpdir) / ert3.workspace.EXPERIMENTS_BASE
+    with pytest.raises(
+        ert3.exceptions.IllegalWorkspaceState,
+        match=f"the workspace {tmpdir} cannot access experiments",
+    ):
+        ert3.workspace.get_experiment_names(tmpdir)
+
+    ert3.workspace.initialize(tmpdir)
+    Path(experiments_dir / "test1").mkdir(parents=True)
+    Path(experiments_dir / "test2").mkdir(parents=True)
+
+    ert3.storage.init_experiment(
+        workspace=tmpdir, experiment_name="test1", parameters=[]
+    )
+
+    assert ert3.workspace.experiment_has_run(tmpdir, "test1")
+    assert not ert3.workspace.experiment_has_run(tmpdir, "test2")


### PR DESCRIPTION
**Issue**
Resolves #1457 


**Approach**
A list is printed of the experiments that have run already, and those that have not run yet.

TODO: We should also print the final status of the jobs that ran: I do not seem to find any info stored in the storage about the final status. 