### PR TITLE
Version 2.28

### DIFF
--- a/ert_shared/cli/monitor.py
+++ b/ert_shared/cli/monitor.py
@@ -129,10 +129,10 @@ class Monitor:
 
         bar_format = "   {desc} |{bar}| {percentage:3.0f}% {unit}"
         tqdm.write(f"    --> {event.phase_name}", file=self._out)
-        tqdm.write("\n", end="")
+        tqdm.write("\n", end="", file=self._out)
         with tqdm(total=100, ncols=100, bar_format=bar_format, file=self._out) as pbar:
             pbar.set_description_str(nphase, refresh=False)
             pbar.unit = "{runtime}".format(runtime=format_running_time(elapsed.seconds))
             pbar.update(event.progress * 100)
-        tqdm.write("\n", end="")
+        tqdm.write("\n", end="", file=self._out)
         tqdm.write(self._get_legends(), file=self._out)

--- a/tests/ert_tests/cli/test_cli_monitor.py
+++ b/tests/ert_tests/cli/test_cli_monitor.py
@@ -90,8 +90,10 @@ class MonitorTest(unittest.TestCase):
         # Seems not be a an issue when used normally.
         expected = """    --> Test Phase
 
+
     |                                                                                      |   0% it
     1/2 |##############################5                              |  50% Running time: 0 seconds
+
     Waiting        50/100
     Pending         0/100
     Running         0/100


### PR DESCRIPTION
**Approach**

Introduction of `tqdm` causes a bug when ert is run with the progress-bar turned off.
@ManInFez has fixed the bug, and it would be nice if it was included in the next release.
Is this still a possibility @jondequinor ?
