### PR TITLE
Return native floats when decoding EclSum files

### DIFF
--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 import aiofiles
 import yaml
@@ -87,10 +87,14 @@ class _ecl_sum_serializer(Serializer):
 
     async def decode_from_path(
         self, path: Union[str, Path], *args: Any, **kwargs: Any
-    ) -> Any:
+    ) -> Dict[str, float]:
+        """Extract a given summary vector (time series) from Eclipse output files.
+
+        Args:
+            key (str): Name of summary vector, e.g. FOPT"""
         key = kwargs.get("key", None)
         if key is None:
             raise ValueError("key must be provided as a keyword argument")
 
         eclsum = EclSum(str(path))
-        return dict(zip(map(str, eclsum.dates), eclsum.numpy_vector(key)))
+        return dict(zip(map(str, eclsum.dates), map(float, eclsum.numpy_vector(key))))

--- a/tests/ert_tests/ert3/data/test_serializer.py
+++ b/tests/ert_tests/ert3/data/test_serializer.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 
+import numpy as np
 import pytest
 from ecl.summary import EclSum
 
@@ -44,6 +45,10 @@ async def test_ecl_sum_serializer(tmp_path):
     result = await _serializer._ecl_sum_serializer().decode_from_path(
         tmp_path / "TEST", key="FOPT"
     )
+    for date, value in result.items():
+        assert isinstance(date, str)
+        assert isinstance(value, float)
+        assert not isinstance(value, np.floating)
     assert result == {
         "2000-01-01 00:00:00": 0,
         "2000-01-02 00:00:00": 1,


### PR DESCRIPTION
**Issue**
Resolves #2537 


**Approach**
Applies `float()` to all elements. An alternative would be to do numpy's `.item()` which would also work if we needed to support integers, but that would not correspond to a supported `RecordType`.