### PR TITLE
Refer to logfiles on unexpected crash

### DIFF
--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -456,7 +456,16 @@ def main():
     except ErtCliError as err:
         logger.exception(str(err))
         sys.exit(str(err))
-    except:
-        logger.exception("ert crashed unexpectedly")
-        sys.exit("ert crashed unexpectedly")
+    except BaseException as err:
+        logger.exception(f'ERT crashed unexpectedly with "{err}"')
+
+        logfiles = set()  # Use set to avoid duplicates...
+        for handler in logging.getLogger().handlers:
+            if isinstance(handler, logging.FileHandler):
+                logfiles.add(handler.baseFilename)
+
+        msg = f'ERT crashed unexpectedly with "{err}".\nSee logfile(s) for details:'
+        msg += "\n   " + "\n   ".join(logfiles)
+
+        sys.exit(msg)
     clear_global_state()

--- a/tests/ert_tests/shared/test_main_entry.py
+++ b/tests/ert_tests/shared/test_main_entry.py
@@ -9,15 +9,18 @@ from ert_shared import main
 
 def test_main_logging(monkeypatch, caplog):
     parser_mock = MagicMock()
-    parser_mock.func.side_effect = ValueError
+    parser_mock.func.side_effect = ValueError("This is a test")
     monkeypatch.setattr(logging.config, "dictConfig", MagicMock())
     monkeypatch.setattr(main, "ert_parser", MagicMock(return_value=parser_mock))
     monkeypatch.setattr(main, "start_ert_server", MagicMock())
     monkeypatch.setattr(main, "ErtPluginContext", MagicMock())
     monkeypatch.setattr(sys, "argv", ["ert", "test_run", "config.ert"])
-    with pytest.raises(SystemExit, match="ert crashed unexpectedly"):
+    with pytest.raises(
+        SystemExit, match='ERT crashed unexpectedly with "This is a test"'
+    ):
         main.main()
-    assert "ert crashed unexpectedly\nTraceback" in caplog.text
+    assert 'ERT crashed unexpectedly with "This is a test"' in caplog.text
+    assert "Traceback" in caplog.text
 
 
 def test_main_logging_argparse(monkeypatch, caplog):


### PR DESCRIPTION
**Issue**
Can be seen as fix for https://github.com/equinor/ert/issues/2085

**Approach**
If ERT crashes unexpectedly, the cause is most likely logged in a file somewhere but the user only get the text "ert crashed unexpectedly". This patch traverses all installed loggers and adds the name of all files used by log-handlers to the exit-message.
