### PR TITLE
Move capturing inside context

### DIFF
--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -183,5 +183,5 @@ def test_cli_test_connection_error(tmpdir, source_root, capsys):
             with pytest.raises(ErtCliError):
                 run_cli(parsed)
 
-    capture = capsys.readouterr()
-    assert "Connection error" in capture.out
+                capture = capsys.readouterr()
+                assert "Connection error" in capture.out


### PR DESCRIPTION
This sometimes fails on a lightening fast M1-based Mac. In order to be robust wrt to timing and scheduling I move the assertion into the context. Might improve test-staility in general.
