### PR TITLE
Initial working example mocked lsf queue running poly

### DIFF
--- a/res/job_queue/__init__.py
+++ b/res/job_queue/__init__.py
@@ -75,6 +75,7 @@ if LSF_HOME:
 from .job_status_type_enum import JobStatusType
 from .run_status_type_enum import RunStatusType
 from .thread_status_type_enum import ThreadStatus
+from .job_submit_status_type_enum import JobSubmitStatusType
 from .job import Job
 from .driver import Driver, QueueDriverEnum
 from .job_queue_node import JobQueueNode

--- a/res/job_queue/job_submit_status_type_enum.py
+++ b/res/job_queue/job_submit_status_type_enum.py
@@ -1,0 +1,19 @@
+from cwrap import BaseCEnum
+
+
+class JobSubmitStatusType(BaseCEnum):
+    TYPE_NAME = "job_submit_status_type_enum"
+    SUBMIT_OK = None
+    SUBMIT_JOB_FAIL = None
+    SUBMIT_DRIVER_FAIL = None
+    SUBMIT_QUEUE_CLOSED = None
+
+    @classmethod
+    def from_string(cls, string):
+        return super().from_string(string)
+
+
+JobSubmitStatusType.addEnum("SUBMIT_OK", 0)
+JobSubmitStatusType.addEnum("SUBMIT_JOB_FAIL", 1)
+JobSubmitStatusType.addEnum("SUBMIT_DRIVER_FAIL", 2)
+JobSubmitStatusType.addEnum("SUBMIT_QUEUE_CLOSED", 3)

--- a/tests/ert_tests/lsf_queue/mocked_commands/mock_bjobs
+++ b/tests/ert_tests/lsf_queue/mocked_commands/mock_bjobs
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import datetime
+import json
+import os.path
+import sys
+
+timestamp = str(datetime.datetime.now())
+
+# File written from the mocked bsub command which provides us with the path to
+# where the job actually runs and where we can find i.e the job_id and status
+with open("job_paths") as job_paths_file:
+    job_paths = job_paths_file.read().splitlines()
+
+print("JOBID USER STAT QUEUE FROM_HOST EXEC_HOST JOB_NAME SUBMIT_TIME")
+for line in job_paths:
+    if not os.path.isfile(line + "/lsf_info.json"):
+        continue
+
+    # ERT has picked up the mocked response
+    # from mock_bsub and written the id to file
+    with open(line + "/lsf_info.json") as id_file:
+        _id = json.load(id_file)["job_id"]
+
+    """
+    Statuses LSF can give us
+    "PEND"
+    "SSUSP"
+    "PSUSP"
+    "USUSP"
+    "RUN"
+    "EXIT"
+    "ZOMBI"  /* The ZOMBI status does not seem to be available from the api. */
+    "DONE"
+    "PDONE"  /* Post-processor is done. */
+    "UNKWN"
+    """
+    status = "RUN"
+    if os.path.isfile(f"{line}/OK"):
+        status = "DONE"
+
+    # Together with the headerline this is actually how LSF is providing its statuses
+    # on the job and how we are picking these up. In this mocked version i just check
+    # if the job is done with the OK file and then print that status for the job_id
+    # retrieved from the same runpath.
+    print(
+        f"{_id} pytest {status} normal mock_host mock_exec_host poly_0 {timestamp}"
+    )
+
+# Just to have a log for test purposes what is actually thrown towards the bjobs command
+with open("bjobs_log", "a+") as f:
+    f.write(f"{str(sys.argv)}\n")

--- a/tests/ert_tests/lsf_queue/mocked_commands/mock_bsub
+++ b/tests/ert_tests/lsf_queue/mocked_commands/mock_bsub
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import random
+import sys
+import subprocess
+
+job_dispatch_path = sys.argv[-2]
+run_path = sys.argv[-1]
+
+# Write a file with the runpaths to where the jobs are running and writing information
+# we later need when providing statuses for the jobs through the mocked bjobs command
+with open("job_paths", "a+") as jobs_file:
+    jobs_file.write(f"{run_path}\n")
+
+# Just a log for testpurposes showing what is thrown against the bsub command
+with open("bsub_log", "a+") as f:
+    f.write(f"{str(sys.argv)}\n")
+
+# Assigning a "unique" job id for each submitted job and print. This is how LSF provide
+# response to ERT with the ID of the job.
+_id = str(random.randint(0, 10000000))
+print(f"Job <{_id}> is submitted to default queue <normal>.")
+
+# Launch job-dispatch
+subprocess.Popen([job_dispatch_path, run_path])

