### PR TITLE
Expose tail in experiment configuration

### DIFF
--- a/ert3/algorithms/_sensitivity.py
+++ b/ert3/algorithms/_sensitivity.py
@@ -1,4 +1,4 @@
-from typing import Set, MutableMapping, List, Dict
+from typing import Set, MutableMapping, List, Dict, Optional
 
 from ert3.stats import Distribution
 from ert.data import Record
@@ -11,19 +11,22 @@ def _build_base_records(
 
 
 def one_at_the_time(
-    parameters: MutableMapping[str, Distribution]
+    parameters: MutableMapping[str, Distribution], tail: Optional[float] = 0.99
 ) -> List[Dict[str, Record]]:
     if len(parameters) == 0:
         raise ValueError("Cannot study the sensitivity of no variables")
 
     # The lower extremal value of the analysis. Each variable will after turn
-    # be explored as ppf(tail) and ppf(1-tail) as the two extremal values.
-    tail = (1 - 0.99) / 2
+    # be explored as ppf(q) and ppf(1-q) as the two extremal values.
+    if tail is not None:
+        q = (1 - tail) / 2
+    else:
+        q = (1 - 0.99) / 2
 
     evaluations = []
     for group_name, dist in parameters.items():
-        lower = dist.ppf(tail)
-        upper = dist.ppf(1 - tail)
+        lower = dist.ppf(q)
+        upper = dist.ppf(1 - q)
         const_records = set(parameters.keys())
         const_records.remove(group_name)
 

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -226,7 +226,7 @@ def _prepare_sensitivity(
     )
 
     sensitivity_input_records = ert3.algorithms.one_at_the_time(
-        sensitivity_distributions
+        sensitivity_distributions, tail=experiment_config.tail
     )
 
     ensemble_size = len(sensitivity_input_records)

--- a/ert3_examples/polynomial/experiments/sensitivity/experiment.yml
+++ b/ert3_examples/polynomial/experiments/sensitivity/experiment.yml
@@ -1,2 +1,3 @@
 type: sensitivity
 algorithm: one-at-a-time
+tail: 0.99

--- a/tests/ert_tests/ert3/algorithms/test_one_at_the_time.py
+++ b/tests/ert_tests/ert3/algorithms/test_one_at_the_time.py
@@ -173,3 +173,48 @@ def test_multi_parameter_groups():
                 else 0
             )
             assert expected_value == pytest.approx(evali["indexed"].data[key])
+
+
+@pytest.mark.parametrize(
+    ("tail", "expected_evaluations"),
+    (
+        (
+            0.99,
+            [
+                {"a": [-CNORM_INV], "b": [0.5]},
+                {"a": [CNORM_INV], "b": [0.5]},
+                {"a": [0], "b": [CUNI_INV]},
+                {"a": [0], "b": [1 - CUNI_INV]},
+            ],
+        ),
+        (
+            0.75,
+            [
+                {"a": [-1.15034938], "b": [0.5]},
+                {"a": [1.15034938], "b": [0.5]},
+                {"a": [0], "b": [0.125]},
+                {"a": [0], "b": [1 - 0.125]},
+            ],
+        ),
+        (
+            0.5,
+            [
+                {"a": [-0.67448975], "b": [0.5]},
+                {"a": [0.67448975], "b": [0.5]},
+                {"a": [0], "b": [0.25]},
+                {"a": [0], "b": [1 - 0.25]},
+            ],
+        ),
+    ),
+)
+def test_tail(tail, expected_evaluations):
+    records = {
+        "a": ert3.stats.Gaussian(0, 1, size=1),
+        "b": ert3.stats.Uniform(0, 1, size=1),
+    }
+    evaluations = ert3.algorithms.one_at_the_time(records, tail)
+
+    for expected, result in zip(expected_evaluations, evaluations):
+        for key in expected.keys():
+            for e, r in zip(expected[key], result[key].data):
+                assert e == pytest.approx(r)

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -84,7 +84,7 @@ def evaluation_experiment_config():
 
 @pytest.fixture()
 def sensitivity_experiment_config():
-    raw_config = {"type": "sensitivity", "algorithm": "one-at-a-time"}
+    raw_config = {"type": "sensitivity", "algorithm": "one-at-a-time", "tail": 0.99}
     yield ert3.config.load_experiment_config(raw_config)
 
 


### PR DESCRIPTION
**Issue**
Resolves #1851


**Approach**
- Added `tail: Optional[float]` to `Experiment Config`
- Added `tail`as parameter to `one-at-the-time()`
- Made 0.99 the default tail
