### PR TITLE
Unite the resolving of port and sockets to use

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/prefect.py
+++ b/ert_shared/ensemble_evaluator/ensemble/prefect.py
@@ -16,7 +16,8 @@ import cloudpickle
 import prefect.utilities.logging
 from cloudevents.http import CloudEvent, to_json
 from dask_jobqueue.lsf import LSFJob
-from ert_shared.ensemble_evaluator.config import find_open_port, EvaluatorServerConfig
+from ert_shared.port_handler import find_available_port
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.ensemble_evaluator.entity import identifiers as ids
 from ert_shared.ensemble_evaluator.ensemble.builder import (
     _Ensemble,
@@ -55,11 +56,12 @@ async def _eq_submit_job(self, script_filename):
     return self._call(piped_cmd, shell=True)
 
 
-def _get_executor(name="local"):
+def _get_executor(custom_port_range, name="local"):
+    _, port = find_available_port(custom_range=custom_port_range)
     if name == "local":
         cluster_kwargs = {
             "silence_logs": "debug",
-            "scheduler_options": {"port": find_open_port()},
+            "scheduler_options": {"port": port},
         }
         return LocalDaskExecutor(**cluster_kwargs)
     elif name == "lsf":
@@ -72,7 +74,7 @@ def _get_executor(name="local"):
             "use_stdin": True,
             "n_workers": 2,
             "silence_logs": "debug",
-            "scheduler_options": {"port": find_open_port()},
+            "scheduler_options": {"port": port},
         }
         return DaskExecutor(
             cluster_class="dask_jobqueue.LSFCluster",
@@ -99,8 +101,9 @@ def _get_executor(name="local"):
 
 
 class PrefectEnsemble(_Ensemble):
-    def __init__(self, config):
+    def __init__(self, config, custom_port_range=None):
         self.config = config
+        self._custom_range = custom_port_range
         self._ee_config = None
         self._reals = self._get_reals()
         self._eval_proc = None
@@ -272,7 +275,11 @@ class PrefectEnsemble(_Ensemble):
             realization_range = real_range[i : i + real_per_batch]
             flow = self.get_flow(ee_id, realization_range)
             with prefect_log_level_context(level="WARNING"):
-                state = flow.run(executor=_get_executor(self.config[ids.EXECUTOR]))
+                state = flow.run(
+                    executor=_get_executor(
+                        self._custom_range, self.config[ids.EXECUTOR]
+                    )
+                )
             for iens in realization_range:
                 state_map[iens] = state
             i = i + real_per_batch

--- a/ert_shared/port_handler.py
+++ b/ert_shared/port_handler.py
@@ -1,0 +1,81 @@
+import random
+import socket
+from typing import Optional, Tuple
+
+
+class PortAlreadyInUseException(Exception):
+    pass
+
+
+class NoPortsInRangeException(Exception):
+    pass
+
+
+class InvalidHostException(Exception):
+    pass
+
+
+def find_available_port(
+    custom_host: Optional[str] = None,
+    custom_range: Optional[range] = None,
+) -> Tuple[str, int]:
+    current_host = custom_host if custom_host is not None else _get_ip_address()
+    current_range = (
+        custom_range if custom_range is not None else range(51820, 55840 + 1)
+    )
+
+    if current_range.start == current_range.stop:
+        return current_host, current_range.start
+
+    attempts = 0
+    while attempts < current_range.stop - current_range.start:
+        try:
+            attempts += 1
+            num = random.randrange(current_range.start, current_range.stop)
+            sock = _bind_socket(host=current_host, port=num)
+            sock.close()
+            return current_host, num
+        except PortAlreadyInUseException:
+            continue
+
+    raise NoPortsInRangeException(f"No available ports in predefined {current_range}.")
+
+
+def get_socket(host: str, port: int) -> socket.socket:
+    return _bind_socket(host=host, port=port, reuse_addr=True)
+
+
+def _bind_socket(host: str, port: int, reuse_addr: bool = False) -> socket.socket:
+    try:
+        family = get_family(host=host)
+        sock = socket.socket(family=family, type=socket.SOCK_STREAM)
+        if reuse_addr:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        return sock
+    except socket.gaierror as err_info:
+        raise InvalidHostException(
+            f"Trying to bind socket with what looks like "
+            f"an invalid hostname ({host}). "
+            f"Actual "
+            f"error msg is: {err_info.strerror}"
+        )
+    except OSError as err_info:
+        if err_info.errno == 48 or err_info.errno == 98:
+            raise PortAlreadyInUseException(f"Port {port} already in use.")
+        raise Exception(
+            f"Unknown `OSError` while binding port {port}. Actual "
+            f"error msg is: {err_info.strerror}"
+        )
+
+
+def get_family(host: str) -> socket.AddressFamily:
+    if host and ":" in host:
+        return socket.AF_INET6
+    return socket.AF_INET
+
+
+def _get_ip_address() -> str:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    return s.getsockname()[0]

--- a/ert_shared/port_handler.py
+++ b/ert_shared/port_handler.py
@@ -70,9 +70,11 @@ def _bind_socket(host: str, port: int, reuse_addr: bool = False) -> socket.socke
 
 
 def get_family(host: str) -> socket.AddressFamily:
-    if host and ":" in host:
+    try:
+        socket.inet_pton(socket.AF_INET6, host)
         return socket.AF_INET6
-    return socket.AF_INET
+    except socket.error:
+        return socket.AF_INET
 
 
 def _get_ip_address() -> str:

--- a/tests/ensemble_evaluator/conftest.py
+++ b/tests/ensemble_evaluator/conftest.py
@@ -189,7 +189,8 @@ def _dump_ext_job(ext_job, index):
 @pytest.fixture
 def make_ee_config(unused_tcp_port):
     def _ee_config(**kwargs):
-        return EvaluatorServerConfig(unused_tcp_port, **kwargs)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        return EvaluatorServerConfig(custom_port_range=fixed_port, **kwargs)
 
     return _ee_config
 

--- a/tests/ensemble_evaluator/test_config.py
+++ b/tests/ensemble_evaluator/test_config.py
@@ -1,9 +1,11 @@
-from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig, _get_ip_address
+from ert_shared import port_handler
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 
 
 def test_load_config(unused_tcp_port):
-    serv_config = EvaluatorServerConfig(unused_tcp_port)
-    expected_host = _get_ip_address()
+    fixed_port = range(unused_tcp_port, unused_tcp_port)
+    serv_config = EvaluatorServerConfig(custom_port_range=fixed_port)
+    expected_host = port_handler._get_ip_address()
     expected_port = unused_tcp_port
     expected_url = f"wss://{expected_host}:{expected_port}"
     expected_client_uri = f"{expected_url}/client"
@@ -22,7 +24,6 @@ def test_load_config(unused_tcp_port):
     sock.close()
 
     ee_config = EvaluatorServerConfig()
-    assert ee_config.port in range(51820, 51840)
     sock = ee_config.get_socket()
     assert sock is not None
     assert not sock._closed

--- a/tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -11,9 +11,10 @@ from ert_shared.status.entity import state
 @pytest.mark.timeout(60)
 def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 2
+    custom_port_range = range(unused_tcp_port, unused_tcp_port)
     with tmpdir.as_cwd():
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
-        config = EvaluatorServerConfig(unused_tcp_port)
+        config = EvaluatorServerConfig(custom_port_range=custom_port_range)
         evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
         with evaluator.run() as monitor:
             for e in monitor.track():
@@ -34,9 +35,10 @@ def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
 @pytest.mark.timeout(60)
 def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 10
+    custom_port_range = range(unused_tcp_port, unused_tcp_port)
     with tmpdir.as_cwd():
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2, job_sleep=5).build()
-        config = EvaluatorServerConfig(unused_tcp_port)
+        config = EvaluatorServerConfig(custom_port_range=custom_port_range)
 
         evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
 
