### PR TITLE
Update Equinor distribution information in docs

### DIFF
--- a/docs/rst/manual/getting_started/setup.rst
+++ b/docs/rst/manual/getting_started/setup.rst
@@ -3,7 +3,7 @@ Setup
 
 If you work at Equinor you should have ert available after sourcing a komodo release. Run the command::
 
-    source /project/res/komodo/stable/enable
+    source /prog/res/komodo/stable/enable
 
 Then you can test the installation by running::
 


### PR DESCRIPTION
The description for how to fetch an ERT distribution was outdated in the documentation. It could be discussed whether we should work even harder to strip the documentation for Equinor examples like this, but let us start by making the current information correct.