### PR TITLE
Refactor the RecordCollection class, allowing invariant content

### DIFF
--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -25,11 +25,11 @@ def _prepare_export(
         )
 
         if not data:
-            data = [{"input": {}, "output": {}} for _ in ensemble_record.records]
+            data = [{"input": {}, "output": {}} for _ in ensemble_record]
 
-        if isinstance(ensemble_record.records[0], ert.data.NumericalRecord):
+        if isinstance(ensemble_record[0], ert.data.NumericalRecord):
             assert len(data) == ensemble_record.ensemble_size
-            for realization, record in zip(data, ensemble_record.records):
+            for realization, record in zip(data, ensemble_record):
                 assert record_name not in realization[data_type]
                 realization[data_type][record_name] = record.data
 

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -50,11 +50,11 @@ def _get_experiment_record_indices(
             record_name=source_record_name,
         )
 
-        if isinstance(ensemble_record.records[0], ert.data.BlobRecord):
+        if isinstance(ensemble_record[0], ert.data.BlobRecord):
             return []
 
         indices: Set[Union[str, int]] = set()
-        for record in ensemble_record.records:
+        for record in ensemble_record:
             assert isinstance(record, ert.data.NumericalRecord)
             assert record.index is not None
             indices.update(record.index)
@@ -100,11 +100,11 @@ def _prepare_experiment_record(
             record_name=record_source[1],
         )
 
-        # The blob record from the workspace has size one
-        # We need to copy it (ensemble size) times into the experiment record
-        if isinstance(ensemble_record.records[0], ert.data.BlobRecord):
+        # Invariant record collections must be adjusted to the ensemble size:
+        if ensemble_record.ensemble_size == 1 and ensemble_size > 1:
             ensemble_record = ert.data.RecordCollection(
-                records=[ensemble_record.records[0] for _ in range(ensemble_size)]
+                records=[ensemble_record[0]],
+                ensemble_size=ensemble_size,
             )
 
         # Workaround to ensure compatible ensemble sizes
@@ -299,7 +299,7 @@ def _store_output_records(
             workspace=workspace_root,
             experiment_name=experiment_name,
             record_name=record_name,
-            ensemble_record=records.ensemble_records[record_name],
+            ensemble_record=records.record_collections[record_name],
         )
 
 
@@ -319,7 +319,7 @@ def _load_experiment_parameters(
             record_name=parameter_name,
         )
 
