### PR TITLE
Introduce uniform/invariant records concept

### DIFF
--- a/ert/data/__init__.py
+++ b/ert/data/__init__.py
@@ -11,6 +11,7 @@ from ert.data._record import (
     SharedDiskRecordTransmitter,
     load_collection_from_file,
     record_data,
+    RecordCollectionType,
 )
 
 __all__ = (
@@ -26,4 +27,5 @@ __all__ = (
     "RecordTransmitterType",
     "record_data",
     "load_collection_from_file",
+    "RecordCollectionType",
 )

--- a/ert/data/_record.py
+++ b/ert/data/_record.py
@@ -95,12 +95,6 @@ class Record(_DataElement):
                     return RecordType.MAPPING_STR_FLOAT
         return record_type
 
-    def get_instance(self) -> "Record":
-        if self.record_type is not None:
-            if self.record_type == RecordType.BYTES:
-                return BlobRecord(data=self.data)
-        return NumericalRecord(data=self.data)
-
 
 class NumericalRecord(Record):
     data: numerical_record_data

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -4,7 +4,7 @@ import asyncio
 from functools import partial
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, Optional, Set, Tuple, List
 
 import pandas as pd
 import requests
@@ -116,13 +116,13 @@ async def _get_record_storage_transmitters(
     record_name: str,
     record_source: Optional[str] = None,
     ensemble_size: Optional[int] = None,
-) -> Dict[int, Dict[str, StorageRecordTransmitter]]:
+) -> Tuple[List[StorageRecordTransmitter], bool]:
     if record_source is None:
         record_source = record_name
     uri = f"{records_url}/{record_source}"
     metadata = await get_record_metadata(uri)
     record_type = metadata["record_type"]
-    is_uniform = metadata["is_uniform"]
+    is_uniform: bool = metadata["is_uniform"]
     uris = metadata["uris"]
     # We expect the number of uris in the record metadata to match the size of
     # the ensemble or be equal to 1, in the case of an uniform record
@@ -610,9 +610,9 @@ def _get_experiment_parameters(experiment_name: str) -> Iterable[str]:
 async def _get_record_collection(
     records_url: str,
     record_name: str,
+    ensemble_size: int,
     record_source: Optional[str] = None,
-    ensemble_size: Optional[int] = None,
-) -> Dict[int, Dict[str, StorageRecordTransmitter]]:
+) -> Tuple[List[StorageRecordTransmitter], bool]:
     return await _get_record_storage_transmitters(
         records_url, record_name, record_source, ensemble_size
     )

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -23,5 +23,5 @@ def sample_record(
 ) -> ert.data.RecordCollection:
     distribution = parameters_config[parameter_group_name].as_distribution()
     return ert.data.RecordCollection(
-        records=[distribution.sample() for _ in range(ensemble_size)]
+        records=tuple(distribution.sample() for _ in range(ensemble_size))
     )

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -162,7 +162,7 @@ def _prepare_sensitivity_records(
     }
     for record_name in sensitivity_parameters:
         ensemble_record = ert.data.RecordCollection(
-            records=sensitivity_parameters[record_name]
+            records=tuple(sensitivity_parameters[record_name])
         )
         future = ert.storage.transmit_record_collection(
             record_coll=ensemble_record,

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -53,7 +53,9 @@ def _prepare_experiment_record(
 
     elif record_source[0] == "resources":
         file_path = workspace_root / "resources" / record_source[1]
-        collection = ert.data.load_collection_from_file(file_path, record_mime)
+        collection = ert.data.load_collection_from_file(
+            file_path, record_mime, ensemble_size=ensemble_size
+        )
         future = ert.storage.transmit_record_collection(
             record_coll=collection,
             record_name=record_name,

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -11,6 +11,7 @@ from ert_shared.storage.server_monitor import (
 
 import requests
 import pytest
+import typing
 
 import ert3
 
@@ -284,3 +285,18 @@ def ert_storage(ert_storage_client, monkeypatch):
         "get_info",
         lambda: {"baseurl": "http://127.0.0.1:51820", "auth": ("", "")},
     )
+
+
+@pytest.fixture
+def raw_ensrec_to_records():
+    def _coerce_raw_ensrec(spec) -> typing.Tuple[ert.data.Record]:
+        recs = []
+        for rec in spec:
+            data = rec["data"]
+            if isinstance(data, bytes):
+                recs.append(ert.data.BlobRecord.parse_obj(rec))
+            else:
+                recs.append(ert.data.NumericalRecord.parse_obj(rec))
+        return tuple(recs)
+
+    return _coerce_raw_ensrec

--- a/tests/ert_tests/ert3/data/test_record.py
+++ b/tests/ert_tests/ert3/data/test_record.py
@@ -123,7 +123,7 @@ def test_inconsistent_index_record(data, index):
 def test_valid_ensemble_record(raw_ensrec, record_type):
     ensrecord = ert.data.RecordCollection(records=raw_ensrec)
     assert ensrecord.record_type == record_type
-    assert ensrecord.is_uniform is False
+    assert ensrecord.collection_type != ert.data.RecordCollectionType.UNIFORM
     assert len(raw_ensrec) == len(ensrecord.records) == ensrecord.ensemble_size
     for raw_record, record in zip(raw_ensrec, ensrecord.records):
         raw_record = raw_record["data"]
@@ -146,9 +146,13 @@ def test_valid_ensemble_record(raw_ensrec, record_type):
 )
 def test_valid_uniform_ensemble_record(raw_ensrec, record_type):
     ens_size = 5
-    ensrecord = ert.data.RecordCollection(records=raw_ensrec, ensemble_size=ens_size)
+    ensrecord = ert.data.RecordCollection(
+        records=(raw_ensrec,),
+        ensemble_size=ens_size,
+        collection_type=ert.data.RecordCollectionType.UNIFORM,
+    )
     assert ensrecord.record_type == record_type
-    assert ensrecord.is_uniform is True
+    assert ensrecord.collection_type == ert.data.RecordCollectionType.UNIFORM
     assert len(ensrecord.records) == ensrecord.ensemble_size == ens_size
     raw_record = raw_ensrec["data"]
     assert len(raw_record) == len(ensrecord.records[0].data)
@@ -172,7 +176,10 @@ def test_invalid_ensemble_record():
 
 def test_uniform_ensemble_record_missing_size():
     with pytest.raises(ValueError):
-        ert.data.RecordCollection(records={"data": b"a"})
+        ert.data.RecordCollection(
+            records={"data": b"a"},
+            collection_type=ert.data.RecordCollectionType.UNIFORM,
+        )
 
 
 @pytest.mark.parametrize(
@@ -211,7 +218,7 @@ def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
     assert len(collection.records) == len(raw_collection)
     assert collection.ensemble_size == len(raw_collection)
     assert collection.record_type != ert.data.RecordType.BYTES
-    assert collection.is_uniform is False
+    assert collection.collection_type != ert.data.RecordCollectionType.UNIFORM
 
 
 def test_load_blob_record_collection_from_file(designed_blob_record_file):
@@ -222,7 +229,7 @@ def test_load_blob_record_collection_from_file(designed_blob_record_file):
     assert len(collection.records) == ens_size
     assert collection.ensemble_size == ens_size
     assert collection.record_type == ert.data.RecordType.BYTES
-    assert collection.is_uniform is True
+    assert collection.collection_type == ert.data.RecordCollectionType.UNIFORM
     # All records must be references to the same object:
     for record in collection.records[1:]:
         assert record is collection.records[0]

--- a/tests/ert_tests/ert3/data/test_record.py
+++ b/tests/ert_tests/ert3/data/test_record.py
@@ -160,18 +160,18 @@ def test_valid_uniform_ensemble_record(raw_ensrec, record_type):
 
 
 def test_ensemble_record_not_empty():
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValueError):
         ert.data.RecordCollection(records=[])
 
 
 def test_invalid_ensemble_record():
     raw_ensrec = [{"data": b"a"}, {"data": [1.1, 2.2]}]
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValueError):
         ert.data.RecordCollection(records=raw_ensrec)
 
 
 def test_uniform_ensemble_record_missing_size():
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValueError):
         ert.data.RecordCollection(records={"data": b"a"})
 
 
