### PR TITLE
Revert "Use pytest-xdist to run tests in parallel"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,13 +154,12 @@ jobs:
         sleep 3
         herbstluftwm &
         sleep 1
-        rm -rf res
+        python -c "import sys; print(sys.path)"
         pytest tests/ert_tests -sv
 
     - name: Test MacOS
       if: matrix.os == 'macos-latest'
       run: |
-        rm -rf res
         pytest tests/ert_tests -sv
 
     - name: Test CLI
@@ -263,8 +262,7 @@ jobs:
     - name: Run Python tests
       run: |
         # Run tests
-        rm -rf res
-        pytest tests/libres_tests -sv
+        pytest tests/libres_tests
 
 
   publish:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,4 +18,3 @@ scikit-build
 setuptools_scm
 pytest-snapshot
 flake8>=4.0.0
-pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,3 @@ markers = [
     "unstable",
     "consumer_driven_contract_verification",
 ]
-addopts = "-n4 --dist loadscope"


### PR DESCRIPTION
This reverts commit fd366161e47b080a1add3141d1fa3700ac77ff6b.

**Issue**
In recent PR's it was found that when we run tests in parallel using `pytest-xdist`, storage files from som `ert` tests leak into some `ert3` tests, causing them to fail in a flaky manner on GitHub actions. The reason is unclear, but not entirely unsurprising behavior for the older `ert`/`libres` code.

The recommendation is to not implement `pytest-xdist` in the repository, and **not** re-enable it in the future. If more parallelization is needed in the CI pipeline it should be implemented in a manner that isolates the sub-sets of tests fully.

**Approach**
Revert the commit that implemented `pytest-xdist` usage.