### PR TITLE
Fix #1538 by introducing SyncWebsocketDuplexer

### DIFF
--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -199,12 +199,7 @@ class EnsembleEvaluator:
     def store_client(self, websocket):
         self._clients.add(websocket)
         yield
-        try:
-            self._clients.remove(websocket)
-        except KeyError:
-            logger.debug(
-                f"Tried removing client {websocket.remote_address} twice. Likely the client was removed after sending a signal."
-            )
+        self._clients.remove(websocket)
 
     async def handle_client(self, websocket, path):
         with self.store_client(websocket):
@@ -230,14 +225,6 @@ class EnsembleEvaluator:
                 if client_event["type"] == identifiers.EVTYPE_EE_USER_DONE:
                     logger.debug(f"Client {websocket.remote_address} signalled done.")
                     self._stop()
-
-                # NOTE: due to how the monitor is implemented, a monitor that
-                # signals will open a connection for each signal and
-                # immediately exit after signalling. Consequently, it should be
-                # harmless to remove the client from the pool.
-                # If https://github.com/equinor/ert/issues/1538 is solved, then
-                # this necessarily needs to change.
-                self._clients.remove(websocket)
 
     @asynccontextmanager
     async def count_dispatcher(self):

--- a/ert_shared/ensemble_evaluator/monitor.py
+++ b/ert_shared/ensemble_evaluator/monitor.py
@@ -1,9 +1,6 @@
-import asyncio
-import websockets
-from websockets.datastructures import Headers
-from ert_shared.ensemble_evaluator.utils import wait_for_evaluator
+from contextlib import ExitStack
+from ert_shared.ensemble_evaluator.sync_ws_duplexer import SyncWebsocketDuplexer
 import logging
-import threading
 from cloudevents.http import from_json
 from cloudevents.http.event import CloudEvent
 from cloudevents.http import to_json
@@ -11,8 +8,7 @@ import ert_shared.ensemble_evaluator.entity.identifiers as identifiers
 from ert_shared.ensemble_evaluator.entity import serialization
 import uuid
 import pickle
-import ssl
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ert3.data import RecordTransmitter
@@ -26,66 +22,46 @@ class _Monitor:
         self._base_uri = f"{protocol}://{host}:{port}"
         self._client_uri = f"{self._base_uri}/client"
         self._result_uri = f"{self._base_uri}/result"
-        self._token = token
-        self._extra_headers = Headers()
-        if token is not None:
-            self._extra_headers["token"] = token
-
-        # Mimics the behavior of the ssl argument when connection to
-        # websockets. If none is specified it will deduce based on the url,
-        # if True it will enforce TLS, and if you want to use self signed
-        # certificates you need to pass an ssl_context with the certificate
-        # loaded.
         self._cert = cert
-        if cert is not None:
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            ssl_context.load_verify_locations(cadata=cert)
-        else:
-            ssl_context = True if protocol == "wss" else None
-        self._ssl_context = ssl_context
-
-        self._loop = None
-        self._incoming = None
-        self._receive_future = None
+        self._token = token
+        self._ws_duplexer: Optional[SyncWebsocketDuplexer] = None
         self._id = str(uuid.uuid1()).split("-")[0]
 
     def __enter__(self):
-        self._loop = asyncio.new_event_loop()
-        self._incoming = asyncio.Queue(loop=self._loop)
+        self._ws_duplexer = SyncWebsocketDuplexer(
+            self._client_uri, self._base_uri, self._cert, self._token
+        )
         return self
 
     def __exit__(self, *args):
-        self._loop.close()
+        self._ws_duplexer.stop()
 
     def get_base_uri(self):
         return self._base_uri
 
-    def get_result(self) -> Dict[int, Dict[str, "RecordTransmitter"]]:
-        async def _send():
-            async with websockets.connect(
-                self._result_uri,
-                ssl=self._ssl_context,
-                extra_headers=self._extra_headers,
-            ) as websocket:
-                result = await websocket.recv()
-                message = from_json(result, lambda x: pickle.loads(x))
-                return message.data
+    def get_result(self) -> Optional[Dict[int, Dict[str, "RecordTransmitter"]]]:
+        data = None
+        with ExitStack() as stack:
+            duplexer = SyncWebsocketDuplexer(
+                self._result_uri, self._base_uri, self._cert, self._token
+            )
+            stack.callback(duplexer.stop)
+            message = next(duplexer.receive())
+            event = from_json(message, pickle.loads)
+            data = event.data
+        return data
 
