### PR TITLE
Let EvaluatorServerConfig be responsible for keeping port allocated

### DIFF
--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -106,6 +106,31 @@ def _generate_certificate(
     return cert_str, key_bytes, pw
 
 
+"""
+This class is responsible for identifying a host:port-combo and then provide
+low-level sockets bound to said combo. The problem is that these sockets may
+be closed by underlying code, while the EvaluatorServerConfig-instance is
+still alive and expected to provide a bound low-level socket. Thus we risk
+that the host:port is hijacked by another process in the meantime.
+
+To prevent this, we keep a handle to the bound socket and every time
+a socket is requested we return a duplicate of this. The duplicate will be
+bound similarly to the handle, but when closed the handle stays open and
+holds the port.
+
+In particular, the websocket-server closes the websocket when exiting a
+context:
+
+   https://github.com/aaugustin/websockets/blob/c439f1d52aafc05064cc11702d1c3014046799b0/src/websockets/legacy/server.py#L890
+
+and digging into the cpython-implementation of asyncio, we see that causes
+the asyncio code to also close the underlying socket:
+
+   https://github.com/python/cpython/blob/b34dd58fee707b8044beaf878962a6fa12b304dc/Lib/asyncio/selector_events.py#L607-L611
+
+"""
+
+
 class EvaluatorServerConfig:
     def __init__(
         self,
@@ -113,7 +138,7 @@ class EvaluatorServerConfig:
         use_token: bool = True,
         generate_cert: bool = True,
     ) -> None:
-        self.host, self.port = port_handler.find_available_port(
+        self.host, self.port, self._socket_handle = port_handler.find_available_port(
             custom_range=custom_port_range
         )
         self.protocol = "wss" if generate_cert else "ws"
@@ -131,8 +156,8 @@ class EvaluatorServerConfig:
 
         self.token = _generate_authentication() if use_token else None
 
-    def get_socket(self):
-        return port_handler.get_socket(host=self.host, port=self.port)
+    def get_socket(self) -> socket.socket:
+        return self._socket_handle.dup()
 
     def get_server_ssl_context(
         self, protocol: int = ssl.PROTOCOL_TLS_SERVER

--- a/ert_shared/ensemble_evaluator/ensemble/prefect.py
+++ b/ert_shared/ensemble_evaluator/ensemble/prefect.py
@@ -53,7 +53,7 @@ async def _eq_submit_job(self, script_filename):
 
 
 def _get_executor(custom_port_range, name="local"):
-    _, port = find_available_port(custom_range=custom_port_range)
+    _, port, _ = find_available_port(custom_range=custom_port_range)
     if name == "local":
         cluster_kwargs = {
             "silence_logs": "debug",
@@ -201,16 +201,16 @@ class PrefectEnsemble(_Ensemble):
         ctx = self._get_multiprocessing_context()
         self._eval_proc = ctx.Process(
             target=self._evaluate,
-            args=(config, ee_id),
+            args=(ee_id, config.dispatch_uri, config.token, config.cert),
         )
         self._eval_proc.daemon = True
         self._eval_proc.start()
         self._allow_cancel.set()
 
-    def _evaluate(self, ee_config: EvaluatorServerConfig, ee_id):
+    def _evaluate(self, ee_id, dispatch_uri, token, cert):
         asyncio.set_event_loop(asyncio.get_event_loop())
         try:
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(dispatch_uri, token, cert) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_STARTED,
@@ -218,12 +218,10 @@ class PrefectEnsemble(_Ensemble):
                     },
                 )
                 c.send(to_json(event).decode())
-            with prefect.context(
-                url=ee_config.dispatch_uri, token=ee_config.token, cert=ee_config.cert
-            ):
+            with prefect.context(url=dispatch_uri, token=token, cert=cert):
                 self.run_flow(ee_id)
 
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(dispatch_uri, token, cert) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_STOPPED,
@@ -238,7 +236,7 @@ class PrefectEnsemble(_Ensemble):
                 "An exception occurred while starting the ensemble evaluation",
                 exc_info=True,
             )
-            with Client(ee_config.dispatch_uri, ee_config.token, ee_config.cert) as c:
+            with Client(dispatch_uri, token, cert) as c:
                 event = CloudEvent(
                     {
                         "type": ids.EVTYPE_ENSEMBLE_FAILED,

--- a/ert_shared/services/_storage_main.py
+++ b/ert_shared/services/_storage_main.py
@@ -91,8 +91,7 @@ def run_server(args=None, debug=False):
         config_args.update(reload=True, reload_dirs=[os.path.dirname(ert_shared_path)])
         os.environ["ERT_STORAGE_DEBUG"] = "1"
 
-    host, port = port_handler.find_available_port(custom_host=args.host)
-    sock = port_handler.get_socket(host=host, port=port)
+    host, port, sock = port_handler.find_available_port(custom_host=args.host)
     connection_info = {
         "urls": [
             f"http://{host}:{sock.getsockname()[1]}"

--- a/tests/ert_tests/shared/test_port_handler.py
+++ b/tests/ert_tests/shared/test_port_handler.py
@@ -7,8 +7,7 @@ from ert_shared import port_handler
 
 def test_find_available_port(unused_tcp_port):
     custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-    host, port = port_handler.find_available_port(custom_range=custom_range)
-    sock = port_handler.get_socket(host, port)
+    host, port, sock = port_handler.find_available_port(custom_range=custom_range)
     assert host is not None
     assert port is not None
     assert port in custom_range
@@ -18,18 +17,15 @@ def test_find_available_port(unused_tcp_port):
 
 def test_find_available_port_forced(unused_tcp_port):
     custom_range = range(unused_tcp_port, unused_tcp_port)
-    host, port = port_handler.find_available_port(custom_range=custom_range)
+    host, port, sock = port_handler.find_available_port(custom_range=custom_range)
     assert port == unused_tcp_port
-
-    sock = port_handler.get_socket(host, port)
     assert sock is not None
     assert sock.fileno() != -1
 
 
 def test_no_more_ports_in_range(unused_tcp_port):
     custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-    host, port = port_handler.find_available_port(custom_range=custom_range)
-    sock = port_handler.get_socket(host, port)
+    host, port, sock = port_handler.find_available_port(custom_range=custom_range)
     assert sock is not None
     assert sock.fileno() != -1
 


### PR DESCRIPTION
**Issue**
Re-commit https://github.com/equinor/ert/commit/ff961657ae9e5774eb981915d8ac61431ab8c5e5

**Approach**
The abovementioned commit was reverted by https://github.com/equinor/ert/commit/712d0ead0829c63d7e5e9134ec53ce213d1118f8  in an attempt to get a stable build. As it turned out, instability was caused by other issues and this PR rebases and re-establishes the original fix.