### PR TITLE
Make function step use one transmitter per output

### DIFF
--- a/ert3_examples/polynomial/function_steps/functions.py
+++ b/ert3_examples/polynomial/function_steps/functions.py
@@ -4,4 +4,4 @@ def polynomial(coefficients: dict) -> tuple:
         coefficients["a"] * x ** 2 + coefficients["b"] * x + coefficients["c"]
         for x in x_range
     )
-    return result
+    return {"polynomial_output": result}

--- a/ert_shared/ensemble_evaluator/entity/function_step.py
+++ b/ert_shared/ensemble_evaluator/entity/function_step.py
@@ -42,7 +42,9 @@ class FunctionTask(prefect.Task):
         futures = []
         for output in self._step.get_outputs():
             transmitter = self._output_transmitters[output.get_name()]
-            futures.append(_transmit(output, transmitter, function_output))
+            futures.append(
+                _transmit(output, transmitter, function_output[output.get_name()])
+            )
         results = asyncio.get_event_loop().run_until_complete(asyncio.gather(*futures))
         transmitter_map = {result[0]: result[1] for result in results}
         return transmitter_map

--- a/tests/ert_tests/ensemble_evaluator/prefect/conftest.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/conftest.py
@@ -456,7 +456,7 @@ def external_sum_function(tmpdir):
         file_path = module_path / "bar.py"
         file_path.write_text(
             "def bar(coeffs):\n    return internal_call(coeffs)\n"
-            "def internal_call(coeffs):\n    return [sum(coeffs.values())]\n"
+            "def internal_call(coeffs):\n    return {'function_output':[sum(coeffs.values())]}\n"
         )
         spec = importlib.util.spec_from_file_location("foo", str(file_path))
         module = importlib.util.module_from_spec(spec)

--- a/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_ensemble.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_ensemble.py
@@ -130,7 +130,7 @@ def test_prefect_retries(
         except FileNotFoundError:
             # some other real beat us to it
             pass
-        return []
+        return {"function_output": []}
 
     pickle_func = cloudpickle.dumps(function_that_fails_once)
     ensemble = function_ensemble_builder_factory(pickle_func).set_retry_delay(2).build()
@@ -170,7 +170,7 @@ def test_prefect_no_retries(
             run_path.touch()
             raise RuntimeError("This is an expected ERROR")
         run_path.unlink()
-        return []
+        return {"function_output": []}
 
     pickle_func = cloudpickle.dumps(function_that_fails_once)
     ensemble = (
@@ -238,7 +238,8 @@ def test_run_prefect_for_function_defined_outside_py_environment(
     successful_realizations = evaluator._ensemble.get_successful_realizations()
     assert successful_realizations == ensemble_size
     expected_results = [
-        pickle.loads(external_sum_function)(coeffs) for coeffs in coefficients
+        pickle.loads(external_sum_function)(coeffs)["function_output"]
+        for coeffs in coefficients
     ]
     transmitter_futures = [res["function_output"].load() for res in results.values()]
     results = asyncio.get_event_loop().run_until_complete(

--- a/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
@@ -129,7 +129,7 @@ def test_function_step(
     inputs = {"values": input_transmitter_factory("values", test_values)}
 
     def sum_function(values):
-        return [sum(values)]
+        return {"output": [sum(values)]}
 
     step = get_step(
         step_name="test_step",
@@ -162,7 +162,7 @@ def test_function_step(
         task_result.result["output"].load()
     )
     transmitted_result = transmitted_record.data
-    expected_result = sum_function(values=test_values)
+    expected_result = sum_function(values=test_values)["output"]
     assert expected_result == transmitted_result
 
 
@@ -180,7 +180,7 @@ def test_function_step_for_function_defined_outside_py_environment(
     step = get_step(
         step_name="test_step",
         inputs=[("coeffs", "NA", "text/whatever")],
-        outputs=[("output", Path("output.out"), "application/json")],
+        outputs=[("function_output", Path("output.out"), "application/json")],
         jobs=[("test_function", external_sum_function, None)],
         type_="function",
     )
@@ -201,11 +201,11 @@ def test_function_step_for_function_defined_outside_py_environment(
     assert flow_run.is_successful()
 
     assert len(task_result.result) == 1
-    expected_uri = output_trans["output"]._uri
-    output_uri = task_result.result["output"]._uri
+    expected_uri = output_trans["function_output"]._uri
+    output_uri = task_result.result["function_output"]._uri
     assert expected_uri == output_uri
     transmitted_record = asyncio.get_event_loop().run_until_complete(
-        task_result.result["output"].load()
+        task_result.result["function_output"].load()
     )
     transmitted_result = transmitted_record.data
     assert [expected_result] == transmitted_result

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -41,10 +41,12 @@ if __name__ == "__main__":
 
 POLY_FUNCTION = """
 def polynomial(coefficients):
-    return tuple(
-        coefficients["a"] * x ** 2 + coefficients["b"] * x + coefficients["c"]
-        for x in range(10)
-    )
+    return {
+        "polynomial_output": tuple(
+            coefficients["a"] * x ** 2 + coefficients["b"] * x + coefficients["c"]
+            for x in range(10)
+        )
+    }
 """
 
 POLY_SCRIPT_X_UNCERTAINTIES = """#!/usr/bin/env python3


### PR DESCRIPTION
**Issue**
Resolves #2160 


**Approach**
Fixes a bug where the function step would upload a transmitter
with all of the return data for each of the step outputs.
The intended behaviour was that the function should return a
dict with key-value pairs matching each of the output names and
data.
