### PR TITLE
Remove res/ interoperability with python 2

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         pip install .  # We need the dependencies of ERT to avoid import-error
         pylint ert ert3
-        pylint --disable=all --enable="line-too-long, unused-import" res
+        pylint --disable=all --enable="line-too-long, unused-import, super-with-arguments, useless-object-inheritance" res

--- a/ert_data/measured.py
+++ b/ert_data/measured.py
@@ -13,7 +13,7 @@ import numpy as np
 from ert_data import loader
 
 
-class MeasuredData(object):
+class MeasuredData:
     def __init__(self, facade, keys, index_lists=None, load_data=True, case_name=None):
         self._facade = facade
 

--- a/job_runner/job.py
+++ b/job_runner/job.py
@@ -11,7 +11,7 @@ from job_runner.io import assert_file_executable
 from job_runner.reporting.message import Exited, Running, Start
 
 
-class Job(object):
+class Job:
     MEMORY_POLL_PERIOD = 5  # Seconds between memory polls
 
     def __init__(self, job_data, index, sleep_interval=1):

--- a/job_runner/reporting/message.py
+++ b/job_runner/reporting/message.py
@@ -44,7 +44,7 @@ class Message(metaclass=_MetaMessage):
 
 class Init(Message):
     def __init__(self, jobs, run_id, ert_pid, ee_id=None, real_id=None, step_id=None):
-        super(Init, self).__init__()
+        super().__init__()
         self.jobs = jobs
         self.run_id = run_id
         self.ert_pid = ert_pid
@@ -55,7 +55,7 @@ class Init(Message):
 
 class Finish(Message):
     def __init__(self):
-        super(Finish, self).__init__()
+        super().__init__()
 
 
 # job level messages
@@ -63,17 +63,17 @@ class Finish(Message):
 
 class Start(Message):
     def __init__(self, job):
-        super(Start, self).__init__(job)
+        super().__init__(job)
 
 
 class Running(Message):
     def __init__(self, job, max_memory_usage, current_memory_usage):
-        super(Running, self).__init__(job)
+        super().__init__(job)
         self.max_memory_usage = max_memory_usage
         self.current_memory_usage = current_memory_usage
 
 
 class Exited(Message):
     def __init__(self, job, exit_code):
-        super(Exited, self).__init__(job)
+        super().__init__(job)
         self.exit_code = exit_code

--- a/job_runner/runner.py
+++ b/job_runner/runner.py
@@ -5,7 +5,7 @@ from job_runner.job import Job
 from job_runner.reporting.message import Init, Finish
 
 
-class JobRunner(object):
+class JobRunner:
     def __init__(self, jobs_data):
         os.umask(int(jobs_data["umask"], 8))
 

--- a/res/__init__.py
+++ b/res/__init__.py
@@ -65,7 +65,7 @@ class ResPrototype(Prototype):
     lib = _load_lib()
 
     def __init__(self, prototype, bind=True):
-        super(ResPrototype, self).__init__(ResPrototype.lib, prototype, bind=bind)
+        super().__init__(ResPrototype.lib, prototype, bind=bind)
 
 
 RES_LIB = ResPrototype.lib

--- a/res/analysis/analysis_module.py
+++ b/res/analysis/analysis_module.py
@@ -134,7 +134,7 @@ class AnalysisModule(BaseCClass):
         if not c_ptr:
             raise KeyError("Failed to load internal module:%s" % name)
 
