### PR TITLE
Add codecov to ci

### DIFF
--- a/.github/actions/install_dependencies/action.yml
+++ b/.github/actions/install_dependencies/action.yml
@@ -1,0 +1,17 @@
+name: install_dependencies
+description: Installs dependencies for the pip build
+
+inputs:
+    os:
+        required: true
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Ubuntu dependencies
+      if: inputs.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3 x11-xserver-utils herbstluftwm
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build libres
       run: |
         mkdir cmake-build
-        cmake -S libres -B cmake-build -DBUILD_TESTS=ON
+        cmake -S libres -B cmake-build -DBUILD_TESTS=ON -DCOVERAGE=ON
         cmake --build cmake-build
 
     - name: Run tests
@@ -55,6 +55,20 @@ jobs:
         cd cmake-build
         export PATH=$PWD/bin:$PATH
         ctest --output-on-failure
+
+    - name: Install gcovr
+      run: |
+        python3 -m pip install gcovr
+
+    - name: generate coverage report
+      run: |
+        gcovr -r libres/ --exclude-directories ".*tests" cmake-build/ --xml -o cov.xml
+
+    - name: Upload c coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: cmake-build/cov.xml
 
   build-wheels:
     timeout-minutes: 30
@@ -71,11 +85,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3 x11-xserver-utils herbstluftwm
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ${{ matrix.os }}
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Build Linux Wheel
       uses: docker://quay.io/pypa/manylinux2014_x86_64
@@ -83,11 +99,6 @@ jobs:
         entrypoint: /github/workspace/ci/github/build_linux_wheel.sh
         args: ${{ matrix.python-version }}
       if: matrix.os == 'ubuntu-latest'
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Build macOS Wheel
       run: pip wheel . --no-deps -w dist
@@ -118,18 +129,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3 x11-xserver-utils herbstluftwm
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ${{ matrix.os }}
+
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -148,10 +156,8 @@ jobs:
       env:
         DISPLAY: ':99.0'
       run: |
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 640x480x24 -ac +extension GLX
-        sleep 3
-        herbstluftwm &
-        sleep 1
+        ci/github/start_herbstluftwm.sh &
+        sleep 5
         pushd tests
         pytest ert_tests -sv --durations=0 -m "not integration_test"
 
@@ -166,10 +172,8 @@ jobs:
       env:
         DISPLAY: ':99.0'
       run: |
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 640x480x24 -ac +extension GLX
-        sleep 3
-        herbstluftwm &
-        sleep 1
+        ci/github/start_herbstluftwm.sh &
+        sleep 5
         pushd tests
         pytest ert_tests -sv --durations=0 -m "integration_test"
 
@@ -196,18 +200,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3 x11-xserver-utils herbstluftwm
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ${{ matrix.os }}
+
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -252,18 +253,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-xfixes0 libxcb-xinerama0 libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libdbus-1-3 x11-xserver-utils herbstluftwm
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ${{ matrix.os }}
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,61 @@
+name: Python coverage
+
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+   tags: "*"
+ pull_request:
+
+jobs:
+  python-test-coverage:
+    name: Python Coverage
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        system-under-test: ['res', 'ert']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ubuntu-latest
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install with dependencies
+      run: |
+        pip install -r dev-requirements.txt
+        pip install .
+
+    - name: Run ert tests
+      if: matrix.system-under-test == 'ert'
+      env:
+        DISPLAY: ':99.0'
+      run: |
+        ci/github/start_herbstluftwm.sh &
+        sleep 5
+        # We run the tests from the test directory as pytest-cov (at least as
+        # of 3.0.0) will create an incorrect report when a directory matches
+        # the package name
+        cd tests
+        pytest ert_tests --cov=ert --cov=ert3 --cov=ert_data --cov=ert_gui --cov=ert_shared --cov=ert_logging --cov=res --cov-report=xml:cov.xml
+
+    - name: Run res tests
+      if: matrix.system-under-test == 'res'
+      run: |
+        cd tests
+        pytest libres_tests --cov=res --cov-report=xml:cov.xml
+
+    - name: Upload python coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: tests/cov.xml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors-anon/equinor/ert)](https://img.shields.io/github/contributors-anon/equinor/ert)
 [![Code Style](https://github.com/equinor/ert/actions/workflows/style.yml/badge.svg)](https://github.com/equinor/ert/actions/workflows/style.yml)
 [![Type checking](https://github.com/equinor/ert/actions/workflows/typing.yml/badge.svg)](https://github.com/equinor/ert/actions/workflows/typing.yml)
+[![codecov](https://codecov.io/gh/equinor/ert/branch/add_code_coverage/graph/badge.svg?token=keVAcWavZ1)](https://codecov.io/gh/equinor/ert)
 [![Run test-data](https://github.com/equinor/ert/actions/workflows/run_ert2_test_data_setups.yml/badge.svg)](https://github.com/equinor/ert/actions/workflows/run_ert2_test_data_setups.yml)
 [![Run polynomial demo](https://github.com/equinor/ert/actions/workflows/run_examples_polynomial.yml/badge.svg)](https://github.com/equinor/ert/actions/workflows/run_examples_polynomial.yml)
 [![Run SPE1 demo](https://github.com/equinor/ert/actions/workflows/run_examples_spe1.yml/badge.svg)](https://github.com/equinor/ert/actions/workflows/run_examples_spe1.yml)

--- a/ci/github/start_herbstluftwm.sh
+++ b/ci/github/start_herbstluftwm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 640x480x24 -ac +extension GLX
+sleep 3
+herbstluftwm

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+fixes:
+    - "*/site-packages/::"
+    - "/home/runner/work/ert/ert/::"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,4 +20,4 @@ setuptools_scm
 pytest-snapshot
 flake8>=4.0.0
 cmake-format
-
+pytest-cov

--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.6.1)
 project(res C CXX)
 
 option(BUILD_TESTS "Should the tests be built" OFF)
+option(COVERAGE "Should binaries record coverage information" OFF)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
@@ -50,6 +51,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
       "Release"
       "MinSizeRel"
       "RelWithDebInfo")
+endif()
+
+if(COVERAGE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -Wall")
 endif()
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
**Issue**
Resolves #my_issue

Adds uploading of test coverage to codecov.

The coverage reporting is set up so that

* `libres/` is covered by the test suite in `libres/old_tests` and `libres/tests` without equinor test data.
* `res/` is covered by the test suite in `tests/libres_tests`
* Everything else should be covered by test suite in `tests/ert_tests`.

This scheme 1) simplifies setup considerably and 2) ensures that code should be covered by appropriate unit tests.

The python code coverage generation is run in a separate workflow so that it does not slow down the release pipeline (running pytest with coverage reporting slows it down). The code coverage workflow ends up running in about the same time as it does not build wheels and does not run on macos.

When running tests with `pytest-cov`, the codecov workflow first does `cd tests/` to sidestep https://github.com/equinor/ert/issues/2492 .