### PR TITLE
Add pytest-like Tmpdir for Catch2

### DIFF
--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -67,6 +67,7 @@ conan_cmake_run(
   # Packages
   REQUIRES
   catch2/2.13.7
+  fmt/8.0.1
   # Options
   OPTIONS
   catch2:with_main=True

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -3,11 +3,13 @@ if(NOT BUILD_TESTS)
 endif()
 
 find_package(Catch2 REQUIRED)
+find_package(fmt REQUIRED)
 include(Catch)
 
-add_executable(ert_test_suite analysis/modules/test_ies_enkf_main.cpp
+add_executable(ert_test_suite tmpdir.cpp
+                              analysis/modules/test_ies_enkf_main.cpp
                               analysis/test_enkf_linalg.cpp
                               res_util/test_matrix.cpp)
-target_link_libraries(ert_test_suite res Catch2::Catch2WithMain)
+target_link_libraries(ert_test_suite res Catch2::Catch2WithMain fmt::fmt)
 
 catch_discover_tests(ert_test_suite)

--- a/libres/tests/tmpdir.cpp
+++ b/libres/tests/tmpdir.cpp
@@ -1,0 +1,158 @@
+#include <string>
+#include <optional>
+#include <regex>
+
+#include <unistd.h>
+#include <pwd.h>
+
+#include <catch2/catch.hpp>
+#include <fmt/format.h>
+
+#include "tmpdir.hpp"
+
+using namespace std::string_literals;
+namespace fs = std::filesystem;
+
+namespace {
+/**
+ * Convert string into a nicer directory name
+ *
+ * Downcases, replaces whitespace-ish chars with '_' and removes the
+ * rest.
+ */
+std::string clean_prefix(const std::string &prefix) {
+    std::string out;
+    out.reserve(prefix.size());
+
+    for (char c : prefix) {
+        if ('a' <= c && c <= 'z')
+            out.push_back(c);
+        else if ('A' <= c && c <= 'Z')
+            out.push_back(c + 'a' - 'A');
+        else if (c == '_' || c == '-' || c == ' ')
+            out.push_back('_');
+    }
+    return out;
+}
+
+/**
+ * Get POSIX username of the current user
+ *
+ * Falls back to the user's UID if their username is unavailable.
+ */
+std::string get_username() {
+    auto uid = getuid();
+    auto pw = getpwuid(uid);
+    return pw ? std::string{pw->pw_name} : std::to_string(uid);
+}
+
+/**
+ * Create a new directory suffixed with a number
+ *
+ * The prefix is normalised with 'clean_string'.
+ *
+ * \param basepath Directory in which to create the new directory
+ * \param prefix Prefix of the directory to be created
+ */
+std::filesystem::path make_numbered_dir(const fs::path &basepath,
+                                        const std::string &prefix) {
+    auto norm_prefix = clean_prefix(prefix);
+    std::regex re{norm_prefix + "(\\d)+"s};
+    std::smatch match;
+
+    // Find largest entry with the given 'prefix'
+    int number = 0;
+    for (auto entry : fs::directory_iterator(basepath)) {
+        auto entry_str = entry.path().filename().string();
+        if (!std::regex_match(entry_str, match, re))
+            continue;
+        number = std::max(std::stoi(match[1]) + 1, number);
+    }
+
+    // A race condition might occur between us finding the largest suffix number
+    // and us creating a directory. Eg, by running two test suites
+    // simulatenously. To avoid this, we try the next 10 suffix numbers. Should
+    // `fs::create_directory` succeed and return true, we know that we were the
+    // ones who created the directory and have exclusive access to it.
+    for (int i{}; i < 10; ++i) {
+        std::error_code ec;
+        auto path = basepath / (norm_prefix + std::to_string(number + i));
+        if (fs::create_directory(path, ec)) {
+            // Create a symlink. Error codes are ignored because we don't really care
+            auto current = basepath / (norm_prefix + "current"s);
+            fs::remove(current, ec);
+            fs::create_directory_symlink(path, current, ec);
+            return path;
+        }
+    }
+
+    throw std::runtime_error(
+        fmt::format("Could not make numbered dir in {} with prefix {}",
+                    basepath.string(), norm_prefix));
+}
+
+/**
+ * Get the base tmpdir for this entire test session
+ */
+const fs::path &get_basedir() {
+    static std::optional<fs::path> basedir;
+    if (basedir.has_value())
+        return *basedir;
+
+    auto tmp = fs::temp_directory_path();
+    tmp /= fmt::format("catch2-of-{}", get_username());
+
+    auto name = Catch::getCurrentContext().getConfig()->name();
+    fs::create_directories(tmp);
+    basedir.emplace(make_numbered_dir(tmp, name));
+
+    // Create a symlink. Error codes are ignored because we don't really care
+    auto current = tmp / (clean_prefix(name) + "current"s);
+    std::error_code ec;
+    fs::remove(current, ec);
+    fs::create_directory_symlink(*basedir, current, ec);
+
+    return *basedir;
+}
+
+fs::path make_path_for_catch2_test() {
+    return make_numbered_dir(get_basedir(),
+                             Catch::getResultCapture().getCurrentTestName());
+}
+
+} // namespace
+
+TmpDir::TmpDir() : m_prev_cwd(fs::current_path()) {
+    auto tmpdir = make_path_for_catch2_test();
+    UNSCOPED_INFO("Using temporary directory " << tmpdir.string() << "\n");
+    fs::current_path(tmpdir);
+}
+
+TmpDir::~TmpDir() { fs::current_path(m_prev_cwd); }
+
+TEST_CASE("Create a single tmpdir", "[tmpdir]") {
+    auto before = fs::current_path();
+    {
+        WITH_TMPDIR;
+        REQUIRE(fs::current_path() != before);
+    }
+    REQUIRE(fs::current_path() == before);
+}
+
+TEST_CASE("Create multiple tmpdirs", "[tmpdir]") {
+    const int N = 10;
+    fs::path paths[N];
+
+    auto before = fs::current_path();
+    for (int i{}; i < N; ++i) {
+        WITH_TMPDIR;
+        paths[i] = fs::current_path();
+    }
+
+    for (int i{}; i < N; ++i) {
+        for (int j = i + 1; j < N; ++j) {
+            REQUIRE(paths[i] != paths[j]);
+        }
+    }
+    REQUIRE(fs::current_path() == before);
+}

--- a/libres/tests/tmpdir.hpp
+++ b/libres/tests/tmpdir.hpp
@@ -1,0 +1,26 @@
+#ifndef __TMPDIR_HPP__
+#define __TMPDIR_HPP__
+
+#include <filesystem>
+
+/**
+ * Utility for temporary directories for testing.
+ *
+ * Creates and chdirs into a new empty directory on initialisation, and chdirs
+ * back on destruction. The directories are created in:
+ *   /tmp/catch2-of-${user}/${test-suite-name}#/${test-name}#
+ *
+ * Eg:
+ *   /tmp/catch2-of-f_scout-ci/ert_test_suite12/test_matrix_addition2
+ */
+class TmpDir {
+    std::filesystem::path m_prev_cwd;
+
+public:
+    TmpDir();
+    ~TmpDir();
+};
+
+#define WITH_TMPDIR TmpDir __t_m_p_d_i_r__##__COUNTER__
+
+#endif //__TMPDIR_HPP__


### PR DESCRIPTION
Add a new header `tmpdir.hpp` in the testing directory which provides
the class `Tmpdir`. The API is simple: On initialisation, it creates and
cd's into a new temporary directory. This directory is unique on every
run and should withstand a bit of race conditions.

It is itself a `std::filesystem::path` and can be used anywhere where
those can be used.

```c++
#include <catch2/catch.hpp>
#include <fmt/format.h>
#include <fmt/ostream.h>
#include "tmpdir.hpp"

TEST_CASE("My Test!!", "[test]") {
    Tmpdir foo;

    fmt::print("TMPDIR: {}\n", foo);
    fmt::print("Current dir: {}\n", fs::current_path());
}

TEST_CASE_METHOD(Tmpdir, "My other test", "[test]") {
    fmt::print("TMPDIR: {}\n", *this);
    fmt::print("Current dir: {}\n", fs::current_path());
}
```

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_
