### PR TITLE
Make ert3 configurations immutable and strict

### DIFF
--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Optional, Dict, Any
+from typing import Tuple, Optional, Dict, Any
 from pydantic import BaseModel, ValidationError
 
 import ert3
@@ -31,7 +31,7 @@ class Input(_EnsembleConfig):
 
 class EnsembleConfig(_EnsembleConfig):
     forward_model: ForwardModel
-    input: List[Input]
+    input: Tuple[Input, ...]
     size: Optional[int] = None
 
 

--- a/ert3/config/_experiment_config.py
+++ b/ert3/config/_experiment_config.py
@@ -11,11 +11,12 @@ else:
 
 
 class _ExperimentConfig(BaseModel):
-    validate_all = True
-    validate_assignment = True
-    extra = "forbid"
-    allow_mutation = False
-    arbitrary_types_allowed = True
+    class Config:
+        validate_all = True
+        validate_assignment = True
+        extra = "forbid"
+        allow_mutation = False
+        arbitrary_types_allowed = True
 
 
 class ExperimentConfig(_ExperimentConfig):

--- a/ert3/config/_stages_config.py
+++ b/ert3/config/_stages_config.py
@@ -1,7 +1,7 @@
 from importlib.abc import Loader
 import importlib.util
 import mimetypes
-from typing import Callable, List, cast, Union, Dict, Any
+from typing import Callable, Tuple, cast, Union, Dict, Any
 
 from pydantic import BaseModel, FilePath, ValidationError, validator
 import ert3
@@ -69,8 +69,8 @@ class TransportableCommand(_MimeBase):
 
 class _Step(_StagesConfig):
     name: str
-    input: List[Record]
-    output: List[Record]
+    input: Tuple[Record, ...]
+    output: Tuple[Record, ...]
 
 
 class Function(_Step):
@@ -82,12 +82,12 @@ class Function(_Step):
 
 
 class Unix(_Step):
-    script: List[str]
-    transportable_commands: List[TransportableCommand]
+    script: Tuple[str, ...]
+    transportable_commands: Tuple[TransportableCommand, ...]
 
 
 class StagesConfig(BaseModel):
-    __root__: List[Union[Function, Unix]]
+    __root__: Tuple[Union[Function, Unix], ...]
 
     def step_from_key(self, key: str) -> Union[Function, Unix, None]:
         return next((step for step in self if step.name == key), None)

--- a/tests/ert3/config/test_ensemble_config.py
+++ b/tests/ert3/config/test_ensemble_config.py
@@ -1,28 +1,32 @@
 import pytest
 import pydantic
+import ert3
 from ert3.config import _ensemble_config
 from copy import deepcopy
 
-_config_dict = {
-    "size": 1000,
-    "input": [{"source": "stochastic.coefficients", "record": "coefficients"}],
-    "forward_model": {
-        "driver": "local",
-        "stage": "evaluate_polynomial",
-    },
-}
+
+@pytest.fixture()
+def base_ensemble_config():
+    yield {
+        "size": 1000,
+        "input": [{"source": "stochastic.coefficients", "record": "coefficients"}],
+        "forward_model": {
+            "driver": "local",
+            "stage": "evaluate_polynomial",
+        },
+    }
 
 
-def test_entry_point():
-    config = _ensemble_config.load_ensemble_config(_config_dict)
+def test_entry_point(base_ensemble_config):
+    config = _ensemble_config.load_ensemble_config(base_ensemble_config)
     assert config.size == 1000
     assert config.forward_model.driver == "local"
     assert config.forward_model.stage == "evaluate_polynomial"
 
 
 @pytest.mark.parametrize("driver", ["local", "pbs"])
-def test_config(driver):
-    config_dict = deepcopy(_config_dict)
+def test_config(driver, base_ensemble_config):
+    config_dict = deepcopy(base_ensemble_config)
     config_dict["forward_model"]["driver"] = driver
     config = _ensemble_config.EnsembleConfig(**config_dict)
     assert config.size == 1000
@@ -74,3 +78,48 @@ def test_input(input_config, expected_source, expected_record):
 def test_invalid_input(input_config, expected_error):
     with pytest.raises(pydantic.error_wrappers.ValidationError, match=expected_error):
         _ensemble_config.Input(**input_config)
+
+
+def test_immutable_base(base_ensemble_config):
+    config = ert3.config.load_ensemble_config(base_ensemble_config)
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        config.size = 42
+
+
+def test_unknown_field_in_base(base_ensemble_config):
+    base_ensemble_config["unknown"] = "field"
+    with pytest.raises(
+        ert3.exceptions.ConfigValidationError, match="extra fields not permitted"
+    ):
+        ert3.config.load_ensemble_config(base_ensemble_config)
+
+
+def test_immutable_input(base_ensemble_config):
+    config = ert3.config.load_ensemble_config(base_ensemble_config)
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        config.input[0].source = "different.source"
+
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        config.input[0] = None
+
+
+def test_unknown_field_in_input(base_ensemble_config):
+    base_ensemble_config["input"][0]["unknown"] = "field"
+    with pytest.raises(
+        ert3.exceptions.ConfigValidationError, match="extra fields not permitted"
+    ):
+        ert3.config.load_ensemble_config(base_ensemble_config)
+
+
+def test_immutable_forward_model(base_ensemble_config):
+    config = ert3.config.load_ensemble_config(base_ensemble_config)
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        config.forward_model.stage = "my_stage"
+
+
+def test_unknown_field_in_forward_model(base_ensemble_config):
+    base_ensemble_config["forward_model"]["unknown"] = "field"
+    with pytest.raises(
+        ert3.exceptions.ConfigValidationError, match="extra fields not permitted"
+    ):
+        ert3.config.load_ensemble_config(base_ensemble_config)

--- a/tests/ert3/config/test_experiment_config.py
+++ b/tests/ert3/config/test_experiment_config.py
@@ -51,3 +51,20 @@ def test_unkown_sensitivity_algorithm():
         match=r"unexpected value; permitted: 'one-at-a-time' \(",
     ):
         ert3.config.load_experiment_config(raw_config)
+
+
+def test_unknown_field():
+    raw_config = {"type": "evaluation", "unknown": "field"}
+    with pytest.raises(
+        ert3.exceptions.ConfigValidationError,
+        match="extra fields not permitted",
+    ):
+        ert3.config.load_experiment_config(raw_config)
+
+
+def test_immutable_field():
+    raw_config = {"type": "evaluation"}
+    experiment_config = ert3.config.load_experiment_config(raw_config)
+
+    with pytest.raises(TypeError, match="immutable and does not support"):
+        experiment_config.type = "toggle"

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -437,7 +437,7 @@ def test_cli_validation_experiment_function(capsys):
     [
         (
             {"name": "name", "type": "unix", "input": [], "output": []},
-            "not a valid list",
+            "not a valid tuple",
         ),
         (
             [{"name": "name", "type": "unix", "input": [], "output": []}],


### PR DESCRIPTION
**Issue**
The Pydantic arguments are still passed wrongly for the experiment configuration. This PR aims at resolving that and adding tests ensuring that we achieve the intended behaviour from our configuration objects with respect to immutability.

As a consequence this PR replaces all usage off `List[T]` with `Tuple[T, ...]` to ensure immutability.

Last, it replaces the private member usage in the ensemble config tests with public functions instead. It makes the test setup a bit more extensive, but at the same time the consequences of errors have already changes since the tests were implemented. My opinion is that it is more important to mitigate the later, but I'm willing to discuss this!