### PR TITLE
Avoid using same objects in multiple tests

### DIFF
--- a/ert_shared/ensemble_evaluator/narratives/dispatch_failing_job.py
+++ b/ert_shared/ensemble_evaluator/narratives/dispatch_failing_job.py
@@ -5,58 +5,60 @@ from ert_shared.ensemble_evaluator.narratives.narrative import (
     Provider,
 )
 
-dispatch_failing_job = (
-    Consumer("Dispatch")
-    .forms_narrative_with(Provider("Ensemble Evaluator"))
-    .given("small ensemble")
-    .receives("a job eventually fails")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_ENSEMBLE_STARTED,
-                source="/ert/ee/0",
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_STEP_RUNNING,
-                source="/ert/ee/0/real/0/stage/0/step/0",
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_JOB_RUNNING,
-                source="/ert/ee/0/real/0/stage/0/step/0/job/0",
-                data={identifiers.CURRENT_MEMORY_USAGE: 1000},
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_STEP_RUNNING,
-                source="/ert/ee/0/real/1/stage/0/step/0",
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_JOB_RUNNING,
-                source="/ert/ee/0/real/1/stage/0/step/0/job/0",
-                data={identifiers.CURRENT_MEMORY_USAGE: 2000},
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_JOB_SUCCESS,
-                source="/ert/ee/0/real/0/stage/0/step/0/job/0",
-                data={identifiers.CURRENT_MEMORY_USAGE: 2000},
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_JOB_FAILURE,
-                source="/ert/ee/0/real/1/stage/0/step/0/job/0",
-                data={identifiers.ERROR_MSG: "error"},
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_STEP_FAILURE,
-                source="/ert/ee/0/real/1/stage/0/step/0",
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_FM_STEP_SUCCESS,
-                source="/ert/ee/0/real/0/stage/0/step/0",
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_ENSEMBLE_STOPPED,
-                source="/ert/ee/0",
-            ),
-        ]
+
+def dispatch_failing_job():
+    return (
+        Consumer("Dispatch")
+        .forms_narrative_with(Provider("Ensemble Evaluator"))
+        .given("small ensemble")
+        .receives("a job eventually fails")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_ENSEMBLE_STARTED,
+                    source="/ert/ee/0",
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_STEP_RUNNING,
+                    source="/ert/ee/0/real/0/stage/0/step/0",
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_JOB_RUNNING,
+                    source="/ert/ee/0/real/0/stage/0/step/0/job/0",
+                    data={identifiers.CURRENT_MEMORY_USAGE: 1000},
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_STEP_RUNNING,
+                    source="/ert/ee/0/real/1/stage/0/step/0",
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_JOB_RUNNING,
+                    source="/ert/ee/0/real/1/stage/0/step/0/job/0",
+                    data={identifiers.CURRENT_MEMORY_USAGE: 2000},
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_JOB_SUCCESS,
+                    source="/ert/ee/0/real/0/stage/0/step/0/job/0",
+                    data={identifiers.CURRENT_MEMORY_USAGE: 2000},
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_JOB_FAILURE,
+                    source="/ert/ee/0/real/1/stage/0/step/0/job/0",
+                    data={identifiers.ERROR_MSG: "error"},
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_STEP_FAILURE,
+                    source="/ert/ee/0/real/1/stage/0/step/0",
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_FM_STEP_SUCCESS,
+                    source="/ert/ee/0/real/0/stage/0/step/0",
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_ENSEMBLE_STOPPED,
+                    source="/ert/ee/0",
+                ),
+            ]
+        )
+        .with_name("Dispatch Failing Job")
     )
-    .with_name("Dispatch Failing Job")
-)

--- a/ert_shared/ensemble_evaluator/narratives/monitor_failing_ensemble.py
+++ b/ert_shared/ensemble_evaluator/narratives/monitor_failing_ensemble.py
@@ -11,82 +11,85 @@ from ert_shared.ensemble_evaluator.narratives.narrative import (
 )
 
 
