### PR TITLE
Have ert3.engine stop closing passed streams

### DIFF
--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -88,6 +88,7 @@ def _record(workspace, args):
         )
     elif args.sub_record_cmd == "load":
         ert3.engine.load_record(workspace, args.record_name, args.record_file)
+        args.record_file.close()
     else:
         raise NotImplementedError(
             f"No implementation to handle record command {args.sub_record_cmd}"

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -7,10 +7,8 @@ from typing import Optional, TextIO
 import yaml
 
 
-def load_record(workspace: Path, record_name: str, record_file: TextIO) -> None:
-    raw_ensrecord = json.load(record_file)
-
-    record_file.close()
+def load_record(workspace: Path, record_name: str, record_stream: TextIO) -> None:
+    raw_ensrecord = json.load(record_stream)
 
     ensrecord = ert3.data.EnsembleRecord(
         records=[ert3.data.Record(data=raw_record) for raw_record in raw_ensrecord]

--- a/tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert3/engine/integration/test_engine.py
@@ -365,8 +365,8 @@ def test_record_load_and_run(
         / "coefficients_record.json"
     )
     shutil.copy(coeffs_file, doe_dir)
-    record_file = (doe_dir / "coefficients_record.json").open("r")
-    ert3.engine.load_record(workspace, "designed_coefficients", record_file)
+    with open(doe_dir / "coefficients_record.json") as rs:
+        ert3.engine.load_record(workspace, "designed_coefficients", rs)
 
     designed_coeff = ert3.storage.get_ensemble_record(
         workspace=workspace, record_name="designed_coefficients"
@@ -406,11 +406,13 @@ def test_record_load_twice(workspace, ensemble, stages_config):
         / "coefficients_record.json"
     )
     shutil.copy(coeffs_file, doe_dir)
-    record_file = (doe_dir / "coefficients_record.json").open("r")
-    ert3.engine.load_record(workspace, "designed_coefficients", record_file)
-    record_file = (doe_dir / "coefficients_record.json").open("r")
-    with pytest.raises(KeyError):
-        ert3.engine.load_record(workspace, "designed_coefficients", record_file)
+
+    with open(doe_dir / "coefficients_record.json") as rs:
+        ert3.engine.load_record(workspace, "designed_coefficients", rs)
+
+    with open(doe_dir / "coefficients_record.json") as rs:
+        with pytest.raises(KeyError):
+            ert3.engine.load_record(workspace, "designed_coefficients", rs)
 
 
 def test_sensitivity_run_and_export(


### PR DESCRIPTION
A stream is passed to ert3.engine such that records can be loaded and
persisted in storage. The stream is opened outside of the engine, but
currently closed within. This is a bad design pattern and a remenant
from when the engine code lived as part of the console submodule!
Instead the one opening the stream should also be responsible for
closing it.

This has been annoying me a few times now and here comes the PR 🤷 