### PR TITLE
ERT3 - store records as numerical

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -10,3 +10,6 @@ ignore_missing_imports = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True

--- a/ert3/data/__init__.py
+++ b/ert3/data/__init__.py
@@ -4,12 +4,14 @@ from ert3.data._record import MultiEnsembleRecord
 from ert3.data._record import RecordTransmitter
 from ert3.data._record import SharedDiskRecordTransmitter
 from ert3.data._record import InMemoryRecordTransmitter
+from ert3.data._record import RecordType
 
 __all__ = (
     "Record",
     "EnsembleRecord",
     "MultiEnsembleRecord",
     "RecordTransmitter",
+    "RecordType",
     "SharedDiskRecordTransmitter",
     "InMemoryRecordTransmitter",
 )

--- a/ert3/exceptions/__init__.py
+++ b/ert3/exceptions/__init__.py
@@ -4,6 +4,8 @@ from ert3.exceptions._exceptions import IllegalWorkspaceState
 from ert3.exceptions._exceptions import NonExistantExperiment
 from ert3.exceptions._exceptions import ConfigValidationError
 from ert3.exceptions._exceptions import StorageError
+from ert3.exceptions._exceptions import ElementExistsError
+from ert3.exceptions._exceptions import ElementMissingError
 
 # Explicitely export again, othwerwise mypy is unhappy.
 __all__ = [
@@ -13,4 +15,6 @@ __all__ = [
     "NonExistantExperiment",
     "ConfigValidationError",
     "StorageError",
+    "ElementExistsError",
+    "ElementMissingError",
 ]

--- a/ert3/exceptions/_exceptions.py
+++ b/ert3/exceptions/_exceptions.py
@@ -31,3 +31,13 @@ class ConfigValidationError(ErtError):
 class StorageError(ErtError):
     def __init__(self, message: str) -> None:
         self.message = "{}".format(message)
+
+
+class ElementExistsError(StorageError):
+    def __init__(self, message: str) -> None:
+        self.message = "{}".format(message)
+
+
+class ElementMissingError(StorageError):
+    def __init__(self, message: str) -> None:
+        self.message = "{}".format(message)

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -1,10 +1,10 @@
-import codecs
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, cast, Set
+from typing import Any, Dict, Iterable, Optional, Set
 import io
 
-import cloudpickle
+import pandas as pd
+from pydantic import BaseModel
 import requests
 import ert3
 
@@ -14,6 +14,18 @@ _DATA = "__data__"
 _PARAMETERS = "__parameters__"
 _ENSEMBLE_RECORDS = "__ensemble_records__"
 _SPECIAL_KEYS = (_ENSEMBLE_RECORDS,)
+
+
+class _NumericalMetaData(BaseModel):
+    class Config:
+        validate_all = True
+        validate_assignment = True
+        extra = "forbid"
+        allow_mutation = False
+        arbitrary_types_allowed = True
+
+    ensemble_size: int
+    record_type: ert3.data.RecordType
 
 
 def _get_experiment_by_name(experiment_name: str) -> Dict[str, Any]:
@@ -96,10 +108,21 @@ def get_experiment_names(*, workspace: Path) -> Set[str]:
     return experiment_names
 
 
-def _add_data(
-    workspace: Path, experiment_name: str, record_name: str, data: Any
-) -> None:
+def _get_record_type(ensemble_record: ert3.data.EnsembleRecord) -> ert3.data.RecordType:
+    record_type = ensemble_record.records[0].record_type
+    for record in ensemble_record.records:
+        if record.record_type != record_type:
+            raise ValueError("Inconsistent record type")
 
+    return record_type
+
+
+def _add_numerical_data(
+    workspace: Path,
+    experiment_name: str,
+    record_name: str,
+    ensemble_record: ert3.data.EnsembleRecord,
+) -> None:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
         raise KeyError(
@@ -107,19 +130,92 @@ def _add_data(
             f"non-existing experiment: {experiment_name}"
         )
 
-    ensemble_id = experiment["ensembles"][0]  # currently just one ens per exp
-    response = requests.post(
-        url=f"{_STORAGE_URL}/ensembles/{ensemble_id}/records/{record_name}/file",
-        files={"file": (record_name, io.StringIO(data), "something")},
+    metadata = _NumericalMetaData(
+        ensemble_size=ensemble_record.ensemble_size,
+        record_type=_get_record_type(ensemble_record),
     )
-    if response.status_code == 409:
-        raise KeyError("Record already exists")
+
+    ensemble_id = experiment["ensembles"][0]  # currently just one ens per exp
+    record_url = f"{_STORAGE_URL}/ensembles/{ensemble_id}/records/{record_name}"
+
+    for idx, record in enumerate(ensemble_record.records):
+        df = pd.DataFrame([record.data], columns=record.index, index=[idx])
+        response = requests.post(
+            url=f"{record_url}/matrix",
+            params={"realization_index": idx},
+            data=df.to_csv().encode(),
+            headers={"content-type": "application/x-dataframe"},
+        )
+
+        if response.status_code == 409:
+            raise KeyError("Record already exists")
+
+        if response.status_code != 200:
+            raise ert3.exceptions.StorageError(response.text)
+
+        meta_response = requests.put(
+            url=f"{record_url}/metadata",
+            params={"realization_index": idx},
+            json=metadata.dict(),
+        )
+
+        if meta_response.status_code != 200:
+            raise ert3.exceptions.StorageError(meta_response.text)
+
+
+def _response2record(
+    response_content: bytes, record_type: ert3.data.RecordType, realization_id: int
+) -> ert3.data.Record:
+    dataframe = pd.read_csv(
+        io.BytesIO(response_content), index_col=0, float_precision="round_trip"
+    )
+
+    raw_index = tuple(dataframe.columns)
+    if record_type == ert3.data.RecordType.LIST_FLOAT:
+        array_data = tuple(
+            float(dataframe.loc[realization_id][raw_idx]) for raw_idx in raw_index
+        )
+        return ert3.data.Record(data=array_data)
+    elif record_type == ert3.data.RecordType.MAPPING_INT_FLOAT:
+        int_index = tuple(int(e) for e in dataframe.columns)
+        idata = {
+            idx: float(dataframe.loc[realization_id][raw_idx])
+            for raw_idx, idx in zip(raw_index, int_index)
+        }
+        return ert3.data.Record(data=idata)
+    elif record_type == ert3.data.RecordType.MAPPING_STR_FLOAT:
+        str_index = tuple(str(e) for e in dataframe.columns)
+        sdata = {
+            idx: float(dataframe.loc[realization_id][raw_idx])
+            for raw_idx, idx in zip(raw_index, str_index)
+        }
+        return ert3.data.Record(data=sdata)
+    else:
+        raise ValueError(
+            f"Unexpected record type when loading numerical record: {record_type}"
+        )
+
+
+def _get_numerical_metadata(ensemble_id: str, record_name: str) -> _NumericalMetaData:
+    response = requests.get(
+        url=f"{_STORAGE_URL}/ensembles/{ensemble_id}/records/{record_name}/metadata",
+        params={"realization_index": 0},  # This assumes there is a realization 0
+    )
+
+    if response.status_code == 404:
+        raise ert3.exceptions.ElementMissingError(
+            f"No metadata for {record_name} in ensemble: {ensemble_id}"
+        )
 
     if response.status_code != 200:
         raise ert3.exceptions.StorageError(response.text)
 
+    return _NumericalMetaData(**json.loads(response.content))
 
-def _get_data(workspace: Path, experiment_name: str, record_name: str) -> Any:
+
+def _get_numerical_data(
+    workspace: Path, experiment_name: str, record_name: str
+) -> ert3.data.EnsembleRecord:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
         raise KeyError(
@@ -127,14 +223,30 @@ def _get_data(workspace: Path, experiment_name: str, record_name: str) -> Any:
         )
 
     ensemble_id = experiment["ensembles"][0]  # currently just one ens per exp
-    response = requests.get(
-        url=f"{_STORAGE_URL}/ensembles/{ensemble_id}/records/{record_name}"
-    )
+    metadata = _get_numerical_metadata(ensemble_id, record_name)
 
-    if response.status_code == 404:
-        raise KeyError(f"No {record_name} data for experiment: {experiment_name}")
+    records = []
+    for real_id in range(metadata.ensemble_size):
+        response = requests.get(
+            url=f"{_STORAGE_URL}/ensembles/{ensemble_id}/records/{record_name}",
+            params={"realization_index": real_id},
+            headers={"accept": "application/x-dataframe"},
+        )
 
-    return response.content
+        if response.status_code == 404:
+            raise KeyError(f"No {record_name} data for experiment: {experiment_name}")
+
+        if response.status_code != 200:
+            raise ert3.exceptions.StorageError(response.text)
+
+        record = _response2record(
+            response.content,
+            metadata.record_type,
+            real_id,
+        )
+        records.append(record)
+
+    return ert3.data.EnsembleRecord(records=records)
 
 
 def add_ensemble_record(
@@ -147,17 +259,7 @@ def add_ensemble_record(
     if experiment_name is None:
         experiment_name = f"{workspace}.{_ENSEMBLE_RECORDS}"
 
-    # If a Record is serialized to JSON without associating it with a type,
-    # information is lost. For instance, serializing an int mapping
-    # {0: 1, 1: 3} to JSON, keys are made into strings in JSON. If it is not
-    # known that the Record is a int, str map, information is lost.
-    #
-    # TODO: https://github.com/equinor/ert/issues/1550 should implement better
-    # usage of ert-storage, specifically using numerical endpoints when
-    # applicable.
-    pickle_str = codecs.encode(cloudpickle.dumps(ensemble_record), "base64").decode()
-    data = json.dumps({"data": pickle_str})
-    _add_data(workspace, experiment_name, record_name, data)
+    _add_numerical_data(workspace, experiment_name, record_name, ensemble_record)
 
 
 def get_ensemble_record(
@@ -168,11 +270,8 @@ def get_ensemble_record(
 ) -> ert3.data.EnsembleRecord:
     if experiment_name is None:
         experiment_name = f"{workspace}.{_ENSEMBLE_RECORDS}"
-    data = json.loads(_get_data(workspace, experiment_name, record_name))["data"]
-    return cast(
-        ert3.data.EnsembleRecord,
-        cloudpickle.loads(codecs.decode(data.encode(), "base64")),
-    )
+
+    return _get_numerical_data(workspace, experiment_name, record_name)
 
 
 def get_ensemble_record_names(

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -80,7 +80,9 @@ def _init_experiment(
         raise ValueError("Cannot initialize experiment without a name")
 
     if _get_experiment_by_name(experiment_name) is not None:
-        raise KeyError(f"Cannot initialize existing experiment: {experiment_name}")
+        raise ert3.exceptions.ElementExistsError(
+            f"Cannot initialize existing experiment: {experiment_name}"
+        )
 
     exp_response = requests.post(
         url=f"{_STORAGE_URL}/experiments", json={"name": experiment_name}
@@ -125,7 +127,7 @@ def _add_numerical_data(
 ) -> None:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise KeyError(
+        raise ert3.exceptions.NonExistantExperiment(
             f"Cannot add {record_name} data to "
             f"non-existing experiment: {experiment_name}"
         )
@@ -148,7 +150,7 @@ def _add_numerical_data(
         )
 
         if response.status_code == 409:
-            raise KeyError("Record already exists")
+            raise ert3.exceptions.ElementExistsError("Record already exists")
 
         if response.status_code != 200:
             raise ert3.exceptions.StorageError(response.text)
@@ -218,7 +220,7 @@ def _get_numerical_data(
 ) -> ert3.data.EnsembleRecord:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise KeyError(
+        raise ert3.exceptions.NonExistantExperiment(
             f"Cannot get {record_name} data, no experiment named: {experiment_name}"
         )
 
@@ -234,7 +236,9 @@ def _get_numerical_data(
         )
 
         if response.status_code == 404:
-            raise KeyError(f"No {record_name} data for experiment: {experiment_name}")
+            raise ert3.exceptions.ElementMissingError(
+                f"No {record_name} data for experiment: {experiment_name}"
+            )
 
         if response.status_code != 200:
             raise ert3.exceptions.StorageError(response.text)
@@ -281,7 +285,7 @@ def get_ensemble_record_names(
         experiment_name = f"{workspace}.{_ENSEMBLE_RECORDS}"
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise KeyError(
+        raise ert3.exceptions.NonExistantExperiment(
             f"Cannot get record names of non-existing experiment: {experiment_name}"
         )
 
@@ -298,7 +302,7 @@ def get_experiment_parameters(
 
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise KeyError(
+        raise ert3.exceptions.NonExistantExperiment(
             f"Cannot get parameters from non-existing experiment: {experiment_name}"
         )
 

--- a/tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert3/engine/integration/test_engine.py
@@ -395,7 +395,7 @@ def test_record_load_twice(
     ert3.engine.load_record(
         workspace, "designed_coefficients", designed_coeffs_record_file
     )
-    with pytest.raises(KeyError):
+    with pytest.raises(ert3.exceptions.ElementExistsError):
         ert3.engine.load_record(
             workspace, "designed_coefficients", designed_coeffs_record_file
         )


### PR DESCRIPTION
**Issue**
Resolves #1550

**Overview**
The two commits should be squashed before merging, but are left as is for the reviewer as is initially. The reason is that the first PR starts passing all records to storage **also** as numerical records and asserts whenever a record is retrieved that the file-based and matrix-based records are equivalent. The second commit simply removes the version stored as a file (and hence also the comparison).

**Outdated controversy**
I was not able to reconstruct the records without some additional metadata. That metadata specifically being the size of the ensemble for which the ensemble record stems from and the type of index. The first can be retrieved from the ensemble data if the record belongs to an ensemble, but it will not work for global ensemble records loaded by the user from disk or sampled before the experiment is launched. The second, being the index type, is necessary to ensure that when loaded again we can recreate the record with the same indexing as it had before being posted.

This metadata is stored in a file record as JSON with the name `{record_name}__metadata__`. It is not pretty, but it is at least encapsulated entirely within `ert3.storage`.

**Future work**
- optimise posting and getting by doing it for the entire ensemble in one API call (we should instead do https://github.com/equinor/ert/issues/1393),
- move exceptions into different modules (https://github.com/equinor/ert/issues/1707)
- ensure consistent record type across ensemble record (https://github.com/equinor/ert/issues/1708)
- logics based on the content of metadata kills migration (https://github.com/equinor/ert/issues/1710)
- storage transmitters (https://github.com/equinor/ert/issues/1393)