### PR TITLE
Show duration in run_dialog for progress

### DIFF
--- a/ert_gui/model/snapshot.py
+++ b/ert_gui/model/snapshot.py
@@ -374,9 +374,9 @@ class SnapshotModel(QAbstractItemModel):
             _, data_name = COLUMNS[NodeType.STEP][index.column()]
             if data_name in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
                 data = node.data.get(ids.DATA)
-                bytes = data.get(data_name) if data else None
-                if bytes:
-                    return byte_with_unit(bytes)
+                _bytes = data.get(data_name) if data else None
+                if _bytes:
+                    return byte_with_unit(_bytes)
             if data_name in [ids.STDOUT, ids.STDERR]:
                 return "OPEN" if node.data.get(data_name) else QVariant()
             if data_name in [DURATION]:

--- a/tests/ert_tests/gui/conftest.py
+++ b/tests/ert_tests/gui/conftest.py
@@ -61,6 +61,19 @@ def full_snapshot() -> Snapshot:
                             MAX_MEMORY_USAGE: "312",
                         },
                     ),
+                    "2": Job(
+                        start_time=dt.now(),
+                        end_time=None,
+                        name="poly_post_mortem",
+                        status=JOB_STATE_START,
+                        error="error",
+                        stdout="std_out_file",
+                        stderr="std_err_file",
+                        data={
+                            CURRENT_MEMORY_USAGE: "123",
+                            MAX_MEMORY_USAGE: "312",
+                        },
+                    ),
                 },
             )
         },


### PR DESCRIPTION
**Issue**
Resolves #995 

**Approach**
Tests not added yet (made in playground time). Also shamelessly hijacked the `START_TIME` column to use for `DURATION`, so might need to refactor slightly.

Checked if the `humanize` package could provide a good results, but in the end simply `str(datetime.timedelta)` looked to be pretty decent, given that microseconds were removed.

Added screenshot to show what it looks like.

<img width="1197" alt="Screenshot 2021-11-19 at 15 21 41" src="https://user-images.githubusercontent.com/26920711/142638638-b9633520-1edf-45b3-ac6f-cd6bc234b0bb.png">


<img width="1197" alt="Screenshot 2021-11-19 at 15 22 44" src="https://user-images.githubusercontent.com/26920711/142638623-2c1a2075-2b7b-4750-bc85-6590ca4ee5e2.png">

