### PR TITLE
Delete unused const LOG_URL

### DIFF
--- a/job_runner/__init__.py
+++ b/job_runner/__init__.py
@@ -1,3 +1,2 @@
 CERT_FILE = ".ee.pem"
 JOBS_FILE = "jobs.json"
-LOG_URL = "http://devnull.statoil.no:4444"


### PR DESCRIPTION
`LOG_URL` defined in `job_runner` seems not to be in use.