### PR TITLE
Speed up running of tests by seperating out integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,12 +155,12 @@ jobs:
         herbstluftwm &
         sleep 1
         python -c "import sys; print(sys.path)"
-        pytest tests/ert_tests -sv
+        pytest tests/ert_tests -sv --durations=0
 
     - name: Test MacOS
       if: matrix.os == 'macos-latest'
       run: |
-        pytest tests/ert_tests -sv
+        pytest tests/ert_tests -sv --durations=0
 
     - name: Test CLI
       run: |
@@ -263,7 +263,7 @@ jobs:
     - name: Run Python tests
       run: |
         # Run tests
-        pytest tests/libres_tests
+        pytest tests/libres_tests --durations=0
 
 
   publish:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest]
+        test-type: ['integration-tests', 'unit-tests']
         # Excluded to keep build times down on Github actions
         exclude:
           - os: macos-latest
@@ -146,7 +147,7 @@ jobs:
         pip install -r dev-requirements.txt
 
     - name: Test Ubuntu
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit-tests'
       env:
         DISPLAY: ':99.0'
       run: |
@@ -155,12 +156,29 @@ jobs:
         herbstluftwm &
         sleep 1
         python -c "import sys; print(sys.path)"
-        pytest tests/ert_tests -sv --durations=0
+        pytest tests/ert_tests -sv --durations=0 -m "not integration_test"
 
     - name: Test MacOS
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest' && matrix.test-type == 'unit-tests'
       run: |
-        pytest tests/ert_tests -sv --durations=0
+        pytest tests/ert_tests -sv --durations=0 -m "not integration_test"
+
+    - name: Integration Test Ubuntu
+      if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'integration-tests'
+      env:
+        DISPLAY: ':99.0'
+      run: |
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 640x480x24 -ac +extension GLX
+        sleep 3
+        herbstluftwm &
+        sleep 1
+        python -c "import sys; print(sys.path)"
+        pytest tests/ert_tests -sv --durations=0 -m "integration_test"
+
+    - name: Integration Test MacOS
+      if: matrix.os == 'macos-latest' && matrix.test-type == 'integration-tests'
+      run: |
+        pytest tests/ert_tests -sv --durations=0 -m "integration_test"
 
     - name: Test CLI
       run: |

--- a/libres/old_tests/enkf/test_row_scaling.cpp
+++ b/libres/old_tests/enkf/test_row_scaling.cpp
@@ -87,7 +87,7 @@ void test_multiply(const row_scaling_type *row_scaling, const matrix_type *A0,
 }
 
 void test_multiply() {
-    const int data_size = 200000;
+    const int data_size = 200;
     const int ens_size = 100;
     matrix_type *A0 = matrix_alloc(data_size, ens_size);
     matrix_type *X0 = matrix_alloc(ens_size, ens_size);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,5 @@ markers = [
     "consumer_driven_contract_test",
     "unstable",
     "consumer_driven_contract_verification",
+    "integration_test"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,5 @@ markers =
     requires_ert_storage
     consumer_driven_contract_test
     consumer_driven_contract_verification
+    integration_test
 log_cli = false

--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -25,6 +25,7 @@ def mock_cli_run(monkeypatch):
     yield mocked_monitor, mocked_thread_join, mocked_thread_start
 
 
+@pytest.mark.integration_test
 def test_target_case_equal_current_case(tmpdir, source_root):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -50,6 +51,7 @@ def test_target_case_equal_current_case(tmpdir, source_root):
             run_cli(parsed)
 
 
+@pytest.mark.integration_test
 def test_runpath_file(tmpdir, source_root):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -87,6 +89,7 @@ def test_runpath_file(tmpdir, source_root):
         assert os.path.isfile("RUNPATH_WORKFLOW_1.OK")
 
 
+@pytest.mark.integration_test
 def test_ensemble_evaluator(tmpdir, source_root):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -117,6 +120,7 @@ def test_ensemble_evaluator(tmpdir, source_root):
         FeatureToggling.reset()
 
 
+@pytest.mark.integration_test
 def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -148,6 +152,7 @@ def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
         FeatureToggling.reset()
 
 
+@pytest.mark.integration_test
 def test_cli_test_run(tmpdir, source_root, mock_cli_run):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -173,6 +178,7 @@ def test_cli_test_run(tmpdir, source_root, mock_cli_run):
     thread_start_mock.assert_has_calls([[call(), call()]])
 
 
+@pytest.mark.integration_test
 def test_cli_test_connection_error(tmpdir, source_root, capsys):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),

--- a/tests/ert_tests/data/test_integration_data.py
+++ b/tests/ert_tests/data/test_integration_data.py
@@ -56,6 +56,7 @@ def test_summary_obs(monkeypatch, facade_snake_oil):
     ] == np.datetime64("2011-12-21")
 
 
