### PR TITLE
Replace parsing of excluded hostnames in lsf with standard library functions

### DIFF
--- a/libres/lib/include/ert/job_queue/lsf_driver.hpp
+++ b/libres/lib/include/ert/job_queue/lsf_driver.hpp
@@ -96,7 +96,6 @@ int lsf_job_parse_bsub_stdout(const char *bsub_cmd, const char *stdout_file);
 char *lsf_job_write_bjobs_to_file(const char *bjobs_cmd,
                                   lsf_driver_type *driver, const long jobid);
 
-stringlist_type *lsf_job_alloc_parse_hostnames(const char *fname);
 UTIL_SAFE_CAST_HEADER(lsf_driver);
 
 #ifdef __cplusplus

--- a/libres/lib/include/ert/res_util/string.hpp
+++ b/libres/lib/include/ert/res_util/string.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace ert {
+
+/**
+ * Non memory allocating string splitting function
+ *
+ * \note The input string is a view. It is therefore Undefined Behaviour to
+ * modify the original string from inside the `func` parameter.
+ */
+template <typename Func>
+void split(std::string_view str, char delimiter, Func &&func) {
+    size_t pos = 0, next_pos = 0;
+
+    if (str.empty())
+        return;
+
+    while ((next_pos = str.find(delimiter, pos)) != str.npos) {
+        func(str.substr(pos, next_pos - pos));
+        pos = next_pos + 1;
+    }
+    func(str.substr(pos));
+}
+
+/**
+ * Split string and get the back element
+ *
+ * Equivalent to Python's: `s.split(delim)[-1]`
+ */
+std::string_view back_element(std::string_view str, char delimiter) {
+    auto pos = str.rfind(delimiter);
+    return pos == str.npos ? str : str.substr(pos + 1);
+}
+
+/**
+ * Join a ForwardIterable container with separator
+ */
+template <typename ForwardIterable>
+std::string join(const ForwardIterable &container, std::string_view separator) {
+    // Require that container contains strings
+    using value_type = typename ForwardIterable::value_type;
+    static_assert(std::is_same_v<value_type, const char *> ||
+                      std::is_same_v<value_type, std::string> ||
+                      std::is_same_v<value_type, std::string_view>,
+                  "'container' must contain string types");
+
+    auto it = container.cbegin();
+    auto end = container.cend();
+
+    std::string joined;
+
+    if (it == end) {
+        // Empty container, return empty string
+        return joined;
+    }
+
+    // Append first element
+    joined.append(*it);
+    ++it;
+
+    // Append the rest
+    for (; it != end; ++it) {
+        joined.append(separator);
+        joined.append(*it);
+    }
+    return joined;
+}
+} // namespace ert

--- a/libres/old_tests/job_queue/test_job_lsf_exclude_hosts.cpp
+++ b/libres/old_tests/job_queue/test_job_lsf_exclude_hosts.cpp
@@ -112,43 +112,9 @@ void test_submit() {
     }
 }
 
-void test_bjobs_parse_hosts() {
-    const char *full_hostnames =
-        "hname1:4*hname2:13*st-rst666-01-42.st.example.org:1*hname4:hname5\n";
-    const char *hostnames =
-        "hname1:hname2:st-rst666-01-42.st.example.org:hname4:hname5";
-    stringlist_type *expected = stringlist_alloc_from_split(hostnames, ":");
-    if (stringlist_get_size(expected) != 5) {
-        printf("Even expected has wrong size.\n");
-        exit(1);
-    }
-
-    char *fname = util_alloc_tmp_file("/tmp", "ert_job_exec_host", true);
-
-    FILE *fptr;
-    fptr = fopen(fname, "w");
-    fputs(full_hostnames, fptr); // : is std bjobs delimiter
-    fclose(fptr);
-
-    stringlist_type *hosts = lsf_job_alloc_parse_hostnames(fname);
-
-    if (!stringlist_equal(expected, hosts)) {
-        printf("hosts differ: expected [%s] got [%s]\n",
-               stringlist_alloc_joined_string(expected, ":"),
-               stringlist_alloc_joined_string(hosts, ":"));
-        exit(1);
-    }
-
-    util_unlink_existing(fname);
-    free(fname);
-    stringlist_free(hosts);
-}
-
 int main(int argc, char **argv) {
     test_submit();
     test_submit_with_resources();
     test_submit_with_select_resources();
-
-    test_bjobs_parse_hosts();
     exit(0);
 }

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -19,9 +19,11 @@ add_executable(
   enkf/test_obs_data.cpp
   res_util/test_matrix.cpp
   res_util/test_memory.cpp
+  res_util/test_string.cpp
   analysis/test_std_enkf.cpp
   analysis/test_compare_initX.cpp
-  analysis/test_update.cpp)
+  analysis/test_update.cpp
+  job_queue/test_lsf_driver.cpp)
 
 target_link_libraries(ert_test_suite res Catch2::Catch2WithMain fmt::fmt)
 

