### PR TITLE
Res config init

### DIFF
--- a/res/enkf/res_config.py
+++ b/res/enkf/res_config.py
@@ -21,7 +21,7 @@ from cwrap import BaseCClass
 
 from ecl.util.util import StringList
 from res import ResPrototype
-from res.config import ConfigParser, ConfigContent, ConfigSettings, UnrecognizedEnum
+from res.config import ConfigParser, ConfigContent
 
 from res.enkf import (
     SiteConfig,
@@ -110,11 +110,7 @@ class ResConfig(BaseCClass):
     ):
 
         configs = sum(
-            [
-                1
-                for x in [user_config_file, config, config_dict]
-                if x is not None
-            ]
+            [1 for x in [user_config_file, config, config_dict] if x is not None]
         )
 
         if configs > 1:

--- a/res/enkf/res_config.py
+++ b/res/enkf/res_config.py
@@ -109,13 +109,22 @@ class ResConfig(BaseCClass):
         self, user_config_file=None, config=None, throw_on_error=True, config_dict=None
     ):
 
-        _assert_configs = (
-            len([x for x in (config, config_dict, user_config_file) if x is not None])
-            == 1
+        configs = sum(
+            [
+                1
+                for x in [user_config_file, config, config_dict]
+                if x is not None
+            ]
         )
-        if _assert_configs is False:
+
+        if configs > 1:
             raise ValueError(
-                "Wrong config input - only one config means needs to be provided!"
+                "Attempting to create ResConfig object with multiple config objects"
+            )
+
+        if configs == 0:
+            raise ValueError(
+                "Error trying to create ResConfig without any configuration"
             )
 
         self._errors, self._failed_keys = None, None

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -18,6 +18,8 @@ import os.path
 import stat
 from datetime import date
 
+import pytest
+
 from cwrap import Prototype, load
 from ecl.util.enums import RngAlgTypeEnum
 from ecl.util.test import TestAreaContext
@@ -304,6 +306,14 @@ class ResConfigTest(ResTest):
         self.case_directory = self.createTestPath("local/snake_oil_structure")
         self.config_file = "snake_oil_structure/ert/model/user_config.ert"
         expand_config_data()
+
+    def test_missing_config(self):
+        with pytest.raises(ValueError, match="Error trying to create ResConfig without any configuration"):
+            ResConfig()
+
+    def test_multiple_configs(self):
+        with pytest.raises(ValueError, match="Attempting to create ResConfig object with multiple config objects"):
+            ResConfig(user_config_file="test", config="test")
 
     @tmpdir()
     def test_invalid_user_config(self):

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -23,7 +23,6 @@ import pytest
 from cwrap import Prototype, load
 from ecl.util.enums import RngAlgTypeEnum
 from ecl.util.test import TestAreaContext
-from ecl.util.util import CTime
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import (
@@ -308,11 +307,17 @@ class ResConfigTest(ResTest):
         expand_config_data()
 
     def test_missing_config(self):
-        with pytest.raises(ValueError, match="Error trying to create ResConfig without any configuration"):
+        with pytest.raises(
+            ValueError,
+            match="Error trying to create ResConfig without any configuration",
+        ):
             ResConfig()
 
     def test_multiple_configs(self):
-        with pytest.raises(ValueError, match="Attempting to create ResConfig object with multiple config objects"):
+        with pytest.raises(
+            ValueError,
+            match="Attempting to create ResConfig object with multiple config objects",
+        ):
             ResConfig(user_config_file="test", config="test")
 
     @tmpdir()


### PR DESCRIPTION
**Approach**

Use same approach in `res.enkf.res_config.py` as in `res.enkf.analysis_config.py` when validating input-parameters.
