### PR TITLE
Update workflows docs

### DIFF
--- a/docs/rst/manual/reference/workflows/built_in.rst
+++ b/docs/rst/manual/reference/workflows/built_in.rst
@@ -7,38 +7,37 @@ Built in Workflow Jobs
    Make sure list of available workflows is complete
 
 ERT comes with a list of default workflow jobs which invoke internal
-ERT functionality. The internal workflows include:
+ERT functionality. The internal workflow jobs include:
 
 Jobs related to case management
 -------------------------------
 
 **SELECT_CASE**
 
-The job SELECT_CASE can be used to change the currently selected
-case. The SELECT_CASE job should be used as:
+The job :code:`SELECT_CASE` can be used to change the currently selected
+case. The :code:`SELECT_CASE` job should be used as:
 
 ::
 
 	SELECT_CASE  newCase
 
-if the case newCase does not exist it will be created.
+if the case `newCase` does not exist it will be created.
 
 **CREATE_CASE**
 
-The job CREATE_CASE can be used to create a new case without selecting
-it. The CREATE_CASE job should be used as:
+The job :code:`CREATE_CASE` can be used to create a new case without selecting
+it. The :code:`CREATE_CASE` job should be used as:
 
 ::
 
 	CREATE_CASE  newCase
 
-
 **INIT_CASE_FROM_EXISTING**
 
-The job INIT_CASE_FROM_EXISTING can be used to initialize a case from
+The job :code:`INIT_CASE_FROM_EXISTING` can be used to initialize a case from
 an existing case. The argument to the workflow should be the name of
 the workflow you are initializing from; so to initialize the current
-case from the existing case "oldCase":
+case from the existing case `oldCase`:
 
 ::
 
@@ -46,23 +45,22 @@ case from the existing case "oldCase":
 
 By default the job will initialize the 'current case', but optionally
 you can give the name of a second case which should be initialized. In
-this example we will initialize "newCase" from "oldCase":
+this example we will initialize `newCase` from `oldCase`:
 
 ::
 
 	INIT_CASE_FROM_EXISTING oldCase newCase
 
 When giving the name of a second case as target for the initialization
-job the 'current' case will not be affected.
-
+job, the 'current' case will not be affected.
 
 Jobs related to export
 ----------------------
 
 **EXPORT_FIELD**
 
-The EXPORT_FIELD workflow job exports field data to roff or grdecl
-format dependent on the extension of the export file argument. The job
+The :code:`EXPORT_FIELD` workflow job exports field data to `roff` or `grdecl`
+format depending on the extension of the export file argument. The job
 takes the following arguments:
 
 #. Field to be exported
@@ -70,14 +68,12 @@ takes the following arguments:
 #. Report_step
 #. Realization range
 
-The filename must contain a %d. This will be replaced with the
+The filename must contain a `%d`. This will be replaced with the
 realization number.
 
-The realization range parameter is optional. Default is all
-realizations.
+The realization range parameter is optional with the default being all realizations.
 
-
-Example use of this job in a workflow:
+Example usage of this job in a workflow:
 
 ::
 
@@ -85,7 +81,7 @@ Example use of this job in a workflow:
 
 **EXPORT_FIELD_RMS_ROFF**
 
-The EXPORT_FIELD_RMS_ROFF workflow job exports field data to roff
+The :code:`EXPORT_FIELD_RMS_ROFF` workflow job exports field data to `roff`
 format. The job takes the following arguments:
 
 #. Field to be exported
@@ -93,23 +89,20 @@ format. The job takes the following arguments:
 #. Report_step
 #. Realization range
 
-The filename must contain a %d. This will be replaced with the
-realization number.
+The filename must contain a `%d`, which will be replaced with the realization number.
 
-The realization range parameter is optional. Default is all realizations.
+The realization range parameter is optional with the default being all realizations.
 
-
-Example uses of this job in a workflow:
+Example usage of this job in a workflow:
 
 ::
 
 	EXPORT_FIELD_RMS_ROFF PERMZ path_to_export/filename%d.roff 0 
 	EXPORT_FIELD_RMS_ROFF PERMX path_to_export/filename%d 0 0-5 
 
-
 **EXPORT_FIELD_ECL_GRDECL**
 