-    return ert.data.RecordCollectionMap(ensemble_records=parameters)
+    return ert.data.RecordCollectionMap(record_collections=parameters)
 
 
 def _evaluate(

--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -40,7 +40,7 @@ def _prepare_input(
 
     futures = []
     for input_ in step_config.input:
-        for iens, record in enumerate(inputs.ensemble_records[input_.record].records):
+        for iens, record in enumerate(inputs.record_collections[input_.record]):
             transmitter: RecordTransmitter
             if storage_type == "shared_disk":
                 transmitter = ert.data.SharedDiskRecordTransmitter(
@@ -253,7 +253,7 @@ def _prepare_output_records(
     for key in output_records:
         ensemble_records[key] = RecordCollection(records=output_records[key])
 
-    return RecordCollectionMap(ensemble_records=ensemble_records)
+    return RecordCollectionMap(record_collections=ensemble_records)
 
 
 def evaluate(

--- a/tests/ert_tests/ert3/engine/integration/integration_utils.py
+++ b/tests/ert_tests/ert3/engine/integration/integration_utils.py
@@ -84,13 +84,13 @@ def assert_distribution(
 ):
     indices = ("a", "b", "c")
 
-    for real_coefficient in coefficients.records:
+    for real_coefficient in coefficients:
         assert sorted(indices) == sorted(real_coefficient.index)
         for idx in real_coefficient.index:
             assert isinstance(real_coefficient.data[idx], float)
 
     samples = {idx: [] for idx in indices}
-    for sample in coefficients.records:
+    for sample in coefficients:
         for key in indices:
             samples[key].append(sample.data[key])
 

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -331,7 +331,7 @@ def test_run_presampled(
         workspace=workspace, record_name="coefficients0"
     )
     assert 10 == coeff0.ensemble_size
-    for real_coeff in coeff0.records:
+    for real_coeff in coeff0:
         assert sorted(("a", "b", "c")) == sorted(real_coeff.index)
         for idx in real_coeff.index:
             assert isinstance(real_coeff.data[idx], float)
@@ -348,7 +348,7 @@ def test_run_presampled(
 
     export_data = _load_export_data(workspace, "presampled_evaluation")
     assert coeff0.ensemble_size == len(export_data)
-    for coeff, real in zip(coeff0.records, export_data):
+    for coeff, real in zip(coeff0, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]
         assert sorted(coeff.index) == sorted(export_coeff.keys())
@@ -380,7 +380,7 @@ def test_run_uniform_presampled(
         workspace=workspace, record_name="uniform_coefficients0"
     )
     assert 10 == uniform_coeff0.ensemble_size
-    for real_coeff in uniform_coeff0.records:
+    for real_coeff in uniform_coeff0:
         assert sorted(("a", "b", "c")) == sorted(real_coeff.index)
         for idx in real_coeff.index:
             assert isinstance(real_coeff.data[idx], float)
@@ -397,7 +397,7 @@ def test_run_uniform_presampled(
 
     export_data = _load_export_data(workspace, "presampled_uniform_evaluation")
     assert uniform_coeff0.ensemble_size == len(export_data)
-    for coeff, real in zip(uniform_coeff0.records, export_data):
+    for coeff, real in zip(uniform_coeff0, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]
         assert sorted(coeff.index) == sorted(export_coeff.keys())
@@ -431,7 +431,7 @@ def test_record_load_and_run(
         workspace=workspace, record_name="designed_coefficients"
     )
     assert 10 == designed_coeff.ensemble_size
-    for real_coeff in designed_coeff.records:
+    for real_coeff in designed_coeff:
         assert sorted(("a", "b", "c")) == sorted(real_coeff.index)
         for val in real_coeff.data.values():
             assert isinstance(val, numbers.Number)
@@ -448,7 +448,7 @@ def test_record_load_and_run(
 
     export_data = _load_export_data(workspace, "doe")
     assert designed_coeff.ensemble_size == len(export_data)
-    for coeff, real in zip(designed_coeff.records, export_data):
+    for coeff, real in zip(designed_coeff, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]
         assert sorted(coeff.index) == sorted(export_coeff.keys())

--- a/tests/ert_tests/ert3/evaluator/test_evaluator.py
+++ b/tests/ert_tests/ert3/evaluator/test_evaluator.py
@@ -27,7 +27,7 @@ def get_inputs(coeffs):
             for (a, b, c) in coeffs
         ]
     )
-    return ert.data.RecordCollectionMap(ensemble_records=input_records)
+    return ert.data.RecordCollectionMap(record_collections=input_records)
 
 
 @pytest.mark.requires_ert_storage
@@ -48,7 +48,7 @@ def test_evaluator_script(
     )
 
     expected = ert.data.RecordCollectionMap(
-        ensemble_records={
+        record_collections={
             "polynomial_output": ert.data.RecordCollection(
                 records=[
                     ert.data.NumericalRecord(data=poly_out) for poly_out in expected
@@ -77,7 +77,7 @@ def test_evaluator_function(
     )
 
     expected = ert.data.RecordCollectionMap(
-        ensemble_records={
+        record_collections={
             "polynomial_output": ert.data.RecordCollection(
                 records=[
                     ert.data.NumericalRecord(data=poly_out) for poly_out in expected

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -149,6 +149,45 @@ def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
 
 @pytest.mark.requires_ert_storage
 @pytest.mark.parametrize(
+    ("raw_ensrec", "index"),
+    (
+        ([{"data": [0.5, 1.1, 2.2]}], [0, 1, 2]),
+        ([{"data": {"a": 0.5, "b": 1.1, "c": 2.2}}], ["a", "b", "c"]),
+        ([{"data": {2: 0.5, 5: 1.1, 7: 2.2}}], [2, 5, 7]),
+        ([{"data": b"asdfkasjdhjflkjah21WE123TTDSG34f"}], []),
+    ),
+)
+def test_add_and_get_invariant_ensemble_record(tmpdir, raw_ensrec, index, ert_storage):
+    ert.storage.init(workspace=tmpdir)
+
+    ert.storage.init_experiment(
+        experiment_name="my_experiment",
+        parameters={"my_ensemble_record": index},
+        ensemble_size=2,
+        responses=[],
+    )
+
+    ensrecords = ert.data.RecordCollection(records=raw_ensrec, ensemble_size=2)
+
+    ert.storage.add_ensemble_record(
+        workspace=tmpdir,
+        record_name="my_ensemble_record",
+        ensemble_record=ensrecords,
+        experiment_name="my_experiment",
+    )
+
+    retrieved_ensrecords = ert.storage.get_ensemble_record(
+        workspace=tmpdir,
+        record_name="my_ensemble_record",
+        experiment_name="my_experiment",
+    )
+    assert ensrecords == retrieved_ensrecords
+    assert retrieved_ensrecords.ensemble_size == 2
+    assert len(retrieved_ensrecords.records) == 1
+
+
+@pytest.mark.requires_ert_storage
+@pytest.mark.parametrize(
     "raw_ensrec",
     (
         [{"data": [i + 0.5, i + 1.1, i + 2.2]} for i in range(3)],


### PR DESCRIPTION
**Issue**
Resolves #1919


**Approach**
Instead of introducing a uniform record, it seemed more appropriate to introduce a uniform record collection.

The `RecordCollection` class has been rewritten as follows:
- Add iterator and index operations, to abstract out the access to the records
- Add the capability to set the size of a collection to larger than one, when created with a single record. The iterator and index operators will always return that single record.

Where appropriate code has been adapted to use the new functionality:
- Blob records are by default loaded as an invariant collection, since currently we assume always that they are.
- Instead of copying the blob record, an invariant collection is used.

**Note**
This should work also for numerical records, not just blob records. For instance, we can now add loading invariant numerical records.
