### PR TITLE
Add output records to ert3 ensemble config

### DIFF
--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -29,9 +29,14 @@ class Input(_EnsembleConfig):
     record: str
 
 
+class Output(_EnsembleConfig):
+    record: str
+
+
 class EnsembleConfig(_EnsembleConfig):
     forward_model: ForwardModel
     input: Tuple[Input, ...]
+    output: Tuple[Output, ...]
     size: Optional[int] = None
 
 

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Set, List, Dict, Any
+from typing import Iterable, List, Dict, Any
 
 import ert3
 from ert3.data import Record
@@ -9,8 +9,8 @@ from ert3.data import Record
 def _prepare_export(
     workspace_root: Path,
     experiment_name: str,
-    parameter_names: Set[str],
-    response_names: Set[str],
+    parameter_names: Iterable[str],
+    response_names: Iterable[str],
 ) -> List[Dict[str, Dict[str, Record]]]:
     data_mapping = [(pname, "input") for pname in parameter_names]
     data_mapping += [(rname, "output") for rname in response_names]
@@ -44,18 +44,11 @@ def export(workspace_root: Path, experiment_name: str) -> None:
     if not ert3.workspace.experiment_has_run(workspace_root, experiment_name):
         raise ValueError("Cannot export experiment that has not been carried out")
 
