### PR TITLE
Allow unlink to fail

### DIFF
--- a/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_ensemble.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_ensemble.py
@@ -125,7 +125,11 @@ def test_prefect_retries(
         if not run_path.exists():
             run_path.touch()
             raise RuntimeError("This is an expected ERROR")
-        run_path.unlink()
+        try:
+            run_path.unlink()
+        except FileNotFoundError:
+            # some other real beat us to it
+            pass
         return []
 
     pickle_func = cloudpickle.dumps(function_that_fails_once)


### PR DESCRIPTION
**Issue**
Resolves #2101 


**Approach**
There's a TOCTOU issue here:
```
    def function_that_fails_once(coeffs):
        run_path = Path("ran_once")
        if not run_path.exists():  # time of check
            run_path.touch()  # time of use
            raise RuntimeError("This is an expected ERROR")
        run_path.unlink()  # time of use
        return []
```



This test is quite brittle. For now, allowing `run_path.unlink()` should suffice. It essentially means that it is okay to "lose" the race.
