### PR TITLE
Use the same enum for inversion type for both std_enkf and ies_enkf

### DIFF
--- a/libres/lib/include/ert/analysis/std_enkf.hpp
+++ b/libres/lib/include/ert/analysis/std_enkf.hpp
@@ -9,6 +9,7 @@ extern "C" {
 
 #include <ert/res_util/matrix.hpp>
 #include <ert/util/rng.hpp>
+#include <ert/analysis/ies/ies_enkf_config.hpp>
 
 #define DEFAULT_ENKF_TRUNCATION_ 0.98
 #define ENKF_TRUNCATION_KEY_ "ENKF_TRUNCATION"
@@ -16,6 +17,11 @@ extern "C" {
 #define USE_EE_KEY_ "USE_EE"
 #define USE_GE_KEY_ "USE_GE"
 #define ANALYSIS_SCALE_DATA_KEY_ "ANALYSIS_SCALE_DATA"
+#define INVERSION_KEY "INVERSION"
+#define STRING_INVERSION_EXACT "EXACT"
+#define STRING_INVERSION_SUBSPACE_EXACT_R "SUBSPACE_EXACT_R"
+#define STRING_INVERSION_SUBSPACE_EE_R "SUBSPACE_EE_R"
+#define STRING_INVERSION_SUBSPACE_RE "SUBSPACE_RE"
 
 typedef struct std_enkf_data_struct std_enkf_data_type;
 
@@ -26,6 +32,7 @@ void std_enkf_set_truncation(std_enkf_data_type *data, double truncation);
 void std_enkf_set_subspace_dimension(std_enkf_data_type *data,
                                      int subspace_dimension);
 bool std_enkf_has_var(const void *arg, const char *var_name);
+ies_inversion_type std_enkf_data_get_inversion(const std_enkf_data_type *data);
 
 double std_enkf_get_truncation(std_enkf_data_type *data);
 void *std_enkf_data_alloc();
@@ -36,6 +43,7 @@ int std_enkf_get_int(const void *arg, const char *var_name);
 double std_enkf_get_double(const void *arg, const char *var_name);
 bool std_enkf_has_var(const void *arg, const char *var_name);
 long std_enkf_get_options(void *arg, long flag);
+bool std_enkf_set_string(void *arg, const char *var_name, const char *value);
 bool std_enkf_set_bool(void *arg, const char *var_name, bool value);
 bool std_enkf_set_int(void *arg, const char *var_name, int value);
 bool std_enkf_set_double(void *arg, const char *var_name, double value);

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -16,7 +16,9 @@ add_executable(
   enkf/test_enkf_fs.cpp
   enkf/test_analysis_config.cpp
   enkf/test_obs_data.cpp
-  res_util/test_matrix.cpp)
+  res_util/test_matrix.cpp
+  analysis/test_std_enkf.cpp)
+
 target_link_libraries(ert_test_suite res Catch2::Catch2WithMain fmt::fmt)
 
 catch_discover_tests(ert_test_suite)

--- a/libres/tests/analysis/test_std_enkf.cpp
+++ b/libres/tests/analysis/test_std_enkf.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch.hpp>
+
+#include <ert/analysis/std_enkf.hpp>
+
+SCENARIO("Can set inversion method", "[std_enkf]") {
+    GIVEN("A default constructed std_enkf_data instance") {
+        std_enkf_data_type *std_enkf_data =
+            static_cast<std_enkf_data_type *>(std_enkf_data_alloc());
+
+        WHEN("Setting invalid key") {
+            REQUIRE(
+                !std_enkf_set_string(std_enkf_data, "NO_SUCH_KEY", "VALUE"));
+        }
+
+        WHEN("Setting invalid value") {
+            REQUIRE(!std_enkf_set_string(std_enkf_data, INVERSION_KEY,
+                                         "INVALID_VALUE"));
+        }
+
+        WHEN("Inversion is set to SUBSPACE_EXACT_R") {
+
+            REQUIRE(std_enkf_set_string(std_enkf_data, INVERSION_KEY,
+                                        STRING_INVERSION_SUBSPACE_EXACT_R));
+            REQUIRE(std_enkf_data_get_inversion(std_enkf_data) ==
+                    IES_INVERSION_SUBSPACE_EXACT_R);
+        }
+
+        WHEN("Inversion is set to SUBSPACE_EE_R") {
+
+            REQUIRE(std_enkf_set_string(std_enkf_data, INVERSION_KEY,
+                                        STRING_INVERSION_SUBSPACE_EE_R));
+            REQUIRE(std_enkf_data_get_inversion(std_enkf_data) ==
+                    IES_INVERSION_SUBSPACE_EE_R);
+        }
+
+        WHEN("Inversion is set to SUBSPACE_RE") {
+
+            REQUIRE(std_enkf_set_string(std_enkf_data, INVERSION_KEY,
+                                        STRING_INVERSION_SUBSPACE_RE));
+            REQUIRE(std_enkf_data_get_inversion(std_enkf_data) ==
+                    IES_INVERSION_SUBSPACE_RE);
+        }
+
+        WHEN("Deprecated bool flags are set to true") {
+            std_enkf_set_bool(std_enkf_data, USE_EE_KEY_, false);
+            std_enkf_set_bool(std_enkf_data, USE_GE_KEY_, false);
+            REQUIRE(std_enkf_data_get_inversion(std_enkf_data) ==
+                    IES_INVERSION_SUBSPACE_EXACT_R);
+        }
+
+        WHEN("Deprecated bool flags aere set to false") {
+            std_enkf_set_bool(std_enkf_data, USE_EE_KEY_, true);
+            std_enkf_set_bool(std_enkf_data, USE_GE_KEY_, true);
+            REQUIRE(std_enkf_data_get_inversion(std_enkf_data) ==
+                    IES_INVERSION_SUBSPACE_RE);
+        }
+
+        std_enkf_data_free(std_enkf_data);
+    }
+}


### PR DESCRIPTION
Part of: https://github.com/equinor/ert/pull/2412

With this PR some of the configuration for the `std_enkf` and `ies_enkf` modules are harmonized.