### PR TITLE
Add ert3 clean command

### DIFF
--- a/ert3/console/__init__.py
+++ b/ert3/console/__init__.py
@@ -1,2 +1,3 @@
 from ert3.console._console import main
 from ert3.console._status import status
+from ert3.console._clean import clean

--- a/ert3/console/_clean.py
+++ b/ert3/console/_clean.py
@@ -1,0 +1,20 @@
+import ert3
+
+
+def clean(workspace, experiment_names, clean_all):
+    if clean_all:
+        non_existant = []
+    else:
+        non_existant = [
+            name
+            for name in experiment_names
+            if name not in ert3.storage.get_experiment_names(workspace=workspace)
+        ]
+
+    ert3.engine.clean(workspace, experiment_names, clean_all)
+
+    if non_existant:
+        print("Following experiment(s) did not exist:")
+        for name in non_existant:
+            print(f"    {name}")
+        print("Perhaps you mistyped an experiment name?")

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -52,6 +52,17 @@ def _build_status_argparser(subparsers):
     subparsers.add_parser("status", help="Report the status of all experiments")
 
 
+def _build_clean_argparser(subparsers):
+    export_parser = subparsers.add_parser("clean", help="Clean experiments")
+    group = export_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "experiment_names", nargs="*", default=[], help="Name of the experiment(s)"
+    )
+    group.add_argument(
+        "--all", action="store_true", default=False, help="Clean all experiments"
+    )
+
+
 def _build_argparser():
     parser = argparse.ArgumentParser(description=_ERT3_DESCRIPTION)
     subparsers = parser.add_subparsers(dest="sub_cmd", help="ert3 commands")
@@ -61,6 +72,7 @@ def _build_argparser():
     _build_export_argparser(subparsers)
     _build_record_argparser(subparsers)
     _build_status_argparser(subparsers)
+    _build_clean_argparser(subparsers)
 
     return parser
 
@@ -105,6 +117,11 @@ def _status(workspace, args):
     ert3.console.status(workspace)
 
 
+def _clean(workspace, args):
+    assert args.sub_cmd == "clean"
+    ert3.console.clean(workspace, args.experiment_names, args.all)
+
+
 def main():
     try:
         _main()
@@ -138,6 +155,8 @@ def _main():
         _record(workspace, args)
     elif args.sub_cmd == "status":
         _status(workspace, args)
+    elif args.sub_cmd == "clean":
+        _clean(workspace, args)
     else:
         raise NotImplementedError(f"No implementation to handle command {args.sub_cmd}")
 

--- a/ert3/engine/__init__.py
+++ b/ert3/engine/__init__.py
@@ -2,3 +2,4 @@ from ert3.engine._run import run
 from ert3.engine._export import export
 from ert3.engine._record import load_record
 from ert3.engine._record import sample_record
+from ert3.engine._clean import clean

--- a/ert3/engine/_clean.py
+++ b/ert3/engine/_clean.py
@@ -1,0 +1,18 @@
+import ert3
+
+
+def clean(workspace, experiment_names, clean_all):
+    assert not (experiment_names and clean_all)
+
+    stored_experiments = ert3.storage.get_experiment_names(workspace=workspace)
+
+    if clean_all:
+        experiment_names = stored_experiments
+    else:
+        experiment_names = [
+            name for name in experiment_names if name in stored_experiments
+        ]
+
+    for name in experiment_names:
+        ert3.storage.delete_experiment(workspace=workspace, experiment_name=name)
+        ert3.evaluator.cleanup(workspace, name)

--- a/ert3/evaluator/__init__.py
+++ b/ert3/evaluator/__init__.py
@@ -1,1 +1,1 @@
-from ert3.evaluator._evaluator import evaluate
+from ert3.evaluator._evaluator import evaluate, cleanup

--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib
+import shutil
 
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
@@ -180,3 +181,9 @@ def evaluate(
     responses = _prepare_responses(results)
 
     return responses
+
+
+def cleanup(workspace_root, evaluation_name):
+    tmp_dir = _create_evaluator_tmp_dir(workspace_root, evaluation_name)
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)

--- a/ert3/exceptions/__init__.py
+++ b/ert3/exceptions/__init__.py
@@ -1,3 +1,12 @@
 from ert3.exceptions._exceptions import ErtError
 from ert3.exceptions._exceptions import IllegalWorkspaceOperation
 from ert3.exceptions._exceptions import IllegalWorkspaceState
