### PR TITLE
fix path to c codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: cmake-build/cov.xml
+        files: cov.xml
 
   build-wheels:
     timeout-minutes: 30


### PR DESCRIPTION
Unfortunately, a bad path in the codecov upload resultet in a silent failure.