### PR TITLE
Add docstrings into `ert3.data` module

### DIFF
--- a/ert/data/record/_transformation.py
+++ b/ert/data/record/_transformation.py
@@ -15,7 +15,7 @@ _BIN_FOLDER = "bin"
 
 
 def _prepare_location(base_path: Path, location: Path) -> None:
-    """Ensure relative, and if the location is within a folder, create those
+    """Ensure relative, and if the location is within a folder create those
     folders."""
     if location.is_absolute():
         raise ValueError(f"location {location} must be relative")
@@ -32,12 +32,24 @@ def _sync_make_tar(file_path: Path) -> bytes:
 
 
 async def _make_tar(file_path: Path) -> bytes:
-    # Walk the files under a filepath and encapsulate them in a tar package.
+    """Walk the files under a filepath and encapsulate the file(s)
+    in a tar package.
+
+    Args:
+        file_path: The path to convert to tar.
+
+    Returns:
+        bytes: bytes from in memory tar object.
+    """
     executor = futures.ThreadPoolExecutor()
     return await get_event_loop().run_in_executor(executor, _sync_make_tar, file_path)
 
 
 class RecordTransformation(ABC):
+    """:class:`RecordTransformation` is an abstract class that handles
+    custom save and load operations on Records to and from disk.
+    """
+
     @abstractmethod
     async def transform_input(
         self, record: Record, mime: str, runpath: Path, location: Path
@@ -50,9 +62,23 @@ class RecordTransformation(ABC):
 
 
 class FileRecordTransformation(RecordTransformation):
+    """:class:`FileRecordTransformation` is :class:`RecordTransformation`
+    implementation which provides basic Record to disk and disk to Record
+    functionality.
+    """
+
     async def transform_input(
         self, record: Record, mime: str, runpath: Path, location: Path
     ) -> None:
+        """Transforms a Record to disk on the given location via a serializer
+        given in the mime type.
+
+        Args:
+            record: a record object to save to disk
+            mime: mime type to fetch the corresponding serializer
+            runpath: the root of the path
+            location: filename to save the Record to
+        """
         if not isinstance(record, (NumericalRecord, BlobRecord)):
             raise TypeError("Record type must be a NumericalRecord or BlobRecord")
 
@@ -60,6 +86,18 @@ class FileRecordTransformation(RecordTransformation):
         await _save_record_to_file(record, runpath / location, mime)
 
     async def transform_output(self, mime: str, location: Path) -> Record:
+        """Transfroms a file to Record from the given location via
+        a serializer given in the mime type.
+
+        Args:
+            mime: mime type to fetch the corresponding serializer
+            runpath: the root of the path
+            location: filename to load the Record from
+
+        Returns:
+            Record: the object is either :class:`BlobRecord` or
+                :class:`NumericalRecord`
+        """
         return await _load_record_from_file(location, mime)
 
     async def transform_output_sequence(
@@ -72,9 +110,29 @@ class FileRecordTransformation(RecordTransformation):
 
 
 class TarRecordTransformation(RecordTransformation):
+    """:class:`TarRecordTransformation` is :class:`RecordTransformation`
+    implementation which provides creating a tar object from a given location
+    into a BlobRecord :func:`TarRecordTransformation.transform_output` and
+    extracting tar object (:class:`BlobRecord`) to the given location.
+    """
+
     async def transform_input(
         self, record: Record, mime: str, runpath: Path, location: Path
     ) -> None:
+        """Transforms BlobRecord (tar object) to disk, ie. extracting tar object
+        on the given location.
+
+        Args:
+            record: BlobRecord object, where :func:`BlobRecord.data`
+                is the binary tar object
+            mime: mime type is ignored in this case
+            runpath: the root of the path
+            location: directory name to extract the tar object into
+
+        Raises:
+            TypeError: Raises when the Record (loaded via transmitter)
+                is not BlobRecord
+        """
         if not isinstance(record, BlobRecord):
             raise TypeError("Record type must be a BlobRecord")
 
@@ -83,14 +141,40 @@ class TarRecordTransformation(RecordTransformation):
             tar.extractall(runpath / location)
 
     async def transform_output(self, mime: str, location: Path) -> Record:
+        """Transfroms directory from the given location into a :class:`BlobRecord`
+        object.
 
+        Args:
+            mime: mime type is ignored
+            runpath: the root of the path
+            location: directory name to create tar representation from
+
+        Returns:
+            Record: returns :class:`BlobRecord` object that is a
+                binary representation of the final tar object.
+        """
         return BlobRecord(data=await _make_tar(location))
 
 
 class ExecutableRecordTransformation(RecordTransformation):
+    """:class:`ExecutableRecordTransformation` is :class:`RecordTransformation`
+    implementation which provides creating an executable file; ie. when
+    storing a Record to the file.
+    """
+
     async def transform_input(
         self, record: Record, mime: str, runpath: Path, location: Path
     ) -> None:
+        """Transforms a Record to disk on the given location via
+        via a serializer given in the mime type. Additionally, it makes
+        executable from the file
+
+        Args:
+            record: a record object to save to disk that becomes executable
+            mime: mime type to fetch the corresponding serializer
+            runpath: the root of the path
+            location: filename to save the Record to
+        """
         if not isinstance(record, BlobRecord):
             raise TypeError("Record type must be a BlobRecord")
 
@@ -108,6 +192,17 @@ class ExecutableRecordTransformation(RecordTransformation):
         path.chmod(st.st_mode | stat.S_IEXEC)
 
     async def transform_output(self, mime: str, location: Path) -> Record:
+        """Transforms a file to Record from the given location via
+        a serializer given in the mime type..
+
+        Args:
+            mime: mime type to fetch the corresponding serializer
+            runpath: the root of the path
+            location: filename to load the Record from
+
+        Returns:
+            Record: return object of :class:`BlobRecord` type.
+        """
         return await _load_record_from_file(location, mime)
 
 


### PR DESCRIPTION
**Issue**
Resolves #2421 


**Approach**
- [x] Include docstring `_record.py`.
- [x] Include docstring `_transmitter.py`.
- [x] Include docstring `_transformation.py`.
- [x] include docstring for RecordTree