### PR TITLE
Separate atexit handler from logic

### DIFF
--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -39,6 +39,10 @@ SERVICE_NAMES: Set[str] = set()
 
 
 @atexit.register
+def atexit_cleanup_service_files():
+    cleanup_service_files()
+
+
 def cleanup_service_files(*args, **kwargs):
     for service_name in SERVICE_NAMES:
         file = Path(f"{service_name}_server.json")


### PR DESCRIPTION
**Issue**
Wrapping the atexit.register as a fixture may manipulate the
argument list and causing the service.signal handlers to fail
because they expect 2 positional arguments.
