### PR TITLE
Fix 1658

### DIFF
--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -81,10 +81,12 @@ class BaseRunModel(object):
             self.completed_realizations_mask = run_context.get_mask()
         except ErtRunError as e:
             self.completed_realizations_mask = BoolVector(default_value=False)
+            self.updateDetailedProgress()
             self._failed = True
             self._fail_message = str(e)
             self._simulationEnded()
         except UserWarning as e:
+            self.updateDetailedProgress()
             self._fail_message = str(e)
             self._simulationEnded()
 

--- a/ert_shared/status/tracker/legacy.py
+++ b/ert_shared/status/tracker/legacy.py
@@ -90,7 +90,7 @@ class LegacyTracker:
             # If a new iteration is seen, an attempt at creating a full
             # snapshot event is made. If it can't be created, it is retried
             # until it can.
-            # NOTE: there's not timeout for this operation.
+            # NOTE: there's no timeout for this operation.
             if current_iter != iter_:
                 full_snapshot_event = self._full_snapshot_event(iter_)
                 if full_snapshot_event is None:
@@ -196,8 +196,9 @@ class LegacyTracker:
     def _retroactive_update_event(self):
         """Return generator producing update events for all queues that has run
         thus far."""
+        detailed_progress = self._model.getDetailedProgress()
         for iter_ in self._iter_queue:
-            partial = self._create_partial_snapshot(None, ({}, -1), iter_)
+            partial = self._create_partial_snapshot(None, detailed_progress, iter_)
 
             if partial is not None:
                 self._set_iter_snapshot(iter_, partial._snapshot)


### PR DESCRIPTION
**Issue**
Resolves #1658 


**Approach**
- Update detailed progress after failure
- It will also ensure that the result of getDetailedProgress is used in retroactive updates in the legacy tracker.
- Haven't found a feasible way to test this, because you need some considerable amount of load to trigger this, and that it works is by virtue of arbitrary synchronization between two different threads and three different processes.