### PR TITLE
Run tests requiring ert-storage on komodo-testing

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -25,9 +25,7 @@ start_tests () {
     # The existence of a running xvfb process will produce
     # a lock filgit ree for the default server and kill the run
     # Allow xvfb to find a new server
-    # requires_ert_storage - tests should be turned back when the storage solution is
-    # integrated in Komodo.
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \
     pytest -k "not test_gui_load and not test_formatting" \
-    -m "not requires_window_manager and not requires_ert_storage"
+    -m "not requires_window_manager"
 }


### PR DESCRIPTION
resolves #1508 

Tests requiring ert-storage was skipped when testing against komodo due to ert-storage was not installed in komodo. Ert-storage has been reintroduced, thus we are introducing the tests.