+from ert3.exceptions._exceptions import NonExistantExperiment
+
+# Explicitely export again, othwerwise mypy is unhappy.
+__all__ = [
+    "ErtError",
+    "IllegalWorkspaceOperation",
+    "IllegalWorkspaceState",
+    "NonExistantExperiment",
+]

--- a/ert3/exceptions/_exceptions.py
+++ b/ert3/exceptions/_exceptions.py
@@ -5,10 +5,15 @@ class ErtError(Exception):
 
 
 class IllegalWorkspaceOperation(ErtError):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = "{}".format(message)
 
 
 class IllegalWorkspaceState(ErtError):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
+        self.message = "{}".format(message)
+
+
+class NonExistantExperiment(IllegalWorkspaceOperation):
+    def __init__(self, message: str) -> None:
         self.message = "{}".format(message)

--- a/ert3/storage/__init__.py
+++ b/ert3/storage/__init__.py
@@ -5,3 +5,4 @@ from ert3.storage._storage import add_ensemble_record
 from ert3.storage._storage import get_ensemble_record
 from ert3.storage._storage import get_ensemble_record_names
 from ert3.storage._storage import get_experiment_parameters
+from ert3.storage._storage import delete_experiment

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -176,3 +176,20 @@ def get_experiment_parameters(
         )
 
     return list(str(pname) for pname in storage[experiment_name][_PARAMETERS])
+
+
+def delete_experiment(*, workspace: Union[str, Path], experiment_name: str) -> None:
+    storage_location = _generate_storage_location(workspace)
+    _assert_storage_initialized(storage_location)
+
+    with open(storage_location) as f:
+        storage = yaml.safe_load(f)
+
+    if experiment_name in storage:
+        del storage[experiment_name]
+        with open(storage_location, "w") as f:
+            yaml.dump(storage, f)
+    else:
+        raise ert3.exceptions.NonExistantExperiment(
+            f"Experiment does not exist: {experiment_name}"
+        )

--- a/examples/polynomial/run_demo
+++ b/examples/polynomial/run_demo
@@ -4,10 +4,22 @@ set -e
 ert3 init
 
 ert3 run evaluation
-ert3 export evaluation
+ert3 status
 
+ert3 clean evaluation
+ert3 status
+
+ert3 run evaluation
+ert3 run uniform_evaluation
+ert3 status
+
+ert3 clean --all
+ert3 status
+ert3 run evaluation
+ert3 export evaluation
 ert3 run uniform_evaluation
 ert3 export uniform_evaluation
+ert3 status
 
 ert3 record load designed_coefficients experiments/doe/coefficients_record.json
 ert3 run doe

--- a/tests/ert3/storage/test_storage.py
+++ b/tests/ert3/storage/test_storage.py
@@ -1,4 +1,5 @@
 import collections
+from ert3 import workspace
 
 import ert3
 
@@ -153,3 +154,24 @@ def test_get_record_names(tmpdir):
                 workspace=tmpdir, experiment_name=experiment
             )
             assert sorted(experiment_records[str(experiment)]) == sorted(recnames)
+
+
+def test_delete_experiment(tmpdir):
+    ert3.storage.init(workspace=tmpdir)
+    ert3.storage.init_experiment(
+        workspace=tmpdir, experiment_name="test", parameters=[]
+    )
+
+    assert "test" in ert3.storage.get_experiment_names(workspace=tmpdir)
+
+    with pytest.raises(
+        ert3.exceptions.NonExistantExperiment,
+        match="Experiment does not exist: does_not_exist",
+    ):
+        ert3.storage.delete_experiment(
+            workspace=tmpdir, experiment_name="does_not_exist"
+        )
+
+    ert3.storage.delete_experiment(workspace=tmpdir, experiment_name="test")
+
+    assert "test" not in ert3.storage.get_experiment_names(workspace=tmpdir)


### PR DESCRIPTION
**Issue**
Resolves #1456


**Approach**
Add a `clean` sub-command that takes the names of the experiments to remove. It has a `--all` option that removes all experiments.

Todo: currently there seems to be no way to check if an experiment failed, if that is possible, something like a `--failed` flag can be implemented.