### PR TITLE
Revert new connection

### DIFF
--- a/ert_shared/storage/main.py
+++ b/ert_shared/storage/main.py
@@ -113,7 +113,7 @@ def run_server(args=None, debug=False):
         "urls": [
             f"http://{host}:{sock.getsockname()[1]}"
             for host in (
-                "127.0.0.1",
+                sock.getsockname()[0],
                 socket.gethostname(),
                 socket.getfqdn(),
             )

--- a/ert_shared/storage/main.py
+++ b/ert_shared/storage/main.py
@@ -49,7 +49,7 @@ def bind_socket(host: str, port: int) -> socket.socket:
 
     sock = socket.socket(family=family)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("", port))  # binding to 0.0.0.0
+    sock.bind((host, port))
     sock.set_inheritable(True)
     return sock
 


### PR DESCRIPTION
**Issue**
Resolves #1692 
Reopens https://github.com/equinor/ert/issues/1676


**Approach**
While https://github.com/equinor/ert/pull/1678 fixed https://github.com/equinor/ert/issues/1676 it also introduced an error where you are not able to run the HM tutorial with the ensemble evaluator, as the evaluator now tries to bind on the same ports for all instances. Since https://github.com/equinor/ert/issues/1676 represents an issue that occurs with a non-default permutation of feature flags, I think we should revert these commits for now to resolve the issue (#1692) we have with the default set of feature flags. 