-The EXPORT_FIELD_ECL_GRDECL workflow job exports field data to grdecl
+The :code:`EXPORT_FIELD_ECL_GRDECL` workflow job exports field data to `grdecl`
 format. The job takes the following arguments:
 
 #. Field to be exported
@@ -117,28 +110,26 @@ format. The job takes the following arguments:
 #. Report_step
 #. Realization range
 
-The filename must contain a %d. This will be replaced with the realization number.
+The filename must contain a `%d` which will be replaced with the realization number.
 
-The realization range parameter is optional. Default is all realizations.
+The realization range parameter is optional with the default being all realizations.
 
-
-Example uses of this job in a workflow:
+Example usage of this job in a workflow:
 
 ::
 
 	EXPORT_FIELD_ECL_GRDECL PERMZ path_to_export/filename%d.grdecl 0 
 	EXPORT_FIELD_ECL_GRDECL PERMX path_to_export/filename%d 0 0-5 
 
-
 **EXPORT_RUNPATH**
 
-The EXPORT_RUNPATH workflow job writes the runpath file RUNPATH_FILE
+The :code:`EXPORT_RUNPATH` workflow job writes the runpath file :code:`RUNPATH_FILE`
 for the selected case.
 
 The job can have no arguments, or one can set a range of realizations
 and a range of iterations as arguments.
 
-Example uses of this job in a workflow:
+Example usage of this job in a workflow:
 
 ::
 
@@ -146,7 +137,7 @@ Example uses of this job in a workflow:
 
 With no arguments, entries for all realizations are written to the
 runpath file. If the runpath supports iterations, entries for all
-realizations in iter0 are written to the runpath file.
+realizations in `iter0` are written to the runpath file.
 
 ::
 
@@ -157,7 +148,6 @@ used as a delimiter to separate realizations and iterations. "*" can
 be used to select all realizations or iterations. In the example
 above, entries for realizations 0-5 for all iterations are written to
 the runpath file.
-
 
 Jobs related to analysis update
 -------------------------------
@@ -172,19 +162,60 @@ and the target case must be given as arguments:
 
    ANALYSIS_UPDATE prior posterior
 
-Will fetch prior parameters and simulated responses from the
-case:`prior` and store updated parameters in the case: `posterior`. If
-you have configured local updates that will be respected, otherwise
+Fetches prior parameters and simulated responses from the
+case:`prior` and stores updated parameters in the case: `posterior`. If
+you have configured local updates they will be respected, otherwise
 all available data will be used - and all parameters will be updated.
 
 
 Jobs related to running simulations - including updates
 -------------------------------------------------------
 
+**RUN_SMOOTHER**
+
+The :code:`RUN_SMOOTHER` job will run a simulation and perform an update. The
+job has one required argument - the name of a case where the updated
+parameters are stored. Optionally the job can take a second boolean
+argument, which if set to true will re-run the job based on the updated parameters.
+
+Run a simulation and an update. Store the updated parameters in the
+specified case. This case is created if it does not exist:
+
+::
+
+	RUN_SMOOTHER new_case
+
+Run a simulation and an update. Store the updated parameters in the
+specified case, then run a simulation on this case:
+
+::
+
+	RUN_SMOOTHER new_case true
+
+**RUN_SMOOTHER_WITH_ITER**
+
+This is exactly like the :code:`RUN_SMOOTHER` job,
+but with an additional first argument `iter`, 
+which can be used to control the `iter`-number in the :code:`RUNPATH`.
+When using the RUN_SMOOTHER job the iter number will be
+defaulted to zero, and one in the optional rerun.
+
+**ENSEMBLE_RUN**
+
+The :code:`ENSEMBLE_RUN` job will run a simulation, no update. The job takes as
+optional arguments a range and/or list of which realizations to run.
+
+::
+
+	ENSEMBLE_RUN
+
+::
+
+	ENSEMBLE_RUN 1-5, 8
 
 **LOAD_RESULTS**
 
-The LOAD_RESULTS loads result from simulation(s). The job takes as
+The :code:`LOAD_RESULTS` loads results from a single, or from multiple simulations. The job takes as
 optional arguments a range and/or list of which realizations to load
 results from. If no realizations are specified, results for all
 realizations are loaded.
@@ -197,18 +228,16 @@ realizations are loaded.
 
 	LOAD_RESULTS 1-5, 8
 
