### PR TITLE
Remove unnecessary step list alloc function

### DIFF
--- a/libres/lib/include/ert/enkf/enkf_main.hpp
+++ b/libres/lib/include/ert/enkf/enkf_main.hpp
@@ -115,9 +115,6 @@ int enkf_main_get_observation_count(const enkf_main_type *enkf_main,
 void enkf_main_install_SIGNALS(void);
 void enkf_main_add_node(enkf_main_type *enkf_main,
                         enkf_config_node_type *enkf_config_node);
-int_vector_type *
-enkf_main_update_alloc_step_list(const enkf_main_type *enkf_main,
-                                 int load_start, int step2, int stride);
 
 const hook_manager_type *
 enkf_main_get_hook_manager(const enkf_main_type *enkf_main);


### PR DESCRIPTION
Simplification of analysis callstack. Function enkf_main_update_alloc_step_list is always called with start=0, end=step2 and stride=1 which is equal to creating an ~~int_vector(0, step2)~~ int_vector(0, 0) and appending [0,step2]