### PR TITLE
Make evaluator able to deal with long updates

### DIFF
--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -247,6 +247,7 @@ class EnsembleEvaluator:
             else:
                 self._stop()
             self._ws_thread.join()
+            raise
         return self._ensemble.get_successful_realizations()
 
     @staticmethod

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -101,6 +101,12 @@ class BaseRunModel(object):
             self.updateDetailedProgress()
             self._fail_message = str(e)
             self._simulationEnded()
+        except Exception as e:
+            self.updateDetailedProgress()
+            self._failed = True
+            self._fail_message = str(e)
+            self._simulationEnded()
+            raise
 
     def runSimulations(self, job_queue, run_context):
         raise NotImplementedError("Method must be implemented by inheritors!")

--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import threading
+import time
 from argparse import ArgumentParser
 from unittest.mock import MagicMock, Mock, call, patch
 
@@ -162,8 +163,12 @@ def test_cli_test_connection_error(tmpdir, source_root, capsys):
         os.path.join(str(tmpdir), "poly_example"),
     )
 
+    def _simulate_connection_refused():
+        time.sleep(1)  # there's always some waiting for a connection
+        raise ConnectionRefusedError("Connection error")
+
     mock_monitor = MagicMock()
-    mock_monitor.__enter__.side_effect = ConnectionRefusedError
+    mock_monitor.__enter__.side_effect = _simulate_connection_refused
 
     with patch(
         "ert_shared.status.tracker.evaluator.create_ee_monitor",


### PR DESCRIPTION
**Issue**
Resolves #2055

Confirmed to work with a case which would always fail.


**Approach**
Wait forever in evaluator tracker. If ERT dies, mark experiment as failed.

@sondreso if `util_abort`, we have an endless/stuck GUI.
