### PR TITLE
Experiment server

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -17,6 +17,8 @@ from ert_shared.status.entity.event import (
 )
 from ert_shared.status.tracker.factory import create_tracker
 from ert_shared.status.utils import format_running_time
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorService
+from ert_shared.feature_toggling import FeatureToggling
 from qtpy.QtCore import QModelIndex, QSize, Qt, QThread, QTimer, Signal, Slot
 from qtpy.QtWidgets import (
     QDialog,
@@ -270,10 +272,16 @@ class RunDialog(QDialog):
 
         self._ticker.start(1000)
 
+        ee_config = (
+            EnsembleEvaluatorService.get_config()
+            if FeatureToggling.is_enabled("ensemble-evaluator")
+            else None
+        )
+
         tracker = create_tracker(
             self._run_model,
             num_realizations=self._simulations_argments["active_realizations"].count(),
-            ee_config=self._simulations_argments.get("ee_config", None),
+            ee_config=ee_config,
         )
 
         worker = TrackerWorker(tracker)

--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -23,18 +23,13 @@ from ert_gui.simulation import (
     SimulationConfigPanel,
 )
 from ert_gui.simulation import RunDialog
-from ert_shared.feature_toggling import FeatureToggling
 from collections import OrderedDict
-from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 
 
 class SimulationPanel(QWidget):
     def __init__(self, config_file):
         QWidget.__init__(self)
         self._config_file = config_file
-        self._ee_config = None
-        if FeatureToggling.is_enabled("ensemble-evaluator"):
-            self._ee_config = EvaluatorServerConfig()
 
         self.setObjectName("Simulation_panel")
         layout = QVBoxLayout()
@@ -110,8 +105,6 @@ class SimulationPanel(QWidget):
         """@rtype: dict[str,object]"""
         simulation_widget = self._simulation_widgets[self.getCurrentSimulationModel()]
         args = simulation_widget.getSimulationArguments()
-        if self._ee_config is not None:
-            args.update({"ee_config": self._ee_config})
         return args
 
     def runSimulation(self):

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -15,7 +15,7 @@ from ert_shared.cli.model_factory import create_model
 from ert_shared.cli.monitor import Monitor
 from ert_shared.cli.notifier import ErtCliNotifier
 from ert_shared.cli.workflow import execute_workflow
-from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorService
 from ert_shared.feature_toggling import FeatureToggling
 from ert_shared.status.tracker.factory import create_tracker
 from res.enkf import EnKFMain, ResConfig
@@ -63,10 +63,11 @@ def run_cli(args):
         clear_global_state()
         raise ErtCliError(msg)
 
-    ee_config = None
-    if FeatureToggling.is_enabled("ensemble-evaluator"):
-        ee_config = EvaluatorServerConfig(custom_port_range=args.port_range)
-        argument.update({"ee_config": ee_config})
+    ee_config = (
+        EnsembleEvaluatorService.get_config()
+        if FeatureToggling.is_enabled("ensemble-evaluator")
+        else None
+    )
 
     thread = threading.Thread(
         name="ert_cli_simulation_thread",

--- a/ert_shared/ensemble_evaluator/ensemble/legacy.py
+++ b/ert_shared/ensemble_evaluator/ensemble/legacy.py
@@ -51,7 +51,7 @@ class _LegacyEnsemble(_Ensemble):
             )
             timeout_queue.put_nowait(timeout_cloudevent)
 
-        dispatch_url = self._config.dispatch_uri
+        dispatch_url = f"{self._config.dispatch_uri}/{self._ee_id}"
         cert = self._config.cert
         token = self._config.token
 
@@ -86,7 +86,7 @@ class _LegacyEnsemble(_Ensemble):
     def _evaluate(self):
         asyncio.set_event_loop(asyncio.new_event_loop())
 
-        dispatch_url = self._config.dispatch_uri
+        dispatch_url = f"{self._config.dispatch_uri}/{self._ee_id}"
         cert = self._config.cert
         token = self._config.token
         try:
@@ -216,7 +216,7 @@ class _LegacyEnsemble(_Ensemble):
         )
         asyncio.get_event_loop().run_until_complete(
             self.send_cloudevent(
-                self._config.dispatch_uri,
+                f"{self._config.dispatch_uri}/{self._ee_id}",
                 out_cloudevent,
                 token=self._config.token,
                 cert=self._config.cert,

--- a/ert_shared/ensemble_evaluator/ensemble/prefect.py
+++ b/ert_shared/ensemble_evaluator/ensemble/prefect.py
@@ -210,7 +210,11 @@ class PrefectEnsemble(_Ensemble):
     def _evaluate(self, ee_config: EvaluatorServerConfig, ee_id):
         asyncio.set_event_loop(asyncio.get_event_loop())
         try:
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(
+                f"{ee_config.dispatch_uri}/{self._ee_id}",
+                ee_config.token,
+                ee_config.cert,
+            ) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_STARTED,
@@ -219,11 +223,17 @@ class PrefectEnsemble(_Ensemble):
                 )
                 c.send(to_json(event).decode())
             with prefect.context(
-                url=ee_config.dispatch_uri, token=ee_config.token, cert=ee_config.cert
+                url=f"{ee_config.dispatch_uri}/{self._ee_id}",
+                token=ee_config.token,
+                cert=ee_config.cert,
             ):
                 self.run_flow(ee_id)
 
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(
+                f"{ee_config.dispatch_uri}/{self._ee_id}",
+                ee_config.token,
+                ee_config.cert,
+            ) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_STOPPED,
@@ -238,7 +248,11 @@ class PrefectEnsemble(_Ensemble):
                 "An exception occurred while starting the ensemble evaluation",
                 exc_info=True,
             )
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(
+                f"{ee_config.dispatch_uri}/{self._ee_id}",
+                ee_config.token,
+                ee_config.cert,
+            ) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_FAILED,
@@ -303,7 +317,7 @@ class PrefectEnsemble(_Ensemble):
         loop = asyncio.new_event_loop()
         loop.run_until_complete(
             self.send_cloudevent(
-                self._ee_config.dispatch_uri,
+                f"{ee_config.dispatch_uri}/{self._ee_id}",
                 event,
                 token=self._ee_config.token,
                 cert=self._ee_config.cert,

--- a/ert_shared/ensemble_evaluator/entity/identifiers.py
+++ b/ert_shared/ensemble_evaluator/entity/identifiers.py
@@ -101,6 +101,15 @@ EVTYPE_EE_TERMINATED = "com.equinor.ert.ee.terminated"
 EVTYPE_EE_USER_CANCEL = "com.equinor.ert.ee.user_cancel"
 EVTYPE_EE_USER_DONE = "com.equinor.ert.ee.user_done"
 
+EVTYPE_EE_EXPERIMENT_UPDATE = "com.equinor.ert.ee.experiment.update"
+EVTYPE_EE_EXPERIMENT_TERMINATED = "com.equinor.ert.ee.experiment.terminated"
+
+EVTYPE_EXPERIMENT_SUBMITTED = "com.equinor.ert.experiment.submitted"
+EVTYPE_EXPERIMENT_RUNNING = "com.equinor.ert.experiment.running"
+EVTYPE_EXPERIMENT_SUCCESS = "com.equinor.ert.experiment.success"
+EVTYPE_EXPERIMENT_FAILURE = "com.equinor.ert.experiment.failure"
+
+
 EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
 EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
 EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"

--- a/ert_shared/ensemble_evaluator/entity/tool.py
+++ b/ert_shared/ensemble_evaluator/entity/tool.py
@@ -37,3 +37,7 @@ def get_step_id(source):
 
 def get_job_id(source):
     return _match_token("job", source)
+
+
+def get_evaluation_id(source):
+    return _match_token("ee", source)

--- a/ert_shared/ensemble_evaluator/monitor.py
+++ b/ert_shared/ensemble_evaluator/monitor.py
@@ -16,10 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 class _Monitor:
-    def __init__(self, host, port, protocol="wss", cert=None, token=None):
+    def __init__(
+        self, evaluation_id, host, port, protocol="wss", cert=None, token=None
+    ):
+        self._evaluation_id = evaluation_id
         self._base_uri = f"{protocol}://{host}:{port}"
-        self._client_uri = f"{self._base_uri}/client"
-        self._result_uri = f"{self._base_uri}/result"
+        self._client_uri = f"{self._base_uri}/client/{self._evaluation_id}"
         self._cert = cert
         self._token = token
         self._ws_duplexer: Optional[SyncWebsocketDuplexer] = None
@@ -96,5 +98,5 @@ class _Monitor:
                     break
 
 
-def create(host, port, protocol, cert, token):
-    return _Monitor(host, port, protocol, cert, token)
+def create(evaluation_id, host, port, protocol, cert, token):
+    return _Monitor(evaluation_id, host, port, protocol, cert, token)

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -7,14 +7,10 @@ from argparse import ArgumentParser, ArgumentTypeError
 from contextlib import contextmanager
 
 import yaml
-
 from ert_logging import LOGGING_CONFIG
+
 import ert_shared
 from ert_shared import clear_global_state
-<<<<<<< HEAD
-from ert_shared.cli.main import run_cli, ErtCliError
-=======
->>>>>>> Import order
 from ert_shared.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -35,18 +31,9 @@ from ert_shared.ide.keywords.definitions import (
     RangeStringArgument,
 )
 from ert_shared.models.multiple_data_assimilation import MultipleDataAssimilation
-<<<<<<< HEAD
 from ert_shared.plugins.plugin_manager import ErtPluginContext
-from ert_shared.feature_toggling import FeatureToggling
-from ert_shared.storage.command import add_parser_options as ert_api_add_parser_options
 from ert_shared.services import Storage, WebvizErt
-import ert_shared
-=======
-from ert_shared.plugins import launch_visualization_plugin
-from ert_shared.plugins.plugin_manager import ErtPluginContext
 from ert_shared.storage.command import add_parser_options as ert_api_add_parser_options
-from ert_shared.storage.main import run_server
->>>>>>> Import order
 
 
 def run_ert_storage(args):
@@ -459,12 +446,12 @@ def start_ensemble_evaluator(custom_port_range=None):
     if FeatureToggling.is_enabled("ensemble-evaluator"):
         ee_config = EvaluatorServerConfig(custom_port_range=custom_port_range)
         EnsembleEvaluatorService.start(config=ee_config)
-        evaluator = EnsembleEvaluatorService.get_evaluator()
+        evaluator = EnsembleEvaluatorService.get_evaluator_session()
     try:
         yield
     finally:
         if evaluator is not None:
-            evaluator.stop()
+            EnsembleEvaluatorService.stop()
 
 
 def main():

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -1,38 +1,52 @@
-from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorService
-from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 import logging
 import logging.config
 import os
-import sys
 import re
-import yaml
+import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from contextlib import contextmanager
 
+import yaml
+
 from ert_logging import LOGGING_CONFIG
+import ert_shared
 from ert_shared import clear_global_state
+<<<<<<< HEAD
 from ert_shared.cli.main import run_cli, ErtCliError
+=======
+>>>>>>> Import order
 from ert_shared.cli import (
-    ENSEMBLE_SMOOTHER_MODE,
     ENSEMBLE_EXPERIMENT_MODE,
-    ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
+    ENSEMBLE_SMOOTHER_MODE,
     ES_MDA_MODE,
+    ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
     TEST_RUN_MODE,
     WORKFLOW_MODE,
 )
+from ert_shared.cli.main import ErtCliError, run_cli
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorService
+from ert_shared.feature_toggling import FeatureToggling
 from ert_shared.ide.keywords.definitions import (
-    RangeStringArgument,
+    IntegerArgument,
+    NumberListStringArgument,
     ProperNameArgument,
     ProperNameFormatArgument,
-    NumberListStringArgument,
-    IntegerArgument,
+    RangeStringArgument,
 )
 from ert_shared.models.multiple_data_assimilation import MultipleDataAssimilation
+<<<<<<< HEAD
 from ert_shared.plugins.plugin_manager import ErtPluginContext
 from ert_shared.feature_toggling import FeatureToggling
 from ert_shared.storage.command import add_parser_options as ert_api_add_parser_options
 from ert_shared.services import Storage, WebvizErt
 import ert_shared
+=======
+from ert_shared.plugins import launch_visualization_plugin
+from ert_shared.plugins.plugin_manager import ErtPluginContext
+from ert_shared.storage.command import add_parser_options as ert_api_add_parser_options
+from ert_shared.storage.main import run_server
+>>>>>>> Import order
 
 
 def run_ert_storage(args):

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -17,7 +17,7 @@ from ert_shared.ensemble_evaluator.ensemble.builder import (
     create_ensemble_builder_from_legacy,
 )
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorService
-from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluatorSession
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
 from res.job_queue import ForwardModelStatus, JobStatusType, RunStatusType
 from res.util import ResLog
@@ -92,7 +92,9 @@ class BaseRunModel(object):
             self.initial_realizations_mask = arguments["active_realizations"]
 
             if FeatureToggling.is_enabled("ensemble-evaluator"):
-                evaluator: EnsembleEvaluator = EnsembleEvaluatorService.get_evaluator()
+                evaluator: EnsembleEvaluatorSession = (
+                    EnsembleEvaluatorService.get_evaluator_session()
+                )
                 self.experiment_id = evaluator.start_experiment(self.__class__.__name__)
 
             run_context = self.runSimulations(arguments, evaluator=evaluator)

--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -10,7 +10,7 @@ class EnsembleExperiment(BaseRunModel):
     def __init__(self):
         super(EnsembleExperiment, self).__init__(ERT.enkf_facade.get_queue_config())
 
-    def runSimulations__(self, arguments, run_msg):
+    def runSimulations__(self, arguments, run_msg, evaluator=None):
 
         run_context = self.create_context(arguments)
 
@@ -27,9 +27,8 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhaseName(run_msg, indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            ee_config = arguments["ee_config"]
             num_successful_realizations = self.run_ensemble_evaluator(
-                run_context, ee_config
+                run_context, evaluator=evaluator
             )
         else:
             self._job_queue = self._queue_config.create_job_queue()
@@ -52,8 +51,10 @@ class EnsembleExperiment(BaseRunModel):
 
         return run_context
 
-    def runSimulations(self, arguments):
-        return self.runSimulations__(arguments, "Running ensemble experiment...")
+    def runSimulations(self, arguments, evaluator=None):
+        return self.runSimulations__(
+            arguments, "Running ensemble experiment...", evaluator=evaluator
+        )
 
     def create_context(self, arguments):
         fs_manager = self.ert().getEnkfFsManager()

--- a/ert_shared/models/ensemble_smoother.py
+++ b/ert_shared/models/ensemble_smoother.py
@@ -1,3 +1,4 @@
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert_shared.feature_toggling import FeatureToggling
 from res.enkf.enums import HookRuntime
 from res.enkf.enums import RealizationStateEnum
@@ -19,7 +20,7 @@ class EnsembleSmoother(BaseRunModel):
         if not module_load_success:
             raise ErtRunError("Unable to load analysis module '%s'!" % module_name)
 
-    def runSimulations(self, arguments):
+    def runSimulations(self, arguments, evaluator=None):
         prior_context = self.create_context(arguments)
 
         self.checkMinimumActiveRealizations(prior_context)
@@ -38,9 +39,8 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhaseName("Running forecast...", indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            ee_config = arguments["ee_config"]
             num_successful_realizations = self.run_ensemble_evaluator(
-                prior_context, ee_config
+                prior_context, evaluator
             )
         else:
             self._job_queue = self._queue_config.create_job_queue()
@@ -87,9 +87,8 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhaseName("Running forecast...", indeterminate=False)
 
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            ee_config = arguments["ee_config"]
             num_successful_realizations = self.run_ensemble_evaluator(
-                rerun_context, ee_config
+                rerun_context, evaluator
             )
         else:
             self._job_queue = self._queue_config.create_job_queue()

--- a/ert_shared/models/iterated_ensemble_smoother.py
+++ b/ert_shared/models/iterated_ensemble_smoother.py
@@ -20,7 +20,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
 
         return self.ert().analysisConfig().getModule(module_name)
 
-    def _runAndPostProcess(self, run_context, arguments, update_id=None):
+    def _runAndPostProcess(
+        self, run_context, arguments, update_id=None, evaluator=None
+    ):
         phase_msg = "Running iteration %d of %d simulation iterations..." % (
             run_context.get_iter(),
             self.phaseCount() - 1,
@@ -34,9 +36,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
         ensemble_id = self._post_ensemble_data(update_id=update_id)
         self.setPhaseName("Running forecast...", indeterminate=False)
         if FeatureToggling.is_enabled("ensemble-evaluator"):
-            ee_config = arguments["ee_config"]
             num_successful_realizations = self.run_ensemble_evaluator(
-                run_context, ee_config
+                run_context, evaluator
             )
         else:
             self._job_queue = self._queue_config.create_job_queue()
@@ -83,7 +84,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         EnkfSimulationRunner.runWorkflows(HookRuntime.POST_UPDATE, ert=ERT.ert)
         return update_id
 
-    def runSimulations(self, arguments):
+    def runSimulations(self, arguments, evaluator=None):
         phase_count = ERT.enkf_facade.get_number_of_iterations() + 1
         self.setPhaseCount(phase_count)
 
@@ -95,7 +96,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
             target_case_format
         )
 
-        ensemble_id = self._runAndPostProcess(run_context, arguments)
+        ensemble_id = self._runAndPostProcess(
+            run_context, arguments, evaluator=evaluator
+        )
 
         analysis_config = self.ert().analysisConfig()
         analysis_iter_config = analysis_config.getAnalysisIterConfig()
@@ -122,13 +125,17 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 run_context = self.create_context(
                     arguments, current_iter, prior_context=run_context
                 )
-                ensemble_id = self._runAndPostProcess(run_context, arguments, update_id)
+                ensemble_id = self._runAndPostProcess(
+                    run_context, arguments, update_id, evaluator=evaluator
+                )
                 num_retries = 0
             else:
                 run_context = self.create_context(
                     arguments, current_iter, prior_context=run_context, rerun=True
                 )
-                ensemble_id = self._runAndPostProcess(run_context, arguments, update_id)
+                ensemble_id = self._runAndPostProcess(
+                    run_context, arguments, update_id, evaluator=evaluator
+                )
                 num_retries += 1
 
         if current_iter == (phase_count - 1):

--- a/ert_shared/models/single_test_run.py
+++ b/ert_shared/models/single_test_run.py
@@ -13,8 +13,10 @@ class SingleTestRun(EnsembleExperiment):
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed!")
 
-    def runSimulations(self, arguments):
-        return self.runSimulations__(arguments, "Running single realisation test ...")
+    def runSimulations(self, arguments, evaluator=None):
+        return self.runSimulations__(
+            arguments, "Running single realisation test ...", evaluator=evaluator
+        )
 
     @classmethod
     def name(cls):

--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -67,7 +67,6 @@ class EvaluatorTracker:
         self._general_interval = general_interval
 
     def _track_evaluation(self, evaluation_id, logger):
-        failures = 0
         try:
             logger.debug("connecting to new monitor...")
             with create_ee_monitor(
@@ -104,13 +103,7 @@ class EvaluatorTracker:
                         logger.debug("got terminator event")
 
         except (ConnectionRefusedError, ClientError) as e:
-            if not self._model.isFinished():
-                logger.debug(f"connection refused: {e}")
-                failures += 1
-                if failures == EvaluatorTracker.MAX_FAILURES:
-                    logger.debug("giving up.")
-                    self._work_queue.put(EvaluatorTracker.CONNECTION_ERROR)
-                    return
+            logger.debug(f"connection error: {e}")
 
     def _drain_monitor(self):
         asyncio.set_event_loop(asyncio.new_event_loop())

--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -1,13 +1,9 @@
-from cloudevents.http.event import CloudEvent
-from datetime import datetime
-from typing import List, Optional, Union
 from ert_shared.status.utils import tracker_progress
 from ert_shared.status.entity.state import (
     ENSEMBLE_STATE_CANCELLED,
     ENSEMBLE_STATE_STOPPED,
     ENSEMBLE_STATE_FAILED,
 )
-import itertools
 import logging
 import queue
 import threading

--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -123,9 +123,13 @@ class EvaluatorTracker:
             if len(not_tracked_yet) > 0:
                 evaluation_id = list(not_tracked_yet)[0]
                 tracked_evaluations.add(evaluation_id)
-                self._track_evaluation(
-                    evaluation_id=evaluation_id, logger=drainer_logger
+                evaluation_tracker_thread = threading.Thread(
+                    target=self._track_evaluation,
+                    args=(evaluation_id, drainer_logger),
+                    name=f"TrackEvaluationThread-{evaluation_id}",
                 )
+                evaluation_tracker_thread.start()
+                evaluation_tracker_thread.join()
             # This sleep needs to be there. Refer to issue #1250: `Authority
             # on information about evaluations/experiments`
             time.sleep(self._next_ensemble_evaluator_wait_time)

--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -59,6 +59,7 @@ class EvaluatorTracker:
         self._monitor_url = f"{self._protocol}://{host}:{port}"
 
         self._work_queue = queue.Queue()
+        self._last_eval_id = None
 
         self._drainer_thread = threading.Thread(
             target=self._drain_monitor,
@@ -135,6 +136,7 @@ class EvaluatorTracker:
                         name=f"TrackEvaluationThread-{evaluation_id}",
                     )
                     tracked_evaluations[evaluation_id].start()
+                    self._last_eval_id = evaluation_id
             for t in tracked_evaluations.values():
                 t.join()
 
@@ -242,6 +244,7 @@ class EvaluatorTracker:
             return
 
         with create_ee_monitor(
+            self._last_eval_id,
             self._monitor_host,
             self._monitor_port,
             token=self._token,

--- a/job_runner/reporting/event.py
+++ b/job_runner/reporting/event.py
@@ -53,7 +53,9 @@ class Event(Reporter):
 
     def _publish_event(self):
         logger.debug("Publishing event.")
-        with Client(self._evaluator_url, self._token, self._cert) as client:
+        with Client(
+            f"{self._evaluator_url}/{self._ee_id}", self._token, self._cert
+        ) as client:
             while True:
                 event = self._event_queue.get()
                 if event is None:

--- a/res/job_queue/job_queue_node.py
+++ b/res/job_queue/job_queue_node.py
@@ -222,7 +222,9 @@ class JobQueueNode(BaseCClass):
         self._set_thread_status(ThreadStatus.RUNNING)
         self._start_time = None
         self._thread = Thread(
-            target=self._job_monitor, args=(driver, pool_sema, max_submit), name=f"{self.job_name} ({self.run_path})"
+            target=self._job_monitor,
+            args=(driver, pool_sema, max_submit),
+            name=f"{self.job_name} ({self.run_path})",
         )
         self._thread.start()
 

--- a/res/job_queue/job_queue_node.py
+++ b/res/job_queue/job_queue_node.py
@@ -72,6 +72,7 @@ class JobQueueNode(BaseCClass):
         self._thread = None
         self._mutex = Lock()
 
+        self.job_name = job_name
         self.run_path = run_path
         self._max_runtime = max_runtime
         self._start_time = None
@@ -221,7 +222,7 @@ class JobQueueNode(BaseCClass):
         self._set_thread_status(ThreadStatus.RUNNING)
         self._start_time = None
         self._thread = Thread(
-            target=self._job_monitor, args=(driver, pool_sema, max_submit)
+            target=self._job_monitor, args=(driver, pool_sema, max_submit), name=f"{self.job_name} ({self.run_path})"
         )
         self._thread.start()
 

--- a/tests/ert_tests/ensemble_evaluator/test_entity.py
+++ b/tests/ert_tests/ensemble_evaluator/test_entity.py
@@ -98,29 +98,35 @@ def test_snapshot_merge(snapshot):
     "source_string, expected_ids",
     [
         (
-            "/ert/ee/0/real/1111/step/asd123ASD/job/0",
-            {"real": "1111", "step": "asd123ASD", "job": "0"},
+            "/ert/ee/1234/real/1111/step/asd123ASD/job/0",
+            {"evaluation_id": "1234", "real": "1111", "step": "asd123ASD", "job": "0"},
         ),
         (
-            "/ert/ee/0/real/1111/step/asd123ASD",
-            {"real": "1111", "step": "asd123ASD", "job": None},
+            "/ert/ee/some_eval_id/real/1111/step/asd123ASD",
+            {
+                "evaluation_id": "some_eval_id",
+                "real": "1111",
+                "step": "asd123ASD",
+                "job": None,
+            },
         ),
         (
             "/ert/ee/0/real/1111",
-            {"real": "1111", "step": None, "job": None},
+            {"evaluation_id": "0", "real": "1111", "step": None, "job": None},
         ),
         (
-            "/ert/ee/0/real/1111",
-            {"real": "1111", "step": None, "job": None},
+            "/ert/ee/a1ff5a4d8/real/1111",
+            {"evaluation_id": "a1ff5a4d8", "real": "1111", "step": None, "job": None},
         ),
         (
-            "/ert/ee/0",
-            {"real": None, "step": None, "job": None},
+            "/ert/ee/ee_id_0",
+            {"evaluation_id": "ee_id_0", "real": None, "step": None, "job": None},
         ),
     ],
 )
 def test_source_get_ids(source_string, expected_ids):
 
+    assert tool.get_evaluation_id(source_string) == expected_ids["evaluation_id"]
     assert tool.get_real_id(source_string) == expected_ids["real"]
     assert tool.get_step_id(source_string) == expected_ids["step"]
     assert tool.get_job_id(source_string) == expected_ids["job"]


### PR DESCRIPTION
**Issue**
Resolves #1250


**Approach**
1. [x] Refactor out the tracking of an evaluation.
2. [x] Allow the evaluator to track multiple evaluations
3. [x] Add the concept of an experiment with its own status, containing multiple evaluations.
4. [x] Make the run models setup, start and finish the experiment at the correct times.
5. [x] Make experiment endpoint for clients (decide on "out-of-band" communication for experiments and evaluations vs all status in one channel)
6. [ ] Make evaluator communication session
7. [ ] Cleanup 
