### PR TITLE
Validate inputs in the ensemble and stage configs

### DIFF
--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -92,6 +92,8 @@ class Workspace:
             config_dict = yaml.safe_load(f)
         ensemble_config = ert3.config.load_ensemble_config(config_dict)
 
+        _validate_inputs(stage_config, ensemble_config)
+
         return experiment_config, stage_config, ensemble_config
 
     def load_parameters_config(self) -> ert3.config.ParametersConfig:
@@ -126,3 +128,18 @@ def initialize(path: Union[str, Path]) -> Workspace:
         )
     (path / _WORKSPACE_DATA_ROOT).mkdir()
     return Workspace(path)
+
+
+def _validate_inputs(
+    stage_config: ert3.config.StagesConfig, ensemble_config: ert3.config.EnsembleConfig
+) -> None:
+    stage_name = ensemble_config.forward_model.stage
+    stage = next((stage for stage in stage_config if stage.name == stage_name), None)
+    if stage is None:
+        raise ert.exceptions.ConfigValidationError(f"Invalid stage: '{stage_name}''.")
+    stage_input_names = set(stage.input.keys())
+    ensemble_input_names = set(input.record for input in ensemble_config.input)
+    if ensemble_input_names != stage_input_names:
+        raise ert.exceptions.ConfigValidationError(
+            "Ensemble and stage inputs do not match."
+        )

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -217,8 +217,8 @@ def ensemble(base_ensemble_dict):
 
 
 @pytest.fixture()
-def stages_config():
-    config_list = [
+def stages_config_list():
+    yield [
         {
             "name": "evaluate_polynomial",
             "input": [{"record": "coefficients", "location": "coefficients.json"}],
@@ -232,17 +232,21 @@ def stages_config():
             ],
         }
     ]
+
+
+@pytest.fixture()
+def stages_config(stages_config_list):
     script_file = pathlib.Path("poly.py")
     script_file.write_text(POLY_SCRIPT)
     st = os.stat(script_file)
     os.chmod(script_file, st.st_mode | stat.S_IEXEC)
 
-    yield ert3.config.load_stages_config(config_list)
+    yield ert3.config.load_stages_config(stages_config_list)
 
 
 @pytest.fixture()
-def double_stages_config():
-    config_list = [
+def double_stages_config_list():
+    yield [
         {
             "name": "evaluate_polynomial",
             "input": [
@@ -268,12 +272,16 @@ def double_stages_config():
             ],
         }
     ]
+
+
+@pytest.fixture()
+def double_stages_config(double_stages_config_list):
     script_file = pathlib.Path("poly.py")
     script_file.write_text(POLY_SCRIPT)
     st = os.stat(script_file)
     os.chmod(script_file, st.st_mode | stat.S_IEXEC)
 
-    yield ert3.config.load_stages_config(config_list)
+    yield ert3.config.load_stages_config(double_stages_config_list)
 
 
 @pytest.fixture()


### PR DESCRIPTION
**Issue**
Resolves #2331


**Approach**
Compare the set of input record names in the ensemble, with those found in the first stage. Currently the sets must be the same.