@@ -53,9 +55,10 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_b
 @pytest.mark.timeout(60)
 def test_run_legacy_ensemble_exception(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 2
+    custom_port_range = range(unused_tcp_port, unused_tcp_port)
     with tmpdir.as_cwd():
         ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
-        config = EvaluatorServerConfig(unused_tcp_port)
+        config = EvaluatorServerConfig(custom_port_range=custom_port_range)
         evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
 
         with patch.object(ensemble, "get_active_reals", side_effect=RuntimeError()):

--- a/tests/ensemble_evaluator/test_prefect_ensemble.py
+++ b/tests/ensemble_evaluator/test_prefect_ensemble.py
@@ -217,12 +217,14 @@ def test_get_flow(coefficients, unused_tcp_port):
                 "outputs": output_transmitters(config),
             }
         )
-        server_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+        server_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         for permuted_steps in permutations(config["steps"]):
             permuted_config = copy.deepcopy(config)
             permuted_config["steps"] = permuted_steps
             permuted_config["dispatch_uri"] = server_config.dispatch_uri
-            ensemble = PrefectEnsemble(permuted_config)
+            ensemble = PrefectEnsemble(permuted_config, custom_port_range=custom_range)
 
             for iens in range(2):
                 with prefect.context(
@@ -611,7 +613,9 @@ def test_prefect_retries(unused_tcp_port, coefficients, tmpdir, function_config)
             coefficients, config.get(ids.STORAGE)["storage_path"]
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["realizations"] = len(coefficients)
         config["executor"] = "local"
         config["max_retries"] = 2
@@ -623,7 +627,7 @@ def test_prefect_retries(unused_tcp_port, coefficients, tmpdir, function_config)
         config["outputs"] = output_transmitters(config)
         config["dispatch_uri"] = service_config.dispatch_uri
 
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
         error_event_reals: Set[str] = set()
         with evaluator.run() as mon:
@@ -664,7 +668,10 @@ def test_prefect_no_retries(unused_tcp_port, coefficients, tmpdir, function_conf
             coefficients, config.get(ids.STORAGE)["storage_path"]
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["realizations"] = len(coefficients)
         config["executor"] = "local"
         config["max_retries"] = 0
@@ -676,7 +683,7 @@ def test_prefect_no_retries(unused_tcp_port, coefficients, tmpdir, function_conf
         config["outputs"] = output_transmitters(config)
         config["dispatch_uri"] = service_config.dispatch_uri
 
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
 
         event_list = []
@@ -735,9 +742,12 @@ def test_run_prefect_ensemble(unused_tcp_port, coefficients):
             }
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["dispatch_uri"] = service_config.dispatch_uri
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
 
         with evaluator.run() as mon:
@@ -792,9 +802,13 @@ def test_run_prefect_for_function_defined_outside_py_environment(
         config["inputs"] = {iens: coeffs_trans[iens] for iens in range(2)}
         config["outputs"] = output_transmitters(config)
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["dispatch_uri"] = service_config.dispatch_uri
-        ensemble = PrefectEnsemble(config)
+
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
         with evaluator.run() as mon:
             for event in mon.track():
@@ -845,13 +859,16 @@ def test_run_prefect_ensemble_with_path(unused_tcp_port, coefficients):
             }
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["config_path"] = Path(config["config_path"])
         config["run_path"] = Path(config["run_path"])
         config["storage"]["storage_path"] = Path(config["storage"]["storage_path"])
         config["dispatch_uri"] = service_config.dispatch_uri
 
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
 
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")
 
@@ -893,13 +910,16 @@ def test_cancel_run_prefect_ensemble(unused_tcp_port, coefficients):
             }
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["config_path"] = Path(config["config_path"])
         config["run_path"] = Path(config["run_path"])
         config["storage"]["storage_path"] = Path(config["storage"]["storage_path"])
         config["dispatch_uri"] = service_config.dispatch_uri
 
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
 
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="2")
 
