### PR TITLE
Add support for blob records

### DIFF
--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -63,9 +63,9 @@ def _build_record_argparser(subparsers: Any) -> None:
         help="Path to resource file",
     )
     record_load_parser.add_argument(
-        "--record-type",
-        help="Record type blob or normal (default: normal)",
-        default="normal",
+        "--blob-record",
+        action="store_true",
+        help="Indicate that the record if of type blob"
     )
     sample_parser = sub_record_parsers.add_parser(
         "sample", help="Sample stochastic parameter into a record"
@@ -220,7 +220,7 @@ def _record(workspace: Path, args: Any) -> None:
         )
     elif args.sub_record_cmd == "load":
         ert3.engine.load_record(
-            workspace, args.record_name, args.record_file, args.record_type
+            workspace, args.record_name, args.record_file, args.blob_record
         )
     else:
         raise NotImplementedError(

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -65,7 +65,7 @@ def _build_record_argparser(subparsers: Any) -> None:
     record_load_parser.add_argument(
         "--blob-record",
         action="store_true",
-        help="Indicate that the record if of type blob"
+        help="Indicate that the record is of type blob",
     )
     sample_parser = sub_record_parsers.add_parser(
         "sample", help="Sample stochastic parameter into a record"

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -65,7 +65,7 @@ def _build_record_argparser(subparsers: Any) -> None:
     record_load_parser.add_argument(
         "--blob-record",
         action="store_true",
-        help="Indicate that the record is of type blob",
+        help="Indicate that the record is a blob",
     )
     sample_parser = sub_record_parsers.add_parser(
         "sample", help="Sample stochastic parameter into a record"

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -62,6 +62,11 @@ def _build_record_argparser(subparsers: Any) -> None:
         type=valid_record_file,
         help="Path to resource file",
     )
+    record_load_parser.add_argument(
+        "--record-type",
+        help="Record type blob or normal (default: normal)",
+        default="normal",
+    )
     sample_parser = sub_record_parsers.add_parser(
         "sample", help="Sample stochastic parameter into a record"
     )
@@ -214,7 +219,9 @@ def _record(workspace: Path, args: Any) -> None:
             args.ensemble_size,
         )
     elif args.sub_record_cmd == "load":
-        ert3.engine.load_record(workspace, args.record_name, args.record_file)
+        ert3.engine.load_record(
+            workspace, args.record_name, args.record_file, args.record_type
+        )
     else:
         raise NotImplementedError(
             f"No implementation to handle record command {args.sub_record_cmd}"

--- a/ert3/engine/_clean.py
+++ b/ert3/engine/_clean.py
@@ -17,5 +17,5 @@ def clean(workspace: Path, experiment_names: Set[str], clean_all: bool) -> None:
         }
 
     for name in experiment_names:
-        ert3.storage.delete_experiment(workspace=workspace, experiment_name=name)
+        ert3.storage.delete_experiment(experiment_name=name)
         ert3.evaluator.cleanup(workspace, name)

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -47,10 +47,10 @@ def export(workspace_root: Path, experiment_name: str) -> None:
         raise ValueError("Cannot export experiment that has not been carried out")
 
     parameter_names = ert3.storage.get_experiment_parameters(
-        workspace=workspace_root, experiment_name=experiment_name
+        experiment_name=experiment_name
     )
     response_names = ert3.storage.get_experiment_responses(
-        workspace=workspace_root, experiment_name=experiment_name
+        experiment_name=experiment_name
     )
 
     data = _prepare_export(

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -27,12 +27,19 @@ def _prepare_export(
         if not data:
             data = [{"input": {}, "output": {}} for _ in ensemble_record.records]
 
+
+    ##TODO fix
         assert len(data) == ensemble_record.ensemble_size
         for realization, record in zip(data, ensemble_record.records):
             assert record_name not in realization[data_type]
             # See the Record class for the reason of the 'type ignore'.
             realization[data_type][record_name] = record.data  # type: ignore
 
+        # Do not add the blob records to output
+        if len(data) == ensemble_record.ensemble_size:
+            for realization, record in zip(data, ensemble_record.records):
+                assert record_name not in realization[data_type]
+                realization[data_type][record_name] = record.data
     return data
 
 

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Iterable, List, Dict, Any
 
 import ert3
-from ert.data import Record
+import ert
 
 
 def _prepare_export(
@@ -11,7 +11,7 @@ def _prepare_export(
     experiment_name: str,
     parameter_names: Iterable[str],
     response_names: Iterable[str],
-) -> List[Dict[str, Dict[str, Record]]]:
+) -> List[Dict[str, Dict[str, ert.data.Record]]]:
     data_mapping = [(pname, "input") for pname in parameter_names]
     data_mapping += [(rname, "output") for rname in response_names]
 
@@ -27,19 +27,13 @@ def _prepare_export(
         if not data:
             data = [{"input": {}, "output": {}} for _ in ensemble_record.records]
 
-
-    ##TODO fix
-        assert len(data) == ensemble_record.ensemble_size
-        for realization, record in zip(data, ensemble_record.records):
-            assert record_name not in realization[data_type]
-            # See the Record class for the reason of the 'type ignore'.
-            realization[data_type][record_name] = record.data  # type: ignore
-
-        # Do not add the blob records to output
-        if len(data) == ensemble_record.ensemble_size:
+        if isinstance(ensemble_record.records[0], ert.data.NumericalRecord):
+            assert len(data) == ensemble_record.ensemble_size
             for realization, record in zip(data, ensemble_record.records):
                 assert record_name not in realization[data_type]
-                realization[data_type][record_name] = record.data
+                # See the Record class for the reason of the 'type ignore'.
+                realization[data_type][record_name] = record.data  # type: ignore
+
     return data
 
 

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -17,7 +17,7 @@ def load_record(
         with open(record_file, "rb") as fb:
             raw_ensrecord = fb.read()
         ensrecord = ert.data.EnsembleRecord(
-            records=[ert.data.BlobRecord(data=[raw_ensrecord])]
+            records=[ert.data.BlobRecord(data=raw_ensrecord)]
         )
     else:
         with open(record_file, "r") as f:

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -17,21 +17,18 @@ def load_record(
         with open(record_file, "rb") as fb:
             raw_ensrecord = fb.read()
         ensrecord = ert.data.EnsembleRecord(
-            records=[ert.data.Record(data=[raw_ensrecord])]
+            records=[ert.data.BlobRecord(data=[raw_ensrecord])]
         )
     else:
         with open(record_file, "r") as f:
             raw_ensrecord = json.load(f)
         ensrecord = ert.data.EnsembleRecord(
-            records=[ert.data.Record(data=raw_record) for raw_record in raw_ensrecord]
+            records=[
+                ert.data.NumericalRecord(data=raw_record)
+                for raw_record in raw_ensrecord
+            ]
         )
 
-    ## TODO fix
-    ensrecord = ert.data.EnsembleRecord(
-        records=[
-            ert.data.NumericalRecord(data=raw_record) for raw_record in raw_ensrecord
-        ]
-    )
     ert3.storage.add_ensemble_record(
         workspace=workspace,
         record_name=record_name,

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -7,10 +7,10 @@ import ert3
 
 
 def load_record(
-    workspace: Path, record_name: str, record_file: Path, record_type: str = "normal"
+    workspace: Path, record_name: str, record_file: Path, blob_record: bool
 ) -> None:
 
-    if record_type == "blob":
+    if blob_record:
         with open(record_file, "rb") as f:
             raw_ensrecord = f.read()
         ensrecord = ert.data.EnsembleRecord(

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -7,7 +7,10 @@ import ert3
 
 
 def load_record(
-    workspace: Path, record_name: str, record_file: Path, blob_record: bool
+    workspace: Path,
+    record_name: str,
+    record_file: Path,
+    blob_record: Optional[bool] = False,
 ) -> None:
 
     if blob_record:

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -6,10 +6,24 @@ import ert
 import ert3
 
 
-def load_record(workspace: Path, record_name: str, record_file: Path) -> None:
-    with open(record_file, "r") as f:
-        raw_ensrecord = json.load(f)
+def load_record(
+    workspace: Path, record_name: str, record_file: Path, record_type: str = "normal"
+) -> None:
 
+    if record_type == "blob":
+        with open(record_file, "rb") as f:
+            raw_ensrecord = f.read()
+        ensrecord = ert.data.EnsembleRecord(
+            records=[ert.data.Record(data=[raw_ensrecord])]
+        )
+    else:
+        with open(record_file, "r") as f:
+            raw_ensrecord = json.load(f)
+        ensrecord = ert.data.EnsembleRecord(
+            records=[ert.data.Record(data=raw_record) for raw_record in raw_ensrecord]
+        )
+
+    ## TODO fix
     ensrecord = ert.data.EnsembleRecord(
         records=[
             ert.data.NumericalRecord(data=raw_record) for raw_record in raw_ensrecord

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -14,8 +14,8 @@ def load_record(
 ) -> None:
 
     if blob_record:
-        with open(record_file, "rb") as f:
-            raw_ensrecord = f.read()
+        with open(record_file, "rb") as fb:
+            raw_ensrecord = fb.read()
         ensrecord = ert.data.EnsembleRecord(
             records=[ert.data.Record(data=[raw_ensrecord])]
         )

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -24,11 +24,10 @@ def _prepare_experiment(
         record_name = input_record.record
         record_source = input_record.source.split(_SOURCE_SEPARATOR)
         parameters[record_name] = _get_experiment_record_indices(
-            workspace_root, record_name, record_source, parameters_config, ensemble_size
+            workspace_root, record_source, parameters_config
         )
     responses = [elem.record for elem in ensemble.output]
     ert3.storage.init_experiment(
-        workspace=workspace_root,
         experiment_name=experiment_name,
         parameters=parameters,
         ensemble_size=ensemble_size,
@@ -38,10 +37,8 @@ def _prepare_experiment(
 
 def _get_experiment_record_indices(
     workspace_root: pathlib.Path,
-    record_name: str,
     record_source: List[str],
     parameters_config: ert3.config.ParametersConfig,
-    ensemble_size: int,
 ) -> List[str]:
     assert len(record_source) == 2
     source, source_record_name = record_source
@@ -284,10 +281,9 @@ def _store_output_records(
 def _load_experiment_parameters(
     workspace_root: pathlib.Path,
     experiment_name: str,
-    ensemble: ert3.config.EnsembleConfig,
 ) -> ert.data.MultiEnsembleRecord:
     parameter_names = ert3.storage.get_experiment_parameters(
-        workspace=workspace_root, experiment_name=experiment_name
+        experiment_name=experiment_name
     )
 
     parameters = {}
@@ -307,7 +303,7 @@ def _evaluate(
     workspace_root: pathlib.Path,
     experiment_name: str,
 ) -> None:
-    parameters = _load_experiment_parameters(workspace_root, experiment_name, ensemble)
+    parameters = _load_experiment_parameters(workspace_root, experiment_name)
     output_records = ert3.evaluator.evaluate(
         workspace_root, experiment_name, parameters, ensemble, stages_config
     )

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -53,9 +53,8 @@ def _get_experiment_record_indices(
             ensemble_size=ensemble_size,
         )
 
-        # TODO Might not be the best way of doing this.
         if ensemble_record.records[0].record_type == ert.data.RecordType.LIST_BYTES:
-            return ["blob"]
+            return []
 
         indices: Set[Union[str, int]] = set()
         for record in ensemble_record.records:

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -50,7 +50,6 @@ def _get_experiment_record_indices(
         ensemble_record = ert3.storage.get_ensemble_record(
             workspace=workspace_root,
             record_name=source_record_name,
-            ensemble_size=ensemble_size,
         )
 
         if isinstance(ensemble_record.records[0], ert.data.BlobRecord):
@@ -91,8 +90,14 @@ def _prepare_experiment_record(
         ensemble_record = ert3.storage.get_ensemble_record(
             workspace=workspace_root,
             record_name=record_source[1],
-            ensemble_size=ensemble_size,
         )
+
+        # The blob record from the workspace has size one
+        # We need to copy it (ensemble size) times into the experiment record
+        if isinstance(ensemble_record.records[0], ert.data.BlobRecord):
+            ensemble_record = ert.data.EnsembleRecord(
+                records=[ensemble_record.records[0] for _ in range(ensemble_size)]
+            )
 
         # Workaround to ensure compatible ensemble sizes
         # for sensitivity experiment
@@ -108,7 +113,6 @@ def _prepare_experiment_record(
             workspace=workspace_root,
             record_name=record_name,
             ensemble_record=ensemble_record,
-            ensemble_size=ensemble_size,
             experiment_name=experiment_name,
         )
     elif record_source[0] == "stochastic":
@@ -292,7 +296,6 @@ def _load_experiment_parameters(
             workspace=workspace_root,
             experiment_name=experiment_name,
             record_name=parameter_name,
-            ensemble_size=ensemble.size,
         )
 
     return ert.data.MultiEnsembleRecord(ensemble_records=parameters)

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -53,7 +53,7 @@ def _get_experiment_record_indices(
             ensemble_size=ensemble_size,
         )
 
-        if ensemble_record.records[0].record_type == ert.data.RecordType.LIST_BYTES:
+        if isinstance(ensemble_record.records[0], ert.data.BlobRecord):
             return []
 
         indices: Set[Union[str, int]] = set()

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -53,7 +53,7 @@ def _get_experiment_record_indices(
             ensemble_size=ensemble_size,
         )
 
-        ## TODO Might not be the best way of doing this.
+        # TODO Might not be the best way of doing this.
         if ensemble_record.records[0].record_type == ert3.data.RecordType.LIST_BYTES:
             return ["blob"]
 

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -54,7 +54,7 @@ def _get_experiment_record_indices(
         )
 
         # TODO Might not be the best way of doing this.
-        if ensemble_record.records[0].record_type == ert3.data.RecordType.LIST_BYTES:
+        if ensemble_record.records[0].record_type == ert.data.RecordType.LIST_BYTES:
             return ["blob"]
 
         indices: Set[Union[str, int]] = set()

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -319,7 +319,7 @@ def _response2records(
         ]
     elif record_type == ert.data.RecordType.LIST_BYTES:
         if not ensemble_size:
-            ensemble_size = 1
+            ensemble_size = metadata.ensemble_size
         records = [
             ert.data.BlobRecord(data=[response_content]) for _ in range(ensemble_size)
         ]

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -272,7 +272,7 @@ def _add_numerical_data(
 
 
 def _response2records(
-    response_content: bytes, 
+    response_content: bytes,
     metadata: _NumericalMetaData,
     ensemble_size: Optional[int] = None,
 ) -> ert.data.EnsembleRecord:

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -308,7 +308,7 @@ def _response2records(
             ert.data.NumericalRecord(data=row.to_dict())
             for _, row in dataframe.iterrows()  # pylint: disable=no-member
         ]
-    elif record_type == ert3.data.RecordType.LIST_BYTES:
+    elif record_type == ert.data.RecordType.LIST_BYTES:
         if not ensemble_size:
             ensemble_size = 1
         records = [
@@ -390,7 +390,7 @@ def _get_data(
     ensemble_id = experiment["ensemble_ids"][0]  # currently just one ens per exp
     metadata = _get_numerical_metadata(ensemble_id, record_name)
 
-    if metadata.record_type == ert3.data.RecordType.LIST_BYTES:
+    if metadata.record_type == ert.data.RecordType.LIST_BYTES:
         headers = {"accept": "application/octet-stream"}
     else:
         headers = {"accept": "text/csv"}
@@ -458,7 +458,7 @@ def add_ensemble_record(
     dataframe = pd.DataFrame([r.data for r in ensemble_record.records])
     record_type = _get_record_type(ensemble_record)
 
-    if record_type == ert3.data.RecordType.LIST_BYTES:
+    if record_type == ert.data.RecordType.LIST_BYTES:
         _add_blob_data(
             experiment_name, record_name, ensemble_record, ensemble_size=ensemble_size
         )
@@ -487,7 +487,7 @@ def add_ensemble_record(
 def _add_blob_data(
     experiment_name: str,
     record_name: str,
-    ensemble_record: ert3.data.EnsembleRecord,
+    ensemble_record: ert.data.EnsembleRecord,
     ensemble_size: int,
 ) -> None:
     experiment = _get_experiment_by_name(experiment_name)
@@ -503,7 +503,7 @@ def _add_blob_data(
 
     metadata = _NumericalMetaData(
         ensemble_size=ensemble_size,
-        record_type=ert3.data.RecordType.LIST_BYTES,
+        record_type=ert.data.RecordType.LIST_BYTES,
     )
 
     ensemble_id = experiment["ensemble_ids"][0]  # currently just one ens per exp

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -382,7 +382,7 @@ def _get_data(
             f"Cannot get {record_name} data, no experiment named: {experiment_name}"
         )
 
-    ## TODO: hack ?
+    # TODO: hack ?
     split = record_name.split(".")
     if len(split) == 2 and split[1] == "blob":
         record_name = split[0]
@@ -497,7 +497,7 @@ def _add_blob_data(
             f"non-existing experiment: {experiment_name}"
         )
 
-    ##TODO dis ok ?
+    # TODO dis ok ?
     if not ensemble_size:
         ensemble_size = ensemble_record.ensemble_size
 

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -172,8 +172,8 @@ def init_experiment(
     )
 
 
-def _is_parameter_numeric(record: str, params: Iterable[str]) -> bool:
-    return bool(params)
+def _is_numeric_parameter(record: str, params: Iterable[str]) -> bool:
+    return len(list(params)) > 0
 
 
 def _init_experiment(
@@ -202,7 +202,7 @@ def _init_experiment(
 
     parameter_names = []
     for record, params in parameters.items():
-        if _is_parameter_numeric(record, params):
+        if _is_numeric_parameter(record, params):
             for param in params:
                 parameter_names.append(f"{record}.{param}")
         else:
@@ -419,8 +419,8 @@ def _get_data(
     )
 
 
-def _is_response_parameter_numeric(name: str) -> bool:
-    return len(name.split(".")) != 1
+def _is_numeric_parameter_response(name: str) -> bool:
+    return "." in name
 
 
 def _get_experiment_parameters(
@@ -440,7 +440,7 @@ def _get_experiment_parameters(
 
     parameters = defaultdict(list)
     for name in response.json():
-        if _is_response_parameter_numeric(name):
+        if _is_numeric_parameter_response(name):
             key, val = name.split(".")
             parameters[key].append(val)
         else:

--- a/ert3/storage/_storage.py
+++ b/ert3/storage/_storage.py
@@ -321,7 +321,7 @@ def _response2records(
         if not ensemble_size:
             ensemble_size = 1
         records = [
-            ert.data.Record(data=[response_content]) for _ in range(ensemble_size)
+            ert.data.BlobRecord(data=[response_content]) for _ in range(ensemble_size)
         ]
     else:
         raise ValueError(

--- a/ert3_examples/spe1/experiments/doe/ensemble.yml
+++ b/ert3_examples/spe1/experiments/doe/ensemble.yml
@@ -7,6 +7,9 @@ input:
   -
     source: storage.designed_wells
     record: wells
+  -
+    source: storage.example_data
+    record: spe1case2_data
 
 output:
     -

--- a/ert3_examples/spe1/experiments/doe/ensemble.yml
+++ b/ert3_examples/spe1/experiments/doe/ensemble.yml
@@ -8,8 +8,8 @@ input:
     source: storage.designed_wells
     record: wells
   -
-    source: storage.example_data
-    record: spe1case2_data
+    source: storage.spe1case2_template
+    record: spe1_template
 
 output:
     -

--- a/ert3_examples/spe1/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/spe1/experiments/evaluation/ensemble.yml
@@ -8,8 +8,8 @@ input:
     source: stochastic.wells_no_delay
     record: wells
   -
-    source: storage.example_data
-    record: spe1case2_data
+    source: storage.spe1case2_template
+    record: spe1_template
 
 output:
     -

--- a/ert3_examples/spe1/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/spe1/experiments/evaluation/ensemble.yml
@@ -7,6 +7,9 @@ input:
   -
     source: stochastic.wells_no_delay
     record: wells
+  -
+    source: storage.example_data
+    record: spe1case2_data
 
 output:
     -

--- a/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
@@ -5,6 +5,9 @@ input:
   -
     source: stochastic.wells
     record: wells
+  -
+    source: storage.example_data
+    record: spe1case2_data
 
 output:
     -

--- a/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
@@ -6,8 +6,8 @@ input:
     source: stochastic.wells
     record: wells
   -
-    source: storage.example_data
-    record: spe1case2_data
+    source: storage.spe1case2_template
+    record: spe1_template
 
 output:
     -

--- a/ert3_examples/spe1/run_demo
+++ b/ert3_examples/spe1/run_demo
@@ -7,11 +7,7 @@
 
 set -e
 
-# TODO: This is a hack because of the lack of blob records. Hence, we currently
-# copy the datafile to the compute nodes and this environment variable makes
-# the workspace transportable.
-export SPE1_WORKSPACE_ROOT=$(pwd)
-
+ert3 record load example_data resources/SPE1CASE2.DATA.jinja2
 ert3 run evaluation
 ert3 export evaluation
 

--- a/ert3_examples/spe1/run_demo
+++ b/ert3_examples/spe1/run_demo
@@ -7,7 +7,7 @@
 
 set -e
 
-ert3 record load example_data resources/SPE1CASE2.DATA.jinja2
+ert3 record load example_data resources/SPE1CASE2.DATA.jinja2 --blob-record
 ert3 run evaluation
 ert3 export evaluation
 

--- a/ert3_examples/spe1/run_demo
+++ b/ert3_examples/spe1/run_demo
@@ -7,7 +7,7 @@
 
 set -e
 
-ert3 record load example_data resources/SPE1CASE2.DATA.jinja2 --blob-record
+ert3 record load spe1case2_template resources/SPE1CASE2.DATA.jinja2 --blob-record
 ert3 run evaluation
 ert3 export evaluation
 

--- a/ert3_examples/spe1/stages.yml
+++ b/ert3_examples/spe1/stages.yml
@@ -8,8 +8,8 @@
       record: wells
       location: wells.json
     -
-      record: spe1case2_data
-      location: SPE1CASE2.DATA.jinja2
+      record: spe1_template
+      location: SPE1.DATA.jinja2
 
   output:
     -
@@ -36,6 +36,6 @@
       location: render.py
 
   script:
-    - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json wells.json -o SPE1CASE2.DATA
-    - flow SPE1CASE2
-    - summary2json --datafile SPE1CASE2.DATA --keywords WOPT:PROD WWPT:PROD WGPT:PROD WWIT:INJ
+    - render -t SPE1.DATA.jinja2 -i field_properties.json wells.json -o SPE1.DATA
+    - flow SPE1
+    - summary2json --datafile SPE1.DATA --keywords WOPT:PROD WWPT:PROD WGPT:PROD WWIT:INJ

--- a/ert3_examples/spe1/stages.yml
+++ b/ert3_examples/spe1/stages.yml
@@ -7,6 +7,9 @@
     -
       record: wells
       location: wells.json
+    -
+      record: spe1case2_data
+      location: SPE1CASE2.DATA.jinja2
 
   output:
     -
@@ -33,9 +36,6 @@
       location: render.py
 
   script:
-    # TODO: The following cp should not be present, instead files should be
-    # transferred as blob records.
-    - cp ${SPE1_WORKSPACE_ROOT}/resources/SPE1CASE2.DATA.jinja2 SPE1CASE2.DATA.jinja2
     - render -t SPE1CASE2.DATA.jinja2 -i field_properties.json wells.json -o SPE1CASE2.DATA
     - flow SPE1CASE2
     - summary2json --datafile SPE1CASE2.DATA --keywords WOPT:PROD WWPT:PROD WGPT:PROD WWIT:INJ

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -215,7 +215,6 @@ def test_cli_status_some_runs(workspace, capsys):
     done_indices = [1, 3]
     for idx in done_indices:
         ert3.storage.init_experiment(
-            workspace=workspace,
             experiment_name=experiments[idx],
             parameters={},
             ensemble_size=42,
@@ -238,7 +237,6 @@ def test_cli_status_all_run(workspace, capsys):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace,
             experiment_name=experiment,
             parameters={},
             ensemble_size=42,
@@ -300,7 +298,6 @@ def test_cli_clean_all(workspace):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace,
             experiment_name=experiment,
             parameters={},
             ensemble_size=42,
@@ -333,7 +330,6 @@ def test_cli_clean_one(workspace):
     for experiment in experiments:
         experiments_folder.mkdir(experiment)
         ert3.storage.init_experiment(
-            workspace=workspace,
             experiment_name=experiment,
             parameters={},
             ensemble_size=42,
@@ -373,7 +369,6 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
 
     for experiment in experiments:
         ert3.storage.init_experiment(
-            workspace=workspace,
             experiment_name=experiment,
             parameters={},
             ensemble_size=42,

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -135,6 +135,7 @@ def _assert_equal_data(a, b):
         [{"data": [i + 0.5, i + 1.1, i + 2.2]} for i in range(3)],
         [{"data": {"a": i + 0.5, "b": i + 1.1, "c": i + 2.2}} for i in range(5)],
         [{"data": {2: i + 0.5, 5: i + 1.1, 7: i + 2.2}} for i in range(2)],
+        [{"data": [b"asdfkasjdhjflkjah21WE123TTDSG34f"]}],
     ),
 )
 def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
@@ -214,7 +215,7 @@ def test_add_and_get_ensemble_parameter_record(tmpdir, raw_ensrec, ert_storage):
         workspace=tmpdir, experiment_name="experiment_name", _flatten=False
     )
     if not indices:
-        assert len(record_names) == 1 and "my_ensemble_record" == record_names[0]
+        assert len(record_names) == 1 and record_names[0] == "my_ensemble_record"
     else:
         assert {f"my_ensemble_record.{x}" for x in indices} == set(record_names)
 

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -457,7 +457,8 @@ def test_ensemble_responses_and_parameters(tmpdir, ert_storage):
 
 @pytest.mark.requires_ert_storage
 def test_add_and_get_blob_record(tmpdir, ert_storage):
-    # this test should be added to the test_add_and_get_ensemble_parameter_record() test above
+    # this test should be added to the
+    # test_add_and_get_ensemble_parameter_record() test above
     record_name = "test_data"
     experiment_name = "exp"
     data = b"ASDFQEWRGFWEzwz3TRHSDFBVWRET12awd"

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -472,7 +472,7 @@ def test_add_and_get_blob_record(tmpdir, ert_storage):
         responses=[],
     )
 
-    ensemble_record = ert3.data.EnsembleRecord(records=[ert3.data.Record(data=[data])])
+    ensemble_record = ert.data.EnsembleRecord(records=[ert.data.Record(data=[data])])
     ert3.storage.add_ensemble_record(
         workspace=tmpdir,
         record_name=record_name,

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -453,3 +453,34 @@ def test_ensemble_responses_and_parameters(tmpdir, ert_storage):
             ensemble_size=1,
             responses=responses,
         )
+
+
+@pytest.mark.requires_ert_storage
+def test_add_and_get_blob_record(tmpdir, ert_storage):
+    # this test should be added to the test_add_and_get_ensemble_parameter_record() test above
+    record_name = "test_data"
+    experiment_name = "exp"
+    data = b"ASDFQEWRGFWEzwz3TRHSDFBVWRET12awd"
+
+    ert3.storage.init(workspace=tmpdir)
+    ert3.storage.init_experiment(
+        workspace=tmpdir,
+        experiment_name=experiment_name,
+        parameters={},
+        ensemble_size=1,
+        responses=[],
+    )
+
+    ensemble_record = ert3.data.EnsembleRecord(records=[ert3.data.Record(data=[data])])
+    ert3.storage.add_ensemble_record(
+        workspace=tmpdir,
+        record_name=record_name,
+        ensemble_record=ensemble_record,
+        experiment_name=experiment_name,
+    )
+
+    blob_ensemble_record = ert3.storage.get_ensemble_record(
+        workspace=tmpdir, record_name=record_name, experiment_name=experiment_name
+    )
+
+    assert blob_ensemble_record.records[0].data[0] == data

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -128,7 +128,7 @@ def _assert_equal_data(a, b):
         [{"data": [i + 0.5, i + 1.1, i + 2.2]} for i in range(3)],
         [{"data": {"a": i + 0.5, "b": i + 1.1, "c": i + 2.2}} for i in range(5)],
         [{"data": {2: i + 0.5, 5: i + 1.1, 7: i + 2.2}} for i in range(2)],
-        [{"data": [b"asdfkasjdhjflkjah21WE123TTDSG34f"]}],
+        [{"data": b"asdfkasjdhjflkjah21WE123TTDSG34f"}],
     ),
 )
 def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
@@ -155,7 +155,7 @@ def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
         [{"data": [i + 0.5, i + 1.1, i + 2.2]} for i in range(3)],
         [{"data": {"a": i + 0.5, "b": i + 1.1, "c": i + 2.2}} for i in range(5)],
         [{"data": {2: i + 0.5, 5: i + 1.1, 7: i + 2.2}} for i in range(2)],
-        [{"data": [b"asdfkasjdhjflkjah21WE123TTDSG34f"]}],
+        [{"data": b"asdfkasjdhjflkjah21WE123TTDSG34f"}],
     ),
 )
 def test_add_and_get_ensemble_parameter_record(tmpdir, raw_ensrec, ert_storage):
@@ -178,12 +178,11 @@ def test_add_and_get_ensemble_parameter_record(tmpdir, raw_ensrec, ert_storage):
 
     """
     raw_data = raw_ensrec[0]["data"]
-    assert isinstance(raw_data, (list, dict))
-    if isinstance(raw_data, list):
-        if isinstance(raw_data[0], bytes):
-            indices = []
-        else:
-            indices = [str(x) for x in range(len(raw_data))]
+    assert isinstance(raw_data, (list, dict, bytes))
+    if isinstance(raw_data, bytes):
+        indices = []
+    elif isinstance(raw_data, list):
+        indices = [str(x) for x in range(len(raw_data))]
     else:
         indices = [str(x) for x in raw_data]
 

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -23,7 +23,6 @@ def test_ensemble_size_zero(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     with pytest.raises(ValueError, match="Ensemble cannot have a size <= 0"):
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name="my_experiment",
             parameters={},
             ensemble_size=0,
@@ -36,7 +35,6 @@ def test_none_as_experiment_name(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     with pytest.raises(ValueError, match="Cannot initialize experiment without a name"):
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name=None,
             parameters={},
             ensemble_size=10,
@@ -48,7 +46,6 @@ def test_none_as_experiment_name(tmpdir, ert_storage):
 def test_double_add_experiment(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     ert3.storage.init_experiment(
-        workspace=tmpdir,
         experiment_name="my_experiment",
         parameters={},
         ensemble_size=42,
@@ -59,7 +56,6 @@ def test_double_add_experiment(tmpdir, ert_storage):
         match="Cannot initialize existing experiment",
     ):
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name="my_experiment",
             parameters={},
             ensemble_size=42,
@@ -84,7 +80,6 @@ def test_add_experiments(tmpdir, ert_storage):
             key: ["some_coeff"] for key in experiment_parameter_records
         }
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name=experiment_name,
             parameters=experiment_parameters,
             ensemble_size=42,
@@ -95,7 +90,7 @@ def test_add_experiments(tmpdir, ert_storage):
         assert expected_names == retrieved_names
 
         parameters = ert3.storage.get_experiment_parameters(
-            workspace=tmpdir, experiment_name=experiment_name
+            experiment_name=experiment_name
         )
         assert experiment_parameter_records == parameters
 
@@ -108,9 +103,7 @@ def test_get_parameters_unknown_experiment(tmpdir, ert_storage):
         ert3.exceptions.NonExistantExperiment,
         match="Cannot get parameters from non-existing experiment: unknown-experiment",
     ):
-        ert3.storage.get_experiment_parameters(
-            workspace=tmpdir, experiment_name="unknown-experiment"
-        )
+        ert3.storage.get_experiment_parameters(experiment_name="unknown-experiment")
 
 
 def _assert_equal_data(a, b):
@@ -196,7 +189,6 @@ def test_add_and_get_ensemble_parameter_record(tmpdir, raw_ensrec, ert_storage):
 
     ert3.storage.init(workspace=tmpdir)
     ert3.storage.init_experiment(
-        workspace=tmpdir,
         experiment_name="experiment_name",
         parameters={"my_ensemble_record": indices},
         ensemble_size=len(raw_ensrec),
@@ -266,7 +258,6 @@ def test_add_and_get_experiment_ensemble_record(tmpdir, ert_storage):
     for eid in range(1, 2):
         experiment = eid * "e"
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name=experiment,
             parameters={},
             ensemble_size=ensemble_size,
@@ -340,7 +331,6 @@ def test_get_record_names(tmpdir, ert_storage):
     for eid in [1, 2, 3]:
         experiment = "e" + str(eid)
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name=experiment,
             parameters={},
             ensemble_size=ensemble_size,
@@ -384,7 +374,6 @@ def test_get_record_names_unknown_experiment(tmpdir, ert_storage):
 def test_delete_experiment(tmpdir, ert_storage):
     ert3.storage.init(workspace=tmpdir)
     ert3.storage.init_experiment(
-        workspace=tmpdir,
         experiment_name="test",
         parameters={},
         ensemble_size=42,
@@ -397,11 +386,9 @@ def test_delete_experiment(tmpdir, ert_storage):
         ert3.exceptions.NonExistantExperiment,
         match="Experiment does not exist: does_not_exist",
     ):
-        ert3.storage.delete_experiment(
-            workspace=tmpdir, experiment_name="does_not_exist"
-        )
+        ert3.storage.delete_experiment(experiment_name="does_not_exist")
 
-    ert3.storage.delete_experiment(workspace=tmpdir, experiment_name="test")
+    ert3.storage.delete_experiment(experiment_name="test")
 
     assert "test" not in ert3.storage.get_experiment_names(workspace=tmpdir)
 
@@ -421,7 +408,6 @@ def test_get_ensemble_responses(
     ert3.storage.init(workspace=tmpdir)
     experiment = "exp"
     ert3.storage.init_experiment(
-        workspace=tmpdir,
         experiment_name=experiment,
         parameters={},
         ensemble_size=1,
@@ -439,7 +425,7 @@ def test_get_ensemble_responses(
         )
 
     fetched_ensemble_responses = ert3.storage.get_experiment_responses(
-        workspace=tmpdir, experiment_name=experiment
+        experiment_name=experiment
     )
 
     assert set(fetched_ensemble_responses) == set(expected_result)
@@ -455,7 +441,6 @@ def test_ensemble_responses_and_parameters(tmpdir, ert_storage):
         match="parameters and responses cannot have a name in common",
     ):
         ert3.storage.init_experiment(
-            workspace=tmpdir,
             experiment_name=experiment,
             parameters={"resp1": ["some-key"]},
             ensemble_size=1,

--- a/tests/ert_tests/ert3/workspace/test_workspace.py
+++ b/tests/ert_tests/ert3/workspace/test_workspace.py
@@ -78,7 +78,6 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
     Path(experiments_dir / "test2").mkdir(parents=True)
 
     ert3.storage.init_experiment(
-        workspace=tmpdir,
         experiment_name="test1",
         parameters={},
         ensemble_size=42,


### PR DESCRIPTION
**Issue**
Resolves #1426

**Approach**
- Add loading of blob record.  Ie: `ert3 record load example_data resources/SPE1CASE2.DATA.jinja2 --blob-record`
- When preparing a blob record for an experiment it is copied N times where N=(ensemble size) 
- Added a new input for the data blob to the `experiment.xml` for each experiment
- Added a new input for the data blob to the `stages.xml` and remove the copy of data blob 
- Update record test fixtures to include blob record
- Fix export so the blob is not included in the exported JSON


