### PR TITLE
Ensure delete connection info is called

### DIFF
--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -117,16 +117,17 @@ class _Proc(threading.Thread):
         except Exception as exc:
             conn_info = exc
 
-        self._set_conn_info(conn_info)
+        try:
+            self._set_conn_info(conn_info)
 
-        while True:
-            if self._proc.poll() is not None:
-                break
-            if self._shutdown.wait(1):
-                self._do_shutdown()
-                break
-
-        self._ensure_delete_conn_info()
+            while True:
+                if self._proc.poll() is not None:
+                    break
+                if self._shutdown.wait(1):
+                    self._do_shutdown()
+                    break
+        finally:
+            self._ensure_delete_conn_info()
 
     def shutdown(self) -> int:
         """Shutdown the server."""


### PR DESCRIPTION
HM tutorial where we have multiple runs of ERT often ends up with the file `storage_server.json` is present and ERT will `sys.exit`. Tried to add a retry mechanism waiting 1 sec * 3 just to avoid race condition on the deletion of the file, but that is not fixing the problem. Another thing to try is to make sure an exception is not causing us to miss the deletion of the file - which i try to do in this PR. 

```
+ ert es_mda --enable-new-storage --port-range 1024-65535 /scratch/oompf/jenkins-hm-tutorial/tmp.ge2N3oNiez/ert_testsuite/ert/model/hm_analysis_short.ert
storage_server.json is present on this location. Retry 0
storage_server.json is present on this location. Retry 1
storage_server.json is present on this location. Retry 2
A file called storage_server.json is present from this location. This indicates there is already a ert instance running. If you are certain that is not the case, try to delete the file and try again.
ert crashed unexpectedly 
```