### PR TITLE
Catch KeyError to avoid gui crashing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         ctest --output-on-failure
 
   build-wheels:
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.11.0-rc0",
-        "ert-storage",
+        "ert-storage<=0.3.1",
         "fastapi",
         "graphene",
         "graphlib_backport; python_version < '3.9'",


### PR DESCRIPTION
Users have reported that popping the file has failed with
KeyError. We have not been able to reproduce the error, might be
a qt bug.