-In the case of multi iteration jobs, e.g. the integrated smoother
-update, the LOAD_RESULTS job will load the results from iter==0. To
-control which iteration is loaded from you can use the
-LOAD_RESULTS_ITER job.
-
+In the case of multi-iteration jobs, e.g. the integrated smoother
+update, the :code:`LOAD_RESULTS` job will load the results from `iter==0`. To
+control which iteration is loaded from, you can use the
+:code:`LOAD_RESULTS_ITER` job.
 
 **LOAD_RESULTS_ITER**
 
-The LOAD_RESULTS_ITER job is similar to the LOAD_RESULTS job, but it
-takes an additional first argument which is the iteration number to
-load from. This should be used when manually loading results from a
-multi iteration workflow:
+The :code:`LOAD_RESULTS_ITER` job is similar to the :code:`LOAD_RESULTS` job,
+but it takes an additional first argument which specifies which iteration number to load from. 
+This should be used when manually loading results from multi-iteration workflows:
 
 ::
 
@@ -221,13 +250,42 @@ multi iteration workflow:
 Will load the realisations 1,2,3 and 8,9,10 from the fourth iteration
 (counting starts at zero).
 
+**MDA_ES**
+
+This workflow job (plugin) is used to run the *Multiple Data
+Assimilation Ensemble Smoother* :code:`MDA ES`.  Only two arguments
+are required to start the :code:`MDA_ES` process; target case format and
+iteration weights. The weights implicitly indicate the number of
+iterations and the normalized global standard deviation scaling
+applied to the update step.
+
+::
+
+	MDA_ES target_case_%d observations/obs.txt
+
+This command will use the weights specified in the `obs.txt` file. This
+file should have a single floating point number per line.
+Alternatively, the weights can be given as arguments as shown here.
+
+::
+
+	MDA_ES target_case_%d 8,4,2,1
+
+This command will use the normalized version of the weights 8,4,2,1
+and run for four iterations. The prior will be in *target_case_0* and
+the results from the last iteration will be in *target_case_4*.
+**Note: the weights must be listed with no spaces and separated with
+commas.**
+
+If this is run as a plugin from Ertshell or the GUI a convenient user
+interface can be shown.
 
 Jobs for ranking realizations
 -----------------------------
 
 **OBSERVATION_RANKING**
 
-The OBSERVATION_RANKING job will rank realizations based on the delta
+The :code:`OBSERVATION_RANKING` job will rank realizations based on the delta
 between observed and simulated values for selected variables and time
 steps. The data for selected variables and time steps are summarized
 for both observed and simulated values, and then the simulated versus
@@ -237,25 +295,22 @@ then the time steps, a "|" character and then variables to rank on. If
 no time steps and/or no variables are given, all time steps and
 variables are taken into account.
 
-
 Rank the realizations on observation/simulation delta value for all
-WOPR data for time steps 0-20:
+:code:`WOPR` data for time steps 0-20:
 
 ::
 
 	OBSERVATION_RANKING Ranking1 0-20 | WOPR:*
 
-
 Rank the simulations on observation/simulation delta value for all
-WOPR and WWCT data for time steps 1 and 10-50
+:code:`WOPR` and :code:`WWCT` data for time steps 1 and 10-50
 
 ::
 
 	OBSERVATION_RANKING Ranking2 1, 10-50 | WOPR:* WWCT:*
 
-
 Rank the realizations on observation/simulation delta value for
-WOPR:OP-1 data for all time steps
+:code:`WOPR` : :code:`OP-1` data for all time steps
 
 ::
 
@@ -263,22 +318,21 @@ WOPR:OP-1 data for all time steps
 
 **DATA_RANKING**
 
-The DATA_RANKING job will rank realizations in increasing or
+The :code:`DATA_RANKING` job will rank realizations in increasing or
 decreasing order on selected data value for a selected time step. The
 job takes as parameters the name of the ranking, the data key to rank
 on, increasing order and selected time steps. If no time step is
 given, the default is the last timestep.
 
-Rank the realizations on PORO:1,2,3 on time step 0 in decreasing order
+Rank the realizations on :code:`PORO`:1,2,3 on time step 0 in decreasing order:
 
 ::
 
 	DATA_RANKING Dataranking1 PORO:1,2,3 false 0
 
