### PR TITLE
Create skeleton Dark Storage

### DIFF
--- a/ert_shared/dark_storage/__init__.py
+++ b/ert_shared/dark_storage/__init__.py
@@ -1,0 +1,11 @@
+"""
+Dark Storage is an implementation of a subset of ERT Storage's API
+(https://github.com/Equinor/ert-storage), where the data is provided by the
+legacy EnKFMain and 'storage/' directory.
+
+The purpose of this is to provide users with an API that they can use without
+requiring a dedicated PostgreSQL server, and that works with their existing
+data. It should be noted that it's unfeasible to implement the entire ERT
+Storage API, nor is it possible to have the same guarantees of data integrity
+that ERT Storage has.
+"""

--- a/ert_shared/dark_storage/app.py
+++ b/ert_shared/dark_storage/app.py
@@ -1,0 +1,74 @@
+from fastapi import FastAPI, Request, status
+from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
+from fastapi.responses import HTMLResponse, RedirectResponse
+from ert_storage.app import app as ert_storage_app, JSONResponse
+from ert_storage.exceptions import ErtStorageError
+
+from ert_shared.version import version as _version
+from ert_shared.dark_storage.endpoints import router as endpoints_router
+
+
+app = FastAPI(
+    title=ert_storage_app.title,
+    version=ert_storage_app.version,
+    debug=True,
+    default_response_class=JSONResponse,
+    # Disable documentation so we can replace it with ERT Storage's later
+    openapi_url=None,
+    docs_url=None,
+    redoc_url=None,
+)
+
+
+@app.exception_handler(ErtStorageError)
+async def ert_storage_error_handler(
+    request: Request, exc: ErtStorageError
+) -> JSONResponse:
+    return JSONResponse(
+        {
+            "detail": {
+                **request.query_params,
+                **request.path_params,
+                **exc.args[1],
+                "error": exc.args[0],
+            }
+        },
+        status_code=exc.__status_code__,
+    )
+
+
+@app.exception_handler(NotImplementedError)
+async def not_implemented_handler(
+    request: Request, exc: NotImplementedError
+) -> JSONResponse:
+    return JSONResponse({}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def get_openapi() -> JSONResponse:
+    return JSONResponse(ert_storage_app.openapi())
+
+
+@app.get("/docs", include_in_schema=False)
+async def get_swagger(req: Request) -> HTMLResponse:
+    return get_swagger_ui_html(
+        openapi_url="/openapi.json", title=f"{app.title} - Swagger UI"
+    )
+
+
+@app.get("/redoc", include_in_schema=False)
+async def get_redoc(req: Request) -> HTMLResponse:
+    return get_redoc_html(openapi_url="/openapi.json", title=f"{app.title} - Redoc")
+
+
+@app.get("/")
+async def root() -> RedirectResponse:
+    return RedirectResponse("/docs")
+
+
+@app.get("/healthcheck")
+async def healthcheck() -> str:
+    return "ALL OK!"
+
+
+app.include_router(endpoints_router)

--- a/ert_shared/dark_storage/endpoints/__init__.py
+++ b/ert_shared/dark_storage/endpoints/__init__.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from .ensembles import router as ensembles_router
+from .records import router as records_router
+from .experiments import router as experiments_router
+from .observations import router as observations_router
+from .updates import router as updates_router
+from .compute.misfits import router as misfits_router
+from .responses import router as response_router
+
+router = APIRouter()
+router.include_router(experiments_router)
+router.include_router(ensembles_router)
+router.include_router(records_router)
+router.include_router(observations_router)
+router.include_router(updates_router)
+router.include_router(misfits_router)
+router.include_router(response_router)

--- a/ert_shared/dark_storage/endpoints/compute/misfits.py
+++ b/ert_shared/dark_storage/endpoints/compute/misfits.py
@@ -1,0 +1,29 @@
+from uuid import UUID
+from typing import Optional
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import Response
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+
+router = APIRouter(tags=["misfits"])
+
+
+@router.get(
+    "/compute/misfits",
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"text/csv": {}},
+        }
+    },
+)
+async def get_response_misfits(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    response_name: str,
+    realization_index: Optional[int] = None,
+    summary_misfits: bool = False,
+) -> Response:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/ensembles.py
+++ b/ert_shared/dark_storage/endpoints/ensembles.py
@@ -1,0 +1,51 @@
+from uuid import UUID
+from typing import Any, Mapping
+
+from fastapi import APIRouter, Body, Depends
+from ert_storage import json_schema as js
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+router = APIRouter(tags=["ensemble"])
+
+
+@router.post("/experiments/{experiment_id}/ensembles", response_model=js.EnsembleOut)
+def post_ensemble(
+    *, res: LibresFacade = Depends(get_res), ens_in: js.EnsembleIn, experiment_id: UUID
+) -> js.EnsembleOut:
+    raise NotImplementedError
+
+
+@router.get("/ensembles/{ensemble_id}", response_model=js.EnsembleOut)
+def get_ensemble(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID
+) -> js.EnsembleOut:
+    raise NotImplementedError
+
+
+@router.put("/ensembles/{ensemble_id}/userdata")
+async def replace_ensemble_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.patch("/ensembles/{ensemble_id}/userdata")
+async def patch_ensemble_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.get("/ensembles/{ensemble_id}/userdata", response_model=Mapping[str, Any])
+async def get_ensemble_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+) -> Mapping[str, Any]:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/experiments.py
+++ b/ert_shared/dark_storage/endpoints/experiments.py
@@ -1,0 +1,76 @@
+from uuid import UUID
+from typing import Any, Mapping, List
+
+from fastapi import APIRouter, Body, Depends
+from ert_storage import json_schema as js
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+
+router = APIRouter(tags=["experiment"])
+
+
+@router.get("/experiments", response_model=List[js.ExperimentOut])
+def get_experiments(*, res: LibresFacade = Depends(get_res)) -> List[js.ExperimentOut]:
+    raise NotImplementedError
+
+
+@router.get("/experiments/{experiment_id}", response_model=js.ExperimentOut)
+def get_experiment_by_id(
+    *, res: LibresFacade = Depends(get_res), experiment_id: UUID
+) -> js.ExperimentOut:
+    raise NotImplementedError
+
+
+@router.post("/experiments", response_model=js.ExperimentOut)
+def post_experiments(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ens_in: js.ExperimentIn,
+) -> js.ExperimentOut:
+    raise NotImplementedError
+
+
+@router.get(
+    "/experiments/{experiment_id}/ensembles", response_model=List[js.EnsembleOut]
+)
+def get_experiment_ensembles(
+    *, res: LibresFacade = Depends(get_res), experiment_id: UUID
+) -> List[js.EnsembleOut]:
+    raise NotImplementedError
+
+
+@router.put("/experiments/{experiment_id}/userdata")
+async def replace_experiment_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    experiment_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.patch("/experiments/{experiment_id}/userdata")
+async def patch_experiment_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    experiment_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.get("/experiments/{experiment_id}/userdata", response_model=Mapping[str, Any])
+async def get_experiment_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    experiment_id: UUID,
+) -> Mapping[str, Any]:
+    raise NotImplementedError
+
+
+@router.delete("/experiments/{experiment_id}")
+def delete_experiment(
+    *, res: LibresFacade = Depends(get_res), experiment_id: UUID
+) -> None:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/observations.py
+++ b/ert_shared/dark_storage/endpoints/observations.py
@@ -1,0 +1,69 @@
+from uuid import UUID
+from typing import Any, List, Mapping
+
+from fastapi import APIRouter, Body, Depends
+from ert_storage import json_schema as js
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+
+router = APIRouter(tags=["ensemble"])
+
+
+@router.post(
+    "/experiments/{experiment_id}/observations", response_model=js.ObservationOut
+)
+def post_observation(
+    *,
+    res: LibresFacade = Depends(get_res),
+    obs_in: js.ObservationIn,
+    experiment_id: UUID,
+) -> js.ObservationOut:
+    raise NotImplementedError
+
+
+@router.get(
+    "/experiments/{experiment_id}/observations", response_model=List[js.ObservationOut]
+)
+def get_observations(
+    *, res: LibresFacade = Depends(get_res), experiment_id: UUID
+) -> List[js.ObservationOut]:
+    raise NotImplementedError
+
+
+@router.get(
+    "/ensembles/{ensemble_id}/observations", response_model=List[js.ObservationOut]
+)
+def get_observations_with_transformation(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID
+) -> List[js.ObservationOut]:
+    raise NotImplementedError
+
+
+@router.put("/observations/{obs_id}/userdata")
+async def replace_observation_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    obs_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.patch("/observations/{obs_id}/userdata")
+async def patch_observation_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    obs_id: UUID,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.get("/observations/{obs_id}/userdata", response_model=Mapping[str, Any])
+async def get_observation_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    obs_id: UUID,
+) -> Mapping[str, Any]:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/records.py
+++ b/ert_shared/dark_storage/endpoints/records.py
@@ -1,0 +1,198 @@
+from uuid import UUID
+from typing import Any, Mapping, Optional, List
+
+from fastapi import APIRouter, Body, Depends, File, Header, Request, UploadFile, status
+from ert_storage import json_schema as js
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+
+router = APIRouter(tags=["record"])
+
+
+@router.post("/ensembles/{ensemble_id}/records/{name}/file")
+async def post_ensemble_record_file(
+    *,
+    res: LibresFacade = Depends(get_res),
+    name: str,
+    ensemble_id: UUID,
+    realization_index: Optional[int] = None,
+    file: UploadFile = File(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.put("/ensembles/{ensemble_id}/records/{name}/blob")
+async def add_block(
+    *,
+    res: LibresFacade = Depends(get_res),
+    name: str,
+    ensemble_id: UUID,
+    block_index: int,
+    realization_index: Optional[int] = None,
+    request: Request,
+) -> None:
+    raise NotImplementedError
+
+
+@router.post("/ensembles/{ensemble_id}/records/{name}/blob")
+async def create_blob(
+    *,
+    res: LibresFacade = Depends(get_res),
+    name: str,
+    ensemble_id: UUID,
+    realization_index: Optional[int] = None,
+) -> None:
+    raise NotImplementedError
+
+
+@router.patch("/ensembles/{ensemble_id}/records/{name}/blob")
+async def finalize_blob(
+    *,
+    res: LibresFacade = Depends(get_res),
+    name: str,
+    ensemble_id: UUID,
+    realization_index: Optional[int] = None,
+) -> None:
+    raise NotImplementedError
+
+
+@router.post(
+    "/ensembles/{ensemble_id}/records/{name}/matrix", response_model=js.RecordOut
+)
+async def post_ensemble_record_matrix(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    prior: Optional[str] = None,
+    realization_index: Optional[int] = None,
+    content_type: str = Header("application/json"),
+    request: Request,
+) -> js.RecordOut:
+    raise NotImplementedError
+
+
+@router.put("/ensembles/{ensemble_id}/records/{name}/userdata")
+async def replace_record_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    realization_index: Optional[int] = None,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.patch("/ensembles/{ensemble_id}/records/{name}/userdata")
+async def patch_record_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    realization_index: Optional[int] = None,
+    body: Any = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.get(
+    "/ensembles/{ensemble_id}/records/{name}/userdata", response_model=Mapping[str, Any]
+)
+async def get_record_userdata(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    realization_index: Optional[int] = None,
+) -> Mapping[str, Any]:
+    raise NotImplementedError
+
+
+@router.post("/ensembles/{ensemble_id}/records/{name}/observations")
+async def post_record_observations(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    realization_index: Optional[int] = None,
+    observation_ids: List[UUID] = Body(...),
+) -> None:
+    raise NotImplementedError
+
+
+@router.get("/ensembles/{ensemble_id}/records/{name}/observations")
+async def get_record_observations(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+    realization_index: Optional[int] = None,
+) -> List[js.ObservationOut]:
+    raise NotImplementedError
+
+
+@router.get(
+    "/ensembles/{ensemble_id}/records/{name}",
+    responses={
+        status.HTTP_200_OK: {
+            "content": {
+                "application/json": {},
+                "text/csv": {},
+                "application/x-numpy": {},
+            }
+        }
+    },
+)
+async def get_ensemble_record(
+    *,
+    res: LibresFacade = Depends(get_res),
+    name: str,
+    ensemble_id: UUID,
+    accept: str = Header("application/json"),
+    realization_index: Optional[int] = None,
+) -> Any:
+    raise NotImplementedError
+
+
+@router.get("/ensembles/{ensemble_id}/parameters", response_model=List[str])
+async def get_ensemble_parameters(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID
+) -> List[str]:
+    raise NotImplementedError
+
+
+@router.get(
+    "/ensembles/{ensemble_id}/records", response_model=Mapping[str, js.RecordOut]
+)
+async def get_ensemble_records(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID
+) -> Mapping[str, js.RecordOut]:
+    raise NotImplementedError
+
+
+@router.get("/records/{record_id}", response_model=js.RecordOut)
+async def get_record(
+    *, res: LibresFacade = Depends(get_res), record_id: UUID
+) -> js.RecordOut:
+    raise NotImplementedError
+
+
+@router.get("/records/{record_id}/data")
+async def get_record_data(
+    *,
+    res: LibresFacade = Depends(get_res),
+    record_id: UUID,
+    accept: Optional[str] = Header(default="application/json"),
+) -> Any:
+    raise NotImplementedError
+
+
+@router.get(
+    "/ensembles/{ensemble_id}/responses", response_model=Mapping[str, js.RecordOut]
+)
+def get_ensemble_responses(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID
+) -> Mapping[str, js.RecordOut]:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/responses.py
+++ b/ert_shared/dark_storage/endpoints/responses.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+router = APIRouter(tags=["response"])
+
+
+@router.get("/ensembles/{ensemble_id}/responses/{response_name}/data")
+async def get_ensemble_response_dataframe(
+    *, res: LibresFacade = Depends(get_res), ensemble_id: UUID, response_name: str
+) -> Response:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/endpoints/updates.py
+++ b/ert_shared/dark_storage/endpoints/updates.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from ert_storage import json_schema as js
+
+from ert_shared.dark_storage.enkf import LibresFacade, get_res
+
+router = APIRouter(tags=["ensemble"])
+
+
+@router.post("/updates", response_model=js.UpdateOut)
+def create_update(
+    *,
+    res: LibresFacade = Depends(get_res),
+    update: js.UpdateIn,
+) -> js.UpdateOut:
+    raise NotImplementedError
+
+
+@router.get("/updates/{update_id}", response_model=js.UpdateOut)
+def get_update(
+    *,
+    res: LibresFacade = Depends(get_res),
+    update_id: UUID,
+) -> js.UpdateOut:
+    raise NotImplementedError

--- a/ert_shared/dark_storage/enkf.py
+++ b/ert_shared/dark_storage/enkf.py
@@ -1,0 +1,11 @@
+from fastapi import Depends
+from ert_storage.security import security
+from ert_shared.libres_facade import LibresFacade
+from ert_shared.ert_adapter import ERT
+
+
+__all__ = ["LibresFacade", "get_res"]
+
+
+async def get_res(*, _: None = Depends(security)) -> LibresFacade:
+    return ERT.enkf_facade

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         "ecl >= 2.11.0-rc0",
         "ert-storage",
         "fastapi",
+        "graphene",
         "graphlib_backport; python_version < '3.9'",
         "jinja2",
         "matplotlib",

--- a/tests/dark_storage/test_api_compatibility.py
+++ b/tests/dark_storage/test_api_compatibility.py
@@ -1,0 +1,41 @@
+import pytest
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("ERT_STORAGE_DATABASE_URL", "sqlite://")
+    monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
+
+
+@pytest.fixture
+def ert_storage_app(env):
+    from ert_storage.app import app
+
+    return app
+
+
+@pytest.fixture
+def dark_storage_app(env):
+    from ert_shared.dark_storage.app import app
+
+    return app
+
+
+def test_openapi(ert_storage_app, dark_storage_app):
+    """
+    Test that the openapi.json of Dark Storage is identical to ERT Storage
+    """
+    expect = ert_storage_app.openapi()
+    actual = dark_storage_app.openapi()
+
+    # Remove textual data (descriptions and such) from ERT Storage's API.
+    def _remove_text(data):
+        if isinstance(data, dict):
+            return {
+                key: _remove_text(val)
+                for key, val in data.items()
+                if key not in ("description", "examples")
+            }
+        return data
+
+    assert _remove_text(expect) == _remove_text(actual)


### PR DESCRIPTION
Dark Storage is an API-compatible version of ERT Storage backed by the
legacy storage/ mechanism rather than a proper database. This commit
only provides the basic skeleton and a test that verifies that the
OpenAPI of Dark Storage and ERT Storage are the same.

- [x] Return 501 errors
- [x] ~Discuss the name EnKF Storage~ (renamed to "Dark Storage")
- [x] ~Make sure `responses` doesn't contain vital API stuff (eg. `response_model` info)~ It does contain vital API stuff, but fixed now.
- [x] ~GraphQL~ (will create a separate issue for this)
- [x] Have `/openapi.json` be from ERT Storage and not EnKF Storage so that the documentation needs only to exist in one place. _(optional)_