### PR TITLE
Add missing release notes

### DIFF
--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,86 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.24
+------------
+
+Bugfixes:
+  - ert3: Fix wrongly typed distribution index
+  - Fix bug in prefect ensemble error handling
+  - Fix retry connection in evaluator tracker
+  - Fix rounding error in realization progress visualisation (`#1672 <https://github.com/equinor/ert/issues/1672>`_)
+  - Re-add `stderr` and `stdout` info
+  - Re-enable retries for Tasks
+  - Add timeout when waiting for cancelled dispatchers
+  - Use isoformat for timestamps when converting to str (`#1637 <https://github.com/equinor/ert/issues/1637>`_)
+  - Pass `ee_id` to `execute_queue_async`
+  - Fix running event loop in gui sim thread
+  - Fix cancelling of ensemble hanging for ever
+  - Handle dns operation timeout (`#1625 <https://github.com/equinor/ert/issues/1625>`_)
+  - Fix JOB_QUEUE_DO_KILL_NODE_FAILURE spelling error
+  - Update detailed progress after failure (`#1658 <https://github.com/equinor/ert/issues/1658>`_)
+
+New features:
+  - Add support for Python 3.9
+  - Add callback function for catching MAX_RUNTIME failure (`#1525 <https://github.com/equinor/ert/issues/1525>`_)
+  - Add method keys() to LocalDataset
+
+Improvements:
+  - Pass ert3 records to storage as numerical data
+  - Define, test and document communication protocols in EE (`#1235 <https://github.com/equinor/ert/issues/1235>`_)
+  - Connection error handling in EvaluatorTracker (`#1679 <https://github.com/equinor/ert/issues/1679>`_)
+  - Batch all event types
+  - Order real status according to state transitions
+  - ert3: Ensure immutable stages config
+  - ert3: Ensure immutable ensemble config
+  - ert3: Ensure immutable experiment config
+  - ert3: Introduce parameters config
+  - ert3: Make distributions expose their arguments
+  - Fix usage of .closed in socket code (`#1600 <https://github.com/equinor/ert/issues/1600>`_)
+  - ERT 3: Feature/step type class
+  - Use the prefect context to pass url, token and certification info
+  - Force x_axis values to be strings before json serialization
+  - Extract priors to new storage
+  - Add certificates and tokens to websocket communication (`#1326 <https://github.com/equinor/ert/issues/1326>`_)
+  - Add batching of events in ensemble evaluator (`#1683 <https://github.com/equinor/ert/issues/1683>`_)
+  - Log evaluator cross talk (`#1647 <https://github.com/equinor/ert/pull/1647>`_)
+  - Remove ensemble evaluator feature flag warning
+  - Use `phaseCount` in progress calculation, drop phase (`#1635 <https://github.com/equinor/ert/issues/1635>`_)
+  - Timeout CI pipeline after 30 mins
+  - Refactor evaluator utils
+  - Refactor `update_step` to refer to step entities
+  - Refactor and extend testing of PartialSnapshot
+  - Remove size cap on ensemble evaluator msg queue
+  - Add 'ensemble_size' as param to 'post_ensemble_data'
+  - Add record class 'response' to extracted responses
+  - Add test to make sure total progress is updated (`#1608 <https://github.com/equinor/ert/issues/1608>`_)
+  - Keep tracker iteration snapshot up to date
+  - Use ERT Storage's TestClient
+  - Improve cancellation of ensembles
+  - Add token and certificates to websocket communication
+  - Re-add stderr and stdout info
+  - Use public MonkeyPatch
+  - Re-use Client for dispatch lifecycle
+  - Add --summary-conversion flag with default no to eclipse run
+  - Require `ee_id` in `execute_queue_async`
+  - Allow certificate to be `None`
+
+Dependencies:
+  - Upgrade to websockets 9 (`#1615 <https://github.com/equinor/ert/issues/1615>`_)
+  - Depend on `dnspython>=2` and `pydantic>=1.8.1`
+
+Miscellaneous:
+  - Cleanup exceptions in ert3.storage
+  - Introduce SyncWebsocketDuplexer (`#1538 <https://github.com/equinor/ert/issues/1538>`_)
+  - Refactor: Remove handlers from evaluator
+  - Pin pytest-qt<4
+  - Add integration tests for post_ensemble_data (`#1669 <https://github.com/equinor/ert/issues/1669>`_)
+  - ert3: Use public interface when testing ensemble config
+  - Add classifiers to setup.py
+  - Cleanup prefect ensemble test for function defined outside the python environment
+  - Add logging to development strategy
+  - Add type hinting to make mypy pass on ert3 in strict mode
+
 Version 2.23
 ------------
 

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,40 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.23
+------------
+
+Bugfixes:
+  - Fix 1307 by removing the signaller from the pool (`#1307 <https://github.com/equinor/ert/issues/1307>`_)
+  - Fix extraction bug when no observations
+  - Fix function ensemble run on PBS cluster by cloudpickling function (`#1505 <https://github.com/equinor/ert/issues/1505>`_)
+
+New features:
+  - Use experiment in ert-storage for ert3 (`#1554 <https://github.com/equinor/ert/issues/1554>`_)
+
+Improvements:
+  - Stop using ArgParse FileType (`#1500 <https://github.com/equinor/ert/issues/1500>`_)
+  - Remove and stop using the nfs_adaptor for status messages (`#1344 <https://github.com/equinor/ert/issues/1344>`_)
+  - Make legacy ensemble members connect through websocket
+  - Updates related to row scaling
+  - Adapt websockets events to new event model
+  - Introduce RecordTransmitter (`#1334 <https://github.com/equinor/ert/issues/1334>`_, `#1447 <https://github.com/equinor/ert/issues/1447>`_, `#1328 <https://github.com/equinor/ert/issues/1328>`_, `#1502 <https://github.com/equinor/ert/issues/1502>`_)
+  - Make ert3 ensemble config forward model point to a single stage (`#1553 <https://github.com/equinor/ert/issues/1553>`_)
+  - Move data extraction to new ert-storage rest api (`#1544 <https://github.com/equinor/ert/issues/1544>`_)
+  - Extract priors to new storage
+  - Force x_axis values to be strings before json serialization
+  - Fix x axis to str, when posting update data
+  - Update detailed progress after failure (`#1658 <https://github.com/equinor/ert/issues/1658>`_)
+  - Use snapshot instead of run_context (`#1658 <https://github.com/equinor/ert/issues/1658>`_)
+
+Miscellaneous:
+  - Refactor Realization/Stages/Steps (`#1220 <https://github.com/equinor/ert/issues/1220>`_)
+  - Drop broken ertplot script (`#547 <https://github.com/equinor/ert/issues/547>`_)
+  - Add development strategy
+  - Remove new legacy storage db (`#1544 <https://github.com/equinor/ert/issues/1544>`_)
+  - Advertise ert_shared entry point as ert (`#418 <https://github.com/equinor/ert/issues/418>`_)
+  - Add function step tests for function defined outside python environment (`#1556 <https://github.com/equinor/ert/issues/1556>`_)
+
 Version 2.22
 ------------
 

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,45 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.20
+------------
+
+Bugfixes:
+  - Fix for default tabs selection (`#1282 <https://github.com/equinor/ert/issues/1282>`_)
+
+New features:
+  - Run eclipse using eclrun when available
+  - Add row scaling API
+  - Fist working iteration of prefect evaluator (`#1125 <https://github.com/equinor/ert/issues/1125>`_)
+  - Introduce ert3 (`#1311 <https://github.com/equinor/ert/issues/1311>`_)
+
+Improvements:
+  - Disable logging in forward models and workflows
+  - Unify code paths with and without monitoring
+  - Graceful exit if storage_server.json exists
+  - Clarify how rel paths in workflow are resolved
+  - Return empty list in create_observations when no obs are available
+  - Add --host setting to ert api
+  - Storage: Allow NaNs to be returned (`#1284 <https://github.com/equinor/ert/issues/1284>`_)
+  - Storage: Move database to /tmp while using it (`#1309 <https://github.com/equinor/ert/issues/1309>`_)
+  - Make evaluator input files configurable
+  - Avoid unnecessary stack trace during `ert vis` (`#1306 <https://github.com/equinor/ert/issues/1306>`_)
+  - Storage: Combine ParameterDefinition & Parameter
+
+Dependencies:
+  - Add `pyrsistent` (`#1376 <https://github.com/equinor/ert/issues/1376>`_)
+
+Miscellaneous:
+  - Remove builtin and __future__ imports
+  - Fix wrong tests folder in Github Actions
+  - Introduce exceptions module for ert3 workspace errors
+  - Create CONTRIBUTING.md
+  - Refactor Storage API Server (`#1102 <https://github.com/equinor/ert/issues/1102>`_, `#1116 <https://github.com/equinor/ert/issues/1116>`_)
+  - Fix extraction.py's create_update
+  - Correct spelling of modelling to British variant
+  - Copy examples when running Jenkins CI
+  - Run flake8 on the ert3 module as part of CI
+
 
 Version 2.19
 ------------

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,71 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.22
+------------
+
+Bugfixes:
+  - Fix wrong use of STDERR identifier
+
+New features:
+  - Add ert3 status command (`#1457 <https://github.com/equinor/ert/issues/1457>`_)
+  - Add ert3 clean sub-command
+  - Use the new storage to fetch/store results running ert3
+  - Add possibility to initialise examples from cli for ert3
+  - Add forward model function step
+  - Make TEMPLATE_RENDER support parameters.json not being present
+
+Improvements:
+  - Revert "Add retry to ert3"
+  - Look up correct stage in stages_config
+  - Remove redundant engine code
+  - Have ert3.engine stop closing passed streams (`#1498 <https://github.com/equinor/ert/issues/1498>`_)
+  - Use forkserver as strategy with multiprocessing
+  - Ensure fresh loop in prefect ensemble to fix the Bad file descriptor
+  - Make observation active mask not a list
+  - Reintroduce rendering of job statuses
+  - Set prefect log level to WARNING when running
+
+Dependencies:
+  - Add ert-storage as extras to setup.py
+
+Miscellaneous:
+  - Reorder ert3 submodule imports
+  - Use conditionals to import Literal
+  - Add __all__ to ert3.data
+  - Introduce type checking for ert3 in CI
+  - Add type hints to ert3.storage
+  - Run strict type checking for ert3.storage
+  - Add type hints to ert3.engine
+  - Add pylintrc
+  - Run pylint for ert3 as part of style CI workflow
+  - Replace usage of ert3 examples folder with generated test data in ert3
+  - Remove used of example folder in ert3 evaluator tests
+  - Remove used of example folder in ert3 cli tests
+  - Fix flake8 errors
+  - Remove used of example folder in ert3 stages config tests
+  - More removal of examples folder reference from ert3 cli tests
+  - Remove unused imports
+  - Enable pylint error: unused-import
+  - Reposition imports
+  - Enable pylint error: wrong-import-position
+  - Reorder imports
+  - Enable pylint error: wrong-import-order
+  - Enable pylint error: ungrouped-imports
+  - Improve reporting of validation errors
+  - Refactor UnixStep
+  - Replacing magic strings
+  - Remove faulty col resize and add tooltip
+  - Improve storage development workflow
+  - Add tests for the prefect ensemble
+  - Use pydantic to instantiate all dicts
+  - Move conftest out to tests/gui
+  - Improve ensemble client and add new tests
+  - Set timeout of all jobs to 15 minutes
+  - Increase build timeout to 30 minutes
+  - Drop SPE1 example templating hack
+  - Fix examples/polynomial Github Actions workflow
+
 Version 2.21
 ------------
 

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,83 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.21
+------------
+
+Bugfixes:
+  - Set correct phase count in ESMDA model
+  - Prevent double startup of storage server
+  - Seperate Update creation from ensemble creation and link observation transformation
+  - Don't assume singular snapshot in CLI. Fixes a problem where ERT would crash on iiteration 1 if a realization failed in iteration 0.
+
+New features:
+  - Add obs_location property to misfits and corresponding test (`#1373 <https://github.com/equinor/ert/issues/1373>`_)
+  - Implement oat sensitivity algorithm
+  - Add ert3 support for sensitivity studies
+  - Apply row scaling in the smoother update
+
+Improvements:
+  - Add failure event and use it in the legacy and prefect ensembles (`#1301 <https://github.com/equinor/ert/issues/1301>`_)
+  - Push ensembles separarate from responses to new storage
+  - Use numpy_vector instead of deprecated method
+  - Fix snake_oil_field ert config
+  - Remove the prefect option from ert
+  - Remove coefficient generation in Prefect Ensemble
+  - Use LocalDaskCluster to run local ensembles
+  - Add index and ppf to distributions
+  - Introduce experiment folder in workspace
+  - Add uniform polynomial experiments
+  - Add ert3 reservoir example based on SPE1 and flow
+  - Refactor of Qt Graphical User Interface (`#566 <https://github.com/equinor/ert/issues/566>`_)
+  - Add error if not response could be loaded for `MeasuredData`
+  - Introduce record data types
+  - Add retry to the ert3 evaluator
+  - Check queue hash when updating in LegacyTracker
+  - Use forkserver as strategy with multiprocessing
+  - Always use queue from map in LegacyTracker (`#1476 <https://github.com/equinor/ert/issues/1476>`_)
+  - Check if partial_snapshot is None before merging
+  - Reintroduce rendering of job statuses
+  - `JobQueue.snapshot` provide the user with a snapshot of the queue state that can be queried independently of `run_context` and `run_arg`
+  - `JobQueue.execute_queue_async` and `JobQueue.stop_jobs_async` provides asynchronous execution and stopping of queue
+  - Remove fs dependency for summary observation collector
+  - Force sequential execution of callbacks
+  - Export shared rng to Python
+
+Deprecations:
+  - Depecate loading functions
+
+Miscellaneous:
+  - Turn monitor into a context manager (`#1332 <https://github.com/equinor/ert/issues/1332>`_)
+  - Load config close to ensemble evaluator evaluation
+  - Refactor data loading
+  - Refactor plot api
+  - Black plot api
+  - Run test-data as a part of CI
+  - Change patch import in ert3 cli test
+  - Add base distribution
+  - Fix Literal imports
+  - Run polynomial demo during CI
+  - Remove trailing whitespace
+  - Break before binary operators
+  - Make lambda's into def's
+  - Run pylint during CI
+  - Create CODE_OF_CONDUCT.md (`#1414 <https://github.com/equinor/ert/issues/1414>`_)
+  - Add black badge to README
+  - Run black on everything in CI
+  - Format all files
+  - Update badges
+  - Move flake8 settings into .flake8 config
+  - Fix test that was testing a (now fixed) bug in `libres`
+  - Run flake on tests/ert3 during style testing
+  - Stop using single character variable names in tests
+  - Stop storing unused return values in tests
+  - Fix deprecated escape characters
+  - Drop support for variables, input and ouput data in storage
+  - Pass data as records in ert3
+  - Move conftest out to tests/gui
+  - Keep ensemble config nodes in an ordered data structure to avoid sampling differences over different build machines
+  - Write all elements in grdecl test data
+
 Version 2.20
 ------------
 

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -1,6 +1,33 @@
 Release Notes
 =============
 
