### PR TITLE
Use snapshot instead of run_context (#1658)

### DIFF
--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -80,8 +80,8 @@ class BaseRunModel(object):
             self.updateDetailedProgress()
             self.completed_realizations_mask = run_context.get_mask()
         except ErtRunError as e:
-            self.completed_realizations_mask = BoolVector(default_value=False)
             self.updateDetailedProgress()
+            self.completed_realizations_mask = BoolVector(default_value=False)
             self._failed = True
             self._fail_message = str(e)
             self._simulationEnded()
@@ -214,12 +214,10 @@ class BaseRunModel(object):
         return not (any((job.status != "Success" for job in progress)))
 
     def update_progress_for_index(self, iteration, idx, run_arg):
-        if not self._run_context.is_active(idx):
-            return
         try:
             # will throw if not yet submitted (is in a limbo state)
             queue_index = run_arg.getQueueIndex()
-        except ValueError:
+        except (ValueError, AttributeError):
             return
 
         status = None

--- a/ert_shared/status/tracker/legacy.py
+++ b/ert_shared/status/tracker/legacy.py
@@ -274,18 +274,17 @@ class LegacyTracker:
                 f"partial: iter_to_progress iter ({progress_iter}) differed from run_context ({iter_})"
             )
 
-        for iens, _ in _enumerate_run_context(run_context):
-            if not _is_iens_active(iens, run_context):
+        for real_id, real in snapshot.get_reals().items():
+            if not real.active:
                 continue
-
-            progress = iter_to_progress[iter_].get(iens, None)
+            progress = iter_to_progress[iter_].get(int(real_id), None)
             if not progress:
                 continue
 
             jobs = progress[0]
             for idx, fm in enumerate(jobs):
                 partial.update_job(
-                    str(iens),  # real_id
+                    real_id,
                     "0",
                     str(idx),
                     Job(


### PR DESCRIPTION
In the creation of snapshot update events, the run_context might be
deleted at any time. Thus, for iterating over detailed_progress, use
the snapshot instead. Fixing #1658.