### PR TITLE
Add callback function to log util_abort

### DIFF
--- a/ert_logging/_log_util_abort.py
+++ b/ert_logging/_log_util_abort.py
@@ -1,0 +1,29 @@
+import logging
+import traceback
+
+
+def _log_util_abort(filename, lineno, function, message, backtrace):
+    """
+    When this function is called we are in util_abort, so will not be able to recover
+    so we flush the logs to make sure we are able to propagate them.
+    """
+
+    class UtilAbort(Exception):
+        pass
+
+    logger = logging.getLogger(__name__)
+    try:
+        # This might deserve a comment. The reason for raising an exception and
+        # immediately catching it is because logger.exception expects to be called
+        # inside a try .. except block, however no python exception has occured. Instead
+        # of manually creating the traceback a custom exception is raised.
+        raise UtilAbort(message)
+    except UtilAbort:
+        logger.exception(
+            f"C trace:\n{backtrace} \nwith message: {message} \nfrom file: {filename} "
+            f"in {function} at line: {lineno}"
+            f"\n\nPython backtrace:\n{''.join(traceback.format_stack())}"
+        )
+    for handle in logger.handlers:
+        handle.flush()
+    logging.shutdown()

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -7,6 +7,10 @@ import yaml
 from argparse import ArgumentParser, ArgumentTypeError
 from contextlib import contextmanager
 
+from ert_logging._log_util_abort import _log_util_abort
+
+from ecl import set_abort_handler
+
 from ert_logging import LOGGING_CONFIG
 from ert_shared import clear_global_state
 from ert_shared.cli.main import run_cli, ErtCliError
@@ -434,6 +438,7 @@ def start_ert_server(mode: str):
 def main():
     with open(LOGGING_CONFIG, encoding="utf-8") as conf_file:
         logging.config.dictConfig(yaml.safe_load(conf_file))
+    set_abort_handler(_log_util_abort)
     import locale
 
     locale.setlocale(locale.LC_NUMERIC, "C")

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "decorator",
         "deprecation",
         "dnspython >= 2",
-        "ecl >= 2.11.0-rc0",
+        "ecl >= 2.12.0",
         "ert-storage",
         "fastapi",
         "graphene",

--- a/tests/ert_tests/shared/test_log_abort.py
+++ b/tests/ert_tests/shared/test_log_abort.py
@@ -1,0 +1,14 @@
+import logging
+from unittest.mock import MagicMock, call
+from ert_logging._log_util_abort import _log_util_abort
+
+
+def test_log_util_abort(caplog, monkeypatch):
+    shutdown_mock = MagicMock()
+    monkeypatch.setattr(logging, "shutdown", shutdown_mock)
+    _log_util_abort("fname", 1, "some_func", "err_message", "my_backtrace")
+    assert (
+        "C trace:\nmy_backtrace \nwith message: err_message \nfrom file: "
+        "fname in some_func at line: 1\n\nPython backtrace:"
+    ) in caplog.text
+    shutdown_mock.assert_called_once_with()  # must shutdown to propagate message


### PR DESCRIPTION
**Issue**
Resolves #1995 

This means that `ert-log` will now contrain C and python traceback.

Note that it would be possible to run `logger.error` here and avoid the whole `try ... except`, however my reasoning for doing it this way is because we automatically populate the traceback and get a - in my opinion - nicer message.