### PR TITLE
Add better error reporting on validation errors

### DIFF
--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,7 +1,8 @@
 import sys
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
+import ert3
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -34,4 +35,7 @@ class EnsembleConfig(_EnsembleConfig):
 
 
 def load_ensemble_config(config_dict):
-    return EnsembleConfig(**config_dict)
+    try:
+        return EnsembleConfig(**config_dict)
+    except ValidationError as err:
+        raise ert3.exceptions.ConfigValidationError(str(err), source="ensemble")

--- a/ert3/config/_experiment_config.py
+++ b/ert3/config/_experiment_config.py
@@ -1,6 +1,8 @@
 import sys
 from typing import Optional
-from pydantic import root_validator, BaseModel
+from pydantic import root_validator, BaseModel, ValidationError
+
+import ert3
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -38,4 +40,7 @@ class ExperimentConfig(_ExperimentConfig):
 
 
 def load_experiment_config(config_dict):
-    return ExperimentConfig(**config_dict)
+    try:
+        return ExperimentConfig(**config_dict)
+    except ValidationError as err:
+        raise ert3.exceptions.ConfigValidationError(str(err), source="experiment")

--- a/ert3/config/_stages_config.py
+++ b/ert3/config/_stages_config.py
@@ -2,7 +2,9 @@ import importlib
 import os
 import sys
 from typing import List, Callable, Optional
-from pydantic import root_validator, validator, FilePath, BaseModel
+from pydantic import root_validator, validator, FilePath, BaseModel, ValidationError
+
+import ert3
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -103,4 +105,7 @@ class StagesConfig(BaseModel):
 
 
 def load_stages_config(config_dict):
-    return StagesConfig.parse_obj(config_dict)
+    try:
+        return StagesConfig.parse_obj(config_dict)
+    except ValidationError as err:
+        raise ert3.exceptions.ConfigValidationError(str(err), source="stages")

--- a/ert3/console/__init__.py
+++ b/ert3/console/__init__.py
@@ -1,3 +1,4 @@
 from ert3.console._console import main
 from ert3.console._status import status
 from ert3.console._clean import clean
+from ert3.console._errors import report_validation_errors

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -126,6 +126,8 @@ def _clean(workspace, args):
 def main():
     try:
         _main()
+    except ert3.exceptions.ConfigValidationError as e:
+        ert3.console.report_validation_errors(e)
     except ert3.exceptions.ErtError as e:
         sys.exit(e)
 

--- a/ert3/console/_errors.py
+++ b/ert3/console/_errors.py
@@ -1,0 +1,7 @@
+from ert3.exceptions import ConfigValidationError
+
+
+def report_validation_errors(error: ConfigValidationError) -> None:
+    if error.source:
+        print(f"Error while loading {error.source} configuration data:")
+    print(error.message)

--- a/ert3/exceptions/__init__.py
+++ b/ert3/exceptions/__init__.py
@@ -2,6 +2,7 @@ from ert3.exceptions._exceptions import ErtError
 from ert3.exceptions._exceptions import IllegalWorkspaceOperation
 from ert3.exceptions._exceptions import IllegalWorkspaceState
 from ert3.exceptions._exceptions import NonExistantExperiment
+from ert3.exceptions._exceptions import ConfigValidationError
 
 # Explicitely export again, othwerwise mypy is unhappy.
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "IllegalWorkspaceOperation",
     "IllegalWorkspaceState",
     "NonExistantExperiment",
+    "ConfigValidationError",
 ]

--- a/ert3/exceptions/_exceptions.py
+++ b/ert3/exceptions/_exceptions.py
@@ -17,3 +17,9 @@ class IllegalWorkspaceState(ErtError):
 class NonExistantExperiment(IllegalWorkspaceOperation):
     def __init__(self, message: str) -> None:
         self.message = "{}".format(message)
+
+
+class ConfigValidationError(ErtError):
+    def __init__(self, message: str, source: str = None) -> None:
+        self.message = "{}".format(message)
+        self.source = source

--- a/tests/ert3/config/test_experiment_config.py
+++ b/tests/ert3/config/test_experiment_config.py
@@ -1,4 +1,3 @@
-import pydantic
 import pytest
 
 import ert3
