### PR TITLE
Add 'size' to 'post_ensemble_data' request

### DIFF
--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -21,7 +21,7 @@ class EnsembleExperiment(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(run_context)
 
         # Push ensemble, parameters, observations to new storage
-        ensemble_id = post_ensemble_data()
+        ensemble_id = post_ensemble_data(ensemble_size=self._ensemble_size)
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ERT.ert)
 
         self.setPhaseName(run_msg, indeterminate=False)

--- a/ert_shared/models/ensemble_smoother.py
+++ b/ert_shared/models/ensemble_smoother.py
@@ -39,7 +39,7 @@ class EnsembleSmoother(BaseRunModel):
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ert=ERT.ert)
 
         # Push ensemble, parameters, observations to new storage
-        ensemble_id = post_ensemble_data()
+        ensemble_id = post_ensemble_data(ensemble_size=self._ensemble_size)
 
         self.setPhaseName("Running forecast...", indeterminate=False)
 
@@ -88,7 +88,9 @@ class EnsembleSmoother(BaseRunModel):
 
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ert=ERT.ert)
         # Push ensemble, parameters, observations to new storage
-        ensemble_id = post_ensemble_data(update_id)
+        ensemble_id = post_ensemble_data(
+            ensemble_size=self._ensemble_size, update_id=update_id
+        )
 
         self.setPhaseName("Running forecast...", indeterminate=False)
 

--- a/ert_shared/models/iterated_ensemble_smoother.py
+++ b/ert_shared/models/iterated_ensemble_smoother.py
@@ -37,7 +37,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(run_context)
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ert=ERT.ert)
         # create ensemble
-        ensemble_id = post_ensemble_data(update_id=update_id)
+        ensemble_id = post_ensemble_data(
+            ensemble_size=self._ensemble_size, update_id=update_id
+        )
         self.setPhaseName("Running forecast...", indeterminate=False)
         if FeatureToggling.is_enabled("ensemble-evaluator"):
             ee_config = arguments["ee_config"]

--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -150,7 +150,9 @@ class MultipleDataAssimilation(BaseRunModel):
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ert=ERT.ert)
 
         # Push ensemble, parameters, observations to new storage
-        new_ensemble_id = post_ensemble_data(update_id)
+        new_ensemble_id = post_ensemble_data(
+            update_id=update_id, ensemble_size=self._ensemble_size
+        )
 
         phase_string = "Running forecast for iteration: %d" % iteration
         self.setPhaseName(phase_string, indeterminate=False)

--- a/ert_shared/storage/extraction.py
+++ b/ert_shared/storage/extraction.py
@@ -18,8 +18,11 @@ def create_experiment(ert) -> dict:
     return dict(name=str(datetime.datetime.now()), priors=_create_priors(ert))
 
 
-def create_ensemble(ert, parameter_names: List[str], update_id: str = None) -> dict:
+def create_ensemble(
+    ert, size: int, parameter_names: List[str], update_id: str = None
+) -> dict:
     return dict(
+        size=size,
         parameters=parameter_names,
         update_id=update_id,
         metadata={"name": ert.get_current_case_name()},
@@ -340,7 +343,7 @@ def post_ensemble_results(ensemble_id: str) -> None:
 
 
 @feature_enabled("new-storage")
-def post_ensemble_data(update_id: str = None) -> str:
+def post_ensemble_data(ensemble_size: int, update_id: str = None) -> str:
     server = ServerMonitor.get_instance()
     ert = ERT.enkf_facade
     if update_id is None:
@@ -364,6 +367,7 @@ def post_ensemble_data(update_id: str = None) -> str:
         f"{server.fetch_url()}/experiments/{experiment_id}/ensembles",
         json=create_ensemble(
             ert,
+            size=ensemble_size,
             parameter_names=[param["name"] for param in parameters],
             update_id=update_id,
         ),

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -6,8 +6,6 @@ import sys
 import copy
 from unittest.mock import patch
 
-from pydantic import ValidationError
-
 import yaml
 
 
@@ -217,7 +215,10 @@ def test_cli_status_some_runs(workspace, capsys):
     done_indices = [1, 3]
     for idx in done_indices:
         ert3.storage.init_experiment(
-            workspace=workspace, experiment_name=experiments[idx], parameters=[]
+            workspace=workspace,
+            experiment_name=experiments[idx],
+            parameters=[],
+            ensemble_size=42,
         )
 
     args = ["ert3", "status"]
@@ -236,7 +237,10 @@ def test_cli_status_all_run(workspace, capsys):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace, experiment_name=experiment, parameters=[]
+            workspace=workspace,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=42,
         )
 
     args = ["ert3", "status"]
