### PR TITLE
Remove `experiment_has_run` function from the workspace module

### DIFF
--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -180,6 +180,7 @@ def _init(args: Any) -> None:
 
     if args.example is None:
         ert3.workspace.initialize(pathlib.Path.cwd())
+        ert.storage.init(workspace=pathlib.Path.cwd())
     else:
         example_name = args.example
         pkg_examples_path = _get_ert3_examples_path()
@@ -208,6 +209,7 @@ def _init(args: Any) -> None:
             )
 
         ert3.workspace.initialize(wd_example_path)
+        ert.storage.init(workspace=wd_example_path)
 
 
 def _run(workspace: Path, args: Any) -> None:

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -85,7 +85,9 @@ def export(
 ) -> None:
     ert3.workspace.assert_experiment_exists(workspace_root, experiment_name)
 
-    if not ert3.workspace.experiment_has_run(workspace_root, experiment_name):
+    if experiment_name not in ert.storage.get_experiment_names(
+        workspace=workspace_root
+    ):
         raise ValueError("Cannot export experiment that has not been carried out")
 
     parameters = _prepare_export_parameters(

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -20,8 +20,8 @@ def _prepare_experiment(
     ensemble: ert3.config.EnsembleConfig,
     ensemble_size: int,
 ) -> None:
-    if ert3.workspace.experiment_has_run(workspace_root, experiment_name):
-        raise ValueError(f"Experiment {experiment_name} have been carried out.")
+    if experiment_name in ert.storage.get_experiment_names(workspace=workspace_root):
+        raise ValueError(f"Experiment {experiment_name} has been carried out.")
 
     parameters = [elem.record for elem in ensemble.input]
     responses = [elem.record for elem in ensemble.output]

--- a/ert3/workspace/__init__.py
+++ b/ert3/workspace/__init__.py
@@ -1,7 +1,6 @@
 from ert3.workspace._workspace import initialize
 from ert3.workspace._workspace import load
 from ert3.workspace._workspace import get_experiment_names
-from ert3.workspace._workspace import experiment_has_run
 from ert3.workspace._workspace import assert_experiment_exists
 from ert3.workspace._workspace import export_json
 
@@ -11,7 +10,6 @@ __all__ = [
     "initialize",
     "load",
     "get_experiment_names",
-    "experiment_has_run",
     "assert_experiment_exists",
     "export_json",
 ]

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -43,11 +43,6 @@ def get_experiment_names(workspace_root: Union[str, Path]) -> Set[str]:
     }
 
 
-def experiment_has_run(workspace_root: Path, experiment_name: str) -> bool:
-    experiments = ert.storage.get_experiment_names(workspace=workspace_root)
-    return experiment_name in experiments
-
-
 def initialize(path: Union[str, Path]) -> None:
     path = Path(path)
     if load(path) is not None:
@@ -56,7 +51,6 @@ def initialize(path: Union[str, Path]) -> None:
         )
 
     os.mkdir(path / ert3._WORKSPACE_DATA_ROOT)
-    ert.storage.init(workspace=path)
 
 
 def load(path: Union[str, Path]) -> Optional[Path]:

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -133,6 +133,7 @@ def workspace_integration(tmpdir):
 
     with Storage.start_server():
         ert3.workspace.initialize(workspace)
+        ert.storage.init(workspace=workspace)
         yield workspace
 
 
@@ -142,6 +143,7 @@ def workspace(tmpdir, ert_storage):
     workspace.mkdir()
     workspace.chdir()
     ert3.workspace.initialize(workspace)
+    ert.storage.init(workspace=workspace)
     yield workspace
 
 

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -167,7 +167,7 @@ def test_run_once_polynomial_evaluation(
         workspace,
         "evaluation",
     )
-    with pytest.raises(ValueError, match="Experiment evaluation have been carried out"):
+    with pytest.raises(ValueError, match="Experiment evaluation has been carried out"):
         ert3.engine.run(
             ensemble,
             stages_config,

--- a/tests/ert_tests/ert3/workspace/test_workspace.py
+++ b/tests/ert_tests/ert3/workspace/test_workspace.py
@@ -9,6 +9,7 @@ import ert
 @pytest.mark.requires_ert_storage
 def test_workspace_initialize(tmpdir, ert_storage):
     ert3.workspace.initialize(tmpdir)
+    ert.storage.init(workspace=tmpdir)
 
     assert (Path(tmpdir) / ert3._WORKSPACE_DATA_ROOT).is_dir()
 
@@ -17,6 +18,7 @@ def test_workspace_initialize(tmpdir, ert_storage):
         match="Already inside an ERT workspace.",
     ):
         ert3.workspace.initialize(tmpdir)
+        ert.storage.init(workspace=tmpdir)
 
 
 @pytest.mark.requires_ert_storage
@@ -24,6 +26,7 @@ def test_workspace_load(tmpdir, ert_storage):
     assert ert3.workspace.load(tmpdir) is None
     assert ert3.workspace.load(tmpdir / "foo") is None
     ert3.workspace.initialize(tmpdir)
+    ert.storage.init(workspace=tmpdir)
     assert ert3.workspace.load(tmpdir) == tmpdir
     assert ert3.workspace.load(tmpdir / "foo") == tmpdir
 
@@ -38,6 +41,7 @@ def test_workspace_assert_experiment_exists(tmpdir, ert_storage):
         ert3.workspace.get_experiment_names(tmpdir)
 
     ert3.workspace.initialize(tmpdir)
+    ert.storage.init(workspace=tmpdir)
     Path(experiments_dir / "test1").mkdir(parents=True)
 
     ert3.workspace.assert_experiment_exists(tmpdir, "test1")
@@ -59,6 +63,7 @@ def test_workspace_assert_get_experiment_names(tmpdir, ert_storage):
         ert3.workspace.get_experiment_names(tmpdir)
 
     ert3.workspace.initialize(tmpdir)
+    ert.storage.init(workspace=tmpdir)
     Path(experiments_dir / "test1").mkdir(parents=True)
     Path(experiments_dir / "test2").mkdir(parents=True)
 
@@ -75,6 +80,7 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
         ert3.workspace.get_experiment_names(tmpdir)
 
     ert3.workspace.initialize(tmpdir)
+    ert.storage.init(workspace=tmpdir)
     Path(experiments_dir / "test1").mkdir(parents=True)
     Path(experiments_dir / "test2").mkdir(parents=True)
 
@@ -85,8 +91,8 @@ def test_workspace_experiment_has_run(tmpdir, ert_storage):
         responses=[],
     )
 
-    assert ert3.workspace.experiment_has_run(tmpdir, "test1")
-    assert not ert3.workspace.experiment_has_run(tmpdir, "test2")
+    assert "test1" in ert.storage.get_experiment_names(workspace=tmpdir)
+    assert "test2" not in ert.storage.get_experiment_names(workspace=tmpdir)
 
 
 @pytest.mark.requires_ert_storage


### PR DESCRIPTION
**Issue**
Resolves #2275


**Approach**
The `experiment_has_been_run` function essentially checks if the experiment is present in storage. It is essentially a simple check. Unless that function would do more fancy things, I think it is not necessary. It would have to be located in the storage module, where it would feel out of place. Renaming it to something like `has_experiment` may be an option, but I opted for just removing it and using the tests directly.