### PR TITLE
Issue 2117

### DIFF
--- a/tests/ert_tests/services/test_base_service.py
+++ b/tests/ert_tests/services/test_base_service.py
@@ -12,6 +12,7 @@ from ert_shared.services._base_service import (
     BaseService,
     local_exec_args,
 )
+import time
 
 
 class _DummyService(BaseService):
@@ -174,6 +175,7 @@ def test_json_deleted(server):
     subprocess is finished running.
     """
     server.fetch_conn_info()  # wait for it to start
+    time.sleep(2)  # ensure subprocess is done before calling shutdown()
     server.shutdown()
 
     assert not os.path.exists("dummy_server.json")


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/2117

**Approach**
Avoid precedence between _proc.poll() and _shutdown.wait(). Factor out _ensure_delete_conn_info() from _do_shutdown() to be more explicit