### PR TITLE
Add a --num-iterations option for the IES cli

### DIFF
--- a/ert_shared/cli/model_factory.py
+++ b/ert_shared/cli/model_factory.py
@@ -90,6 +90,7 @@ def _setup_iterative_ensemble_smoother(args):
         "analysis_module": _get_analysis_module_name(
             active_name, modules, iterable=iterable
         ),
+        "num_iterations": _num_iterations(args),
     }
     return model, simulations_argument
 
@@ -143,3 +144,11 @@ def _target_case_name(args, format_mode=False):
 
     case_name = ERT.enkf_facade.get_current_case_name()
     return "{}_%d".format(case_name)
+
+
+def _num_iterations(args):
+    if args.num_iterations is not None:
+        ERT.ert.analysisConfig().getAnalysisIterConfig().setNumIterations(
+            int(args.num_iterations)
+        )
+    return None

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -83,6 +83,14 @@ def valid_iter_num(user_input):
     return user_input
 
 
+def valid_num_iterations(user_input):
+    validator = IntegerArgument(from_value=1)
+    validated = validator.validate(user_input)
+    if validated.failed():
+        strip_error_message_and_raise_exception(validated)
+    return user_input
+
+
 def range_limited_int(user_input):
     try:
         i = int(user_input)
@@ -279,6 +287,12 @@ def get_ert_parser(parser=None):
         required=False,
         help="Name of the case where the results for the simulation "
         "using the prior parameters will be stored.",
+    )
+    iterative_ensemble_smoother_parser.add_argument(
+        "--num-iterations",
+        type=valid_num_iterations,
+        required=False,
+        help="The number of iterations to run.",
     )
 
     # es_mda_parser


### PR DESCRIPTION
**Issue**
Resolves #1848


**Approach**
- Add a validator and the option in `ert_shared.main`.
- Add the option to the model factory, setting the number of iterations in the ERT analysis config object.
- Add a test for setting up the iterative ensemble smoothing, which was missing

**NOTE:** The issue description mentions that the default iteration number is equal to five, but this seems to be incorrect. It is equal to four, and careful inspection shows this. The output shows a counter going from `1/5` to `5/5`, but also prints 4 lines of the form `Iter 0 --> 1`, `Iter 1 --> 2`, and so on. I assuming the latter indicated the iterations? Indeed specifying `--num-iterations=3` will show 3 of these lines, but also a counter fromf `1/4` to `4/4`, which I guess could be misinterpreted.