### PR TITLE
Fix retry connection in evaluator tracker

### DIFF
--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -110,7 +110,7 @@ class EvaluatorTracker:
                 # on information about evaluations/experiments`
                 time.sleep(self._next_ensemble_evaluator_wait_time)
 
-            except ConnectionRefusedError as e:
+            except (ConnectionRefusedError, ClientError) as e:
                 if not self._model.isFinished():
                     drainer_logger.debug(f"connection refused: {e}")
                     failures += 1


### PR DESCRIPTION
**Issue**
With the introduction of `aiohttp` the exception thrown on connection attempts have changed. 
Also related to https://github.com/equinor/ert/issues/1679


**Approach**
Also catch `aiohttp.ClientError`