-
 **EXPORT_RANKING**
 
-The EXPORT_RANKING job exports ranking results to file. The job takes
+The :code:`EXPORT_RANKING` job exports ranking results to file. The job takes
 two parameters; the name of the ranking to export and the file to
 export to.
 
@@ -286,19 +340,17 @@ export to.
 
 	EXPORT_RANKING Dataranking1 /tmp/dataranking1.txt
 
-
 **INIT_MISFIT_TABLE**
 
 Calculating the misfit for all observations and all timesteps can
-potentially be a bit timeconsuming, the results are therefore cached
+potentially be a bit time consuming, the results are therefore cached
 internally. If you need to force the recalculation of this cache you
-can use the INIT_MISFIT_TABLE job to initialize the misfit table that
+can use the :code:`INIT_MISFIT_TABLE` job to initialize the misfit table that
 is used in observation ranking.
 
 ::
 
 	INIT_MISFIT_TABLE
-
 
 **STD_SCALE_CORRELATED_OBS**
 
@@ -320,8 +372,7 @@ time and spatial direction. Wildcards are allow, i.e.
 
 	STD_SCALE_CORRELATED_OBS  W*:OP_1
 
-Will scale based on all the observations of well 'OP_1'. For more
+Will scale based on all the observations of well :code:`OP_1`. For more
 advanced selections of observations, where you only want to scale
-based on parts of the observation - spatially or temporaly you must
+based on parts of the observation - spatially or temporaly, you must
 write your own plugin.
-

--- a/docs/rst/manual/reference/workflows/complete_workflows.rst
+++ b/docs/rst/manual/reference/workflows/complete_workflows.rst
@@ -14,45 +14,43 @@ jobs PLOT and ECL_HIST we can create a small workflow example:
 	ECL_HIST  <RUNPATH_FILE>   <QC_PATH>/<ERTCASE>/wwct_hist   WWCT:OP_1  WWCT:OP_2
 
 In this workflow we create plots of the nodes
-WWCT:OP_1, WWCT:OP_3, PRESSURE:10,10,10, FGPT and FOPT. The plot job we
+:code:`WWCT` : :code:`OP_1`, :code:`WWCT` : :code:`OP_3`, :code:`PRESSURE`:10,10,10, :code:`FGPT` and :code:`FOPT`. The plot job we
 have created in this example is general, if we limited
 ourselves to ECLIPSE summary variables we could get wildcard
 support. Then we invoke the ECL_HIST example job to create a
 histogram. See below for documentation of <RUNPATH_FILE> and
 <ERTCASE>.
 
-
 Loading workflows
 -----------------
 
-Workflows are loaded with the configuration option LOAD_WORKFLOW:
+Workflows are loaded with the configuration option :code:`LOAD_WORKFLOW`:
 
 ::
 
 	LOAD_WORKFLOW  /path/to/workflow/WFLOW1
 	LOAD_WORKFLOW  /path/to/workflow/workflow2  WFLOW2
 
-The LOAD_WORKFLOW takes the path to a workflow file as the first
+The :code:`LOAD_WORKFLOW` takes the path to a workflow file as the first
 argument. By default the workflow will be labeled with the filename
-internally in ERT, but optionally you can supply a second extra
-argument which will be used as name for the workflow. Alternatively
+internally in ERT, but you can optionally supply a second extra argument 
+which will be used as the name for the workflow.  Alternatively,
 you can load a workflow interactively.
-
 
 .. _hook_workflow:
 
-Automatically run workflows : HOOK_WORKFLOW
--------------------------------------------
+Automatically run workflows : :code:`HOOK_WORKFLOW`
+---------------------------------------------------
 
 With the keyword :code:`HOOK_WORKFLOW` you can configure workflow
 'hooks'; meaning workflows which will be run automatically at certain
 points during ERTs execution. Currently there are four points in ERTs
-flow of execution where you can hook in a workflow, before the
-simulations start, :code:`PRE_SIMULATION`;  after all the simulations
-have completed :code:`POST_SIMULATION`; before the update step,
-:code:`PRE_UPDATE` and after the update step, :code:`POST_UPDATE`. The
-:code:`POST_SIMULATION` hook is typically used to trigger QC
-workflows:
+flow of execution where you can hook in a workflow:
+
+- Before the simulations start using :code:`PRE_SIMULATION`,
+- after all the simulations have completed using :code:`POST_SIMULATION`,
+- before the update step using :code:`PRE_UPDATE` and
+- after the update step using :code:`POST_UPDATE`. 
 
 ::
 
