### PR TITLE
Tune timeouts on tests for Storage(service)

### DIFF
--- a/tests/ert_tests/services/test_storage_service.py
+++ b/tests/ert_tests/services/test_storage_service.py
@@ -8,7 +8,11 @@ def test_integration(tmp_path, monkeypatch):
     """Actually start the server, wait for it to be online and do a health check"""
     monkeypatch.chdir(tmp_path)
 
-    with Storage.start_server() as server:
+    # Note: Sqlite needs at least 4-5 seconds to spin up even on
+    # an unloaded M1-based Mac using local disk. On the CI-server
+    # we have less control of available resources, so set timeout-
+    # value large to allow time for sqlite to get ready
+    with Storage.start_server(timeout=120) as server:
         resp = requests.get(
             f"{server.fetch_url()}/healthcheck", auth=server.fetch_auth()
         )
@@ -16,5 +20,21 @@ def test_integration(tmp_path, monkeypatch):
 
         with Storage.session() as session:
             session.get("/healthcheck")
+
+    assert not (tmp_path / "storage_server.json").exists()
+
+
+@pytest.mark.requires_ert_storage
+def test_integration_timeout(tmp_path, monkeypatch):
+    """Try to start the server but give it too small time to get ready and
+    expect a timeout"""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(TimeoutError):
+        # Note timeout-value here in context of note above
+        with Storage.start_server(timeout=0.01) as server:
+            resp = requests.get(
+                f"{server.fetch_url()}/healthcheck", auth=server.fetch_auth()
+            )
 
     assert not (tmp_path / "storage_server.json").exists()


### PR DESCRIPTION
The default timeout seems to be challenging when Storage is spun up in a
CI-environment, making this test fail occasionally. Also added a test
which deliberately makes Storage time out.

An alternative is of-course to set a larger timeout in Storage itself,
but since this problem only occurs occasionally while running the
test-suite it is done in the test.
