### PR TITLE
add serializer

### DIFF
--- a/ert/serialization/_registry.py
+++ b/ert/serialization/_registry.py
@@ -2,12 +2,14 @@ from typing import Tuple
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from ._serializer import Serializer, _json_serializer, _yaml_serializer
+from ._transmitter import _transmitter_serializer
 
 
 _registry: PMap[str, Serializer] = pmap(
     {
         "application/json": _json_serializer(),
         "application/x-yaml": _yaml_serializer(),
+        "application/x-record-transmitter": _transmitter_serializer(),
     }
 )
 

--- a/ert/serialization/_transmitter.py
+++ b/ert/serialization/_transmitter.py
@@ -1,0 +1,41 @@
+import json
+from ._serializer import Serializer
+from typing import Any, TextIO
+import ert
+
+
+class _transmitter_serializer(Serializer):
+    _JSON_SCHEMA_VERSION = "0"
+
+    def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
+        return json.dumps(
+            {
+                "_version": self._JSON_SCHEMA_VERSION,
+                **obj.to_dict(),
+            }
+        )
+
+    def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
+        data = json.loads(series, *args, **kwargs)
+
+        if data["_version"] != self._JSON_SCHEMA_VERSION:
+            raise RuntimeError(
+                f"unexpected transmitter schema version {data['_version']}, expected {self._JSON_SCHEMA_VERSION}"
+            )
+
+        del data["_version"]
+
+        type_ = ert.data.RecordTransmitterType(data["transmitter_type"])
+        if type_ == ert.data.RecordTransmitterType.in_memory:
+            return ert.data.InMemoryRecordTransmitter.from_dict(data)
+        elif type_ == ert.data.RecordTransmitterType.shared_disk:
+            return ert.data.SharedDiskRecordTransmitter.from_dict(data)
+        elif type_ == ert.data.RecordTransmitterType.ert_storage:
+            return ert.storage.StorageRecordTransmitter.from_dict(data)
+        raise NotImplementedError(f"unsupported transmitter type {type_}")
+
+    def encode_to_file(self, obj: Any, fp: TextIO, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("file IO of record transmitter not yet implemented")
+
+    def decode_from_file(self, fp: TextIO, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("file IO of record transmitter not yet implemented")

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -98,6 +98,22 @@ class StorageRecordTransmitter(ert.data.RecordTransmitter):
         record = await load_record(self._uri, self._record_type)
         return ert.data.BlobRecord(data=record.data)
 
+    def _special_serialization_data(self) -> Dict[str, Any]:
+        return {
+            "name": self._name,
+            "uri": self._uri,
+            "real_id": self._real_id,
+        }
+
+    @classmethod
+    def _from_special_serialization_data(
+        cls, data: Dict[str, Any]
+    ) -> "ert.data.RecordTransmitter":
+        transmitter = cls(data["name"], "")
+        transmitter._uri = data["uri"]
+        transmitter._real_id = data["real_id"]
+        return transmitter
+
 
 async def _get_from_server_async(
     url: str,

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import logging
+import multiprocessing
 import os
 import sys
 import re
@@ -419,4 +420,5 @@ def main():
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("forkserver")
     main()

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -156,6 +156,12 @@ def test_run_once_polynomial_evaluation(
     evaluation_experiment_config,
     gaussian_parameters_config,
 ):
+    import multiprocessing
+
+    multiprocessing.set_start_method("spawn")
+    import time
+
+    time.sleep(2)
     ert3.engine.run(
         ensemble,
         stages_config,


### PR DESCRIPTION
**Issue**
Resolves #2031 


**Approach**
- Looked at solving this in pydantic, marshmallow, etc, and found both to be lacking. Neither handles (de)serialization of ambiguity well, i.e. serializing a FooTransmitter(RecordTransmitter) would not easily be deserialized back to FooTransmitter without some code specific to (de)serialization (constants, e.g.).
- Pydantic worries too much about a data's full life cycle; in our case we control every part of the life cycle.
- Validation isn't really a concern. Any user supplied information needs to be validated long before a transmitter is created.
- We're not sure what we're optimizing for, but it's clear that pickling has downsides that literally induces crashes.
- (De)serialization is only really relevant for Prefect, so (de)serialization is only going to be exposed there.