### PR TITLE
What's another bool among friends?

### DIFF
--- a/res/job_queue/queue.py
+++ b/res/job_queue/queue.py
@@ -302,6 +302,9 @@ class JobQueue(BaseCClass):
         """@rtype: JobStatusType"""
         return self._get_job_status(job_number)
 
+    def did_job_time_out(self, job_number):
+        return self.job_list[job_number].timed_out
+
     def is_active(self):
         for job in self.job_list:
             if (

--- a/tests/models/test_base_run_model.py
+++ b/tests/models/test_base_run_model.py
@@ -43,6 +43,7 @@ class InMemoryBaseRunModelTest(unittest.TestCase):
 
         brm._job_queue = Mock()
         brm._job_queue.getJobStatus.side_effect = job_status
+        brm._job_queue.did_job_time_out.return_value = False
 
         with patch("ert_shared.models.base_run_model.ForwardModelStatus") as f:
             f.load.return_value = Mock()

--- a/tests/status/test_legacy_tracker.py
+++ b/tests/status/test_legacy_tracker.py
@@ -40,7 +40,7 @@ def check_expression(original, path_expression, expected, msg_start):
 @pytest.mark.parametrize(
     "experiment_folder,cmd_line_arguments,num_successful,num_iters,assert_present_in_snapshot",
     [
-        (
+        pytest.param(
             "max_runtime_poly_example",
             [
                 ENSEMBLE_EXPERIMENT_MODE,
@@ -58,8 +58,9 @@ def check_expression(original, path_expression, expected, msg_start):
                     "The run is cancelled due to reaching MAX_RUNTIME",
                 ),
             ],
+            id="legacy_poly_experiment_cancelled_by_max_runtime",
         ),
-        (
+        pytest.param(
             "poly_example",
             [
                 ENSEMBLE_EXPERIMENT_MODE,
@@ -70,8 +71,9 @@ def check_expression(original, path_expression, expected, msg_start):
             5,
             1,
             [(".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FINISHED)],
+            id="legacy_poly_experiment",
         ),
-        (
+        pytest.param(
             "poly_example",
             [
                 ENSEMBLE_SMOOTHER_MODE,
@@ -84,8 +86,9 @@ def check_expression(original, path_expression, expected, msg_start):
             7,
             2,
             [(".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FINISHED)],
+            id="leagcy_poly_smoother",
         ),
-        (
+        pytest.param(
             "poly_example",
             [
                 ENSEMBLE_SMOOTHER_MODE,
@@ -99,8 +102,9 @@ def check_expression(original, path_expression, expected, msg_start):
             7,
             2,
             [(".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FINISHED)],
+            id="ee_poly_smoother",
         ),
-        (
+        pytest.param(
             "failing_poly_example",
             [
                 ENSEMBLE_SMOOTHER_MODE,
@@ -117,6 +121,7 @@ def check_expression(original, path_expression, expected, msg_start):
                 ("0", "reals.'0'.steps.*.jobs.'1'.status", state.JOB_STATE_START),
                 (".*", "reals.'1'.steps.*.jobs.*.status", state.JOB_STATE_FINISHED),
             ],
+            id="legacy_failing_poly_smoother",
         ),
     ],
 )

--- a/tests/status/test_tracking_integration.py
+++ b/tests/status/test_tracking_integration.py
@@ -61,6 +61,27 @@ def check_expression(original, path_expression, expected, msg_start):
             id="legacy_poly_experiment_cancelled_by_max_runtime",
         ),
         pytest.param(
+            "max_runtime_poly_example",
+            [
+                ENSEMBLE_EXPERIMENT_MODE,
+                "--enable-ensemble-evaluator",
+                "--realizations",
+                "0,1",
+                "max_runtime_poly_example/poly.ert",
+            ],
+            0,
+            1,
+            [
+                (".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FAILURE),
+                (
+                    ".*",
+                    "reals.*.steps.*.jobs.*.error",
+                    "The run is cancelled due to reaching MAX_RUNTIME",
+                ),
+            ],
+            id="ee_poly_experiment_cancelled_by_max_runtime",
+        ),
+        pytest.param(
             "poly_example",
             [
                 ENSEMBLE_EXPERIMENT_MODE,
@@ -76,6 +97,20 @@ def check_expression(original, path_expression, expected, msg_start):
         pytest.param(
             "poly_example",
             [
+                ENSEMBLE_EXPERIMENT_MODE,
+                "--enable-ensemble-evaluator",
+                "--realizations",
+                "0,1,2,3,4",
+                "poly_example/poly.ert",
+            ],
+            5,
+            1,
+            [(".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FINISHED)],
+            id="ee_poly_experiment",
+        ),
+        pytest.param(
+            "poly_example",
+            [
                 ENSEMBLE_SMOOTHER_MODE,
                 "--target-case",
                 "poly_runpath_file",
@@ -86,7 +121,7 @@ def check_expression(original, path_expression, expected, msg_start):
             7,
             2,
             [(".*", "reals.*.steps.*.jobs.*.status", state.JOB_STATE_FINISHED)],
-            id="leagcy_poly_smoother",
+            id="legacy_poly_smoother",
         ),
         pytest.param(
             "poly_example",
@@ -122,6 +157,26 @@ def check_expression(original, path_expression, expected, msg_start):
                 (".*", "reals.'1'.steps.*.jobs.*.status", state.JOB_STATE_FINISHED),
             ],
             id="legacy_failing_poly_smoother",
+        ),
+        pytest.param(
+            "failing_poly_example",
+            [
+                ENSEMBLE_SMOOTHER_MODE,
+                "--enable-ensemble-evaluator",
+                "--target-case",
+                "poly_runpath_file",
+                "--realizations",
+                "0,1",
+                "failing_poly_example/poly.ert",
+            ],
+            1,
+            2,
+            [
+                ("0", "reals.'0'.steps.*.jobs.'0'.status", state.JOB_STATE_FAILURE),
+                ("0", "reals.'0'.steps.*.jobs.'1'.status", state.JOB_STATE_START),
+                (".*", "reals.'1'.steps.*.jobs.*.status", state.JOB_STATE_FINISHED),
+            ],
+            id="ee_failing_poly_smoother",
         ),
     ],
 )
@@ -213,3 +268,4 @@ def test_tracking(
                         f"Snapshot {i} did not match:\n",
                     )
         thread.join()
+    FeatureToggling.reset()


### PR DESCRIPTION
- Add a `timed_out` field on the job queue node, which is set to true if the node times out.
- When updating the `detailed_progress` dict, override values if the job queue node timed out.
- Add ids to parameterized tests
- For every legacy test, add an EE test in `test_tracking`.