### PR TITLE
Introducing class and methods to log memory usage in scope

### DIFF
--- a/libres/lib/CMakeLists.txt
+++ b/libres/lib/CMakeLists.txt
@@ -10,6 +10,7 @@ pybind11_add_module(
   SHARED
   res_util/res_log.cpp
   res_util/log.cpp
+  res_util/memory.cpp
   res_util/es_testdata.cpp
   res_util/file_utils.cpp
   res_util/arg_pack.cpp

--- a/libres/lib/analysis/update.cpp
+++ b/libres/lib/analysis/update.cpp
@@ -16,8 +16,11 @@
 #include <ert/util/vector.hpp>
 #include <ert/enkf/obs_data.hpp>
 #include <ert/enkf/meas_data.hpp>
+#include <ert/res_util/memory.hpp>
 
 namespace analysis {
+
+auto logger = ert::get_logger("analysis");
 
 /*
    Helper structs used to pass information to the multithreaded serialize and
@@ -620,6 +623,8 @@ bool smoother_update(std::vector<int> step_list,
     if (!assert_update_viable(analysis_config, source_fs, total_ens_size,
                               updatestep))
         return false;
+
+    ert::utils::scoped_memory_logger memlogger(logger, "smoother_update");
     /*
     Observations and measurements are collected in these temporary
     structures. obs_data is a precursor for the 'd' vector, and

--- a/libres/lib/include/ert/logging.hpp
+++ b/libres/lib/include/ert/logging.hpp
@@ -1,0 +1,64 @@
+/**
+ * Contains the ert::ILogger "interface"
+ */
+#ifndef RES_LOGGING_HPP
+#define RES_LOGGING_HPP
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+namespace ert {
+/**
+ * The ILogger is primarily used to log from C++ to Python via <ert/python.hpp>
+ * but is kept separate in case we want other implementations, like
+ * in unit-tests
+ */
+class ILogger {
+public:
+    enum struct Level { debug, info, warning, error, critical };
+    virtual ~ILogger() = default;
+
+    template <typename... Args> void debug(fmt::string_view f, Args &&...args) {
+        this->log(Level::debug, f,
+                  fmt::make_format_args(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args> void info(fmt::string_view f, Args &&...args) {
+        this->log(Level::info, f,
+                  fmt::make_format_args(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    void warning(fmt::string_view f, Args &&...args) {
+        this->log(Level::warning, f,
+                  fmt::make_format_args(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args> void error(fmt::string_view f, Args &&...args) {
+        this->log(Level::error, f,
+                  fmt::make_format_args(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    void critical(fmt::string_view f, Args &&...args) {
+        this->log(Level::critical, f,
+                  fmt::make_format_args(std::forward<Args>(args)...));
+    }
+
+protected:
+    virtual void log(Level level, fmt::string_view f,
+                     fmt::format_args args) = 0;
+};
+/*
+* Creates a logger that logs only to Python's logger of the same
+* name, prefixed with libres' namespace. Can be created statically, although
+* it no-ops outside of the lifetime of this Python module.
+*
+* That is, this logger will only log after this module's Python init function
+* is called, and before Python shuts down, but is valid for all other times.
+*/
+std::shared_ptr<ILogger> get_logger(const std::string &name);
+
+} // namespace ert
+
+#endif

--- a/libres/lib/include/ert/python.hpp
+++ b/libres/lib/include/ert/python.hpp
@@ -5,67 +5,13 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+
+#include <ert/logging.hpp>
 
 namespace py = pybind11;
 /**
  * This header contains utilities for interacting with Python via pybind11
  */
-namespace ert {
-/**
- * Logger which forwards to Python
- */
-class ILogger {
-public:
-    enum struct Level { debug, info, warning, error, critical };
-    virtual ~ILogger() = default;
-
-    template <typename... Args> void debug(fmt::string_view f, Args &&...args) {
-        this->log(Level::debug, f,
-                  fmt::make_format_args(std::forward<Args>(args)...));
-    }
-
-    template <typename... Args> void info(fmt::string_view f, Args &&...args) {
-        this->log(Level::info, f,
-                  fmt::make_format_args(std::forward<Args>(args)...));
-    }
-
-    template <typename... Args>
-    void warning(fmt::string_view f, Args &&...args) {
-        this->log(Level::warning, f,
-                  fmt::make_format_args(std::forward<Args>(args)...));
-    }
-
-    template <typename... Args> void error(fmt::string_view f, Args &&...args) {
-        this->log(Level::error, f,
-                  fmt::make_format_args(std::forward<Args>(args)...));
-    }
-
-    template <typename... Args>
-    void critical(fmt::string_view f, Args &&...args) {
-        this->log(Level::critical, f,
-                  fmt::make_format_args(std::forward<Args>(args)...));
-    }
-
-protected:
-    virtual void log(Level level, fmt::string_view f,
-                     fmt::format_args args) = 0;
-};
-
-/**
- * Create or get a Logger which syncs to Python
- *
- * Creates a logger that logs only to Python's logger of the same
- * name, prefixed with libres' namespace. Can be created statically, although
- * it no-ops outside of the lifetime of this Python module.
- *
- * That is, this logger will only log after this module's Python init function
- * is called, and before Python shuts down, but is valid for all other times.
- */
-std::shared_ptr<ILogger> get_logger(const std::string &name);
-} // namespace ert
-
 #endif
 
 /**

--- a/libres/lib/include/ert/res_util/memory.hpp
+++ b/libres/lib/include/ert/res_util/memory.hpp
@@ -1,0 +1,64 @@
+#ifndef ERT_MEMORY_H
+#define ERT_MEMORY_H
+
+#include <cstddef>
+#include <ert/logging.hpp>
+
+namespace ert {
+namespace utils {
+
+std::size_t system_ram_free(void);
+std::size_t process_memory(void);
+std::size_t process_max_memory(void);
+std::size_t process_max_rss(void);
+
+class scoped_memory_logger {
+public:
+    scoped_memory_logger(std::shared_ptr<ert::ILogger> logger,
+                         const std::string &message)
+        : m_logger(logger), m_message(message), m_enter_mem(process_memory()),
+          m_enter_max_mem(process_max_memory()) {
+
+        if (m_enter_mem == 0 || m_enter_max_mem == 0)
+            m_logger->info(
+                "Enter {} Memory information not available on this platform",
+                m_message);
+        else
+            m_logger->info("Enter {} Mem: {}Mb  MaxMem: {}Mb", m_message,
+                           m_enter_mem, m_enter_max_mem);
+    };
+
+    ~scoped_memory_logger() {
+        if (m_enter_mem == 0 || m_enter_max_mem == 0)
+            m_logger->info(
+                "Exit  {} Memory information not available on this platform",
+                m_message);
+        else {
+            std::size_t cur_mem = process_memory();
+            std::string delta_cur_mem =
+                (m_enter_mem > cur_mem)
+                    ? "-" + std::to_string(m_enter_mem - cur_mem)
+                    : "+" + std::to_string(cur_mem - m_enter_mem);
+
+            std::size_t max_mem = process_max_memory();
+            std::string delta_max_mem =
+                (m_enter_max_mem > max_mem)
+                    ? "-" + std::to_string(m_enter_max_mem - max_mem)
+                    : "+" + std::to_string(max_mem - m_enter_max_mem);
+
+            m_logger->info("Exit  {} Mem: {}Mb ({}) MaxMem: {}Mb ({})",
+                           m_message, cur_mem, delta_cur_mem, max_mem,
+                           delta_max_mem);
+        }
+    };
+
+private:
+    std::shared_ptr<ert::ILogger> m_logger;
+    const std::string m_message;
+    std::size_t m_enter_mem, m_enter_max_mem;
+};
+
+} // namespace utils
+} // namespace ert
+
+#endif

--- a/libres/lib/res_util/memory.cpp
+++ b/libres/lib/res_util/memory.cpp
@@ -1,0 +1,98 @@
+#include <memory>
+#include <iostream>
+#include <fstream>
+#include <sys/resource.h>
+
+namespace ert {
+namespace utils {
+
+/**
+ * Internal utils
+ *
+ * get_file() exists to make testing simple. Note that the weak-attribute
+ * is crucial to allow the method to be replaced in tests.
+ */
+[[gnu::weak]] std::shared_ptr<std::istream> get_file(const char *filename) {
+    auto stream = std::make_shared<std::ifstream>(filename);
+    return stream;
+}
+
+std::size_t parse_meminfo_linux(const char *file, const char *pattern) {
+    auto meminfo = get_file(file);
+    if (meminfo->good()) {
+        std::string tp;
+        std::size_t info;
+        while (std::getline(*meminfo, tp)) {
+            if (sscanf(tp.data(), pattern, &info) == 1)
+                return info / 1000;
+        }
+    }
+    // Returning 0 indicates that no memory-info was found
+    return 0;
+}
+
+/**
+ * NOTE: Linux only.
+ *
+ * Returns available memory (Mb) or 0 if the information is unavailable,
+ * for example on the Mac-platform.
+ *
+ * For details and explanation of the returned value, see
+ * the field MemFree in the section on /proc/meminfo in
+ *
+ *   https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+ */
+std::size_t system_ram_free(void) {
+    return parse_meminfo_linux("/proc/meminfo", "MemFree: %zd kB");
+}
+
+/**
+ * NOTE: Linux only.
+ *
+ * Returns the current memory (Mb) used by the process or 0 if the,
+ * information is unavailable, for example on the Mac-platform.
+ *
+ * For details and explanation of the returned value, see
+ * the field VmSize in section on /proc/self/status in
+ *
+ *   https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+ */
+std::size_t process_memory(void) {
+    return parse_meminfo_linux("/proc/self/status", "VmSize: %zd kB");
+}
+
+/**
+ * NOTE: Linux only.
+ *
+ * Returns the maximum memory (Mb) used by the process so far or 0
+ * if the information is unavailable, for example on the Mac-platform.
+ *
+ * For details and explanation of the returned value, see
+ * the field VmMax in the section on /proc/self/status in
+ *
+ *   https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+ */
+std::size_t process_max_memory(void) {
+    return parse_meminfo_linux("/proc/self/status", "VmPeak: %zd kB");
+}
+
+/**
+ * NOTE: Linux only.
+ *
+ * Returns the maximum resident set size (RSS) of calling process in Mb,
+ * i.e the max RSS so far in the lifetime of the process. Returns 0 if
+ * this information is unavailable.
+ *
+ * For details of RSS see https://en.wikipedia.org/wiki/Resident_set_size
+ * and the manpage for the getrusage() system-call.
+ */
+std::size_t process_max_rss(void) {
+    struct rusage r_usage;
+    long ret = getrusage(RUSAGE_SELF, &r_usage);
+    if (ret == 0)
+        return r_usage.ru_maxrss / 1000;
+
+    return 0;
+}
+} // namespace utils
+} // namespace ert

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   enkf/test_analysis_config.cpp
   enkf/test_obs_data.cpp
   res_util/test_matrix.cpp
+  res_util/test_memory.cpp
   analysis/test_std_enkf.cpp
   analysis/test_compare_initX.cpp)
 

--- a/libres/tests/res_util/test_memory.cpp
+++ b/libres/tests/res_util/test_memory.cpp
@@ -1,0 +1,104 @@
+#include <sstream>
+#include <fmt/format.h>
+#include "catch2/catch.hpp"
+
+#include <ert/logging.hpp>
+#include <ert/res_util/memory.hpp>
+
+static int callno = 0;
+
+/*
+ * "Mock" the internal function which reads memory-info from
+ * the /proc-filesystem.
+ *
+ * Note that although the real memory-info is only available
+ * on Linux, this "mocking" makes the test run also on MacOs
+ */
+namespace ert {
+namespace utils {
+std::shared_ptr<std::istream> get_file(const char *filename) {
+    std::string s = R"(
+Name:	test
+Umask:	0022
+State:	R (running)
+Tgid:	72786
+Ngid:	0
+Pid:	72786
+PPid:	1
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:
+NStgid:	72786
+NSpid:	72786
+NSpgid:	72786
+NSsid:	1
+VmPeak:	  160560 kB
+VmSize:	  146680 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	    7892 kB
+VmRSS:	    7892 kB
+RssAnon:	    4680 kB
+RssFile:	    3212 kB
+RssShmem:	       0 kB
+VmData:	  141976 kB
+VmStk:	     132 kB
+VmExe:	    1628 kB
+VmLib:	       4 kB
+VmPTE:	      68 kB
+VmSwap:	       0 kB
+nonvoluntary_ctxt_switches:	4)";
+
+    /**
+    * This method is called four times while the test runs.
+	* The last two calls are upon exiting the scope,
+	* hence simulate changes
+	**/
+    if (callno > 1) {
+        std::string find1("160560 kB"), find2("146680 kB");
+        std::string replace1("260560 kB"), replace2("46680 kB");
+
+        // Pretend VmPeak increased
+        s.replace(s.find(find1), find1.size(), replace1);
+        // Pretend VmSize decreased
+        s.replace(s.find(find2), find2.size(), replace2);
+    }
+    callno++;
+
+    return std::make_shared<std::istringstream>(s);
+}
+} // namespace utils
+} // namespace ert
+
+class MockLogger : public ert::ILogger {
+public:
+    std::vector<std::string> calls;
+
+protected:
+    void log(ert::ILogger::Level level, fmt::string_view f,
+             fmt::format_args args) override {
+        std::string s = fmt::vformat(f, args);
+        calls.push_back(s);
+    }
+};
+
+TEST_CASE("simple memory logger test", "[res_util]") {
+    auto logger = std::make_shared<MockLogger>();
+    { ert::utils::scoped_memory_logger memlogger(logger, "test"); }
+
+    /* Dbl-check that the correct number of "mocked" calls were made */
+    REQUIRE(callno == 4);
+
+    /*
+	 * The logger should now hold the following two strings
+	 * 1. "Enter test Mem: 146Mb  MaxMem: 160Mb"
+	 * 2. "Exit  test Mem: 46Mb (-100) MaxMem: 260Mb (+100)"
+	 */
+    REQUIRE(logger->calls.size() == 2);
+    REQUIRE(logger->calls[0].find("Mem: 146Mb  MaxMem: 160Mb") !=
+            std::string::npos);
+    REQUIRE(logger->calls[1].find("(-100)") != std::string::npos);
+    REQUIRE(logger->calls[1].find("(+100)") != std::string::npos);
+}


### PR DESCRIPTION
**Issue**
Resolves #2353

**Approach**
Introduced some methods to report different aspects of memory usage. Wrapped methods by RAII to log mem-usage in process on entering and exiting scope. Example of usage in `smoother_update`