@@ -942,13 +962,16 @@ def test_run_prefect_ensemble_exception(unused_tcp_port, coefficients):
             }
         )
 
-        service_config = EvaluatorServerConfig(unused_tcp_port)
+        fixed_port = range(unused_tcp_port, unused_tcp_port)
+        custom_range = range(1024, 65535)
+
+        service_config = EvaluatorServerConfig(custom_port_range=fixed_port)
         config["config_path"] = Path(config["config_path"])
         config["run_path"] = Path(config["run_path"])
         config["storage"]["storage_path"] = Path(config["storage"]["storage_path"])
         config["dispatch_uri"] = service_config.dispatch_uri
 
-        ensemble = PrefectEnsemble(config)
+        ensemble = PrefectEnsemble(config, custom_port_range=custom_range)
         ensemble.get_flow = dummy_get_flow
 
         evaluator = EnsembleEvaluator(ensemble, service_config, 0, ee_id="1")

--- a/tests/ensemble_evaluator/test_sync_ws_duplexer.py
+++ b/tests/ensemble_evaluator/test_sync_ws_duplexer.py
@@ -140,7 +140,8 @@ def test_generator(unused_tcp_port, ws):
 
 
 def test_secure_echo(unused_tcp_port, ws):
-    config = EvaluatorServerConfig(unused_tcp_port)
+    custom_port_range = range(unused_tcp_port, unused_tcp_port)
+    config = EvaluatorServerConfig(custom_port_range=custom_port_range)
 
     async def handler(websocket, path):
         msg = await websocket.recv()

