### PR TITLE
Delay GC of run_context on BaseRunModel

### DIFF
--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -131,6 +131,7 @@ class EvaluatorTracker:
         self._work_queue.put(EvaluatorTracker.DONE)
         self._work_queue.join()
         drainer_logger.debug("tasks complete")
+        self._model.teardown_context()
 
     def track(self):
         while True:

--- a/ert_shared/status/tracker/legacy.py
+++ b/ert_shared/status/tracker/legacy.py
@@ -112,6 +112,8 @@ class LegacyTracker:
         yield from self._retroactive_update_event()
         yield self._end_event()
 
+        self._model.teardown_context()
+
     def _create_snapshot_dict(
         self,
         run_context: ErtRunContext,


### PR DESCRIPTION
**Issue**
Resolves #1973 


**Approach**
Delay garbage collection of the model `RunContext` after an experiment is complete. This is because it is needed in tracking status.

Also, fix an issue where timed out jobs weren't updated because `status.json` couldn't be loaded.

**Why GC of `RunContext` is delayed in this PR**
When forward models (FM) are killed off, as in the case of MAX_RUNTIME, there's no grace period where status can be read, which is normally granted by a sleep in `job_dispatch`. This means that `RunContext/RunArgs` are garbage collected, and the FM status cannot be produced.

Hence we delay the garbage collection until status tracking is done.