### PR TITLE
Avoid flaky tests

### DIFF
--- a/tests/ert_tests/ert3/stats/test_distributions.py
+++ b/tests/ert_tests/ert3/stats/test_distributions.py
@@ -1,16 +1,11 @@
-import flaky
 import numpy as np
 import pytest
 import scipy
+from unittest.mock import patch, MagicMock
 
 import ert3
 
 
-def approx(x, eps=0.2):
-    return pytest.approx(x, abs=eps, rel=eps)
-
-
-@flaky.flaky(max_runs=4, min_passes=2)
 @pytest.mark.parametrize(
     ("size", "mean", "std"),
     (
@@ -18,27 +13,44 @@ def approx(x, eps=0.2):
         (30000, 10, 10),
     ),
 )
-def test_gaussian_distribution(size, mean, std):
+def test_gaussian_samples_unique(size, mean, std):
     gauss = ert3.stats.Gaussian(mean, std, size=size)
 
     assert gauss.mean == mean
     assert gauss.std == std
 
+    # Essentially tests that samples drawn from Gaussian are unique
     prev_samples = set()
-    for _ in range(10):
+    for _ in range(100):
         sample = gauss.sample()
 
-        assert len(sample.data) == size
-        assert sorted(gauss.index) == sorted(range(size))
+        assert gauss.index == tuple(range(size)), "Indices should be identical"
+        assert tuple(sample.data) not in prev_samples, "Samples should be unique"
 
-        assert tuple(sample.data) not in prev_samples
         prev_samples.add(tuple(sample.data))
 
-        assert np.array(sample.data).mean() == approx(mean)
-        assert np.array(sample.data).std() == approx(std)
+
+@pytest.mark.parametrize(
+    ("size", "mean", "std"),
+    (
+        (30000, 0, 1),
+        (30000, 10, 10),
+    ),
+)
+def test_gaussian_samples_comesfromscipy(size, mean, std):
+    with patch("scipy.stats.norm.rvs") as scipy:
+        retval = np.array(range(100))
+        scipy.return_value = retval  # never mind the content
+
+        gauss = ert3.stats.Gaussian(mean, std, size=size)
+        data = gauss.sample().data
+
+        scipy.assert_called_once_with(loc=mean, scale=std, size=size)
+        assert np.array_equal(
+            retval, data
+        ), "Samples should be identical to rvs from Scipy"
 
 
-@flaky.flaky(max_runs=4, min_passes=2)
 @pytest.mark.parametrize(
     ("index", "mean", "std"),
     (
@@ -46,25 +58,31 @@ def test_gaussian_distribution(size, mean, std):
         (tuple("a" * i for i in range(1, 10)), 2, 5),
     ),
 )
-def test_gaussian_distribution_index(index, mean, std):
-    gauss = ert3.stats.Gaussian(mean, std, index=index)
+def test_gaussian_index(index, mean, std):
+    with patch("scipy.stats.norm.rvs") as scipy:
+        gauss = ert3.stats.Gaussian(mean, std, index=index)
 
-    assert gauss.mean == mean
-    assert gauss.std == std
+        assert gauss.mean == mean
+        assert gauss.std == std
 
-    samples = {idx: [] for idx in index}
-    for i in range(2000):
-        sample = gauss.sample()
-        assert sorted(gauss.index) == sorted(sample.index)
-        assert sorted(sample.index) == sorted(index)
+        samples = {idx: [] for idx in index}
+        for i in range(100):
 
-        for key in index:
-            samples[key].append(sample.data[key])
+            # The return-value is an array of "i"
+            scipy.return_value = [i] * len(index)
+            sample = gauss.sample()
+            scipy.assert_called_once_with(loc=mean, scale=std, size=len(index))
+            scipy.reset_mock()
+
+            assert sorted(gauss.index) == sorted(index), "Indices should be the same"
+            assert sorted(sample.index) == sorted(index), "Indices should be the same"
+
+            for key in index:
+                samples[key].append(sample.data[key])
 
     for key in index:
         s = np.array(samples[key])
-        assert s.mean() == approx(mean)
-        assert s.std() == approx(std)
+        assert np.alltrue(s == range(100)), f"Wrong samples for key {key}"
 
 
 def test_gaussian_distribution_invalid():
@@ -77,7 +95,6 @@ def test_gaussian_distribution_invalid():
         ert3.stats.Gaussian(0, 1, size=10, index=list(range(10)))
 
 
