### PR TITLE
Change __token__ to Token for fetching connection info

### DIFF
--- a/ert_shared/storage/connection.py
+++ b/ert_shared/storage/connection.py
@@ -38,7 +38,7 @@ def get_info(project_path: Union[str, Path] = None) -> Dict[str, Any]:
     with path.open() as f:
         info = json.load(f)
 
-    auth = ("__token__", info["authtoken"])
+    auth = ("Token", info["authtoken"])
     for baseurl in info["urls"]:
         try:
             resp = requests.get(f"{baseurl}/healthcheck", auth=auth)


### PR DESCRIPTION
**Issue**
ert-storage uses `Token` and not `__token__` keyword for authorization token

