### PR TITLE
Remove unused writeSummaryFile

### DIFF
--- a/docs/rst/manual/advanced/api.rst
+++ b/docs/rst/manual/advanced/api.rst
@@ -74,10 +74,6 @@ config commands by writing a Python script, and invoking it from a workflow.
          # Then attach the ministep to the update step
          updatestep.attachMinistep(ministep)
 
-         # Write a .csv file for debugging.  The generated file can be imported
-         # into Excel for better tabulation of the setup
-         local_config.writeSummaryFile("tmp/summary_local_config.csv")
-
 =========================================================================  ===================================================================================
 ERT script function                                                        Purpose
 =========================================================================  ===================================================================================

--- a/libres/lib/enkf/local_config.cpp
+++ b/libres/lib/enkf/local_config.cpp
@@ -290,31 +290,3 @@ local_config_get_updatestep(const local_config_type *local_config) {
 
     return updatestep;
 }
-
-void local_config_summary_fprintf(const local_config_type *local_config,
-                                  const char *config_file) {
-
-    FILE *stream = util_mkdir_fopen(config_file, "w");
-
-    const local_updatestep_type *updatestep = local_config_get_updatestep(
-        local_config); // There is only one update step, the default
-    {
-        hash_iter_type *hash_iter =
-            hash_iter_alloc(local_config->ministep_storage);
-
-        while (!hash_iter_is_complete(hash_iter)) {
-            const local_ministep_type *ministep =
-                (const local_ministep_type *)hash_iter_get_next_value(
-                    hash_iter);
-
-            fprintf(stream, "UPDATE_STEP:%s,",
-                    local_updatestep_get_name(updatestep));
-
-            local_ministep_summary_fprintf(ministep, stream);
-        }
-
-        hash_iter_free(hash_iter);
-    }
-
-    fclose(stream);
-}

--- a/libres/lib/include/ert/enkf/local_config.hpp
+++ b/libres/lib/include/ert/enkf/local_config.hpp
@@ -60,8 +60,6 @@ local_config_get_updatestep(const local_config_type *local_config);
 local_ministep_type *
 local_config_get_ministep(const local_config_type *local_config,
                           const char *key);
-PY_USED void local_config_summary_fprintf(const local_config_type *local_config,
-                                          const char *config_file);
 local_obsdata_type *local_config_alloc_obsdata(local_config_type *local_config,
                                                const char *obsdata_name);
 bool local_config_has_obsdata(const local_config_type *local_config,

--- a/res/enkf/local_config.py
+++ b/res/enkf/local_config.py
@@ -73,9 +73,6 @@ class LocalConfig(BaseCClass):
     _copy_dataset = ResPrototype(
         "local_dataset_ref    local_config_alloc_dataset_copy(local_config, char*, char*)"
     )
-    _smry_fprintf = ResPrototype(
-        "void local_config_summary_fprintf(local_config, char*)"
-    )
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
@@ -178,15 +175,6 @@ class LocalConfig(BaseCClass):
         assert isinstance(mini_step, LocalMinistep)
         assert isinstance(update_step, LocalUpdateStep)
         self._attach_ministep(update_step, mini_step)
-
-    def writeSummaryFile(self, filename):
-        """
-        Writes a summary of the local config object
-        The summary contains the Obsset with their respective
-        number of observations and the Datasets with the number of active indices
-        """
-        assert isinstance(filename, str)
-        self._smry_fprintf(filename)
 
     def __repr__(self):
         return self._create_repr()

--- a/tests/libres_tests/res/enkf/test_local_config.py
+++ b/tests/libres_tests/res/enkf/test_local_config.py
@@ -31,16 +31,6 @@ class LocalConfigTest(ResTest):
         self.config = self.createTestPath("local/mini_ert/mini_config")
         self.local_conf_path = "python/enkf/data/local_config"
 
-    def test_write_summary(self):
-        with ErtTestContext(self.local_conf_path, self.config) as test_context:
-            main = test_context.getErt()
-
-            local_config = main.getLocalConfig()
-
-            fname = "local_config_summary.txt"
-            local_config.writeSummaryFile(fname)
-            self.assertTrue(os.path.isfile(fname))
-
     def test_get_grid(self):
         with ErtTestContext(self.local_conf_path, self.config) as test_context:
             main = test_context.getErt()


### PR DESCRIPTION
I was thinking about writing a test for this since it uses `util_mkdir_fopen` and I want to replace that with standard C++.
After searching the Equinor organization it seems as if the function is not called except from within a test in ERT.
I therefore assume it is safe to remove it.