### PR TITLE
Remove unused loadGenDataObservations

### DIFF
--- a/res/enkf/export/gen_data_observation_collector.py
+++ b/res/enkf/export/gen_data_observation_collector.py
@@ -1,5 +1,3 @@
-from pandas import DataFrame
-
 from res.enkf import EnKFMain
 from res.enkf.enums import EnkfObservationImplementationType
 
@@ -35,44 +33,3 @@ class GenDataObservationCollector:
                     observation_key = obs_vector.getObservationKey()
 
         return observation_key
-
-    @staticmethod
-    def loadGenDataObservations(ert: EnKFMain, case_name, key):
-        """
-        @type ert: EnKFMain
-        @type case_name: str
-        @type key: name of an observation key
-        @rtype: DataFrame
-        """
-        fs = ert.getEnkfFsManager().getFileSystem(case_name)
-
-        available_observation_keys = GenDataObservationCollector.getAllObservationKeys(
-            ert
-        )
-        if key not in available_observation_keys:
-            raise KeyError("Key '%s' is not a valid observation key")
-
-        columns = [key]
-        std_columns = ["STD_%s" % key]
-
-        enkf_obs = ert.getObservations()
-
-        index_set = set()
-        obs_vector = enkf_obs[key]
-        report_step = obs_vector.activeStep()
-
-        obs_node = obs_vector.getNode(report_step)
-        # """ :type: res.enkf.observations.GenObservation """
-
-        for obs_index in range(len(obs_node)):
-            index_set.add(obs_node.getIndex(obs_index))
-
-        index_list = sorted(list(index_set))
-        data = DataFrame(index=index_list, columns=columns + std_columns)
-
-        for obs_index, (value, std) in enumerate(obs_node):
-            data_index = obs_node.getIndex(obs_index)
-            data[key][data_index] = value
-            data["STD_%s" % key][data_index] = std
-
-        return data

--- a/tests/libres_tests/res/enkf/export/test_gen_data_observation_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_gen_data_observation_collector.py
@@ -36,15 +36,3 @@ class GenDataObservationCollectorTest(ResTest):
                 ert, "PERLINk", 1
             )
             self.assertIsNone(obs_key)
-
-            data = GenDataObservationCollector.loadGenDataObservations(
-                ert, "default", "GEN_PERLIN_1"
-            )
-
-            self.assertFloatEqual(data["GEN_PERLIN_1"][0], -0.616789)
-            self.assertFloatEqual(data["STD_GEN_PERLIN_1"][0], 0.2)
-
-            with self.assertRaises(KeyError):
-                GenDataObservationCollector.loadGenDataObservations(
-                    ert, "default", "GEN_PERLIN_4"
-                )


### PR DESCRIPTION
loadGenDataObservations is unused by ert, everest, and subscript.

The function was introduced in https://github.com/equinor/ert/commit/8a01e74b38580e326e47aa4012e206d15ec3dffe and used by `ert_gui/shell/gen_data_keys.py` which stopped using the module in favor of `ert_gui.plotterty:PlotDataGatherer` in https://github.com/equinor/ert/commit/2c23dc40c832ff42cfaf73ec5c4163f02bcbc122 . `ert_gui.shell` was deprecated in  https://github.com/equinor/ert/commit/5183380c0439ad6116d6fd19e859bbe697688fb0