-monitor_failing_ensemble = (
-    Consumer("Monitor")
-    .forms_narrative_with(Provider("Ensemble Evaluator"))
-    .given(
-        "Ensemble with 2 reals, with 2 steps each, with 2 jobs each, job 1 in real 1 fails"
-    )
-    .responds_with("Snapshot")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT,
-                source=ReMatch(re.compile(".*"), ""),
-            )
-        ]
-    )
-    .responds_with("Starting")
-    .cloudevents_in_order(
-        [
-            EventDescription(
+def monitor_failing_ensemble():
+    return (
+        Consumer("Monitor")
+        .forms_narrative_with(Provider("Ensemble Evaluator"))
+        .given(
+            "Ensemble with 2 reals, with 2 steps each, with 2 jobs each, job 1 in real 1 fails"
+        )
+        .responds_with("Snapshot")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT,
+                    source=ReMatch(re.compile(".*"), ""),
+                )
+            ]
+        )
+        .responds_with("Starting")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                    source=ReMatch(re.compile(".*"), ""),
+                    data={identifiers.STATUS: state.ENSEMBLE_STATE_STARTED},
+                )
+            ]
+        )
+        .responds_with("Failure")
+        .repeating_unordered_events(
+            [],
+            terminator=EventDescription(
                 type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
                 source=ReMatch(re.compile(".*"), ""),
-                data={identifiers.STATUS: state.ENSEMBLE_STATE_STARTED},
-            )
-        ]
-    )
-    .responds_with("Failure")
-    .repeating_unordered_events(
-        [],
-        terminator=EventDescription(
-            type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-            source=ReMatch(re.compile(".*"), ""),
-            data={
-                identifiers.REALS: {
-                    "1": {
-                        identifiers.STEPS: {
-                            "0": {
-                                identifiers.JOBS: {
-                                    "1": {identifiers.STATUS: state.JOB_STATE_FAILURE}
+                data={
+                    identifiers.REALS: {
+                        "1": {
+                            identifiers.STEPS: {
+                                "0": {
+                                    identifiers.JOBS: {
+                                        "1": {
+                                            identifiers.STATUS: state.JOB_STATE_FAILURE
+                                        }
+                                    }
                                 }
-                            }
+                            },
+                            identifiers.STATUS: state.REALIZATION_STATE_FAILED,
                         },
-                        identifiers.STATUS: state.REALIZATION_STATE_FAILED,
-                    },
-                }
-            },
-        ),
+                    }
+                },
+            ),
+        )
+        .responds_with("Stopped")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                    source=ReMatch(re.compile(".*"), ""),
+                    data={identifiers.STATUS: state.ENSEMBLE_STATE_STOPPED},
+                )
+            ]
+        )
+        .receives("Monitor done")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_USER_DONE,
+                    source=ReMatch(re.compile(".*"), ""),
+                )
+            ]
+        )
+        .responds_with("Termination")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_TERMINATED,
+                    source=ReMatch(re.compile(".*"), ""),
+                )
+            ]
+        )
+        .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
+        .with_marshaller("application/json", serialization.evaluator_marshaller)
+        .with_name("Monitor Failing Ensemble")
     )
-    .responds_with("Stopped")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                source=ReMatch(re.compile(".*"), ""),
-                data={identifiers.STATUS: state.ENSEMBLE_STATE_STOPPED},
-            )
-        ]
-    )
-    .receives("Monitor done")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_USER_DONE,
-                source=ReMatch(re.compile(".*"), ""),
-            )
-        ]
-    )
-    .responds_with("Termination")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_TERMINATED,
-                source=ReMatch(re.compile(".*"), ""),
-            )
-        ]
-    )
-    .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
-    .with_marshaller("application/json", serialization.evaluator_marshaller)
-    .with_name("Monitor Failing Ensemble")
-)

--- a/ert_shared/ensemble_evaluator/narratives/monitor_failing_evaluation.py
+++ b/ert_shared/ensemble_evaluator/narratives/monitor_failing_evaluation.py
@@ -11,50 +11,51 @@ from ert_shared.ensemble_evaluator.narratives.narrative import (
 )
 
 
-monitor_failing_evaluation = (
-    Consumer("Monitor")
-    .forms_narrative_with(
-        Provider("Ensemble Evaluator"),
+def monitor_failing_evaluation():
+    return (
+        Consumer("Monitor")
+        .forms_narrative_with(
+            Provider("Ensemble Evaluator"),
+        )
+        .given("a failing evaluation")
+        .responds_with("start then failure")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    data={identifiers.STATUS: state.ENSEMBLE_STATE_STARTED},
+                ),
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    data={identifiers.STATUS: state.ENSEMBLE_STATE_FAILED},
+                ),
+            ]
+        )
+        .receives("done")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_USER_DONE,
+                    source=ReMatch(re.compile(r"/ert/monitor/."), "/ert/monitor/007"),
+                ),
+            ]
+        )
+        .responds_with("termination")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_TERMINATED,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                ),
+            ]
+        )
+        .with_marshaller("application/json", serialization.evaluator_marshaller)
+        .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
+        .with_name("Monitor Failed Evaluation")
     )
