### PR TITLE
wip: Replace SummaryObservation cwrap with pybind11

### DIFF
--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -134,3 +134,8 @@ endfunction()
 
 
 add_subdirectory(lib)
+
+if(SKBUILD)
+  # Compile the Python C Extension
+  add_subdirectory(pybind)
+endif()

--- a/libres/lib/enkf/summary_obs.cpp
+++ b/libres/lib/enkf/summary_obs.cpp
@@ -28,17 +28,6 @@
 #define SUMMARY_OBS_TYPE_ID 66103
 #define OBS_SIZE 1
 
-struct summary_obs_struct {
-    UTIL_TYPE_ID_DECLARATION;
-    char *
-        summary_key; /* The observation, in summary.x syntax, e.g. GOPR:FIELD.    */
-    char *obs_key;
-
-    double value; /* Observation value. */
-    double std;   /* Standard deviation of observation. */
-    double std_scaling;
-};
-
 /*
   This function allocates a summary_obs instance. The summary_key
   string should be of the format used by the summary.x program.

--- a/libres/lib/include/ert/enkf/summary_obs.hpp
+++ b/libres/lib/include/ert/enkf/summary_obs.hpp
@@ -36,7 +36,16 @@
 extern "C" {
 #endif
 
-typedef struct summary_obs_struct summary_obs_type;
+typedef struct summary_obs_struct {
+    UTIL_TYPE_ID_DECLARATION;
+    char *
+        summary_key; /* The observation, in summary.x syntax, e.g. GOPR:FIELD.    */
+    char *obs_key;
+
+    double value; /* Observation value. */
+    double std;   /* Standard deviation of observation. */
+    double std_scaling;
+} summary_obs_type;
 
 void summary_obs_free(summary_obs_type *summary_obs);
 

