### PR TITLE
EE and launching ert-storage use same code for finding open port

### DIFF
--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -2,7 +2,7 @@ import yaml
 import ipaddress
 import logging
 import socket
-from ert_shared.storage.main import bind_socket
+from ert_shared.storage.main import bind_open_socket, bind_socket
 import tempfile
 
 import os
@@ -134,13 +134,16 @@ class EvaluatorServerConfig:
         self, port: int = None, use_token: bool = True, generate_cert: bool = True
     ) -> None:
         self.host = _get_ip_address()
-        self.port = find_open_port() if port is None else port
+        if port is None:
+            self._socket = bind_open_socket(self.host)
+            self.port = self._socket.getsockname()[1]
+        else:
+            self._socket = bind_socket(self.host, port)
+            self.port = port
         self.protocol = "wss" if generate_cert else "ws"
         self.url = f"{self.protocol}://{self.host}:{self.port}"
         self.client_uri = f"{self.url}/client"
         self.dispatch_uri = f"{self.url}/dispatch"
-
-        self._socket = bind_socket(self.host, self.port)
 
         if generate_cert:
             cert, key, pw = _generate_certificate(ip_address=self.host)
@@ -158,7 +161,8 @@ class EvaluatorServerConfig:
         # private. Here we check if the underlying file-descriptor is valid,
         # which should work on both Unix and Windows.
         if self._socket.fileno() < 0:
-            self._socket = bind_socket(self.host, self.port)
+            self._socket = bind_open_socket(self.host)
+            self.port = self._socket.getsockname()[1]
         return self._socket
 
     def get_server_ssl_context(

--- a/ert_shared/storage/main.py
+++ b/ert_shared/storage/main.py
@@ -113,7 +113,7 @@ def run_server(args=None, debug=False):
         "urls": [
             f"http://{host}:{sock.getsockname()[1]}"
             for host in (
-                sock.getsockname()[0],
+                "127.0.0.1",
                 socket.gethostname(),
                 socket.getfqdn(),
             )

--- a/ert_shared/storage/main.py
+++ b/ert_shared/storage/main.py
@@ -49,7 +49,7 @@ def bind_socket(host: str, port: int) -> socket.socket:
 
     sock = socket.socket(family=family)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((host, port))
+    sock.bind(("", port))  # binding to 0.0.0.0
     sock.set_inheritable(True)
     return sock
 


### PR DESCRIPTION
**Issue**
Resolves #1676 

`socket.bind` takes optionally empty string for binding on `0.0.0.0`