### PR TITLE
Introduction of RecordTree

### DIFF
--- a/ert/data/__init__.py
+++ b/ert/data/__init__.py
@@ -1,4 +1,6 @@
 from ert.data.record._record import (
+    BlobRecordTree,
+    NumericalRecordTree,
     BlobRecord,
     load_collection_from_file,
     NumericalRecord,
@@ -27,6 +29,8 @@ from .record._transformation import (
 )
 
 __all__ = (
+    "BlobRecordTree",
+    "NumericalRecordTree",
     "BlobRecord",
     "InMemoryRecordTransmitter",
     "load_collection_from_file",

--- a/ert/data/record/_transmitter.py
+++ b/ert/data/record/_transmitter.py
@@ -1,15 +1,10 @@
 import shutil
 import uuid
+import json
 from abc import abstractmethod
 from enum import Enum, auto
 from pathlib import Path
-from typing import (
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Union,
-)
+from typing import Callable, Dict, List, Optional, Union, Any
 import aiofiles
 
 # Type hinting for wrap must be turned off until (1) is resolved.
@@ -23,7 +18,14 @@ from pydantic import (
 )
 from ert.serialization import get_serializer
 
-from ._record import Record, RecordType, NumericalRecord, BlobRecord
+from ._record import (
+    Record,
+    RecordType,
+    NumericalRecord,
+    BlobRecord,
+    NumericalRecordTree,
+    BlobRecordTree,
+)
 
 _copy = wrap(shutil.copy)
 
@@ -47,6 +49,22 @@ class RecordTransmitterType(Enum):
     in_memory = auto()
     ert_storage = auto()
     shared_disk = auto()
+
+
+def _unflatten_record_dict(
+    flat_record_dict: Union[Dict[str, BlobRecord], Dict[str, NumericalRecord]]
+) -> Dict[str, Any]:
+    record_dict: Dict[str, Any] = {}
+    for rec_path, rec in flat_record_dict.items():
+        keys = rec_path.split("/")
+        sub_rec_name = keys[-1]
+        branch = record_dict
+        for key in keys[:-1]:
+            if key not in branch:
+                branch[key] = {}
+            branch = branch[key]
+        branch[sub_rec_name] = rec
+    return record_dict
 
 
 class RecordTransmitter:
@@ -78,12 +96,63 @@ class RecordTransmitter:
     async def _load_blob_record(self) -> BlobRecord:
         raise NotImplementedError("not implemented")
 
+    @abstractmethod
+    async def _get_recordtree_transmitters(
+        self,
+        trans_records: Dict[str, str],
+        record_type: RecordType,
+        path: Optional[str] = None,
+    ) -> Dict[str, "RecordTransmitter"]:
+        raise NotImplementedError("not implemented")
+
+    async def _load_numerical_recordtree(
+        self,
+        transmitters: Dict[str, "RecordTransmitter"],
+    ) -> NumericalRecordTree:
+        flat_record_dict = {
+            rec_path: await transmitter._load_numerical_record()
+            for rec_path, transmitter in transmitters.items()
+        }
+        record_dict = _unflatten_record_dict(flat_record_dict)
+        return NumericalRecordTree(record_dict=record_dict)
+
+    async def _load_blob_recordtree(
+        self,
+        transmitters: Dict[str, "RecordTransmitter"],
+    ) -> BlobRecordTree:
+        record_path_dict = {
+            rec_path: await transmitter._load_blob_record()
+            for rec_path, transmitter in transmitters.items()
+        }
+        record_dict = _unflatten_record_dict(record_path_dict)
+        return BlobRecordTree(record_dict=record_dict)
+
     async def load(self) -> Record:
         if not self.is_transmitted():
             raise RuntimeError("cannot load untransmitted record")
-        if self._record_type != RecordType.BYTES:
+        if self._record_type == RecordType.NUMERICAL_TREE:
+            record = await self._load_blob_record()
+            sub_records = json.loads(record.data.decode("utf-8"))
+            transmitters = await self._get_recordtree_transmitters(
+                sub_records, RecordType.MAPPING_STR_FLOAT
+            )
+            return await self._load_numerical_recordtree(transmitters)
+        elif self._record_type == RecordType.BLOB_TREE:
+            record = await self._load_blob_record()
+            sub_records = json.loads(record.data.decode("utf-8"))
+            transmitters = await self._get_recordtree_transmitters(
+                sub_records, RecordType.BYTES
+            )
+            return await self._load_blob_recordtree(transmitters)
+        elif self._record_type != RecordType.BYTES:
             return await self._load_numerical_record()
         return await self._load_blob_record()
+
+    @abstractmethod
+    async def _transmit_recordtree(
+        self, record: Union[NumericalRecordTree, BlobRecordTree]
+    ) -> str:
+        raise NotImplementedError("not implemented")
 
     @abstractmethod
     async def _transmit_numerical_record(self, record: NumericalRecord) -> str:
@@ -100,6 +169,8 @@ class RecordTransmitter:
             uri = await self._transmit_numerical_record(record)
         elif isinstance(record, BlobRecord):
             uri = await self._transmit_blob_record(record)
+        elif isinstance(record, (NumericalRecordTree, BlobRecordTree)):
+            uri = await self._transmit_recordtree(record)
         else:
             raise TypeError(f"Record type not supported {type(record)}")
         self._set_transmitted_state(uri, record_type=record.record_type)
@@ -127,6 +198,11 @@ class RecordTransmitter:
     async def dump(self, location: Path, mime: str) -> None:
         if not self.is_transmitted():
             raise RuntimeError("cannot dump untransmitted record")
+        if self._record_type in (RecordType.NUMERICAL_TREE, RecordType.BLOB_TREE):
+            record_blob = await self._load_blob_record()
+            async with aiofiles.open(str(location), mode="wb") as fb:
+                await fb.write(record_blob.data)
+                return
         record = await self.load()
         if isinstance(record, NumericalRecord):
             async with aiofiles.open(str(location), mode="wt", encoding="utf-8") as ft:
@@ -145,6 +221,40 @@ class SharedDiskRecordTransmitter(RecordTransmitter):
         self._storage_path.mkdir(parents=True, exist_ok=True)
         self._concrete_key = f"{name}_{uuid.uuid4()}"
         self._storage_uri = self._storage_path / self._concrete_key
+
+    async def _get_recordtree_transmitters(
+        self,
+        trans_records: Dict[str, str],
+        record_type: RecordType,
+        path: Optional[str] = None,
+    ) -> Dict[str, RecordTransmitter]:
+        transmitters: Dict[str, RecordTransmitter] = {}
+        for record_path, record_uri in trans_records.items():
+            if path is None or path in record_path:
+                record_name = record_path.split("/")[-1]
+                transmitter = SharedDiskRecordTransmitter(
+                    record_name, self._storage_path
+                )
+                transmitter._set_transmitted_state(record_uri, record_type)
+                transmitters[record_path] = transmitter
+        return transmitters
+
+    async def _transmit_recordtree(
+        self, record: Union[NumericalRecordTree, BlobRecordTree]
+    ) -> str:
+        data = {}
+        for rec_path in record.flat_record_dict:
+            rec_key = rec_path.split("/")[-1]
+            transmitter = SharedDiskRecordTransmitter(
+                name=rec_key,
+                storage_path=self._storage_path,
+            )
+            await transmitter.transmit_record(record.flat_record_dict[rec_path])
+            data[rec_path] = transmitter._uri
+        await self._transmit_blob_record(
+            BlobRecord(data=json.dumps(data).encode("utf-8"))
+        )
+        return str(self._storage_uri)
 
     async def _transmit_numerical_record(self, record: NumericalRecord) -> str:
         contents = get_serializer(
@@ -191,6 +301,20 @@ class InMemoryRecordTransmitter(RecordTransmitter):
         super().__init__(RecordTransmitterType.in_memory)
         self._name = name
         self._record: Record
+        self._sub_transmitters: Dict[str, RecordTransmitter] = {}
+
+    async def _get_recordtree_transmitters(
+        self,
+        trans_records: Dict[str, str],
+        record_type: RecordType,
+        path: Optional[str] = None,
+    ) -> Dict[str, RecordTransmitter]:
+        transmitters = {
+            record_path: self._sub_transmitters[record_path]
+            for record_path in trans_records
+            if path is None or path in record_path
+        }
+        return transmitters
 
     async def _transmit_numerical_record(self, record: NumericalRecord) -> str:
         self._record = record
@@ -198,6 +322,19 @@ class InMemoryRecordTransmitter(RecordTransmitter):
 
     async def _transmit_blob_record(self, record: BlobRecord) -> str:
         self._record = record
+        return "in_memory"
+
+    async def _transmit_recordtree(
+        self, record: Union[NumericalRecordTree, BlobRecordTree]
+    ) -> str:
+        data = {}
+        for rec_path in record.flat_record_dict:
+            rec_key = rec_path.split("/")[-1]
+            transmitter = InMemoryRecordTransmitter(name=rec_key)
+            await transmitter.transmit_record(record.flat_record_dict[rec_path])
+            data[rec_path] = transmitter._uri
+            self._sub_transmitters[rec_path] = transmitter
+        self._record = BlobRecord(data=json.dumps(data).encode("utf-8"))
         return "in_memory"
 
     async def _load_numerical_record(self) -> NumericalRecord:

--- a/tests/ert_tests/ert3/data/test_record.py
+++ b/tests/ert_tests/ert3/data/test_record.py
@@ -183,6 +183,64 @@ def test_empty_record_collection(length, collection_type):
         )
 
 
+@pytest.mark.parametrize(
+    ("record_dict"),
+    (
+        {
+            "key_A:OP1": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+            "key_B:OP1": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+            "group_OP2": {
+                "key_AA:OP2": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+                "key_BA:OP2": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+            },
+        },
+        {
+            "key_A:OP2": ert.data.NumericalRecord(data={"a": 0, "b": 1, "c": 2}),
+            "key_B:OP2": ert.data.NumericalRecord(
+                data={"a": 0, "b": 1, "c": 2},
+            ),
+            "key_C:OP2": ert.data.NumericalRecord(
+                data={"a": 0, "b": 1, "c": 2},
+            ),
+        },
+    ),
+)
+def test_valid_recordtree_creation(record_dict):
+    if isinstance(list(record_dict.values())[0], ert.data.BlobRecord):
+        record = ert.data.BlobRecordTree(record_dict=record_dict)
+        assert record.record_type == ert.data.RecordType.BLOB_TREE
+    else:
+        record = ert.data.NumericalRecordTree(record_dict=record_dict)
+        assert record.record_type == ert.data.RecordType.NUMERICAL_TREE
+
+
+@pytest.mark.parametrize(
+    ("record_dict"),
+    (
+        {
+            "key_A:OP1": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+            "key_B:OP1": ert.data.NumericalRecord(data={"a": 0, "b": 1, "c": 2}),
+        },
+        {
+            "key_B:OP1": ert.data.NumericalRecord(data={"a": 0, "b": 1, "c": 2}),
+            "key_A:OP1": ert.data.BlobRecord(data=b"\xF0\x9F\xA6\x89"),
+        },
+        {
+            "key_A:OP2": ert.data.NumericalRecord(data={"a": 0, "b": 1, "c": 2}),
+            "key_B:OP2": ert.data.NumericalRecord(
+                data=(0, 2, 4),
+            ),
+            "key_C:OP2": ert.data.NumericalRecord(
+                data={"a": 0, "b": 1, "c": 2},
+            ),
+        },
+    ),
+)
+def test_invalid_recordtree_creation(record_dict):
+    with pytest.raises(ert.data.RecordValidationError):
+        ert.data.BlobRecordTree(record_dict=record_dict)
+
+
 def test_invalid_ensemble_record(raw_ensrec_to_records):
     raw_ensrec = [{"data": b"a"}, {"data": [1.1, 2.2]}]
     with pytest.raises(ValueError):


### PR DESCRIPTION
**Issue**
Resolves #2009 

The name which fits better the `MetarRecord` API's actually `RecordTree`.
Currently `RecordTree` is stored as a BlobRecord where `data=dict[path_to_rec, rec_transmitter_uri]`, ie. data describes its tree structure and where to load it from. 
Transformations that will take care of preparing the input and output records will come as a standalone PR.