### PR TITLE
Force x_axis values to be strings before json serialization

### DIFF
--- a/ert_shared/storage/extraction.py
+++ b/ert_shared/storage/extraction.py
@@ -144,6 +144,7 @@ def create_observations(ert) -> List[Mapping[str, dict]]:
             list(t)
             for t in zip(*sorted(zip(obs["x_axis"], obs["values"], obs["errors"])))
         )
+        x_axis = [str(x) for x in x_axis]
         grouped_obs[key]["x_axis"] = x_axis
         grouped_obs[key]["values"] = values
         grouped_obs[key]["errors"] = error


### PR DESCRIPTION
The x_axis for observations have been implicitly converted to string. In the snake_oil case this throws an exception as Timestamp was not json serialisable. The solution is to explicitly convert x_axis to string, which is the expected format. 