### PR TITLE
Fix <NUM_CPU> not being subst. when set in .ert

### DIFF
--- a/libres/lib/enkf/subst_config.cpp
+++ b/libres/lib/enkf/subst_config.cpp
@@ -253,4 +253,10 @@ static void subst_config_init_load(subst_config_type *subst_config,
         int num_cpu = ecl_util_get_num_cpu(data_file);
         subst_config_install_num_cpu(subst_config, num_cpu);
     }
+
+    // The NUM_CPU keyword in the user's config overrides the one set by the DATA_FILE above
+    if (config_content_has_item(content, NUM_CPU_KEY)) {
+        int num_cpu = config_content_get_value_as_int(content, NUM_CPU_KEY);
+        subst_config_install_num_cpu(subst_config, num_cpu);
+    }
 }

--- a/tests/libres_tests/test_integration_config.py
+++ b/tests/libres_tests/test_integration_config.py
@@ -1,0 +1,76 @@
+import pytest
+from ecl.util.util import BoolVector
+from res.enkf import ErtRunContext
+from res.enkf.enkf_main import EnKFMain
+from res.enkf.res_config import ResConfig
+
+
+def _create_runpath(enkf_main: EnKFMain) -> ErtRunContext:
+    """
+    Instantiate an ERT runpath. This will create the parameter coefficients.
+    """
+    result_fs = enkf_main.getEnkfFsManager().getCurrentFileSystem()
+
+    model_config = enkf_main.getModelConfig()
+    runpath_fmt = model_config.getRunpathFormat()
+    jobname_fmt = model_config.getJobnameFormat()
+    subst_list = enkf_main.getDataKW()
+
+    run_context = ErtRunContext.ensemble_smoother(
+        result_fs,
+        None,
+        BoolVector(default_value=True, initial_size=1),
+        runpath_fmt,
+        jobname_fmt,
+        subst_list,
+        0,
+    )
+
+    enkf_main.getEnkfSimulationRunner().createRunPath(run_context)
+    return run_context
+
+
+def _evaluate_ensemble(enkf_main: EnKFMain, run_context: ErtRunContext):
+    """
+    Launch ensemble experiment with the created config
+    """
+    queue_config = enkf_main.get_queue_config()
+    job_queue = queue_config.create_job_queue()
+
+    enkf_main.getEnkfSimulationRunner().runSimpleStep(job_queue, run_context)
+
+
+@pytest.mark.parametrize(
+    "append,numcpu",
+    [
+        ("", 1),  # Default is 1
+        ("NUM_CPU 2\n", 2),
+        ("DATA_FILE DATA\n", 8),  # Data file dictates NUM_CPU with PARALLEL
+        ("NUM_CPU 3\nDATA_FILE DATA\n", 3),  # Explicit NUM_CPU supersedes PARALLEL
+    ],
+)
+def test_num_cpu_subst(monkeypatch, tmp_path, append, numcpu):
+    """
+    Make sure that <NUM_CPU> is substituted to the correct values
+    """
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "test.ert").write_text(
+        "JOBNAME test_%d\n"
+        "QUEUE_SYSTEM LOCAL\n"
+        "QUEUE_OPTION LOCAL MAX_RUNNING 50\n"
+        "NUM_REALIZATIONS 1\n"
+        "RUNPATH test/real_%d/iter_%d\n"
+        "INSTALL_JOB dump DUMP\n"
+        "FORWARD_MODEL dump\n" + append
+    )
+    (tmp_path / "DATA").write_text("PARALLEL 8 /")
+    (tmp_path / "DUMP").write_text("EXECUTABLE echo\nARGLIST <NUM_CPU>\n")
+
+    config = ResConfig(str(tmp_path / "test.ert"))
+    enkf_main = EnKFMain(config)
+    run_context = _create_runpath(enkf_main)
+    _evaluate_ensemble(enkf_main, run_context)
+
+    with open("test/real_0/iter_0/dump.stdout.0") as f:
+        assert f.read() == f"{numcpu}\n"


### PR DESCRIPTION
If the user specifies NUM_CPU in their .ert config file, it should
affect future substitutions <NUM_CPU>. Previously this happened only
when the PARALLEL keyword was used inside a DATA_FILE.

Resolves: #2091 
