### PR TITLE
Avoid hanging test on M1-based Macs.

### DIFF
--- a/tests/libres_tests/res/util/test_subprocess.py
+++ b/tests/libres_tests/res/util/test_subprocess.py
@@ -34,7 +34,7 @@ def _find_system_pipe_max_size():
         return len(p.stdout.read())
 
 
-_maxBytes = _find_system_pipe_max_size()
+_maxBytes = _find_system_pipe_max_size() - 1
 
 
 class TestSubprocess(unittest.TestCase):


### PR DESCRIPTION
On M1-based Macs, the file /bin/cat is larger than the capacity pipe-buffers, causing the test to hang in call to Popen.wait().

The solution is to add a method to determine the capacity of system pipe-buffer, then use it to limit amount of data to pipe.