-@flaky.flaky(max_runs=4, min_passes=2)
 @pytest.mark.parametrize(
     ("size", "lower_bound", "upper_bound"),
     (
@@ -85,27 +102,46 @@ def test_gaussian_distribution_invalid():
         (20000, 10, 20),
     ),
 )
-def test_uniform_distribution(size, lower_bound, upper_bound):
+def test_uniform_samples_unique(size, lower_bound, upper_bound):
     uniform = ert3.stats.Uniform(lower_bound, upper_bound, size=size)
 
     assert uniform.lower_bound == lower_bound
     assert uniform.upper_bound == upper_bound
 
+    # Essentially tests that samples drawn from Uniform are unique
     prev_samples = set()
-    for _ in range(10):
+    for _ in range(100):
         sample = uniform.sample()
 
-        assert len(sample.data) == size
+        assert uniform.index == tuple(range(size)), "Indices should be identical"
+        assert tuple(sample.data) not in prev_samples, "Samples should be different"
 
-        assert tuple(sample.data) not in prev_samples
         prev_samples.add(tuple(sample.data))
 
-        assert np.array(sample.data).min() == approx(lower_bound)
-        assert np.array(sample.data).mean() == approx((lower_bound + upper_bound) / 2)
-        assert np.array(sample.data).max() == approx(upper_bound)
+
+@pytest.mark.parametrize(
+    ("size", "lower_bound", "upper_bound"),
+    (
+        (10000, 0, 1),
+        (20000, 10, 20),
+    ),
+)
+def test_uniform_samples_comesfromscipy(size, lower_bound, upper_bound):
+    with patch("scipy.stats.uniform.rvs") as scipy:
+        retval = np.array(range(100))
+        scipy.return_value = retval  # never mind the content
+
+        uniform = ert3.stats.Uniform(lower_bound, upper_bound, size=size)
+        data = uniform.sample().data
+
+        scipy.assert_called_once_with(
+            loc=lower_bound, scale=(upper_bound - lower_bound), size=size
+        )
+        assert np.array_equal(
+            retval, data
+        ), "Samples should be identical to rvs from Scipy"
 
 
-@flaky.flaky(max_runs=4, min_passes=2)
 @pytest.mark.parametrize(
     ("index", "lower_bound", "upper_bound"),
     (
@@ -113,25 +149,31 @@ def test_uniform_distribution(size, lower_bound, upper_bound):
         (tuple("a" * i for i in range(1, 10)), 2, 5),
     ),
 )
-def test_uniform_distribution_index(index, lower_bound, upper_bound):
-    uniform = ert3.stats.Uniform(lower_bound, upper_bound, index=index)
+def test_uniform_index(index, lower_bound, upper_bound):
+    with patch("scipy.stats.uniform.rvs") as scipy:
+        uniform = ert3.stats.Uniform(lower_bound, upper_bound, index=index)
 
-    assert uniform.lower_bound == lower_bound
-    assert uniform.upper_bound == upper_bound
+        assert uniform.lower_bound == lower_bound
+        assert uniform.upper_bound == upper_bound
 
-    samples = {idx: [] for idx in index}
-    for i in range(1000):
-        sample = uniform.sample()
-        assert sorted(sample.index) == sorted(index)
+        samples = {idx: [] for idx in index}
+        for i in range(100):
 
-        for key in index:
-            samples[key].append(sample.data[key])
+            scipy.return_value = [i] * len(index)
+            sample = uniform.sample()
+            scipy.assert_called_once_with(
+                loc=lower_bound, scale=(upper_bound - lower_bound), size=len(index)
+            )
+            scipy.reset_mock()
+
+            assert sorted(uniform.index) == sorted(index), "Indices should be the same"
+            assert sorted(sample.index) == sorted(index), "Indices should be the same"
+            for key in index:
+                samples[key].append(sample.data[key])
 
     for key in index:
         s = np.array(samples[key])
-        assert s.min() == approx(lower_bound)
-        assert s.mean() == approx((lower_bound + upper_bound) / 2)
-        assert s.max() == approx(upper_bound)
+        assert np.alltrue(s == range(100)), f"Wrong samples for key {key}"
 
 
 def test_uniform_distribution_invalid():


### PR DESCRIPTION
**Issue**
Resolves #1231


**Approach**
Changed approach from trying to test that samples fit an expected distribution (which cannot be deterministic, only made statistically probable), to verifying that the correct methods in Scipy is called. Also verifies that our wrappers (Gaussian and Uniform) don't mess up values returned from Scipy.