--- a/libres/tests/job_queue/test_lsf_driver.cpp
+++ b/libres/tests/job_queue/test_lsf_driver.cpp
@@ -1,0 +1,41 @@
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <filesystem>
+
+#include "catch2/catch.hpp"
+
+#include "../tmpdir.hpp"
+
+namespace fs = std::filesystem;
+namespace detail {
+std::vector<std::string> parse_hostnames(const char *);
+}
+
+TEST_CASE("parse hostnames", "[lsf]") {
+    WITH_TMPDIR;
+    fs::path file_path = fs::current_path() / "exclud_hosts";
+
+    GIVEN("Empty stream") {
+        std::ofstream stream{file_path};
+        stream.close();
+
+        auto hosts = detail::parse_hostnames(file_path.c_str());
+        REQUIRE(hosts == std::vector<std::string>{});
+    }
+
+    GIVEN("Non-empty stream") {
+        std::ofstream stream{file_path};
+        stream << "hname1:4*hname2:13*st-rst666-01-42.st.example.org:1*hname4:"
+                  "hname5\n";
+        stream.close();
+
+        auto hosts = detail::parse_hostnames(file_path.c_str());
+
+        REQUIRE(hosts ==
+                std::vector<std::string>{"hname1", "hname2",
+                                         "st-rst666-01-42.st.example.org",
+                                         "hname4", "hname5"});
+    }
+}

