### PR TITLE
Async `load_collection_from_file` and `load_record`, rename tar-creator.

### DIFF
--- a/ert/data/__init__.py
+++ b/ert/data/__init__.py
@@ -9,7 +9,7 @@ from ert.data.record._record import (
     RecordIndex,
     RecordType,
     RecordValidationError,
-    path_to_bytes,
+    make_tar,
 )
 from .record._transmitter import (
     InMemoryRecordTransmitter,
@@ -45,6 +45,6 @@ __all__ = (
     "TarRecordTransformation",
     "ExecutableRecordTransformation",
     "RecordTransformation",
-    "path_to_bytes",
+    "make_tar",
     "transmitter_factory",
 )

--- a/ert/data/record/_record.py
+++ b/ert/data/record/_record.py
@@ -4,6 +4,7 @@ import tarfile
 from abc import ABC, abstractmethod
 from collections import deque
 from enum import Enum
+from concurrent import futures
 from typing import (
     Any,
     Dict,
@@ -16,6 +17,7 @@ from typing import (
     cast,
 )
 
+import aiofiles
 from beartype import beartype
 from beartype.roar import BeartypeException  # type: ignore
 from pydantic import PositiveInt
@@ -236,14 +238,21 @@ class RecordCollection:
         return self._collection_type
 
 
-def path_to_bytes(file_path: pathlib.Path) -> bytes:
+async def make_tar(file_path: pathlib.Path) -> bytes:
+    """Walk the files under a filepath and encapsulate the file(s)
+    in a tar package."""
+    _executor = futures.ThreadPoolExecutor()
+    return await get_event_loop().run_in_executor(_executor, _sync_make_tar, file_path)
+
+
+def _sync_make_tar(file_path: pathlib.Path) -> bytes:
     tar_obj = io.BytesIO()
     with tarfile.open(fileobj=tar_obj, mode="w") as tar:
         tar.add(file_path, arcname="")
     return tar_obj.getvalue()
 
 
-def load_collection_from_file(
+async def load_collection_from_file(
     file_path: pathlib.Path,
     mime: str,
     ensemble_size: int = 1,
@@ -252,20 +261,18 @@ def load_collection_from_file(
     if mime == "application/octet-stream":
         if is_directory:
             return RecordCollection(
-                records=(BlobRecord(data=path_to_bytes(file_path)),),
+                records=(BlobRecord(data=await make_tar(file_path)),),
                 ensemble_size=ensemble_size,
                 collection_type=RecordCollectionType.UNIFORM,
             )
         else:
-            with open(file_path, "rb") as fb:
+            async with aiofiles.open(file_path, "rb") as filebinary:
                 return RecordCollection(
-                    records=(BlobRecord(data=fb.read()),),
+                    records=(BlobRecord(data=await filebinary.read()),),
                     ensemble_size=ensemble_size,
                     collection_type=RecordCollectionType.UNIFORM,
                 )
-    raw_ensrecord = get_event_loop().run_until_complete(
-        get_serializer(mime).decode_from_path(file_path)
-    )
+    raw_ensrecord = await get_serializer(mime).decode_from_path(file_path)
     return RecordCollection(
         records=tuple(NumericalRecord(data=raw_record) for raw_record in raw_ensrecord)
     )

--- a/ert/data/record/_transformation.py
+++ b/ert/data/record/_transformation.py
@@ -4,7 +4,7 @@ import tarfile
 import io
 import stat
 
-from ert.data import RecordTransmitter, BlobRecord, path_to_bytes
+from ert.data import RecordTransmitter, BlobRecord, make_tar
 
 _BIN_FOLDER = "bin"
 
@@ -65,7 +65,7 @@ class TarRecordTransformation(RecordTransformation):
     async def transform_output(
         self, transmitter: RecordTransmitter, mime: str, runpath: Path, location: Path
     ) -> None:
-        blob_record = BlobRecord(data=path_to_bytes(runpath / location))
+        blob_record = BlobRecord(data=await make_tar(runpath / location))
         await transmitter.transmit_record(blob_record)
 
 

--- a/ert/storage/__init__.py
+++ b/ert/storage/__init__.py
@@ -15,6 +15,7 @@ from ert.storage._storage import (
     get_record_metadata,
     add_record_metadata,
     get_record_storage_transmitters,
+    transmit_awaitable_record_collection,
     transmit_record_collection,
 )
 
@@ -35,5 +36,6 @@ __all__ = [
     "get_record_metadata",
     "add_record_metadata",
     "get_record_storage_transmitters",
+    "transmit_awaitable_record_collection",
     "transmit_record_collection",
 ]

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -2,7 +2,7 @@ import io
 import logging
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Dict, Iterable, Optional, Set, Tuple, List
+from typing import Any, Awaitable, Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 import requests
@@ -296,6 +296,18 @@ async def add_record_metadata(
 ) -> None:
     url = f"{record_urls}/{record_name}/userdata?realization_index=0"
     await _put_to_server_async(url, {}, json=metadata)
+
+
+async def transmit_awaitable_record_collection(
+    record_awaitable: Awaitable[ert.data.RecordCollection],
+    record_name: str,
+    workspace_name: str,
+    experiment_name: Optional[str] = None,
+) -> Dict[int, Dict[str, ert.data.RecordTransmitter]]:
+    record_coll = await record_awaitable
+    return await transmit_record_collection(
+        record_coll, record_name, workspace_name, experiment_name
+    )
 
 
 async def transmit_record_collection(

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -268,12 +268,14 @@ def _record(workspace: Workspace, args: Any) -> None:
         if args.blob_record or args.is_directory:
             record_mime = "application/octet-stream"
 
-        ert3.engine.load_record(
-            workspace,
-            args.record_name,
-            args.record_file,
-            record_mime,
-            args.is_directory,
+        get_event_loop().run_until_complete(
+            ert3.engine.load_record(
+                workspace,
+                args.record_name,
+                args.record_file,
+                record_mime,
+                args.is_directory,
+            )
         )
     else:
         raise NotImplementedError(

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
 import ert
 import ert3
 from ert_shared.asyncio import get_event_loop
@@ -46,7 +47,9 @@ def _prepare_export_parameters(
             if record_mime == "application/octet-stream":
                 continue
             file_path = workspace.get_resources_dir() / record_source[1]
-            collection = ert.data.load_collection_from_file(file_path, record_mime)
+            collection = get_event_loop().run_until_complete(
+                ert.data.load_collection_from_file(file_path, record_mime)
+            )
             assert collection.ensemble_size == ensemble_size
             for record in collection.records:
                 inputs[record_name].append(record.data)

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -1,10 +1,10 @@
 from pathlib import Path
+
 import ert
 import ert3
-from ert_shared.asyncio import get_event_loop
 
 
-def load_record(
+async def load_record(
     workspace: ert3.workspace.Workspace,
     record_name: str,
     record_file: Path,
@@ -12,13 +12,12 @@ def load_record(
     record_is_directory: bool = False,
 ) -> None:
 
-    collection = ert.data.load_collection_from_file(
+    collection = await ert.data.load_collection_from_file(
         file_path=record_file, mime=record_mime, is_directory=record_is_directory
     )
-    future = ert.storage.transmit_record_collection(
+    await ert.storage.transmit_record_collection(
         collection, record_name, workspace.name
     )
-    get_event_loop().run_until_complete(future)
 
 
 def sample_record(

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -2,18 +2,20 @@ import asyncio
 import logging
 import tempfile
 from pathlib import Path
-from typing import Dict, Tuple, List
+from typing import Dict, List, Tuple
+
 import ert
 import ert3
 from ert3.config import SourceNS
 from ert_shared.asyncio import get_event_loop
 from ert_shared.ensemble_evaluator.ensemble.builder import create_step_builder
+
+from ._entity import TransmitterCoroutine
 from ._sensitivity import (
     analyze_sensitivity,
-    transmitter_map_sensitivity,
     prepare_sensitivity,
+    transmitter_map_sensitivity,
 )
-from ._entity import TransmitterCoroutine
 
 logger = logging.getLogger(__name__)
 
@@ -79,19 +81,21 @@ def _transmitter_map_resources(
     futures: List[TransmitterCoroutine] = []
     for input_ in inputs:
         file_path = workspace.get_resources_dir() / input_.source_location
-        collection = ert.data.load_collection_from_file(
+
+        collection_awaitable = ert.data.load_collection_from_file(
             file_path,
             input_.source_mime,
             ensemble_size=ensemble_size,
             is_directory=input_.source_is_directory,
         )
-        future = ert.storage.transmit_record_collection(
-            record_coll=collection,
+        future = ert.storage.transmit_awaitable_record_collection(
+            record_awaitable=collection_awaitable,
             record_name=input_.name,
             workspace_name=workspace.name,
             experiment_name=experiment_name,
         )
         futures.append(future)
+
     return futures
 
 

--- a/tests/ert_tests/ert3/data/test_record.py
+++ b/tests/ert_tests/ert3/data/test_record.py
@@ -214,11 +214,12 @@ def test_inconsistent_size_ensemble_record(
         )
 
 
-def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
+@pytest.mark.asyncio
+async def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
     with open(designed_coeffs_record_file, "r") as f:
         raw_collection = json.load(f)
 
-    collection = ert.data.load_collection_from_file(
+    collection = await ert.data.load_collection_from_file(
         designed_coeffs_record_file, "application/json"
     )
     assert len(collection.records) == len(raw_collection)
@@ -227,9 +228,10 @@ def test_load_numeric_record_collection_from_file(designed_coeffs_record_file):
     assert collection.collection_type != ert.data.RecordCollectionType.UNIFORM
 
 
-def test_load_blob_record_collection_from_file(designed_blob_record_file):
+@pytest.mark.asyncio
+async def test_load_blob_record_collection_from_file(designed_blob_record_file):
     ens_size = 5
-    collection = ert.data.load_collection_from_file(
+    collection = await ert.data.load_collection_from_file(
         designed_blob_record_file, "application/octet-stream", ensemble_size=ens_size
     )
     assert len(collection.records) == ens_size

--- a/tests/ert_tests/ert3/data/test_transformers.py
+++ b/tests/ert_tests/ert3/data/test_transformers.py
@@ -1,19 +1,20 @@
-import pytest
 import contextlib
-import pathlib
 import os
+import pathlib
 from typing import Callable, ContextManager, List
 
+import pytest
 from ert_utils import tmp
+
 from ert.data import (
-    RecordTransformation,
-    FileRecordTransformation,
-    TarRecordTransformation,
-    ExecutableRecordTransformation,
-    path_to_bytes,
-    RecordTransmitter,
     BlobRecord,
+    ExecutableRecordTransformation,
+    FileRecordTransformation,
+    RecordTransformation,
+    RecordTransmitter,
+    TarRecordTransformation,
 )
+from ert.data.record._record import _sync_make_tar
 
 
 @contextlib.contextmanager
@@ -35,7 +36,9 @@ def record_factory_context(tmpdir):
             _files = [dir_path / "a.txt", dir_path / "b.txt"]
             with file_factory_context(tmpdir) as file_factory:
                 file_factory(_files)
-            return BlobRecord(data=path_to_bytes(dir_path))
+            # Using the private sync version for simplicity in tests:
+            tardata = _sync_make_tar(dir_path)
+            return BlobRecord(data=tardata)
         else:
             return BlobRecord(data=b"\xF0\x9F\xA6\x89")
 

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -493,11 +493,13 @@ def test_record_load_and_run(
 ):
     workspace = workspace_integration
     with assert_clean_workspace(workspace):
-        ert3.engine.load_record(
-            workspace,
-            "designed_coefficients",
-            designed_coeffs_record_file_integration,
-            "application/json",
+        get_event_loop().run_until_complete(
+            ert3.engine.load_record(
+                workspace,
+                "designed_coefficients",
+                designed_coeffs_record_file_integration,
+                "application/json",
+            )
         )
 
         experiment_run_config = ert3.config.ExperimentRunConfig(
@@ -510,8 +512,10 @@ def test_record_load_and_run(
     with assert_clean_workspace(workspace, allowed_files={"data.json"}):
         ert3.engine.export(workspace, "doe", experiment_run_config)
 
-    designed_collection = ert.data.load_collection_from_file(
-        designed_coeffs_record_file_integration, "application/json"
+    designed_collection = get_event_loop().run_until_complete(
+        ert.data.load_collection_from_file(
+            designed_coeffs_record_file_integration, "application/json"
+        )
     )
     export_data = _load_export_data(workspace, "doe")
     assert designed_collection.ensemble_size == len(export_data)
@@ -524,16 +528,17 @@ def test_record_load_and_run(
 
 
 @pytest.mark.requires_ert_storage
-def test_record_load_twice(workspace, designed_coeffs_record_file):
+@pytest.mark.asyncio
+async def test_record_load_twice(workspace, designed_coeffs_record_file):
     with assert_clean_workspace(workspace):
-        ert3.engine.load_record(
+        await ert3.engine.load_record(
             workspace,
             "designed_coefficients",
             designed_coeffs_record_file,
             "application/json",
         )
         with pytest.raises(ert.exceptions.ElementExistsError):
-            ert3.engine.load_record(
+            await ert3.engine.load_record(
                 workspace,
                 "designed_coefficients",
                 designed_coeffs_record_file,
@@ -625,11 +630,13 @@ def test_partial_sensitivity_run_and_export(
         gaussian_parameters_config,
     )
     with assert_clean_workspace(workspace):
-        ert3.engine.load_record(
-            workspace,
-            "other_coefficients",
-            oat_compatible_record_file,
-            "application/json",
+        get_event_loop().run_until_complete(
+            ert3.engine.load_record(
+                workspace,
+                "other_coefficients",
+                oat_compatible_record_file,
+                "application/json",
+            )
         )
         ert3.engine.run_sensitivity_analysis(
             experiment_run_config, workspace, "partial_sensitivity"
@@ -661,11 +668,13 @@ def test_incompatible_partial_sensitivity_run(
     experiment_dir = workspace._path / _EXPERIMENTS_BASE / "partial_sensitivity"
     assert experiment_dir.is_dir()
     with assert_clean_workspace(workspace):
-        ert3.engine.load_record(
-            workspace,
-            "other_coefficients",
-            oat_incompatible_record_file,
-            "application/json",
+        get_event_loop().run_until_complete(
+            ert3.engine.load_record(
+                workspace,
+                "other_coefficients",
+                oat_incompatible_record_file,
+                "application/json",
+            )
         )
 
     err_msg = "Ensemble size 6 does not match stored record ensemble size 10"


### PR DESCRIPTION
**Issue**
Resolves #2409 


**Approach**
Change to async function signature. 

**Missing**
~~path_to_bytes is still blocking due to unavailable async tarfiles module.~~ "Solved" by running in a ThreadPoolExecutor