@@ -61,7 +59,6 @@ workflows:
    HOOK_WORKFLOW postUpdateWFLOW  POST_UPDATE
    HOOK_WORKFLOW QC_WFLOW1        POST_SIMULATION
    HOOK_WORKFLOW QC_WFLOW2        POST_SIMULATION
-
 
 In this example the workflow :code:`initWFLOW` will run after all the
 simulation directories have been created, just before the forward
@@ -73,7 +70,6 @@ two workflows :code:`QC_WFLOW1` and :code:`QC_WFLOW2` will be run.
 Observe that the workflows being 'hooked in' with the
 :code:`HOOK_WORKFLOW` must be loaded with the :code:`LOAD_WORKFLOW`
 keyword.
-
 
 Locating the realisations: <RUNPATH_FILE>
 -----------------------------------------
@@ -106,10 +102,9 @@ like this:
 	9   /path/to/real9  CASE_0009
 
 The name and location of this file is available as the magical string
-<RUNPATH_FILE> and that is typically used as the first argument to
-external workflow jobs which should iterate over all realisations. The
-realisations referred to in the <RUNPATH_FILE> are meant to be last
-simulations you have run; the file is updated every time you run
-simulations. This implies that it is (currently) not so convenient to
+<RUNPATH_FILE> which is typically used as the first argument to
+external workflow jobs which should iterate over all realisations. 
+The realisations referred to in the <RUNPATH_FILE> should be the last simulations you have run. 
+The file is updated every time you run simulations. 
+This implies that it is (currently) not so convenient to
 alter which directories should be used when running a workflow.
-

--- a/docs/rst/manual/reference/workflows/configuring_jobs.rst
+++ b/docs/rst/manual/reference/workflows/configuring_jobs.rst
@@ -7,7 +7,6 @@ keywords used in the configuration file are in two *classes* - those
 related to how the job should be located/run and the arguments which
 should be passed from the workflow to the job.
 
-
 Configure an internal job
 -------------------------
 
@@ -20,10 +19,9 @@ keyword you can request the loading of an external shared library:
 
 ::
 
-    INTERNAL  TRUE                     -- The job will call an internal function of the current running ERT instance.
+    INTERNAL  TRUE                     -- The job will call an internal function or script of the currently running ERT instance.
     FUNCTION  enkf_main_plot_all       -- Name of the ERT function we are calling; must be marked exportable.
-    MODULE    /name/of/shared/library  -- Very optional - to load an extra shared library.
-
+    MODULE    /name/of/shared/library  -- Optional - to load an extra shared library.
 
 Configure an internal job: Python
 -----------------------------------
@@ -34,8 +32,8 @@ If you wish to implement your job as a Python class, derived from
 
 ::
 
-   INTERNAL  TRUE                     -- The job will call an internal function of the current running ERT instance.
-   SCRIPT scripts/my_script.py         -- An existing Python script
+   INTERNAL  TRUE                     -- The job will call an internal function or script of the currently running ERT instance.
+   SCRIPT scripts/my_script.py        -- An existing Python script
 
 Observe that the important thing here is the fact that we are writing
 an *internal* Python script; if you are writing an external script to
@@ -44,7 +42,7 @@ loop through all your realization folders that will typically be an
 i.e. Python, Perl, C++, F77 ... has no relevance.
 
 NB: note that relative paths are resolved from the location of the job
-configuration file, not the configuration file provided to ert
+configuration file, not the configuration file provided to ert.
 
 Configure an external job
 -------------------------
@@ -57,16 +55,16 @@ executable:
 
 ::
 
-    INTERNAL   FALSE                    -- This is the default - not necessary to include.
+    INTERNAL   FALSE                    -- Optional - Set to FALSE by default.
     EXECUTABLE path/to/program          -- Path to a program/script which will be invoked by the job.
 
 NB: note that relative paths are resolved from the location of the job
-configuration file, not the configuration file provided to ert
+configuration file, not the configuration file provided to ert.
 
 Configuring the arguments
 -------------------------
 
