### PR TITLE
Use namespace for analysis update

### DIFF
--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -300,7 +300,7 @@ bool enkf_main_smoother_update(enkf_main_type *enkf_main,
     FILE *log_stream = enkf_main_log_step_list(
         analysis_config_get_log_path(analysis_config), step_list);
 
-    bool ok = analysis_smoother_update(
+    bool ok = analysis::smoother_update(
         step_list, updatestep, total_ens_size, obs, shared_rng, analysis_config,
         ensemble_config, ensemble, source_fs, target_fs, log_stream, verbose);
 

--- a/libres/lib/include/ert/analysis/update.hpp
+++ b/libres/lib/include/ert/analysis/update.hpp
@@ -9,12 +9,13 @@
 #include <ert/enkf/enkf_state.hpp>
 #include <ert/enkf/enkf_obs.hpp>
 
-bool analysis_smoother_update(std::vector<int> step_list,
-                              const local_updatestep_type *updatestep,
-                              int total_ens_size, enkf_obs_type *obs,
-                              rng_type *shared_rng,
-                              const analysis_config_type *analysis_config,
-                              ensemble_config_type *ensemble_config,
-                              enkf_state_type **ensemble,
-                              enkf_fs_type *source_fs, enkf_fs_type *target_fs,
-                              FILE *log_stream, bool verbose);
+namespace analysis {
+bool smoother_update(std::vector<int> step_list,
+                     const local_updatestep_type *updatestep,
+                     int total_ens_size, enkf_obs_type *obs,
+                     rng_type *shared_rng,
+                     const analysis_config_type *analysis_config,
+                     ensemble_config_type *ensemble_config,
+                     enkf_state_type **ensemble, enkf_fs_type *source_fs,
+                     enkf_fs_type *target_fs, FILE *log_stream, bool verbose);
+}


### PR DESCRIPTION
**Issue**
Resolves #2575


**Approach**
Uses cpp namespace for analysis/update. Also removes static as we would like to test these functions and renames `get_active_size` to conform to standard cpp naming practices.

## Pre review checklist

- [x] Added appropriate labels
