### PR TITLE
Test fwd_step_log_open

### DIFF
--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -67,6 +67,7 @@ conan_cmake_run(
   # Packages
   REQUIRES
   catch2/2.13.7
+  stduuid/1.0
   # Options
   OPTIONS
   catch2:with_main=True

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(Catch)
 
 add_executable(ert_test_suite analysis/modules/test_ies_enkf_main.cpp
                               analysis/test_enkf_linalg.cpp
+                              analysis/test_fwd_step_log.cpp
                               res_util/test_matrix.cpp)
 target_link_libraries(ert_test_suite res Catch2::Catch2WithMain)
 

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -5,10 +5,13 @@ endif()
 find_package(Catch2 REQUIRED)
 include(Catch)
 
+find_package(stduuid REQUIRED)
+# include(stduuid)
+
 add_executable(ert_test_suite analysis/modules/test_ies_enkf_main.cpp
                               analysis/test_enkf_linalg.cpp
                               analysis/test_fwd_step_log.cpp
                               res_util/test_matrix.cpp)
-target_link_libraries(ert_test_suite res Catch2::Catch2WithMain)
+target_link_libraries(ert_test_suite res Catch2::Catch2WithMain stduuid)
 
 catch_discover_tests(ert_test_suite)

--- a/libres/tests/analysis/test_fwd_step_log.cpp
+++ b/libres/tests/analysis/test_fwd_step_log.cpp
@@ -1,0 +1,45 @@
+#include <string>
+#include <filesystem>
+
+#include "catch2/catch.hpp"
+
+#include "ert/analysis/fwd_step_log.hpp"
+
+namespace {
+class TmpLog {
+public:
+    std::filesystem::path log_file_path;
+    fwd_step_log_type *fwd_step_log;
+
+    TmpLog() : log_file_path("tmp_fwd_step_log_open/test.txt") {
+        fwd_step_log = fwd_step_log_alloc();
+        fwd_step_log_set_log_file(fwd_step_log, log_file_path.c_str());
+    }
+    ~TmpLog() {
+        fwd_step_log_free(fwd_step_log);
+        std::filesystem::remove_all(log_file_path.parent_path());
+    }
+};
+} // namespace
+
+TEST_CASE_METHOD(TmpLog, "fwd_step_log_open clear_log is true", "[analysis]") {
+    bool exists_before = std::filesystem::exists(log_file_path);
+    REQUIRE(!exists_before);
+
+    fwd_step_log_set_clear_log(fwd_step_log, true);
+    fwd_step_log_open(fwd_step_log);
+
+    bool exists_after = std::filesystem::exists(log_file_path);
+    REQUIRE(exists_after);
+}
+
+TEST_CASE_METHOD(TmpLog, "fwd_step_log_open clear_log is false", "[analysis]") {
+    bool exists_before = std::filesystem::exists(log_file_path);
+    REQUIRE(!exists_before);
+
+    fwd_step_log_set_clear_log(fwd_step_log, false);
+    fwd_step_log_open(fwd_step_log);
+
+    bool exists_after = std::filesystem::exists(log_file_path);
+    REQUIRE(exists_after);
+}

--- a/libres/tests/analysis/test_fwd_step_log.cpp
+++ b/libres/tests/analysis/test_fwd_step_log.cpp
@@ -2,6 +2,7 @@
 #include <filesystem>
 
 #include "catch2/catch.hpp"
+#include "stduuid/uuid.h"
 
 #include "ert/analysis/fwd_step_log.hpp"
 


### PR DESCRIPTION
**Issue**
Resolves #2387 

Will all code under `WHEN` always run even if something crashes?
I would like to always run the following,

```C
            fwd_step_log_free(fwd_step_log);
            std::filesystem::remove_all(log_file_path);
```

but am not sure if this is the right way to go about it.

