### PR TITLE
Allow for flexible (de)serialization fixing #1555

### DIFF
--- a/ert/__init__.py
+++ b/ert/__init__.py
@@ -1,1 +1,1 @@
-from . import data, exceptions, storage
+from . import data, exceptions, storage, serialization

--- a/ert/serialization/__init__.py
+++ b/ert/serialization/__init__.py
@@ -1,0 +1,14 @@
+from ert.serialization._registry import (
+    get_serializer,
+    has_serializer,
+    registered_types,
+)
+
+from ert.serialization._serializer import Serializer
+
+__all__ = [
+    "Serializer",
+    "has_serializer",
+    "get_serializer",
+    "registered_types",
+]

--- a/ert/serialization/_registry.py
+++ b/ert/serialization/_registry.py
@@ -1,0 +1,25 @@
+from typing import Tuple
+from pyrsistent import pmap
+from pyrsistent.typing import PMap
+from ._serializer import Serializer, _json_serializer
+
+
+_registry: PMap[str, Serializer] = pmap(
+    {
+        "application/json": _json_serializer(),
+    }
+)
+
+
+def has_serializer(mime: str) -> bool:
+    return mime in _registry
+
+
+def get_serializer(mime: str) -> Serializer:
+    if mime not in _registry:
+        raise ValueError(f"no serializer for {mime}")
+    return _registry[mime]
+
+
+def registered_types() -> Tuple[str, ...]:
+    return tuple(sorted(_registry.keys()))

