### PR TITLE
Use localhost for local connections to evaluator

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -285,11 +285,25 @@ class RunDialog(QDialog):
 
         self._ticker.start(1000)
 
-        tracker = create_tracker(
-            self._run_model,
-            num_realizations=self._simulations_argments["active_realizations"].count(),
-            ee_config=self._simulations_argments.get("ee_config", None),
-        )
+        ee_config = self._simulations_argments.get("ee_config", None)
+        if ee_config is None:
+            tracker = create_tracker(
+                self._run_model,
+                num_realizations=self._simulations_argments[
+                    "active_realizations"
+                ].count(),
+            )
+        else:
+            tracker = create_tracker(
+                self._run_model,
+                num_realizations=self._simulations_argments[
+                    "active_realizations"
+                ].count(),
+                ee_host="127.0.0.1",
+                ee_port=ee_config.port,
+                ee_cert=ee_config.cert,
+                ee_token=ee_config.token,
+            )
 
         worker = TrackerWorker(tracker)
         worker_thread = QThread()

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -74,7 +74,17 @@ def run_cli(args):
         )
         thread.start()
 
-        tracker = create_tracker(model, detailed_interval=0, ee_config=ee_config)
+        if ee_config is None:
+            tracker = create_tracker(model, detailed_interval=0)
+        else:
+            tracker = create_tracker(
+                model,
+                detailed_interval=0,
+                ee_host="127.0.0.1",
+                ee_port=ee_config.port,
+                ee_cert=ee_config.cert,
+                ee_token=ee_config.token,
+            )
 
         out = open(os.devnull, "w") if args.disable_monitoring else sys.stderr
         monitor = Monitor(out=out, color_always=args.color_always)

--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -92,6 +92,10 @@ def _generate_certificate(
                     x509.DNSName("{}".format(cert_name)),
                     x509.DNSName(ip_address),
                     x509.IPAddress(ipaddress.ip_address(ip_address)),
+                    x509.DNSName("localhost"),
+                    x509.DNSName("*.localhost"),
+                    x509.DNSName("127.0.0.1"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
                 ]
             ),
             critical=False,
@@ -142,7 +146,7 @@ class EvaluatorServerConfig:
         generate_cert: bool = True,
     ) -> None:
         self.host, self.port, self._socket_handle = port_handler.find_available_port(
-            custom_range=custom_port_range, reuse_addr=True
+            custom_range=custom_port_range, reuse_addr=True, bind_all_interfaces=True
         )
         self.protocol = "wss" if generate_cert else "ws"
         self.url = f"{self.protocol}://{self.host}:{self.port}"

--- a/ert_shared/port_handler.py
+++ b/ert_shared/port_handler.py
@@ -19,18 +19,20 @@ def find_available_port(
     custom_host: Optional[str] = None,
     custom_range: Optional[range] = None,
     reuse_addr: bool = False,
+    bind_all_interfaces: bool = False,
 ) -> Tuple[str, int, socket.socket]:
     current_host = custom_host if custom_host is not None else _get_ip_address()
     current_range = (
         custom_range if custom_range is not None else range(51820, 51840 + 1)
     )
+    bind_host = "0.0.0.0" if bind_all_interfaces else current_host
     if current_range.start == current_range.stop:
         try:
             return (
                 current_host,
                 current_range.start,
                 _bind_socket(
-                    host=current_host, port=current_range.start, reuse_addr=reuse_addr
+                    host=bind_host, port=current_range.start, reuse_addr=reuse_addr
                 ),
             )
         except PortAlreadyInUseException:
@@ -44,7 +46,7 @@ def find_available_port(
                 return (
                     current_host,
                     num,
-                    _bind_socket(host=current_host, port=num, reuse_addr=reuse_addr),
+                    _bind_socket(host=bind_host, port=num, reuse_addr=reuse_addr),
                 )
             except PortAlreadyInUseException:
                 continue

--- a/ert_shared/status/tracker/factory.py
+++ b/ert_shared/status/tracker/factory.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from ert_shared.status.tracker.legacy import LegacyTracker
 from ert_shared.status.tracker.evaluator import EvaluatorTracker
 from ert_shared.status.utils import scale_intervals
@@ -6,10 +7,13 @@ from ert_shared.feature_toggling import FeatureToggling
 
 def create_tracker(
     model,
-    general_interval=5,
-    detailed_interval=10,
-    num_realizations=None,
-    ee_config=None,
+    general_interval: int = 5,
+    detailed_interval: int = 10,
+    num_realizations: Optional[int] = None,
+    ee_host: Optional[str] = None,
+    ee_port: Optional[int] = None,
+    ee_token: Optional[str] = None,
+    ee_cert: Optional[str] = None,
 ):
     """Creates a tracker tracking a @model. The provided model
     is updated either purely event-driven, or in two tiers: @general_interval,
@@ -30,12 +34,12 @@ def create_tracker(
     if FeatureToggling.is_enabled("ensemble-evaluator"):
         return EvaluatorTracker(
             model,
-            ee_config.host,
-            ee_config.port,
-            general_interval,
-            detailed_interval,
-            token=ee_config.token,
-            cert=ee_config.cert,
+            host=ee_host,
+            port=ee_port,
+            general_interval=general_interval,
+            detailed_interval=detailed_interval,
+            token=ee_token,
+            cert=ee_cert,
         )
     return LegacyTracker(
         model,

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -228,9 +228,18 @@ def test_tracking(
             )
             thread.start()
 
-            tracker = create_tracker(
-                model, general_interval=1, detailed_interval=2, ee_config=ee_config
-            )
+            if ee_config is None:
+                tracker = create_tracker(model, general_interval=1, detailed_interval=2)
+            else:
+                tracker = create_tracker(
+                    model,
+                    general_interval=1,
+                    detailed_interval=2,
+                    ee_host="localhost",
+                    ee_port=ee_config.port,
+                    ee_cert=ee_config.cert,
+                    ee_token=ee_config.token,
+                )
 
             snapshots = {}
 


### PR DESCRIPTION
**Issue**
Resolves #2452 


**Approach**
Modules that uses local connections to the evaluator (the queue system
and the monitor) used the external IP of the machine to connect to the
evaluator. This means that all traffic will pass through the proxy
if it exists on the network.

This PR makes the evaluator bind to all interfaces (0.0.0.0), and
uses localhost (127.0.0.1) when connecting from the monitor/tracker and
the queue system.