-    .given("a failing evaluation")
-    .responds_with("start then failure")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-                data={identifiers.STATUS: state.ENSEMBLE_STATE_STARTED},
-            ),
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-                data={identifiers.STATUS: state.ENSEMBLE_STATE_FAILED},
-            ),
-        ]
-    )
-    .receives("done")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_USER_DONE,
-                source=ReMatch(re.compile(r"/ert/monitor/."), "/ert/monitor/007"),
-            ),
-        ]
-    )
-    .responds_with("termination")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_TERMINATED,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-            ),
-        ]
-    )
-    .with_marshaller("application/json", serialization.evaluator_marshaller)
-    .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
-    .with_name("Monitor Failed Evaluation")
-)

--- a/ert_shared/ensemble_evaluator/narratives/monitor_successful_ensemble.py
+++ b/ert_shared/ensemble_evaluator/narratives/monitor_successful_ensemble.py
@@ -14,57 +14,58 @@ from ert_shared.ensemble_evaluator.narratives.narrative import (
 )
 
 
-monitor_successful_ensemble = (
-    Consumer("Monitor")
-    .forms_narrative_with(
-        Provider("Ensemble Evaluator"),
-    )
-    .given("a successful one-member one-step one-job ensemble")
-    .responds_with("starting snapshot")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_SNAPSHOT,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-            ),
-        ]
-    )
-    .responds_with("a bunch of snapshot updates")
-    .repeating_unordered_events(
-        [
-            EventDescription(
+def monitor_successful_ensemble():
+    return (
+        Consumer("Monitor")
+        .forms_narrative_with(
+            Provider("Ensemble Evaluator"),
+        )
+        .given("a successful one-member one-step one-job ensemble")
+        .responds_with("starting snapshot")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                ),
+            ]
+        )
+        .responds_with("a bunch of snapshot updates")
+        .repeating_unordered_events(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                ),
+            ],
+            terminator=EventDescription(
                 type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
                 source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                data={identifiers.STATUS: state.ENSEMBLE_STATE_STOPPED},
             ),
-        ],
-        terminator=EventDescription(
-            type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-            source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-            data={identifiers.STATUS: state.ENSEMBLE_STATE_STOPPED},
-        ),
+        )
+        .receives("done")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_USER_DONE,
+                    source=ReMatch(re.compile(r"/ert/monitor/."), "/ert/monitor/007"),
+                ),
+            ]
+        )
+        .responds_with("termination")
+        .cloudevents_in_order(
+            [
+                EventDescription(
+                    type_=identifiers.EVTYPE_EE_TERMINATED,
+                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    datacontenttype="application/octet-stream",
+                    data=cloudpickle.dumps("hello world"),
+                ),
+            ]
+        )
+        .with_marshaller("application/json", serialization.evaluator_marshaller)
+        .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
+        .with_unmarshaller("application/octet-stream", pickle.loads)
+        .with_name("Monitor Successful Ensemble")
     )
-    .receives("done")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_USER_DONE,
-                source=ReMatch(re.compile(r"/ert/monitor/."), "/ert/monitor/007"),
-            ),
-        ]
-    )
-    .responds_with("termination")
-    .cloudevents_in_order(
-        [
-            EventDescription(
-                type_=identifiers.EVTYPE_EE_TERMINATED,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
-                datacontenttype="application/octet-stream",
-                data=cloudpickle.dumps("hello world"),
-            ),
-        ]
-    )
-    .with_marshaller("application/json", serialization.evaluator_marshaller)
-    .with_unmarshaller("application/json", serialization.evaluator_unmarshaller)
-    .with_unmarshaller("application/octet-stream", pickle.loads)
-    .with_name("Monitor Successful Ensemble")
-)

--- a/ert_shared/port_handler.py
+++ b/ert_shared/port_handler.py
@@ -69,6 +69,10 @@ def _bind_socket(host: str, port: int, reuse_addr: bool = False) -> socket.socke
         )
 
 
+def get_family_for_localhost() -> socket.AddressFamily:
+    return get_family(_get_ip_address())
+
+
 def get_family(host: str) -> socket.AddressFamily:
     try:
         socket.inet_pton(socket.AF_INET6, host)