+
+.. Release notes template
+ Version <MAJOR.MINOR>
+ ------------
+
+ Breaking changes:
+   -
+
+ Bugfixes:
+   -
+
+ New features:
+   -
+
+ Improvements:
+   -
+
+ Deprecations:
+   -
+
+ Dependencies:
+   -
+
+ Miscellaneous:
+   -
+
+
 Version 2.19
 ------------
 

--- a/docs/rst/manual/about/release_notes.rst
+++ b/docs/rst/manual/about/release_notes.rst
@@ -27,6 +27,67 @@ Release Notes
  Miscellaneous:
    -
 
+Version 2.25
+------------
+
+Bugfixes:
+  - Fix initial ensemble state
+  - Fix flaky legacy ensemble test by making job queue always launch jobs (`#1794 <https://github.com/equinor/ert/issues/1794>`_)
+  - Fix GUI crash (`#457 <https://github.com/equinor/ert/issues/457>`_)
+  - Fix bug where the last summary obs was not loaded (`#1813 <https://github.com/equinor/ert/issues/1813>`_)
+  - Fix bug in progress calculation (`#1830 <https://github.com/equinor/ert/issues/1830>`_)
+
+New features:
+  - Make it possible to visualise ERT3 results
+  - Check the status of ert3 services
+  - Support space and comma in forward model job arguments (`#1472 <https://github.com/equinor/ert/issues/1472>`_)
+
+Improvements:
+  - Rename: userdata and ensemble_ids endpoints
+  - Add section on how to restart ES-MDA in GUI (`#1290 <https://github.com/equinor/ert/issues/1290>`_)
+  - Generate narratives on the fly when building the docs
+  - Support building the documenation on ReadTheDocs (`#1610 <https://github.com/equinor/ert/issues/1610>`_)
+  - ert2 use servermonitor for fetching ert-storage auth
+  - Add ert-storage, clean experiment and webviz-ert to spe1-README (`#1736 <https://github.com/equinor/ert/issues/1736>`_)
+  - Fix typo in RMS documantion and CLI (`#1438 <https://github.com/equinor/ert/issues/1438>`_)
+  - Add output records to ert3 ensemble config
+  - Implement time out for legacy evaluator
+  - Fix resolve socket family (INET/INET6) (`#1676 <https://github.com/equinor/ert/issues/1676>`_)
+
+Deprecations:
+  - Deprecate PORTABLE_EXE (`#1718 <https://github.com/equinor/ert/issues/1718>`_)
+
+Dependencies:
+  - Add type stub packages to types-requirements
+  - Require semeio>=1.1.3rc0
+  - Remove ert-storage from dev-requirements.txt
+  - Add scikit-build as a dev-requirement
+  - Add setuptools_scm as a dev-requirement
+
+Miscellaneous:
+  - Move all the libres code into the ert repository
+  - ert3: Introduce common RecordIndex
+  - Add integration tests for post_update_data (`#1671 <https://github.com/equinor/ert/issues/1671>`_)
+  - Add some temporary debuging of events
+  - Make cancel test more consistent (`#1755 <https://github.com/equinor/ert/issues/1755>`_)
+  - Fix flaky prefect retry test by ignoring order of events in the test (`#1730 <https://github.com/equinor/ert/issues/1730>`_)
+  - Use example servers in comments
+  - Ignore some numpy type annotions that are difficult to handle in python
+  - Added Docs Section In README.md
+  - Split ERT 3 parameters into separate records
+  - Have mypy ignore missing numpy imports
+  - Make deploy to PyPi also depend on ctests
+  - Change workflows to not trigger on all push events (`#1739 <https://github.com/equinor/ert/issues/1739>`_)
+  - Reduce the number of macos builds on GA (`#1756 <https://github.com/equinor/ert/issues/1756>`_)
+  - Run ert2 test data setup on python 3.8 instead of 3.7
+  - Clone with tags in style and typing workflows
+  - Merge ert and libres test-data
+  - Delete libres test-data
+  - Remove init from tests (`#1734 <https://github.com/equinor/ert/issues/1734>`_)
+  - Remove use of temp test folder in GA
+  - Unite the resolving of port and sockets to use (`#1676 <https://github.com/equinor/ert/issues/1676>`_)
+  - Make verification tests wait for the ensemble evaluator to finish (`#1819 <https://github.com/equinor/ert/issues/1819>`_)
+
 Version 2.24
 ------------
 


### PR DESCRIPTION
We are missing quite some release notes! I'll do my best to add them now for 2.20 - 2.25 based on the bodies of the releases in ERT and libres.

Here is what I'm doing:
- Copy the content of all the relevant releases in ERT
- For the last tag identify the libres version
- Copy the content of all the relevant releases in libres
- Do a manual evaluation of the various changes and inject them into the templated sections
- Repeat from top for next version in ERT

It will probably not be perfect nor complete, but at least it will allow us to close the gap such and then we can try to do better moving forward...