### PR TITLE
Let serializers write to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .idea
 .vscode
 .pytest_cache
+__pycache__
 python/lib64
 /libenkf/src/.faultlist
 /develbranch/libenkf/src/.faultlist

--- a/ert/data/record/_record.py
+++ b/ert/data/record/_record.py
@@ -1,6 +1,6 @@
+import io
 import pathlib
 import tarfile
-import io
 from abc import ABC, abstractmethod
 from collections import deque
 from enum import Enum
@@ -19,7 +19,9 @@ from typing import (
 from beartype import beartype
 from beartype.roar import BeartypeException  # type: ignore
 from pydantic import PositiveInt
+
 from ert.serialization import get_serializer
+from ert_shared.asyncio import get_event_loop
 
 number = Union[int, float]
 numerical_record_data = Union[
@@ -261,8 +263,9 @@ def load_collection_from_file(
                     ensemble_size=ensemble_size,
                     collection_type=RecordCollectionType.UNIFORM,
                 )
-    with open(file_path, "rt", encoding="utf-8") as f:
-        raw_ensrecord = get_serializer(mime).decode_from_file(f)
+    raw_ensrecord = get_event_loop().run_until_complete(
+        get_serializer(mime).decode_from_path(file_path)
+    )
     return RecordCollection(
         records=tuple(NumericalRecord(data=raw_record) for raw_record in raw_ensrecord)
     )

--- a/ert/data/record/_transmitter.py
+++ b/ert/data/record/_transmitter.py
@@ -119,9 +119,8 @@ class RecordTransmitter:
             self._set_transmitted_state(uri, blob_record.record_type)
         else:
             serializer = get_serializer(mime)
-            async with aiofiles.open(str(file), mode="rt", encoding="utf-8") as ft:
-                contents_t: str = await ft.read()
-                num_record = NumericalRecord(data=serializer.decode(contents_t))
+            _record_data = await serializer.decode_from_path(file)
+            num_record = NumericalRecord(data=_record_data)
             uri = await self._transmit_numerical_record(num_record)
             self._set_transmitted_state(uri, num_record.record_type)
 

--- a/ert/serialization/_registry.py
+++ b/ert/serialization/_registry.py
@@ -1,8 +1,9 @@
 from typing import Tuple
+
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
-from ._serializer import Serializer, _json_serializer, _yaml_serializer
 
+from ._serializer import Serializer, _json_serializer, _yaml_serializer
 
 _registry: PMap[str, Serializer] = pmap(
     {

--- a/tests/ert_tests/ert3/data/test_serializer.py
+++ b/tests/ert_tests/ert3/data/test_serializer.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ert.serialization import _serializer
+
+OBJECTS = [None, {}, {"foo": "bar"}]
+OBJECTS_JSON = ["null", "{}", '{"foo": "bar"}']
+OBJECTS_YAML = ["null\n...", "{}", "foo: bar"]
+assert len(OBJECTS) == len(OBJECTS_JSON) == len(OBJECTS_YAML)
+
+
+@pytest.mark.parametrize("obj, obj_json", zip(OBJECTS, OBJECTS_JSON))
+def test_json_serializer_encode_decode(obj, obj_json):
+    json_serializer = _serializer._json_serializer()
+
+    assert json_serializer.encode(obj) == obj_json
+    assert json_serializer.decode(obj_json) == obj
+
+    # Test that keyword arguments are passed through
+    assert json_serializer.decode(json_serializer.encode(obj, indent=True)) == obj
+    assert json_serializer.encode(obj, separators=(",", ":")) == obj_json.replace(
+        " ", ""
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("obj, obj_json", zip(OBJECTS, OBJECTS_JSON))
+async def test_json_serializer_path(obj, obj_json, tmp_path):
+    json_serializer = _serializer._json_serializer()
+
+    await json_serializer.encode_to_path(obj, tmp_path / "foo.json")
+    obj_fromdisk = await json_serializer.decode_from_path(tmp_path / "foo.json")
+    assert obj_fromdisk == obj
+
+
+@pytest.mark.parametrize("obj, obj_yaml", zip(OBJECTS, OBJECTS_YAML))
+def test_yaml_serializer(obj, obj_yaml):
+    yaml_serializer = _serializer._yaml_serializer()
+
+    assert yaml_serializer.encode(obj).strip() == obj_yaml
+    assert yaml_serializer.decode(obj_yaml) == obj
+
+    # Test that keyword arguments are passed through
+    assert (
+        yaml_serializer.encode(obj, explicit_end=True).strip()
+        == obj_yaml.replace("\n...", "") + "\n..."
+        # NB: explicit_end is implicitly True on None input
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("obj, obj_yaml", zip(OBJECTS, OBJECTS_YAML))
+async def test_yaml_serializer_path(obj, obj_yaml, tmp_path):
+    yaml_serializer = _serializer._yaml_serializer()
+
+    await yaml_serializer.encode_to_path(obj, tmp_path / "foo.yaml")
+    obj_fromdisk = await yaml_serializer.decode_from_path(tmp_path / "foo.yaml")
+    assert obj_fromdisk == obj


### PR DESCRIPTION
This is opposed to have the transmitter open filehandles
for the serializers to write to.

This is needed in order to serialize binary files.

**Issue**
Resolves #2382

**Approach**
Move the async opening of files into the serializer encode/decode functions.
