### PR TITLE
Avoid timeout when fetch connection info

### DIFF
--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import json
 import time
-import atexit
 import signal
 
 from select import select, PIPE_BUF
@@ -351,7 +350,7 @@ class BaseService:
 
         self._conn_info_event.set()
 
-    def fetch_conn_info(self, timeout: Optional[float] = None) -> Mapping[str, Any]:
+    def fetch_conn_info(self, timeout: float = 20) -> Mapping[str, Any]:
         self.wait_until_ready(timeout)
         if self._conn_info is None:
             raise ValueError("conn_info is None")


### PR DESCRIPTION
Testing has been flaky and utilize the timeout argument in `fetch_conn_info` hopefully make this issue go away if it is related to timing.

