### PR TITLE
Distinct use of ert2 and 3

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/legacy.py
+++ b/ert_shared/ensemble_evaluator/ensemble/legacy.py
@@ -133,7 +133,11 @@ class _LegacyEnsemble(_Ensemble):
                 ]
 
             self._job_queue.add_ensemble_evaluator_information_to_jobs_file(
-                self._ee_id, dispatch_url, cert, token
+                self._ee_id,
+                dispatch_url,
+                cert,
+                token,
+                # process="ert2",
             )
 
             try:


### PR DESCRIPTION
**Issue**
Resolves #1890 


**Approach**
Find the distinction between when ert2 and ert3 is being referenced and log it in a way that can be retrieved by the Azure logger handler (fmu-logging) 
