### PR TITLE
Implement more data roles to satisfy modeltester

### DIFF
--- a/ert_gui/model/progress_proxy.py
+++ b/ert_gui/model/progress_proxy.py
@@ -1,12 +1,9 @@
 import typing
-from qtpy.QtCore import (
-    QModelIndex,
-    Qt,
-    QAbstractItemModel,
-    QVariant,
-)
 from collections import defaultdict
+
 from ert_gui.model.snapshot import ProgressRole
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, QSize, Qt, QVariant
+from qtpy.QtGui import QColor, QFont
 
 
 class ProgressProxyModel(QAbstractItemModel):
@@ -58,6 +55,22 @@ class ProgressProxyModel(QAbstractItemModel):
 
         if role == ProgressRole:
             return self._progress
+
+        if role in (Qt.StatusTipRole, Qt.WhatsThisRole, Qt.ToolTipRole):
+            return ""
+
+        if role == Qt.SizeHintRole:
+            return QSize(30, 30)
+
+        if role == Qt.FontRole:
+            return QFont()
+
+        if role in (Qt.BackgroundRole, Qt.ForegroundRole, Qt.DecorationRole):
+            return QColor()
+
+        if role == Qt.DisplayRole:
+            return ""
+
         return QVariant()
 
     def _recalculate_progress(self, iter_):

--- a/ert_gui/model/snapshot.py
+++ b/ert_gui/model/snapshot.py
@@ -9,8 +9,8 @@ from ert_shared.ensemble_evaluator.entity.snapshot import (
     SnapshotDict,
 )
 from ert_shared.status.utils import byte_with_unit
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, QVariant
-from qtpy.QtGui import QColor
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, QVariant, QSize
+from qtpy.QtGui import QColor, QFont
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +203,18 @@ class SnapshotModel(QAbstractItemModel):
                 return f"{node.type}:{node.id}"
             if index.column() == 1:
                 return f"{node.data['status']}"
+
+        if role in (Qt.StatusTipRole, Qt.WhatsThisRole, Qt.ToolTipRole):
+            return ""
+
+        if role == Qt.SizeHintRole:
+            return QSize()
+
+        if role == Qt.FontRole:
+            return QFont()
+
+        if role in (Qt.BackgroundRole, Qt.ForegroundRole, Qt.DecorationRole):
+            return QColor()
 
         return QVariant()
 

--- a/ert_gui/simulation/view/progress.py
+++ b/ert_gui/simulation/view/progress.py
@@ -94,5 +94,4 @@ class ProgressDelegate(QStyledItemDelegate):
         painter.restore()
 
     def sizeHint(self, option, index) -> QSize:
-        # x size is ignored
-        return QSize(30, 30)
+        return index.data(role=Qt.SizeHintRole)


### PR DESCRIPTION
pytest-qt 4.0.0 introduces a new modeltester that requires additional
roles to be set, namely StatusTipRole, WhatsThisRole, ToolTipRole,
SizeHintRole, FontRole, BackgroundRole, ForegroundRole, and
DecorationRole. They are now all set for the snapshot and progress
models, usually to some value that represents "no value".