--- a/tests/shared/test_port_handler.py
+++ b/tests/shared/test_port_handler.py
@@ -50,8 +50,11 @@ def test_invalid_host_name():
 
 
 def test_get_family():
-    family_inet6 = port_handler.get_family("host:port")
+    family_inet6 = port_handler.get_family("::1")
     assert family_inet6 == socket.AF_INET6
+
+    family_inet = port_handler.get_family("host:port")
+    assert family_inet == socket.AF_INET
 
     family_inet = port_handler.get_family("host")
     assert family_inet == socket.AF_INET

--- a/tests/shared/test_port_handler.py
+++ b/tests/shared/test_port_handler.py
@@ -1,0 +1,57 @@
+import socket
+
+import pytest
+
+from ert_shared import port_handler
+
+
+def test_find_available_port():
+    custom_range = range(50000, 50001)
+    host, port = port_handler.find_available_port(custom_range=custom_range)
+    sock = port_handler.get_socket(host, port)
+    assert host is not None
+    assert port is not None
+    assert port in custom_range
+    assert sock is not None
+    assert sock.fileno() != -1
+
+
+def test_find_available_port_forced(unused_tcp_port):
+    custom_range = range(unused_tcp_port, unused_tcp_port)
+    host, port = port_handler.find_available_port(custom_range=custom_range)
+    assert port == unused_tcp_port
+
+    sock = port_handler.get_socket(host, port)
+    assert sock is not None
+    assert sock.fileno() != -1
+
+
+def test_no_more_ports_in_range():
+    custom_range = range(50000, 50001)
+    host, port = port_handler.find_available_port(custom_range=custom_range)
+    sock = port_handler.get_socket(host, port)
+    assert sock is not None
+    assert sock.fileno() != -1
+
+    with pytest.raises(port_handler.NoPortsInRangeException) as exc_info:
+        port_handler.find_available_port(custom_range=custom_range)
+
+
+def test_invalid_host_name():
+    invalid_host = "invalid_host"
+
+    with pytest.raises(port_handler.InvalidHostException) as exc_info:
+        port_handler.find_available_port(custom_host=invalid_host)
+
+    assert (
+        f"Trying to bind socket with what looks like an invalid hostname ({invalid_host})"
+        in str(exc_info.value)
+    )
+
+
+def test_get_family():
+    family_inet6 = port_handler.get_family("host:port")
+    assert family_inet6 == socket.AF_INET6
+
+    family_inet = port_handler.get_family("host")
+    assert family_inet == socket.AF_INET


### PR DESCRIPTION
**Issue**
Connection failure at random times while testing. Seems like the main problem is our quite narrow range of ports available for use in production. Using this in the tests causing open / close of sockets many times inside this range and we - at some point - are running out of ports and will get a connection error / trying to bind to a port already bound in a previous test and by that could potentially be in time_wait state. 


**Approach**
Merge the code dealing with ports and sockets. Initially i had a plan of keeping track of what was assigned to the different services to avoid the above mentioned issue, but that does not work due to various reasons ( main one - the `prefect_ensemble's` `get_executor` function which is running in new threads ). 

As-is now, the code is merged and i've added tests to it along with some proper exception handling trying to communicate at least some of the known errors that might show up better to us.  The exception handling is a bit difficult as well since osx / linux / different linux versions / different python versions / c versions are all / some giving slightly different msgs in the exceptions / different error codes and have different timeouts.