### PR TITLE
Use get to read dict

### DIFF
--- a/job_runner/job.py
+++ b/job_runner/job.py
@@ -18,12 +18,8 @@ class Job(object):
         self.sleep_interval = sleep_interval
         self.job_data = job_data
         self.index = index
-        self.std_err = None
-        self.std_out = None
-        if "stderr" in job_data and job_data["stderr"]:
-            self.std_err = job_data["stderr"]
-        if "stdout" in job_data and job_data["stdout"]:
-            self.std_out = job_data["stdout"]
+        self.std_err = job_data.get("stderr")
+        self.std_out = job_data.get("stdout")
 
     def run(self):
         start_message = Start(self)

--- a/tests/libres_tests/job_runner/test_job.py
+++ b/tests/libres_tests/job_runner/test_job.py
@@ -92,3 +92,24 @@ class JobTests(TestCase):
         with self.assertRaises(IOError):
             for _ in job.run():
                 pass
+
+
+def test_init_job_no_std():
+    job = Job(
+        {},
+        0,
+    )
+    assert job.std_err is None
+    assert job.std_out is None
+
+
+def test_init_job_with_std():
+    job = Job(
+        {
+            "stdout": "exit_out",
+            "stderr": "exit_err",
+        },
+        0,
+    )
+    assert job.std_err == "exit_err"
+    assert job.std_out == "exit_out"


### PR DESCRIPTION
**Approach**
Using that `get` returns `None` if no key exists.

`self.std_err` and `self.std_out` are used in the following manner:

```python
        if self.std_err:
            stderr = open(self.std_err, "w")
        else:
            stderr = None

        if self.std_out:
            stdout = open(self.std_out, "w")
        else:
            stdout = None
```

This should still work as before, i.e., that we only open up files if `self.std_err` and `self.std_out` are not None or are a string with length larger than 0. 

