### PR TITLE
Specify version-range for beartype

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "ansicolors==1.1.8",
         "async-exit-stack; python_version < '3.7'",
         "async-generator",
-        "beartype",
+        "beartype >= 0.8.0, <0.9.0",
         "cloudevents",
         "cloudpickle",
         "tqdm>=4.62.0",


### PR DESCRIPTION
**Approach**
The release of [beartype 0.9.0](https://pypi.org/project/beartype/0.9.0/), which is a new major release, caused our GitHub action `type-checking` to fail.
I therefore propose we specify a range in `setup.py`.
Starting using a new major version of a dependency should in my opinion be a controlled event, since it may break stuff.
