### PR TITLE
Replace bare except with ValueError in ecl config

### DIFF
--- a/res/fm/ecl/ecl_config.py
+++ b/res/fm/ecl/ecl_config.py
@@ -111,9 +111,7 @@ class EclConfig(object):
             version = version_arg
 
         if version is None:
-            # TODO: Do not raise Exception
-            # https://github.com/equinor/ert/issues/1955
-            raise Exception(
+            raise ValueError(
                 "The default version has not not been set in the config file:{}".format(
                     self._config_file
                 )

--- a/tests/libres_tests/res/fm/test_ecl_run_new_config.py
+++ b/tests/libres_tests/res/fm/test_ecl_run_new_config.py
@@ -60,6 +60,14 @@ class EclRunTest(ResTest):
             f.write(yaml.dump(conf))
         self.monkeypatch.setenv("ECL100_SITE_CONFIG", "ecl100_config.yml")
 
+    def test_get_version_raise(self):
+        ecl_config = Ecl100Config()
+        class_file = inspect.getfile(Ecl100Config)
+        class_dir = os.path.dirname(os.path.abspath(class_file))
+        msg = os.path.join(class_dir, "ecl100_config.yml")
+        with pytest.raises(ValueError, match=msg):
+            ecl_config._get_version(None)
+
     @tmpdir()
     @mock.patch.dict(os.environ, {"LSB_JOBID": "some-id"})
     def test_env(self):


### PR DESCRIPTION
**Issue**
Resolves #1955 

**Approach**
Proposing to throw `ValueError`.

Discussed with @oyvindeide and we think that it in this case in not necessary to throw a custom ert-error.