### PR TITLE
Remove libres version from about dialog

### DIFF
--- a/ert_gui/about_dialog.py
+++ b/ert_gui/about_dialog.py
@@ -73,8 +73,7 @@ class AboutDialog(QDialog):
 
         version.setAlignment(Qt.AlignHCenter)
         version.setText(
-            "Versions: ecl:%s    res:%s    ert:%s"
-            % (ecl.__version__, res.__version__, ert_gui.__version__)
+            "Versions: ecl:%s  ert:%s" % (ecl.__version__, ert_gui.__version__)
         )
         info_layout.addWidget(version)
 


### PR DESCRIPTION
**Issue**
Resolves #2077 

res module does not have a separate version after the merger of libres and ert