--- a/libres/pybind/CMakeLists.txt
+++ b/libres/pybind/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Scikit-Build does not add your site-packages to the search path automatically,
+# so we need to add it _or_ the pybind11 specific directory here.
+execute_process(
+  COMMAND
+    "${PYTHON_EXECUTABLE}" -c
+    "import pybind11; print(pybind11.get_cmake_dir())"
+  OUTPUT_VARIABLE _tmp_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(_clib MODULE init.cpp)
+target_link_libraries(_clib PRIVATE res)
+target_include_directories(_clib
+PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private-include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private-include/ext/json>
+        "${ECL_INCLUDE_DIRS}"
+  )
+
+install(TARGETS _clib DESTINATION res)

--- a/libres/pybind/init.cpp
+++ b/libres/pybind/init.cpp
@@ -19,6 +19,7 @@ struct deleter {
 };
 
 class summary_observation {
+public:
     std::unique_ptr<summary_obs_type, deleter> m_ptr;
 
 public:
@@ -30,18 +31,6 @@ public:
                                      const std::string &arg1, double arg2,
                                      double arg3) {
         return {summary_obs_alloc(arg0.c_str(), arg1.c_str(), arg2, arg3)};
-    }
-
-    double get_value() const { return summary_obs_get_value(m_ptr.get()); }
-
-    double get_std() const { return summary_obs_get_std(m_ptr.get()); }
-
-    double get_std_scaling() const {
-        return summary_obs_get_std_scaling(m_ptr.get());
-    }
-
-    std::string get_summary_key() const {
-        return summary_obs_get_summary_key(m_ptr.get());
     }
 
     void update_std_scale(double arg0, py::object arg1) {
@@ -58,10 +47,18 @@ public:
 PYBIND11_MODULE(_clib, m) {
     py::class_<summary_observation>(m, "_SummaryObservationImpl")
         .def(py::init(&summary_observation::alloc))
-        .def("_get_value", &summary_observation::get_value)
-        .def("_get_std", &summary_observation::get_std)
-        .def("_get_std_scaling", &summary_observation::get_std_scaling)
-        .def("_get_summary_key", &summary_observation::get_summary_key)
+        .def("_get_value",
+             [](const summary_observation &self) { return self.m_ptr->value; })
+        .def("_get_std",
+             [](const summary_observation &self) { return self.m_ptr->std; })
+        .def("_get_std_scaling",
+             [](const summary_observation &self) {
+                 return self.m_ptr->std_scaling;
+             })
+        .def("_get_summary_key",
+             [](const summary_observation &self) {
+                 return std::string(self.m_ptr->summary_key);
+             })
         .def("_update_std_scale", &summary_observation::update_std_scale)
         .def("_set_std_scale", &summary_observation::set_std_scale);
 }

--- a/libres/pybind/init.cpp
+++ b/libres/pybind/init.cpp
@@ -1,0 +1,67 @@
+#include <string>
+#include <memory>
+#include <pybind11/pybind11.h>
+
+#include <ert/enkf/summary_obs.hpp>
+
+namespace py = pybind11;
+
+template <class T> T cwrap_cast(py::object obj) {
+    PyObject *handle = obj.attr("_BaseCClass__c_pointer").ptr();
+    void *cwrap_ptr = PyLong_AsVoidPtr(handle);
+    return reinterpret_cast<T>(cwrap_ptr);
+}
+
+namespace {
+
+struct deleter {
+    void operator()(summary_obs_type *ptr) { summary_obs_free(ptr); }
+};
+
+class summary_observation {
+    std::unique_ptr<summary_obs_type, deleter> m_ptr;
+
+public:
+    summary_observation(summary_obs_type *ptr) : m_ptr(ptr) {}
+    summary_observation(summary_observation &&) = default;
+    summary_observation &operator=(summary_observation &&) = default;
+
+    static summary_observation alloc(const std::string &arg0,
+                                     const std::string &arg1, double arg2,
+                                     double arg3) {
+        return {summary_obs_alloc(arg0.c_str(), arg1.c_str(), arg2, arg3)};
+    }
+
+    double get_value() const { return summary_obs_get_value(m_ptr.get()); }
+
+    double get_std() const { return summary_obs_get_std(m_ptr.get()); }
+
+    double get_std_scaling() const {
+        return summary_obs_get_std_scaling(m_ptr.get());
+    }
+
+    std::string get_summary_key() const {
+        return summary_obs_get_summary_key(m_ptr.get());
+    }
+
+    void update_std_scale(double arg0, py::object arg1) {
+        summary_obs_update_std_scale(m_ptr.get(), arg0,
+                                     cwrap_cast<active_list_type *>(arg1));
+    }
+
+    void set_std_scale(double arg0) {
+        summary_obs_set_std_scale(m_ptr.get(), arg0);
+    }
+};
+} // namespace
+
+PYBIND11_MODULE(_clib, m) {
+    py::class_<summary_observation>(m, "_SummaryObservationImpl")
+        .def(py::init(&summary_observation::alloc))
+        .def("_get_value", &summary_observation::get_value)
+        .def("_get_std", &summary_observation::get_std)
+        .def("_get_std_scaling", &summary_observation::get_std_scaling)
+        .def("_get_summary_key", &summary_observation::get_summary_key)
+        .def("_update_std_scale", &summary_observation::update_std_scale)
+        .def("_set_std_scale", &summary_observation::set_std_scale);
+}

--- a/libres/pybind/init.cpp
+++ b/libres/pybind/init.cpp
@@ -12,53 +12,41 @@ template <class T> T cwrap_cast(py::object obj) {
     return reinterpret_cast<T>(cwrap_ptr);
 }
 
-namespace {
+using type = summary_obs_type;
+using type_ref = type &;
+using type_cref = const type &;
+using shared = std::shared_ptr<type>;
 
-struct deleter {
-    void operator()(summary_obs_type *ptr) { summary_obs_free(ptr); }
-};
+template <class T, class B> auto fgetter(T B::*p) {
+    return [p](const B &s) { return s.*p; };
+}
 
-class summary_observation {
-public:
-    std::unique_ptr<summary_obs_type, deleter> m_ptr;
-
-public:
-    summary_observation(summary_obs_type *ptr) : m_ptr(ptr) {}
-    summary_observation(summary_observation &&) = default;
-    summary_observation &operator=(summary_observation &&) = default;
-
-    static summary_observation alloc(const std::string &arg0,
-                                     const std::string &arg1, double arg2,
-                                     double arg3) {
-        return {summary_obs_alloc(arg0.c_str(), arg1.c_str(), arg2, arg3)};
-    }
-
-    void update_std_scale(double arg0, py::object arg1) {
-        summary_obs_update_std_scale(m_ptr.get(), arg0,
-                                     cwrap_cast<active_list_type *>(arg1));
-    }
-
-    void set_std_scale(double arg0) {
-        summary_obs_set_std_scale(m_ptr.get(), arg0);
-    }
-};
-} // namespace
+template <class R, class T, class B> auto frgetter(T B::*p) {
+    return [p](const B &s) { return R{s.*p}; };
+}
 
 PYBIND11_MODULE(_clib, m) {
-    py::class_<summary_observation>(m, "_SummaryObservationImpl")
-        .def(py::init(&summary_observation::alloc))
-        .def("getValue",
-             [](const summary_observation &self) { return self.m_ptr->value; })
-        .def("getStandardDeviation",
-             [](const summary_observation &self) { return self.m_ptr->std; })
-        .def("getStdScaling",
-             [](const summary_observation &self, int index=0) {
-                 return self.m_ptr->std_scaling;
-             })
-        .def("getSummaryKey",
-             [](const summary_observation &self) {
-                 return std::string(self.m_ptr->summary_key);
-             })
-        .def("updateStdScaling", &summary_observation::update_std_scale)
-        .def("set_std_scaling", &summary_observation::set_std_scale);
+    py::class_<type, shared> cls(m, "_SummaryObservationImpl");
+    cls.def(py::init([](const std::string &arg0, const std::string &arg1,
+                        double arg2, double arg3) {
+        return shared{summary_obs_alloc(arg0.c_str(), arg1.c_str(), arg2, arg3),
+                      summary_obs_free};
+    }));
+    cls.def("getValue", fgetter(&summary_obs_type::value));
+    cls.def("getStandardDeviation", fgetter(&summary_obs_type::std));
+
+    // This getter takes an optional index so we can't use `fgetter`
+    cls.def(
+        "getStdScaling",
+        [](type_cref self, int index) { return self.std_scaling; },
+        py::arg("index") = 0);
+    cls.def("getSummaryKey", frgetter<std::string>(&summary_obs_type::summary_key));
+    cls.def("updateStdScaling",
+            [](type_ref self, double arg0, py::object arg1) {
+                summary_obs_update_std_scale(
+                    &self, arg0, cwrap_cast<active_list_type *>(arg1));
+            });
+    cls.def("set_std_scaling", [](type_ref self, double arg0) {
+        summary_obs_set_std_scale(&self, arg0);
+    });
 }

--- a/libres/pybind/init.cpp
+++ b/libres/pybind/init.cpp
@@ -47,18 +47,18 @@ public:
 PYBIND11_MODULE(_clib, m) {
     py::class_<summary_observation>(m, "_SummaryObservationImpl")
         .def(py::init(&summary_observation::alloc))
-        .def("_get_value",
+        .def("getValue",
              [](const summary_observation &self) { return self.m_ptr->value; })
-        .def("_get_std",
+        .def("getStandardDeviation",
              [](const summary_observation &self) { return self.m_ptr->std; })
-        .def("_get_std_scaling",
-             [](const summary_observation &self) {
+        .def("getStdScaling",
+             [](const summary_observation &self, int index=0) {
                  return self.m_ptr->std_scaling;
              })
-        .def("_get_summary_key",
+        .def("getSummaryKey",
              [](const summary_observation &self) {
                  return std::string(self.m_ptr->summary_key);
              })
-        .def("_update_std_scale", &summary_observation::update_std_scale)
-        .def("_set_std_scale", &summary_observation::set_std_scale);
+        .def("updateStdScaling", &summary_observation::update_std_scale)
+        .def("set_std_scaling", &summary_observation::set_std_scale);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "ninja", "ecl"]
+requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "pybind11", "ecl"]

--- a/res/enkf/observations/summary_observation.py
+++ b/res/enkf/observations/summary_observation.py
@@ -14,29 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from cwrap import BaseCClass
-from res import ResPrototype
+from res._clib import _SummaryObservationImpl
 
 
-class SummaryObservation(BaseCClass):
-    TYPE_NAME = "summary_obs"
-
-    _alloc = ResPrototype(
-        "void*  summary_obs_alloc(char*, char*, double, double, char*, double)",
-        bind=False,
-    )
-    _free = ResPrototype("void   summary_obs_free(summary_obs)")
-    _get_value = ResPrototype("double summary_obs_get_value(summary_obs)")
-    _get_std = ResPrototype("double summary_obs_get_std(summary_obs)")
-    _get_std_scaling = ResPrototype("double summary_obs_get_std_scaling(summary_obs)")
-    _get_summary_key = ResPrototype("char*  summary_obs_get_summary_key(summary_obs)")
-    _update_std_scale = ResPrototype(
-        "void   summary_obs_update_std_scale(summary_obs , double , active_list)"
-    )
-    _set_std_scale = ResPrototype(
-        "void   summary_obs_set_std_scale(summary_obs , double)"
-    )
-
+class SummaryObservation(_SummaryObservationImpl):
     def __init__(
         self,
         summary_key,
@@ -55,15 +36,7 @@ class SummaryObservation(BaseCClass):
             assert isinstance(auto_corrf_name, str)
 
         assert isinstance(auto_corrf_param, float)
-        c_ptr = self._alloc(
-            summary_key, observation_key, value, std, auto_corrf_name, auto_corrf_param
-        )
-        if c_ptr:
-            super(SummaryObservation, self).__init__(c_ptr)
-        else:
-            raise ValueError(
-                "Unable to construct SummaryObservation with given configuration!"
-            )
+        super().__init__(summary_key, observation_key, value, std)
 
     def getValue(self):
         """@rtype: float"""
@@ -89,9 +62,6 @@ class SummaryObservation(BaseCClass):
 
     def updateStdScaling(self, factor, active_list):
         self._update_std_scale(factor, active_list)
-
-    def free(self):
-        self._free()
 
     def __repr__(self):
         sk = self.getSummaryKey()

--- a/res/enkf/observations/summary_observation.py
+++ b/res/enkf/observations/summary_observation.py
@@ -38,30 +38,8 @@ class SummaryObservation(_SummaryObservationImpl):
         assert isinstance(auto_corrf_param, float)
         super().__init__(summary_key, observation_key, value, std)
 
-    def getValue(self):
-        """@rtype: float"""
-        return self._get_value()
-
-    def getStandardDeviation(self):
-        """@rtype: float"""
-        return self._get_std()
-
-    def getStdScaling(self, index=0):
-        """@rtype: float"""
-        return self._get_std_scaling()
-
-    def set_std_scaling(self, scaling_factor):
-        self._set_std_scale(scaling_factor)
-
     def __len__(self):
         return 1
-
-    def getSummaryKey(self):
-        """@rtype: str"""
-        return self._get_summary_key()
-
-    def updateStdScaling(self, factor, active_list):
-        self._update_std_scale(factor, active_list)
 
     def __repr__(self):
         sk = self.getSummaryKey()


### PR DESCRIPTION
This is an experimental PR which replaces 1 CWrapped class with a pybind11-ed one. This allows for tighter integration between C and Python later down the line. For example:
1. It'll allow our C++ code to directly convert between Python `list`, `dict`, etc to typechecked C++ `std::vector`, `std::unordered_map` with zero effort
2. C++ will be able to interact with numpy directly
3. C++ will be able to interact with Python code without it being callback spaghetti

---

This PR shows 3 stages of integration, each as its own commit:
1. Simple wrapper, replacing `ResPrototype` with C++ equivalents
2. By moving the libres struct definition to the header, we can bypass all getter functions
3. Some Python functions just directly call the wrapped C++ functions, which we can avoid by having the wrapped class be partially defined in C++