### PR TITLE
Require that libres event log is on disk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "console-progressbar==1.1.2",
         "decorator",
         "deprecation",
-        "equinor-libres >= 9.1.0rc0",
+        "equinor-libres >= 9.1.0rc0, < 10",
         "fastapi",
         "jinja2",
         "matplotlib",


### PR DESCRIPTION
**Issue**
Resolves build failures for ert 2.22


**Approach**
Pins libres to be less than 10 where the breaking change was introduced