### PR TITLE
Support numerical characters in parameter names

### DIFF
--- a/ert3/config/_parameters_config.py
+++ b/ert3/config/_parameters_config.py
@@ -29,9 +29,14 @@ def _ensure_valid_name(name: str) -> str:
     if not name:
         raise ValueError("Names cannot be of zero length")
 
-    if not all(c.isalpha() or c == "_" for c in name):
+    if not all(c.isalnum() or c == "_" for c in name):
         raise ValueError(
-            "Names are expected to only contain characters and `_`, was: {name}"
+            "Names must consist of only characters, numbers " f"and `_`, was: {name}"
+        )
+
+    if not name[0].isalpha():
+        raise ValueError(
+            f"First character in a name must be a character. Name was {name}"
         )
 
     return name

--- a/tests/ert_tests/ert3/config/test_parameters_config.py
+++ b/tests/ert_tests/ert3/config/test_parameters_config.py
@@ -201,10 +201,15 @@ def test_invalid_uniform(input_):
 @pytest.mark.parametrize(
     ("name", "err_msg"),
     (
-        ("no.go", "Names are expected to only contain characters"),
-        ("no-go", "Names are expected to only contain characters"),
-        ("no???", "Names are expected to only contain characters"),
-        ("no:go", "Names are expected to only contain characters"),
+        (
+            "no.go",
+            "Names must consist of only characters, numbers and `_`, was: no.go",
+        ),
+        ("no-go", "Names must consist of only characters"),
+        ("no???", "Names must consist of only characters"),
+        ("no:go", "Names must consist of only characters"),
+        ("1nogo", "First character in a name"),
+        ("_nogo", "First character in a name"),
         ("", "Names cannot be of zero length"),
     ),
 )
@@ -263,10 +268,12 @@ def test_valid_variables(variables):
 @pytest.mark.parametrize(
     ("name", "err_msg"),
     (
-        ("no.go", "Names are expected to only contain characters"),
-        ("no-go", "Names are expected to only contain characters"),
-        ("no???", "Names are expected to only contain characters"),
-        ("no:go", "Names are expected to only contain characters"),
+        ("no-go", "Names must consist of only characters"),
+        ("no.go", "Names must consist of only characters"),
+        ("no???", "Names must consist of only characters"),
+        ("no:go", "Names must consist of only characters"),
+        ("1nogo", "First character in a name"),
+        ("_nogo", "First character in a name"),
         ("", "Names cannot be of zero length"),
     ),
 )


### PR DESCRIPTION
**Issue**
Resolves #2659


**Approach**
Change from `isalpha()` to `isalnum()`. But not allow digit in first character.

Bonus bugfix: Missing f-string `f` in error message.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
