### PR TITLE
Fix x axis to str, when posting update data

### DIFF
--- a/ert_shared/storage/extraction.py
+++ b/ert_shared/storage/extraction.py
@@ -212,6 +212,7 @@ def _create_observation_transformation(ert, db_observations) -> List[dict]:
             list(t)
             for t in zip(*sorted(zip(obs["x_axis"], obs["active"], obs["scale"])))
         )
+        x_axis = [str(x) for x in x_axis]
         transformations[key]["x_axis"] = x_axis
         transformations[key]["active"] = active
         transformations[key]["scale"] = scale


### PR DESCRIPTION
Seems like I missed a spot. 

Same as in https://github.com/equinor/ert/pull/1596

When posting update data, we need to enforce str for x_axis in observation_transformations

Tested running ensemble_smoother on snake_oil example