### PR TITLE
Remove transmit_data from transmitters

### DIFF
--- a/ert/data/_record.py
+++ b/ert/data/_record.py
@@ -286,15 +286,6 @@ class RecordTransmitter:
             raise TypeError(f"Record type not supported {type(record)}")
         self._set_transmitted_state(uri, record_type=record.record_type)
 
-    async def transmit_data(
-        self,
-        data: record_data,
-    ) -> None:
-        if self.is_transmitted():
-            raise RuntimeError("Record already transmitted")
-        record = Record(data=data)
-        await self.transmit_record(record.get_instance())
-
     async def transmit_file(
         self,
         file: Path,

--- a/tests/ert_tests/ensemble_evaluator/test_prefect_ensemble.py
+++ b/tests/ert_tests/ensemble_evaluator/test_prefect_ensemble.py
@@ -52,7 +52,8 @@ def input_transmitter(name, data, storage_path):
     transmitter = ert.data.SharedDiskRecordTransmitter(
         name=name, storage_path=Path(storage_path)
     )
-    asyncio.get_event_loop().run_until_complete(transmitter.transmit_data(data))
+    record = ert.data.NumericalRecord(data=data)
+    asyncio.get_event_loop().run_until_complete(transmitter.transmit_record(record))
     return {name: transmitter}
 
 
@@ -83,9 +84,9 @@ def script_transmitter(name, location, storage_path):
     transmitter = ert.data.SharedDiskRecordTransmitter(
         name=name, storage_path=Path(storage_path)
     )
-    with open(location, "rb") as f:
-        asyncio.get_event_loop().run_until_complete(transmitter.transmit_data(f.read()))
-
+    asyncio.get_event_loop().run_until_complete(
+        transmitter.transmit_file(location, mime="application/octet-stream")
+    )
     return {name: transmitter}
 
 

--- a/tests/ert_tests/ert3/data/test_transmitters.py
+++ b/tests/ert_tests/ert3/data/test_transmitters.py
@@ -14,6 +14,8 @@ from ert.data import (
     InMemoryRecordTransmitter,
     RecordTransmitter,
     SharedDiskRecordTransmitter,
+    NumericalRecord,
+    BlobRecord,
 )
 import ert
 
@@ -67,42 +69,42 @@ factory_params = pytest.mark.parametrize(
 )
 
 simple_records = pytest.mark.parametrize(
-    ("data_in", "expected_data"),
+    ("record_in", "expected_data"),
     (
         (
-            [1, 2, 3],
+            NumericalRecord(data=[1, 2, 3]),
             [1, 2, 3],
         ),
         (
-            (1.0, 10.0, 42.0, 999.0),
+            NumericalRecord(data=(1.0, 10.0, 42.0, 999.0)),
             [1.0, 10.0, 42.0, 999.0],
         ),
         (
-            [],
+            NumericalRecord(data=[]),
             [],
         ),
         (
-            [12.0],
+            NumericalRecord(data=[12.0]),
             [12.0],
         ),
         (
-            {1, 2, 3},
+            NumericalRecord(data={1, 2, 3}),
             [1, 2, 3],
         ),
         (
+            NumericalRecord(data={"a": 0, "b": 1, "c": 2}),
             {"a": 0, "b": 1, "c": 2},
-            {"a": 0, "b": 1, "c": 2},
         ),
         (
+            NumericalRecord(data={0: 10, 100: 0}),
             {0: 10, 100: 0},
-            {0: 10, 100: 0},
         ),
         (
-            b"\x00",
+            BlobRecord(data=b"\x00"),
             b"\x00",
         ),
         (
-            b"\xF0\x9F\xA6\x89",
+            BlobRecord(data=b"\xF0\x9F\xA6\x89"),
             b"\xF0\x9F\xA6\x89",
         ),
     ),
@@ -121,7 +123,7 @@ async def test_simple_record_transmit(
     record_transmitter_factory_context: ContextManager[
         Callable[[str], RecordTransmitter]
     ],
-    data_in,
+    record_in,
     expected_data,
     storage_path,
 ):
@@ -129,10 +131,10 @@ async def test_simple_record_transmit(
         storage_path=storage_path
     ) as record_transmitter_factory:
         transmitter = record_transmitter_factory(name="some_name")
-        await transmitter.transmit_data(data_in)
+        await transmitter.transmit_record(record_in)
         assert transmitter.is_transmitted()
         with pytest.raises(RuntimeError, match="Record already transmitted"):
-            await transmitter.transmit_data([1, 2, 3])
+            await transmitter.transmit_record(NumericalRecord(data=[1, 2, 3]))
 
 
 @pytest.mark.asyncio
@@ -143,14 +145,17 @@ async def test_simple_record_transmit_from_file(
     record_transmitter_factory_context: ContextManager[
         Callable[[str], RecordTransmitter]
     ],
-    data_in,
+    record_in,
     expected_data,
     mime_type,
     storage_path,
 ):
-    if isinstance(data_in, bytes) and mime_type != "application/octet-stream":
+    if isinstance(record_in, BlobRecord) and mime_type != "application/octet-stream":
         pytest.skip(f"unsupported serialization of opaque record to {mime_type}")
-    if not isinstance(data_in, bytes) and mime_type == "application/octet-stream":
+    if (
+        isinstance(record_in, NumericalRecord)
+        and mime_type == "application/octet-stream"
+    ):
         pytest.skip(f"unsupported serialization of num record to {mime_type}")
     filename = "record.file"
     with record_transmitter_factory_context(
@@ -178,7 +183,7 @@ async def test_simple_record_transmit_and_load(
     record_transmitter_factory_context: ContextManager[
         Callable[[str], RecordTransmitter]
     ],
-    data_in,
+    record_in,
     expected_data,
     storage_path,
 ):
@@ -186,7 +191,7 @@ async def test_simple_record_transmit_and_load(
         storage_path=storage_path
     ) as record_transmitter_factory:
         transmitter = record_transmitter_factory(name="some_name")
-        await transmitter.transmit_data(data_in)
+        await transmitter.transmit_record(record_in)
 
         record = await transmitter.load()
         assert record.data == expected_data
@@ -200,20 +205,23 @@ async def test_simple_record_transmit_and_dump(
     record_transmitter_factory_context: ContextManager[
         Callable[[str], RecordTransmitter]
     ],
-    data_in,
+    record_in,
     expected_data,
     mime_type,
     storage_path,
 ):
-    if isinstance(data_in, bytes) and mime_type != "application/octet-stream":
+    if isinstance(record_in, BlobRecord) and mime_type != "application/octet-stream":
         pytest.skip(f"unsupported serialization of opaque record to {mime_type}")
-    if not isinstance(data_in, bytes) and mime_type == "application/octet-stream":
+    if (
+        isinstance(record_in, NumericalRecord)
+        and mime_type == "application/octet-stream"
+    ):
         pytest.skip(f"unsupported serialization of num record to {mime_type}")
     with record_transmitter_factory_context(
         storage_path=storage_path
     ) as record_transmitter_factory, tmp():
         transmitter = record_transmitter_factory(name="some_name")
-        await transmitter.transmit_data(data_in)
+        await transmitter.transmit_record(record_in)
 
         await transmitter.dump("record", mime_type)
         if mime_type == "application/octet-stream":
@@ -234,7 +242,7 @@ async def test_simple_record_transmit_pickle_and_load(
     record_transmitter_factory_context: ContextManager[
         Callable[[str], RecordTransmitter]
     ],
-    data_in,
+    record_in,
     expected_data,
     storage_path,
 ):
@@ -243,7 +251,7 @@ async def test_simple_record_transmit_pickle_and_load(
     ) as record_transmitter_factory:
         transmitter = record_transmitter_factory(name="some_name")
         transmitter = pickle.loads(cloudpickle.dumps(transmitter))
-        await transmitter.transmit_data(data_in)
+        await transmitter.transmit_record(record_in)
         transmitter = pickle.loads(cloudpickle.dumps(transmitter))
         record = await transmitter.load()
 


### PR DESCRIPTION
**Issue**
Resolves #2005 


**Approach**
Remove the function and convert all usage to either transmit_data or transmit_file. See also https://github.com/equinor/ert/issues/2005#issuecomment-915298662
