### PR TITLE
Run GitHub Actions on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
    branches:
      - main
      - 'version-**'
+   tags: "*"
  pull_request:
 
 env:


### PR DESCRIPTION
When trying to prevent double CI for upstream branches we probably ended up excluding running CI on tags in the process. This pull request tries to fix that...