### PR TITLE
Only comment coverage after all reports are sent

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
 fixes:
     - "*/site-packages/::"
     - "/home/runner/work/ert/ert/::"
+comment:
+    # The code coverage is made up of 4 separate
+    # test runs so only after all coverage reports have
+    # been uploaded will the comparison be sane
+    after_n_builds: 4


### PR DESCRIPTION
**Issue**
Resolves #2622


**Approach**

Sets codecov pr comments to be sent after all 4 reports are sent to codecov.


## Pre review checklist

- [x] Added appropriate labels
