### PR TITLE
Rename GitHub Action workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ env:
   ERT_SHOW_BACKTRACE: 1
 
 jobs:
-  build:
+  build-and-test:
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -62,7 +62,7 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-and-test]
 
     # If this is a tagged release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/run_ert2_test_data_setups.yml
+++ b/.github/workflows/run_ert2_test_data_setups.yml
@@ -6,7 +6,7 @@ env:
   ERT_SHOW_BACKTRACE: 1
 
 jobs:
-  build:
+  run-ert2-test-data:
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -3,7 +3,7 @@ name: Run polynomial demo
 on: [push, pull_request]
 
 jobs:
-  local:
+  run-ert3-polynomial-local:
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
         ./run_demo
         popd
 
-  postgres:
+  run-ert3-polynomial-postgres:
     timeout-minutes: 15
     services:
       postgres:

--- a/.github/workflows/run_examples_spe1.yml
+++ b/.github/workflows/run_examples_spe1.yml
@@ -3,7 +3,7 @@ name: Run SPE1 demo
 on: [push, pull_request]
 
 jobs:
-  build:
+  run-ert3-spe1:
     timeout-minutes: 15
     services:
       postgres:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,7 +3,7 @@ name: Style
 on: [push, pull_request]
 
 jobs:
-  build:
+  check-style:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -3,7 +3,7 @@ name: Type checking
 on: [push, pull_request]
 
 jobs:
-  build:
+  type-checking:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:


### PR DESCRIPTION
I discovered while checking whether the SPE1 workflow (that is currently failing) is required to pass that the names of the workflows appearing in the GitHub settings are dictated by the job names. The are more or less all called `build` at the time, which is not very descriptive and makes maintenance harder. This PR suggests some descriptive names, but suggestions are welcome 👍🏻 