### PR TITLE
Shared disk transmitter use internal mime

### DIFF
--- a/ert/data/_record.py
+++ b/ert/data/_record.py
@@ -329,7 +329,7 @@ class RecordTransmitter:
 
 
 class SharedDiskRecordTransmitter(RecordTransmitter):
-    _INTERNAL_MIME_TYPE = "application/json"
+    _INTERNAL_MIME_TYPE = "application/x-yaml"
 
     def __init__(self, name: str, storage_path: Path):
         super().__init__(RecordTransmitterType.shared_disk)
@@ -355,10 +355,7 @@ class SharedDiskRecordTransmitter(RecordTransmitter):
         async with aiofiles.open(str(self._uri), mode="rt", encoding="utf-8") as f:
             contents = await f.read()
         serializer = get_serializer(SharedDiskRecordTransmitter._INTERNAL_MIME_TYPE)
-        if self._record_type == RecordType.MAPPING_INT_FLOAT:
-            data = serializer.decode(contents, object_hook=parse_json_key_as_int)
-        else:
-            data = serializer.decode(contents)
+        data = serializer.decode(contents)
         return NumericalRecord(data=data)
 
     async def _load_blob_record(self) -> BlobRecord:

--- a/ert/serialization/_registry.py
+++ b/ert/serialization/_registry.py
@@ -1,12 +1,13 @@
 from typing import Tuple
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
-from ._serializer import Serializer, _json_serializer
+from ._serializer import Serializer, _json_serializer, _yaml_serializer
 
 
 _registry: PMap[str, Serializer] = pmap(
     {
         "application/json": _json_serializer(),
+        "application/x-yaml": _yaml_serializer(),
     }
 )
 

--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -2,6 +2,8 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, TextIO
 
+import yaml
+
 
 class Serializer(ABC):
     @abstractmethod
@@ -33,3 +35,18 @@ class _json_serializer(Serializer):
 
     def decode_from_file(self, fp: TextIO, *args: Any, **kwargs: Any) -> Any:
         return json.load(fp)
+
+
+class _yaml_serializer(Serializer):
+    def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
+        res: str = yaml.dump(obj, *args, **kwargs)
+        return res
+
+    def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
+        return yaml.safe_load(series)
+
+    def encode_to_file(self, obj: Any, fp: TextIO, *args: Any, **kwargs: Any) -> None:
+        yaml.dump(obj, fp)
+
+    def decode_from_file(self, fp: TextIO, *args: Any, **kwargs: Any) -> Any:
+        return yaml.safe_load(fp)


### PR DESCRIPTION
**Issue**
Resolves #1964 


**Approach**
Add internal mime type for `SharedDiskTransmitter`. Add YAML serializer to actually get usage of two different formats. 