### PR TITLE
Ertsummary readthrough

### DIFF
--- a/ert_gui/ertwidgets/models/ertsummary.py
+++ b/ert_gui/ertwidgets/models/ertsummary.py
@@ -42,14 +42,5 @@ class ErtSummary(object):
             else:
                 keys.append("%s [%s]" % (key, data_key))
 
-        # keys = []
-        # for key in summary_keys:
-        #     count = summary_keys_count[key]
-        #     if count > 1:
-        #         #keys.append("%s (%d)" % (key, count))
-        #         keys.append("%s" % key)
-        #     else:
-        #         keys.append(key)
-
         obs_keys = list(gen_obs) + summary_keys
         return sorted(obs_keys, key=lambda k: k.lower())

--- a/ert_gui/ertwidgets/models/ertsummary.py
+++ b/ert_gui/ertwidgets/models/ertsummary.py
@@ -5,7 +5,7 @@ from res.enkf.enums.enkf_var_type_enum import EnkfVarType
 from ert_shared import ERT
 
 
-class ErtSummary():
+class ErtSummary:
     def getForwardModels(self) -> List[str]:
         forward_model = ERT.ert.getModelConfig().getForwardModel()
         return list(forward_model.joblist())
@@ -40,7 +40,7 @@ class ErtSummary():
             if key == data_key:
                 keys.append(key)
             else:
-                keys.append("%s [%s]" % (key, data_key))
+                keys.append(f"{key} [{data_key}]")
 
         obs_keys = list(gen_obs) + summary_keys
         return sorted(obs_keys, key=lambda k: k.lower())

--- a/ert_gui/ertwidgets/models/ertsummary.py
+++ b/ert_gui/ertwidgets/models/ertsummary.py
@@ -5,7 +5,7 @@ from res.enkf.enums.enkf_var_type_enum import EnkfVarType
 from ert_shared import ERT
 
 
-class ErtSummary(object):
+class ErtSummary():
     def getForwardModels(self) -> List[str]:
         forward_model = ERT.ert.getModelConfig().getForwardModel()
         return list(forward_model.joblist())

--- a/ert_gui/ertwidgets/models/ertsummary.py
+++ b/ert_gui/ertwidgets/models/ertsummary.py
@@ -1,23 +1,22 @@
+from typing import List
+
 from res.enkf.enums.enkf_obs_impl_type_enum import EnkfObservationImplementationType
 from res.enkf.enums.enkf_var_type_enum import EnkfVarType
 from ert_shared import ERT
 
 
 class ErtSummary(object):
-    def getForwardModels(self):
-        """@rtype: list of str"""
+    def getForwardModels(self) -> List[str]:
         forward_model = ERT.ert.getModelConfig().getForwardModel()
-        return [job for job in forward_model.joblist()]
+        return list(forward_model.joblist())
 
-    def getParameters(self):
-        """@rtype: list of str"""
+    def getParameters(self) -> List[str]:
         parameters = ERT.ert.ensembleConfig().getKeylistFromVarType(
             EnkfVarType.PARAMETER
         )
-        return sorted([parameter for parameter in parameters], key=lambda k: k.lower())
+        return sorted(list(parameters), key=lambda k: k.lower())
 
-    def getObservations(self):
-        """@rtype: list of str"""
+    def getObservations(self) -> List[str]:
         gen_obs = ERT.ert.getObservations().getTypedKeylist(
             EnkfObservationImplementationType.GEN_OBS
         )
@@ -52,5 +51,5 @@ class ErtSummary(object):
         #     else:
         #         keys.append(key)
 
-        obs_keys = [observation for observation in gen_obs] + summary_keys
+        obs_keys = list(gen_obs) + summary_keys
         return sorted(obs_keys, key=lambda k: k.lower())

--- a/tests/ert_tests/gui/ertwidgets/test_ertsummary.py
+++ b/tests/ert_tests/gui/ertwidgets/test_ertsummary.py
@@ -1,0 +1,42 @@
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from ecl.util.util import StringList
+from ert_gui.ertwidgets.models.ertsummary import ErtSummary
+
+
+@pytest.fixture
+def mock_ert_summary(monkeypatch, autouse=True):
+    ERT_mock = MagicMock()
+    test_module = inspect.getmodule(ErtSummary)
+    monkeypatch.setattr(test_module, "ERT", ERT_mock)
+
+    string_list = StringList(["forward_model_1", "forward_model_2"])
+    ERT_mock.ert.getModelConfig.return_value.getForwardModel.return_value.joblist.return_value = (
+        string_list
+    )
+
+    string_list = StringList(["param_1", "param_2"])
+    ERT_mock.ert.ensembleConfig.return_value.getKeylistFromVarType.return_value = (
+        string_list
+    )
+
+
+@pytest.mark.usefixtures("mock_ert_summary")
+def test_getForwardModels():
+    regular_list = ["forward_model_1", "forward_model_2"]
+
+    forward_models = ErtSummary().getForwardModels()
+
+    assert forward_models == regular_list
+
+
+@pytest.mark.usefixtures("mock_ert_summary")
+def test_getParameters():
+    regular_list = ["param_1", "param_2"]
+
+    parameters = ErtSummary().getParameters()
+
+    assert parameters == regular_list


### PR DESCRIPTION
**Approach**
Came over this reading up on forward models, and thought I'd try cleaning up a bit.

Seems like we don't need to use list comprehension to convert the type `StringList` to `list`.

I've also added some typing, mostly to get rid of docstrings that just define return type.

From what I can gather, the class `ErtSummary` seems a bit under-tested, but perhaps it's not something to worry about.
Thoughts?