### PR TITLE
Use the prefect context to pass url,token and certification info

### DIFF
--- a/ert_shared/ensemble_evaluator/entity/ensemble.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble.py
@@ -378,12 +378,8 @@ class _UnixStep(_Step):
     ):
         super().__init__(id_, inputs, outputs, jobs, name, source)
 
-    def get_task(
-        self, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-    ):
-        return UnixTask(
-            self, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-        )
+    def get_task(self, output_transmitters, ee_id, *args, **kwargs):
+        return UnixTask(self, output_transmitters, ee_id, *args, **kwargs)
 
 
 class _FunctionStep(_Step):
@@ -398,12 +394,8 @@ class _FunctionStep(_Step):
     ):
         super().__init__(id_, inputs, outputs, jobs, name, source)
 
-    def get_task(
-        self, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-    ):
-        return FunctionTask(
-            self, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-        )
+    def get_task(self, output_transmitters, ee_id, *args, **kwargs):
+        return FunctionTask(self, output_transmitters, ee_id, *args, **kwargs)
 
 
 class _LegacyStep(_Step):

--- a/ert_shared/ensemble_evaluator/entity/function_step.py
+++ b/ert_shared/ensemble_evaluator/entity/function_step.py
@@ -10,16 +10,11 @@ if TYPE_CHECKING:
 
 
 class FunctionTask(prefect.Task):
-    def __init__(
-        self, step, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-    ) -> None:
+    def __init__(self, step, output_transmitters, ee_id, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._step = step
         self._output_transmitters = output_transmitters
         self._ee_id = ee_id
-        self._ee_url = ee_url
-        self._cert = cert
-        self._token = token
 
     def _attempt_execute(self, *, func, transmitters):
         async def _load(io_, transmitter):
@@ -70,7 +65,9 @@ class FunctionTask(prefect.Task):
         return output
 
     def run(self, inputs: Dict[str, "RecordTransmitter"]):  # type: ignore
-        with Client(self._ee_url, self._token, self._cert) as ee_client:
+        with Client(
+            prefect.context.url, prefect.context.token, prefect.context.cert
+        ) as ee_client:
             ee_client.send_event(
                 ev_type=ids.EVTYPE_FM_STEP_RUNNING,
                 ev_source=self._step.get_source(self._ee_id),

--- a/ert_shared/ensemble_evaluator/entity/unix_step.py
+++ b/ert_shared/ensemble_evaluator/entity/unix_step.py
@@ -17,16 +17,11 @@ _BIN_FOLDER = "bin"
 
 
 class UnixTask(prefect.Task):
-    def __init__(
-        self, step, output_transmitters, ee_id, ee_url, cert, token, *args, **kwargs
-    ) -> None:
+    def __init__(self, step, output_transmitters, ee_id, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._step = step
         self._output_transmitters = output_transmitters
         self._ee_id = ee_id
-        self._ee_url = ee_url
-        self._cert = cert
-        self._token = token
 
     def get_step(self):
         return self._step
@@ -99,7 +94,9 @@ class UnixTask(prefect.Task):
         with tempfile.TemporaryDirectory() as run_path:
             run_path = Path(run_path)
             self._load_and_dump_input(transmitters=inputs, runpath=run_path)
-            with Client(self._ee_url, self._token, self._cert) as ee_client:
+            with Client(
+                prefect.context.url, prefect.context.token, prefect.context.cert
+            ) as ee_client:
                 ee_client.send_event(
                     ev_type=ids.EVTYPE_FM_STEP_RUNNING,
                     ev_source=self._step.get_source(self._ee_id),


### PR DESCRIPTION
**Issue**
Resolves #1588 

**Approach**
Remove the url, token and certification passed to the flow code, and put them in the prefect context. Adapt the tests accordingly.