### PR TITLE
Pass python executable to cmake

### DIFF
--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.1)
+cmake_minimum_required(VERSION 3.12)
 project(res C CXX)
 
 option(BUILD_TESTS "Should the tests be built" OFF)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from setuptools import find_packages
 from skbuild import setup
@@ -120,6 +121,7 @@ setup(
         # everything not OS X. We depend on C++17, which makes our minimum
         # supported OS X release 10.15
         "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
+        f"-DPYTHON_EXECUTABLE={sys.executable}",
     ],
     cmake_source_dir="libres/",
     classifiers=[


### PR DESCRIPTION
We have had issues with pybind11 not finding the correct python
development headers. Will explicitly pass the python version.