### PR TITLE
Make cancel test more consistent

### DIFF
--- a/tests/ensemble_evaluator/conftest.py
+++ b/tests/ensemble_evaluator/conftest.py
@@ -77,7 +77,7 @@ def queue_config():
 
 @pytest.fixture
 def make_ensemble_builder(queue_config):
-    def _make_ensemble_builder(tmpdir, num_reals, num_jobs):
+    def _make_ensemble_builder(tmpdir, num_reals, num_jobs, job_sleep=0):
         builder = create_ensemble_builder()
         with tmpdir.as_cwd():
             ext_job_list = []
@@ -90,8 +90,11 @@ def make_ensemble_builder(queue_config):
                 with open(ext_job_exec, "w") as f:
                     f.write(
                         "#!/usr/bin/env python\n"
+                        "import time\n"
+                        "\n"
                         'if __name__ == "__main__":\n'
                         f'    print("stdout from {job_index}")\n'
+                        f"    time.sleep({job_sleep})\n"
                     )
 
                 ext_job_list.append(

--- a/tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -33,7 +33,7 @@ def test_run_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
 def test_run_and_cancel_legacy_ensemble(tmpdir, unused_tcp_port, make_ensemble_builder):
     num_reals = 10
     with tmpdir.as_cwd():
-        ensemble = make_ensemble_builder(tmpdir, num_reals, 2).build()
+        ensemble = make_ensemble_builder(tmpdir, num_reals, 2, job_sleep=5).build()
         config = EvaluatorServerConfig(unused_tcp_port)
 
         evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")


### PR DESCRIPTION
**Issue**
Resolves #1755 


**Approach**
Since the jobs in the cancel test was almost instant it could happen
that the ensemble finished before the test was able to cancel it.
This commits adds 2 seconds of sleep to ensure that the ensemble
runs long enough to be cancelled.