### PR TITLE
Treat warnings as errors when testing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -232,8 +232,7 @@ jobs:
 
     - name: Test docs
       run: |
-        # The -W flag was disabled due to a unavoidable warning on Python 3.6, re-enable when 3.6 is dropped.
-        sphinx-build -n -v -E ./docs/rst/manual ./tmp/ert_docs
+        sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
 
   tests-libres:
     name: Run libres tests

--- a/docs/rst/manual/api_reference/data.rst
+++ b/docs/rst/manual/api_reference/data.rst
@@ -1,0 +1,6 @@
+Data reference
+==============
+
+.. automodule:: ert.data
+    :members:
+    :undoc-members:

--- a/docs/rst/manual/api_reference/index.rst
+++ b/docs/rst/manual/api_reference/index.rst
@@ -5,3 +5,4 @@
   exceptions
   config
   workspace
+  data

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -59,7 +59,10 @@ extensions = [
 # Autodoc settings:
 autodoc_class_signature = "separated"
 autodoc_inherit_docstrings = False
-nitpick_ignore = [("py:class", "pydantic.types.FilePath")]
+nitpick_ignore = [
+    ("py:class", "pydantic.types.FilePath"),
+    ("py:class", "pydantic.types.PositiveInt"),
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
**Issue**
In 378caf4 the "warnings-as-errors"
flag was removed, due to a incompatibility with Python 3.6 and 3.7.

**Approach**
This PR removes testing of documentation on Python 3.6 in favor
of having the "warning-as-errors" flag enabled. This will give us much
more rigid testing of the documentation. You can still build the
documentation on Python 3.6 locally by removing the flag.
