### PR TITLE
Fix mypy `unused "type: ignore" comment`

### DIFF
--- a/ert3/algorithms/_sensitivity.py
+++ b/ert3/algorithms/_sensitivity.py
@@ -106,7 +106,7 @@ def fast_sample(
             data = dict(zip(dist.index, sample[: dist.size]))
             record = NumericalRecord(data=data, index=dist.index)  # type: ignore
             records.append(record)
-        samples = np.delete(samples, list(range(dist.size)), axis=1)  # type: ignore
+        samples = np.delete(samples, list(range(dist.size)), axis=1)
         group_records.append(records)
 
     evaluations = []

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -42,9 +42,7 @@ class Input(_EnsembleConfig):
     mime: str = ""
     is_directory: Optional[bool]
 
-    # This is copied from the pydantic documentation, but is apparently not
-    # popular with mypy, so ignore entire block.
-    @no_type_check  # type: ignore
+    @no_type_check
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
         parts = data["source"].split(".", maxsplit=1)


### PR DESCRIPTION
This was introduced due to an update to pydantic, which seemingly let
mypy understand `no_type_check` decorators.