-    parameter_names = set(
-        ert3.storage.get_experiment_parameters(
-            workspace=workspace_root, experiment_name=experiment_name
-        )
+    parameter_names = ert3.storage.get_experiment_parameters(
+        workspace=workspace_root, experiment_name=experiment_name
     )
-    response_names = (
-        set(
-            ert3.storage.get_ensemble_record_names(
-                workspace=workspace_root, experiment_name=experiment_name
-            )
-        )
-        - parameter_names
+    response_names = ert3.storage.get_experiment_responses(
+        workspace=workspace_root, experiment_name=experiment_name
     )
 
     data = _prepare_export(

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -14,11 +14,13 @@ def _prepare_experiment(
         raise ValueError(f"Experiment {experiment_name} have been carried out.")
 
     parameter_names = [elem.record for elem in ensemble.input]
+    responses = [elem.record for elem in ensemble.output]
     ert3.storage.init_experiment(
         workspace=workspace_root,
         experiment_name=experiment_name,
         parameters=parameter_names,
         ensemble_size=ensemble_size,
+        responses=responses,
     )
 
 
@@ -131,18 +133,18 @@ def _prepare_sensitivity(
         )
 
 
-def _store_responses(
+def _store_output_records(
     workspace_root: pathlib.Path,
     experiment_name: str,
-    responses: ert3.data.MultiEnsembleRecord,
+    records: ert3.data.MultiEnsembleRecord,
 ) -> None:
-    assert responses.record_names is not None
-    for record_name in responses.record_names:
+    assert records.record_names is not None
+    for record_name in records.record_names:
         ert3.storage.add_ensemble_record(
             workspace=workspace_root,
             experiment_name=experiment_name,
             record_name=record_name,
-            ensemble_record=responses.ensemble_records[record_name],
+            ensemble_record=records.ensemble_records[record_name],
         )
 
 
@@ -172,10 +174,10 @@ def _evaluate(
     experiment_name: str,
 ) -> None:
     parameters = _load_experiment_parameters(workspace_root, experiment_name)
-    responses = ert3.evaluator.evaluate(
+    output_records = ert3.evaluator.evaluate(
         workspace_root, experiment_name, parameters, ensemble, stages_config
     )
-    _store_responses(workspace_root, experiment_name, responses)
+    _store_output_records(workspace_root, experiment_name, output_records)
 
 
 # pylint: disable=too-many-arguments

--- a/ert3/storage/__init__.py
+++ b/ert3/storage/__init__.py
@@ -5,6 +5,7 @@ from ert3.storage._storage import add_ensemble_record
 from ert3.storage._storage import get_ensemble_record
 from ert3.storage._storage import get_ensemble_record_names
 from ert3.storage._storage import get_experiment_parameters
+from ert3.storage._storage import get_experiment_responses
 from ert3.storage._storage import delete_experiment
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "get_ensemble_record",
     "get_ensemble_record_names",
     "get_experiment_parameters",
+    "get_experiment_responses",
     "delete_experiment",
 ]

--- a/ert3_examples/polynomial/experiments/doe/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/doe/ensemble.yml
@@ -5,6 +5,10 @@ input:
     source: storage.designed_coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
 forward_model:
   driver: local
   stage: evaluate_polynomial

--- a/ert3_examples/polynomial/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/evaluation/ensemble.yml
@@ -5,6 +5,10 @@ input:
     source: stochastic.coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
 forward_model:
   driver: local
   stage: evaluate_polynomial

--- a/ert3_examples/polynomial/experiments/function_evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/function_evaluation/ensemble.yml
@@ -5,6 +5,10 @@ input:
     source: stochastic.coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
 forward_model:
   driver: local
   stage: function_polynomial

--- a/ert3_examples/polynomial/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/sensitivity/ensemble.yml
@@ -3,6 +3,11 @@ input:
     source: stochastic.coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
+
 forward_model:
   driver: local
   stage: evaluate_polynomial

--- a/ert3_examples/polynomial/experiments/uniform_evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/uniform_evaluation/ensemble.yml
@@ -5,6 +5,10 @@ input:
     source: stochastic.uniform_coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
 forward_model:
   driver: local
   stage: evaluate_polynomial

--- a/ert3_examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
@@ -3,6 +3,10 @@ input:
     source: stochastic.uniform_coefficients
     record: coefficients
 
+output:
+  -
+    record: polynomial_output
+
 forward_model:
   driver: local
   stage: evaluate_polynomial

--- a/ert3_examples/spe1/experiments/doe/ensemble.yml
+++ b/ert3_examples/spe1/experiments/doe/ensemble.yml
@@ -8,6 +8,15 @@ input:
     source: storage.designed_wells
     record: wells
 
+output:
+    -
+      record: wopt_prod
+    -
+      record: wwpt_prod
+    -
+      record: wgpt_prod
+    -
+      record: wwit_inj
 
 forward_model:
   driver: local

--- a/ert3_examples/spe1/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/spe1/experiments/evaluation/ensemble.yml
@@ -8,6 +8,15 @@ input:
     source: stochastic.wells_no_delay
     record: wells
 
+output:
+    -
+      record: wopt_prod
+    -
+      record: wwpt_prod
+    -
+      record: wgpt_prod
+    -
+      record: wwit_inj
 
 forward_model:
   driver: local

--- a/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
@@ -6,6 +6,15 @@ input:
     source: stochastic.wells
     record: wells
 
+output:
+    -
+      record: wopt_prod
+    -
+      record: wwpt_prod
+    -
+      record: wgpt_prod
+    -
+      record: wwit_inj
 
 forward_model:
   driver: local

--- a/tests/ert3/conftest.py
+++ b/tests/ert3/conftest.py
@@ -60,6 +60,7 @@ def base_ensemble_dict():
     yield {
         "size": 10,
         "input": [{"source": "stochastic.coefficients", "record": "coefficients"}],
+        "output": [{"record": "polynomial_output"}],
         "forward_model": {"driver": "local", "stage": "evaluate_polynomial"},
     }
 

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -219,6 +219,7 @@ def test_cli_status_some_runs(workspace, capsys):
             experiment_name=experiments[idx],
             parameters=[],
             ensemble_size=42,
+            responses=[],
         )
 
     args = ["ert3", "status"]
@@ -241,6 +242,7 @@ def test_cli_status_all_run(workspace, capsys):
             experiment_name=experiment,
             parameters=[],
             ensemble_size=42,
+            responses=[],
         )
 
     args = ["ert3", "status"]
@@ -302,6 +304,7 @@ def test_cli_clean_all(workspace):
             experiment_name=experiment,
             parameters=[],
             ensemble_size=42,
+            responses=[],
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment
@@ -334,6 +337,7 @@ def test_cli_clean_one(workspace):
             experiment_name=experiment,
             parameters=[],
             ensemble_size=42,
+            responses=[],
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment
@@ -373,6 +377,7 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
             experiment_name=experiment,
             parameters=[],
             ensemble_size=42,
+            responses=[],
         )
         ert3.evaluator._evaluator._create_evaluator_tmp_dir(
             workspace, experiment

--- a/tests/ert3/evaluator/test_evaluator.py
+++ b/tests/ert3/evaluator/test_evaluator.py
@@ -37,7 +37,7 @@ def test_evaluator_script(
     base_ensemble_dict["size"] = len(coeffs)
     ensemble = ert3.config.load_ensemble_config(base_ensemble_dict)
 
-    evaluation_responses = ert3.evaluator.evaluate(
+    evaluation_records = ert3.evaluator.evaluate(
         workspace,
         "test_evaluation",
         input_records,
@@ -52,7 +52,7 @@ def test_evaluator_script(
             )
         }
     )
-    assert expected == evaluation_responses
+    assert expected == evaluation_records
 
 
 @pytest.mark.requires_ert_storage
@@ -64,7 +64,7 @@ def test_evaluator_function(
     base_ensemble_dict.update({"size": len(coeffs)})
     ensemble = ert3.config.load_ensemble_config(base_ensemble_dict)
 
-    evaluation_responses = ert3.evaluator.evaluate(
+    evaluation_records = ert3.evaluator.evaluate(
         workspace,
         "test_evaluation",
         input_records,
@@ -79,4 +79,4 @@ def test_evaluator_function(
             )
         }
     )
-    assert expected == evaluation_responses
+    assert expected == evaluation_records

--- a/tests/ert3/workspace/test_workspace.py
+++ b/tests/ert3/workspace/test_workspace.py
@@ -82,6 +82,7 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
         experiment_name="test1",
         parameters=[],
         ensemble_size=42,
+        responses=[],
     )
 
     assert ert3.workspace.experiment_has_run(tmpdir, "test1")


### PR DESCRIPTION
**Issue**
ert-storage deduces record types based on if the record name is in the ensemble parameter list or in ensemble response list.


**Approach**
Add output records to er3 ensemble config, and pass the list when posting ensemble info to ert-storage