--- a/libres/tests/res_util/test_string.cpp
+++ b/libres/tests/res_util/test_string.cpp
@@ -1,0 +1,182 @@
+#include <array>
+#include <set>
+#include <list>
+
+#include "catch2/catch.hpp"
+#include <ert/res_util/string.hpp>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST_CASE("String splitting", "[res_util]") {
+    GIVEN("Empty string") {
+        std::string str;
+
+        THEN("Callable is never called") {
+            int num_called{};
+            ert::split(str, ':', [&](auto) { ++num_called; });
+
+            REQUIRE(num_called == 0);
+        }
+    }
+
+    GIVEN("String without delimiter character") {
+        std::string str = "hello world";
+
+        THEN("Callable is called once") {
+            int num_called{};
+            ert::split(str, ':', [&](auto) { ++num_called; });
+
+            REQUIRE(num_called == 1);
+        }
+
+        THEN("Parameter is equal to the whole string") {
+            ert::split(str, ':', [&](auto x) { REQUIRE(x == str); });
+        }
+    }
+
+    GIVEN("String with delimiter characters") {
+        std::string str = "foo:bar baz:qux";
+
+        THEN("Callable is called for each split part") {
+            int num_called{};
+            ert::split(str, ':', [&](auto x) {
+                REQUIRE(num_called < 3);
+                switch (num_called) {
+                case 0:
+                    REQUIRE(x == "foo");
+                    break;
+                case 1:
+                    REQUIRE(x == "bar baz");
+                    break;
+                case 2:
+                    REQUIRE(x == "qux");
+                    break;
+                }
+                ++num_called;
+            });
+
+            REQUIRE(num_called == 3);
+        }
+    }
+
+    GIVEN("String with consecutive delimiter characters") {
+        std::string str = ":::::";
+
+        THEN("Called is called five+1 times, with empty strings") {
+            int num_called{};
+            ert::split(str, ':', [&](auto x) {
+                REQUIRE(x == "");
+                ++num_called;
+            });
+            REQUIRE(num_called == 6);
+        }
+    }
+}
+
+TEST_CASE("Back element", "[res_util]") {
+    GIVEN("Empty string") {
+        std::string str;
+
+        THEN("Return empty string") {
+            auto res = ert::back_element(str, '.');
+            REQUIRE(str == res);
+        }
+    }
+
+    GIVEN("String with no delimiters") {
+        std::string str = "hello world";
+
+        THEN("Return same string") {
+            auto res = ert::back_element(str, '.');
+            REQUIRE(str == res);
+        }
+    }
+
+    GIVEN("String with multiple delimiters") {
+        std::string str = "hello.world.test";
+
+        THEN("Return last part") {
+            auto res = ert::back_element(str, '.');
+            REQUIRE(res == "test");
+        }
+    }
+
+    GIVEN("String only delimiters") {
+        std::string str = "....";
+
+        THEN("Return empty string") {
+            auto res = ert::back_element(str, '.');
+            REQUIRE(res == "");
+        }
+    }
+
+    GIVEN("String where delimiter is the last character") {
+        std::string str = "test.";
+
+        THEN("Return empty string") {
+            auto res = ert::back_element(str, '.');
+            REQUIRE(res == "");
+        }
+    }
+}
+
+TEST_CASE("Join string", "[res_util]") {
+    GIVEN("An empty std::array") {
+        std::array<std::string, 0> strs;
+
+        THEN("Joining produces empty string") {
+            REQUIRE(ert::join(strs, "foo") == "");
+        }
+    }
+
+    GIVEN("An std::array with a single element") {
+        std::array<std::string, 1> strs{"foo"};
+
+        THEN("Joining produces string with no seperator") {
+            REQUIRE(ert::join(strs, "bar") == "foo");
+        }
+    }
+
+    GIVEN("An std::array of strings") {
+        std::array strs{"foo", "bar", "quiz"};
+
+        THEN("Joining produces correct result") {
+            REQUIRE(ert::join(strs, "") == "foobarquiz");
+            REQUIRE(ert::join(strs, ",") == "foo,bar,quiz");
+            REQUIRE(ert::join(strs, " :: ") == "foo :: bar :: quiz");
+        }
+    }
+
+    GIVEN("An std::vector of std::string_view") {
+        std::vector strs{"foo"sv, "bar"sv, "quiz"sv};
+
+        THEN("Joining produces correct result") {
+            REQUIRE(ert::join(strs, "") == "foobarquiz");
+            REQUIRE(ert::join(strs, ",") == "foo,bar,quiz");
+            REQUIRE(ert::join(strs, " :: ") == "foo :: bar :: quiz");
+        }
+    }
+
+    GIVEN("An std::list of const char*") {
+        std::list strs{"foo", "bar", "quiz"};
+
+        THEN("Joining produces correct result") {
+            REQUIRE(ert::join(strs, "") == "foobarquiz");
+            REQUIRE(ert::join(strs, ",") == "foo,bar,quiz");
+            REQUIRE(ert::join(strs, " :: ") == "foo :: bar :: quiz");
+        }
+    }
+
+    GIVEN("An std::set of std::string") {
+        std::set strs{"foo"s, "bar"s, "quiz"s};
+
+        // std::set is a sorted container, so the iteration happens in
+        // lexicographical order, which is different from the other joins.
+        THEN("Joining produces correct result") {
+            REQUIRE(ert::join(strs, "") == "barfooquiz");
+            REQUIRE(ert::join(strs, ",") == "bar,foo,quiz");
+            REQUIRE(ert::join(strs, " :: ") == "bar :: foo :: quiz");
+        }
+    }
+}


### PR DESCRIPTION
**Issue**
Partly addresses #2482 

**Approach**
Replaces the parsing of exclude hostnames with standard cpp functions. The test for it is replaced to match the new interface, and therefore moved to catch2 simultaneously.

Note: removes the hostname parsing from the header file to only add externally used functions to headers and repeating the prototype in the test. It was discussed over video that we would attempt this scheme.

The `parse_hostnames` function is also moved closer to where it is referenced.

## Pre review checklist
- [x] Added appropriate labels
