### PR TITLE
Add dark storage record labels endpoints

### DIFF
--- a/ert_shared/dark_storage/endpoints/records.py
+++ b/ert_shared/dark_storage/endpoints/records.py
@@ -174,6 +174,7 @@ async def get_ensemble_record(
     ensemble_id: UUID,
     accept: str = Header("application/json"),
     realization_index: Optional[int] = None,
+    label: Optional[str] = None,
 ) -> Any:
     ensemble_name = get_name("ensemble", ensemble_id)
     dataframe = data_for_key(ensemble_name, name, realization_index)
@@ -195,6 +196,16 @@ async def get_ensemble_record(
             content=dataframe.to_csv().encode(),
             media_type="text/csv",
         )
+
+
+@router.get("/ensembles/{ensemble_id}/records/{name}/labels", response_model=List[str])
+async def get_record_labels(
+    *,
+    res: LibresFacade = Depends(get_res),
+    ensemble_id: UUID,
+    name: str,
+) -> List[str]:
+    return []
 
 
 @router.get("/ensembles/{ensemble_id}/parameters", response_model=List[str])

--- a/tests/ert_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert_tests/dark_storage/test_http_endpoints.py
@@ -176,3 +176,17 @@ def test_misfit_endpoint(poly_example_tmp_dir, dark_storage_client):
 
     assert_array_equal(misfit.columns, ["0", "2", "4", "6", "8"])
     assert misfit.shape == (3, 5)
+
+
+def test_get_record_labels(poly_example_tmp_dir, dark_storage_client):
+    resp: Response = dark_storage_client.post(
+        "/gql", json={"query": "{experiments{ensembles{id}}}"}
+    )
+    answer_json = resp.json()
+    ensemble_id = answer_json["data"]["experiments"][0]["ensembles"][0]["id"]
+    resp: Response = dark_storage_client.get(
+        f"/ensembles/{ensemble_id}/records/POLY_RES@0/labels"
+    )
+    labels = resp.json()
+
+    assert labels == []


### PR DESCRIPTION
**Issue**

Relate to issue [#webviz-ert/](https://github.com/equinor/webviz-ert/issues/191)


**Approach**
Add a get_record_labels HTTP dark storage endpoint to match new new-storage endpoint 
