### PR TITLE
Set phase name before/after extraction

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -37,7 +37,7 @@ from ert_gui.simulation.view.realization import RealizationWidget
 from ert_gui.model.progress_proxy import ProgressProxyModel
 
 
-_TOTAL_PROGRESS_TEMPLATE = "Total progress {}%"
+_TOTAL_PROGRESS_TEMPLATE = "Total progress {total_progress}% — {phase_name}"
 
 
 class RunDialog(QDialog):
@@ -69,7 +69,12 @@ class RunDialog(QDialog):
 
         progress_proxy_model = ProgressProxyModel(self._snapshot_model, parent=self)
 
-        self._total_progress_label = QLabel(_TOTAL_PROGRESS_TEMPLATE.format(0), self)
+        self._total_progress_label = QLabel(
+            _TOTAL_PROGRESS_TEMPLATE.format(
+                total_progress=0, phase_name=run_model.getPhaseName()
+            ),
+            self,
+        )
 
         self._total_progress_bar = QProgressBar(self)
         self._total_progress_bar.setRange(0, 100)
@@ -295,7 +300,11 @@ class RunDialog(QDialog):
         self.restart_button.setVisible(self.has_failed_realizations())
         self.restart_button.setEnabled(self._run_model.support_restart)
         self._total_progress_bar.setValue(100)
-        self._total_progress_label.setText(_TOTAL_PROGRESS_TEMPLATE.format(100))
+        self._total_progress_label.setText(
+            _TOTAL_PROGRESS_TEMPLATE.format(
+                total_progress=100, phase_name=self._run_model.getPhaseName()
+            )
+        )
 
         if failed:
             QMessageBox.critical(
@@ -323,7 +332,9 @@ class RunDialog(QDialog):
             progress = int(event.progress * 100)
             self._total_progress_bar.setValue(progress)
             self._total_progress_label.setText(
-                _TOTAL_PROGRESS_TEMPLATE.format(progress)
+                _TOTAL_PROGRESS_TEMPLATE.format(
+                    total_progress=progress, phase_name=event.phase_name
+                )
             )
 
         elif isinstance(event, SnapshotUpdateEvent):
@@ -335,7 +346,9 @@ class RunDialog(QDialog):
             progress = int(event.progress * 100)
             self._total_progress_bar.setValue(progress)
             self._total_progress_label.setText(
-                _TOTAL_PROGRESS_TEMPLATE.format(progress)
+                _TOTAL_PROGRESS_TEMPLATE.format(
+                    total_progress=progress, phase_name=event.phase_name
+                )
             )
 
     def has_failed_realizations(self):

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -1,5 +1,11 @@
+from typing import Optional
+from ert_shared.storage.extraction import (
+    post_ensemble_data,
+    post_ensemble_results,
+    post_update_data,
+)
 from res.enkf.ert_run_context import ErtRunContext
-from ert_shared.feature_toggling import FeatureToggling
+from ert_shared.feature_toggling import FeatureToggling, feature_enabled
 import logging
 import time
 import uuid
@@ -370,3 +376,25 @@ class BaseRunModel(object):
 
     def get_run_context(self) -> ErtRunContext:
         return self._run_context
+
+    @feature_enabled("new-storage")
+    def _post_ensemble_data(self, update_id: Optional[str] = None) -> str:
+        self.setPhaseName("Uploading data...")
+        ensemble_id = post_ensemble_data(
+            ensemble_size=self._ensemble_size, update_id=update_id
+        )
+        self.setPhaseName("Uploading done")
+        return ensemble_id
+
+    @feature_enabled("new-storage")
+    def _post_ensemble_results(self, ensemble_id: str) -> None:
+        self.setPhaseName("Uploading results...")
+        post_ensemble_results(ensemble_id)
+        self.setPhaseName("Uploading done")
+
+    @feature_enabled("new-storage")
+    def _post_update_data(self, parent_ensemble_id: str, algorithm: str) -> str:
+        self.setPhaseName("Uploading update...")
+        update_id = post_update_data(parent_ensemble_id, algorithm)
+        self.setPhaseName("Uploading done")
+        return update_id

--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -3,7 +3,6 @@ from res.enkf import ErtRunContext, EnkfSimulationRunner
 
 from ert_shared.models import BaseRunModel
 from ert_shared import ERT
-from ert_shared.storage.extraction import post_ensemble_data, post_ensemble_results
 from ert_shared.feature_toggling import FeatureToggling
 
 
@@ -21,7 +20,8 @@ class EnsembleExperiment(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(run_context)
 
         # Push ensemble, parameters, observations to new storage
-        ensemble_id = post_ensemble_data(ensemble_size=self._ensemble_size)
+        ensemble_id = self._post_ensemble_data()
+
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ERT.ert)
 
         self.setPhaseName(run_msg, indeterminate=False)
@@ -44,10 +44,11 @@ class EnsembleExperiment(BaseRunModel):
 
         self.setPhaseName("Post processing...", indeterminate=True)
         EnkfSimulationRunner.runWorkflows(HookRuntime.POST_SIMULATION, ERT.ert)
-        self.setPhase(1, "Simulations completed.")  # done...
 
         # Push simulation results to storage
-        post_ensemble_results(ensemble_id)
+        self._post_ensemble_results(ensemble_id)
+
+        self.setPhase(1, "Simulations completed.")  # done...
 
         return run_context
 

--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -20,11 +20,6 @@ from res.enkf import ErtRunContext, EnkfSimulationRunner
 
 from ert_shared.models import BaseRunModel, ErtRunError
 from ert_shared import ERT
-from ert_shared.storage.extraction import (
-    post_ensemble_data,
-    post_ensemble_results,
-    post_update_data,
-)
 
 import logging
 
@@ -128,7 +123,7 @@ class MultipleDataAssimilation(BaseRunModel):
 
         # Push update data to new storage
         analysis_module_name = self.ert().analysisConfig().activeModuleName()
-        update_id = post_update_data(
+        update_id = self._post_update_data(
             parent_ensemble_id=ensemble_id, algorithm=analysis_module_name
         )
 
@@ -150,9 +145,7 @@ class MultipleDataAssimilation(BaseRunModel):
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, ert=ERT.ert)
 
         # Push ensemble, parameters, observations to new storage
-        new_ensemble_id = post_ensemble_data(
-            update_id=update_id, ensemble_size=self._ensemble_size
-        )
+        new_ensemble_id = self._post_ensemble_data(update_id=update_id)
 
         phase_string = "Running forecast for iteration: %d" % iteration
         self.setPhaseName(phase_string, indeterminate=False)
@@ -171,7 +164,7 @@ class MultipleDataAssimilation(BaseRunModel):
             )
 
         # Push simulation results to storage
-        post_ensemble_results(new_ensemble_id)
+        self._post_ensemble_results(new_ensemble_id)
 
         num_successful_realizations += arguments.get("prev_successful_realizations", 0)
         self.checkHaveSufficientRealizations(num_successful_realizations)


### PR DESCRIPTION
**Issue**
Resolves #1675


**Approach**
- Show the phase name in the GUI (as we do in the CLI)
- Set phase names before and after extraction methods
- Move some extraction calls in front of the `setPhase(n…)` where _n_ indicates completion.
