### PR TITLE
Accept args and kwargs in base service signal handler

### DIFF
--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -39,7 +39,7 @@ SERVICE_NAMES: Set[str] = set()
 
 
 @atexit.register
-def cleanup_service_files():
+def cleanup_service_files(*args, **kwargs):
     for service_name in SERVICE_NAMES:
         file = Path(f"{service_name}_server.json")
         if file.exists():


### PR DESCRIPTION
**Issue**
Handlers that are given to signal.signal are called with signal number
and current stack frame. We do not use this information, but the
function should not crash when called by signal. atexit.register
does not invoke the function with any arguments.

**Approach**
Accept args and kwargs