### PR TITLE
Convert IES to C++

### DIFF
--- a/libres/lib/CMakeLists.txt
+++ b/libres/lib/CMakeLists.txt
@@ -194,9 +194,9 @@ add_library(res SHARED
 #-----------------------------------------------------------------
 
 add_library(ies SHARED
-  analysis/modules/ies_enkf.c
-  analysis/modules/ies_enkf_config.c
-  analysis/modules/ies_enkf_data.c)
+  analysis/modules/ies_enkf.cpp
+  analysis/modules/ies_enkf_config.cpp
+  analysis/modules/ies_enkf_data.cpp)
 target_link_libraries(ies PRIVATE ${RES} ${ECL} ${CMAKE_DL_LIBS})
 target_include_directories(ies PRIVATE ${ECL_INCLUDE_DIRS} include analysis/modules)
 

--- a/libres/lib/analysis/modules/ies_enkf.cpp
+++ b/libres/lib/analysis/modules/ies_enkf.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 2019  Equinor ASA, Norway.
 
-   The file 'ies_enkf.c' is part of ERT - Ensemble based Reservoir Tool.
+   The file 'ies_enkf.cpp' is part of ERT - Ensemble based Reservoir Tool.
 
    ERT is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -32,12 +32,8 @@
 #include <ert/analysis/analysis_table.hpp>
 #include <ert/analysis/enkf_linalg.hpp>
 
-#include "ies_enkf_config.h"
-#include "ies_enkf_data.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <ies_enkf_config.hpp>
+#include <ies_enkf_data.hpp>
 
 void ies_enkf_linalg_extract_active(const ies_enkf_data_type *data,
                                     matrix_type *E, FILE *log_fp, bool dbg);
@@ -67,10 +63,6 @@ void ies_enkf_linalg_store_active_W(ies_enkf_data_type *data,
 
 void ies_enkf_linalg_extract_active_A0(const ies_enkf_data_type *data,
                                        matrix_type *A0, FILE *log_fp, bool dbg);
-
-#ifdef __cplusplus
-}
-#endif
 
 #define ENKF_SUBSPACE_DIMENSION_KEY "ENKF_SUBSPACE_DIMENSION"
 #define ENKF_TRUNCATION_KEY "ENKF_TRUNCATION"
