### PR TITLE
Remove hardcoded path to 'true' executable in test

### DIFF
--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -97,7 +97,9 @@ class ErtConfigBuilder:
         f.write("INSTALL_JOB job JOB\n" "SIMULATION_JOB job\n")
 
         if self.job_script is None:
-            (path / "JOB").write_text("EXECUTABLE /usr/bin/true\n")
+            # true is an executable which should exist on the path for all normal distros
+            # and it is then reasonable to expect this instead of using hardcoded path
+            (path / "JOB").write_text("EXECUTABLE true\n")
         else:
             (path / "JOB").write_text(f"EXECUTABLE {path}/script\n")
             (path / "script").write_text(self.job_script)


### PR DESCRIPTION
Running ERT on chromebook causing an error in this test because the executable `true` is not found on the specified path, but `/bin/true`. It think it is reasonable to expect this executable to be present on path and could be called directly and by that work by default on chromebook as well.