### PR TITLE
Change workflows to not trigger on all push events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 env:
   ERT_SHOW_BACKTRACE: 1

--- a/.github/workflows/run_ert2_test_data_setups.yml
+++ b/.github/workflows/run_ert2_test_data_setups.yml
@@ -1,6 +1,11 @@
 name: Run test-data
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 env:
   ERT_SHOW_BACKTRACE: 1

--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -1,6 +1,11 @@
 name: Run polynomial demo
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 jobs:
   run-ert3-polynomial-local:

--- a/.github/workflows/run_examples_spe1.yml
+++ b/.github/workflows/run_examples_spe1.yml
@@ -1,6 +1,11 @@
 name: Run SPE1 demo
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 jobs:
   run-ert3-spe1:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,11 @@
 name: Style
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 jobs:
   check-style:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,6 +1,11 @@
 name: Type checking
 
-on: [push, pull_request]
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
 
 jobs:
   type-checking:


### PR DESCRIPTION
**Issue**
Resolves #1739 


**Approach**
Only trigger on push events for `main` and `version-*`. Demonstrated by this branch not running on the `push` event, only the `pull_request` event.
