### PR TITLE
Fix function ensemble run on PBS cluster by cloudpickling function

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -5,3 +5,6 @@ ignore_errors = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True
+
+[mypy-cloudpickle.*]
+ignore_missing_imports=True

--- a/ert3/config/_stages_config.py
+++ b/ert3/config/_stages_config.py
@@ -16,7 +16,11 @@ def _import_from(path):
     if ":" not in path:
         raise ValueError("Function should be defined as module:function")
     module_str, func = path.split(":")
-    module = importlib.import_module(module_str)
+    spec = importlib.util.find_spec(module_str)
+    if spec is None:
+        raise ModuleNotFoundError(f"No module named '{module_str}'")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     try:
         func = getattr(module, func)
     except AttributeError:

--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -2,7 +2,7 @@ import json
 import os
 import pathlib
 import shutil
-
+import cloudpickle
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert_shared.ensemble_evaluator.prefect_ensemble.prefect_ensemble import (
@@ -70,7 +70,7 @@ def _build_ee_config(evaluation_tmp_dir, ensemble, stages_config, input_records)
         jobs.append(
             {
                 "name": stage.function.__name__,
-                "executable": stage.function,
+                "executable": cloudpickle.dumps(stage.function),
                 "output": output_locations[0],
             }
         )

--- a/ert_shared/ensemble_evaluator/prefect_ensemble/function_step.py
+++ b/ert_shared/ensemble_evaluator/prefect_ensemble/function_step.py
@@ -4,6 +4,7 @@ from ert_shared.ensemble_evaluator.entity import identifiers as ids
 from ert_shared.ensemble_evaluator.prefect_ensemble.storage_driver import (
     storage_driver_factory,
 )
+import pickle
 
 
 class FunctionStep(Task):
@@ -50,7 +51,8 @@ class FunctionStep(Task):
 
     def run_job(self, client, job):
         try:
-            result = job["executable"](**self._step["step_input"])
+            function = pickle.loads(job["executable"])
+            result = function(**self._step["step_input"])
             # Store the results
             return self._storage.store_data(result, job["output"], self.get_iens())
         except Exception as e:

--- a/tests/ensemble_evaluator/test_prefect_ensemble.py
+++ b/tests/ensemble_evaluator/test_prefect_ensemble.py
@@ -1,3 +1,4 @@
+import cloudpickle
 from pathlib import Path
 import sys
 import os
@@ -295,7 +296,7 @@ def test_function_step(unused_tcp_port):
             {
                 ids.ID: "0",
                 ids.NAME: "test_script",
-                ids.EXECUTABLE: sum_function,
+                ids.EXECUTABLE: cloudpickle.dumps(sum_function),
                 "output": "output.out",
             }
         ]


### PR DESCRIPTION
**Issue**
Partial fix for #1505 


**Approach**
Stop depending on prefect to pickle the task attributes and use cloudpickle to serialize the job function before creating the Task and running the flow. 

Use cloudpickle to serialize the function when the job is created for the `ee_config`