### PR TITLE
Remove dependency on fs_driver_type

### DIFF
--- a/libres/lib/include/ert/enkf/block_fs_driver.hpp
+++ b/libres/lib/include/ert/enkf/block_fs_driver.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2011  Equinor ASA, Norway.
+   Copyright (C) 2011-2021  Equinor ASA, Norway.
 
    The file 'block_fs_driver.h' is part of ERT - Ensemble based Reservoir Tool.
 
@@ -18,27 +18,57 @@
 
 #ifndef ERT_BLOCK_FS_DRIVER_H
 #define ERT_BLOCK_FS_DRIVER_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdio.h>
 #include <stdbool.h>
 
 #include <ert/enkf/fs_types.hpp>
 
-typedef struct block_fs_driver_struct block_fs_driver_type;
+typedef struct buffer_struct buffer_type;
+typedef struct bfs_config_struct bfs_config_type;
+typedef struct bfs_struct bfs_type;
+
+namespace ert {
+
+class block_fs_driver {
+    int num_fs;
+    bfs_config_type *config{};
+    bfs_type **fs_list;
+
+public:
+    block_fs_driver(int num_fs);
+    ~block_fs_driver();
+
+    static block_fs_driver *new_(bool preload, bool read_only, int num_fs,
+                                 const char *mountfile_fmt,
+                                 bool block_level_lock);
+    static block_fs_driver *open(FILE *fstab_stream, const char *mount_point,
+                                 bool preload, bool read_only);
+
+    bool has_node(const char *node_key, int report_step, int iens);
+    void load_node(const char *node_key, int report_step, int iens,
+                   buffer_type *buffer);
+    void save_node(const char *node_key, int report_step, int iens,
+                   buffer_type *buffer);
+
+    bool has_vector(const char *node_key, int iens);
+    void load_vector(const char *node_key, int iens, buffer_type *buffer);
+    void save_vector(const char *node_key, int iens, buffer_type *buffer);
+
+    void fsync();
+
+private:
+    void mount();
+    bfs_type *get_fs(int iens);
+};
+
+} // namespace ert
 
 bool block_fs_sscanf_key(const char *key, char **config_key, int *__report_step,
                          int *__iens);
-void *block_fs_driver_open(FILE *fstab_stream, const char *mount_point,
-                           fs_driver_enum driver_type, bool read_only);
 void block_fs_driver_create_fs(FILE *stream, const char *mount_point,
                                fs_driver_enum driver_type, int num_fs,
                                const char *ens_path_fmt, const char *filename);
 void block_fs_driver_fskip(FILE *fstab_stream);
 
-#ifdef __cplusplus
-}
-#endif
 #endif


### PR DESCRIPTION
This commit removes the link between `block_fs_driver_type` and
`fs_driver_type`, as well as removing the need for `enkf_fs` to
communicate with `block_fs_driver_type` via `fs_driver_type`.

It also does a lift-and-shift job into making `block_fs_type` as fully
C++ class. The contents have deliberately been largerly untouched.

This is a step towards removing the notion of 'filesystem' 'drivers' in
ERT, and doesn't do it all at once. The end result should be where
anything related to "block" is renamed to "storage" (the colloquial term
for it) and no 'driver' concept is present.

**Issue**
Resolves #2223 