--- a/tests/ert_tests/lsf_queue/test_lsf_driver.py
+++ b/tests/ert_tests/lsf_queue/test_lsf_driver.py
@@ -1,0 +1,126 @@
+import os
+import shutil
+from argparse import ArgumentParser
+from textwrap import dedent
+
+import pytest
+
+from ert_shared.cli import ENSEMBLE_EXPERIMENT_MODE
+from ert_shared.cli.main import run_cli
+from ert_shared.main import ert_parser
+
+
+@pytest.fixture
+def poly_case_context(tmpdir, source_root):
+    # Copy the poly_example files needed
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+
+    # Add the mocked lsf commands to the runpath
+    shutil.copytree(
+        os.path.join(source_root, "tests", "ert_tests", "lsf_queue", "mocked_commands"),
+        os.path.join(str(tmpdir), "poly_example", "mocked_commands"),
+    )
+
+    with tmpdir.as_cwd():
+        yield
+
+
+def test_run_mocked_lsf_queue(poly_case_context):
+    apply_customized_config(log_level="WARNING")
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            ENSEMBLE_EXPERIMENT_MODE,
+            "poly_example/poly.ert",
+        ],
+    )
+
+    run_cli(parsed)
+
+
+def test_mock_bsub_fail_random(poly_case_context):
+    """
+    Approx 7/10 of the submits will fail due to the random generator in the
+    created mocked bsub script. By using the retry functionality towards
+    queue-errors in job_queue.cpp we should still manage to finalize all our runs
+    before exhausting the limits
+    """
+    bsub_random_fail_name = "bsub_random_fail"
+    introduce_bsub_failures(
+        script_name=bsub_random_fail_name, fraction_successful_submits=0.3
+    )
+
+    apply_customized_config(mocked_bsub=bsub_random_fail_name, log_level="WARNING")
+
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            ENSEMBLE_EXPERIMENT_MODE,
+            "poly_example/poly.ert",
+        ],
+    )
+
+    run_cli(parsed)
+
+
+def apply_customized_config(
+    max_running: int = 10,
+    num_realizations: int = 10,
+    min_realizations: int = 1,
+    log_level: str = "INFO",
+    mocked_bsub: str = "mock_bsub",
+):
+
+    # Overwriting the "poly.ert" config file in tmpdir runpath
+    # with our own customized config with at least sets queue option to LSF and
+    # introducing the mocked jobs from "mocked_commands" folder.
+
+    config = [
+        "JOBNAME poly_%d\n",
+        "QUEUE_SYSTEM  LSF\n",
+        f"QUEUE_OPTION LSF  MAX_RUNNING {max_running}\n",
+        "QUEUE_OPTION  LSF  BJOBS_CMD   mocked_commands/mock_bjobs\n",
+        f"QUEUE_OPTION LSF  BSUB_CMD    mocked_commands/{mocked_bsub}\n",
+        "RUNPATH poly_out/real_%d/iter_%d\n",
+        "OBS_CONFIG observations\n",
+        "TIME_MAP time_map\n",
+        f"NUM_REALIZATIONS {num_realizations}\n",
+        f"MIN_REALIZATIONS {min_realizations}\n",
+        "GEN_KW COEFFS coeff.tmpl coeffs.json coeff_priors\n",
+        "GEN_DATA POLY_RES RESULT_FILE:poly_%d.out REPORT_STEPS:0 INPUT_FORMAT:ASCII\n",
+        "INSTALL_JOB poly_eval POLY_EVAL\n",
+        "SIMULATION_JOB poly_eval\n",
+        f"LOG_LEVEL {log_level}\n",
+    ]
+    with open("poly_example/poly.ert", "w") as fh:
+        fh.writelines(config)
+
+
+def introduce_bsub_failures(script_name: str, fraction_successful_submits: float = 1.0):
+    script = dedent(
+        f"""#!/usr/bin/env python3
+import random
+import sys
+import subprocess
+
+num = random.random()
+if num > {fraction_successful_submits}:
+    exit(1)
+
+job_dispatch_path = sys.argv[-2]
+run_path = sys.argv[-1]
+
+subprocess.call(["python", "mocked_commands/mock_bsub", job_dispatch_path, run_path])
+        """
+    )
+
+    manipulated_script_path = f"poly_example/mocked_commands/{script_name}"
+    with open(manipulated_script_path, "w") as fh:
+        fh.write(script)
+
+    os.chmod(manipulated_script_path, 0o755)


### PR DESCRIPTION
In order for us to enable testing on different feedback from LSF we have decided to implement a mocked version enabling us to tweak on the responses and then verify how ERT interacts / handles different responses / errors. 

Based on this we verified the current behavior did not work as expected - and we ended up in an infitie loop inside job_monitor. By using the returned status from submit job and based on set status to `JobStatusType.JOB_QUEUE_DONE` . Then we will utilize the retry mechanism again in the queue itself when fail to submit ( which is currently a 100 x 2 sec schema ). 

The sad thing about this functionality which has been bypassed for a while and caused ERT just hanging when loosing connection to LSF is that the queue after the number of retries specified are throwing the util abort and ERT blows up. We should mitigate this and let jobs fail individually if LSF is unavailable. If i.e 5 out of 100 jobs fails due to lsf have some kind of hiccup that should be ok. 

Will spawn a new issue around this. 
