### PR TITLE
Add scikit-build and setuptools_scm to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ flaky
 pytest>=6.2.0
 pytest-qt
 schemathesis==1.3.4
+scikit-build
 sphinx
 sphinx-argparse
 sphinx_rtd_theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ flaky
 pytest>=6.2.0
 pytest-qt
 schemathesis==1.3.4
-scikit-build
 sphinx
 sphinx-argparse
 sphinx_rtd_theme
@@ -15,3 +14,5 @@ sphinxcontrib.datatemplates
 decorator
 pylint
 click
+scikit-build
+setuptools_scm


### PR DESCRIPTION
**Issue**
Resolves #1806 


**Approach**
Added `scikit-build and` `setuptools_scm` to `dev_requirements.txt`.
`setuptools_scm` is specified in `setup_requires` but is used for the setup.