### PR TITLE
Fix #1830 bug in progress calculation

### DIFF
--- a/ert_shared/status/utils.py
+++ b/ert_shared/status/utils.py
@@ -40,7 +40,7 @@ def tracker_progress(tracker) -> float:
                 state.REALIZATION_STATE_FAILED,
             ]:
                 done_reals += 1
-    total_reals = len(tracker._iter_snapshot[0].get_reals())
+    total_reals = len(tracker._iter_snapshot[current_iter].get_reals())
     return _calculate_progress(
         tracker.is_finished(),
         current_iter,


### PR DESCRIPTION
**Issue**
Resolves #1830 


**Approach**
Fix bug where we would calculate on top of total_reals which always came from iter 0.
For good measure, use `unused_tcp_port` fixture.