### PR TITLE
Remove the `get_experiment_tmp_dir` method from the workspace object

### DIFF
--- a/ert3/engine/_clean.py
+++ b/ert3/engine/_clean.py
@@ -20,4 +20,3 @@ def clean(
 
     for name in experiment_names:
         ert.storage.delete_experiment(experiment_name=name)
-        workspace.clean_experiment(name)

--- a/ert3/engine/_run.py
+++ b/ert3/engine/_run.py
@@ -1,4 +1,7 @@
 import asyncio
+import logging
+import tempfile
+from pathlib import Path
 from typing import Dict, Tuple, List
 import ert
 import ert3
@@ -11,6 +14,8 @@ from ._sensitivity import (
     prepare_sensitivity,
 )
 from ._entity import TransmitterCoroutine
+
+logger = logging.getLogger(__name__)
 
 
 def _prepare_experiment(
@@ -122,8 +127,11 @@ def _get_storage_path(
     if ensemble_config.storage_type == "ert_storage":
         return ert.storage.get_records_url(workspace.name, experiment_name)
     else:
-        evaluation_tmp_dir = workspace.get_experiment_tmp_dir(experiment_name)
-        return str(evaluation_tmp_dir / ".my_storage")
+        storage_tmp_dir = str(Path(tempfile.mkdtemp()) / experiment_name / "storage")
+        logger.info(  # pylint: disable=logging-fstring-interpolation
+            f"temporary storage location: {storage_tmp_dir}"
+        )
+        return storage_tmp_dir
 
 
 # pylint: disable=too-many-arguments

--- a/ert3/workspace/__init__.py
+++ b/ert3/workspace/__init__.py
@@ -20,14 +20,9 @@ and input data is initialized via a separate initialization function
 creating workspace objects.
 
 .. note:: The current file-based implementation still leaks some of the
-   underlying representation:
-
-   * Currently some resources in the workspace directory are stored in a
-     :file:`resources` directory, and its path is exposed by the
-     :py:meth:`ert3.workspace.Workspace.get_resources_dir` method.
-   * :py:meth:`ert3.workspace.Workspace.get_experiment_tmp_dir` may be
-     considered leaky and its location in the workspace object may need to be
-     reconsidered.
+   underlying representation: some resources in the workspace directory are
+   stored in a :file:`resources` directory, and its path is exposed by the
+   :py:meth:`ert3.workspace.Workspace.get_resources_dir` method.
 """
 
 from ert3.workspace._workspace import Workspace

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import shutil
 from pathlib import Path
 from typing import Union, Optional, Set, List, Dict, Any, Tuple
 
@@ -67,28 +66,6 @@ class Workspace:
             str: The workspace name
         """
         return str(self._path)
-
-    def get_experiment_tmp_dir(self, experiment_name: str) -> Path:
-        """Return a path to a temporary directory for an experiment.
-
-        This function does not check if the returned path exists, nor does it
-        create the directory.
-
-        Args:
-            experiment_name (str): Name of the experiment
-
-        Raises:
-            ert.exceptions._exceptions.IllegalWorkspaceOperation:
-                Raised when the experiment does not exist.
-
-        Returns:
-            pathlib.Path: The path to the temporary directory.
-        """
-        if experiment_name not in self.get_experiment_names():
-            raise ert.exceptions.IllegalWorkspaceOperation(
-                f"experiment {experiment_name} does not exist"
-            )
-        return self._path / _WORKSPACE_DATA_ROOT / "tmp" / experiment_name
 
     def get_resources_dir(self) -> Path:
         """Return the path to the :file:`resources` directory.
@@ -185,16 +162,6 @@ class Workspace:
         with open(self._path / "parameters.yml", encoding="utf-8") as f:
             config_dict = yaml.safe_load(f)
         return ert3.config.load_parameters_config(config_dict)
-
-    def clean_experiment(self, experiment_name: str) -> None:
-        """Clean up any temporary experiment data.
-
-        Args:
-            experiment_name (str): The name of the experiment.
-        """
-        tmp_dir = self.get_experiment_tmp_dir(experiment_name)
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
 
     def export_json(
         self,

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -361,7 +361,6 @@ def test_cli_clean_all(workspace):
             ensemble_size=42,
             responses=[],
         )
-        workspace.get_experiment_tmp_dir(experiment).mkdir(parents=True)
 
     assert (
         ert.storage.get_experiment_names(workspace_name=workspace.name) == experiments
@@ -372,8 +371,6 @@ def test_cli_clean_all(workspace):
         ert3.console.main()
 
     assert ert.storage.get_experiment_names(workspace_name=workspace.name) == set()
-    for experiment in experiments:
-        assert not workspace.get_experiment_tmp_dir(experiment).exists()
 
 
 @pytest.mark.requires_ert_storage
@@ -388,7 +385,6 @@ def test_cli_clean_one(workspace):
             ensemble_size=42,
             responses=[],
         )
-        workspace.get_experiment_tmp_dir(experiment).mkdir(parents=True)
 
     assert (
         ert.storage.get_experiment_names(workspace_name=workspace.name) == experiments
@@ -403,9 +399,6 @@ def test_cli_clean_one(workspace):
     assert (
         ert.storage.get_experiment_names(workspace_name=workspace.name) == experiments
     )
-    for experiment in experiments:
-        assert workspace.get_experiment_tmp_dir(experiment).exists()
-    assert not workspace.get_experiment_tmp_dir(deleted_experiment).exists()
 
 
 @pytest.mark.requires_ert_storage
@@ -422,7 +415,6 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
             ensemble_size=42,
             responses=[],
         )
-        workspace.get_experiment_tmp_dir(experiment).mkdir(parents=True)
 
     assert (
         ert.storage.get_experiment_names(workspace_name=workspace.name) == experiments
@@ -437,9 +429,6 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
     assert (
         ert.storage.get_experiment_names(workspace_name=workspace.name) == experiments
     )
-    for experiment in experiments:
-        workspace.get_experiment_tmp_dir(experiment).exists()
-    assert not workspace.get_experiment_tmp_dir(deleted_experiment).exists()
 
     captured = capsys.readouterr()
     assert (


### PR DESCRIPTION
**Issue**
Resolves #2418


**Approach**
Replace functionality with creating a tmp dir using the standard Python library. Remove everything related to the old functionality.