### PR TITLE
Make input source configuration more independent

### DIFF
--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -1,16 +1,16 @@
 from typing import Union
 
-from ert3.config._ensemble_config import load_ensemble_config, EnsembleConfig
-from ert3.config._stages_config import (
+from ._ensemble_config import load_ensemble_config, EnsembleConfig, SourceNS
+from ._stages_config import (
     load_stages_config,
     StagesConfig,
     Function,
     Unix,
-    DEFAULT_RECORD_MIME_TYPE,
     IndexedOrderedDict,
 )
-from ert3.config._experiment_config import load_experiment_config, ExperimentConfig
-from ert3.config._parameters_config import load_parameters_config, ParametersConfig
+from ._validator import DEFAULT_RECORD_MIME_TYPE
+from ._experiment_config import load_experiment_config, ExperimentConfig
+from ._parameters_config import load_parameters_config, ParametersConfig
 
 Step = Union[Function, Unix]
 
@@ -27,4 +27,6 @@ __all__ = [
     "load_parameters_config",
     "ParametersConfig",
     "DEFAULT_RECORD_MIME_TYPE",
+    "SourceNS",
+    "IndexedOrderedDict",
 ]

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -1,13 +1,22 @@
 import sys
-from typing import Tuple, Optional, Dict, Any
-from pydantic import BaseModel, ValidationError
+from enum import Enum
+from typing import Any, Dict, Optional, Tuple, no_type_check
+
+from pydantic import BaseModel, ValidationError, validator
 
 import ert
+from ._validator import ensure_mime
 
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+
+class SourceNS(str, Enum):
+    stochastic = "stochastic"
+    storage = "storage"
+    resources = "resources"
 
 
 class _EnsembleConfig(BaseModel):
@@ -17,6 +26,7 @@ class _EnsembleConfig(BaseModel):
         extra = "forbid"
         allow_mutation = False
         arbitrary_types_allowed = True
+        underscore_attrs_are_private = True
 
 
 class ForwardModel(_EnsembleConfig):
@@ -25,8 +35,38 @@ class ForwardModel(_EnsembleConfig):
 
 
 class Input(_EnsembleConfig):
+    _namespace: SourceNS
+    _location: str
     source: str
     record: str
+    mime: str = ""
+    is_directory: Optional[bool]
+
+    # This is copied from the pydantic documentation, but is apparently not
+    # popular with mypy, so ignore entire block.
+    @no_type_check  # type: ignore
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        parts = data["source"].split(".", maxsplit=1)
+        self._namespace = SourceNS(parts[0])
+        self._location = parts[1]
+
+    @property
+    def source_namespace(self) -> SourceNS:
+        return self._namespace
+
+    @property
+    def source_location(self) -> str:
+        return self._location
+
+    @validator("source")
+    def split_source(cls, v: str) -> str:
+        parts = v.split(".", maxsplit=1)
+        if not len(parts) == 2:
+            raise ValueError(f"{v} missing at least one dot (.) to form a namespace")
+        return v
+
+    _ensure_mime = validator("mime", allow_reuse=True)(ensure_mime("source"))
 
 
 class Output(_EnsembleConfig):

--- a/ert3/config/_validator.py
+++ b/ert3/config/_validator.py
@@ -1,0 +1,34 @@
+import mimetypes
+from typing import Callable, Any
+
+import ert
+
+DEFAULT_RECORD_MIME_TYPE: str = "application/octet-stream"
+
+
+def _ensure_mime(val: str, **kwargs: Any) -> str:
+    """Guess on mime based on the value of basis_for_guess."""
+    if val:
+        return val
+
+    basis = kwargs["basis_for_guess"]
+    values = kwargs["values"]
+    if basis is None:
+        raise ValueError("no basis for guess")
+    guess = mimetypes.guess_type(str(values.get(basis, "")))[0]
+    if guess:
+        if not ert.serialization.has_serializer(guess):
+            return DEFAULT_RECORD_MIME_TYPE
+        return guess
+    return DEFAULT_RECORD_MIME_TYPE
+
+
+def ensure_mime(basis_for_guess: str) -> Callable[[Any, Any], str]:
+    """Create a mime validator that will guess a mime, or use a default one, based on
+    basis_for_guess."""
+
+    def wrap(*args: Any, **kwargs: Any) -> str:
+        kwargs["basis_for_guess"] = basis_for_guess
+        return _ensure_mime(*args, **kwargs)
+
+    return wrap

--- a/tests/ert_tests/ert3/config/test_ert3_ensemble_config.py
+++ b/tests/ert_tests/ert3/config/test_ert3_ensemble_config.py
@@ -55,16 +55,79 @@ def test_forward_model_invalid_driver(base_ensemble_config):
 
 
 @pytest.mark.parametrize(
-    "input_config, expected_source, expected_record",
+    ",".join(
+        (
+            "input_config",
+            "expected_source",
+            "expected_record",
+            "expected_namespace",
+            "expected_location",
+            "expected_mime",
+            "expected_is_directory",
+        )
+    ),
     [
-        ({"source": "some.source", "record": "coeffs"}, "some.source", "coeffs"),
+        pytest.param(
+            {"source": "some.source", "record": "coeffs"},
+            "some.source",
+            "coeffs",
+            "",
+            "",
+            "",
+            None,
+            marks=pytest.mark.xfail(),
+        ),
+        (
+            {"source": "stochastic.source", "record": "coeffs"},
+            "stochastic.source",
+            "coeffs",
+            "stochastic",
+            "source",
+            "application/octet-stream",
+            None,
+        ),
+        (
+            {"source": "resources.some.json", "record": "coeffs"},
+            "resources.some.json",
+            "coeffs",
+            "resources",
+            "some.json",
+            "application/json",
+            None,
+        ),
+        (
+            {
+                "source": "storage.my_folder",
+                "record": "my_folder",
+                "is_directory": True,
+            },
+            "storage.my_folder",
+            "my_folder",
+            "storage",
+            "my_folder",
+            "application/octet-stream",
+            True,
+        ),
     ],
 )
-def test_input(input_config, expected_source, expected_record, base_ensemble_config):
+def test_input(
+    input_config,
+    expected_source,
+    expected_record,
+    expected_namespace,
+    expected_location,
+    expected_mime,
+    expected_is_directory,
+    base_ensemble_config,
+):
     base_ensemble_config["input"] = [input_config]
     config = ert3.config.load_ensemble_config(base_ensemble_config)
     assert config.input[0].source == expected_source
     assert config.input[0].record == expected_record
+    assert config.input[0].source_namespace == expected_namespace
+    assert config.input[0].source_location == expected_location
+    assert config.input[0].mime == expected_mime
+    assert config.input[0].is_directory == expected_is_directory
 
 
 @pytest.mark.parametrize(
@@ -72,7 +135,7 @@ def test_input(input_config, expected_source, expected_record, base_ensemble_con
     [
         ({}, "2 validation errors for EnsembleConfig"),
         ({"record": "coeffs"}, "source\n  field required"),
-        ({"source": "some.source"}, "record\n  field required"),
+        ({"source": "storage.source"}, "record\n  field required"),
     ],
 )
 def test_invalid_input(input_config, expected_error, base_ensemble_config):

--- a/tests/ert_tests/ert3/config/test_stages_config.py
+++ b/tests/ert_tests/ert3/config/test_stages_config.py
@@ -88,18 +88,13 @@ def test_check_loaded_mime_types(base_unix_stage_config):
     config = ert3.config.load_stages_config(raw_config)
     # Check transportable_commands
     assert (
-        config[0].transportable_commands[0].mime
-        == ert3.config._stages_config.DEFAULT_CMD_MIME_TYPE
+        config[0].transportable_commands[0].mime == ert3.config.DEFAULT_RECORD_MIME_TYPE
     )
     # Check input
-    assert (
-        config[0].input[0].mime == ert3.config._stages_config.DEFAULT_RECORD_MIME_TYPE
-    )
+    assert config[0].input[0].mime == ert3.config.DEFAULT_RECORD_MIME_TYPE
     assert config[0].input["some_json_record"].mime == "application/json"
     # Check output
-    assert (
-        config[0].output[0].mime == ert3.config._stages_config.DEFAULT_RECORD_MIME_TYPE
-    )
+    assert config[0].output[0].mime == ert3.config.DEFAULT_RECORD_MIME_TYPE
     assert config[0].output["some_json_record"].mime == "application/json"
 
 


### PR DESCRIPTION
**Issue**
Source configuration was missing `mime` and `is_directory`, which previously was just blindly using stage configuration values, which won't always be appropriate.

**Approach**
Introduce `mime` and `is_directory` on ensemble input configuration, such that it can vary from whatever's configured on the stage.

- Also, get rid of magical strings `storage`, `resources` and `stochastic`, make enums.
- Move mime validator into `_validator.py`, adding some wrapping to allow the guess value to vary.