-        return asyncio.run_coroutine_threadsafe(_send(), self._loop).result()
-
-    def _send_event(self, cloud_event):
-        async def _send():
-            async with websockets.connect(
-                self._client_uri,
-                ssl=self._ssl_context,
-                extra_headers=self._extra_headers,
-            ) as websocket:
-                message = to_json(
-                    cloud_event, data_marshaller=serialization.evaluator_marshaller
+    def _send_event(self, cloud_event: CloudEvent) -> None:
+        with ExitStack() as stack:
+            duplexer = self._ws_duplexer
+            if not duplexer:
+                duplexer = SyncWebsocketDuplexer(
+                    self._client_uri, self._base_uri, self._cert, self._token
                 )
-                await websocket.send(message)
-
-        asyncio.run_coroutine_threadsafe(_send(), self._loop).result()
+                stack.callback(duplexer.stop)
+            duplexer.send(
+                to_json(cloud_event, data_marshaller=serialization.evaluator_marshaller)
+            )
 
     def signal_cancel(self):
         logger.debug(f"monitor-{self._id} asking server to cancel...")
@@ -113,63 +89,22 @@ class _Monitor:
         self._send_event(out_cloudevent)
         logger.debug(f"monitor-{self._id} informing server monitor is done...")
 
-    async def _receive(self):
-        logger.debug(f"monitor-{self._id} starting receive")
-        async with websockets.connect(
-            self._client_uri,
-            ssl=self._ssl_context,
-            extra_headers=self._extra_headers,
-            max_size=2 ** 26,
-            max_queue=500,
-        ) as websocket:
-            async for message in websocket:
+    def track(self):
+        with ExitStack() as stack:
+            duplexer = self._ws_duplexer
+            if not duplexer:
+                duplexer = SyncWebsocketDuplexer(
+                    self._client_uri, self._base_uri, self._cert, self._token
+                )
+                stack.callback(duplexer.stop)
+            for message in duplexer.receive():
                 event = from_json(
                     message, data_unmarshaller=serialization.evaluator_unmarshaller
                 )
-                self._incoming.put_nowait(event)
+                yield event
                 if event["type"] == identifiers.EVTYPE_EE_TERMINATED:
                     logger.debug(f"monitor-{self._id} client received terminated")
                     break
-
-        logger.debug(f"monitor-{self._id} disconnected")
-
-    def _run(self, done_future):
-        asyncio.set_event_loop(self._loop)
-        self._receive_future = self._loop.create_task(self._receive())
-        try:
-            self._loop.run_until_complete(self._receive_future)
-        except asyncio.CancelledError:
-            logger.debug(f"monitor-{self._id} receive cancelled")
-        self._loop.run_until_complete(done_future)
-
-    def track(self):
-        asyncio.get_event_loop().run_until_complete(
-            wait_for_evaluator(
-                base_url=self._base_uri, token=self._token, cert=self._cert
-            )
-        )
-
-        done_future = asyncio.Future(loop=self._loop)
-
-        thread = threading.Thread(
-            name=f"ert_monitor-{self._id}_loop", target=self._run, args=(done_future,)
-        )
-        thread.start()
-
-        event = None
-        try:
-            while event is None or event["type"] != identifiers.EVTYPE_EE_TERMINATED:
-                event = asyncio.run_coroutine_threadsafe(
-                    self._incoming.get(), self._loop
-                ).result()
-                yield event
-            self._loop.call_soon_threadsafe(done_future.set_result, None)
-        except GeneratorExit:
-            logger.debug(f"monitor-{self._id} generator exit")
-            self._loop.call_soon_threadsafe(self._receive_future.cancel)
-            if not done_future.done():
-                self._loop.call_soon_threadsafe(done_future.set_result, None)
-        thread.join()
 
 
 def create(host, port, protocol, cert, token):

--- a/ert_shared/ensemble_evaluator/sync_ws_duplexer.py
+++ b/ert_shared/ensemble_evaluator/sync_ws_duplexer.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+import ssl
+import threading
+from typing import Iterator, Optional, Union
+from concurrent.futures import CancelledError
+import websockets
+from ert_shared.ensemble_evaluator.utils import wait_for_evaluator
+from websockets.client import WebSocketClientProtocol
+from websockets.datastructures import Headers
+
+logger = logging.getLogger(__name__)
+
+
+class SyncWebsocketDuplexer:
+    """Class for communicating bi-directionally with a websocket using a
+    synchronous API. Reentrant, but not thread-safe. One must call stop() after
+    communication ends."""
+
+    def __init__(self, uri: str, health_check_uri: str, cert, token):
+        self._uri = uri
+        self._hc_uri = health_check_uri
+        self._token = token
+        self._extra_headers = Headers()
+        if token is not None:
+            self._extra_headers["token"] = token
+
+        # Mimics the behavior of the ssl argument when connection to
+        # websockets. If none is specified it will deduce based on the url,
+        # if True it will enforce TLS, and if you want to use self signed
+        # certificates you need to pass an ssl_context with the certificate
+        # loaded.
+        self._cert = cert
+        ssl_context: Optional[Union[bool, ssl.SSLContext]] = None
+        if cert is not None:
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_context.load_verify_locations(cadata=cert)
+        else:
+            ssl_context = True if self._uri.startswith("wss") else None
+        self._ssl_context: Optional[Union[bool, ssl.SSLContext]] = ssl_context
+
+        self._loop = asyncio.new_event_loop()
+        self._connection: asyncio.Task = self._loop.create_task(self._connect())
+        self._ws: Optional[WebSocketClientProtocol] = None
+        self._loop_thread = threading.Thread(target=self._loop.run_forever)
+        self._loop_thread.start()
+
+    async def _connect(self):
+        connect = websockets.connect(
+            self._uri,
+            ssl=self._ssl_context,
+            extra_headers=self._extra_headers,
+            max_size=2 ** 26,
+            max_queue=500,
+        )
+
+        await wait_for_evaluator(
+            base_url=self._hc_uri,
+            token=self._token,
+            cert=self._cert,
+        )
+
+        self._ws = await connect
+
+    def _ensure_running(self):
+        try:
+            asyncio.run_coroutine_threadsafe(
+                asyncio.wait_for(self._connection, None, loop=self._loop),
+                loop=self._loop,
+            ).result()
+        except OSError:
+            self.stop()
+            raise
+        if not self._ws:
+            raise RuntimeError("was connected but _ws was not set")
+
+    def send(self, msg: str) -> None:
+        """Send a message."""
+        self._ensure_running()
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self._ws.send(msg), loop=self._loop  # type: ignore
+            ).result()
+        except OSError:
+            self.stop()
+            raise
+
+    def receive(self):
+        """Create a generator with which you can iterate over incoming
+        websocket messages."""
+        self._ensure_running()
+        while True:
+            try:
+                event = asyncio.run_coroutine_threadsafe(
+                    self._ws.recv(), loop=self._loop  # type: ignore
+                ).result()
+                yield event
+            except OSError:
+                self.stop()
+                raise
+
+    def stop(self) -> None:
+        """Stop the duplexer. Most likely idempotent."""
+        if self._loop.is_running():
+            if self._ws:
+                asyncio.run_coroutine_threadsafe(
+                    self._ws.close(), loop=self._loop
+                ).result()
+            try:
+                self._loop.call_soon_threadsafe(self._connection.cancel)
+                asyncio.run_coroutine_threadsafe(
+                    asyncio.wait_for(self._connection, None, loop=self._loop),
+                    loop=self._loop,
+                ).result()
+            except (OSError, asyncio.CancelledError, CancelledError):
+                # The OSError will have been raised in send/receive already.
+                pass
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join()

