### PR TITLE
Change description and fix type-name

### DIFF
--- a/ert_shared/plugins/hook_specifications/logging.py
+++ b/ert_shared/plugins/hook_specifications/logging.py
@@ -4,9 +4,9 @@ from ert_shared.plugins.plugin_manager import hook_specification
 @hook_specification
 def add_log_handle(logging):
     """
-    This hook allows the user to add log hooks and change formatting
+    Modify ert's logging instance, for example adding handlers and changing formatting.
 
     :param logging: A handle to the ert logging instance.
-    :type config: :class:`logging.Logger`
+    :type logging: :module:`logging`
     :return: None
     """


### PR DESCRIPTION
**Issue**
No issue.


**Approach**
Question: Is ":type logging: :class:`logging.Logger`" the right thing to specify when the parameter `logging` is a module?