@@ -183,7 +183,7 @@ def test_uniform_ensemble_record_missing_size():
     ),
 )
 def test_non_uniform_ensemble_record_types(raw_ensrec):
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValueError):
         ert.data.RecordCollection(records=raw_ensrec)
 
 
@@ -197,7 +197,7 @@ def test_non_uniform_ensemble_record_types(raw_ensrec):
     ),
 )
 def test_inconsistent_size_ensemble_record(raw_ensrec, ensemble_size):
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValueError):
         ert.data.RecordCollection(records=raw_ensrec, ensemble_size=ensemble_size)
 
 

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -164,7 +164,11 @@ def test_add_and_get_ensemble_record(tmpdir, raw_ensrec, ert_storage):
 def test_add_and_get_uniform_ensemble_record(tmpdir, raw_ensrec, ert_storage):
     ert.storage.init(workspace=tmpdir)
     ens_size = 5
-    ensrecord = ert.data.RecordCollection(records=raw_ensrec, ensemble_size=ens_size)
+    ensrecord = ert.data.RecordCollection(
+        records=(raw_ensrec,),
+        ensemble_size=ens_size,
+        collection_type=ert.data.RecordCollectionType.UNIFORM,
+    )
     future = ert.storage.transmit_record_collection(
         record_coll=ensrecord,
         record_name="my_ensemble_record",
@@ -175,8 +179,6 @@ def test_add_and_get_uniform_ensemble_record(tmpdir, raw_ensrec, ert_storage):
     res = ert.storage.get_ensemble_record(
         workspace=tmpdir, record_name="my_ensemble_record", ensemble_size=ens_size
     )
-
-    assert res.is_uniform is True
     assert res == ensrecord
 
 


### PR DESCRIPTION
**Issue**
Resolves #1919 


**Approach**
There was a previous attempt in the code to introduce some optimizations for records that are invariant over ensemble. The basic idea was to hold a tuple of references to the same object, and deal with that case when loading or transmitting records. Detecting of this case was done in a non-obvious way, by setting the `ensemble_size` of the invariant collection equal to one and testing for that.

This was not working properly. First of all, it was not done entirely consistently, secondly because `pydantic` has some unexpected behavior:  if one of the fields is a tuple, `pydantic `will make a deep copy of the tuple. So a tuple consisting of references becomes a tuple of copies.

To work around this issue with `pydantic`, the `RecordCollection`  is changed to accept a single record in addition to tuples of records, plus an ensemble size. Single records are then internally changed to a tuple of references of that record. Thus, uniform records are creating by passing a records with an ensemble size, instead of a tuple of records. A `is_uniform` field is added to allow checking if a collection is uniform or not.

Tests are added to make sure that a uniform collection is indeed a collection of references to a single object.