-In addition to the INTERNAL, FUNCTION, MODULE and EXECUTABLE keys
+In addition to the :code:`INTERNAL`, :code:`FUNCTION`, :code:`MODULE` and :code:`EXECUTABLE` keys
 which are used to configure what the job should do, there are some keys
 which can be used to configure the number of arguments and their
 type. These arguments apply to both internal and external jobs:
@@ -75,18 +73,20 @@ type. These arguments apply to both internal and external jobs:
 
 	MIN_ARG    2                 -- The job should have at least 2 arguments.
 	MAX_ARG    3                 -- The job should have maximum 3 arguments.
-	ARG_TYPE   0    INT          -- The first argument should be an integer
-	ARG_TYPE   1    FLOAT        -- The second argument should be a float value
+	ARG_TYPE   0    INT          -- The first argument should be an integer.
+	ARG_TYPE   1    FLOAT        -- The second argument should be a float value.
 	ARG_TYPE   2    STRING       -- The third argument should be a string - the default.
-	ARGLIST    <ARG0> <ARG1>     -- A list of arguments to pass on to the executable
+	ARGLIST    <ARG0> <ARG1>     -- A list of arguments to pass on to the executable.
 
-The MIN_ARG, MAX_ARG and ARG_TYPE arguments are used to validate workflows.
+The :code:`MIN_ARG`, :code:`MAX_ARG` and :code:`ARG_TYPE` arguments are used to validate workflows.
 
 Note
 ____
-When configuring ARGLIST for WORKFLOW_JOB jobs it is not suitable to use
-:code:`--some-option` for named options as it treated as a comment by the
-configuration compiler. Single letter options, i.e. :code:`-s`, are needed.
+
+When configuring :code:`ARGLIST` for workflow jobs,
+named options such as :code:`--some-option` cannot be used
+since they are treated as comments by the configuration compiler.
+Single letter options, i.e. :code:`-s`, are needed.
 
 **Example 1 : Plot variables**
 
@@ -97,10 +97,9 @@ configuration compiler. Single letter options, i.e. :code:`-s`, are needed.
 	FUNCTION  ert_tui_plot_JOB
 	MIN_ARG   1
 
-This job will use the ERT internal function ert_tui_plot_JOB to plot
+This job will use the ERT internal function :code:`ert_tui_plot_JOB` to plot
 an ensemble of an arbitrary ERT variable. The job needs at least one
 argument; there is no upper limit on the number of arguments.
-
 
 **Example 2 : Run external script**
 
@@ -110,37 +109,39 @@ argument; there is no upper limit on the number of arguments.
 	EXECUTABLE  Script/ecl_hist.py
 	MIN_ARG     3
 
-This job will invoke the external script Script/ecl_host.py; the
-script should have at least three commandline arguments. The path to
-the script, Script/ecl_hist.py is interpreted relative to the location
+This job will invoke the external script :code:`Script/ecl_host.py`
+which is expected to have at least three command line arguments. The path to
+the script, :code:`Script/ecl_hist.py` is interpreted relative to the location
 of the configuration file.
-
 
 Loading workflow jobs into ERT
 ------------------------------
 
-Before the jobs can be used in workflows they must be 'loaded' into
-ERT. This is done with two different ERT keywords:
+Before the jobs can be used in workflows they must be "loaded" into
+ERT. This can be done either by specifying jobs by name,
+or by specifying a directory containing jobs.
+
+Use the keyword :code:`LOAD_WORKFLOW_JOB` to specify jobs by name:
 
 ::
 
 	LOAD_WORKFLOW_JOB     jobConfigFile     JobName
 
-The LOAD_WORKFLOW_JOB keyword will load one workflow job. The name of
-the job is optional, if not provided the job will get name from the
-configuration file. Alternatively you can use the command
-WORKFLOW_JOB_DIRECTORY which will load all the jobs in a
-directory. The command:
+The :code:`LOAD_WORKFLOW_JOB` keyword will load one workflow job.
+The name of the job is optional, and will be fetched from the configuration file if not provided. 
+Alternatively, you can use the command
+:code:`WORKFLOW_JOB_DIRECTORY` which will load all the jobs in a
+directory.
+
+Use the keyword :code:`WORKFLOW_JOB_DIRECTORY` to specify a directory containing jobs:
 
 ::
 
 	WORKFLOW_JOB_DIRECTORY /path/to/jobs
 
