### PR TITLE
Mute PEP-585 warnings from BearType in Py39

### DIFF
--- a/ert/data/record/_record.py
+++ b/ert/data/record/_record.py
@@ -1,27 +1,34 @@
-import pathlib
 import json
+import pathlib
+import warnings
 from abc import ABC, abstractmethod
 from collections import deque
 from enum import Enum
 from typing import (
     Any,
     Dict,
+    Generic,
     List,
     Mapping,
     MutableMapping,
     Optional,
     Tuple,
+    TypeVar,
     Union,
     cast,
-    Generic,
-    TypeVar,
 )
 
 from beartype import beartype
-from beartype.roar import BeartypeException  # type: ignore
+from beartype.roar import (  # type: ignore
+    BeartypeDecorHintPepDeprecatedWarning,
+    BeartypeException,
+)
 from pydantic import PositiveInt
 
 import ert
+
+# Mute PEP-585 warnings from Python 3.9:
+warnings.simplefilter(action="ignore", category=BeartypeDecorHintPepDeprecatedWarning)
 
 number = Union[int, float]
 numerical_record_data = Union[List[number], Dict[str, number], Dict[int, number]]


### PR DESCRIPTION
**Issue**
Resolves #2609 


**Approach**
Mute using `warnings` module. The muted deprecation warning must be fixed properly by ~2026 (or whenever support for Python < 3.9 is dropped).

## Pre review checklist

- [x] Added appropriate labels