@@ -21,7 +20,7 @@ def test_valid_sensitivity():
 def test_unknown_experiment_type():
     raw_config = {"type": "unknown_experiment_type"}
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"unexpected value; permitted: 'evaluation', 'sensitivity' \(",
     ):
         ert3.config.load_experiment_config(raw_config)
@@ -30,7 +29,7 @@ def test_unknown_experiment_type():
 def test_evaluation_and_algorithm():
     raw_config = {"type": "evaluation", "algorithm": "one-at-a-time"}
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match="Did not expect algorithm for evaluation experiment",
     ):
         ert3.config.load_experiment_config(raw_config)
@@ -39,7 +38,7 @@ def test_evaluation_and_algorithm():
 def test_sensitivity_and_no_algorithm():
     raw_config = {"type": "sensitivity"}
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match="Expected an algorithm for sensitivity experiments",
     ):
         ert3.config.load_experiment_config(raw_config)
@@ -48,7 +47,7 @@ def test_sensitivity_and_no_algorithm():
 def test_unkown_sensitivity_algorithm():
     raw_config = {"type": "sensitivity", "algorithm": "unknown_algorithm"}
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"unexpected value; permitted: 'one-at-a-time' \(",
     ):
         ert3.config.load_experiment_config(raw_config)

--- a/tests/ert3/config/test_stages_config.py
+++ b/tests/ert3/config/test_stages_config.py
@@ -60,7 +60,7 @@ def test_entry_point(base_unix_stage_config):
     ),
 )
 def test_entry_point_not_valid(config, expected_error):
-    with pytest.raises(pydantic.error_wrappers.ValidationError, match=expected_error):
+    with pytest.raises(ert3.exceptions.ConfigValidationError, match=expected_error):
         ert3.config.load_stages_config(config)
 
 
@@ -99,7 +99,7 @@ def test_step_non_existing_transportable_cmd(base_unix_stage_config):
     )
 
     err_msg = '"/not/a/file" does not exist'
-    with pytest.raises(pydantic.error_wrappers.ValidationError, match=err_msg):
+    with pytest.raises(ert3.exceptions.ConfigValidationError, match=err_msg):
         ert3.config.load_stages_config(config)
 
 
@@ -112,7 +112,7 @@ def test_step_non_executable_transportable_cmd(base_unix_stage_config):
     )
 
     err_msg = f"{str(non_executable)} is not executable"
-    with pytest.raises(pydantic.error_wrappers.ValidationError, match=err_msg):
+    with pytest.raises(ert3.exceptions.ConfigValidationError, match=err_msg):
         ert3.config.load_stages_config(config)
 
 
@@ -121,7 +121,7 @@ def test_step_unknown_script(base_unix_stage_config):
     config[0]["script"].append("unknown_command")
 
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"unknown_command is not a known command",
     ):
         ert3.config.load_stages_config(config)
@@ -131,7 +131,7 @@ def test_step_function_definition_error(base_function_stage_config):
     config = base_function_stage_config
     config[0]["function"] = "builtinssum"
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"Function should be defined as module:function",
     ):
         ert3.config.load_stages_config(config)
@@ -149,7 +149,7 @@ def test_step_unix_and_function_error(base_unix_stage_config):
     config[0].update({"function": "builtins:sum"})
 
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"Function defined for unix step",
     ):
         ert3.config.load_stages_config(config)
@@ -169,7 +169,7 @@ def test_step_function_and_script_error(base_function_stage_config):
     config = base_function_stage_config
     config[0].update({"script": ["poly --help"]})
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"Scripts defined for a function stage",
     ):
         ert3.config.load_stages_config(config)
@@ -181,7 +181,7 @@ def test_step_function_and_command_error(base_function_stage_config):
         {"transportable_commands": [{"name": "poly", "location": "poly.py"}]}
     )
     with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
+        ert3.exceptions.ConfigValidationError,
         match=r"Commands defined for a function stage",
     ):
         ert3.config.load_stages_config(config)


### PR DESCRIPTION
**Issue**
Resolves #1341 


**Approach**
- Extend the exceptions with a validation error that stores the source of the error (i.e. which config) and pydantic validation error.
- Print a message when a validation error occurs that includes the already nicely formatted pydantic messages.
