### PR TITLE
Add workspace documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,8 @@ jobs:
 
     - name: Test docs
       run: |
-        sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
+        # The -W flag was disabled due to a unavoidable warning on Python 3.6, re-enable when 3.6 is dropped.
+        sphinx-build -n -v -E ./docs/rst/manual ./tmp/ert_docs
 
   tests-libres:
     name: Run libres tests

--- a/docs/rst/manual/api_reference/config.rst
+++ b/docs/rst/manual/api_reference/config.rst
@@ -1,0 +1,18 @@
+Configuration reference
+=======================
+
+.. automodule:: ert3.config
+    :members:
+    :undoc-members:
+
+.. autoclass:: ert3.config._ensemble_config::ForwardModel
+    :members:
+    :undoc-members:
+
+.. autoclass:: ert3.config._ensemble_config::Input
+    :members:
+    :undoc-members:
+
+.. autoclass:: ert3.config._ensemble_config::Output
+    :members:
+    :undoc-members:

--- a/docs/rst/manual/api_reference/exceptions.rst
+++ b/docs/rst/manual/api_reference/exceptions.rst
@@ -1,0 +1,6 @@
+Exceptions reference
+====================
+
+.. automodule:: ert.exceptions
+    :members:
+    :undoc-members:

--- a/docs/rst/manual/api_reference/index.rst
+++ b/docs/rst/manual/api_reference/index.rst
@@ -1,0 +1,4 @@
+.. toctree::
+  :maxdepth: 1
+  :hidden:
+

--- a/docs/rst/manual/api_reference/index.rst
+++ b/docs/rst/manual/api_reference/index.rst
@@ -2,3 +2,6 @@
   :maxdepth: 1
   :hidden:
 
+  exceptions
+  config
+  workspace

--- a/docs/rst/manual/api_reference/workspace.rst
+++ b/docs/rst/manual/api_reference/workspace.rst
@@ -1,0 +1,12 @@
+Workspace reference
+===================
+
+.. automodule:: ert3.workspace
+    :members:
+    :undoc-members:
+
+.. py:class:: ExperimentConfigurations
+
+    A type alias equal to: ``Tuple[ert3.config.ExperimentConfig, ert3.config.StagesConfig, ert3.config.EnsembleConfig]``
+
+    These are the configuration objects needed to run an ERT3 experiment.

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -59,6 +59,7 @@ extensions = [
 # Autodoc settings:
 autodoc_class_signature = "separated"
 autodoc_inherit_docstrings = False
+nitpick_ignore = [("py:class", "pydantic.types.FilePath")]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -47,26 +47,18 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.githubpages",
+    "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinxarg.ext",
     "sphinx.ext.todo",
     "sphinxcontrib.datatemplates",
     "ert_jobs",
     "ert_narratives",
-    "autoapi.extension",
 ]
-autoapi_type = "python"
-autoapi_dirs = ["../../../ert3/workspace"]
-autoapi_add_toctree_entry = False
-# Options: https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#customisation-options
-autoapi_options = [
-    "members",
-    "inherited-members",
-    "private-members",
-    "special-members",
-    "show-inheritance",
-]
-autoapi_python_class_content = "both"
+
+# Autodoc settings:
+autodoc_class_signature = "separated"
+autodoc_inherit_docstrings = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/rst/manual/index.rst
+++ b/docs/rst/manual/index.rst
@@ -60,7 +60,13 @@ with model updates and uncertainty estimation. You can read more about the theor
    :caption: Developer Documentation
 
    developer_documentation/index
-   autoapi/ert3/workspace/index
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: API Reference
+
+   api_reference/index
 
 .. toctree::
    :hidden:

--- a/ert3/workspace/__init__.py
+++ b/ert3/workspace/__init__.py
@@ -1,5 +1,33 @@
 """
-API reference documentation for the ert3 `workspace` module.
+The :py:mod:`ert3.workspace` module is reponsible for persisting and handling
+configuration and input data, and making those accessible to the remainder of
+ERT via a high-level API. The actual representation of the workspace data should
+not leak out of this module, allowing the underlying implementation to be
+exchanged as needed. Moreover, the workspace API and its implemenation are
+agnostic of the storage solution used by ERT.
+
+The current implementation stores configuration and input data on disk in a
+workspace directory, which is marked as a `workspace` by the presence of a
+hidden :file:`.ert` directory, that may be used to store internal data that is
+not to be exposed to the user. Other than that, the contents of the workspace
+directory should be immutable, apart from output files generated after running
+experiments.
+
+The high-level API that exposes the configuration and input data is implemented
+as a class (:py:class:`ert3.workspace.Workspace`). The persisted configuration
+and input data is initialized via a separate initialization function
+(:py:func:`ert3.workspace.initialize`), and can be accessed repeatedly by
+creating workspace objects.
+
+.. note:: The current file-based implementation still leaks some of the
+   underlying representation:
+
+   * Currently some resources in the workspace directory are stored in a
+     :file:`resources` directory, and its path is exposed by the
+     :py:meth:`ert3.workspace.Workspace.get_resources_dir` method.
+   * :py:meth:`ert3.workspace.Workspace.get_experiment_tmp_dir` may be
+     considered leaky and its location in the workspace object may need to be
+     reconsidered.
 """
 
 from ert3.workspace._workspace import Workspace


### PR DESCRIPTION
**Issue**
Resolves #2276 

See also: #2168 and possibly #2170

**Approach**
Add doc strings to the `workspace` module and the `Workspace` class. Generate the data using sphinx `autodoc`.

**Note**
Unfortunately, it turns out that with our source code layout, the usage of `autoapi` seems to be impossible or at least extremely cumbersome. I therefore switched to `autodoc`.

**Another note**
It turns out that it is impossible to get rid of one particular warning, so I removed the flag in the build that turns warnings into errors. It only happens on Python 3.6, so one day we might be able to switch it on again.