+@pytest.mark.integration_test
 def test_summary_obs_runtime(monkeypatch, copy_snake_oil):
     """
     This is mostly a regression test, as reading SUMMARY_OBS was very slow when using
@@ -121,6 +122,7 @@ def test_summary_obs_last_entry(monkeypatch, copy_snake_oil):
     ]
 
 
+@pytest.mark.integration_test
 def test_gen_obs_runtime(monkeypatch, copy_snake_oil, snapshot):
     obs_file = pathlib.Path.cwd() / "observations" / "observations.txt"
     with obs_file.open(mode="a") as fin:

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -561,6 +561,7 @@ def test_failing_check_service(tmpdir):
                 ert3.console._console._main()
 
 
+@pytest.mark.integration_test
 def test_check_service(tmpdir, monkeypatch):
     with tmpdir.as_cwd():
         with patch.object(

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -169,6 +169,7 @@ def assert_clean_workspace(workspace, allowed_files=None):
         assert set(item.name for item in new_files) == set(allowed_files)
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_run_once_polynomial_evaluation(
     workspace_integration,
@@ -217,6 +218,7 @@ def _load_export_data(workspace, experiment_name):
         return json.load(f)
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_export_polynomial_evaluation(
     workspace_integration,
@@ -243,6 +245,7 @@ def test_export_polynomial_evaluation(
     assert_export(export_data, ensemble, stages_config, gaussian_parameters_config)
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_export_uniform_polynomial_evaluation(
     workspace_integration,
@@ -271,6 +274,7 @@ def test_export_uniform_polynomial_evaluation(
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_export_x_uncertainties_polynomial_evaluation(
     workspace_integration,
@@ -372,6 +376,7 @@ def test_uniform_distribution(
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_run_presampled(
     workspace_integration,
@@ -420,6 +425,7 @@ def test_run_presampled(
             assert coeff.data[key] == export_coeff[key]
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_run_uniform_presampled(
     workspace_integration,
@@ -482,6 +488,7 @@ def test_sample_unknown_parameter_group(uniform_parameters_config):
         ert3.engine.sample_record(uniform_parameters_config, "coeffs", 100)
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_record_load_and_run(
     workspace_integration,
@@ -546,6 +553,7 @@ async def test_record_load_twice(workspace, designed_coeffs_record_file):
             )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_sensitivity_oat_run_and_export(
     workspace_integration,
@@ -578,6 +586,7 @@ def test_sensitivity_oat_run_and_export(
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_sensitivity_fast_run_and_export(
     workspace_integration,
@@ -611,6 +620,7 @@ def test_sensitivity_fast_run_and_export(
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_partial_sensitivity_run_and_export(
     workspace_integration,
@@ -655,6 +665,7 @@ def test_partial_sensitivity_run_and_export(
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_incompatible_partial_sensitivity_run(
     workspace_integration,

--- a/tests/ert_tests/services/test_storage_service.py
+++ b/tests/ert_tests/services/test_storage_service.py
@@ -6,6 +6,7 @@ from ert_shared.services import Storage, _storage_main
 from ert_shared import port_handler
 
 
+@pytest.mark.integration_test
 @pytest.mark.requires_ert_storage
 def test_integration(tmp_path, monkeypatch):
     """Actually start the server, wait for it to be online and do a health check"""

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -37,6 +37,7 @@ def check_expression(original, path_expression, expected, msg_start):
     assert match_found, f"{msg_start} Nothing matched {path_expression}"
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "experiment_folder,cmd_line_arguments,num_successful,num_iters,assert_present_in_snapshot",
     [


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
A small number of tests dominate the amount of time it takes to run the test suite. This PR
speeds up CI by either reducing the size of those tests or running them in parallel.

In the case of the libres ctests, one test (`row_scaling_test`) tok 100 seconds to run while the
remaining tests took 9 seconds in total (all less than one second). After reducing the size of
test data in that test by a factor of 100, the entire test suite runs in under 10 seconds.

There are about 20 tests in `ert_tests` that dominate the run time for that suite.  Many of them
are integration tests. Therefore these tests that both 1) takes a long time and 2) somehow indicated that is
an integration test, is now given the `integration_test` mark and run separately. (Perhaps
a better mark might be `big_integration_test` :D ).

The polynomial demo takes 24 minutes so it is now the bottleneck.

As workflows are renamed, required jobs will have to be changed for protected branches.