### PR TITLE
WIP: ERT3 inputs: handling directories / tar files

### DIFF
--- a/ert/data/_record.py
+++ b/ert/data/_record.py
@@ -66,6 +66,7 @@ class RecordType(str, Enum):
     MAPPING_INT_FLOAT = "MAPPING_INT_FLOAT"
     MAPPING_STR_FLOAT = "MAPPING_STR_FLOAT"
     BYTES = "BYTES"
+    TAR = "TAR"
 
 
 class Record(_DataElement):

--- a/ert/data/_record.py
+++ b/ert/data/_record.py
@@ -327,6 +327,11 @@ class RecordTransmitter:
         if isinstance(record, NumericalRecord):
             async with aiofiles.open(str(location), mode="wt", encoding="utf-8") as ft:
                 await ft.write(get_serializer(mime).encode(record.data))
+        elif record.record_type == RecordType.TAR:
+            async with aiofiles.open(str(location) + ".tar", mode="wb") as ft:
+                await ft.write(record.data)
+            async with tarfile.open(str(location) + ".tar") as tar:
+                await tar.extractall(str(location))
         else:
             async with aiofiles.open(str(location), mode="wb") as fb:
                 await fb.write(record.data)  # type: ignore

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -565,7 +565,10 @@ def add_ensemble_record(
 
     dataframe = pd.DataFrame([r.data for r in ensemble_record.records])
 
-    if ensemble_record.record_type == ert.data.RecordType.BYTES:
+    if ensemble_record.record_type in [
+        ert.data.RecordType.BYTES,
+        ert.data.RecordType.TAR,
+    ]:
         _add_blob_data(experiment_name, record_name, ensemble_record)
     else:
         parameters = _get_experiment_parameters(experiment_name)
@@ -601,7 +604,7 @@ def _add_blob_data(
 
     metadata = _NumericalMetaData(
         ensemble_size=ensemble_record.ensemble_size,
-        record_type=ert.data.RecordType.BYTES,
+        record_type=ensemble_record.record_type,
     )
 
     ensemble_id = experiment["ensemble_ids"][0]  # currently just one ens per exp


### PR DESCRIPTION
**Issue**
Resolves #2016 


**Approach**
We need to provide a way that a given input (in the stage/step config) can be specified as directory or a tar file (essentially created and passed over). The unix step can then process such an input by unpacking it first. In the first iteration, this will add `application/x-tar` type into the file mimes. 

We might drop `RecordType.TAR` type when we make sure that specifying such input in the config suffices.