### PR TITLE
Change ensemble_size to __len__ in RecordCollection

### DIFF
--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -316,7 +316,6 @@ async def transmit_record_collection(
     workspace_name: str,
     experiment_name: Optional[str] = None,
 ) -> Dict[int, Dict[str, ert.data.RecordTransmitter]]:
-    assert record_coll.ensemble_size is not None
     record: ert.data.Record
     metadata: Dict[Any, Any] = {
         "record_type": record_coll.record_type,
@@ -329,12 +328,12 @@ async def transmit_record_collection(
         ensemble_id = await _get_ensemble_id_async(workspace_name, experiment_name)
         ensemble_size = await _get_ensemble_size(ensemble_id=ensemble_id)
     else:
-        ensemble_size = record_coll.ensemble_size
+        ensemble_size = len(record_coll)
 
-    if record_coll.ensemble_size != ensemble_size:
+    if len(record_coll) != ensemble_size:
         raise ert.exceptions.ErtError(
             f"Experiment ensemble size {ensemble_size} does not match"
-            f" data size {record_coll.ensemble_size}"
+            f" data size {len(record_coll)}"
         )
 
     # Handle special case of a uniform record collection
@@ -610,7 +609,7 @@ def get_ensemble_record(
         for transmitter in transmitters
     )
     return ert.data.RecordCollection(
-        records=records, ensemble_size=ensemble_size, collection_type=collection_type
+        records=records, length=ensemble_size, collection_type=collection_type
     )
 
 

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -53,7 +53,7 @@ def _prepare_export_parameters(
                     linked_inputs[ert3.config.SourceNS.resources][record_name],
                 )
             )
-            assert collection.ensemble_size == ensemble_size
+            assert len(collection) == ensemble_size
             for record in collection.records:
                 inputs[record_name].append(record.data)
         else:

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -327,7 +327,7 @@ def test_gaussian_distribution(
             gaussian_parameters_config, "coefficients", 1000
         )
 
-        assert 1000 == coefficients.ensemble_size
+        assert 1000 == len(coefficients)
         assert 1000 == len(sample_calls.call_args_list)
         assert 1000 == len(returned_samples)
 
@@ -364,7 +364,7 @@ def test_uniform_distribution(
             1000,
         )
 
-        assert 1000 == coefficients.ensemble_size
+        assert 1000 == len(coefficients)
         assert 1000 == len(sample_calls.call_args_list)
         assert 1000 == len(returned_samples)
 
@@ -401,7 +401,7 @@ def test_run_presampled(
         )
         get_event_loop().run_until_complete(future)
 
-        assert 10 == coeff0.ensemble_size
+        assert 10 == len(coeff0)
         for real_coeff in coeff0.records:
             assert sorted(("a", "b", "c")) == sorted(real_coeff.index)
             for idx in real_coeff.index:
@@ -418,7 +418,7 @@ def test_run_presampled(
         ert3.engine.export(workspace, "presampled_evaluation", experiment_run_config)
 
     export_data = _load_export_data(workspace, "presampled_evaluation")
-    assert coeff0.ensemble_size == len(export_data)
+    assert len(coeff0) == len(export_data)
     for coeff, real in zip(coeff0.records, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]
@@ -454,7 +454,7 @@ def test_run_uniform_presampled(
             workspace_name=workspace.name,
         )
         get_event_loop().run_until_complete(future)
-        assert 10 == uniform_coeff0.ensemble_size
+        assert 10 == len(uniform_coeff0)
         for real_coeff in uniform_coeff0.records:
             assert sorted(("a", "b", "c")) == sorted(real_coeff.index)
             for idx in real_coeff.index:
@@ -475,7 +475,7 @@ def test_run_uniform_presampled(
         )
 
     export_data = _load_export_data(workspace, "presampled_uniform_evaluation")
-    assert uniform_coeff0.ensemble_size == len(export_data)
+    assert len(uniform_coeff0) == len(export_data)
     for coeff, real in zip(uniform_coeff0.records, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]
@@ -527,7 +527,7 @@ def test_record_load_and_run(
         )
     )
     export_data = _load_export_data(workspace, "doe")
-    assert designed_collection.ensemble_size == len(export_data)
+    assert len(designed_collection) == len(export_data)
     for coeff, real in zip(designed_collection.records, export_data):
         assert ["coefficients"] == list(real["input"].keys())
         export_coeff = real["input"]["coefficients"]

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -172,7 +172,7 @@ def test_add_and_get_uniform_ensemble_record(
     ens_size = 5
     ensrecord = ert.data.RecordCollection(
         records=raw_ensrec_to_records(raw_ensrec),
-        ensemble_size=ens_size,
+        length=ens_size,
         collection_type=ert.data.RecordCollectionType.UNIFORM,
     )
     future = ert.storage.transmit_record_collection(


### PR DESCRIPTION
**Issue**
Resolves #2383 

**Approach**
Changing from `ensemble_size` to`__len__` in `RecordCollection` and its associated utility functions, but keeping `ensemble_size` in surrounding code where the context is indeed ensembles.