--- a/tests/ert_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert_tests/ensemble_evaluator/conftest.py
@@ -187,10 +187,9 @@ def _dump_ext_job(ext_job, index):
 
 
 @pytest.fixture
-def make_ee_config(unused_tcp_port):
+def make_ee_config():
     def _ee_config(**kwargs):
-        fixed_port = range(unused_tcp_port, unused_tcp_port)
-        return EvaluatorServerConfig(custom_port_range=fixed_port, **kwargs)
+        return EvaluatorServerConfig(custom_port_range=range(60000, 65000), **kwargs)
 
     return _ee_config
 

--- a/tests/ert_tests/ensemble_evaluator/test_dispatchers.py
+++ b/tests/ert_tests/ensemble_evaluator/test_dispatchers.py
@@ -5,5 +5,5 @@ from ert_shared.ensemble_evaluator.narratives import dispatch_failing_job
 
 @pytest.mark.consumer_driven_contract_test
 def test_dispatchers_with_failing_job(unused_tcp_port):
-    with dispatch_failing_job.on_uri(f"ws://localhost:{unused_tcp_port}/dispatch"):
+    with dispatch_failing_job().on_uri(f"ws://localhost:{unused_tcp_port}/dispatch"):
         pass

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -184,7 +184,7 @@ def test_verify_monitor_failing_ensemble(make_ee_config, event_loop):
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
-    monitor_failing_ensemble.verify(ee_config.client_uri, on_connect=ensemble.start)
+    monitor_failing_ensemble().verify(ee_config.client_uri, on_connect=ensemble.start)
     ensemble.join()
 
 
@@ -201,7 +201,7 @@ def test_verify_monitor_failing_evaluation(make_ee_config, event_loop):
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
-    monitor_failing_evaluation.verify(ee_config.client_uri, on_connect=ensemble.start)
+    monitor_failing_evaluation().verify(ee_config.client_uri, on_connect=ensemble.start)
     ensemble.join()
 
 
@@ -220,7 +220,9 @@ def test_verify_monitor_successful_ensemble(make_ee_config, event_loop):
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
-    monitor_successful_ensemble.verify(ee_config.client_uri, on_connect=ensemble.start)
+    monitor_successful_ensemble().verify(
+        ee_config.client_uri, on_connect=ensemble.start
+    )
     ensemble.join()
 
 
@@ -237,5 +239,5 @@ def test_verify_dispatch_failing_job(make_ee_config, event_loop):
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
-    dispatch_failing_job.verify(ee_config.client_uri, on_connect=lambda: None)
+    dispatch_failing_job().verify(ee_config.client_uri, on_connect=lambda: None)
     ee.stop()

--- a/tests/ert_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert_tests/ensemble_evaluator/test_monitor.py
@@ -25,7 +25,7 @@ def test_monitor_successful_ensemble(make_ee_config):
     )
 
     ee.run()
-    with NarrativeProxy(monitor_successful_ensemble).proxy(ee_config.url) as port:
+    with NarrativeProxy(monitor_successful_ensemble()).proxy(ee_config.url) as port:
         with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
             for event in monitor.track():
                 if event["type"] == identifiers.EVTYPE_EE_SNAPSHOT:
@@ -52,7 +52,7 @@ def test_monitor_failing_evaluation(make_ee_config, unused_tcp_port):
     )
     ee.run()
     with NarrativeProxy(
-        monitor_failing_evaluation.on_uri(f"ws://localhost:{unused_tcp_port}")
+        monitor_failing_evaluation().on_uri(f"ws://localhost:{unused_tcp_port}")
     ).proxy(ee_config.url) as port:
         with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
             for event in monitor.track():
@@ -81,7 +81,7 @@ def test_monitor_failing_ensemble(make_ee_config, unused_tcp_port):
     with ee.run():
         pass
     with NarrativeProxy(
-        monitor_failing_ensemble.on_uri(f"ws://localhost:{unused_tcp_port}")
+        monitor_failing_ensemble().on_uri(f"ws://localhost:{unused_tcp_port}")
     ).proxy(ee_config.url) as port:
         with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
             for event in monitor.track():


### PR DESCRIPTION
**Issue**
Some tests under ensemble_evaluator import and mutate narrative-objects which (apparently) are imported as singletons and shared between tests. 

**Approach**
Change imported narratives to factory-methods and consequently tests to call these factory-methods in order to create separate narrative-instances.