### PR TITLE
Loosen semeio requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "qtpy",
         "requests",
         "scipy",
-        "semeio>=1.1.3rc0",
+        "semeio",
         "sqlalchemy",
         "typing-extensions; python_version < '3.8'",
         "uvicorn",


### PR DESCRIPTION
Because there is a circular dependency, this requirement should be as loose as possible to avoid causing problems in semeio.