@@ -294,7 +298,10 @@ def test_cli_clean_all(workspace):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace, experiment_name=experiment, parameters=[]
+            workspace=workspace,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=42,
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment
@@ -323,7 +330,10 @@ def test_cli_clean_one(workspace):
     for experiment in experiments:
         experiments_folder.mkdir(experiment)
         ert3.storage.init_experiment(
-            workspace=workspace, experiment_name=experiment, parameters=[]
+            workspace=workspace,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=42,
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment
@@ -359,7 +369,10 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace, experiment_name=experiment, parameters=[]
+            workspace=workspace,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=42,
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment

--- a/tests/ert3/storage/test_storage.py
+++ b/tests/ert3/storage/test_storage.py
@@ -19,14 +19,32 @@ def test_double_init(tmpdir, ert_storage):
 
 
 @pytest.mark.requires_ert_storage
+def test_ensemble_size_zero(tmpdir, ert_storage):
+    ert3.storage.init(workspace=tmpdir)
+    with pytest.raises(ValueError, match="Ensemble cannot have a size <= 0"):
+        ert3.storage.init_experiment(
+            workspace=tmpdir,
+            experiment_name="my_experiment",
+            parameters=[],
+            ensemble_size=0,
+        )
+
+
+@pytest.mark.requires_ert_storage
 def test_double_add_experiment(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     ert3.storage.init_experiment(
-        workspace=tmpdir, experiment_name="my_experiment", parameters=[]
+        workspace=tmpdir,
+        experiment_name="my_experiment",
+        parameters=[],
+        ensemble_size=42,
     )
     with pytest.raises(KeyError, match="Cannot initialize existing experiment"):
         ert3.storage.init_experiment(
-            workspace=tmpdir, experiment_name="my_experiment", parameters=[]
+            workspace=tmpdir,
+            experiment_name="my_experiment",
+            parameters=[],
+            ensemble_size=42,
         )
 
 
@@ -47,6 +65,7 @@ def test_add_experiments(tmpdir, ert_storage):
             workspace=tmpdir,
             experiment_name=experiment_name,
             parameters=experiment_parameters,
+            ensemble_size=42,
         )
         expected_names = sorted(experiment_names[: idx + 1])
         retrieved_names = sorted(ert3.storage.get_experiment_names(workspace=tmpdir))
@@ -100,16 +119,21 @@ def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
 def test_add_and_get_experiment_ensemble_record(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
 
+    ensemble_size = 5
     for eid in range(1, 2):
         experiment = eid * "e"
         ert3.storage.init_experiment(
-            workspace=tmpdir, experiment_name=experiment, parameters=[]
+            workspace=tmpdir,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=ensemble_size,
         )
         for nid in range(1, 3):
             name = nid * "n"
             ensemble_record = ert3.data.EnsembleRecord(
                 records=[
-                    ert3.data.Record(data=[nid * eid * rid]) for rid in range(0, 5)
+                    ert3.data.Record(data=[nid * eid * rid])
+                    for rid in range(ensemble_size)
                 ]
             )
             ert3.storage.add_ensemble_record(
@@ -125,7 +149,8 @@ def test_add_and_get_experiment_ensemble_record(tmpdir, ert_storage):
             name = nid * "n"
             ensemble_record = ert3.data.EnsembleRecord(
                 records=[
-                    ert3.data.Record(data=[nid * eid * rid]) for rid in range(0, 5)
+                    ert3.data.Record(data=[nid * eid * rid])
+                    for rid in range(ensemble_size)
                 ]
             )
             fetched_ensemble_record = ert3.storage.get_ensemble_record(
@@ -137,17 +162,20 @@ def test_add_and_get_experiment_ensemble_record(tmpdir, ert_storage):
 @pytest.mark.requires_ert_storage
 def test_get_record_names(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
-
+    ensemble_size = 5
     experiment_records = collections.defaultdict(list)
     for eid in [1, 2, 3]:
         experiment = "e" + str(eid)
         ert3.storage.init_experiment(
-            workspace=tmpdir, experiment_name=experiment, parameters=[]
+            workspace=tmpdir,
+            experiment_name=experiment,
+            parameters=[],
+            ensemble_size=ensemble_size,
         )
         for nid in range(1, 3):
             name = nid * "n"
             ensemble_record = ert3.data.EnsembleRecord(
-                records=[ert3.data.Record(data=[0]) for rid in range(0, 5)]
+                records=[ert3.data.Record(data=[0]) for rid in range(ensemble_size)]
             )
             ert3.storage.add_ensemble_record(
                 workspace=tmpdir,
@@ -167,7 +195,10 @@ def test_get_record_names(tmpdir, ert_storage):
 def test_delete_experiment(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     ert3.storage.init_experiment(
-        workspace=tmpdir, experiment_name="test", parameters=[]
+        workspace=tmpdir,
+        experiment_name="test",
+        parameters=[],
+        ensemble_size=42,
     )
 
     assert "test" in ert3.storage.get_experiment_names(workspace=tmpdir)

--- a/tests/ert3/workspace/test_workspace.py
+++ b/tests/ert3/workspace/test_workspace.py
@@ -78,7 +78,10 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
     Path(experiments_dir / "test2").mkdir(parents=True)
 
     ert3.storage.init_experiment(
-        workspace=tmpdir, experiment_name="test1", parameters=[]
+        workspace=tmpdir,
+        experiment_name="test1",
+        parameters=[],
+        ensemble_size=42,
     )
 
     assert ert3.workspace.experiment_has_run(tmpdir, "test1")


### PR DESCRIPTION
Adding ensemble_size to the `post_ensemble_data` requests to adhere to the newly applied param in the ert-storage API.
