### PR TITLE
Increase wait for ert-storage when testing

### DIFF
--- a/tests/ert3/conftest.py
+++ b/tests/ert3/conftest.py
@@ -267,14 +267,14 @@ def ert_storage(request, tmpdir):
         process.wait()
 
     request.addfinalizer(shut_down)
-    for _ in range(20):
+    for _ in range(30):
         try:
             r = requests.get("http://127.0.0.1:8000/healthcheck")
             if r.status_code == 200:
                 break
         except requests.exceptions.ConnectionError:
             pass
-        time.sleep(0.5)
+        time.sleep(1)
     else:
         raise requests.exceptions.ConnectionError("Ert-storage not starting")
     yield


### PR DESCRIPTION
**Issue**
Tests using ert-storage are failing - seems to be randomly


**Approach**
Increase time to wait for the server to be up when running tests from 20 x 0.5 sek -> 30 x 1.0 sek