### PR TITLE
Fix res import errors

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         pip install .  # We need the dependencies of ERT to avoid import-error
         pylint ert ert3
-        pylint --disable=all --enable=line-too-long res
+        pylint --disable=all --enable="line-too-long, unused-import" res

--- a/res/analysis/__init__.py
+++ b/res/analysis/__init__.py
@@ -15,9 +15,7 @@
 #  for more details.
 
 
-import res
-from cwrap import Prototype
-import ecl.util
-
-from .enums import AnalysisModuleOptionsEnum
 from .analysis_module import AnalysisModule
+from .enums import AnalysisModuleOptionsEnum
+
+__all__ = ["AnalysisModuleOptionsEnum", "AnalysisModule"]

--- a/res/analysis/analysis_module.py
+++ b/res/analysis/analysis_module.py
@@ -15,12 +15,12 @@
 #  for more details.
 
 from cwrap import BaseCClass
-from ecl.util.util.rng import RandomNumberGenerator
-from res import ResPrototype
-from os import path
+from ecl.util.util import BoolVector, RandomNumberGenerator
 
-import res
+from res import ResPrototype
 from res.util import Matrix
+
+from .enums import AnalysisModuleOptionsEnum
 
 
 class AnalysisModule(BaseCClass):
@@ -200,7 +200,7 @@ class AnalysisModule(BaseCClass):
     def name(self):
         return self._get_name()
 
-    def checkOption(self, flag):
+    def checkOption(self, flag: AnalysisModuleOptionsEnum):
         return self._check_option(flag)
 
     def hasVar(self, var):
@@ -227,7 +227,17 @@ class AnalysisModule(BaseCClass):
         self.__assertVar(var)
         return self._get_str(var)
 
-    def initUpdate(self, ens_mask, obs_mask, S, R, dObs, E, D, rng):
+    def initUpdate(
+        self,
+        ens_mask: BoolVector,
+        obs_mask: BoolVector,
+        S: Matrix,
+        R: Matrix,
+        dObs: Matrix,
+        E: Matrix,
+        D: Matrix,
+        rng: RandomNumberGenerator,
+    ):
         self._init_update(ens_mask, obs_mask, S, R, dObs, E, D, rng)
 
     def updateA(self, A, S, R, dObs, E, D, rng):

--- a/res/analysis/enums/__init__.py
+++ b/res/analysis/enums/__init__.py
@@ -1,1 +1,3 @@
 from .analysis_module_options_enum import AnalysisModuleOptionsEnum
+
+__all__ = ["AnalysisModuleOptionsEnum"]

--- a/res/config/__init__.py
+++ b/res/config/__init__.py
@@ -13,15 +13,25 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import Prototype
-import res
 
-
-from .config_path_elm import ConfigPathElm
-from .unrecognized_enum import UnrecognizedEnum
-from .content_type_enum import ContentTypeEnum
-from .config_error import ConfigError
-from .schema_item import SchemaItem
 from .config_content import ConfigContent, ContentItem, ContentNode
+from .config_error import ConfigError
 from .config_parser import ConfigParser
+from .config_path_elm import ConfigPathElm
 from .config_settings import ConfigSettings
+from .content_type_enum import ContentTypeEnum
+from .schema_item import SchemaItem
+from .unrecognized_enum import UnrecognizedEnum
+
+__all__ = [
+    "ConfigPathElm",
+    "UnrecognizedEnum",
+    "ContentTypeEnum",
+    "ConfigError",
+    "SchemaItem",
+    "ConfigContent",
+    "ContentItem",
+    "ContentNode",
+    "ConfigParser",
+    "ConfigSettings",
+]

--- a/res/config/config_content.py
+++ b/res/config/config_content.py
@@ -15,9 +15,14 @@
 #  for more details.
 
 import os.path
-from res import ResPrototype
-from res.config import UnrecognizedEnum, ContentTypeEnum, ConfigError, SchemaItem
+
 from cwrap import BaseCClass
+
+from res import ResPrototype
+from res.config.config_error import ConfigError
+from res.config.config_path_elm import ConfigPathElm
+from res.config.content_type_enum import ContentTypeEnum
+from res.config.schema_item import SchemaItem
 
 
 class ContentNode(BaseCClass):
@@ -238,7 +243,7 @@ class ConfigContent(BaseCClass):
     def free(self):
         self._free()
 
-    def getErrors(self):
+    def getErrors(self) -> ConfigError:
         """@rtype: ConfigError"""
         return self._get_errors()
 
@@ -249,7 +254,7 @@ class ConfigContent(BaseCClass):
     def get_config_path(self):
         return self._get_config_path()
 
-    def create_path_elm(self, path):
+    def create_path_elm(self, path) -> ConfigPathElm:
         return self._create_path_elm(path)
 
     def add_define(self, key, value):

--- a/res/config/config_parser.py
+++ b/res/config/config_parser.py
@@ -14,12 +14,14 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-import sys
 import os.path
+import sys
 
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.config import ConfigContent, UnrecognizedEnum
+from res.config.config_content import ConfigContent
+from res.config.unrecognized_enum import UnrecognizedEnum
 
 
 class ConfigParser(BaseCClass):
@@ -92,7 +94,7 @@ class ConfigParser(BaseCClass):
         pre_defined_kw_map=None,
         unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_WARN,
         validate=True,
-    ):
+    ) -> ConfigContent:
         """@rtype: ConfigContent"""
 
         assert isinstance(unrecognized, UnrecognizedEnum)

--- a/res/config/config_settings.py
+++ b/res/config/config_settings.py
@@ -17,8 +17,7 @@
 from cwrap import BaseCClass
 
 from res import ResPrototype
-from res.config import ContentTypeEnum
-from res.config import SchemaItem
+from res.config.content_type_enum import ContentTypeEnum
 
 
 class ConfigSettings(BaseCClass):

--- a/res/config/schema_item.py
+++ b/res/config/schema_item.py
@@ -13,12 +13,11 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import ctypes
 
-from ecl import EclPrototype
-from res import ResPrototype
-from res.config import ContentTypeEnum
 from cwrap import BaseCClass
+
+from res import ResPrototype
+from res.config.content_type_enum import ContentTypeEnum
 
 
 class SchemaItem(BaseCClass):
@@ -46,7 +45,7 @@ class SchemaItem(BaseCClass):
         c_ptr = self._alloc(keyword, required)
         super(SchemaItem, self).__init__(c_ptr)
 
-    def iget_type(self, index):
+    def iget_type(self, index) -> ContentTypeEnum:
         """@rtype: ContentTypeEnum"""
         return self._iget_type(index)
 

--- a/res/enkf/__init__.py
+++ b/res/enkf/__init__.py
@@ -14,88 +14,166 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from res.job_queue import CancelPluginException, ErtPlugin, ErtScript
 
-from cwrap import Prototype
-import res
-from .config_keys import ConfigKeys
-import ecl.util
-import ecl.util.geometry
-import ecl
-import ecl.eclfile
-import ecl.grid
-import ecl.grid.faults
-import ecl.gravimetry
-import ecl.summary
-import ecl.rft
-
-import res.analysis
-import res.sched
-import res.config
-import res.job_queue
-
-from .enums import *
-
-from .node_id import NodeId
-
-from .util import TimeMap
-from .state_map import StateMap
-from .summary_key_set import SummaryKeySet
-from .summary_key_matcher import SummaryKeyMatcher
-from .enkf_fs import EnkfFs
-
-
-from .row_scaling import RowScaling
 from .active_list import ActiveList
-from .config import *
-from .data import *
-
-from .obs_block import ObsBlock
-from .obs_data import ObsData
-from .local_dataset import LocalDataset
-from .local_obsdata_node import LocalObsdataNode
-from .local_obsdata import LocalObsdata
-from .local_ministep import LocalMinistep
-from .local_updatestep import LocalUpdateStep
-
-from .observations import *
-
-from .meas_block import MeasBlock
-from .meas_data import MeasData
-
-from .analysis_iter_config import AnalysisIterConfig
 from .analysis_config import AnalysisConfig
-
-from .enkf_defaults import EnkfDefaults
-
+from .analysis_iter_config import AnalysisIterConfig
+from .config import (
+    EnkfConfigNode,
+    ExtParamConfig,
+    FieldConfig,
+    FieldTypeEnum,
+    GenDataConfig,
+    GenKwConfig,
+    SummaryConfig,
+)
+from .config_keys import ConfigKeys
+from .data import EnkfNode, ExtParam, Field, GenData, GenKw
 from .ecl_config import EclConfig
-from .queue_config import QueueConfig
-from .ert_workflow_list import ErtWorkflowList
-from .site_config import SiteConfig
-from .subst_config import SubstConfig
-from .ensemble_config import EnsembleConfig
-from .enkf_obs import EnkfObs
-from .ert_template import ErtTemplate
-from .ert_templates import ErtTemplates
-from .local_config import LocalConfig
-from .model_config import ModelConfig
-from .runpath_list import RunpathList, RunpathNode
-from .hook_workflow import HookWorkflow
-from .hook_manager import HookManager
-from .rng_config import RNGConfig
-from .log_config import LogConfig
-from .res_config import ResConfig
-
-from .es_update import ESUpdate
-from .run_arg import RunArg
-from .enkf_state import EnKFState
-from .ert_run_context import ErtRunContext
-from .enkf_simulation_runner import EnkfSimulationRunner
+from .enkf_defaults import EnkfDefaults
+from .enkf_fs import EnkfFs
 from .enkf_fs_manager import EnkfFsManager
 from .enkf_main import EnKFMain
-from .forward_load_context import ForwardLoadContext
-
-from res.job_queue import ErtScript as ErtScript
-from res.job_queue import (
-    ErtPlugin as ErtPlugin,
-    CancelPluginException as CancelPluginException,
+from .enkf_obs import EnkfObs
+from .enkf_simulation_runner import EnkfSimulationRunner
+from .enkf_state import EnKFState
+from .ensemble_config import EnsembleConfig
+from .enums import (
+    ActiveMode,
+    EnkfFieldFileFormatEnum,
+    EnKFFSType,
+    EnkfInitModeEnum,
+    EnkfObservationImplementationType,
+    EnkfRunType,
+    EnkfTruncationType,
+    EnkfVarType,
+    ErtImplType,
+    GenDataFileType,
+    HookRuntime,
+    LoadFailTypeEnum,
+    RealizationStateEnum,
 )
+from .ert_run_context import ErtRunContext
+from .ert_template import ErtTemplate
+from .ert_templates import ErtTemplates
+from .ert_workflow_list import ErtWorkflowList
+from .es_update import ESUpdate
+from .forward_load_context import ForwardLoadContext
+from .hook_manager import HookManager
+from .hook_workflow import HookWorkflow
+from .local_config import LocalConfig
+from .local_dataset import LocalDataset
+from .local_ministep import LocalMinistep
+from .local_obsdata import LocalObsdata
+from .local_obsdata_node import LocalObsdataNode
+from .local_updatestep import LocalUpdateStep
+from .log_config import LogConfig
+from .meas_block import MeasBlock
+from .meas_data import MeasData
+from .model_config import ModelConfig
+from .node_id import NodeId
+from .obs_block import ObsBlock
+from .obs_data import ObsData
+from .observations import (
+    BlockDataConfig,
+    BlockObservation,
+    GenObservation,
+    ObsVector,
+    SummaryObservation,
+)
+from .queue_config import QueueConfig
+from .res_config import ResConfig
+from .rng_config import RNGConfig
+from .row_scaling import RowScaling
+from .run_arg import RunArg
+from .runpath_list import RunpathList, RunpathNode
+from .site_config import SiteConfig
+from .state_map import StateMap
+from .subst_config import SubstConfig
+from .summary_key_matcher import SummaryKeyMatcher
+from .summary_key_set import SummaryKeySet
+from .util import TimeMap
+
+__all__ = [
+    "SummaryObservation",
+    "GenObservation",
+    "BlockDataConfig",
+    "BlockObservation",
+    "ObsVector",
+    "Field",
+    "GenKw",
+    "GenData",
+    "ExtParam",
+    "EnkfNode",
+    "CancelPluginException",
+    "ErtPlugin",
+    "ErtScript",
+    "FieldConfig",
+    "FieldTypeEnum",
+    "GenKwConfig",
+    "GenDataConfig",
+    "EnkfConfigNode",
+    "SummaryConfig",
+    "ExtParamConfig",
+    "NodeId",
+    "TimeMap",
+    "StateMap",
+    "SummaryKeySet",
+    "SummaryKeyMatcher",
+    "EnkfFs",
+    "RowScaling",
+    "ActiveList",
+    "ObsBlock",
+    "ObsData",
+    "LocalDataset",
+    "LocalObsdataNode",
+    "LocalObsdata",
+    "LocalMinistep",
+    "LocalUpdateStep",
+    "MeasBlock",
+    "MeasData",
+    "EnkfFieldFileFormatEnum",
+    "LoadFailTypeEnum",
+    "EnkfVarType",
+    "EnkfRunType",
+    "EnkfObservationImplementationType",
+    "ErtImplType",
+    "EnkfInitModeEnum",
+    "RealizationStateEnum",
+    "EnkfTruncationType",
+    "EnKFFSType",
+    "GenDataFileType",
+    "ActiveMode",
+    "HookRuntime",
+    "AnalysisIterConfig",
+    "AnalysisConfig",
+    "ConfigKeys",
+    "EnkfDefaults",
+    "EclConfig",
+    "QueueConfig",
+    "ErtWorkflowList",
+    "SiteConfig",
+    "SubstConfig",
+    "EnsembleConfig",
+    "EnkfObs",
+    "ErtTemplate",
+    "ErtTemplates",
+    "LocalConfig",
+    "ModelConfig",
+    "RunpathList",
+    "RunpathNode",
+    "HookWorkflow",
+    "HookManager",
+    "RNGConfig",
+    "LogConfig",
+    "ResConfig",
+    "ESUpdate",
+    "RunArg",
+    "EnKFState",
+    "ErtRunContext",
+    "EnkfSimulationRunner",
+    "EnkfFsManager",
+    "EnKFMain",
+    "ForwardLoadContext",
+]

--- a/res/enkf/active_list.py
+++ b/res/enkf/active_list.py
@@ -15,8 +15,9 @@
 #  for more details.
 
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import ActiveMode
+from res.enkf.enums import ActiveMode
 
 
 class ActiveList(BaseCClass):

--- a/res/enkf/analysis_config.py
+++ b/res/enkf/analysis_config.py
@@ -14,17 +14,17 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from os.path import isfile
-from os.path import realpath
+from os.path import isfile, realpath
+from typing import Optional
 
 from cwrap import BaseCClass
-
 from ecl.util.util import StringList
 
 from res import ResPrototype
-from res.enkf import ConfigKeys
-from res.enkf import AnalysisIterConfig
 from res.analysis import AnalysisModule
+from res.config import ConfigContent
+from res.enkf.analysis_iter_config import AnalysisIterConfig
+from res.enkf.config_keys import ConfigKeys
 
 
 class AnalysisConfig(BaseCClass):
@@ -104,7 +104,12 @@ class AnalysisConfig(BaseCClass):
         "int analysis_config_get_min_realisations(analysis_config)"
     )
 
