### PR TITLE
Use reduced ErtTestData in Jenkins CI

### DIFF
--- a/ci/jenkins/test_libres_jenkins.sh
+++ b/ci/jenkins/test_libres_jenkins.sh
@@ -58,7 +58,7 @@ build_libres () {
 		  -DCMAKE_INSTALL_PREFIX=$INSTALL \
 		  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		  -DBUILD_TESTS=ON \
-		  -DEQUINOR_TESTDATA_ROOT=/project/res-testdata/ErtTestData
+		  -DEQUINOR_TESTDATA_ROOT=/project/oompf/ErtTestData
 	make -j 6 install
 	popd
 }

--- a/ci/jenkins/testkomodo-libres-ctest.sh
+++ b/ci/jenkins/testkomodo-libres-ctest.sh
@@ -28,7 +28,7 @@ build_libres () {
           -DCMAKE_PREFIX_PATH=$INSTALL \
           -DCMAKE_INSTALL_PREFIX=$INSTALL \
           -DBUILD_TESTS=ON \
-          -DEQUINOR_TESTDATA_ROOT=/project/res-testdata/ErtTestData
+          -DEQUINOR_TESTDATA_ROOT=/project/oompf/ErtTestData
     ninja
     popd
     # Remove built .so files when it is not a PR build

--- a/ci/jenkins/testkomodo-libres-pytest.sh
+++ b/ci/jenkins/testkomodo-libres-pytest.sh
@@ -23,7 +23,7 @@ install_package () {
 
 start_tests () {
     pushd ${CI_TEST_ROOT}/tests/libres_tests
-    ln -s /project/res-testdata/ErtTestData ${CI_TEST_ROOT}/test-data/Equinor
+    ln -s /project/oompf/ErtTestData ${CI_TEST_ROOT}/test-data/Equinor
     export ECL_SKIP_SIGNAL=ON
     pytest                                                   \
         --ignore="tests/libres_tests/res/enkf/test_analysis_config.py"    \

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -38,7 +38,7 @@ build_libres () {
           -DCMAKE_PREFIX_PATH=$INSTALL \
           -DCMAKE_INSTALL_PREFIX=$INSTALL \
           -DBUILD_TESTS=ON \
-          -DEQUINOR_TESTDATA_ROOT=/project/res-testdata/ErtTestData
+          -DEQUINOR_TESTDATA_ROOT=/project/oompf/ErtTestData
     ninja
     popd
     # Remove built .so files when it is not a PR build


### PR DESCRIPTION
I spent some time today reducing ErtTestData to only the files that are opened by the test suite. This narrowed the test-data from 600GB to 1.7GB. There's still a lot of wasted space, but we can now keep this information a single Dual-layer MiniDVD!

The data is accessible on `/project/oompf/ErtTestData` in both Bergen and Stavanger and should be a good starting point for future data reduction endeavours.