### PR TITLE
Fix compatibility wity beartype==0.9.1

### DIFF
--- a/ert/data/record/_record.py
+++ b/ert/data/record/_record.py
@@ -19,16 +19,13 @@ from typing import (
 )
 
 from beartype import beartype
-from beartype.roar import (  # type: ignore
-    BeartypeDecorHintPepDeprecatedWarning,
-    BeartypeException,
-)
+from beartype.roar import BeartypeDecorHintPepDeprecationWarning, BeartypeException
 from pydantic import PositiveInt
 
 import ert
 
 # Mute PEP-585 warnings from Python 3.9:
-warnings.simplefilter(action="ignore", category=BeartypeDecorHintPepDeprecatedWarning)
+warnings.simplefilter(action="ignore", category=BeartypeDecorHintPepDeprecationWarning)
 
 number = Union[int, float]
 numerical_record_data = Union[List[number], Dict[str, number], Dict[int, number]]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-import sys
 import os
-from setuptools import find_packages
-from skbuild import setup
-from setuptools_scm import get_version
+import sys
 
+from setuptools import find_packages
+from setuptools_scm import get_version
+from skbuild import setup
 
 # Corporate networks tend to be behind a proxy server with their own non-public
 # SSL certificates. Conan keeps its own certificates, whose path we can override
@@ -68,7 +68,7 @@ setup(
         "ansicolors==1.1.8",
         "async-exit-stack; python_version < '3.7'",
         "async-generator",
-        "beartype >= 0.8.0, <0.9.0",
+        "beartype >= 0.9.1",
         "cloudevents",
         "cloudpickle",
         "tqdm>=4.62.0",

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -1,4 +1,4 @@
-mypy != 0.920
+mypy < 0.920
 types-aiofiles
 types-requests
 types-pkg_resources


### PR DESCRIPTION
**Issue**
Resolves #2632 


**Approach**
Follow up breaking change from beartype 0.8.1 to 0.9.x.  Bump beartype requirements in setup.py. Komodo bleeding already has version 0.9.1

## Pre review checklist

- [x] Added appropriate labels
