### PR TITLE
Treat warnings as errors when testing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -214,8 +214,7 @@ jobs:
 
     - name: Test docs
       run: |
-        # The -W flag was disabled due to a unavoidable warning on Python 3.6, re-enable when 3.6 is dropped.
-        sphinx-build -n -v -E ./docs/rst/manual ./tmp/ert_docs
+        sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
 
   tests-libres:
     name: Run libres tests


### PR DESCRIPTION
In 378caf44bef056c7c58c841a6617ad9ff26658a8 the "warnings-as-errors"
flag was removed, due to a incompatibility with Python 3.6.

This commit removes testing of documentation on Python 3.6 in favor
of having the "warning-as-errors" flag enabled. This will give us much
more rigid testing of the documentation. You can still build the
documentation on Python 3.6 locally by removing the flag.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_
