### PR TITLE
Fix initial ensemble state

### DIFF
--- a/ert_shared/ensemble_evaluator/entity/ensemble_base.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble_base.py
@@ -115,7 +115,10 @@ class _Ensemble:
         for event in events:
             snapshot_mutate_event.from_cloudevent(event)
         self._snapshot.merge_event(snapshot_mutate_event)
-        self._status = self._status_tracker.update_state(self._snapshot.get_status())
+        if self._status != self._snapshot.get_status():
+            self._status = self._status_tracker.update_state(
+                self._snapshot.get_status()
+            )
         return snapshot_mutate_event
 
     def get_status(self):
@@ -152,7 +155,7 @@ class _Ensemble:
                     )
         top = SnapshotDict(
             reals=reals,
-            status=state.ENSEMBLE_STATE_STARTED,
+            status=state.ENSEMBLE_STATE_UNKNOWN,
             metadata=self.get_metadata(),
         )
 

--- a/tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -10,6 +10,7 @@ from ert_shared.status.entity.state import (
     JOB_STATE_FAILURE,
     JOB_STATE_FINISHED,
     JOB_STATE_RUNNING,
+    ENSEMBLE_STATE_UNKNOWN,
 )
 from tests.ensemble_evaluator.ensemble_test import TestEnsemble, send_dispatch_event
 from tests.narratives import (
@@ -32,7 +33,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
         # first snapshot before any event occurs
         snapshot_event = next(events)
         snapshot = Snapshot(snapshot_event.data)
-        assert snapshot.get_status() == ENSEMBLE_STATE_STARTED
+        assert snapshot.get_status() == ENSEMBLE_STATE_UNKNOWN
         # two dispatchers connect
         with Client(
             url + "/dispatch",
@@ -94,7 +95,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             full_snapshot_event = next(events2)
             assert full_snapshot_event["type"] == identifiers.EVTYPE_EE_SNAPSHOT
             snapshot = Snapshot(full_snapshot_event.data)
-            assert snapshot.get_status() == ENSEMBLE_STATE_STARTED
+            assert snapshot.get_status() == ENSEMBLE_STATE_UNKNOWN
             assert snapshot.get_job("0", "0", "0").status == JOB_STATE_RUNNING
             assert snapshot.get_job("1", "0", "0").status == JOB_STATE_FINISHED
 


### PR DESCRIPTION
**Issue**

The following warning was appearing in the polynomial output:

```
Illegal state transition from Starting to Starting
```


**Approach**
Set initial ensemble state to unknown only check transition when the ensemble state is actually changed by the received events 