### PR TITLE
Reduce number of macos jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,12 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest]
+        # Excluded to keep build times down on Github actions
+        exclude:
+          - os: macos-latest
+            python-version: 3.7
+          - os: macos-latest
+            python-version: 3.9
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -235,6 +241,12 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest]
+        # Excluded to keep build times down on Github actions
+        exclude:
+          - os: macos-latest
+            python-version: 3.7
+          - os: macos-latest
+            python-version: 3.9
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run_ert2_test_data_setups.yml
+++ b/.github/workflows/run_ert2_test_data_setups.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.8]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -15,6 +15,12 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest]
+        # Excluded to keep build times down on Github actions
+        exclude:
+          - os: macos-latest
+            python-version: 3.7
+          - os: macos-latest
+            python-version: 3.9
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
**Issue**
Resolves #1756 


**Approach**
Remove Python 3.7 and Python 3.9 runs on macos. Also, run ert2 example tests on Python 3.8 instead of 3.7. 

This means admins need  to make 3.7 and 3.9 runs not required and add the Python 3.8 ert2 examples as required. 