-will load all the workflow jobs in the /path/to/jobs
-directory. Observe that all the files in the /path/to/jobs directory
+The :code:`WORKFLOW_JOB_DIRECTORY` loads all workflow jobs found in the `/path/to/jobs` directory.
+Observe that all the files in the `/path/to/jobs` directory
 should be job configuration files. The jobs loaded in this way will
 all get the name of the file as the name of the job. The
 :code:`WORKFLOW_JOB_DIRECTORY` keyword will *not* load configuration
 files recursively.
-
-

--- a/docs/rst/manual/reference/workflows/external.rst
+++ b/docs/rst/manual/reference/workflows/external.rst
@@ -1,11 +1,11 @@
-External Workflows
-==================
+External Workflow Jobs
+======================
 
-These jobs invoke an external program/script to do the job, this is
-very similar to the jobs of the forward model, but instead of running
-as separate jobs on the cluster - one for each realization, the
-workflow jobs will be invoked on the workstation running ERT, and
-typically go through all the realizations in one loop.
+External workflow jobs invoke programs and scripts that are not bundled with ERT, 
+which makes them similar to jobs defined as part of forward models.
+The difference lies in the way they are run.
+While workflow jobs are run on the workstation running ERT
+and go through all the realizations in one loop, forward model jobs run in parallell on HPC clusters. 
 
 The executable invoked by the workflow job can be an executable you
 have written yourself - in any language, or it can be an existing

--- a/docs/rst/manual/reference/workflows/index.rst
+++ b/docs/rst/manual/reference/workflows/index.rst
@@ -5,9 +5,9 @@ The Forward Model in ERT runs in the context of a single realization,
 i.e. there is no communication between the different processes, and
 the jobs are run outside of the main ERT process.
 
-As an alternative to the forward model ERT has a system with
-*workflows*. Using workflows way you can automate cumbersome normal
-ERT processes, and also invoke external programs. The workflows are
+As an alternative to the forward model, ERT has a system with
+*workflows*. Workflows allow you to automate combersome ERT processes,
+as well as invoke external programs. The workflows are
 run serially on the workstation actually running ERT, and should not
 be used for computationally heavy tasks.
 

--- a/docs/rst/manual/reference/workflows/internal.rst
+++ b/docs/rst/manual/reference/workflows/internal.rst
@@ -1,12 +1,10 @@
-Internal Workflows
-==================
+Internal Workflows Jobs
+=======================
 
 These jobs invoke a function in the address space of the ERT program
 itself; i.e. they are run as part of the running ERT process - and can
 in principle do anything that ERT can do itself. There are two
 varieties of the internal workflow jobs:
-
-
 
 Invoke a pre exported function
 ------------------------------
@@ -14,9 +12,8 @@ Invoke a pre exported function
 This is the simplest, where you can invoke a predefined ERT
 function. The function must already have been marked as *exported* in
 the ert code base. The list of predefined workflow jobs based on this
-method can be found here: :ref:`built_in_workflow_jobs`. Marking a new
-function as exported is quite simple, but it requires changes to the
-core code and a new version must be installed.
+method can be found here: :ref:`built_in_workflow_jobs`.
+Feel free to reach out if you have suggestions for new predefined workflow jobs.
 
 .. _ert_script:
 
@@ -33,7 +30,6 @@ of this kind must:
 
   1. Be implemented as a class which inherits from :code:`ErtScript`
   2. Have a method :code:`run(self)` which does the actual job
-
 
 .. code:: python
 
@@ -77,7 +73,3 @@ of this kind must:
                     print "%2d     %2d            %10.5f" % (index , iens , misfit[iens])
 
                 print "-----------------------------------\n"
-
-
-
-


### PR DESCRIPTION
**Approach**
Reformatted such that we have one sentence per line. This makes future diffing easier.

Fixed typos, and in some cases changed wording or entire sentences.

**Question**:

In [Internal Workflows](https://ert.readthedocs.io/en/latest/reference/workflows/internal.html#invoke-a-pre-exported-function) we write "Marking a new function as exported is quite simple, but it requires changes to the core code and a new version must be installed.".

Do we have a document describing how to export a function?