--- a/tests/ensemble_evaluator/test_sync_ws_duplexer.py
+++ b/tests/ensemble_evaluator/test_sync_ws_duplexer.py
@@ -1,0 +1,164 @@
+import asyncio
+from contextlib import ExitStack
+from http import HTTPStatus
+from threading import Thread
+from unittest.mock import patch
+
+import pytest
+import websockets
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+from ert_shared.ensemble_evaluator.sync_ws_duplexer import SyncWebsocketDuplexer
+from websockets.exceptions import ConnectionClosedOK
+
+
+@pytest.fixture
+def ws(event_loop: asyncio.AbstractEventLoop):
+    t = Thread(target=event_loop.run_forever)
+    t.start()
+
+    async def _process_request(path, request_headers):
+        if path == "/healthcheck":
+            return HTTPStatus.OK, {}, b""
+
+    def _start_ws(host: str, port: int, handler, ssl=None, sock=None):
+        kwargs = {
+            "process_request": _process_request,
+            "ssl": ssl,
+        }
+        if sock:
+            kwargs["sock"] = sock
+        else:
+            kwargs["host"] = host
+            kwargs["port"] = port
+        event_loop.call_soon_threadsafe(
+            asyncio.ensure_future,
+            websockets.serve(
+                handler,
+                **kwargs,
+            ),
+        )
+
+    yield _start_ws
+    event_loop.call_soon_threadsafe(event_loop.stop)
+    t.join()
+
+
+def test_immediate_stop():
+    duplexer = SyncWebsocketDuplexer("ws://localhost", "", None, None)
+    duplexer.stop()
+
+
+def test_failed_connection():
+    with patch(
+        "ert_shared.ensemble_evaluator.sync_ws_duplexer.wait_for_evaluator"
+    ) as w:
+        w.side_effect = OSError("expected oserror")
+        duplexer = SyncWebsocketDuplexer(
+            "ws://localhost:0", "http://localhost:0", None, None
+        )
+        with pytest.raises(OSError):
+            duplexer.send("hello")
+
+
+def test_unexpected_close(unused_tcp_port, ws):
+    async def handler(websocket, path):
+        await websocket.close()
+
+    ws("localhost", unused_tcp_port, handler)
+    with ExitStack() as stack:
+        duplexer = SyncWebsocketDuplexer(
+            f"ws://localhost:{unused_tcp_port}",
+            f"ws://localhost:{unused_tcp_port}",
+            None,
+            None,
+        )
+        stack.callback(duplexer.stop)
+        with pytest.raises(ConnectionClosedOK):
+            next(duplexer.receive())
+
+
+def test_receive(unused_tcp_port, ws):
+    async def handler(websocket, path):
+        await websocket.send("Hello World")
+
+    ws("localhost", unused_tcp_port, handler)
+    with ExitStack() as stack:
+        duplexer = SyncWebsocketDuplexer(
+            f"ws://localhost:{unused_tcp_port}",
+            f"ws://localhost:{unused_tcp_port}",
+            None,
+            None,
+        )
+        stack.callback(duplexer.stop)
+        assert next(duplexer.receive()) == "Hello World"
+
+
+def test_echo(unused_tcp_port, ws):
+    async def handler(websocket, path):
+        msg = await websocket.recv()
+        await websocket.send(msg)
+
+    ws("localhost", unused_tcp_port, handler)
+    with ExitStack() as stack:
+        duplexer = SyncWebsocketDuplexer(
+            f"ws://localhost:{unused_tcp_port}",
+            f"ws://localhost:{unused_tcp_port}",
+            None,
+            None,
+        )
+        stack.callback(duplexer.stop)
+
+        duplexer.send("Hello World")
+        assert next(duplexer.receive()) == "Hello World"
+
+
+def test_generator(unused_tcp_port, ws):
+    async def handler(websocket, path):
+        await websocket.send("one")
+        await websocket.send("two")
+        await websocket.send("three")
+        await websocket.send("four")
+
+    ws("localhost", unused_tcp_port, handler)
+    with ExitStack() as stack:
+        duplexer = SyncWebsocketDuplexer(
+            f"ws://localhost:{unused_tcp_port}",
+            f"ws://localhost:{unused_tcp_port}",
+            None,
+            None,
+        )
+        stack.callback(duplexer.stop)
+
+        expected = ["one", "two", "three"]
+        for msg in duplexer.receive():
+            assert msg == expected.pop(0)
+
+            # Cause a GeneratorExit
+            if len(expected) == 1:
+                break
+
+
+def test_secure_echo(unused_tcp_port, ws):
+    config = EvaluatorServerConfig(unused_tcp_port)
+
+    async def handler(websocket, path):
+        msg = await websocket.recv()
+        await websocket.send(msg)
+
+    ws(
+        config.host,
+        unused_tcp_port,
+        handler,
+        ssl=config.get_server_ssl_context(),
+        sock=config.get_socket(),
+    )
+    with ExitStack() as stack:
+        duplexer = SyncWebsocketDuplexer(
+            f"wss://{config.host}:{unused_tcp_port}",
+            f"wss://{config.host}:{unused_tcp_port}",
+            cert=config.cert,
+            token=None,
+        )
+        stack.callback(duplexer.stop)
+        duplexer.send("Hello Secure World")
+        assert next(duplexer.receive()) == "Hello Secure World"


### PR DESCRIPTION
**Issue**
Resolves #1538 


**Approach**
Mainly drop queues from communication between the consumer and async loop, leaning on the fact that there is probably queuing going on in the implementation of `_threadsafe` `asyncio`-methods.