### PR TITLE
Remove unused functions in enkf_fs_manager

### DIFF
--- a/ert_shared/share/ert/gui/doc/info.txt
+++ b/ert_shared/share/ert/gui/doc/info.txt
@@ -58,16 +58,6 @@ log_path = analysis_config_get_log_path( analysis_config );
 analysis_config_set_log_path( analysis_config , log_path );
 
 
-
-
-INITIALIZED
------------
-
-enkf_main_is_initialized(enkf_main);
-
-
-
-
 TEMPLATES:
 ----------
 Get:

--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -447,18 +447,6 @@ state_map_type *enkf_fs_alloc_readonly_state_map(const char *mount_point) {
     return state_map;
 }
 
-time_map_type *enkf_fs_alloc_readonly_time_map(const char *mount_point) {
-    path_fmt_type *path_fmt = path_fmt_alloc_directory_fmt(DEFAULT_CASE_PATH);
-    char *filename =
-        path_fmt_alloc_file(path_fmt, false, mount_point, TIME_MAP_FILE);
-
-    time_map_type *time_map = time_map_fread_alloc_readonly(filename);
-
-    path_fmt_free(path_fmt);
-    free(filename);
-    return time_map;
-}
-
 static void enkf_fs_fread_misfit(enkf_fs_type *fs) {
     FILE *stream = enkf_fs_open_excase_file(fs, MISFIT_ENSEMBLE_FILE);
     if (stream != NULL) {

--- a/libres/lib/enkf/enkf_main_manage_fs.cpp
+++ b/libres/lib/enkf/enkf_main_manage_fs.cpp
@@ -277,12 +277,6 @@ bool enkf_main_case_is_initialized(const enkf_main_type *enkf_main,
         return false;
 }
 
-bool enkf_main_is_initialized(const enkf_main_type *enkf_main) {
-    return enkf_main_case_is_initialized__(
-        enkf_main_get_ensemble_config(enkf_main), enkf_main->dbase,
-        enkf_main->ens_size);
-}
-
 static void update_case_log(enkf_main_type *enkf_main, const char *case_path) {
     /*  : Update a small text file with the name of the host currently
         running ert, the pid number of the process, the active case
@@ -614,15 +608,6 @@ enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
     state_map_type *state_map = enkf_fs_alloc_readonly_state_map(mount_point);
     free(mount_point);
     return state_map;
-}
-
-time_map_type *
-enkf_main_alloc_readonly_time_map(const enkf_main_type *enkf_main,
-                                  const char *case_path) {
-    char *mount_point = enkf_main_alloc_mount_point(enkf_main, case_path);
-    time_map_type *time_map = enkf_fs_alloc_readonly_time_map(mount_point);
-    free(mount_point);
-    return time_map;
 }
 
 void enkf_main_close_fs(enkf_main_type *enkf_main) {

--- a/libres/lib/enkf/time_map.cpp
+++ b/libres/lib/enkf/time_map.cpp
@@ -130,16 +130,6 @@ void time_map_set_strict(time_map_type *time_map, bool strict) {
     time_map->strict = strict;
 }
 
-time_map_type *time_map_fread_alloc_readonly(const char *filename) {
-    time_map_type *tm = time_map_alloc();
-
-    if (fs::exists(filename))
-        time_map_fread(tm, filename);
-    tm->read_only = true;
-
-    return tm;
-}
-
 bool time_map_fscanf(time_map_type *map, const char *filename) {
     bool fscanf_ok = true;
     if (util_is_file(filename)) {

--- a/libres/lib/include/ert/enkf/enkf_fs.hpp
+++ b/libres/lib/include/ert/enkf/enkf_fs.hpp
@@ -98,7 +98,6 @@ FILE *enkf_fs_open_excase_file(const enkf_fs_type *fs, const char *input_name);
 FILE *enkf_fs_open_excase_tstep_file(const enkf_fs_type *fs,
                                      const char *input_name, int tstep);
 
-time_map_type *enkf_fs_alloc_readonly_time_map(const char *mount_point);
 state_map_type *enkf_fs_alloc_readonly_state_map(const char *mount_point);
 state_map_type *enkf_fs_get_state_map(const enkf_fs_type *fs);
 time_map_type *enkf_fs_get_time_map(const enkf_fs_type *fs);

--- a/libres/lib/include/ert/enkf/enkf_main.hpp
+++ b/libres/lib/include/ert/enkf/enkf_main.hpp
@@ -200,8 +200,6 @@ extern "C++" void enkf_main_init_case_from_existing_custom(
 bool enkf_main_case_is_initialized(const enkf_main_type *enkf_main,
                                    const char *case_name);
 
-bool enkf_main_is_initialized(const enkf_main_type *enkf_main);
-
 char *enkf_main_alloc_mount_point(const enkf_main_type *enkf_main,
                                   const char *case_path);
 enkf_fs_type *enkf_main_get_fs(const enkf_main_type *);
@@ -220,9 +218,6 @@ const char *enkf_main_get_mount_root(const enkf_main_type *enkf_main);
 state_map_type *
 enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
                                    const char *case_path);
-PY_USED time_map_type *
-enkf_main_alloc_readonly_time_map(const enkf_main_type *enkf_main,
-                                  const char *case_path);
 
 runpath_list_type *
 enkf_main_alloc_runpath_list(const enkf_main_type *enkf_main);

--- a/libres/lib/include/ert/enkf/time_map.hpp
+++ b/libres/lib/include/ert/enkf/time_map.hpp
@@ -58,7 +58,6 @@ time_t time_map_get_start_time(time_map_type *map);
 time_t time_map_get_end_time(time_map_type *map);
 double time_map_get_end_days(time_map_type *map);
 bool time_map_is_readonly(const time_map_type *tm);
-time_map_type *time_map_fread_alloc_readonly(const char *filename);
 int_vector_type *time_map_alloc_index_map(time_map_type *map,
                                           const ecl_sum_type *ecl_sum);
 int time_map_lookup_time(time_map_type *map, time_t time);

--- a/libres/old_tests/enkf/test_enkf_time_map.cpp
+++ b/libres/old_tests/enkf/test_enkf_time_map.cpp
@@ -336,30 +336,6 @@ void test_read_only() {
         time_map_fwrite(tm, "case/files/time-map");
         time_map_free(tm);
     }
-    {
-        time_map_type *tm =
-            time_map_fread_alloc_readonly("case/files/time-map");
-        test_assert_time_t_equal(0, time_map_iget(tm, 0));
-        test_assert_time_t_equal(10, time_map_iget(tm, 1));
-        test_assert_time_t_equal(20, time_map_iget(tm, 2));
-        test_assert_int_equal(3, time_map_get_size(tm));
-        time_map_free(tm);
-    }
-    {
-        time_map_type *tm = enkf_fs_alloc_readonly_time_map("case");
-        test_assert_time_t_equal(0, time_map_iget(tm, 0));
-        test_assert_time_t_equal(10, time_map_iget(tm, 1));
-        test_assert_time_t_equal(20, time_map_iget(tm, 2));
-        test_assert_int_equal(3, time_map_get_size(tm));
-        time_map_free(tm);
-    }
-    {
-        time_map_type *tm = time_map_fread_alloc_readonly("DoesNotExist");
-        test_assert_true(time_map_is_instance(tm));
-        test_assert_true(time_map_is_readonly(tm));
-        test_assert_int_equal(0, time_map_get_size(tm));
-        time_map_free(tm);
-    }
 }
 
 int main(int argc, char **argv) {

--- a/res/enkf/enkf_fs_manager.py
+++ b/res/enkf/enkf_fs_manager.py
@@ -13,7 +13,6 @@ from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums import RealizationStateEnum
 from res.enkf.ert_run_context import ErtRunContext
 from res.enkf.state_map import StateMap
-from res.enkf.util import TimeMap
 
 
 def naturalSortKey(s, _nsre=re.compile("([0-9]+)")):
@@ -93,7 +92,6 @@ class EnkfFsManager(BaseCClass):
     )
     _ensemble_size = ResPrototype("int enkf_main_get_ensemble_size(enkf_fs_manager)")
 
-    _is_initialized = ResPrototype("bool enkf_main_is_initialized(enkf_fs_manager)")
     _is_case_initialized = ResPrototype(
         "bool enkf_main_case_is_initialized(enkf_fs_manager, char*)"
     )
@@ -106,9 +104,6 @@ class EnkfFsManager(BaseCClass):
 
     _alloc_readonly_state_map = ResPrototype(
         "state_map_obj enkf_main_alloc_readonly_state_map(enkf_fs_manager, char*)"
-    )
-    _alloc_readonly_time_map = ResPrototype(
-        "time_map_obj enkf_main_alloc_readonly_time_map(enkf_fs_manager, char*)"
     )
 
     DEFAULT_CAPACITY = 5
@@ -220,10 +215,6 @@ class EnkfFsManager(BaseCClass):
     def isCaseInitialized(self, case):
         return self._is_case_initialized(case)
 
-    def isInitialized(self):
-        """@rtype: bool"""
-        return self._is_initialized()
-
     def getCaseList(self):
         """@rtype: list[str]"""
         caselist = [case for case in self._alloc_caselist()]
@@ -314,13 +305,6 @@ class EnkfFsManager(BaseCClass):
             return fs.getStateMap()
         else:
             return self._alloc_readonly_state_map(case)
-
-    def getTimeMapForCase(self, case) -> TimeMap:
-        """
-        @type case: str
-        @rtype: TimeMap
-        """
-        return self._alloc_readonly_time_map(case)
 
     def isCaseHidden(self, case_name):
         """


### PR DESCRIPTION
Have checked the usual suspects (everest, subscript and semeio), and the python functionality appears to be unused.

## Pre review checklist

- [x] Added appropriate labels
