### PR TITLE
Make project_id Optional in connection get_info()

### DIFF
--- a/ert_shared/storage/connection.py
+++ b/ert_shared/storage/connection.py
@@ -1,7 +1,10 @@
+import os
+from typing import Optional
+
 from ert_shared.services import Storage
 
 
-def get_info(project_id):
+def get_info(project_id: Optional[os.PathLike] = None):
     client = Storage.connect(project=project_id)
     return {
         "baseurl": client.fetch_url(),


### PR DESCRIPTION
A change has been made in ERT `connection.py` -> `get_info()`. Integration tests has uncovered errors in webviz-ert and ert-storage after the change which looks like this
```
___________________ ERROR at setup of test_read_experiments ____________________

    @pytest.fixture(scope="session")
    def get_info():
        from ert_shared.storage.connection import get_info
    
>       info = get_info()
E       TypeError: get_info() missing 1 required positional argument: 'project_id'
```