### PR TITLE
Use `ies::config::config` class for configuration also of std enkf module

### DIFF
--- a/libres/lib/analysis/ies/ies.cpp
+++ b/libres/lib/analysis/ies/ies.cpp
@@ -68,7 +68,6 @@ auto logger = ert::get_logger("ies");
 #define ITER_KEY "ITER"
 #define IES_DEBUG_KEY "IES_DEBUG"
 
-#define IES_SUBSPACE_KEY "IES_SUBSPACE"
 #define IES_INVERSION_KEY "IES_INVERSION"
 #define IES_LOGFILE_KEY "IES_LOGFILE"
 #define IES_AAPROJECTION_KEY "IES_AAPROJECTION"
@@ -622,9 +621,7 @@ bool set_bool(void *arg, const char *var_name, bool value) {
     {
         bool name_recognized = true;
 
-        if (strcmp(var_name, IES_SUBSPACE_KEY) == 0)
-            ies::config::set_subspace(ies_config, value);
-        else if (strcmp(var_name, IES_AAPROJECTION_KEY) == 0)
+        if (strcmp(var_name, IES_AAPROJECTION_KEY) == 0)
             ies::config::set_aaprojection(ies_config, value);
         else if (strcmp(var_name, IES_DEBUG_KEY) == 0)
             logger->warning("The key {} is ignored", IES_DEBUG_KEY);
@@ -640,9 +637,7 @@ bool get_bool(const void *arg, const char *var_name) {
     const ies::config::config_type *ies_config =
         ies::data_get_config(module_data);
     {
-        if (strcmp(var_name, IES_SUBSPACE_KEY) == 0)
-            return ies::config::get_subspace(ies_config);
-        else if (strcmp(var_name, IES_AAPROJECTION_KEY) == 0)
+        if (strcmp(var_name, IES_AAPROJECTION_KEY) == 0)
             return ies::config::get_aaprojection(ies_config);
         else
             return false;
@@ -703,8 +698,6 @@ bool has_var(const void *arg, const char *var_name) {
         else if (strcmp(var_name, IES_MIN_STEPLENGTH_KEY) == 0)
             return true;
         else if (strcmp(var_name, IES_DEC_STEPLENGTH_KEY) == 0)
-            return true;
-        else if (strcmp(var_name, IES_SUBSPACE_KEY) == 0)
             return true;
         else if (strcmp(var_name, IES_INVERSION_KEY) == 0)
             return true;

--- a/libres/lib/analysis/ies/ies_config.cpp
+++ b/libres/lib/analysis/ies/ies_config.cpp
@@ -36,7 +36,6 @@
 #define DEFAULT_IES_MIN_STEPLENGTH 0.30
 #define DEFAULT_IES_DEC_STEPLENGTH 2.50
 #define MIN_IES_DEC_STEPLENGTH 1.1
-#define DEFAULT_IES_SUBSPACE false
 #define DEFAULT_IES_INVERSION ies::config::IES_INVERSION_SUBSPACE_EXACT_R
 #define DEFAULT_IES_LOGFILE "ies.log"
 #define DEFAULT_IES_AAPROJECTION false
@@ -54,8 +53,8 @@ struct ies::config::config_struct {
         ies_min_steplength; // Controlled by config key: DEFAULT_IES_MIN_STEPLENGTH_KEY
     double
         ies_dec_steplength; // Controlled by config key: DEFAULT_IES_DEC_STEPLENGTH_KEY
-    bool ies_subspace;     // Controlled by config key: DEFAULT_IES_SUBSPACE
-    int ies_inversion;     // Controlled by config key: DEFAULT_IES_INVERSION
+    inversion_type
+        ies_inversion;     // Controlled by config key: DEFAULT_IES_INVERSION
     char *ies_logfile;     // Controlled by config key: DEFAULT_IES_LOGFILE
     bool ies_aaprojection; // Controlled by config key: DEFAULT_IES_AAPROJECTION
 };
@@ -72,7 +71,6 @@ ies::config::config_type *ies::config::alloc() {
     ies::config::set_max_steplength(config, DEFAULT_IES_MAX_STEPLENGTH);
     ies::config::set_min_steplength(config, DEFAULT_IES_MIN_STEPLENGTH);
     ies::config::set_dec_steplength(config, DEFAULT_IES_DEC_STEPLENGTH);
-    ies::config::set_subspace(config, DEFAULT_IES_SUBSPACE);
     ies::config::set_inversion(config, DEFAULT_IES_INVERSION);
     ies::config::set_logfile(config, DEFAULT_IES_LOGFILE);
     ies::config::set_aaprojection(config, DEFAULT_IES_AAPROJECTION);
@@ -117,6 +115,22 @@ void ies::config::set_option_flags(config_type *config, long flags) {
     config->option_flags = flags;
 }
 
+bool ies::config::get_option(const config_type *config,
+                             analysis_module_flag_enum option) {
+    return ((config->option_flags & option) == option);
+}
+
+void ies::config::set_option(config_type *config,
+                             analysis_module_flag_enum option) {
+    config->option_flags |= option;
+}
+
+void ies::config::del_option(config_type *config,
+                             analysis_module_flag_enum option) {
+    if (ies::config::get_option(config, option))
+        config->option_flags -= option;
+}
+
 /*------------------------------------------------------------------------------------------------*/
 /* IES_MAX_STEPLENGTH */
 double ies::config::get_max_steplength(const ies::config::config_type *config) {
@@ -155,21 +169,11 @@ void ies::config::set_dec_steplength(ies::config::config_type *config,
 /* IES_INVERSION          */
 ies::config::inversion_type
 ies::config::get_inversion(const ies::config::config_type *config) {
-    return static_cast<ies::config::inversion_type>(config->ies_inversion);
+    return config->ies_inversion;
 }
 void ies::config::set_inversion(ies::config::config_type *config,
                                 ies::config::inversion_type ies_inversion) {
     config->ies_inversion = ies_inversion;
-}
-
-/*------------------------------------------------------------------------------------------------*/
-/* IES_SUBSPACE      */
-bool ies::config::get_subspace(const ies::config::config_type *config) {
-    return config->ies_subspace;
-}
-void ies::config::set_subspace(ies::config::config_type *config,
-                               bool ies_subspace) {
-    config->ies_subspace = ies_subspace;
 }
 
 /*------------------------------------------------------------------------------------------------*/

--- a/libres/lib/include/ert/analysis/ies/ies_config.hpp
+++ b/libres/lib/include/ert/analysis/ies/ies_config.hpp
@@ -19,6 +19,8 @@
 #ifndef IES_CONFIG_H
 #define IES_CONFIG_H
 
+#include <ert/analysis/analysis_module.hpp>
+
 namespace ies {
 namespace config {
 
@@ -42,6 +44,9 @@ void set_truncation(config_type *config, double truncation);
 
 void set_option_flags(config_type *config, long flags);
 long get_option_flags(const config_type *config);
+bool get_option(const config_type *config, analysis_module_flag_enum option);
+void set_option(config_type *config, analysis_module_flag_enum option);
+void del_option(config_type *config, analysis_module_flag_enum option);
 
 double get_max_steplength(const config_type *config);
 void set_max_steplength(config_type *config, double max_steplength);

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
   ert_test_suite
   tmpdir.cpp
   analysis/ies/test_ies_enkf_main.cpp
+  analysis/ies/test_ies_config.cpp
   analysis/test_enkf_linalg.cpp
   analysis/test_save_parameters.cpp
   enkf/enkf_obs_paths_detailed.cpp

--- a/libres/tests/analysis/ies/test_ies_config.cpp
+++ b/libres/tests/analysis/ies/test_ies_config.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch.hpp>
+
+#include <ert/analysis/ies/ies_config.hpp>
+#include <ert/analysis/analysis_module.hpp>
+
+TEST_CASE("ies_config", "[analysis]") {
+    auto *config = ies::config::alloc();
+    ies::config::set_option_flags(config, 0);
+
+    SECTION("set_and_get_option") {
+        REQUIRE(ies::config::get_option(config, ANALYSIS_NEED_ED) == false);
+        ies::config::set_option(config, ANALYSIS_NEED_ED);
+        REQUIRE(ies::config::get_option(config, ANALYSIS_NEED_ED) == true);
+
+        ies::config::set_option(config, ANALYSIS_NEED_ED);
+        REQUIRE(ies::config::get_option_flags(config) == ANALYSIS_NEED_ED);
+    }
+
+    SECTION("del_option") {
+        ies::config::set_option(config, ANALYSIS_NEED_ED);
+        REQUIRE(ies::config::get_option_flags(config) == ANALYSIS_NEED_ED);
+
+        ies::config::del_option(config, ANALYSIS_NEED_ED);
+        REQUIRE(ies::config::get_option(config, ANALYSIS_NEED_ED) == false);
+        REQUIRE(ies::config::get_option_flags(config) == 0);
+
+        ies::config::del_option(config, ANALYSIS_NEED_ED);
+        REQUIRE(ies::config::get_option_flags(config) == 0);
+    }
+
+    ies::config::free(config);
+}


### PR DESCRIPTION
Another small step in the direction of unifying the std_enkf module and the ies module

~~This is on top of: https://github.com/equinor/ert/pull/2621~~