@@ -302,7 +294,7 @@ void ies_enkf_updateA(
      * ies_inversion=IES_INVERSION_SUBSPACE_RE is much faster (N^2m) than
      * ies_inversion=IES_INVERSION_SUBSPACE_EE_R (Nm^2).
      *
-     * See the enum: ies_inverson in ies_enkf_config.h:
+     * See the enum: ies_inverson in ies_enkf_config.hpp:
      *
      * ies_inversion=IES_INVERSION_EXACT(0)            -> exact inversion from (b) with exact R=I
      * ies_inversion=IES_INVERSION_SUBSPACE_EXACT_R(1) -> subspace inversion from (a) with exact R
@@ -759,7 +751,8 @@ bool ies_enkf_set_int(void *arg, const char *var_name, int value) {
         else if (
             strcmp(var_name, IES_INVERSION_KEY) ==
             0) // This should probably translate string value - now it goes directly on the value of the ies_inversion_type enum.
-            ies_enkf_config_set_ies_inversion(config, value);
+            ies_enkf_config_set_ies_inversion(
+                config, static_cast<ies_inversion_type>(value));
         else
             name_recognized = false;
 
@@ -927,18 +920,18 @@ void *ies_enkf_get_ptr(const void *arg, const char *var_name) {
 
 analysis_table_type LINK_NAME = {
     .name = "IES_ENKF",
-    .initX = NULL,
     .updateA = ies_enkf_updateA,
+    .initX = NULL,
     .init_update = ies_enkf_init_update,
     .complete_update = NULL,
-    .alloc = ies_enkf_data_alloc,
     .freef = ies_enkf_data_free,
-    .has_var = ies_enkf_has_var,
+    .alloc = ies_enkf_data_alloc,
     .set_int = ies_enkf_set_int,
     .set_double = ies_enkf_set_double,
     .set_bool = ies_enkf_set_bool,
     .set_string = ies_enkf_set_string,
     .get_options = ies_enkf_get_options,
+    .has_var = ies_enkf_has_var,
     .get_int = ies_enkf_get_int,
     .get_double = ies_enkf_get_double,
     .get_bool = ies_enkf_get_bool,

--- a/libres/lib/analysis/modules/ies_enkf.hpp
+++ b/libres/lib/analysis/modules/ies_enkf.hpp
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 2019  Equinor ASA, Norway.
 
-  The file 'ies_enkf.h' is part of ERT - Ensemble based Reservoir Tool.
+  The file 'ies_enkf.hpp' is part of ERT - Ensemble based Reservoir Tool.
 
   ERT is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -25,10 +25,6 @@
 #include <ert/analysis/module_info.hpp>
 #include <ert/res_util/matrix.hpp>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 void ies_enkf_init_update(void *arg, const bool_vector_type *ens_mask,
                           const bool_vector_type *obs_mask,
                           const matrix_type *S, const matrix_type *R,
@@ -37,16 +33,12 @@ void ies_enkf_init_update(void *arg, const bool_vector_type *ens_mask,
 
 void ies_enkf_updateA(
     void *module_data,
-    matrix_type *A,    // Updated ensemble A retured to ERT.
-    matrix_type *Yin,  // Ensemble of predicted measurements
-    matrix_type *Rin,  // Measurement error covariance matrix (not used)
-    matrix_type *dObs, // Actual observations (not used)
-    matrix_type *Ein,  // Ensemble of observation perturbations
-    matrix_type *Din,  // (d+E-Y) Ensemble of perturbed observations - Y
+    matrix_type *A,          // Updated ensemble A returned to ERT.
+    const matrix_type *Yin,  // Ensemble of predicted measurements
+    const matrix_type *Rin,  // Measurement error covariance matrix (not used)
+    const matrix_type *dObs, // Actual observations (not used)
+    const matrix_type *Ein,  // Ensemble of observation perturbations
+    const matrix_type *Din,  // (d+E-Y) Ensemble of perturbed observations - Y
     const module_info_type *module_info, rng_type *rng);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/libres/lib/analysis/modules/ies_enkf_config.cpp
+++ b/libres/lib/analysis/modules/ies_enkf_config.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 2019  Equinor ASA, Norway.
 
-   The file 'ies_enkf_config.c' is part of ERT - Ensemble based Reservoir Tool.
+   The file 'ies_enkf_config.cpp' is part of ERT - Ensemble based Reservoir Tool.
 
    ERT is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@
 #include <ert/analysis/std_enkf.hpp>
 #include <ert/analysis/analysis_module.hpp>
 
-#include <ies_enkf_config.h>
+#include <ies_enkf_config.hpp>
 
 #define INVALID_TRUNCATION -1
 #define INVALID_SUBSPACE_DIMENSION -1
@@ -59,7 +59,8 @@ struct ies_enkf_config_struct {
 };
 
 ies_enkf_config_type *ies_enkf_config_alloc() {
-    ies_enkf_config_type *config = util_malloc(sizeof *config);
+    ies_enkf_config_type *config =
+        static_cast<ies_enkf_config_type *>(util_malloc(sizeof *config));
     UTIL_TYPE_ID_INIT(config, IES_ENKF_CONFIG_TYPE_ID);
     config->ies_logfile = NULL;
     ies_enkf_config_set_truncation(config, DEFAULT_ENKF_TRUNCATION);
@@ -155,7 +156,7 @@ void ies_enkf_config_set_ies_dec_steplength(ies_enkf_config_type *config,
 /* IES_INVERSION          */
 ies_inversion_type
 ies_enkf_config_get_ies_inversion(const ies_enkf_config_type *config) {
-    return config->ies_inversion;
+    return static_cast<ies_inversion_type>(config->ies_inversion);
 }
 void ies_enkf_config_set_ies_inversion(ies_enkf_config_type *config,
                                        ies_inversion_type ies_inversion) {

--- a/libres/lib/analysis/modules/ies_enkf_config.hpp
+++ b/libres/lib/analysis/modules/ies_enkf_config.hpp
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 2019  Equinor ASA, Norway.
 
-   The file 'ies_enkf_config.h' is part of ERT - Ensemble based Reservoir Tool.
+   The file 'ies_enkf_config.hpp' is part of ERT - Ensemble based Reservoir Tool.
 
    ERT is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/libres/lib/analysis/modules/ies_enkf_data.cpp
+++ b/libres/lib/analysis/modules/ies_enkf_data.cpp
@@ -1,5 +1,5 @@
-#include "ies_enkf_config.h"
-#include "ies_enkf_data.h"
+#include <ies_enkf_config.hpp>
+#include <ies_enkf_data.hpp>
 
 /*
   The configuration data used by the ies_enkf module is contained in a
@@ -37,7 +37,7 @@ struct ies_enkf_data_struct {
         E; // Prior ensemble of measurement perturations (should be the same for all iterations)
     bool converged; // GN has converged
     ies_enkf_config_type *
-        config; // This I don't understand but I assume I include data from the ies_enkf_config_type defined in ies_enkf_config.c
+        config; // This I don't understand but I assume I include data from the ies_enkf_config_type defined in ies_enkf_config.cpp
     FILE *log_fp; // logfile id
 };
 
@@ -45,7 +45,8 @@ UTIL_SAFE_CAST_FUNCTION(ies_enkf_data, IES_ENKF_DATA_TYPE_ID)
 UTIL_SAFE_CAST_FUNCTION_CONST(ies_enkf_data, IES_ENKF_DATA_TYPE_ID)
 
 void *ies_enkf_data_alloc() {
-    ies_enkf_data_type *data = util_malloc(sizeof *data);
+    ies_enkf_data_type *data =
+        static_cast<ies_enkf_data_type *>(util_malloc(sizeof *data));
     UTIL_TYPE_ID_INIT(data, IES_ENKF_DATA_TYPE_ID);
     data->iteration_nr = 0;
     data->state_size = 0;

--- a/libres/lib/analysis/modules/ies_enkf_data.hpp
+++ b/libres/lib/analysis/modules/ies_enkf_data.hpp
@@ -6,7 +6,7 @@
 #include <ert/util/bool_vector.hpp>
 #include <ert/util/type_macros.hpp>
 
-#include "ies_enkf_config.h"
+#include <ies_enkf_config.hpp>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libres/lib/analysis/modules/tests/ies_enkf_config.cpp
+++ b/libres/lib/analysis/modules/tests/ies_enkf_config.cpp
@@ -1,6 +1,5 @@
 
-
-#include "ies_enkf_data.h"
+#include <ies_enkf_data.hpp>
 
 void test_create() {
     ies_enkf_config_type *config = ies_enkf_config_alloc();

--- a/libres/lib/analysis/modules/tests/ies_enkf_data.cpp
+++ b/libres/lib/analysis/modules/tests/ies_enkf_data.cpp
@@ -2,7 +2,7 @@
 
 #include <ert/util/rng.h>
 
-#include "ies_enkf_data.h"
+#include <ies_enkf_data.hpp>
 
 void test_create() {
     rng_type *rng = rng_alloc(MZRAN, INIT_DEFAULT);

--- a/libres/lib/analysis/modules/tests/ies_iteration.cpp
+++ b/libres/lib/analysis/modules/tests/ies_iteration.cpp
@@ -4,8 +4,8 @@
 #include <ert/res_util/es_testdata.hpp>
 
 #include <ert/analysis/std_enkf.hpp>
-#include "ies_enkf_data.h"
-#include "ies_enkf.h"
+#include <ies_enkf_data.hpp>
+#include <ies_enkf.hpp>
 
 void init_stdA(const res::es_testdata &testdata, matrix_type *A2) {
     rng_type *rng = rng_alloc(MZRAN, INIT_DEFAULT);

--- a/libres/lib/analysis/modules/tests/ies_linalg.cpp
+++ b/libres/lib/analysis/modules/tests/ies_linalg.cpp
@@ -3,8 +3,8 @@
 
 #include <ert/res_util/es_testdata.hpp>
 
-#include "ies_enkf_data.h"
-#include "ies_enkf.h"
+#include <ies_enkf_data.hpp>
+#include <ies_enkf.hpp>
 
 void update_exact_scheme_subspace_no_truncation_diagR(
     const res::es_testdata &testdata, ies_enkf_data_type *ies_data,

--- a/libres/lib/analysis/modules/tests/ies_std_compare.cpp
+++ b/libres/lib/analysis/modules/tests/ies_std_compare.cpp
@@ -4,8 +4,8 @@
 #include <ert/res_util/es_testdata.hpp>
 
 #include <ert/analysis/std_enkf.hpp>
-#include "ies_enkf_data.h"
-#include "ies_enkf.h"
+#include <ies_enkf_data.hpp>
+#include <ies_enkf.hpp>
 
 /*
 TEST 3 (consistency between IES and STD_ENKF):


### PR DESCRIPTION
**Issue**
Resolves #2310 


**Approach**
I wrapped all function in `ies_enkf.cpp` in `extern C` to make `dlsym` work.
Is there a better way?

Other than that, I had to do a few ´static_casts`.