--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -1,0 +1,35 @@
+import json
+from abc import ABC, abstractmethod
+from typing import Any, TextIO
+
+
+class Serializer(ABC):
+    @abstractmethod
+    def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("not implemented")
+
+    @abstractmethod
+    def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("not implemented")
+
+    @abstractmethod
+    def encode_to_file(self, obj: Any, fp: TextIO, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("not implemented")
+
+    @abstractmethod
+    def decode_from_file(self, fp: TextIO, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("not implemented")
+
+
+class _json_serializer(Serializer):
+    def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
+        return json.dumps(obj, *args, **kwargs)
+
+    def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
+        return json.loads(series, *args, **kwargs)
+
+    def encode_to_file(self, obj: Any, fp: TextIO, *args: Any, **kwargs: Any) -> None:
+        json.dump(obj, fp)
+
+    def decode_from_file(self, fp: TextIO, *args: Any, **kwargs: Any) -> Any:
+        return json.load(fp)

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -1,7 +1,13 @@
 from typing import Union
 
 from ert3.config._ensemble_config import load_ensemble_config, EnsembleConfig
-from ert3.config._stages_config import load_stages_config, StagesConfig, Function, Unix
+from ert3.config._stages_config import (
+    load_stages_config,
+    StagesConfig,
+    Function,
+    Unix,
+    DEFAULT_RECORD_MIME_TYPE,
+)
 from ert3.config._experiment_config import load_experiment_config, ExperimentConfig
 from ert3.config._parameters_config import load_parameters_config, ParametersConfig
 
@@ -19,4 +25,5 @@ __all__ = [
     "ExperimentConfig",
     "load_parameters_config",
     "ParametersConfig",
+    "DEFAULT_RECORD_MIME_TYPE",
 ]

--- a/ert3/config/_stages_config.py
+++ b/ert3/config/_stages_config.py
@@ -1,13 +1,13 @@
 from importlib.abc import Loader
 import importlib.util
 import mimetypes
-from typing import Callable, Tuple, cast, Union, Dict, Any
+from typing import Callable, Tuple, Type, cast, Union, Dict, Any
 
 from pydantic import BaseModel, FilePath, ValidationError, validator
 import ert
 
-_DEFAULT_RECORD_MIME_TYPE: str = "application/json"
-_DEFAULT_CMD_MIME_TYPE: str = "application/octet-stream"
+DEFAULT_RECORD_MIME_TYPE: str = "application/octet-stream"
+DEFAULT_CMD_MIME_TYPE: str = "application/octet-stream"
 
 
 def _import_from(path: str) -> Callable[..., Any]:
@@ -36,33 +36,37 @@ class _StagesConfig(BaseModel):
         arbitrary_types_allowed = True
 
 
-def _ensure_mime(field: str, values: Dict[str, Any]) -> str:
+def _ensure_mime(cls: Type[_StagesConfig], field: str, values: Dict[str, Any]) -> str:
     if field:
         return field
     guess = mimetypes.guess_type(str(values.get("location", "")))[0]
-    if guess != _DEFAULT_RECORD_MIME_TYPE:
-        return _DEFAULT_CMD_MIME_TYPE
-    return _DEFAULT_RECORD_MIME_TYPE
+    if guess:
+        if not ert.serialization.has_serializer(guess):
+            return DEFAULT_RECORD_MIME_TYPE
+        return guess
+    return (
+        DEFAULT_CMD_MIME_TYPE
+        if cls == TransportableCommand
+        else DEFAULT_RECORD_MIME_TYPE
+    )
 
 
-class _MimeBase(_StagesConfig):
-    @validator("mime", check_fields=False)
-    def _ensure_input_record_mime(cls, field: str, values: Dict[str, Any]) -> str:
-        if cls == TransportableCommand:
-            return _DEFAULT_CMD_MIME_TYPE
-        return _ensure_mime(field, values)
-
-
-class Record(_MimeBase):
+class Record(_StagesConfig):
     record: str
     location: str
     mime: str = ""
 
+    _ensure_record_mime = validator("mime", allow_reuse=True)(_ensure_mime)
 
-class TransportableCommand(_MimeBase):
+
+class TransportableCommand(_StagesConfig):
     name: str
     location: FilePath
     mime: str = ""
+
+    _ensure_transportablecommand_mime = validator("mime", allow_reuse=True)(
+        _ensure_mime
+    )
 
 
 class _Step(_StagesConfig):

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -9,10 +9,10 @@ def load_record(
     workspace: Path,
     record_name: str,
     record_file: Path,
-    blob_record: bool = False,
+    record_mime: str,
 ) -> None:
 
-    record_coll = ert.data.load_collection_from_file(record_file, blob_record)
+    record_coll = ert.data.load_collection_from_file(record_file, record_mime)
 
     ert.storage.add_ensemble_record(
         workspace=workspace,

--- a/ert_shared/ensemble_evaluator/entity/unix_step.py
+++ b/ert_shared/ensemble_evaluator/entity/unix_step.py
@@ -80,7 +80,9 @@ class UnixTask(prefect.Task):
         for input_ in self._step.get_inputs():
             path_base = runpath / _BIN_FOLDER if input_.is_executable() else runpath
             futures.append(
-                transmitters[input_.get_name()].dump(path_base / input_.get_path())
+                transmitters[input_.get_name()].dump(
+                    path_base / input_.get_path(), input_.get_mime()
+                )
             )
         asyncio.get_event_loop().run_until_complete(asyncio.gather(*futures))
         for input_ in self._step.get_inputs():

--- a/tests/ert_tests/ert3/config/test_stages_config.py
+++ b/tests/ert_tests/ert3/config/test_stages_config.py
@@ -88,18 +88,18 @@ def test_check_loaded_mime_types(base_unix_stage_config):
 
     assert (
         config[0].transportable_commands[0].mime
-        == ert3.config._stages_config._DEFAULT_CMD_MIME_TYPE
+        == ert3.config._stages_config.DEFAULT_CMD_MIME_TYPE
     )
 
-    assert config[0].input[0].mime == ert3.config._stages_config._DEFAULT_CMD_MIME_TYPE
     assert (
-        config[0].input[1].mime == ert3.config._stages_config._DEFAULT_RECORD_MIME_TYPE
+        config[0].input[0].mime == ert3.config._stages_config.DEFAULT_RECORD_MIME_TYPE
     )
+    assert config[0].input[1].mime == "application/json"
 
-    assert config[0].output[0].mime == ert3.config._stages_config._DEFAULT_CMD_MIME_TYPE
     assert (
-        config[0].output[1].mime == ert3.config._stages_config._DEFAULT_RECORD_MIME_TYPE
+        config[0].output[0].mime == ert3.config._stages_config.DEFAULT_RECORD_MIME_TYPE
     )
+    assert config[0].output[1].mime == "application/json"
 
 
 def test_step_multi_cmd(base_unix_stage_config):

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -164,6 +164,58 @@ def test_cli_record_load(designed_coeffs_record_file):
         ert3.console._console._main()
 
 
+@pytest.mark.requires_ert_storage
+def test_cli_record_load_supported_mime(designed_coeffs_record_file):
+    args = [
+        "ert3",
+        "record",
+        "load",
+        "--mime-type",
+        "application/json",
+        "designed_coefficients",
+        str(designed_coeffs_record_file),
+    ]
+    with patch.object(sys, "argv", args):
+        ert3.console._console._main()
+
+
+def test_cli_record_load_unsupported_mime(capsys):
+    args = [
+        "ert3",
+        "record",
+        "load",
+        "--mime-type",
+        "text/bar.baz",
+        "designed_coefficients",
+        "foo.bar.baz",
+    ]
+    with patch.object(sys, "argv", args):
+        with pytest.raises(
+            SystemExit,
+        ):
+            ert3.console._console._main()
+
+            captured = capsys.readouterr()
+            assert captured.out.strip().contains(
+                "error: argument --mime-type: invalid choice: 'text/bar.baz'"
+            )
+
+
+def test_cli_record_load_default_mime(designed_blob_record_file):
+    # Remove the .bin extension, forcing the load command to choose a default
+    path = pathlib.Path(str(designed_blob_record_file))
+    path.rename(path.stem)
+    args = [
+        "ert3",
+        "record",
+        "load",
+        "designed_coefficients",
+        str(path.stem),
+    ]
+    with patch.object(sys, "argv", args):
+        ert3.console._console._main()
+
+
 def _assert_done_or_pending(captured, experiments, done_indices):
     lines = [
         line.strip()

--- a/tests/ert_tests/ert3/data/test_record.py
+++ b/tests/ert_tests/ert3/data/test_record.py
@@ -258,7 +258,9 @@ def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
     with open(designed_coeffs_record_file, "r") as f:
         raw_collection = json.load(f)
 
-    collection = ert.data.load_collection_from_file(designed_coeffs_record_file)
+    collection = ert.data.load_collection_from_file(
+        designed_coeffs_record_file, "application/json"
+    )
     assert len(collection.records) == len(raw_collection)
     assert collection.ensemble_size == len(raw_collection)
     assert collection.record_type != ert.data.RecordType.BYTES
@@ -267,7 +269,7 @@ def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
 def test_load_blob_record_collection_from_file(designed_blob_record_file):
     ens_size = 5
     collection = ert.data.load_collection_from_file(
-        designed_blob_record_file, blob_record=True, ens_size=ens_size
+        designed_blob_record_file, "application/octet-stream", ens_size=ens_size
     )
     assert len(collection.records) == ens_size
     assert collection.ensemble_size == ens_size

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -436,7 +436,10 @@ def test_record_load_and_run(
 ):
 
     ert3.engine.load_record(
-        workspace, "designed_coefficients", designed_coeffs_record_file
+        workspace,
+        "designed_coefficients",
+        designed_coeffs_record_file,
+        "application/json",
     )
     designed_coeff = ert.storage.get_ensemble_record(
         workspace=workspace, record_name="designed_coefficients"
@@ -472,11 +475,17 @@ def test_record_load_twice(
     workspace, ensemble, stages_config, designed_coeffs_record_file
 ):
     ert3.engine.load_record(
-        workspace, "designed_coefficients", designed_coeffs_record_file
+        workspace,
+        "designed_coefficients",
+        designed_coeffs_record_file,
+        "application/json",
     )
     with pytest.raises(ert.exceptions.ElementExistsError):
         ert3.engine.load_record(
-            workspace, "designed_coefficients", designed_coeffs_record_file
+            workspace,
+            "designed_coefficients",
+            designed_coeffs_record_file,
+            "application/json",
         )
 
 
@@ -549,7 +558,9 @@ def test_partial_sensitivity_run_and_export(
 ):
     experiment_dir = workspace / ert3.workspace.EXPERIMENTS_BASE / "partial_sensitivity"
     experiment_dir.ensure(dir=True)
-    ert3.engine.load_record(workspace, "other_coefficients", oat_compatible_record_file)
+    ert3.engine.load_record(
+        workspace, "other_coefficients", oat_compatible_record_file, "application/json"
+    )
     ert3.engine.run(
         partial_sensitivity_ensemble,
         double_stages_config,
@@ -582,7 +593,10 @@ def test_incompatible_partial_sensitivity_run(
     experiment_dir = workspace / ert3.workspace.EXPERIMENTS_BASE / "partial_sensitivity"
     experiment_dir.ensure(dir=True)
     ert3.engine.load_record(
-        workspace, "other_coefficients", oat_incompatible_record_file
+        workspace,
+        "other_coefficients",
+        oat_incompatible_record_file,
+        "application/json",
     )
 
     err_msg = (


### PR DESCRIPTION
**Issue**
Resolves #1555


**Approach**
- a central registry controls MIME type support and allows for (de)serializing
- `ert3 record load` now can handle any supported MIME types
- `ert.data.load_collection_from_file` now handles arbitrary MIME types
- implementing MIME validation according to pydantic docs
- `RecordTransmitter.dump` and `RecordTransmitter.transmit_file` now
  require MIME type, but is no longer binary/JSON only.
- extended transmitter test suite to test every supported MIME type (json for now).