### PR TITLE
Make Workspace use transformations

### DIFF
--- a/ert/data/__init__.py
+++ b/ert/data/__init__.py
@@ -11,7 +11,6 @@ from ert.data.record._record import (
     RecordIndex,
     RecordType,
     RecordValidationError,
-    make_tar,
 )
 from .record._transmitter import (
     InMemoryRecordTransmitter,
@@ -49,6 +48,5 @@ __all__ = (
     "TarRecordTransformation",
     "ExecutableRecordTransformation",
     "RecordTransformation",
-    "make_tar",
     "transmitter_factory",
 )


### PR DESCRIPTION
**Issue**
Resolves #2513


**Approach**
By rewriting `load_collections_from_file ` in terms of transformations, this solves the issue for the workspace object, but also in the `load_record` function.
