### PR TITLE
Test block_fs_driver_create_fs

### DIFF
--- a/libres/lib/enkf/block_fs_driver.cpp
+++ b/libres/lib/enkf/block_fs_driver.cpp
@@ -16,6 +16,11 @@
    for more details.
 */
 
+#include <filesystem>
+#include <cstdio>
+
+namespace fs = std::filesystem;
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -390,24 +395,27 @@ void block_fs_driver_create_fs(FILE *stream, const char *mount_point,
                                fs_driver_enum driver_type, int num_fs,
                                const char *ens_path_fmt, const char *filename) {
 
-    util_fwrite_int(driver_type, stream);
-    util_fwrite_int(num_fs, stream);
+    std::fwrite(&driver_type, sizeof driver_type, 1, stream);
+    std::fwrite(&num_fs, sizeof num_fs, 1, stream);
+
     {
-        char *mountfile_fmt = util_alloc_sprintf("%s%c%s.mnt", ens_path_fmt,
-                                                 UTIL_PATH_SEP_CHAR, filename);
-        util_fwrite_string(mountfile_fmt, stream);
-        free(mountfile_fmt);
+        std::string mountfile_fmt = std::string(ens_path_fmt) +
+                                    std::string(1, UTIL_PATH_SEP_CHAR) +
+                                    std::string(filename) + std::string(".mnt");
+
+        int len = mountfile_fmt.length();
+        std::fwrite(&len, sizeof len, 1, stream);
+        std::fwrite(mountfile_fmt.c_str(), sizeof(char), len + 1, stream);
     }
 
     for (int ifs = 0; ifs < num_fs; ifs++) {
-        char *path_fmt = util_alloc_sprintf("%s%c%s", mount_point,
-                                            UTIL_PATH_SEP_CHAR, ens_path_fmt);
-        char *ens_path = util_alloc_sprintf(path_fmt, ifs);
+        char *path_fmt;
+        asprintf(&path_fmt, ens_path_fmt, ifs);
 
-        util_make_path(ens_path);
+        fs::path ens_path = fs::path(mount_point) / fs::path(path_fmt);
+        fs::create_directories(ens_path);
 
         free(path_fmt);
-        free(ens_path);
     }
 }
 

--- a/libres/lib/enkf/tests/enkf_fs.cpp
+++ b/libres/lib/enkf/tests/enkf_fs.cpp
@@ -41,12 +41,12 @@ typedef struct {
 
 static shared_data *data = NULL;
 
-
 void test_block_fs_driver_create_fs() {
     ecl::util::TestArea ta("block_fs_driver_create_fs");
 
     FILE *file_write = fopen("ert_fstab", "w");
-    block_fs_driver_create_fs(file_write, "mnt", DRIVER_PARAMETER, 32, "Ensemble/mod_%d", "PARAMETER");
+    block_fs_driver_create_fs(file_write, "mnt", DRIVER_PARAMETER, 32,
+                              "Ensemble/mod_%d", "PARAMETER");
     fclose(file_write);
 
     FILE *file_read = fopen("ert_fstab", "r");
@@ -63,7 +63,8 @@ void test_block_fs_driver_create_fs() {
     test_assert_int_equal(read_driver_type, 1);
     test_assert_int_equal(read_num_fs, 32);
     test_assert_int_equal(read_len, 29);
-    test_assert_string_equal(read_mountfile_fmt, "Ensemble/mod_%d/PARAMETER.mnt");
+    test_assert_string_equal(read_mountfile_fmt,
+                             "Ensemble/mod_%d/PARAMETER.mnt");
 
     // `num_fs` parameter of `block_fs_driver_create_fs` specifies
     // how many sub-folders Ensemble/ should have.


### PR DESCRIPTION
**Approach**
Proposing re-factoring `block_fs_driver_create_fs` to not use functions from `util`.

Is it OK that the test is part of `enkf_fs.cpp`, or should it be in a separate file? (I think I know the non-lazy answer to this)

By the way, it's curious that `enkf_fs_create_fs` has a `const int num_drivers=32` that seems to be responsible for how many sub-folders are created in the `Ensemble/` folder.
I'm thinking about the `mod_0, mod_1, ..., mod_31` folders.
