### PR TITLE
Fixes #1794 by making job queue always launch jobs

### DIFF
--- a/res/job_queue/queue.py
+++ b/res/job_queue/queue.py
@@ -451,7 +451,7 @@ class JobQueue(BaseCClass):
             await JobQueue._publish_changes(ee_id, self.snapshot(), websocket)
 
             try:
-                while self.is_active() and not self.stopped:
+                while True:
                     self.launch_jobs(pool_sema)
 
                     await asyncio.sleep(1)
@@ -463,6 +463,8 @@ class JobQueue(BaseCClass):
                     await JobQueue._publish_changes(
                         ee_id, self._changes_after_transition(), websocket
                     )
+                    if not self.is_active() or self.stopped:
+                        break
             except asyncio.CancelledError:
                 if self.stopped:
                     logger.debug(


### PR DESCRIPTION
The legacy ensemble cancel test hit a code path that allowed the legacy
job queue to never enter its work loop, thus never launching jobs.
Having never launched jobs, the thread responsible for running the
queue exits before the thread doing cancel starts/cancels.

If cancellation occurs after a certain point in time, a STOPPED event
will be sent, which is described in #1794.

