### PR TITLE
Revert "Enable ensemble evaluator by default"

### DIFF
--- a/ert_shared/feature_toggling.py
+++ b/ert_shared/feature_toggling.py
@@ -16,7 +16,12 @@ class FeatureToggling:
             msg="The new storage solution is experimental! Thank you for testing our new features.",
         ),
         "ensemble-evaluator": _Feature(
-            default_enabled=True,
+            default_enabled=False,
+            msg="The new ensemble evaluator is experimental! "
+            "The new evaluator will offer the user an expressive, "
+            "high-level configuration system in YAML, as "
+            "well as evaluating ensembles in a concurrent, cloud-ready "
+            "and distributed way.",
         ),
     }
 

--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -98,13 +98,13 @@ def test_ensemble_evaluator(tmpdir, source_root):
                 "poly_runpath_file",
                 "--realizations",
                 "1,2,4,8,16,32,64",
-                "--disable-ensemble-evaluator",
+                "--enable-ensemble-evaluator",
                 "poly_example/poly.ert",
             ],
         )
         FeatureToggling.update_from_args(parsed)
 
-        assert FeatureToggling.is_enabled("ensemble-evaluator") is False
+        assert FeatureToggling.is_enabled("ensemble-evaluator") is True
 
         run_cli(parsed)
         FeatureToggling.reset()
@@ -122,7 +122,7 @@ def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
             parser,
             [
                 ENSEMBLE_SMOOTHER_MODE,
-                "--disable-ensemble-evaluator",
+                "--enable-ensemble-evaluator",
                 "--disable-monitoring",
                 "--target-case",
                 "poly_runpath_file",
@@ -133,7 +133,7 @@ def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
         )
         FeatureToggling.update_from_args(parsed)
 
-        assert FeatureToggling.is_enabled("ensemble-evaluator") is False
+        assert FeatureToggling.is_enabled("ensemble-evaluator") is True
 
         run_cli(parsed)
         FeatureToggling.reset()
@@ -153,30 +153,4 @@ def test_cli_test_run(tmpdir, source_root, mock_cli_run):
     monitor_mock, thread_join_mock, thread_start_mock = mock_cli_run
     monitor_mock.assert_called_once()
     thread_join_mock.assert_called_once()
-    thread_start_mock.assert_has_calls([[call(), call()]])
-
-
-def test_cli_test_connection_error(tmpdir, source_root, capsys):
-    shutil.copytree(
-        os.path.join(source_root, "test-data", "local", "poly_example"),
-        os.path.join(str(tmpdir), "poly_example"),
-    )
-
-    mock_monitor = MagicMock()
-    mock_monitor.__enter__.side_effect = ConnectionRefusedError
-
-    with patch(
-        "ert_shared.status.tracker.evaluator.create_ee_monitor",
-        return_value=mock_monitor,
-    ), patch(
-        "ert_shared.ensemble_evaluator.evaluator.ee_monitor.create",
-        return_value=mock_monitor,
-    ):
-        with tmpdir.as_cwd():
-            parser = ArgumentParser(prog="test_main")
-            parsed = ert_parser(parser, [TEST_RUN_MODE, "poly_example/poly.ert"])
-            with pytest.raises(SystemExit):
-                run_cli(parsed)
-
-    capture = capsys.readouterr()
-    assert "Connection error" in capture.out
+    thread_start_mock.assert_called_once()

--- a/tests/cli/test_model_hook_order.py
+++ b/tests/cli/test_model_hook_order.py
@@ -7,6 +7,9 @@ from ert_shared.models import (
     IteratedEnsembleSmoother,
     MultipleDataAssimilation,
 )
+import inspect
+
+from unittest.mock import MagicMock, call
 from res.enkf.enums import HookRuntime
 
 EXPECTED_CALL_ORDER = [
@@ -51,7 +54,6 @@ def test_hook_call_order_es_mda(monkeypatch):
         "start_iteration": 0,
         "weights": [1],
         "analysis_module": "some_module",
-        "ee_config": EvaluatorServerConfig(),
     }
     mock_sim_runner = MagicMock()
     mock_parent = MagicMock()
@@ -69,7 +71,9 @@ def test_hook_call_order_es_mda(monkeypatch):
     test_class.setAnalysisModule = MagicMock()
     test_class.ert = MagicMock()
 
-    test_class.run_ensemble_evaluator = MagicMock(return_value=1)
+    sim_runner_mock = MagicMock()
+    sim_runner_mock.runSimpleStep.return_value = 1
+    test_class.ert.return_value.getEnkfSimulationRunner = sim_runner_mock
 
     test_class.runSimulations(minimum_args)
 
@@ -108,7 +112,9 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
     analysis_config.getAnalysisIterConfig.return_value.getNumRetries.return_value = 1
     test_class.ert.return_value.analysisConfig.return_value = analysis_config
 
-    test_class.run_ensemble_evaluator = MagicMock(return_value=1)
+    simple_step_mock = MagicMock()
+    simple_step_mock.runSimpleStep.return_value = 1
+    test_class.ert.return_value.getEnkfSimulationRunner.return_value = simple_step_mock
 
     test_class.setAnalysisModule = MagicMock()
     test_class.setAnalysisModule.return_value.getInt.return_value = 1

--- a/tests/status/test_legacy_tracker.py
+++ b/tests/status/test_legacy_tracker.py
@@ -89,7 +89,7 @@ def check_expression(original, path_expression, expected, msg_start):
             "poly_example",
             [
                 ENSEMBLE_SMOOTHER_MODE,
-                "--disable-ensemble-evaluator",
+                "--enable-ensemble-evaluator",
                 "--target-case",
                 "poly_runpath_file",
                 "--realizations",


### PR DESCRIPTION
This reverts commit 8c41328ed8c8b3a10a3a31b665bc6f46dca80abc.

Ports are yet to be opened on-premise.

Cherry-picked the revert commit from the `version-2.24` branch and fixed some conflicting imports.