### PR TITLE
Test changing default mime

### DIFF
--- a/ert3/config/_validator.py
+++ b/ert3/config/_validator.py
@@ -9,6 +9,8 @@ DEFAULT_RECORD_MIME_TYPE: str = "application/octet-stream"
 def _ensure_mime(val: str, **kwargs: Any) -> str:
     """Guess on mime based on the value of basis_for_guess."""
     if val:
+        if not ert.serialization.has_serializer(val):
+            raise ValueError(f"{val} is not a valid mime.")
         return val
 
     basis = kwargs["basis_for_guess"]


### PR DESCRIPTION
**Approach**

The `_ensure_mime` validator returns early if a `Record`'s mime is by default set to something else than an empty string.
This was not obvious to me, so I've added a test to test and document this behaviour, although I'm not sure if the test is necessary. 

https://github.com/equinor/ert/blob/278921bc2ef781eac39827d34120fcc789b015fe/ert3/config/_stages_config.py#L41-L43

Thoughts?
