### PR TITLE
Use Ubuntu 20.04 for Read The Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,6 @@ sphinx:
    configuration: docs/conf.py
 
 python:
-   version: 3.7
    install:
    - requirements: dev-requirements.txt
    - method: pip
@@ -15,6 +14,9 @@ sphinx:
   configuration: docs/rst/manual/conf.py
 
 build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
   apt_packages:
     - cmake
     - libblas-dev


### PR DESCRIPTION
**Issue**
Read The Docs currently fails to build a new version of our documentation with the following error:

```
...
Cannot Compile simple program using std::filesystem
...
```

**Approach**
Start using Ubuntu 20.04 instead, which comes with gcc 9.3 as default.