### PR TITLE
Rewrite parts of code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,76 +1,53 @@
 # Code of conduct for open source projects in Equinor
+
 In Equinor, [how we deliver is as important as what we deliver](https://www.equinor.com/en/careers/our-culture.html).
 
-This principle applies to all work done in Equinor maintained projects as well
-as for any Equinor contribution to other projects within the open source
-community.
+This principle applies to all work done in projects maintained by Equinor, as well as for any contributions by Equinor to other projects within the open-source community.
 
 ## Open, Collaborative, Courageous, Caring
 
-As a values-based organization, our code of conduct for open source projects is
-simply a reflection of our values and how we live up to these as teams as well
-as individuals.
+As a values-based organization, our code of conduct for open-source projects is simply a reflection of our values, and how we live up to them as teams and as individuals.
 
-This set the expectations for how we collaborate in our open source projects.
-These expectations applies to all community members and participants in any
-Equinor maintained project.
+This sets the expectations for how we collaborate in our open-source projects, which apply to all community members and participants of any project maintained by Equinor.
 
-In addition to any definition or interpretation of the open source code of
-conduct, the company wide [Equinor code of conduct](https://www.equinor.com/content/dam/statoil/documents/ethics/equinor-code-of-conduct.pdf)
-always applies to all employees and hired contractors.
+In addition to any definition or interpretation of the open source code of conduct, the company wide [Equinor code of conduct](https://www.equinor.com/content/dam/statoil/documents/ethics/equinor-code-of-conduct.pdf) always applies to all employees and hired contractors.
 
 # Handling issues within the communities
-At any point, if anyone should raise the concern that a group or member is not
-acting in accordance with our values, the behaviour in question should cease, be
-discussed and tried to be resolved.
 
-We expect all to have a low threshold for raising issues, or in general discuss
-how we live up to our values. Equally, we also encourage all community members
-to appreciate when concerns are raised, and make its best effort in solving
-them.
+If at any point concerns are raised that a group or member is not acting according to our values, the behaviour in question should cease, be discussed, and tried to be resolved.
 
-As well as responsibility for what is delivered the project maintainers are
-also responsible for how we deliver. This includes creating an environment for
-proper handling of issues raised within the communities.
+We expect everyone to have a low threshold for raising issues, or in general discuss how we live up to our values. 
+Equally, we encourage all community members to appreciate when concerns are raised and do their best to solve them.
 
-# Call out for assistance
-For any problem not directly resolvable within the community, we encourage you
-to call out for assistance. Getting an outsiders perspective on the topic might
-be just what is needed for you to proceed.
+Project maintainers are responsible both for *what* is delivered, as well as *how* it is delivered.
+This includes creating an environment for proper handling of issues raised within the communities.
+
+# Reach out for assistance
+
+For any problem not directly resolvable within the community, we encourage you to reach out for assistance.
+An outsider’s perspective might be just what is needed for you to proceed.
 
 Send an e-mail to opensource_at_equinor.com and invite for a discussion.
-The email will be handled by a team within the Equinor organization.
+The e-mail will be handled by a team within the Equinor organization.
 
 # Reporting an issue
-If you or your team want to report a direct violation of the code of conduct,
-or a failed attempt in solving a conflict within the community. Contact the
-same team, opensource_at_equinor.com, with a description of the issue.
 
-Your report will be kept confidential from the team or community in question,
-unless you chose to disclose it yourself. We have safe environment for
-reporting issues.
+For reporting direct violations of the code of conduct, or failed attempts at solving conflicts within the community, send a description of the issue to opensource_at_equinor.com.
 
-Consequences of violations are measured after the severity of the issue, or if
-it is a matter of repeatedly failing to take actions with respect to a mandated
-decision.
+To encourage members of the community to file reports, all reports are kept confidential unless you choose to disclose it yourself.
 
-For Equinor maintained projects, only the Equinor open source team has the
-mandate for making a corrective action against individuals based on the code of
-conduct. These decisions are never made within each project alone. As a last
-resort, a potential consequence may be exclusion from participation in that
-particular community.
+Consequences of violations reflect the severity of the issue, and/or repeated failure to take action following mandated decisions.
+
+For projects maintained by Equinor, only the Equinor open-source team has the mandate to take corrective actions against individuals that have violated the code of conduct.
+These decisions are never made within each project alone.
+As a last resort, a potential consequence may be the exclusion from participation in that particular community.
 
 # Ethics helpline
-In Equinor, we want you to speak up whenever you see unethical behaviour that
-conflicts with our values or threatens our reputation.
 
-To underline this, we continuously encourage and remind our employees and any
-external third parties interacting with us to raise concerns or report any
-suspected or potential breaches of law or company policies.
+In Equinor, we want you to speak up whenever you see unethical behaviour that conflicts with our values or threatens our reputation.
 
-For any questions or issues that one suspect falls outside the scope of
-behaviour regulated, and handled within the open source code of conduct, or you
-wish to place an anonymous, confidential report we encourage to use the
-[Equinor Ethics helpline](https://secure.ethicspoint.eu/domain/media/en/gui/102166/index.html).
+To underline this, we continuously encourage and remind our employees and any external third parties interacting with us to raise concerns or report any suspected or potential breaches of law or company policies.
+
+For any questions or issues that one suspect falls outside the scope of behaviour regulated, and handled within the open source code of conduct, or you wish to place an anonymous, confidential report we encourage to use the [Equinor Ethics helpline](https://secure.ethicspoint.eu/domain/media/en/gui/102166/index.html).
 
 This helpline is hosted by a third party helpline provider.


### PR DESCRIPTION
**Issue**
No issue

**Approach**
In large part a rewrite to more "active" English. 
Not sure if "active" is the right way to describe this, but typically instead of "Equinor maintained projects", I propose writing "projects maintained by Equinor".

A few paragraphs are rewritten more completely.

I also propose having one sentence per line for easier diffing. 


