### PR TITLE
Pin fastapi==0.70.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "dnspython >= 2",
         "ecl >= 2.12.0",
         "ert-storage >= 0.3.4",
-        "fastapi",
+        "fastapi==0.70.1",
         "graphene",
         "graphlib_backport; python_version < '3.9'",
         "jinja2",


### PR DESCRIPTION
**Issue**
The latest fastapi is not compatible with ert-storage. Therefore pinning the version. 
The long-term solution would be to replace graphql usage from starlette by another 3rd party library: https://www.starlette.io/graphql/