-        super(AnalysisModule, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def getVariableNames(self):
         """@rtype: list of str"""

--- a/res/config/config_content.py
+++ b/res/config/config_content.py
@@ -139,7 +139,7 @@ class ContentItem(BaseCClass):
     def __init__(self, schema_item):
         path_elm = None
         c_ptr = self._alloc(schema_item, path_elm)
-        super(ContentItem, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __len__(self):
         return self._size()
@@ -202,7 +202,7 @@ class ConfigContent(BaseCClass):
         c_ptr = self._alloc(filename)
 
         if c_ptr:
-            super(ConfigContent, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Failed to construct ConfigContent instance from config file %s."

--- a/res/config/config_parser.py
+++ b/res/config/config_parser.py
@@ -60,7 +60,7 @@ class ConfigParser(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(ConfigParser, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __contains__(self, keyword):
         return self._has_schema_item(keyword)

--- a/res/config/config_settings.py
+++ b/res/config/config_settings.py
@@ -79,7 +79,7 @@ class ConfigSettings(BaseCClass):
         if c_ptr is None:
             c_ptr = ConfigSettings._alloc(root_key)
 
-        super(ConfigSettings, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __contains__(self, key):
         return self._has_key(key)

--- a/res/config/schema_item.py
+++ b/res/config/schema_item.py
@@ -43,7 +43,7 @@ class SchemaItem(BaseCClass):
 
     def __init__(self, keyword, required=False):
         c_ptr = self._alloc(keyword, required)
-        super(SchemaItem, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def iget_type(self, index) -> ContentTypeEnum:
         """@rtype: ContentTypeEnum"""

--- a/res/enkf/active_list.py
+++ b/res/enkf/active_list.py
@@ -31,7 +31,7 @@ class ActiveList(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(ActiveList, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def getMode(self):
         return self._get_mode()

--- a/res/enkf/analysis_config.py
+++ b/res/enkf/analysis_config.py
@@ -134,7 +134,7 @@ class AnalysisConfig(BaseCClass):
 
             c_ptr = self._alloc_load(user_config_file)
             if c_ptr:
-                super(AnalysisConfig, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ValueError(
                     "Failed to construct AnalysisConfig instance from config file %s."
@@ -144,7 +144,7 @@ class AnalysisConfig(BaseCClass):
         if config_content is not None:
             c_ptr = self._alloc(config_content)
             if c_ptr:
-                super(AnalysisConfig, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ValueError("Failed to construct AnalysisConfig instance.")
 
@@ -162,7 +162,7 @@ class AnalysisConfig(BaseCClass):
                 config_dict.get(ConfigKeys.MIN_REALIZATIONS, 0),
             )
             if c_ptr:
-                super(AnalysisConfig, self).__init__(c_ptr)
+                super().__init__(c_ptr)
 
                 # copy modules
                 analysis_copy_list = config_dict.get(ConfigKeys.ANALYSIS_COPY, [])

--- a/res/enkf/analysis_iter_config.py
+++ b/res/enkf/analysis_iter_config.py
@@ -54,7 +54,7 @@ class AnalysisIterConfig(BaseCClass):
         if config_dict is None:
             c_ptr = self._alloc()
             if c_ptr:
-                super(AnalysisIterConfig, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ValueError("Failed to construct AnalysisIterConfig instance.")
         else:
@@ -64,7 +64,7 @@ class AnalysisIterConfig(BaseCClass):
                 config_dict[ConfigKeys.ITER_RETRY_COUNT],
             )
             if c_ptr:
-                super(AnalysisIterConfig, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ValueError(
                     "Failed to construct AnalysisIterConfig instance for dictionary."

--- a/res/enkf/config/ext_param_config.py
+++ b/res/enkf/config/ext_param_config.py
@@ -14,7 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
-from six import string_types
+
 from res import ResPrototype
 from ecl.util.util import StringList
 
@@ -64,7 +64,7 @@ class ExtParamConfig(BaseCClass):
 
         keys = StringList(initial=input_keys)
         c_ptr = self._alloc(key, keys)
-        super(ExtParamConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
         for k, suffixes in suffixmap:
             suffixlist = StringList(initial=suffixes)
@@ -115,7 +115,7 @@ class ExtParamConfig(BaseCClass):
         that index
         An IndexError is raised if the item is not found
         """
-        if isinstance(index, string_types):
+        if isinstance(index, str):
             index = self._key_index(index)
             if index < 0:
                 raise IndexError('Key "{}" not found'.format(index))

--- a/res/enkf/config/field_config.py
+++ b/res/enkf/config/field_config.py
@@ -65,7 +65,7 @@ class FieldConfig(BaseCClass):
 
     def __init__(self, kw, grid):
         c_ptr = self._alloc(kw, grid, None, False)
-        super(FieldConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     @classmethod
     def exportFormat(cls, filename):

--- a/res/enkf/config/gen_data_config.py
+++ b/res/enkf/config/gen_data_config.py
@@ -62,7 +62,7 @@ class GenDataConfig(BaseCClass):
         # Can currently only create GEN_DATA instances which should be used
         # as result variables.
         c_pointer = self._alloc(key, input_format)
-        super(GenDataConfig, self).__init__(c_pointer)
+        super().__init__(c_pointer)
 
     def get_template_file(self):
         return self._get_template_file()

--- a/res/enkf/config/gen_kw_config.py
+++ b/res/enkf/config/gen_kw_config.py
@@ -73,7 +73,7 @@ class GenKwConfig(BaseCClass):
 
         c_ptr = self._alloc_empty(key, tag_fmt)
         if c_ptr:
-            super(GenKwConfig, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 'Could not instantiate GenKwConfig with key="%s" and tag_fmt="%s"'

--- a/res/enkf/config/summary_config.py
+++ b/res/enkf/config/summary_config.py
@@ -29,7 +29,7 @@ class SummaryConfig(BaseCClass):
 
     def __init__(self, key, load_fail=LoadFailTypeEnum.LOAD_FAIL_WARN):
         c_ptr = self._alloc(key, load_fail)
-        super(SummaryConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __repr__(self):
         return "SummaryConfig() %s" % self._ad_str()

--- a/res/enkf/data/enkf_node.py
+++ b/res/enkf/data/enkf_node.py
@@ -52,7 +52,7 @@ class EnkfNode(BaseCClass):
             c_pointer = self._alloc(config_node)
 
         if c_pointer:
-            super(EnkfNode, self).__init__(c_pointer, config_node, True)
+            super().__init__(c_pointer, config_node, True)
         else:
             p_err = "private " if private else ""
             raise ValueError(

--- a/res/enkf/data/ext_param.py
+++ b/res/enkf/data/ext_param.py
@@ -15,7 +15,6 @@
 #  for more details.
 
 from cwrap import BaseCClass
-from six import string_types
 
 from res import ResPrototype
 from res.enkf.config import ExtParamConfig
@@ -40,7 +39,7 @@ class ExtParam(BaseCClass):
 
     def __init__(self, config):
         c_ptr = self._alloc(config)
-        super(ExtParam, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __contains__(self, key):
         return key in self.config
@@ -52,15 +51,13 @@ class ExtParam(BaseCClass):
         if isinstance(index, tuple):
             # if the index is key suffix, assume they are both strings
             key, suffix = index
-            if not isinstance(key, string_types) or not isinstance(
-                suffix, string_types
-            ):
+            if not isinstance(key, str) or not isinstance(suffix, str):
                 raise TypeError("Expected a pair of strings, got {}".format(index))
             self._check_key_suffix(key, suffix)
             return self._key_suffix_get(key, suffix)
 
         # index is just the key, it can be either a string or an int
-        if isinstance(index, string_types):
+        if isinstance(index, str):
             self._check_key_suffix(index)
             return self._key_get(index)
 
@@ -72,16 +69,14 @@ class ExtParam(BaseCClass):
         if isinstance(index, tuple):
             # if the index is key suffix, assume they are both strings
             key, suffix = index
-            if not isinstance(key, string_types) or not isinstance(
-                suffix, string_types
-            ):
+            if not isinstance(key, str) or not isinstance(suffix, str):
                 raise TypeError("Expected a pair of strings, got {}".format(index))
             self._check_key_suffix(key, suffix)
             self._key_suffix_set(key, suffix, value)
             return
 
         # index is just the key, it can be either a string or an int
-        if isinstance(index, string_types):
+        if isinstance(index, str):
             self._check_key_suffix(index)
             self._key_set(index, value)
         else:

--- a/res/enkf/data/gen_data.py
+++ b/res/enkf/data/gen_data.py
@@ -17,7 +17,7 @@ class GenData(BaseCClass):
     def __init__(self):
         c_ptr = self._alloc()
         if c_ptr:
-            super(GenData, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError("Unable to construct GenData object.")
 

--- a/res/enkf/data/gen_kw.py
+++ b/res/enkf/data/gen_kw.py
@@ -48,7 +48,7 @@ class GenKw(BaseCClass):
         c_ptr = self._alloc(gen_kw_config)
 
         if c_ptr:
-            super(GenKw, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Cannot issue a GenKw from the given keyword config: %s."

--- a/res/enkf/data/summary.py
+++ b/res/enkf/data/summary.py
@@ -29,7 +29,7 @@ class Summary(BaseCClass):
     def __init__(self, config):
         c_ptr = self._alloc(config)
         self._config = config
-        super(Summary, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         self._undefined_value = self._get_undef_value()
 
     def __len__(self):

--- a/res/enkf/ecl_config.py
+++ b/res/enkf/ecl_config.py
@@ -135,7 +135,7 @@ class EclConfig(BaseCClass):
                 grid.convertToCReference(None)
 
         if c_ptr:
-            super(EclConfig, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise RuntimeError("Internal error: Failed constructing EclConfig!")
 

--- a/res/enkf/enkf_fs.py
+++ b/res/enkf/enkf_fs.py
@@ -51,7 +51,7 @@ class EnkfFs(BaseCClass):
 
     def __init__(self, mount_point):
         c_ptr = self._mount(mount_point)
-        super(EnkfFs, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def copy(self):
         fs = self.createPythonObject(self._address())

--- a/res/enkf/enkf_fs_manager.py
+++ b/res/enkf/enkf_fs_manager.py
@@ -18,9 +18,9 @@ def naturalSortKey(s, _nsre=re.compile("([0-9]+)")):
     ]
 
 
-class FileSystemRotator(object):
+class FileSystemRotator:
     def __init__(self, capacity):
-        super(FileSystemRotator, self).__init__()
+        super().__init__()
         self._capacity = capacity
         """:type: int"""
         self._fs_list = []
@@ -129,7 +129,7 @@ class EnkfFsManager(BaseCClass):
         # enkf_main should be an EnKFMain, get the _RealEnKFMain object
         real_enkf_main = enkf_main.parent()
 
-        super(EnkfFsManager, self).__init__(
+        super().__init__(
             real_enkf_main.from_param(real_enkf_main).value,
             parent=real_enkf_main,
             is_reference=True,
@@ -141,7 +141,7 @@ class EnkfFsManager(BaseCClass):
     def __del__(self):
         # This object is a reference, so free() won't be called on it
         # Any clean-up must be done here
-        super(EnkfFsManager, self).__del__()
+        super().__del__()
 
     def _createFullCaseName(self, mount_root, case_name):
         return os.path.join(mount_root, case_name)

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -75,7 +75,7 @@ class EnKFMain(BaseCClass):
         self._monkey_patch_methods(real_enkf_main)
 
     def _init_from_real_enkf_main(self, real_enkf_main):
-        super(EnKFMain, self).__init__(
+        super().__init__(
             real_enkf_main.from_param(real_enkf_main).value,
             parent=real_enkf_main,
             is_reference=True,
@@ -274,7 +274,7 @@ class _RealEnKFMain(BaseCClass):
 
         c_ptr = self._alloc(res_config, strict, verbose)
         if c_ptr:
-            super(_RealEnKFMain, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Failed to construct EnKFMain instance from config %s." % res_config

--- a/res/enkf/enkf_obs.py
+++ b/res/enkf/enkf_obs.py
@@ -81,7 +81,7 @@ class EnkfObs(BaseCClass):
         refcase: EclSum = None,
     ):
         c_ptr = self._alloc(history, external_time_map, grid, refcase, ensemble_config)
-        super(EnkfObs, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __len__(self):
         return self._get_size()

--- a/res/enkf/enkf_simulation_runner.py
+++ b/res/enkf/enkf_simulation_runner.py
@@ -20,7 +20,7 @@ class EnkfSimulationRunner(BaseCClass):
         assert isinstance(enkf_main, BaseCClass)
         # enkf_main should be an EnKFMain, get the _RealEnKFMain object
         real_enkf_main = enkf_main.parent()
-        super(EnkfSimulationRunner, self).__init__(
+        super().__init__(
             real_enkf_main.from_param(real_enkf_main).value,
             parent=real_enkf_main,
             is_reference=True,

--- a/res/enkf/ensemble_config.py
+++ b/res/enkf/ensemble_config.py
@@ -104,7 +104,7 @@ class EnsembleConfig(BaseCClass):
                     "Failed to construct EnsembleConfig instance from dict"
                 )
 
-            super(EnsembleConfig, self).__init__(c_ptr)
+            super().__init__(c_ptr)
 
             gen_param_list = config_dict.get(ConfigKeys.GEN_PARAM, [])
             for gene_param in gen_param_list:
@@ -215,7 +215,7 @@ class EnsembleConfig(BaseCClass):
         c_ptr = self._alloc(config_content, grid, refcase)
         if c_ptr is None:
             raise ValueError("Failed to construct EnsembleConfig instance")
-        super(EnsembleConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __len__(self):
         return self._size()

--- a/res/enkf/ert_run_context.py
+++ b/res/enkf/ert_run_context.py
@@ -122,7 +122,7 @@ class ErtRunContext(BaseCClass):
             subst_list,
             itr,
         )
-        super(ErtRunContext, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
         # The C object ert_run_context uses a shared object for the
         # path_fmt and subst_list objects. We therefor hold on

--- a/res/enkf/ert_templates.py
+++ b/res/enkf/ert_templates.py
@@ -56,7 +56,7 @@ class ErtTemplates(BaseCClass):
             c_ptr = self._alloc_default(parent_subst)
             if c_ptr is None:
                 raise ValueError("Failed to construct ErtTemplates instance")
-            super(ErtTemplates, self).__init__(c_ptr)
+            super().__init__(c_ptr)
             run_template = config_dict.get(ConfigKeys.RUN_TEMPLATE)
             if isinstance(run_template, list):
                 for template_file_name, target_file, arguments in run_template:
@@ -81,7 +81,7 @@ class ErtTemplates(BaseCClass):
             c_ptr = self._alloc(parent_subst, config_content)
             if c_ptr is None:
                 raise ValueError("Failed to construct ErtTemplates instance")
-            super(ErtTemplates, self).__init__(c_ptr)
+            super().__init__(c_ptr)
 
     def getTemplateNames(self) -> StringList:
         """@rtype: StringList"""

--- a/res/enkf/ert_workflow_list.py
+++ b/res/enkf/ert_workflow_list.py
@@ -112,7 +112,7 @@ class ErtWorkflowList(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct ErtWorkflowList instance")
 
-        super(ErtWorkflowList, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
         if config_dict is not None:
             for job in config_dict.get(ConfigKeys.LOAD_WORKFLOW, []):

--- a/res/enkf/es_update.py
+++ b/res/enkf/es_update.py
@@ -14,7 +14,7 @@ class ESUpdate(BaseCClass):
         # enkf_main should be an EnKFMain, get the _RealEnKFMain object
         real_enkf_main = enkf_main.parent()
 
-        super(ESUpdate, self).__init__(
+        super().__init__(
             real_enkf_main.from_param(real_enkf_main).value,
             parent=real_enkf_main,
             is_reference=True,

--- a/res/enkf/export/arg_loader.py
+++ b/res/enkf/export/arg_loader.py
@@ -2,7 +2,7 @@ import numpy
 from pandas import DataFrame
 
 
-class ArgLoader(object):
+class ArgLoader:
     @staticmethod
     def load(filename, column_names=None):
         rows = 0

--- a/res/enkf/export/design_matrix_reader.py
+++ b/res/enkf/export/design_matrix_reader.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-class DesignMatrixReader(object):
+class DesignMatrixReader:
     @staticmethod
     def loadDesignMatrix(filename):
         """@rtype: DataFrame"""

--- a/res/enkf/export/gen_data_collector.py
+++ b/res/enkf/export/gen_data_collector.py
@@ -7,7 +7,7 @@ from res.enkf.enums import RealizationStateEnum
 from res.enkf.plot_data import EnsemblePlotGenData
 
 
-class GenDataCollector(object):
+class GenDataCollector:
     @staticmethod
     def loadGenData(ert: EnKFMain, case_name, key, report_step, realization_index=None):
         """@type ert: EnKFMain

--- a/res/enkf/export/gen_data_observation_collector.py
+++ b/res/enkf/export/gen_data_observation_collector.py
@@ -4,7 +4,7 @@ from res.enkf import EnKFMain
 from res.enkf.enums import EnkfObservationImplementationType
 
 
-class GenDataObservationCollector(object):
+class GenDataObservationCollector:
     @staticmethod
     def getAllObservationKeys(ert: EnKFMain):
         """

--- a/res/enkf/export/gen_kw_collector.py
+++ b/res/enkf/export/gen_kw_collector.py
@@ -10,7 +10,7 @@ from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotGenKW
 
 
-class GenKwCollector(object):
+class GenKwCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()

--- a/res/enkf/export/misfit_collector.py
+++ b/res/enkf/export/misfit_collector.py
@@ -7,7 +7,7 @@ from res.enkf.enums import RealizationStateEnum
 from res.enkf.key_manager import KeyManager
 
 
-class MisfitCollector(object):
+class MisfitCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()

--- a/res/enkf/export/summary_collector.py
+++ b/res/enkf/export/summary_collector.py
@@ -8,7 +8,7 @@ from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotData
 
 
-class SummaryCollector(object):
+class SummaryCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()

--- a/res/enkf/export/summary_observation_collector.py
+++ b/res/enkf/export/summary_observation_collector.py
@@ -4,7 +4,7 @@ from res.enkf import EnKFMain
 from res.enkf.key_manager import KeyManager
 
 
-class SummaryObservationCollector(object):
+class SummaryObservationCollector:
     @staticmethod
     def getAllObservationKeys(ert: EnKFMain):
         """

--- a/res/enkf/forward_load_context.py
+++ b/res/enkf/forward_load_context.py
@@ -14,9 +14,8 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from res import ResPrototype
 from cwrap import BaseCClass
-
+from res import ResPrototype
 
 # The Python wrapping of the forward_load_context is extremely
 # minimal; when creating the Python implementation the only purpose
@@ -47,8 +46,8 @@ class ForwardLoadContext(BaseCClass):
         report_step=None,
     ):
         c_ptr = self._alloc(run_arg, load_summary, ecl_config, ecl_base, messages)
-        super(ForwardLoadContext, self).__init__(c_ptr)
-        if report_step is not None:
+        super().__init__(c_ptr)
+        if not report_step is None:
             self.selectStep(report_step)
 
     def getLoadStep(self):

--- a/res/enkf/hook_manager.py
+++ b/res/enkf/hook_manager.py
@@ -85,7 +85,7 @@ class HookManager(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct RNGConfig instance")
 
-        super(HookManager, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def _to_c_string_arr(self, L):
         arr = (ctypes.c_char_p * len(L))()

--- a/res/enkf/key_manager.py
+++ b/res/enkf/key_manager.py
@@ -4,9 +4,9 @@ from res.enkf.config import GenKwConfig
 from res.enkf.enums import EnkfObservationImplementationType, ErtImplType
 
 
-class KeyManager(object):
+class KeyManager:
     def __init__(self, ert):
-        super(KeyManager, self).__init__()
+        super().__init__()
         """
         @type ert: res.enkf.EnKFMain
         """

--- a/res/enkf/local_obsdata.py
+++ b/res/enkf/local_obsdata.py
@@ -53,7 +53,7 @@ object as:
 
         c_ptr = self._alloc(name)
         if c_ptr:
-            super(LocalObsdata, self).__init__(c_ptr)
+            super().__init__(c_ptr)
             self.initObservations(obs)
         else:
             raise ValueError(

--- a/res/enkf/local_obsdata_node.py
+++ b/res/enkf/local_obsdata_node.py
@@ -29,7 +29,7 @@ class LocalObsdataNode(BaseCClass):
         if isinstance(obs_key, str):
             c_ptr = self._alloc(obs_key, all_timestep_active)
             if c_ptr:
-                super(LocalObsdataNode, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ArgumentError(
                     'Unable to construct LocalObsdataNode with key = "%s".' % obs_key

--- a/res/enkf/log_config.py
+++ b/res/enkf/log_config.py
@@ -77,7 +77,7 @@ class LogConfig(BaseCClass):
 
         if c_ptr is None:
             raise ValueError("Failed to construct LogConfig instance")
-        super(LogConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __repr__(self):
         return "LogConfig(log_file=%s, log_level=%r)" % (self.log_file, self.log_level)

--- a/res/enkf/meas_block.py
+++ b/res/enkf/meas_block.py
@@ -32,7 +32,7 @@ class MeasBlock(BaseCClass):
         assert isinstance(ens_mask, BoolVector)
         c_ptr = self._alloc(obs_key, ens_mask, obs_size)
         if c_ptr:
-            super(MeasBlock, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError("Unable to construct MeasBlock.")
 

--- a/res/enkf/meas_data.py
+++ b/res/enkf/meas_data.py
@@ -36,7 +36,7 @@ class MeasData(BaseCClass):
     def __init__(self, ens_mask):
         c_ptr = self._alloc(ens_mask)
         if c_ptr:
-            super(MeasData, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Unable to construct MeasData from given ensemble mask of type %s."

--- a/res/enkf/model_config.py
+++ b/res/enkf/model_config.py
@@ -212,7 +212,7 @@ class ModelConfig(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct ModelConfig instance.")
 
-        super(ModelConfig, self).__init__(c_ptr, is_reference=is_reference)
+        super().__init__(c_ptr, is_reference=is_reference)
 
     def hasHistory(self):
         return self._has_history()

--- a/res/enkf/node_id.py
+++ b/res/enkf/node_id.py
@@ -15,7 +15,7 @@ class NodeId(Structure):
         @type report_step: int
         @type realization_number: int
         """
-        super(NodeId, self).__init__(report_step, realization_number)
+        super().__init__(report_step, realization_number)
 
     def __repr__(self):
         rs = self.report_step

--- a/res/enkf/obs_block.py
+++ b/res/enkf/obs_block.py
@@ -27,7 +27,7 @@ class ObsBlock(BaseCClass):
         c_pointer = self._alloc(
             obs_key, obs_size, error_covar, error_covar_owner, global_std_scaling
         )
-        super(ObsBlock, self).__init__(c_pointer)
+        super().__init__(c_pointer)
 
     def totalSize(self):
         return self._total_size()

--- a/res/enkf/obs_data.py
+++ b/res/enkf/obs_data.py
@@ -46,7 +46,7 @@ class ObsData(BaseCClass):
 
     def __init__(self, global_std_scaling=1.0):
         c_pointer = self._alloc(global_std_scaling)
-        super(ObsData, self).__init__(c_pointer)
+        super().__init__(c_pointer)
 
     def __len__(self):
         """@rtype: int"""

--- a/res/enkf/observations/block_observation.py
+++ b/res/enkf/observations/block_observation.py
@@ -58,7 +58,7 @@ class BlockObservation(BaseCClass):
         self, obs_key, data_config: Union[BlockDataConfig, FieldConfig], grid: EclGrid
     ):
         c_ptr = self._alloc(obs_key, data_config, grid)
-        super(BlockObservation, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def getCoordinate(self, index):
         """@rtype: tuple of (int, int, int)"""

--- a/res/enkf/observations/gen_observation.py
+++ b/res/enkf/observations/gen_observation.py
@@ -59,7 +59,7 @@ class GenObservation(BaseCClass):
     ):
         c_ptr = self._alloc(data_config, obs_key)
         if c_ptr:
-            super(GenObservation, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Unable to construct GenObservation with given obs_key and data_config!"

--- a/res/enkf/observations/obs_vector.py
+++ b/res/enkf/observations/obs_vector.py
@@ -70,7 +70,7 @@ class ObsVector(BaseCClass):
         assert isinstance(config_node, EnkfConfigNode)
         assert isinstance(num_reports, int)
         c_ptr = self._alloc(observation_type, observation_key, config_node, num_reports)
-        super(ObsVector, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def getDataKey(self):
         """@rtype: str"""

--- a/res/enkf/observations/summary_observation.py
+++ b/res/enkf/observations/summary_observation.py
@@ -59,7 +59,7 @@ class SummaryObservation(BaseCClass):
             summary_key, observation_key, value, std, auto_corrf_name, auto_corrf_param
         )
         if c_ptr:
-            super(SummaryObservation, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Unable to construct SummaryObservation with given configuration!"

--- a/res/enkf/plot_data/ensemble_plot_data.py
+++ b/res/enkf/plot_data/ensemble_plot_data.py
@@ -26,7 +26,7 @@ class EnsemblePlotData(BaseCClass):
         assert isinstance(ensemble_config_node, EnkfConfigNode)
 
         c_pointer = self._alloc(ensemble_config_node)
-        super(EnsemblePlotData, self).__init__(c_pointer)
+        super().__init__(c_pointer)
 
         if file_system is not None:
             self.load(file_system, user_index, input_mask)

--- a/res/enkf/plot_data/ensemble_plot_gen_data.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_data.py
@@ -48,7 +48,7 @@ class EnsemblePlotGenData(BaseCClass):
 
         c_ptr = self._alloc(ensemble_config_node)
         if c_ptr:
-            super(EnsemblePlotGenData, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Unable to construct EnsemplePlotGenData from given config node!"

--- a/res/enkf/plot_data/ensemble_plot_gen_kw.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_kw.py
@@ -54,7 +54,7 @@ class EnsemblePlotGenKW(BaseCClass):
         assert ensemble_config_node.getImplementationType() == ErtImplType.GEN_KW
 
         c_pointer = self._alloc(ensemble_config_node)
-        super(EnsemblePlotGenKW, self).__init__(c_pointer)
+        super().__init__(c_pointer)
 
         self.__load(file_system, input_mask)
 

--- a/res/enkf/plot_data/plot_block_data.py
+++ b/res/enkf/plot_data/plot_block_data.py
@@ -3,7 +3,7 @@ from ecl.util.util import DoubleVector
 from res.enkf.plot_data.plot_block_vector import PlotBlockVector
 
 
-class PlotBlockData(object):
+class PlotBlockData:
     def __init__(self, depth_vector):
         """
         @type depth_vector: DoubleVector

--- a/res/enkf/plot_data/plot_block_data_loader.py
+++ b/res/enkf/plot_data/plot_block_data_loader.py
@@ -7,7 +7,7 @@ from res.enkf.plot_data.plot_block_data import PlotBlockData
 from res.enkf.plot_data.plot_block_vector import PlotBlockVector
 
 
-class PlotBlockDataLoader(object):
+class PlotBlockDataLoader:
     def __init__(self, obs_vector):
         """
         @type obs_vector: ObsVector
@@ -16,7 +16,7 @@ class PlotBlockDataLoader(object):
             raise ArgumentError(
                 "Cannot construct PlotBlockDataLoader without obs_vector.  Was None."
             )
-        super(PlotBlockDataLoader, self).__init__()
+        super().__init__()
         self.__obs_vector = obs_vector
         self.__permutation_vector = None
 

--- a/res/enkf/plot_data/plot_block_vector.py
+++ b/res/enkf/plot_data/plot_block_vector.py
@@ -1,13 +1,13 @@
 from ecl.util.util import DoubleVector
 
 
-class PlotBlockVector(object):
+class PlotBlockVector:
     def __init__(self, realization_number, data):
         """
         @type realization_number: int
         @type data: DoubleVector
         """
-        super(PlotBlockVector, self).__init__()
+        super().__init__()
 
         assert isinstance(data, DoubleVector)
 

--- a/res/enkf/queue_config.py
+++ b/res/enkf/queue_config.py
@@ -95,7 +95,7 @@ class QueueConfig(BaseCClass):
         if not c_ptr:
             raise ValueError("Unable to create QueueConfig instance")
 
-        super(QueueConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
         # Need to create
         if config_dict is not None:

--- a/res/enkf/res_config.py
+++ b/res/enkf/res_config.py
@@ -130,7 +130,7 @@ class ResConfig(BaseCClass):
         c_ptr = self._alloc_full(config_dir, user_config_file, *configs)
 
         if c_ptr:
-            super(ResConfig, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Failed to construct ResConfig instance from %r."

--- a/res/enkf/rng_config.py
+++ b/res/enkf/rng_config.py
@@ -49,7 +49,7 @@ class RNGConfig(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct RNGConfig instance")
 
-        super(RNGConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     @property
     def alg_type(self):

--- a/res/enkf/row_scaling.py
+++ b/res/enkf/row_scaling.py
@@ -38,7 +38,7 @@ class RowScaling(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(RowScaling, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def free(self):
         self._free()

--- a/res/enkf/runpath_list.py
+++ b/res/enkf/runpath_list.py
@@ -29,7 +29,7 @@ class RunpathList(BaseCClass):
     def __init__(self, export_file):
         c_ptr = self._alloc(export_file)
         if c_ptr:
-            super(RunpathList, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise IOError(
                 'Could not construct RunpathList with export_file "%s".' % export_file

--- a/res/enkf/site_config.py
+++ b/res/enkf/site_config.py
@@ -148,7 +148,7 @@ class SiteConfig(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct SiteConfig instance.")
 
-        super(SiteConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __repr__(self):
         return "Site Config {}".format(SiteConfig.getLocation())

--- a/res/enkf/state_map.py
+++ b/res/enkf/state_map.py
@@ -42,7 +42,7 @@ class StateMap(BaseCClass):
 
     def __init__(self, filename=None):
         c_ptr = self._alloc()
-        super(StateMap, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         if filename:
             self.load(filename)
 

--- a/res/enkf/subst_config.py
+++ b/res/enkf/subst_config.py
@@ -121,7 +121,7 @@ class SubstConfig(BaseCClass):
         if c_ptr is None:
             raise ValueError("Failed to construct Substonfig instance")
 
-        super(SubstConfig, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __getitem__(self, key):
         subst_list = self._get_subst_list()

--- a/res/enkf/summary_key_matcher.py
+++ b/res/enkf/summary_key_matcher.py
@@ -26,7 +26,7 @@ class SummaryKeyMatcher(BaseCClass):
     def __init__(self):
         c_ptr = self._alloc()
 
-        super(SummaryKeyMatcher, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def addSummaryKey(self, key):
         assert isinstance(key, str)

--- a/res/enkf/summary_key_set.py
+++ b/res/enkf/summary_key_set.py
@@ -29,7 +29,7 @@ class SummaryKeySet(BaseCClass):
         else:
             c_ptr = self._alloc_from_file(filename, read_only)
 
-        super(SummaryKeySet, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def addSummaryKey(self, key):
         assert isinstance(key, str)

--- a/res/enkf/util/time_map.py
+++ b/res/enkf/util/time_map.py
@@ -51,7 +51,7 @@ class TimeMap(BaseCClass):
 
     def __init__(self, filename=None):
         c_ptr = self._alloc()
-        super(TimeMap, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         if filename:
             self.load(filename)
 

--- a/res/fm/ecl/ecl_config.py
+++ b/res/fm/ecl/ecl_config.py
@@ -24,7 +24,7 @@ def _replace_env(env):
     return new_env
 
 
-class Keys(object):
+class Keys:
     default_version = "default_version"
     default = "default"
     versions = "versions"
@@ -35,7 +35,7 @@ class Keys(object):
     scalar = "scalar"
 
 
-class Simulator(object):
+class Simulator:
     """Small 'struct' with the config information for one simulator."""
 
     def __init__(self, version, executable, env, mpirun=None):
@@ -67,7 +67,7 @@ class Simulator(object):
         )
 
 
-class EclConfig(object):
+class EclConfig:
     """Represent the eclipse configuration at a site.
 
     The EclConfig class internalizes information of where the various eclipse
@@ -182,7 +182,7 @@ class Ecl100Config(EclConfig):
 
     def __init__(self):
         config_file = os.getenv("ECL100_SITE_CONFIG", default=self.DEFAULT_CONFIG_FILE)
-        super(Ecl100Config, self).__init__(config_file, simulator_name="eclipse")
+        super().__init__(config_file, simulator_name="eclipse")
 
 
 class Ecl300Config(EclConfig):
@@ -191,7 +191,7 @@ class Ecl300Config(EclConfig):
 
     def __init__(self):
         config_file = os.getenv("ECL300_SITE_CONFIG", default=self.DEFAULT_CONFIG_FILE)
-        super(Ecl300Config, self).__init__(config_file, simulator_name="e300")
+        super().__init__(config_file, simulator_name="e300")
 
 
 class FlowConfig(EclConfig):
@@ -200,7 +200,7 @@ class FlowConfig(EclConfig):
 
     def __init__(self):
         config_file = os.getenv("FLOW_SITE_CONFIG", default=self.DEFAULT_CONFIG_FILE)
-        super(FlowConfig, self).__init__(config_file, simulator_name="flow")
+        super().__init__(config_file, simulator_name="flow")
 
 
 class EclrunConfig:

--- a/res/fm/ecl/ecl_run.py
+++ b/res/fm/ecl/ecl_run.py
@@ -124,7 +124,7 @@ def pushd(run_path):
     os.chdir(starting_directory)
 
 
-class EclRun(object):
+class EclRun:
     """Wrapper class to run Eclipse simulations.
 
     The EclRun class is a small wrapper class which is used to run Eclipse

--- a/res/fm/rms/rms_config.py
+++ b/res/fm/rms/rms_config.py
@@ -4,7 +4,7 @@ import yaml
 import shutil
 
 
-class RMSConfig(object):
+class RMSConfig:
     DEFAULT_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "rms_config.yml")
 
     def __init__(self):

--- a/res/fm/rms/rms_run.py
+++ b/res/fm/rms/rms_run.py
@@ -24,7 +24,7 @@ class RMSRunException(Exception):
     pass
 
 
-class RMSRun(object):
+class RMSRun:
     _single_seed_file = "RMS_SEED"
     _multi_seed_file = "random.seeds"
     _max_seed = 2146483648

--- a/res/fm/shell/shell.py
+++ b/res/fm/shell/shell.py
@@ -5,7 +5,7 @@ import sys
 import distutils.dir_util
 
 
-class Shell(object):
+class Shell:
     """
     Utility class to simplify common shell operations.
     """

--- a/res/job_queue/driver.py
+++ b/res/job_queue/driver.py
@@ -65,7 +65,7 @@ class Driver(BaseCClass):
         Creates a new driver instance
         """
         c_ptr = self._alloc(driver_type)
-        super(Driver, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         if options:
             for (key, value) in options:
                 self.set_option(key, value)

--- a/res/job_queue/environment_varlist.py
+++ b/res/job_queue/environment_varlist.py
@@ -29,7 +29,7 @@ class EnvironmentVarlist(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(EnvironmentVarlist, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def __len__(self):
         """

--- a/res/job_queue/ert_plugin.py
+++ b/res/job_queue/ert_plugin.py
@@ -5,7 +5,7 @@ import time
 
 class CancelPluginException(Exception):
     def __init__(self, cancel_message):
-        super(CancelPluginException, self).__init__(cancel_message)
+        super().__init__(cancel_message)
 
 
 class ErtPlugin(ErtScript):

--- a/res/job_queue/ert_script.py
+++ b/res/job_queue/ert_script.py
@@ -5,12 +5,12 @@ import traceback
 import importlib.util
 
 
-class ErtScript(object):
+class ErtScript:
     def __init__(self, ert):
         """
         @type ert: EnKFMain
         """
-        super(ErtScript, self).__init__()
+        super().__init__()
 
         if not hasattr(self, "run"):
             raise UserWarning(

--- a/res/job_queue/ext_job.py
+++ b/res/job_queue/ext_job.py
@@ -86,7 +86,7 @@ class ExtJob(BaseCClass):
                 name, license_root_path, private, config_file, search_PATH
             )
             if c_ptr:
-                super(ExtJob, self).__init__(c_ptr)
+                super().__init__(c_ptr)
             else:
                 raise ValueError(
                     "Unable to construct ExtJob(name=%s, config_file=%s, private=%s)"

--- a/res/job_queue/ext_joblist.py
+++ b/res/job_queue/ext_joblist.py
@@ -34,7 +34,7 @@ class ExtJoblist(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(ExtJoblist, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def get_jobs(self):
         """@rtype: Hash"""

--- a/res/job_queue/external_ert_script.py
+++ b/res/job_queue/external_ert_script.py
@@ -6,7 +6,7 @@ from res.job_queue import ErtScript
 
 class ExternalErtScript(ErtScript):
     def __init__(self, ert, executable):
-        super(ExternalErtScript, self).__init__(ert)
+        super().__init__(ert)
 
         self.__executable = executable
         self.__job = None
@@ -31,7 +31,7 @@ class ExternalErtScript(ErtScript):
         return None
 
     def cancel(self):
-        super(ExternalErtScript, self).cancel()
+        super().cancel()
         if self.__job is not None:
             self.__job.terminate()
 

--- a/res/job_queue/forward_model.py
+++ b/res/job_queue/forward_model.py
@@ -46,7 +46,7 @@ class ForwardModel(BaseCClass):
     def __init__(self, ext_joblist: ExtJoblist):
         c_ptr = self._alloc(ext_joblist)
         if c_ptr:
-            super(ForwardModel, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Failed to construct forward model from provided ext_joblist %s"

--- a/res/job_queue/forward_model_status.py
+++ b/res/job_queue/forward_model_status.py
@@ -37,7 +37,7 @@ def _deserialize_date(serial_dt):
     return datetime.datetime(*time_struct[0:6])
 
 
-class ForwardModelJobStatus(object):
+class ForwardModelJobStatus:
     def __init__(
         self,
         name,
@@ -103,7 +103,7 @@ class ForwardModelJobStatus(object):
         }
 
 
-class ForwardModelStatus(object):
+class ForwardModelStatus:
     def __init__(self, run_id, start_time, end_time=None):
         self.run_id = run_id
         self.start_time = start_time

--- a/res/job_queue/function_ert_script.py
+++ b/res/job_queue/function_ert_script.py
@@ -8,12 +8,12 @@ class _NonePrototype(cwrap.Prototype):
     lib = cwrap.load(None)
 
     def __init__(self, prototype, bind=True):
-        super(_NonePrototype, self).__init__(_NonePrototype.lib, prototype, bind=bind)
+        super().__init__(_NonePrototype.lib, prototype, bind=bind)
 
 
 class FunctionErtScript(ErtScript):
     def __init__(self, ert, function_name, argument_types, argument_count):
-        super(FunctionErtScript, self).__init__(ert)
+        super().__init__(ert)
 
         parsed_argument_types = []
 

--- a/res/job_queue/job.py
+++ b/res/job_queue/job.py
@@ -34,7 +34,7 @@ class Job(BaseCClass):
     def __init__(self, c_ptr, driver):
         self.driver = driver
         self.submit_time = datetime.datetime.now()
-        super(Job, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def free(self):
         pass

--- a/res/job_queue/job_queue_node.py
+++ b/res/job_queue/job_queue_node.py
@@ -97,7 +97,7 @@ class JobQueueNode(BaseCClass):
         )
 
         if c_ptr is not None:
-            super(JobQueueNode, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError("Unable to create job node object")
 

--- a/res/job_queue/queue.py
+++ b/res/job_queue/queue.py
@@ -162,7 +162,7 @@ class JobQueue(BaseCClass):
         self.job_list = []
         self._stopped = False
         c_ptr = self._alloc(max_submit, OK_file, status_file, exit_file)
-        super(JobQueue, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         self.size = size
 
         self.driver = driver

--- a/res/job_queue/workflow.py
+++ b/res/job_queue/workflow.py
@@ -28,7 +28,7 @@ class Workflow(BaseCClass):
         @type job_list: WorkflowJoblist
         """
         c_ptr = self._alloc(src_file, job_list)
-        super(Workflow, self).__init__(c_ptr)  # pylint: disable=super-with-arguments
+        super().__init__(c_ptr)
 
         self.__running = False
         self.__cancelled = False
@@ -138,7 +138,7 @@ class Workflow(BaseCClass):
 
     @classmethod
     def createCReference(cls, c_pointer, parent=None):
-        workflow = super(Workflow, cls).createCReference(c_pointer, parent)
+        workflow = super().createCReference(c_pointer, parent)
         workflow.__running = False
         workflow.__cancelled = False
         workflow.__current_job = None

--- a/res/job_queue/workflow_job.py
+++ b/res/job_queue/workflow_job.py
@@ -54,7 +54,7 @@ class WorkflowJob(BaseCClass):
 
     def __init__(self, name, internal=True):
         c_ptr = self._alloc(name, internal)
-        super(WorkflowJob, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
         self.__script = None
         """ :type: ErtScript """
@@ -211,7 +211,7 @@ class WorkflowJob(BaseCClass):
 
     @classmethod
     def createCReference(cls, c_pointer, parent=None):
-        workflow = super(WorkflowJob, cls).createCReference(c_pointer, parent)
+        workflow = super().createCReference(c_pointer, parent)
         workflow.__script = None
         workflow.__running = False
         return workflow

--- a/res/job_queue/workflow_joblist.py
+++ b/res/job_queue/workflow_joblist.py
@@ -25,7 +25,7 @@ class WorkflowJoblist(BaseCClass):
 
     def __init__(self):
         c_ptr = self._alloc()
-        super(WorkflowJoblist, self).__init__(c_ptr)
+        super().__init__(c_ptr)
 
     def addJob(self, job):
         """@type job: WorkflowJob"""

--- a/res/job_queue/workflow_runner.py
+++ b/res/job_queue/workflow_runner.py
@@ -4,14 +4,14 @@ from res.job_queue import Workflow
 from res.util.substitution_list import SubstitutionList
 
 
-class WorkflowRunner(object):
+class WorkflowRunner:
     def __init__(self, workflow: Workflow, ert=None, context: SubstitutionList = None):
         """
         @type workflow: Workflow
         @type ert: res.enkf.EnKFMain
         @type context: SubstitutionList
         """
-        super(WorkflowRunner, self).__init__()
+        super().__init__()
 
         self.__workflow = workflow
         self.__ert = ert

--- a/res/sched/history.py
+++ b/res/sched/history.py
@@ -52,7 +52,7 @@ class History(BaseCClass):
         self._init_val = str(refcase)
         c_ptr = self._alloc_from_refcase(refcase, use_history)
         if c_ptr:
-            super(History, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError("Invalid input.  Failed to create History.")
 

--- a/res/simulator/batch_simulator.py
+++ b/res/simulator/batch_simulator.py
@@ -12,7 +12,7 @@ def _slug(entity):
     return "".join([x if x.isalnum() else "_" for x in entity.strip()])
 
 
-class BatchSimulator(object):
+class BatchSimulator:
     def __init__(self, res_config, controls, results, callback=None):
         """Will create simulator which can be used to run multiple simulations.
 

--- a/res/simulator/batch_simulator_context.py
+++ b/res/simulator/batch_simulator_context.py
@@ -17,7 +17,7 @@ class BatchContext(SimulationContext):
         """
         Handle which can be used to query status and results for batch simulation.
         """
-        super(BatchContext, self).__init__(ert, fs, mask, itr, case_data)
+        super().__init__(ert, fs, mask, itr, case_data)
         self.result_keys = result_keys
         self.res_config = ert.resConfig()
 

--- a/res/simulator/simulation_context.py
+++ b/res/simulator/simulation_context.py
@@ -5,7 +5,7 @@ from threading import Thread
 from time import sleep
 
 
-class SimulationContext(object):
+class SimulationContext:
     def __init__(self, ert, sim_fs, mask, itr, case_data):
         self._ert = ert
         """ :type: res.enkf.EnKFMain """

--- a/res/test/ert_test_context.py
+++ b/res/test/ert_test_context.py
@@ -21,7 +21,7 @@ import tempfile
 import shutil
 
 
-class ErtTestContext(object):
+class ErtTestContext:
     def __init__(self, test_name, model_config):
         self._tmp_dir = tempfile.mkdtemp()
         self._model_config = model_config

--- a/res/test/synthesizer/oil_simulator.py
+++ b/res/test/synthesizer/oil_simulator.py
@@ -1,7 +1,7 @@
 from .shaped_perlin import ShapeCreator, ShapeFunction
 
 
-class OilSimulator(object):
+class OilSimulator:
     OPR_SHAPE = ShapeFunction([0.0, 0.2, 0.5, 0.7, 1.0], [0.0, 0.7, 0.2, 0.1, 0.01])
     GPR_SHAPE = ShapeFunction([0.0, 0.2, 0.5, 0.7, 1.0], [0.0, 0.5, 0.7, 0.7, 0.3])
     WPR_SHAPE = ShapeFunction([0.0, 0.2, 0.5, 0.7, 1.0], [0.0, 0.01, 0.3, 0.7, 1])

--- a/res/test/synthesizer/perlin.py
+++ b/res/test/synthesizer/perlin.py
@@ -3,7 +3,7 @@ import math
 from .prime_generator import PrimeGenerator
 
 
-class PerlinNoise(object):
+class PerlinNoise:
     def __init__(self, persistence=0.5, number_of_octaves=4, prime_generator=None):
         self.persistence = persistence
         self.number_of_octaves = number_of_octaves

--- a/res/test/synthesizer/prime_generator.py
+++ b/res/test/synthesizer/prime_generator.py
@@ -21,7 +21,7 @@ def rwh_primes2(n):
     return [2, 3] + [3 * i + 1 | 1 for i in range(1, n // 3 - correction) if sieve[i]]
 
 
-class PrimeGenerator(object):
+class PrimeGenerator:
     LIST_OF_PRIMES = rwh_primes2(10000)
 
     def __init__(self, seed=None):

--- a/res/test/synthesizer/shaped_perlin.py
+++ b/res/test/synthesizer/shaped_perlin.py
@@ -4,7 +4,7 @@ from .perlin import PerlinNoise
 from .prime_generator import PrimeGenerator
 
 
-class Interpolator(object):
+class Interpolator:
     def __init__(self, x, y):
         self.x = x
         self.y = y
@@ -33,7 +33,7 @@ class Interpolator(object):
         return a * (1 - f) + b * f
 
 
-class ShapeFunction(object):
+class ShapeFunction:
     def __init__(self, x, y, scale=1.0):
         self.scale = scale
         self.interpolator = Interpolator(x, y)
@@ -47,10 +47,10 @@ class ShapeFunction(object):
 
 class ConstantShapeFunction(ShapeFunction):
     def __init__(self, value):
-        super(ConstantShapeFunction, self).__init__([0.0], [value])
+        super().__init__([0.0], [value])
 
 
-class ShapedNoise(object):
+class ShapedNoise:
     def __init__(
         self, noiseFunction, shapeFunction, divergenceFunction, offset=0.0, cutoff=None
     ):
@@ -71,7 +71,7 @@ class ShapedNoise(object):
         return result
 
 
-class ShapeCreator(object):
+class ShapeCreator:
     @staticmethod
     def createShapeFunction(count=1000, persistence=0.2, octaves=8, seed=1):
         """@rtype: ShapeFunction"""

--- a/res/util/matrix.py
+++ b/res/util/matrix.py
@@ -75,7 +75,7 @@ class Matrix(BaseCClass):
 
     def __init__(self, rows, columns, value=0):
         c_ptr = self._matrix_alloc(rows, columns)
-        super(Matrix, self).__init__(c_ptr)
+        super().__init__(c_ptr)
         self.setAll(value)
 
     def copy(self):

--- a/res/util/path_format.py
+++ b/res/util/path_format.py
@@ -32,7 +32,7 @@ class PathFormat(BaseCClass):
     def __init__(self, path_fmt):
         c_ptr = self._alloc(path_fmt)
         if c_ptr:
-            super(PathFormat, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError('Unable to construct path format "%s"' % path_fmt)
 

--- a/res/util/substitution_list.py
+++ b/res/util/substitution_list.py
@@ -20,7 +20,7 @@ class SubstitutionList(BaseCClass):
         c_ptr = self._alloc(None)
 
         if c_ptr:
-            super(SubstitutionList, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError("Failed to construct subst_list instance.")
 

--- a/res/util/ui_return.py
+++ b/res/util/ui_return.py
@@ -36,7 +36,7 @@ class UIReturn(BaseCClass):
     def __init__(self, status):
         c_ptr = self._alloc(status)
         if c_ptr:
-            super(UIReturn, self).__init__(c_ptr)
+            super().__init__(c_ptr)
         else:
             raise ValueError(
                 "Unable to construct UIReturn with status = %s" % str(status)

--- a/test-data/local/mini_ert/jobs/perlin.py
+++ b/test-data/local/mini_ert/jobs/perlin.py
@@ -396,7 +396,7 @@ PRIME_INDEX_3 = [
 ]
 
 
-class PerlinNoise(object):
+class PerlinNoise:
     def __init__(
         self,
         persistence=0.5,

--- a/tests/ert_tests/data/mocked_block_observation.py
+++ b/tests/ert_tests/data/mocked_block_observation.py
@@ -1,4 +1,4 @@
-class MockedBlockObservation(object):
+class MockedBlockObservation:
     def __init__(self, data):
         self.values = data["values"]
         self.stds = data["stds"]

--- a/tests/ert_tests/gui/run_analysis/test_run_analysis.py
+++ b/tests/ert_tests/gui/run_analysis/test_run_analysis.py
@@ -18,7 +18,7 @@ class MockedQIcon(QIcon):
 
 class RunAnalysisTests(ErtTest):
     def __init__(self, *args, **kwargs):
-        super(ErtTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         with patch("ert_gui.tools.run_analysis.run_analysis_tool.resourceIcon") as rs:
             rs.return_value = MockedQIcon()

--- a/tests/ert_tests/gui/simulation/test_realization_view.py
+++ b/tests/ert_tests/gui/simulation/test_realization_view.py
@@ -10,7 +10,7 @@ from ert_gui.simulation.view.realization import RealizationWidget
 
 class MockDelegate(QStyledItemDelegate):
     def __init__(self, parent=None) -> None:
-        super(MockDelegate, self).__init__(parent)
+        super().__init__(parent)
         self._size = QSize(50, 50)
         self._max_id = 0
 

--- a/tests/libres_tests/import_tester.py
+++ b/tests/libres_tests/import_tester.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 
 
-class ImportTester(object):
+class ImportTester:
     @staticmethod
     def testImport(module):
         try:

--- a/tests/libres_tests/res/config/test_config.py
+++ b/tests/libres_tests/res/config/test_config.py
@@ -32,7 +32,7 @@ from res.config import (
 
 class TestConfigPrototype(ResPrototype):
     def __init__(self, prototype, bind=False):
-        super(TestConfigPrototype, self).__init__(prototype, bind=bind)
+        super().__init__(prototype, bind=bind)
 
 
 # Adding extra functions to the ConfigContent object for the ability

--- a/tests/libres_tests/res/enkf/test_row_scaling_case.py
+++ b/tests/libres_tests/res/enkf/test_row_scaling_case.py
@@ -107,7 +107,7 @@ def init_data(main):
 # This is an example callable which decays as a gaussian away from a position
 # obs_pos; this is (probaly) a simplified version of tapering function which
 # will be interesting to use.
-class GaussianDecay(object):
+class GaussianDecay:
     def __init__(self, obs_pos, length_scale, grid):
         self.obs_pos = obs_pos
         self.length_scale = length_scale
@@ -123,7 +123,7 @@ class GaussianDecay(object):
         return math.exp(exp_arg)
 
 
-class SelectLayer(object):
+class SelectLayer:
     def __init__(self, layer, grid):
         self.layer = layer
         self.grid = grid
@@ -156,7 +156,7 @@ class SelectLayer(object):
 # these constraints.
 
 
-class ScalingTest(object):
+class ScalingTest:
     def __init__(self, grid):
         self.grid = grid
 

--- a/tests/libres_tests/res/job_queue/test_workflow_job.py
+++ b/tests/libres_tests/res/job_queue/test_workflow_job.py
@@ -8,7 +8,7 @@ from res.job_queue import WorkflowJob
 
 class _TestWorkflowJobPrototype(ResPrototype):
     def __init__(self, prototype, bind=True):
-        super(_TestWorkflowJobPrototype, self).__init__(prototype, bind=bind)
+        super().__init__(prototype, bind=bind)
 
 
 class WorkflowJobTest(ResTest):

--- a/tests/libres_tests/res/job_queue/workflow_common.py
+++ b/tests/libres_tests/res/job_queue/workflow_common.py
@@ -2,7 +2,7 @@ import os
 import stat
 
 
-class WorkflowCommon(object):
+class WorkflowCommon:
     @staticmethod
     def createExternalDumpJob():
         with open("dump_job", "w") as f:

--- a/tests/libres_tests/res/simulator/test_batch_sim.py
+++ b/tests/libres_tests/res/simulator/test_batch_sim.py
@@ -12,7 +12,7 @@ from res.job_queue import JobStatusType
 from res.simulator import BatchContext, BatchSimulator
 
 
-class MockMonitor(object):
+class MockMonitor:
     def __init__(self):
         self.sim_context = None
 


### PR DESCRIPTION
Removes use of `six`, super with arguments and inheritance from `object` which were left over from interoperability with python 2. python2 interoperability is spotty in any case as `six` is not part of `install_requires` and f-strings are used in some places.