### PR TITLE
Drop SPE1 example templating hack

### DIFF
--- a/examples/spe1/stages.yml
+++ b/examples/spe1/stages.yml
@@ -40,9 +40,6 @@
     # TODO: The following cp should not be present, instead files should be
     # transfered as blob records.
     - bash cp ${SPE1_WORKSPACE_ROOT}/resources/SPE1CASE2.DATA.jinja2 SPE1CASE2.DATA.jinja2
-    # TODO: This is a hack because render currently expects there to be a
-    # "parameters.json" from ert2.
-    - bash echo "{}" > parameters.json
     - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json wells.json -o SPE1CASE2.DATA
     # TODO: When executables can be ran directly, the `bash` prefix should be
     # removed.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "console-progressbar==1.1.2",
         "decorator",
         "deprecation",
-        "equinor-libres >= 9.0.0rc1",
+        "equinor-libres >= 9.1.0rc0",
         "fastapi",
         "jinja2",
         "matplotlib",


### PR DESCRIPTION
With https://github.com/equinor/libres/pull/1132 being merged we can now drop the templating hack in the SPE1 example where an empty `parameters.json` file is created using `echo`.