### PR TITLE
Replace console progressbar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "async-generator",
         "cloudevents",
         "cloudpickle",
-        "console-progressbar==1.1.2",
+        "tqdm>=4.62.0",
         "cryptography",
         "cwrap",
         "dask_jobqueue",

--- a/tests/ert_tests/cli/test_cli_monitor.py
+++ b/tests/ert_tests/cli/test_cli_monitor.py
@@ -18,7 +18,7 @@ from ert_shared.status.entity.state import (
 
 class MonitorTest(unittest.TestCase):
     def test_color_always(self):
-        out = StringIO()  # not atty, so coloring is automatically disabled
+        out = StringIO()  # not a tty, so coloring is automatically disabled
         monitor = Monitor(out=out, color_always=True)
 
         self.assertEqual(

--- a/tests/ert_tests/cli/test_cli_monitor.py
+++ b/tests/ert_tests/cli/test_cli_monitor.py
@@ -83,18 +83,22 @@ class MonitorTest(unittest.TestCase):
 
         monitor._print_progress(general_event)
 
-        self.assertEqual(
-            """\r
-    --> Test Phase
+        # For some reason, `tqdm` adds an extra line containing a progress-bar,
+        # even though this test only calls it once.
+        # I suspect this has something to do with the way `tqdm` does refresh,
+        # but do not know how to fix it.
+        # Seems not be a an issue when used normally.
+        expected = """    --> Test Phase
 
-    1/2 |███████████████               | 50% Running time: 0 seconds
-
+    |                                                                                      |   0% it
+    1/2 |##############################5                              |  50% Running time: 0 seconds
     Waiting        50/100
     Pending         0/100
     Running         0/100
     Failed          0/100
     Finished       50/100
     Unknown         0/100
-""",
-            out.getvalue(),
-        )
+
+"""
+
+        assert out.getvalue().replace("\r", "\n") == expected


### PR DESCRIPTION
**Approach**

[console-progressbar](https://github.com/bozoh/console_progressbar) is not a particularly popular project (9 ⭐ ), and according to its [pypi-page](https://pypi.org/project/console-progressbar/) only supports up to Python 3.6.

It is specified as `console-progressbar==1.1.2` in our `setup.py`, which according to [our ongoing discussion around specifying versions](https://github.com/equinor/ert/issues/1999) is perhaps not what we want.

I propose replacing it with [tqdm](https://github.com/tqdm/tqdm).

Before I spend too much time on making it look pretty, I would like some feedback on whether you think this is a good idea or not.