-    def __init__(self, user_config_file=None, config_content=None, config_dict=None):
+    def __init__(
+        self,
+        user_config_file=None,
+        config_content: Optional[ConfigContent] = None,
+        config_dict=None,
+    ):
         configs = sum(
             [
                 1
@@ -215,7 +220,7 @@ class AnalysisConfig(BaseCClass):
     def setStdCutoff(self, std_cutoff):
         self._set_std_cutoff(std_cutoff)
 
-    def getAnalysisIterConfig(self):
+    def getAnalysisIterConfig(self) -> AnalysisIterConfig:
         """@rtype: AnalysisIterConfig"""
         return self._get_iter_config().setParent(self)
 
@@ -240,11 +245,11 @@ class AnalysisConfig(BaseCClass):
         """:rtype: str"""
         return self._get_active_module_name()
 
-    def getModuleList(self):
+    def getModuleList(self) -> StringList:
         """:rtype: StringList"""
         return self._get_module_list()
 
-    def getModule(self, module_name):
+    def getModule(self, module_name) -> AnalysisModule:
         """@rtype: AnalysisModule"""
         return self._get_module(module_name)
 

--- a/res/enkf/analysis_iter_config.py
+++ b/res/enkf/analysis_iter_config.py
@@ -14,8 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import ConfigKeys
+from res.enkf.config_keys import ConfigKeys
 
 
 class AnalysisIterConfig(BaseCClass):

--- a/res/enkf/config/enkf_config_node.py
+++ b/res/enkf/config/enkf_config_node.py
@@ -13,27 +13,26 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+import os
+
 from cwrap import BaseCClass
-
 from ecl.grid import EclGrid
-from ecl.util.util import StringList, IntVector
-
+from ecl.util.util import IntVector, StringList
 from res import ResPrototype
 from res.enkf.config import (
+    ExtParamConfig,
     FieldConfig,
     GenDataConfig,
     GenKwConfig,
     SummaryConfig,
-    ExtParamConfig,
 )
+from res.enkf.config_keys import ConfigKeys
 from res.enkf.enums import (
     EnkfTruncationType,
+    EnkfVarType,
     ErtImplType,
     LoadFailTypeEnum,
-    EnkfVarType,
 )
-from res.enkf import ConfigKeys
-import os
 
 
 class EnkfConfigNode(BaseCClass):
@@ -237,7 +236,7 @@ class EnkfConfigNode(BaseCClass):
     def get_init_file_fmt(self):
         return self._get_init_file_fmt()
 
-    def getObservationKeys(self):
+    def getObservationKeys(self) -> StringList:
         """@rtype:  StringList"""
         return self._get_obs_keys().setParent(self)
 
@@ -253,7 +252,9 @@ class EnkfConfigNode(BaseCClass):
         return cls._alloc_summary_node(key, load_fail_type)
 
     @classmethod
-    def createFieldConfigNode(cls, key, grid, trans_table=None, forward_init=False):
+    def createFieldConfigNode(
+        cls, key, grid: EclGrid, trans_table=None, forward_init=False
+    ):
         """
         @type grid: EclGrid
         @rtype: EnkfConfigNode

--- a/res/enkf/config/field_config.py
+++ b/res/enkf/config/field_config.py
@@ -14,10 +14,11 @@
 # See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 # for more details.
 from cwrap import BaseCClass
+from ecl.grid import EclGrid
 
 from res import ResPrototype
 from res.enkf.enums import EnkfFieldFileFormatEnum
-from ecl.grid import EclGrid
+
 from .field_type_enum import FieldTypeEnum
 
 
@@ -83,7 +84,7 @@ class FieldConfig(BaseCClass):
     def guessFiletype(cls, filename):
         return cls._guess_filetype(filename)
 
-    def get_type(self):
+    def get_type(self) -> FieldTypeEnum:
         return self._get_type()
 
     def get_truncation_mode(self):
@@ -113,7 +114,7 @@ class FieldConfig(BaseCClass):
     def get_data_size(self):
         return self._get_data_size()
 
-    def get_grid(self):
+    def get_grid(self) -> EclGrid:
         return self._get_grid()
 
     def ijk_active(self, i, j, k):

--- a/res/enkf/config/gen_kw_config.py
+++ b/res/enkf/config/gen_kw_config.py
@@ -13,10 +13,12 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass
 import os
-from res import ResPrototype
+
+from cwrap import BaseCClass
 from ecl.util.util import StringList
+
+from res import ResPrototype
 
 
 class GenKwConfig(BaseCClass):
@@ -87,7 +89,7 @@ class GenKwConfig(BaseCClass):
     def getParameterFile(self):
         return self._get_parameter_file()
 
-    def getKeyWords(self):
+    def getKeyWords(self) -> StringList:
         """@rtype: StringList"""
         return self._alloc_name_list()
 

--- a/res/enkf/config/summary_config.py
+++ b/res/enkf/config/summary_config.py
@@ -14,8 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import LoadFailTypeEnum
+from res.enkf.enums import LoadFailTypeEnum
 
 
 class SummaryConfig(BaseCClass):

--- a/res/enkf/data/enkf_node.py
+++ b/res/enkf/data/enkf_node.py
@@ -14,12 +14,18 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import sys
-from res.enkf.enums import ErtImplType
+
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import EnkfFs, NodeId
-from res.enkf.data import GenKw, GenData, Field, ExtParam
+from res.enkf.data.ext_param import ExtParam
+from res.enkf.data.field import Field
+from res.enkf.data.gen_data import GenData
+from res.enkf.data.gen_kw import GenKw
 from res.enkf.data.summary import Summary
+from res.enkf.enkf_fs import EnkfFs
+from res.enkf.enums import ErtImplType
+from res.enkf.node_id import NodeId
 
 
 class EnkfNode(BaseCClass):

--- a/res/enkf/data/ext_param.py
+++ b/res/enkf/data/ext_param.py
@@ -13,9 +13,8 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import os.path
 
-from cwrap import BaseCClass, CFILE
+from cwrap import BaseCClass
 from six import string_types
 
 from res import ResPrototype

--- a/res/enkf/data/gen_kw.py
+++ b/res/enkf/data/gen_kw.py
@@ -13,12 +13,12 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+import numbers
 import os.path
 
-from cwrap import BaseCClass, CFILE
-import numbers
-
+from cwrap import BaseCClass
 from ecl.util.util import DoubleVector
+
 from res import ResPrototype
 from res.enkf.config import GenKwConfig
 
@@ -41,7 +41,7 @@ class GenKw(BaseCClass):
     )
     _iget_key = ResPrototype("char*  gen_kw_get_name(gen_kw, int)")
 
-    def __init__(self, gen_kw_config):
+    def __init__(self, gen_kw_config: GenKwConfig):
         """
         @type gen_kw_config: GenKwConfig
         """
@@ -49,12 +49,14 @@ class GenKw(BaseCClass):
 
         if c_ptr:
             super(GenKw, self).__init__(c_ptr)
-            self.__str__ = self.__repr__
         else:
             raise ValueError(
                 "Cannot issue a GenKw from the given keyword config: %s."
                 % str(gen_kw_config)
             )
+
+    def __str__(self):
+        return repr(self)
 
     def exportParameters(self, file_name):
         """@type: str"""

--- a/res/enkf/ecl_config.py
+++ b/res/enkf/ecl_config.py
@@ -14,15 +14,18 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from cwrap import BaseCClass
-from res import ResPrototype
-from ecl.grid import EclGrid
-from ecl.summary import EclSum
-from ecl.util.util import StringList, CTime
-from res.util import UIReturn
-from res.enkf import ConfigKeys
 import os
 from datetime import datetime
+
+from cwrap import BaseCClass
+from ecl.grid import EclGrid
+from ecl.summary import EclSum
+from ecl.util.util import CTime, StringList
+
+from res import ResPrototype
+from res.util import UIReturn
+
+from .config_keys import ConfigKeys
 
 
 class EclConfig(BaseCClass):
@@ -145,7 +148,7 @@ class EclConfig(BaseCClass):
     def setDataFile(self, datafile):
         self._set_data_file(datafile)
 
-    def validateDataFile(self, datafile):
+    def validateDataFile(self, datafile) -> UIReturn:
         """@rtype: UIReturn"""
         return self._validate_data_file(datafile)
 
@@ -170,7 +173,7 @@ class EclConfig(BaseCClass):
     def loadRefcase(self, refcase):
         self._load_refcase(refcase)
 
-    def getRefcase(self):
+    def getRefcase(self) -> EclSum:
         """@rtype: EclSum"""
         refcase = self._get_refcase()
         if refcase is not None:

--- a/res/enkf/enkf_fs.py
+++ b/res/enkf/enkf_fs.py
@@ -13,11 +13,13 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import sys
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import TimeMap, StateMap, SummaryKeySet
 from res.enkf.enums import EnKFFSType
+from res.enkf.state_map import StateMap
+from res.enkf.summary_key_set import SummaryKeySet
+from res.enkf.util import TimeMap
 
 
 class EnkfFs(BaseCClass):
@@ -65,11 +67,11 @@ class EnkfFs(BaseCClass):
         fs = self.createCReference(self._address())
         return fs
 
-    def getTimeMap(self):
+    def getTimeMap(self) -> TimeMap:
         """@rtype: TimeMap"""
         return self._get_time_map().setParent(self)
 
-    def getStateMap(self):
+    def getStateMap(self) -> StateMap:
         """@rtype: StateMap"""
         return self._get_state_map().setParent(self)
 
@@ -142,7 +144,7 @@ class EnkfFs(BaseCClass):
     def fsync(self):
         self._fsync()
 
-    def getSummaryKeySet(self):
+    def getSummaryKeySet(self) -> SummaryKeySet:
         """@rtype: SummaryKeySet"""
         return self._summary_key_set().setParent(self)
 

--- a/res/enkf/enkf_fs_manager.py
+++ b/res/enkf/enkf_fs_manager.py
@@ -2,16 +2,14 @@ import os.path
 import re
 
 from cwrap import BaseCClass
-from ecl.util.util import StringList, BoolVector
+from ecl.util.util import BoolVector, StringList
+
 from res import ResPrototype
-from res.enkf import (
-    EnkfFs,
-    StateMap,
-    TimeMap,
-    RealizationStateEnum,
-    EnkfInitModeEnum,
-    EnKFFSType,
-)
+from res.enkf.enkf_fs import EnkfFs
+from res.enkf.enums import RealizationStateEnum
+from res.enkf.ert_run_context import ErtRunContext
+from res.enkf.state_map import StateMap
+from res.enkf.util import TimeMap
 
 
 def naturalSortKey(s, _nsre=re.compile("([0-9]+)")):
@@ -57,7 +55,7 @@ class FileSystemRotator(object):
         fs = self._fs_map[name]
         return fs.copy()
 
-    def __getitem__(self, case):
+    def __getitem__(self, case) -> EnkfFs:
         """@rtype: EnkfFs"""
         if isinstance(case, str):
             return self.__get_fs(case)
@@ -151,7 +149,7 @@ class EnkfFsManager(BaseCClass):
     # The return value from the getFileSystem will be a weak reference to the
     # underlying enkf_fs object. That implies that the fs manager must be in
     # scope for the return value to be valid.
-    def getFileSystem(self, case_name, mount_root=None):
+    def getFileSystem(self, case_name, mount_root=None) -> EnkfFs:
         """
         @rtype: EnkfFs
         """
@@ -198,7 +196,7 @@ class EnkfFsManager(BaseCClass):
 
         return case_has_data
 
-    def getCurrentFileSystem(self):
+    def getCurrentFileSystem(self) -> EnkfFs:
         """Returns the currently selected file system
         @rtype: EnkfFs
         """
@@ -221,7 +219,7 @@ class EnkfFsManager(BaseCClass):
         """@rtype: int"""
         return self._ensemble_size()
 
-    def switchFileSystem(self, file_system):
+    def switchFileSystem(self, file_system: EnkfFs):
         """
         @type file_system: EnkfFs
         """
@@ -240,7 +238,11 @@ class EnkfFsManager(BaseCClass):
         return sorted(caselist, key=naturalSortKey)
 
     def customInitializeCurrentFromExistingCase(
-        self, source_case, source_report_step, member_mask, node_list
+        self,
+        source_case,
+        source_report_step,
+        member_mask: BoolVector,
+        node_list: StringList,
     ):
         """
         @type source_case: str
@@ -268,7 +270,7 @@ class EnkfFsManager(BaseCClass):
         """
         self._initialize_case_from_existing(source_fs, source_report_step, target_fs)
 
-    def initializeFromScratch(self, parameter_list, run_context):
+    def initializeFromScratch(self, parameter_list, run_context: ErtRunContext):
         self._initialize_from_scratch(parameter_list, run_context)
 
     def isCaseMounted(self, case_name, mount_root=None):
@@ -284,7 +286,7 @@ class EnkfFsManager(BaseCClass):
 
         return full_case_name in self._fs_rotator
 
-    def getStateMapForCase(self, case):
+    def getStateMapForCase(self, case) -> StateMap:
         """
         @type case: str
         @rtype: StateMap
@@ -295,7 +297,7 @@ class EnkfFsManager(BaseCClass):
         else:
             return self._alloc_readonly_state_map(case)
 
-    def getTimeMapForCase(self, case):
+    def getTimeMapForCase(self, case) -> TimeMap:
         """
         @type case: str
         @rtype: TimeMap

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -13,28 +13,28 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import sys
-import ctypes, warnings
-from os.path import isfile
 
 from cwrap import BaseCClass
+from ecl.util.util import RandomNumberGenerator
+
 from res import ResPrototype
-from res.enkf import (
-    AnalysisConfig,
-    EclConfig,
-    LocalConfig,
-    ModelConfig,
-    EnsembleConfig,
-    SiteConfig,
-    ResConfig,
-    QueueConfig,
-)
-from res.enkf import EnkfObs, EnKFState, EnkfSimulationRunner, EnkfFsManager
-from res.enkf import ErtWorkflowList, HookManager, HookWorkflow, ESUpdate
-from res.enkf.enums import EnkfInitModeEnum
+from res.enkf.analysis_config import AnalysisConfig
+from res.enkf.ecl_config import EclConfig
+from res.enkf.enkf_fs_manager import EnkfFsManager
+from res.enkf.enkf_obs import EnkfObs
+from res.enkf.enkf_simulation_runner import EnkfSimulationRunner
+from res.enkf.enkf_state import EnKFState
+from res.enkf.ensemble_config import EnsembleConfig
+from res.enkf.ert_workflow_list import ErtWorkflowList
+from res.enkf.es_update import ESUpdate
+from res.enkf.hook_manager import HookManager
 from res.enkf.key_manager import KeyManager
+from res.enkf.local_config import LocalConfig
+from res.enkf.model_config import ModelConfig
+from res.enkf.queue_config import QueueConfig
+from res.enkf.res_config import ResConfig
+from res.enkf.site_config import SiteConfig
 from res.util.substitution_list import SubstitutionList
-from ecl.util.util import rng
 
 
 class EnKFMain(BaseCClass):
@@ -115,8 +115,8 @@ class EnKFMain(BaseCClass):
         # the call to the real method on the real_enkf_main object. That's done
         # via monkey patching, so we don't need to manually keep the classes
         # synchronized
-        from inspect import getmembers, ismethod
         from functools import partial
+        from inspect import getmembers, ismethod
 
         methods = getmembers(self._real_enkf_main(), predicate=ismethod)
         dont_patch = [name for name, _ in getmembers(BaseCClass)]
@@ -296,10 +296,10 @@ class _RealEnKFMain(BaseCClass):
 
         raise TypeError("Expected ResConfig, received: %r" % config)
 
-    def get_queue_config(self):
+    def get_queue_config(self) -> QueueConfig:
         return self._get_queue_config()
 
-    def getRealisation(self, iens):
+    def getRealisation(self, iens) -> EnKFState:
         """@rtype: EnKFState"""
         if 0 <= iens < self.getEnsembleSize():
             return self._iget_state(iens).setParent(self)
@@ -318,26 +318,26 @@ class _RealEnKFMain(BaseCClass):
         cnt = "ensemble_size = %d, config_file = %s" % (ens, cfg)
         return self._create_repr(cnt)
 
-    def getEnsembleSize(self):
+    def getEnsembleSize(self) -> int:
         """@rtype: int"""
         return self._get_ensemble_size()
 
     def resizeEnsemble(self, value):
         self._resize_ensemble(value)
 
-    def ensembleConfig(self):
+    def ensembleConfig(self) -> EnsembleConfig:
         """@rtype: EnsembleConfig"""
         return self._get_ens_config().setParent(self)
 
-    def analysisConfig(self):
+    def analysisConfig(self) -> AnalysisConfig:
         """@rtype: AnalysisConfig"""
         return self._get_analysis_config().setParent(self)
 
-    def getModelConfig(self):
+    def getModelConfig(self) -> ModelConfig:
         """@rtype: ModelConfig"""
         return self._get_model_config().setParent(self)
 
-    def getLocalConfig(self):
+    def getLocalConfig(self) -> LocalConfig:
         """@rtype: LocalConfig"""
         config = self._get_local_config().setParent(self)
         config.initAttributes(
@@ -345,14 +345,14 @@ class _RealEnKFMain(BaseCClass):
         )
         return config
 
-    def siteConfig(self):
+    def siteConfig(self) -> SiteConfig:
         """@rtype: SiteConfig"""
         return self._get_site_config().setParent(self)
 
     def resConfig(self):
         return self._get_res_config().setParent(self)
 
-    def eclConfig(self):
+    def eclConfig(self) -> EclConfig:
         """@rtype: EclConfig"""
         return self._get_ecl_config().setParent(self)
 
@@ -360,7 +360,7 @@ class _RealEnKFMain(BaseCClass):
         schedule_prediction_file = self._get_schedule_prediction_file()
         return schedule_prediction_file
 
-    def getDataKW(self):
+    def getDataKW(self) -> SubstitutionList:
         """@rtype: SubstitutionList"""
         return self._get_data_kw()
 
@@ -373,7 +373,7 @@ class _RealEnKFMain(BaseCClass):
     def getMountPoint(self):
         return self._get_mount_point()
 
-    def getObservations(self):
+    def getObservations(self) -> EnkfObs:
         """@rtype: EnkfObs"""
         return self._get_obs().setParent(self)
 
@@ -411,11 +411,11 @@ class _RealEnKFMain(BaseCClass):
         """:rtype: KeyManager"""
         return self.__key_manager
 
-    def getWorkflowList(self):
+    def getWorkflowList(self) -> ErtWorkflowList:
         """@rtype: ErtWorkflowList"""
         return self._get_workflow_list().setParent(self)
 
-    def getHookManager(self):
+    def getHookManager(self) -> HookManager:
         """@rtype: HookManager"""
         return self._get_hook_manager()
 
@@ -462,6 +462,6 @@ class _RealEnKFMain(BaseCClass):
     def addNode(self, enkf_config_node):
         self._add_node(enkf_config_node)
 
-    def rng(self):
+    def rng(self) -> RandomNumberGenerator:
         "Will return the random number generator used for updates."
         return self._get_shared_rng()

--- a/res/enkf/enkf_obs.py
+++ b/res/enkf/enkf_obs.py
@@ -16,15 +16,20 @@
 import os.path
 
 from cwrap import BaseCClass
-from ecl.util.util import StringList, IntVector
-from res.sched import History
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
-from res import ResPrototype
-from res.enkf import EnkfFs, LocalObsdataNode, LocalObsdata, MeasData, ObsData
-from res.enkf.enums import EnkfObservationImplementationType
+from ecl.util.util import IntVector, StringList
 
+from res import ResPrototype
+from res.enkf.enkf_fs import EnkfFs
+from res.enkf.ensemble_config import EnsembleConfig
+from res.enkf.enums import EnkfObservationImplementationType
+from res.enkf.local_obsdata import LocalObsdata
+from res.enkf.meas_data import MeasData
+from res.enkf.obs_data import ObsData
 from res.enkf.observations import ObsVector
+from res.enkf.util import TimeMap
+from res.sched import History
 
 
 class EnkfObs(BaseCClass):
@@ -69,11 +74,11 @@ class EnkfObs(BaseCClass):
 
     def __init__(
         self,
-        ensemble_config,
-        history=None,
-        external_time_map=None,
-        grid=None,
-        refcase=None,
+        ensemble_config: EnsembleConfig,
+        history: History = None,
+        external_time_map: TimeMap = None,
+        grid: EclGrid = None,
+        refcase: EclSum = None,
     ):
         c_ptr = self._alloc(history, external_time_map, grid, refcase, ensemble_config)
         super(EnkfObs, self).__init__(c_ptr)
@@ -125,7 +130,9 @@ class EnkfObs(BaseCClass):
     def getAllActiveLocalObsdata(self, key="ALL-OBS"):
         return self._create_all_active_obs(key)
 
-    def getTypedKeylist(self, observation_implementation_type):
+    def getTypedKeylist(
+        self, observation_implementation_type: EnkfObservationImplementationType
+    ) -> StringList:
         """
         @type observation_implementation_type: EnkfObservationImplementationType
         @rtype: StringList

--- a/res/enkf/enkf_simulation_runner.py
+++ b/res/enkf/enkf_simulation_runner.py
@@ -1,16 +1,12 @@
-from cwrap import BaseCClass
-from ecl.util.util import BoolVector
-from res import ResPrototype
-from res.enkf import EnkfFs
-from res.enkf import ErtRunContext
-from res.enkf import EnKFState
-from res.enkf.enums import EnkfInitModeEnum
-from res.enkf.enums.realization_state_enum import RealizationStateEnum
-from res.job_queue import RunStatusType, JobQueueManager, JobQueueNode, JobStatusType
-
 from functools import partial
-import time
-import threading
+
+from cwrap import BaseCClass
+
+from res import ResPrototype
+from res.enkf.enkf_state import EnKFState
+from res.enkf.enums import RealizationStateEnum
+from res.enkf.ert_run_context import ErtRunContext
+from res.job_queue import JobQueueManager, RunStatusType
 
 
 class EnkfSimulationRunner(BaseCClass):
@@ -77,7 +73,7 @@ class EnkfSimulationRunner(BaseCClass):
 
         return totalOk
 
-    def createRunPath(self, run_context):
+    def createRunPath(self, run_context: ErtRunContext):
         """@rtype: bool"""
         return self._create_run_path(run_context)
 

--- a/res/enkf/enkf_state.py
+++ b/res/enkf/enkf_state.py
@@ -13,9 +13,16 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from typing import Optional
+
 from cwrap import BaseCClass
+from ecl.util.util import StringList
+
 from res import ResPrototype
+from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums import EnkfInitModeEnum, EnkfVarType
+from res.enkf.res_config import ResConfig
+from res.enkf.run_arg import RunArg
 
 
 class EnKFState(BaseCClass):
@@ -45,7 +52,10 @@ class EnKFState(BaseCClass):
         return self._get_ens_config()
 
     def initialize(
-        self, fs, param_list=None, init_mode=EnkfInitModeEnum.INIT_CONDITIONAL
+        self,
+        fs: EnkfFs,
+        param_list: Optional[StringList] = None,
+        init_mode=EnkfInitModeEnum.INIT_CONDITIONAL,
     ):
         if param_list is None:
             ens_config = self.ensembleConfig()
@@ -54,8 +64,14 @@ class EnKFState(BaseCClass):
 
     @classmethod
     def forward_model_exit_callback(cls, args):
+        if not isinstance(args[0], RunArg):
+            raise ValueError("Expected RunArg as second argument")
         return cls._forward_model_EXIT(args[0])
 
     @classmethod
     def forward_model_ok_callback(cls, args):
+        if not isinstance(args[1], ResConfig):
+            raise ValueError("Expected ResConfig as second argument")
+        if not isinstance(args[0], RunArg):
+            raise ValueError("Expected RunArg as second argument")
         return cls._forward_model_OK(args[1], args[0])

--- a/res/enkf/ensemble_config.py
+++ b/res/enkf/ensemble_config.py
@@ -13,16 +13,20 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+import os
+from typing import Optional
+
 from cwrap import BaseCClass
-from ecl.util.util import StringList
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
+from ecl.util.util import StringList
+
 from res import ResPrototype
-from res.enkf import SummaryKeyMatcher, ConfigKeys
 from res.config import ConfigContent
 from res.enkf.config import EnkfConfigNode
-from res.enkf.enums import EnkfVarType, ErtImplType, LoadFailTypeEnum
-import os
+from res.enkf.config_keys import ConfigKeys
+from res.enkf.enums import EnkfVarType, ErtImplType
+from res.enkf.summary_key_matcher import SummaryKeyMatcher
 
 
 def _get_abs_path(file):
@@ -80,7 +84,13 @@ class EnsembleConfig(BaseCClass):
         "void ensemble_config_init_SUMMARY_full(ens_config, char*, ecl_sum)"
     )
 
-    def __init__(self, config_content=None, grid=None, refcase=None, config_dict=None):
+    def __init__(
+        self,
+        config_content: Optional[ConfigContent] = None,
+        grid: Optional[EclGrid] = None,
+        refcase: Optional[EclSum] = None,
+        config_dict=None,
+    ):
         if config_content is not None and config_dict is not None:
             raise ValueError(
                 "Attempting to create EnsembleConfig object with multiple config objects"
@@ -220,32 +230,32 @@ class EnsembleConfig(BaseCClass):
     def getNode(self, key):
         return self[key]
 
-    def alloc_keylist(self):
+    def alloc_keylist(self) -> StringList:
         """@rtype: StringList"""
         return self._alloc_keylist()
 
-    def add_summary(self, key):
+    def add_summary(self, key) -> EnkfConfigNode:
         """@rtype: EnkfConfigNode"""
         return self._add_summary(key, 2).setParent(self)
 
-    def add_summary_full(self, key, refcase):
+    def add_summary_full(self, key, refcase) -> EnkfConfigNode:
         """@rtype: EnkfConfigNode"""
         return self._add_summary_full(key, refcase)
 
-    def add_gen_kw(self, key):
+    def add_gen_kw(self, key) -> EnkfConfigNode:
         """@rtype: EnkfConfigNode"""
         return self._add_gen_kw(key).setParent(self)
 
-    def addNode(self, config_node):
+    def addNode(self, config_node: EnkfConfigNode):
         assert isinstance(config_node, EnkfConfigNode)
         self._add_node(config_node)
         config_node.convertToCReference(self)
 
-    def add_field(self, key, eclipse_grid):
+    def add_field(self, key, eclipse_grid: EclGrid) -> EnkfConfigNode:
         """@rtype: EnkfConfigNode"""
         return self._add_field(key, eclipse_grid).setParent(self)
 
-    def getKeylistFromVarType(self, var_mask):
+    def getKeylistFromVarType(self, var_mask: EnkfVarType) -> StringList:
         """@rtype: StringList"""
         assert isinstance(var_mask, EnkfVarType)
         return self._alloc_keylist_from_var_type(var_mask)
@@ -258,7 +268,7 @@ class EnsembleConfig(BaseCClass):
     def __contains__(self, key):
         return self._has_key(key)
 
-    def getSummaryKeyMatcher(self):
+    def getSummaryKeyMatcher(self) -> SummaryKeyMatcher:
         """@rtype: SummaryKeyMatcher"""
         return self._summary_key_matcher()
 

--- a/res/enkf/ert_run_context.py
+++ b/res/enkf/ert_run_context.py
@@ -14,13 +14,13 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector, StringList
 
-from ecl.util.util import StringList
-
-from res.util import PathFormat
 from res import ResPrototype
-from res.enkf import TimeMap, StateMap, RunArg
+from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums import EnkfInitModeEnum
+from res.enkf.run_arg import RunArg
+from res.util import PathFormat, SubstitutionList
 
 
 class ErtRunContext(BaseCClass):
@@ -102,12 +102,12 @@ class ErtRunContext(BaseCClass):
     def __init__(
         self,
         run_type,
-        sim_fs,
-        target_fs,
+        sim_fs: EnkfFs,
+        target_fs: EnkfFs,
         mask,
-        path_fmt,
+        path_fmt: PathFormat,
         jobname_fmt,
-        subst_list,
+        subst_list: SubstitutionList,
         itr,
         init_mode=EnkfInitModeEnum.INIT_CONDITIONAL,
     ):
@@ -179,7 +179,7 @@ class ErtRunContext(BaseCClass):
     def __len__(self):
         return self._get_size()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> RunArg:
         if not isinstance(index, int):
             raise TypeError("Invalid type - expetected integer")
 
@@ -198,28 +198,36 @@ class ErtRunContext(BaseCClass):
         return "ErtRunContext(size = %d) %s" % (len(self), self._ad_str())
 
     @classmethod
-    def createRunpathList(cls, mask, runpath_fmt, subst_list, iter=0):
+    def createRunpathList(
+        cls,
+        mask: BoolVector,
+        runpath_fmt: PathFormat,
+        subst_list: SubstitutionList,
+        iter=0,
+    ) -> StringList:
         """@rtype: ecl.util.stringlist.StringList"""
         return cls._alloc_runpath_list(mask, runpath_fmt, subst_list, iter)
 
     @classmethod
-    def createRunpath(cls, iens, runpath_fmt, subst_list, iter=0):
+    def createRunpath(
+        cls, iens, runpath_fmt: PathFormat, subst_list: SubstitutionList, iter=0
+    ):
         """@rtype: str"""
         return cls._alloc_runpath(iens, runpath_fmt, subst_list, iter)
 
     def get_id(self):
         return self._get_id()
 
-    def get_mask(self):
+    def get_mask(self) -> BoolVector:
         return self._get_mask()
 
     def get_iter(self):
         return self._get_iter()
 
-    def get_target_fs(self):
+    def get_target_fs(self) -> EnkfFs:
         return self._get_target_fs()
 
-    def get_sim_fs(self):
+    def get_sim_fs(self) -> EnkfFs:
         return self._get_sim_fs()
 
     def get_init_mode(self):

--- a/res/enkf/ert_templates.py
+++ b/res/enkf/ert_templates.py
@@ -13,11 +13,14 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass
-from res import ResPrototype
-from res.enkf import ErtTemplate, ConfigKeys
-from ecl.util.util import StringList
 import os
+
+from cwrap import BaseCClass
+from ecl.util.util import StringList
+
+from res import ResPrototype
+from res.enkf.config_keys import ConfigKeys
+from res.enkf.ert_template import ErtTemplate
 
 
 class ErtTemplates(BaseCClass):
@@ -80,18 +83,18 @@ class ErtTemplates(BaseCClass):
                 raise ValueError("Failed to construct ErtTemplates instance")
             super(ErtTemplates, self).__init__(c_ptr)
 
-    def getTemplateNames(self):
+    def getTemplateNames(self) -> StringList:
         """@rtype: StringList"""
         return self._alloc_list().setParent(self)
 
     def clear(self):
         self._clear()
 
-    def get_template(self, key):
+    def get_template(self, key) -> ErtTemplate:
         """@rtype: ErtTemplate"""
         return self._get_template(key).setParent(self)
 
-    def add_template(self, key, template_file, target_file, arg_string):
+    def add_template(self, key, template_file, target_file, arg_string) -> ErtTemplate:
         """@rtype: ErtTemplate"""
         return self._add_template(
             key, template_file, target_file, arg_string

--- a/res/enkf/ert_workflow_list.py
+++ b/res/enkf/ert_workflow_list.py
@@ -1,10 +1,13 @@
-from cwrap import BaseCClass
-from res import ResPrototype
-from ecl.util.util import StringList
-from res.util.substitution_list import SubstitutionList
-from res.job_queue import Workflow, WorkflowJob, WorkflowJoblist
-from res.enkf import ConfigKeys
 import os
+from typing import List
+
+from cwrap import BaseCClass
+from ecl.util.util import StringList
+
+from res import ResPrototype
+from res.enkf.config_keys import ConfigKeys
+from res.job_queue import Workflow, WorkflowJob, WorkflowJoblist
+from res.util.substitution_list import SubstitutionList
 
 
 class ErtWorkflowList(BaseCClass):
@@ -115,7 +118,7 @@ class ErtWorkflowList(BaseCClass):
             for job in config_dict.get(ConfigKeys.LOAD_WORKFLOW, []):
                 self.addWorkflow(job[ConfigKeys.PATH], job[ConfigKeys.NAME])
 
-    def getWorkflowNames(self):
+    def getWorkflowNames(self) -> StringList:
         """@rtype: StringList"""
         return [name for name in self._alloc_namelist()]
 
@@ -123,7 +126,7 @@ class ErtWorkflowList(BaseCClass):
         assert isinstance(workflow_name, str)
         return self._has_workflow(workflow_name)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> Workflow:
         """@rtype: Workflow"""
         if item not in self:
             raise KeyError(
@@ -132,7 +135,7 @@ class ErtWorkflowList(BaseCClass):
 
         return self._get_workflow(item).setParent(self)
 
-    def getContext(self):
+    def getContext(self) -> SubstitutionList:
         """@rtype: SubstitutionList"""
         return self._get_context()
 
@@ -156,15 +159,14 @@ class ErtWorkflowList(BaseCClass):
         """
         return self._has_job(job_name)
 
-    def getJob(self, job_name):
+    def getJob(self, job_name) -> WorkflowJob:
         """@rtype: WorkflowJob"""
         return self._get_job(job_name)
 
-    def getJobNames(self):
-        """@rtype: StringList"""
+    def getJobNames(self) -> List[str]:
         return [name for name in self._get_job_names()]
 
-    def getPluginJobs(self):
+    def getPluginJobs(self) -> List[WorkflowJob]:
         """@rtype: list of WorkflowJob"""
         plugins = []
         for job_name in self.getJobNames():

--- a/res/enkf/export/arg_loader.py
+++ b/res/enkf/export/arg_loader.py
@@ -1,9 +1,5 @@
-import math
-from pandas import DataFrame, MultiIndex
 import numpy
-from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
-from res.enkf.plot_data import EnsemblePlotGenData
-from ecl.util.util import BoolVector
+from pandas import DataFrame
 
 
 class ArgLoader(object):

--- a/res/enkf/export/design_matrix_reader.py
+++ b/res/enkf/export/design_matrix_reader.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from pandas import DataFrame
 
 
 class DesignMatrixReader(object):

--- a/res/enkf/export/gen_data_collector.py
+++ b/res/enkf/export/gen_data_collector.py
@@ -1,14 +1,15 @@
-import math
-from pandas import DataFrame, MultiIndex
 import numpy
-from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
+from ecl.util.util import IntVector
+from pandas import DataFrame
+
+from res.enkf import EnKFMain
+from res.enkf.enums import RealizationStateEnum
 from res.enkf.plot_data import EnsemblePlotGenData
-from ecl.util.util import BoolVector, IntVector
 
 
 class GenDataCollector(object):
     @staticmethod
-    def loadGenData(ert, case_name, key, report_step, realization_index=None):
+    def loadGenData(ert: EnKFMain, case_name, key, report_step, realization_index=None):
         """@type ert: EnKFMain
         @type case_name: str
         @type key: str

--- a/res/enkf/export/gen_data_observation_collector.py
+++ b/res/enkf/export/gen_data_observation_collector.py
@@ -1,10 +1,12 @@
 from pandas import DataFrame
-from res.enkf import EnKFMain, EnkfFs, EnkfObservationImplementationType
+
+from res.enkf import EnKFMain
+from res.enkf.enums import EnkfObservationImplementationType
 
 
 class GenDataObservationCollector(object):
     @staticmethod
-    def getAllObservationKeys(ert):
+    def getAllObservationKeys(ert: EnKFMain):
         """
         @type ert: EnKFMain
         @rtype: list of str
@@ -16,7 +18,7 @@ class GenDataObservationCollector(object):
         return [key for key in observation_keys]
 
     @staticmethod
-    def getObservationKeyForDataKey(ert, data_key, data_report_step):
+    def getObservationKeyForDataKey(ert: EnKFMain, data_key, data_report_step):
         """
         @type ert: EnKFMain
         @rtype: str
@@ -35,7 +37,7 @@ class GenDataObservationCollector(object):
         return observation_key
 
     @staticmethod
-    def loadGenDataObservations(ert, case_name, key):
+    def loadGenDataObservations(ert: EnKFMain, case_name, key):
         """
         @type ert: EnKFMain
         @type case_name: str

--- a/res/enkf/export/gen_kw_collector.py
+++ b/res/enkf/export/gen_kw_collector.py
@@ -1,10 +1,13 @@
 import math
-from pandas import DataFrame, MultiIndex
+
 import numpy
-from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
+from ecl.util.util import BoolVector
+from pandas import DataFrame
+
+from res.enkf import EnKFMain
+from res.enkf.enums import RealizationStateEnum
 from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotGenKW
-from ecl.util.util import BoolVector
 
 
 class GenKwCollector(object):
@@ -28,7 +31,7 @@ class GenKwCollector(object):
         return key_manager.genKwKeys()
 
     @staticmethod
-    def loadAllGenKwData(ert, case_name, keys=None, realization_index=None):
+    def loadAllGenKwData(ert: EnKFMain, case_name, keys=None, realization_index=None):
         """
         @type ert: EnKFMain
         @type case_name: str

--- a/res/enkf/export/misfit_collector.py
+++ b/res/enkf/export/misfit_collector.py
@@ -1,8 +1,10 @@
-from pandas import DataFrame
 import numpy
-from res.enkf import EnKFMain, EnkfFs, RealizationStateEnum
-from res.enkf.key_manager import KeyManager
 from ecl.util.util import BoolVector
+from pandas import DataFrame
+
+from res.enkf import EnKFMain
+from res.enkf.enums import RealizationStateEnum
+from res.enkf.key_manager import KeyManager
 
 
 class MisfitCollector(object):
@@ -22,7 +24,7 @@ class MisfitCollector(object):
         return key_manager.misfitKeys(sort_keys=sort_keys)
 
     @staticmethod
-    def loadAllMisfitData(ert, case_name):
+    def loadAllMisfitData(ert: EnKFMain, case_name) -> DataFrame:
         """
         @type ert: EnKFMain
         @type case_name: str

--- a/res/enkf/export/summary_collector.py
+++ b/res/enkf/export/summary_collector.py
@@ -1,9 +1,11 @@
-from pandas import DataFrame, MultiIndex
 import numpy
-from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum
+from ecl.util.util import BoolVector
+from pandas import DataFrame, MultiIndex
+
+from res.enkf import EnKFMain
+from res.enkf.enums import RealizationStateEnum
 from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotData
-from ecl.util.util import BoolVector
 
 
 class SummaryCollector(object):
@@ -23,7 +25,7 @@ class SummaryCollector(object):
         return key_manager.summaryKeys()
 
     @staticmethod
-    def loadAllSummaryData(ert, case_name, keys=None, realization_index=None):
+    def loadAllSummaryData(ert: EnKFMain, case_name, keys=None, realization_index=None):
         """
         @type ert: EnKFMain
         @type case_name: str

--- a/res/enkf/export/summary_observation_collector.py
+++ b/res/enkf/export/summary_observation_collector.py
@@ -1,20 +1,12 @@
-from pandas import DataFrame, MultiIndex
-import numpy
-from res.enkf import (
-    ErtImplType,
-    EnKFMain,
-    EnkfFs,
-    RealizationStateEnum,
-    EnkfObservationImplementationType,
-)
+from pandas import DataFrame
+
+from res.enkf import EnKFMain
 from res.enkf.key_manager import KeyManager
-from res.enkf.plot_data import EnsemblePlotData
-from ecl.util.util import BoolVector
 
 
 class SummaryObservationCollector(object):
     @staticmethod
-    def getAllObservationKeys(ert):
+    def getAllObservationKeys(ert: EnKFMain):
         """
         @type ert: EnKFMain
         @rtype: list of str
@@ -23,7 +15,7 @@ class SummaryObservationCollector(object):
         return key_manager.summaryKeysWithObservations()
 
     @staticmethod
-    def loadObservationData(ert, case_name, keys=None):
+    def loadObservationData(ert: EnKFMain, case_name, keys=None):
         """
         @type ert: EnKFMain
         @type case_name: str
@@ -59,5 +51,5 @@ class SummaryObservationCollector(object):
         return df
 
     @classmethod
-    def summaryKeyHasObservations(cls, ert, key):
+    def summaryKeyHasObservations(cls, ert: EnKFMain, key):
         return len(ert.ensembleConfig().getNode(key).getObservationKeys()) > 0

--- a/res/enkf/hook_manager.py
+++ b/res/enkf/hook_manager.py
@@ -1,10 +1,14 @@
+import ctypes
 import os
 import sys
-import ctypes
+
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import ConfigKeys
+from res.enkf.config_keys import ConfigKeys
 from res.enkf.enums import HookRuntime
+from res.enkf.hook_workflow import HookWorkflow
+from res.enkf.runpath_list import RunpathList
 
 
 class HookManager(BaseCClass):
@@ -95,8 +99,7 @@ class HookManager(BaseCClass):
     def __repr__(self):
         return "HookManager({})".format(", ".join([str(x) for x in self]))
 
-    def __getitem__(self, index):
-        """@rtype: Hook workflow"""
+    def __getitem__(self, index) -> HookWorkflow:
         assert isinstance(index, int)
         if index < 0:
             index += len(self)
@@ -119,7 +122,7 @@ class HookManager(BaseCClass):
                 " - hook workflow will probably fail.\n"
             )
 
-    def getRunpathList(self):
+    def getRunpathList(self) -> RunpathList:
         """@rtype: RunpathList"""
         return self._get_runpath_list()
 

--- a/res/enkf/hook_manager.py
+++ b/res/enkf/hook_manager.py
@@ -18,7 +18,7 @@ class HookManager(BaseCClass):
     _alloc_full = ResPrototype(
         "void* hook_manager_alloc_full(ert_workflow_list, char*)", bind=False
     )
-    _free = ResPrototype("void hook_manager_free(subst_config)")
+    _free = ResPrototype("void hook_manager_free(hook_manager)")
     _get_runpath_list_file = ResPrototype(
         "char* hook_manager_get_runpath_list_file(hook_manager)"
     )

--- a/res/enkf/hook_workflow.py
+++ b/res/enkf/hook_workflow.py
@@ -1,8 +1,8 @@
-import os
-import sys
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import RunpathList
+from res.enkf.enums import HookRuntime
+from res.job_queue import Workflow
 
 
 class HookWorkflow(BaseCClass):
@@ -18,11 +18,11 @@ class HookWorkflow(BaseCClass):
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
-    def getWorkflow(self):
+    def getWorkflow(self) -> Workflow:
         """@rtype: Workflow"""
         return self._get_workflow()
 
-    def getRunMode(self):
+    def getRunMode(self) -> HookRuntime:
         return self._get_runmode()
 
     def __eq__(self, other):

--- a/res/enkf/key_manager.py
+++ b/res/enkf/key_manager.py
@@ -1,7 +1,7 @@
 import weakref
 
-from res.enkf import ErtImplType, GenKwConfig
-from res.enkf.enums import EnkfObservationImplementationType
+from res.enkf.config import GenKwConfig
+from res.enkf.enums import EnkfObservationImplementationType, ErtImplType
 
 
 class KeyManager(object):

--- a/res/enkf/local_config.py
+++ b/res/enkf/local_config.py
@@ -15,10 +15,11 @@
 #  for more details.
 
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import LocalUpdateStep
-from res.enkf.local_ministep import LocalMinistep
 from res.analysis import AnalysisModule
+from res.enkf.local_ministep import LocalMinistep
+from res.enkf.local_updatestep import LocalUpdateStep
 
 
 class LocalConfig(BaseCClass):

--- a/res/enkf/local_dataset.py
+++ b/res/enkf/local_dataset.py
@@ -1,8 +1,9 @@
 from cwrap import BaseCClass
-from res import ResPrototype
 from ecl.grid import EclRegion
 from ecl.util.geometry import GeoRegion
-from ecl.util.util import StringList
+
+from res import ResPrototype
+from res.enkf.row_scaling import RowScaling
 
 
 class LocalDataset(BaseCClass):
@@ -43,7 +44,7 @@ class LocalDataset(BaseCClass):
         else:
             raise KeyError('Unknown key "%s"' % key)
 
-    def row_scaling(self, key):
+    def row_scaling(self, key) -> RowScaling:
         if key not in self:
             raise KeyError(f"Unknown key: {key}")
 

--- a/res/enkf/local_ministep.py
+++ b/res/enkf/local_ministep.py
@@ -1,7 +1,10 @@
-import ecl.util
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import LocalObsdata, LocalObsdataNode, LocalDataset, ObsData
+from res.enkf.local_dataset import LocalDataset
+from res.enkf.local_obsdata import LocalObsdata
+from res.enkf.local_obsdata_node import LocalObsdataNode
+from res.enkf.obs_data import ObsData
 
 
 class LocalMinistep(BaseCClass):
@@ -73,7 +76,7 @@ class LocalMinistep(BaseCClass):
         """@rtype: str"""
         return self.name()
 
-    def get_obs_data(self):
+    def get_obs_data(self) -> ObsData:
         """@rtype: ObsData"""
         return self._get_obs_data()
 

--- a/res/enkf/local_obsdata.py
+++ b/res/enkf/local_obsdata.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import LocalObsdataNode
+from res.enkf.local_obsdata_node import LocalObsdataNode
 
 
 class LocalObsdata(BaseCClass):

--- a/res/enkf/local_obsdata_node.py
+++ b/res/enkf/local_obsdata_node.py
@@ -1,4 +1,5 @@
 from cwrap import BaseCClass
+
 from res import ResPrototype
 
 

--- a/res/enkf/local_updatestep.py
+++ b/res/enkf/local_updatestep.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import LocalMinistep
+from res.enkf.local_ministep import LocalMinistep
 
 
 class LocalUpdateStep(BaseCClass):

--- a/res/enkf/log_config.py
+++ b/res/enkf/log_config.py
@@ -18,10 +18,9 @@ from os.path import isfile, realpath
 
 from cwrap import BaseCClass
 
-from res.util.enums import MessageLevelEnum
-
 from res import ResPrototype
-from res.enkf import ConfigKeys
+from res.enkf.config_keys import ConfigKeys
+from res.util.enums import MessageLevelEnum
 
 
 class LogConfig(BaseCClass):
@@ -91,7 +90,7 @@ class LogConfig(BaseCClass):
         return self._log_file()
 
     @property
-    def log_level(self):
+    def log_level(self) -> MessageLevelEnum:
         return self._log_level()
 
     def __eq__(self, other):

--- a/res/enkf/meas_block.py
+++ b/res/enkf/meas_block.py
@@ -1,8 +1,7 @@
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector
+
 from res import ResPrototype
-from res.enkf.obs_data import ObsData
-from ecl.util.util import IntVector, BoolVector
-from res.util import Matrix
 
 
 class MeasBlock(BaseCClass):

--- a/res/enkf/meas_data.py
+++ b/res/enkf/meas_data.py
@@ -1,7 +1,8 @@
 from cwrap import BaseCClass
+
 from res import ResPrototype
+from res.enkf.meas_block import MeasBlock
 from res.enkf.obs_data import ObsData
-from ecl.util.util import IntVector
 from res.util import Matrix
 
 
@@ -87,7 +88,7 @@ class MeasData(BaseCClass):
     def __str__(self):
         return "\n".join([str(block) for block in self])
 
-    def createS(self):
+    def createS(self) -> Matrix:
         """@rtype: Matrix"""
         S = self._allocS()
         if S is None:
@@ -101,7 +102,7 @@ class MeasData(BaseCClass):
         assert isinstance(obs_data, ObsData)
         self._deactivate_outliers(obs_data, self)
 
-    def addBlock(self, obs_key, report_step, obs_size):
+    def addBlock(self, obs_key, report_step, obs_size) -> MeasBlock:
         return self._add_block(obs_key, report_step, obs_size)
 
     def activeObsSize(self):

--- a/res/enkf/model_config.py
+++ b/res/enkf/model_config.py
@@ -13,18 +13,16 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass
+import os
 
+from cwrap import BaseCClass
 from ecl.summary import EclSum
-from ecl.util.util import StringList
 from res import ResPrototype
-from res.job_queue import ForwardModel, ExtJob, ExtJoblist
+from res.enkf.config_keys import ConfigKeys
+from res.enkf.util import TimeMap
+from res.job_queue import ForwardModel
 from res.sched import HistorySourceEnum
 from res.util import PathFormat
-from res.enkf import ConfigKeys
-from res.enkf.util import TimeMap
-
-import os
 
 
 class ModelConfig(BaseCClass):
@@ -278,7 +276,7 @@ class ModelConfig(BaseCClass):
         """@rtype: str"""
         return self._get_enspath()
 
-    def getRunpathFormat(self):
+    def getRunpathFormat(self) -> PathFormat:
         """@rtype: PathFormat"""
         return self._get_runpath_fmt()
 

--- a/res/enkf/node_id.py
+++ b/res/enkf/node_id.py
@@ -1,4 +1,5 @@
 from ctypes import Structure, c_int
+
 from cwrap import Prototype
 
 

--- a/res/enkf/obs_block.py
+++ b/res/enkf/obs_block.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from cwrap import BaseCClass
+
 from res import ResPrototype
 from res.util import Matrix
 
@@ -19,7 +22,7 @@ class ObsBlock(BaseCClass):
     _iget_is_active = ResPrototype("bool obs_block_iget_is_active( obs_block , int)")
 
     def __init__(self, obs_key, obs_size, global_std_scaling=1.0):
-        error_covar = None
+        error_covar: Optional[Matrix] = None
         error_covar_owner = False
         c_pointer = self._alloc(
             obs_key, obs_size, error_covar, error_covar_owner, global_std_scaling

--- a/res/enkf/obs_data.py
+++ b/res/enkf/obs_data.py
@@ -15,7 +15,9 @@
 #  for more details.
 
 from cwrap import BaseCClass
+
 from res import ResPrototype
+from res.enkf.obs_block import ObsBlock
 from res.util import Matrix
 
 
@@ -70,7 +72,7 @@ class ObsData(BaseCClass):
     def __repr__(self):
         return "ObsData(total_size = %d) at 0x%x" % (len(self), self._address())
 
-    def addBlock(self, obs_key, obs_size):
+    def addBlock(self, obs_key, obs_size) -> ObsBlock:
         error_covar = None
         error_covar_owner = False
         return self._add_block(obs_key, obs_size, error_covar, error_covar_owner)

--- a/res/enkf/observations/__init__.py
+++ b/res/enkf/observations/__init__.py
@@ -1,5 +1,13 @@
-from .summary_observation import SummaryObservation
-from .gen_observation import GenObservation
 from .block_data_config import BlockDataConfig
 from .block_observation import BlockObservation
+from .gen_observation import GenObservation
 from .obs_vector import ObsVector
+from .summary_observation import SummaryObservation
+
+__all__ = [
+    "SummaryObservation",
+    "GenObservation",
+    "BlockDataConfig",
+    "BlockObservation",
+    "ObsVector",
+]

--- a/res/enkf/observations/block_data_config.py
+++ b/res/enkf/observations/block_data_config.py
@@ -13,10 +13,11 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass
-from res.enkf import NodeId, FieldConfig
-from res import ResPrototype
 import ctypes
+
+from cwrap import BaseCClass
+
+from res.enkf.config import FieldConfig
 
 
 class BlockDataConfig(BaseCClass):

--- a/res/enkf/observations/block_observation.py
+++ b/res/enkf/observations/block_observation.py
@@ -13,9 +13,14 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from typing import Union
+
 from cwrap import BaseCClass
+from ecl.grid import EclGrid
+
 from res import ResPrototype
-from res.enkf import NodeId, FieldConfig
+from res.enkf.config import FieldConfig
+from res.enkf.node_id import NodeId
 from res.enkf.observations import BlockDataConfig
 
 
@@ -49,7 +54,9 @@ class BlockObservation(BaseCClass):
         "double block_obs_iget_data(block_obs, void*, int, node_id)"
     )
 
-    def __init__(self, obs_key, data_config, grid):
+    def __init__(
+        self, obs_key, data_config: Union[BlockDataConfig, FieldConfig], grid: EclGrid
+    ):
         c_ptr = self._alloc(obs_key, data_config, grid)
         super(BlockObservation, self).__init__(c_ptr)
 
@@ -95,7 +102,7 @@ class BlockObservation(BaseCClass):
         """@rtype: float"""
         return self._get_depth(index)
 
-    def getData(self, state, obs_index, node_id):
+    def getData(self, state, obs_index, node_id: NodeId):
         """
         @type state: c_void_p
         @type obs_index: int

--- a/res/enkf/observations/gen_observation.py
+++ b/res/enkf/observations/gen_observation.py
@@ -19,8 +19,10 @@ import os.path
 import numpy as np
 from cwrap import BaseCClass
 from ecl.util.util import IntVector
+
 from res import ResPrototype
-from res.enkf import GenDataConfig
+from res.enkf import ActiveList
+from res.enkf.config import GenDataConfig
 
 
 class GenObservation(BaseCClass):
@@ -48,7 +50,12 @@ class GenObservation(BaseCClass):
     _get_std_vector = ResPrototype("void   gen_obs_load_std(gen_obs, int, double*)")
 
     def __init__(
-        self, obs_key, data_config, scalar_value=None, obs_file=None, data_index=None
+        self,
+        obs_key,
+        data_config: GenDataConfig,
+        scalar_value=None,
+        obs_file=None,
+        data_index=None,
     ):
         c_ptr = self._alloc(data_config, obs_key)
         if c_ptr:
@@ -110,7 +117,7 @@ class GenObservation(BaseCClass):
         """@rtype: float"""
         return self._get_std_scaling(obs_index)
 
-    def updateStdScaling(self, factor, active_list):
+    def updateStdScaling(self, factor, active_list: ActiveList):
         self._update_std_scaling(factor, active_list)
 
     def get_data_points(self):

--- a/res/enkf/observations/obs_vector.py
+++ b/res/enkf/observations/obs_vector.py
@@ -14,11 +14,12 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
-from res import ResPrototype
+from res import ResPrototype, _lib
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enums import EnkfObservationImplementationType
-from res.enkf.observations import BlockObservation, SummaryObservation, GenObservation
-from res import _lib
+from res.enkf.observations.block_observation import BlockObservation
+from res.enkf.observations.gen_observation import GenObservation
+from res.enkf.observations.summary_observation import SummaryObservation
 
 
 class ObsVector(BaseCClass):

--- a/res/enkf/plot/__init__.py
+++ b/res/enkf/plot/__init__.py
@@ -1,9 +1,21 @@
-from .data_fetcher import DataFetcher
-from .observation_data_fetcher import ObservationDataFetcher
-from .refcase_data_fetcher import RefcaseDataFetcher
-from .ensemble_data_fetcher import EnsembleDataFetcher
-from .ensemble_block_data_fetcher import EnsembleBlockDataFetcher
 from .block_observation_data_fetcher import BlockObservationDataFetcher
-from .ensemble_gen_kw_fetcher import EnsembleGenKWFetcher
+from .data_fetcher import DataFetcher
+from .ensemble_block_data_fetcher import EnsembleBlockDataFetcher
+from .ensemble_data_fetcher import EnsembleDataFetcher
 from .ensemble_gen_data_fetcher import EnsembleGenDataFetcher
+from .ensemble_gen_kw_fetcher import EnsembleGenKWFetcher
+from .observation_data_fetcher import ObservationDataFetcher
 from .observation_gen_data_fetcher import ObservationGenDataFetcher
+from .refcase_data_fetcher import RefcaseDataFetcher
+
+__all__ = [
+    "DataFetcher",
+    "ObservationDataFetcher",
+    "RefcaseDataFetcher",
+    "EnsembleDataFetcher",
+    "EnsembleBlockDataFetcher",
+    "BlockObservationDataFetcher",
+    "EnsembleGenKWFetcher",
+    "EnsembleGenDataFetcher",
+    "ObservationGenDataFetcher",
+]

--- a/res/enkf/plot/ensemble_block_data_fetcher.py
+++ b/res/enkf/plot/ensemble_block_data_fetcher.py
@@ -16,7 +16,7 @@
 
 from res.enkf.enums import ErtImplType
 from res.enkf.plot import DataFetcher
-from res.enkf.plot_data import PlotBlockDataLoader, PlotBlockData
+from res.enkf.plot_data import PlotBlockData, PlotBlockDataLoader
 
 
 class EnsembleBlockDataFetcher(DataFetcher):
@@ -24,7 +24,7 @@ class EnsembleBlockDataFetcher(DataFetcher):
         super(EnsembleBlockDataFetcher, self).__init__(ert)
         self.__selected_report_step_index = None
 
-    def __fetchSimulationData(self, block_data):
+    def __fetchSimulationData(self, block_data) -> PlotBlockData:
         """
         @type block_data: PlotBlockData
         @rtype dict

--- a/res/enkf/plot/ensemble_data_fetcher.py
+++ b/res/enkf/plot/ensemble_data_fetcher.py
@@ -1,7 +1,7 @@
 from res.enkf import EnsembleConfig
-from res.enkf.plot_data import EnsemblePlotData
 from res.enkf.enums import ErtImplType
 from res.enkf.plot.data_fetcher import DataFetcher
+from res.enkf.plot_data import EnsemblePlotData
 
 
 class EnsembleDataFetcher(DataFetcher):
@@ -17,7 +17,7 @@ class EnsembleDataFetcher(DataFetcher):
             .getKeylistFromImplType(ErtImplType.SUMMARY)
         ]
 
-    def getEnsembleConfigNode(self, key):
+    def getEnsembleConfigNode(self, key) -> EnsembleConfig:
         """@rtype: EnsembleConfig"""
         ensemble_config = self.ert().ensembleConfig()
         assert key in ensemble_config

--- a/res/enkf/plot/refcase_data_fetcher.py
+++ b/res/enkf/plot/refcase_data_fetcher.py
@@ -1,4 +1,6 @@
-from ecl.summary import EclSum, EclSumVector, EclSumNode
+from ecl.summary import EclSum
+from ecl.util.util import StringList
+
 from res.enkf.enums import ErtImplType
 from res.enkf.plot.data_fetcher import DataFetcher
 
@@ -8,15 +10,15 @@ class RefcaseDataFetcher(DataFetcher):
         super(RefcaseDataFetcher, self).__init__(ert)
         self.report_times = {}
 
-    def hasRefcase(self):
+    def hasRefcase(self) -> bool:
         """@rtype: bool"""
         return self.ert().eclConfig().hasRefcase()
 
-    def getRefCase(self):
+    def getRefCase(self) -> EclSum:
         """@rtype: EclSum"""
         return self.ert().eclConfig().getRefcase()
 
-    def getSummaryKeys(self):
+    def getSummaryKeys(self) -> StringList:
         """@rtype: StringList"""
         return self.ert().ensembleConfig().getKeylistFromImplType(ErtImplType.SUMMARY)
 

--- a/res/enkf/plot_data/__init__.py
+++ b/res/enkf/plot_data/__init__.py
@@ -1,9 +1,21 @@
-from .ensemble_plot_data_vector import EnsemblePlotDataVector
 from .ensemble_plot_data import EnsemblePlotData
-from .plot_block_vector import PlotBlockVector
+from .ensemble_plot_data_vector import EnsemblePlotDataVector
+from .ensemble_plot_gen_data import EnsemblePlotGenData
+from .ensemble_plot_gen_data_vector import EnsemblePlotGenDataVector
+from .ensemble_plot_gen_kw import EnsemblePlotGenKW
+from .ensemble_plot_gen_kw_vector import EnsemblePlotGenKWVector
 from .plot_block_data import PlotBlockData
 from .plot_block_data_loader import PlotBlockDataLoader
-from .ensemble_plot_gen_data_vector import EnsemblePlotGenDataVector
-from .ensemble_plot_gen_data import EnsemblePlotGenData
-from .ensemble_plot_gen_kw_vector import EnsemblePlotGenKWVector
-from .ensemble_plot_gen_kw import EnsemblePlotGenKW
+from .plot_block_vector import PlotBlockVector
+
+__all__ = [
+    "EnsemblePlotDataVector",
+    "EnsemblePlotData",
+    "PlotBlockVector",
+    "PlotBlockData",
+    "PlotBlockDataLoader",
+    "EnsemblePlotGenDataVector",
+    "EnsemblePlotGenData",
+    "EnsemblePlotGenKWVector",
+    "EnsemblePlotGenKW",
+]

--- a/res/enkf/plot_data/ensemble_plot_data.py
+++ b/res/enkf/plot_data/ensemble_plot_data.py
@@ -1,8 +1,10 @@
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector
+
 from res import ResPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
-from ecl.util.util import BoolVector
+from res.enkf.plot_data.ensemble_plot_data_vector import EnsemblePlotDataVector
 
 
 class EnsemblePlotData(BaseCClass):
@@ -40,7 +42,7 @@ class EnsemblePlotData(BaseCClass):
         """@rtype: int"""
         return self._size()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> EnsemblePlotDataVector:
         """@rtype: EnsemblePlotDataVector"""
         return self._get(index)
 

--- a/res/enkf/plot_data/ensemble_plot_data_vector.py
+++ b/res/enkf/plot_data/ensemble_plot_data_vector.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
-from res import ResPrototype
 from ecl.util.util import CTime
+
+from res import ResPrototype
 
 
 class EnsemblePlotDataVector(BaseCClass):
@@ -28,7 +29,7 @@ class EnsemblePlotDataVector(BaseCClass):
         """@rtype: float"""
         return self._get_value(index)
 
-    def getTime(self, index):
+    def getTime(self, index) -> CTime:
         """@rtype: CTime"""
         return self._get_time(index)
 

--- a/res/enkf/plot_data/ensemble_plot_gen_data.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_data.py
@@ -15,11 +15,12 @@
 #  for more details.
 
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector, DoubleVector
 from res import ResPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
-from res.enkf.enums.ert_impl_type_enum import ErtImplType
-from ecl.util.util import BoolVector, DoubleVector
+from res.enkf.enums import ErtImplType
+from res.enkf.plot_data.ensemble_plot_gen_data_vector import EnsemblePlotGenDataVector
 
 
 class EnsemblePlotGenData(BaseCClass):
@@ -66,7 +67,7 @@ class EnsemblePlotGenData(BaseCClass):
         """@rtype: int"""
         return self._size()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> EnsemblePlotGenDataVector:
         """@rtype: EnsemblePlotGenDataVector"""
         return self._get(index)
 
@@ -76,11 +77,11 @@ class EnsemblePlotGenData(BaseCClass):
             yield self[cur]
             cur += 1
 
-    def getMaxValues(self):
+    def getMaxValues(self) -> DoubleVector:
         """@rtype: DoubleVector"""
         return self._max_values().setParent(self)
 
-    def getMinValues(self):
+    def getMinValues(self) -> DoubleVector:
         """@rtype: DoubleVector"""
         return self._min_values().setParent(self)
 

--- a/res/enkf/plot_data/ensemble_plot_gen_kw.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_kw.py
@@ -14,13 +14,15 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from typing import Optional
+
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector
 from res import ResPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums.ert_impl_type_enum import ErtImplType
-from ecl.util.util import BoolVector
-from res.enkf.plot_data import EnsemblePlotGenKWVector
+from res.enkf.plot_data.ensemble_plot_gen_kw_vector import EnsemblePlotGenKWVector
 
 
 class EnsemblePlotGenKW(BaseCClass):
@@ -45,7 +47,9 @@ class EnsemblePlotGenKW(BaseCClass):
     )
     _free = ResPrototype("void  enkf_plot_gen_kw_free(ensemble_plot_gen_kw)")
 
-    def __init__(self, ensemble_config_node, file_system, input_mask=None):
+    def __init__(
+        self, ensemble_config_node: EnkfConfigNode, file_system, input_mask=None
+    ):
         assert isinstance(ensemble_config_node, EnkfConfigNode)
         assert ensemble_config_node.getImplementationType() == ErtImplType.GEN_KW
 
@@ -54,7 +58,7 @@ class EnsemblePlotGenKW(BaseCClass):
 
         self.__load(file_system, input_mask)
 
-    def __load(self, file_system, input_mask=None):
+    def __load(self, file_system: EnkfFs, input_mask: Optional[BoolVector] = None):
         assert isinstance(file_system, EnkfFs)
         if input_mask is not None:
             assert isinstance(input_mask, BoolVector)
@@ -65,7 +69,7 @@ class EnsemblePlotGenKW(BaseCClass):
         """@rtype: int"""
         return self._size()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> EnsemblePlotGenKWVector:
         """@rtype: EnsemblePlotGenKWVector"""
         return self._get(index)
 

--- a/res/enkf/plot_data/plot_block_data.py
+++ b/res/enkf/plot_data/plot_block_data.py
@@ -1,5 +1,6 @@
-from res.enkf.plot_data import PlotBlockVector
 from ecl.util.util import DoubleVector
+
+from res.enkf.plot_data.plot_block_vector import PlotBlockVector
 
 
 class PlotBlockData(object):
@@ -15,7 +16,7 @@ class PlotBlockData(object):
         """@rtype: int"""
         return len(self.__plot_block_vectors)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> PlotBlockVector:
         """
         @type index: int
         @rtype: PlotBlockVector
@@ -33,7 +34,7 @@ class PlotBlockData(object):
         """@rtype: DoubleVector"""
         return self.__depth_vector
 
-    def addPlotBlockVector(self, vector):
+    def addPlotBlockVector(self, vector: PlotBlockVector):
         """
         @type vector: PlotBlockVector
         """

--- a/res/enkf/plot_data/plot_block_data_loader.py
+++ b/res/enkf/plot_data/plot_block_data_loader.py
@@ -1,6 +1,10 @@
-from res.enkf import RealizationStateEnum, EnkfNode, ErtImplType, NodeId
-from res.enkf.plot_data import PlotBlockData, PlotBlockVector
-from ecl.util.util import DoubleVector, BoolVector, ThreadPool
+from ecl.util.util import BoolVector, DoubleVector, ThreadPool
+
+from res.enkf import NodeId
+from res.enkf.data import EnkfNode
+from res.enkf.enums import ErtImplType, RealizationStateEnum
+from res.enkf.plot_data.plot_block_data import PlotBlockData
+from res.enkf.plot_data.plot_block_vector import PlotBlockVector
 
 
 class PlotBlockDataLoader(object):

--- a/res/enkf/queue_config.py
+++ b/res/enkf/queue_config.py
@@ -14,13 +14,13 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from typing import Optional
+
 from cwrap import BaseCClass
-
-from ecl.util.util import StringList, Hash
-
 from res import ResPrototype
-from res.enkf import ConfigKeys
-from res.job_queue import JobQueue, ExtJoblist, Driver
+from res.config import ConfigContent
+from res.enkf.config_keys import ConfigKeys
+from res.job_queue import Driver, JobQueue
 
 
 class QueueConfig(BaseCClass):
@@ -53,7 +53,12 @@ class QueueConfig(BaseCClass):
     _lsf_resource_opt = ResPrototype("char* queue_config_lsf_resource()", bind=False)
     _lsf_driver_opt = ResPrototype("char* queue_config_lsf_driver_name()", bind=False)
 
-    def __init__(self, user_config_file=None, config_content=None, config_dict=None):
+    def __init__(
+        self,
+        user_config_file=None,
+        config_content: Optional[ConfigContent] = None,
+        config_dict=None,
+    ):
         configs = sum(
             [
                 1
@@ -131,7 +136,7 @@ class QueueConfig(BaseCClass):
         return self._get_job_script()
 
     @property
-    def driver(self):
+    def driver(self) -> Driver:
         return self._queue_driver(self.queue_system).setParent(self)
 
     def _assert_lsf(self, key="driver"):

--- a/res/enkf/res_config.py
+++ b/res/enkf/res_config.py
@@ -18,26 +18,23 @@ import os
 from os.path import isfile
 
 from cwrap import BaseCClass
-
 from ecl.util.util import StringList
-from res import ResPrototype
-from res.config import ConfigParser, ConfigContent
 
-from res.enkf import (
-    SiteConfig,
-    AnalysisConfig,
-    SubstConfig,
-    ModelConfig,
-    EclConfig,
-    QueueConfig,
-    EnsembleConfig,
-    RNGConfig,
-    ConfigKeys,
-    ErtWorkflowList,
-    HookManager,
-    ErtTemplates,
-    LogConfig,
-)
+from res import ResPrototype
+from res.config import ConfigContent, ConfigParser
+from res.enkf.analysis_config import AnalysisConfig
+from res.enkf.config_keys import ConfigKeys
+from res.enkf.ecl_config import EclConfig
+from res.enkf.ensemble_config import EnsembleConfig
+from res.enkf.ert_templates import ErtTemplates
+from res.enkf.ert_workflow_list import ErtWorkflowList
+from res.enkf.hook_manager import HookManager
+from res.enkf.log_config import LogConfig
+from res.enkf.model_config import ModelConfig
+from res.enkf.queue_config import QueueConfig
+from res.enkf.rng_config import RNGConfig
+from res.enkf.site_config import SiteConfig
+from res.enkf.subst_config import SubstConfig
 
 
 class ResConfig(BaseCClass):

--- a/res/enkf/rng_config.py
+++ b/res/enkf/rng_config.py
@@ -18,7 +18,7 @@
 from cwrap import BaseCClass
 
 from res import ResPrototype
-from res.enkf import ConfigKeys
+from res.enkf.config_keys import ConfigKeys
 
 
 class RNGConfig(BaseCClass):

--- a/res/enkf/site_config.py
+++ b/res/enkf/site_config.py
@@ -15,10 +15,12 @@
 #  for more details.
 
 import os
+
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.enkf import ConfigKeys
-from res.job_queue import ExtJob, ExtJoblist, EnvironmentVarlist
+from res.enkf.config_keys import ConfigKeys
+from res.job_queue import EnvironmentVarlist, ExtJob, ExtJoblist
 
 
 class SiteConfig(BaseCClass):

--- a/res/enkf/state_map.py
+++ b/res/enkf/state_map.py
@@ -14,9 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector
+
 from res import ResPrototype
 from res.enkf.enums import RealizationStateEnum
-from ecl.util.util import BoolVector
 
 
 class StateMap(BaseCClass):

--- a/res/enkf/subst_config.py
+++ b/res/enkf/subst_config.py
@@ -17,9 +17,10 @@
 import os.path
 
 from cwrap import BaseCClass
-from res import ResPrototype
 from ecl import EclPrototype
-from res.enkf import ConfigKeys
+
+from res import ResPrototype
+from res.enkf.config_keys import ConfigKeys
 from res.util import SubstitutionList
 
 

--- a/res/enkf/summary_key_matcher.py
+++ b/res/enkf/summary_key_matcher.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
-from res import ResPrototype
 from ecl.util.util import StringList
+
+from res import ResPrototype
 
 
 class SummaryKeyMatcher(BaseCClass):
@@ -41,7 +42,7 @@ class SummaryKeyMatcher(BaseCClass):
         """@rtype: bool"""
         return self._is_required(key)
 
-    def keys(self):
+    def keys(self) -> StringList:
         """@rtype: StringList"""
         return self._keys()
 

--- a/res/enkf/summary_key_set.py
+++ b/res/enkf/summary_key_set.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
-from res import ResPrototype
 from ecl.util.util import StringList
+
+from res import ResPrototype
 
 
 class SummaryKeySet(BaseCClass):
@@ -40,7 +41,7 @@ class SummaryKeySet(BaseCClass):
     def __contains__(self, key):
         return self._has_key(key)
 
-    def keys(self):
+    def keys(self) -> StringList:
         """@rtype: StringList"""
         return self._keys()
 

--- a/res/enkf/util/__init__.py
+++ b/res/enkf/util/__init__.py
@@ -1,1 +1,3 @@
 from .time_map import TimeMap
+
+__all__ = ["TimeMap"]

--- a/res/enkf/util/time_map.py
+++ b/res/enkf/util/time_map.py
@@ -13,12 +13,14 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import os
 import errno
+import os
 
 from cwrap import BaseCClass
-from res import ResPrototype
+from ecl.summary import EclSum
 from ecl.util.util import CTime
+
+from res import ResPrototype
 
 
 class TimeMap(BaseCClass):
@@ -199,5 +201,5 @@ class TimeMap(BaseCClass):
     def getLastStep(self):
         return self._last_step()
 
-    def upgrade107(self, refcase):
+    def upgrade107(self, refcase: EclSum):
         self._upgrade107(refcase)

--- a/res/fm/ecl/ecl_run.py
+++ b/res/fm/ecl/ecl_run.py
@@ -10,14 +10,10 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from packaging import version
+from res.fm.ecl.ecl_config import EclrunConfig
 from res.util.subprocess import await_process_tee
 
-from .ecl_config import EclConfig
-
-try:
-    from ecl.summary import EclSum
-except ImportError:
-    from ert.ecl import EclSum
+from ecl.summary import EclSum
 
 EclipseResult = namedtuple("EclipseResult", "errors bugs")
 body_sub_pattern = r"(\s^\s@.+$)*"
@@ -256,7 +252,7 @@ class EclRun(object):
             for host in machine_list:
                 fileH.write("%s\n" % host)
 
-    def _get_run_command(self, eclrun_config):
+    def _get_run_command(self, eclrun_config: EclrunConfig):
         summary_conversion = "yes" if self.summary_conversion else "no"
         return [
             "eclrun",

--- a/res/job_queue/__init__.py
+++ b/res/job_queue/__init__.py
@@ -54,8 +54,9 @@ external commands.
 
 
 import os
-from cwrap import Prototype
+
 import res
+from cwrap import Prototype
 
 
 def setenv(var, value):
@@ -72,28 +73,58 @@ if LSF_HOME:
     setenv("LSF_SERVERDIR", "%s/etc" % LSF_HOME)
     setenv("LSF_ENVDIR", "%s/conf" % LSF_HOME)  # This is wrong: Equinor: /prog/LSF/conf
 
-from .job_status_type_enum import JobStatusType
-from .run_status_type_enum import RunStatusType
-from .thread_status_type_enum import ThreadStatus
-from .job_submit_status_type_enum import JobSubmitStatusType
-from .job import Job
-from .driver import Driver, QueueDriverEnum
-from .job_queue_node import JobQueueNode
-from .queue import JobQueue
-from .job_queue_manager import JobQueueManager
-from .driver import QueueDriverEnum, Driver, LSFDriver, RSHDriver, LocalDriver
+from .driver import Driver, LocalDriver, LSFDriver, QueueDriverEnum, RSHDriver
+from .environment_varlist import EnvironmentVarlist
+from .ert_plugin import CancelPluginException, ErtPlugin
+from .ert_script import ErtScript
 from .ext_job import ExtJob
 from .ext_joblist import ExtJoblist
-from .environment_varlist import EnvironmentVarlist
+from .external_ert_script import ExternalErtScript
 from .forward_model import ForwardModel
 from .forward_model_status import ForwardModelJobStatus, ForwardModelStatus
-
-from .ert_script import ErtScript
-from .ert_plugin import ErtPlugin, CancelPluginException
 from .function_ert_script import FunctionErtScript
-from .external_ert_script import ExternalErtScript
-
+from .job import Job
+from .job_queue_manager import JobQueueManager
+from .job_queue_node import JobQueueNode
+from .job_status_type_enum import JobStatusType
+from .job_submit_status_type_enum import JobSubmitStatusType
+from .queue import JobQueue
+from .run_status_type_enum import RunStatusType
+from .thread_status_type_enum import ThreadStatus
+from .workflow import Workflow
 from .workflow_job import WorkflowJob
 from .workflow_joblist import WorkflowJoblist
-from .workflow import Workflow
 from .workflow_runner import WorkflowRunner
+
+__all__ = [
+    "JobStatusType",
+    "RunStatusType",
+    "ThreadStatus",
+    "JobSubmitStatusType",
+    "Job",
+    "Driver",
+    "QueueDriverEnum",
+    "JobQueueNode",
+    "JobQueue",
+    "JobQueueManager",
+    "QueueDriverEnum",
+    "Driver",
+    "LSFDriver",
+    "RSHDriver",
+    "LocalDriver",
+    "ExtJob",
+    "ExtJoblist",
+    "EnvironmentVarlist",
+    "ForwardModel",
+    "ForwardModelJobStatus",
+    "ForwardModelStatus",
+    "ErtScript",
+    "ErtPlugin",
+    "CancelPluginException",
+    "FunctionErtScript",
+    "ExternalErtScript",
+    "WorkflowJob",
+    "WorkflowJoblist",
+    "Workflow",
+    "WorkflowRunner",
+]

--- a/res/job_queue/driver.py
+++ b/res/job_queue/driver.py
@@ -15,10 +15,10 @@
 #  for more details.
 
 
-import ctypes
 from cwrap import BaseCClass, BaseCEnum
 from res import ResPrototype
-from res.job_queue import Job
+
+from .job import Job
 
 
 class QueueDriverEnum(BaseCEnum):
@@ -88,7 +88,7 @@ class Driver(BaseCClass):
     def is_driver_instance(self):
         return True
 
-    def free_job(self, job):
+    def free_job(self, job: Job):
         self._free_job(job)
 
     def get_status(self, job):

--- a/res/job_queue/ext_job.py
+++ b/res/job_queue/ext_job.py
@@ -14,10 +14,12 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import os.path
+from typing import List
 
 from cwrap import BaseCClass
+from ecl.util.util import StringHash, StringList
+
 from res import ResPrototype
-from ecl.util.util import StringList, Hash
 from res.config import ContentTypeEnum
 
 
@@ -173,7 +175,7 @@ class ExtJob(BaseCClass):
         return self._max_arg()
 
     @property
-    def arg_types(self):
+    def arg_types(self) -> List[ContentTypeEnum]:
         """@rtype: list of type"""
 
         result = []
@@ -190,7 +192,7 @@ class ExtJob(BaseCClass):
                 return False
             return True
 
-    def get_environment(self):
+    def get_environment(self) -> StringHash:
         return self._get_environment()
 
     def set_environment(self, key, value):
@@ -207,7 +209,7 @@ class ExtJob(BaseCClass):
         # The return type is cast from a <StringList> to a regular Python list.
         return list(self._get_argvalues())
 
-    def set_arglist(self, args):
+    def set_arglist(self, args: StringList):
         return self._set_arglist(args)
 
     def clear_environment(self):

--- a/res/job_queue/ext_joblist.py
+++ b/res/job_queue/ext_joblist.py
@@ -14,9 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
+from ecl.util.util import StringList
+
 from res import ResPrototype
 from res.job_queue import ExtJob
-from ecl.util.util import StringList
 
 
 class ExtJoblist(BaseCClass):
@@ -56,7 +57,7 @@ class ExtJoblist(BaseCClass):
         if job in self:
             return self._get_job(job).setParent(self)
 
-    def getAvailableJobNames(self):
+    def getAvailableJobNames(self) -> StringList:
         """@rtype: StringList"""
         return [str(x) for x in self._alloc_list().setParent(self)]
 
@@ -66,7 +67,7 @@ class ExtJoblist(BaseCClass):
     def has_job(self, job):
         return job in self
 
-    def get_job(self, job):
+    def get_job(self, job) -> ExtJob:
         """@rtype: ExtJob"""
         return self[job]
 

--- a/res/job_queue/forward_model.py
+++ b/res/job_queue/forward_model.py
@@ -14,10 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
-from res import ResPrototype
-from res.job_queue import ExtJob, ExtJoblist
-from res.job_queue import EnvironmentVarlist
 from ecl.util.util import StringList
+
+from res import ResPrototype
+from res.job_queue import EnvironmentVarlist, ExtJob, ExtJoblist
 from res.util.substitution_list import SubstitutionList
 
 
@@ -43,7 +43,7 @@ class ForwardModel(BaseCClass):
                                               env_varlist)"
     )
 
-    def __init__(self, ext_joblist):
+    def __init__(self, ext_joblist: ExtJoblist):
         c_ptr = self._alloc(ext_joblist)
         if c_ptr:
             super(ForwardModel, self).__init__(c_ptr)
@@ -56,11 +56,11 @@ class ForwardModel(BaseCClass):
     def __len__(self):
         return self._get_length()
 
-    def joblist(self):
+    def joblist(self) -> StringList:
         """@rtype: StringList"""
         return self._alloc_joblist()
 
-    def iget_job(self, index):
+    def iget_job(self, index) -> ExtJob:
         """@rtype: ExtJob"""
         return self._iget_job(index).setParent(self)
 
@@ -75,7 +75,13 @@ class ForwardModel(BaseCClass):
         self._free()
 
     def formatted_fprintf(
-        self, run_id, path, data_root, global_args, umask, env_varlist
+        self,
+        run_id,
+        path,
+        data_root,
+        global_args: SubstitutionList,
+        umask,
+        env_varlist: EnvironmentVarlist,
     ):
         self._formatted_fprintf(
             run_id, path, data_root, global_args, umask, env_varlist

--- a/res/job_queue/forward_model_status.py
+++ b/res/job_queue/forward_model_status.py
@@ -13,13 +13,13 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import os.path
-import json
 import datetime
+import json
+import os.path
 import time
-import sys
-from job_runner.reporting.file import File
+
 from job_runner import JOBS_FILE
+from job_runner.reporting.file import File
 
 
 def _serialize_date(dt):

--- a/res/job_queue/function_ert_script.py
+++ b/res/job_queue/function_ert_script.py
@@ -1,8 +1,7 @@
-import ecl
 import cwrap
+from ecl.util.util.stringlist import StringList
 
 from res.job_queue import ErtScript
-from ecl.util.util.stringlist import StringList
 
 
 class _NonePrototype(cwrap.Prototype):

--- a/res/job_queue/job.py
+++ b/res/job_queue/job.py
@@ -15,10 +15,12 @@
 #  for more details.
 
 
-import time
 import datetime
+import time
+
 from cwrap import BaseCClass
-from res.job_queue import JobStatusType
+
+from .job_status_type_enum import JobStatusType
 
 # This class and the interplay between this class and the Driver and
 # JobQueue classes is quite fragile; in particular the Job class

--- a/res/job_queue/job_queue_manager.py
+++ b/res/job_queue/job_queue_manager.py
@@ -17,8 +17,9 @@
 Module implementing a queue for managing external jobs.
 
 """
-from res.job_queue import JobStatusType
 from threading import BoundedSemaphore
+
+from res.job_queue.job_status_type_enum import JobStatusType
 
 CONCURRENT_INTERNALIZATION = 1
 

--- a/res/job_queue/job_queue_node.py
+++ b/res/job_queue/job_queue_node.py
@@ -1,11 +1,14 @@
+import logging
+import time
+from threading import Lock, Thread
+
 from cwrap import BaseCClass
 from ecl.util.util import StringList
-from res import ResPrototype
-from res.job_queue import JobStatusType, ThreadStatus, JobSubmitStatusType
-from threading import Thread, Lock
 
-import time
-import logging
+from res import ResPrototype
+from res.job_queue.job_status_type_enum import JobStatusType
+from res.job_queue.job_submit_status_type_enum import JobSubmitStatusType
+from res.job_queue.thread_status_type_enum import ThreadStatus
 
 logger = logging.getLogger(__name__)
 

--- a/res/job_queue/queue.py
+++ b/res/job_queue/queue.py
@@ -19,21 +19,22 @@ Module implementing a queue for managing external jobs.
 """
 
 import asyncio
-import copy
 import json
 import logging
-import time
 import ssl
+import time
 import typing
 
 import websockets
-from websockets.datastructures import Headers
 from cloudevents.http import CloudEvent, to_json
 from cwrap import BaseCClass
-from job_runner import JOBS_FILE, CERT_FILE
+from job_runner import CERT_FILE, JOBS_FILE
 from res import ResPrototype
-from res.job_queue import JobQueueNode, JobStatusType, ThreadStatus
+from res.job_queue.job_queue_node import JobQueueNode
+from res.job_queue.job_status_type_enum import JobStatusType
 from res.job_queue.queue_differ import QueueDiffer
+from res.job_queue.thread_status_type_enum import ThreadStatus
+from websockets.datastructures import Headers
 
 logger = logging.getLogger(__name__)
 

--- a/res/job_queue/workflow.py
+++ b/res/job_queue/workflow.py
@@ -1,11 +1,13 @@
+import logging
 import os
 import sys
 import time
-import logging
+from typing import Any, Dict
 
 from cwrap import BaseCClass  # pylint: disable=import-error
 
 from res import ResPrototype
+from res.job_queue.workflow_joblist import WorkflowJoblist
 
 
 class Workflow(BaseCClass):
@@ -20,7 +22,7 @@ class Workflow(BaseCClass):
     _get_last_error = ResPrototype("config_error_ref workflow_get_last_error(workflow)")
     _get_src_file = ResPrototype("char* worflow_get_src_file(workflow)")
 
-    def __init__(self, src_file, job_list):
+    def __init__(self, src_file, job_list: WorkflowJoblist):
         """
         @type src_file: str
         @type job_list: WorkflowJoblist
@@ -31,7 +33,7 @@ class Workflow(BaseCClass):
         self.__running = False
         self.__cancelled = False
         self.__current_job = None
-        self.__status = {}
+        self.__status: Dict[str, Any] = {}
 
     def __len__(self):
         return self._count()

--- a/res/job_queue/workflow_joblist.py
+++ b/res/job_queue/workflow_joblist.py
@@ -1,7 +1,9 @@
 import os
+
 from cwrap import BaseCClass
+
 from res import ResPrototype
-from res.job_queue import WorkflowJob
+from res.job_queue.workflow_job import WorkflowJob
 
 
 class WorkflowJoblist(BaseCClass):

--- a/res/job_queue/workflow_runner.py
+++ b/res/job_queue/workflow_runner.py
@@ -1,10 +1,11 @@
+from concurrent import futures
+
 from res.job_queue import Workflow
 from res.util.substitution_list import SubstitutionList
-from concurrent import futures
 
 
 class WorkflowRunner(object):
-    def __init__(self, workflow, ert=None, context=None):
+    def __init__(self, workflow: Workflow, ert=None, context: SubstitutionList = None):
         """
         @type workflow: Workflow
         @type ert: res.enkf.EnKFMain

--- a/res/sched/__init__.py
+++ b/res/sched/__init__.py
@@ -13,12 +13,16 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import res
 import ecl
 import ecl.util
 import ecl.util.geometry
-
+import res
 from cwrap import Prototype
 
-from .history_source_enum import HistorySourceEnum
 from .history import History
+from .history_source_enum import HistorySourceEnum
+
+__all__ = [
+    "HistorySourceEnum",
+    "History",
+]

--- a/res/sched/history.py
+++ b/res/sched/history.py
@@ -14,10 +14,13 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from typing import Optional
+
 from cwrap import BaseCClass
-from res import ResPrototype
-from res.sched import HistorySourceEnum
 from ecl.summary import EclSum
+
+from res import ResPrototype
+from res.sched.history_source_enum import HistorySourceEnum
 
 
 class History(BaseCClass):
@@ -31,7 +34,9 @@ class History(BaseCClass):
     )
     _free = ResPrototype("void  history_free( history )")
 
-    def __init__(self, refcase=None, use_history=False, sched_file=None):
+    def __init__(
+        self, refcase: Optional[EclSum] = None, use_history=False, sched_file=None
+    ):
         """
         @type refcase: EclSum
         @type use_history: bool
@@ -52,7 +57,7 @@ class History(BaseCClass):
             raise ValueError("Invalid input.  Failed to create History.")
 
     @staticmethod
-    def get_source_string(history_source_type):
+    def get_source_string(history_source_type: HistorySourceEnum):
         """
         @type history_source_type: HistorySourceEnum
         @rtype: str

--- a/res/simulator/__init__.py
+++ b/res/simulator/__init__.py
@@ -1,3 +1,9 @@
 from .batch_simulator import BatchSimulator
 from .batch_simulator_context import BatchContext
 from .simulation_context import SimulationContext
+
+__all__ = [
+    "BatchSimulator",
+    "BatchContext",
+    "SimulationContext",
+]

--- a/res/simulator/batch_simulator.py
+++ b/res/simulator/batch_simulator.py
@@ -1,6 +1,9 @@
 from ecl.util.util import BoolVector
 
-from res.enkf import ResConfig, EnKFMain, EnkfConfigNode, EnkfNode, NodeId
+from res.enkf import EnKFMain, NodeId, ResConfig
+from res.enkf.config import EnkfConfigNode
+from res.enkf.data import EnkfNode
+
 from .batch_simulator_context import BatchContext
 
 

--- a/res/simulator/batch_simulator_context.py
+++ b/res/simulator/batch_simulator_context.py
@@ -1,8 +1,12 @@
+import logging
 import time
 from collections import namedtuple
-from res.enkf import NodeId, EnkfNode
-import logging
+
 import numpy as np
+
+from res.enkf import NodeId
+from res.enkf.data import EnkfNode
+
 from .simulation_context import SimulationContext
 
 Status = namedtuple("Status", "waiting pending running complete failed")

--- a/res/test/__init__.py
+++ b/res/test/__init__.py
@@ -1,1 +1,3 @@
 from .ert_test_context import ErtTestContext
+
+__all__ = ["ErtTestContext"]

--- a/res/test/synthesizer/__init__.py
+++ b/res/test/synthesizer/__init__.py
@@ -1,4 +1,13 @@
-from .prime_generator import PrimeGenerator
-from .perlin import PerlinNoise
-from .shaped_perlin import ShapedNoise, ShapeFunction, ShapeCreator
 from .oil_simulator import OilSimulator
+from .perlin import PerlinNoise
+from .prime_generator import PrimeGenerator
+from .shaped_perlin import ShapeCreator, ShapedNoise, ShapeFunction
+
+__all__ = [
+    "PrimeGenerator",
+    "PerlinNoise",
+    "ShapedNoise",
+    "ShapeFunction",
+    "ShapeCreator",
+    "OilSimulator",
+]

--- a/res/test/synthesizer/oil_simulator.py
+++ b/res/test/synthesizer/oil_simulator.py
@@ -1,4 +1,4 @@
-from . import ShapeFunction, ShapeCreator
+from .shaped_perlin import ShapeCreator, ShapeFunction
 
 
 class OilSimulator(object):

--- a/res/test/synthesizer/prime_generator.py
+++ b/res/test/synthesizer/prime_generator.py
@@ -1,4 +1,5 @@
-import random, numbers
+import numbers
+import random
 
 
 def rwh_primes2(n):

--- a/res/test/synthesizer/shaped_perlin.py
+++ b/res/test/synthesizer/shaped_perlin.py
@@ -1,5 +1,7 @@
 import math
-from . import PrimeGenerator, PerlinNoise
+
+from .perlin import PerlinNoise
+from .prime_generator import PrimeGenerator
 
 
 class Interpolator(object):

--- a/res/util/enums/__init__.py
+++ b/res/util/enums/__init__.py
@@ -1,3 +1,9 @@
-from .ui_return_status_enum import UIReturnStatusEnum
-from .message_level_enum import MessageLevelEnum
 from .llsq_result_enum import LLSQResultEnum
+from .message_level_enum import MessageLevelEnum
+from .ui_return_status_enum import UIReturnStatusEnum
+
+__all__ = [
+    "UIReturnStatusEnum",
+    "MessageLevelEnum",
+    "LLSQResultEnum",
+]


### PR DESCRIPTION
**Issue**

#2503

**Approach**
* Adds `__all__` to `__init__`
* Import implicit dependencies in the module it is used
* Use typing to make the use of the import explicit
* Remove unused dependencies

Several files would rely on importing from the `__init__.py` of its module. This is quite fragile as the order of imports in the `__init__.py` must facilitate a partial instantiation in order to avoid circular imports. As more imports are added to resolve the above issue, it becomes very difficult to continue with that scheme. Therefore imports such as `from . import EnkFMain` is changed to `from .enkf_main import EnkFMain` for any file inside `res/enkf` while files outside `res/enkf` can use `from res.enkf import EnkFMain`.