### PR TITLE
Cleanup unnecessary use of run_mode

### DIFF
--- a/libres/lib/enkf/ert_run_context.cpp
+++ b/libres/lib/enkf/ert_run_context.cpp
@@ -325,10 +325,6 @@ int ert_run_context_get_size(const ert_run_context_type *context) {
     return vector_get_size(context->run_args);
 }
 
-run_mode_type ert_run_context_get_mode(const ert_run_context_type *context) {
-    return context->run_mode;
-}
-
 int ert_run_context_get_iter(const ert_run_context_type *context) {
     return context->iter;
 }


### PR DESCRIPTION
**Issue**
Resolves #2462


**Approach**
Only one value of run_mode is used in this file and it is now hardcoded in `serialize_info_alloc()`