### PR TITLE
Split ERT 3 parameters into separate records

### DIFF
--- a/ert3/config/_parameters_config.py
+++ b/ert3/config/_parameters_config.py
@@ -145,8 +145,15 @@ class ParametersConfig(_ParametersConfig):
     def __iter__(self) -> Iterator[_ParameterConfig]:  # type: ignore
         return iter(self.__root__)
 
-    def __getitem__(self, item: int) -> _ParameterConfig:
-        return self.__root__[item]
+    def __getitem__(self, item: Union[int, str]) -> _ParameterConfig:
+        if isinstance(item, int):
+            return self.__root__[item]
+        elif isinstance(item, str):
+            for group in self:
+                if group.name == item:
+                    return group
+            raise ValueError(f"No parameter group found named: {item}")
+        raise TypeError(f"Item should be int or str, not {type(item)}")
 
     def __len__(self) -> int:
         return len(self.__root__)

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -19,16 +19,6 @@ def load_record(workspace: Path, record_name: str, record_file: Path) -> None:
     )
 
 
-def _get_distribution(
-    parameter_group_name: str, parameters_config: ert3.config.ParametersConfig
-) -> ert3.stats.Distribution:
-    for parameter_group in parameters_config:
-        if parameter_group.name == parameter_group_name:
-            return parameter_group.as_distribution()
-
-    raise ValueError(f"No parameter group found named: {parameter_group_name}")
-
-
 # pylint: disable=too-many-arguments
 def sample_record(
     workspace: Path,
@@ -38,7 +28,7 @@ def sample_record(
     ensemble_size: int,
     experiment_name: Optional[str] = None,
 ) -> None:
-    distribution = _get_distribution(parameter_group_name, parameters_config)
+    distribution = parameters_config[parameter_group_name].as_distribution()
     ensrecord = ert3.data.EnsembleRecord(
         records=[distribution.sample() for _ in range(ensemble_size)]
     )

--- a/tests/ert3/console/integration/test_cli.py
+++ b/tests/ert3/console/integration/test_cli.py
@@ -217,7 +217,7 @@ def test_cli_status_some_runs(workspace, capsys):
         ert3.storage.init_experiment(
             workspace=workspace,
             experiment_name=experiments[idx],
-            parameters=[],
+            parameters={},
             ensemble_size=42,
             responses=[],
         )
@@ -240,7 +240,7 @@ def test_cli_status_all_run(workspace, capsys):
         ert3.storage.init_experiment(
             workspace=workspace,
             experiment_name=experiment,
-            parameters=[],
+            parameters={},
             ensemble_size=42,
             responses=[],
         )
@@ -302,7 +302,7 @@ def test_cli_clean_all(workspace):
         ert3.storage.init_experiment(
             workspace=workspace,
             experiment_name=experiment,
-            parameters=[],
+            parameters={},
             ensemble_size=42,
             responses=[],
         )
@@ -335,7 +335,7 @@ def test_cli_clean_one(workspace):
         ert3.storage.init_experiment(
             workspace=workspace,
             experiment_name=experiment,
-            parameters=[],
+            parameters={},
             ensemble_size=42,
             responses=[],
         )
@@ -375,7 +375,7 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
         ert3.storage.init_experiment(
             workspace=workspace,
             experiment_name=experiment,
-            parameters=[],
+            parameters={},
             ensemble_size=42,
             responses=[],
         )

--- a/tests/ert3/workspace/test_workspace.py
+++ b/tests/ert3/workspace/test_workspace.py
@@ -80,7 +80,7 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
     ert3.storage.init_experiment(
         workspace=tmpdir,
         experiment_name="test1",
-        parameters=[],
+        parameters={},
         ensemble_size=42,
         responses=[],
     )


### PR DESCRIPTION
**Issue**
Resolves #1720 

**Todo**
- [x] Write test which uploads a set of parameters and then checks that it is correct
- [x] Check that all realisations inside a `EnsembleRecord` contain the same `index` and contain valid data
- [x] ~~Check that all parameter `EnsembleRecord`s are of the `Mapping[str, Numeric]` type rather than `Iterable[Numeric]`, which is another alternative.~~ We handle this case too now.