### PR TITLE
Gendata ndarray copy

### DIFF
--- a/libres/lib/CMakeLists.txt
+++ b/libres/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ pybind11_add_module(
   python/logging.cpp
   python/ensemble_config.cpp
   python/enkf_fs_manager.cpp
+  python/enkf_fs_general_data.cpp
   python/py_conversion.cpp
   python/enkf_defaults.cpp
   config/conf_util.cpp

--- a/libres/lib/include/ert/enkf/enkf_plot_gendata.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_gendata.hpp
@@ -39,6 +39,9 @@ enkf_plot_gendata_type *
 enkf_plot_gendata_alloc_from_obs_vector(const obs_vector_type *obs_vector);
 void enkf_plot_gendata_free(enkf_plot_gendata_type *data);
 int enkf_plot_gendata_get_size(const enkf_plot_gendata_type *data);
+int enkf_plot_gendata_get_data_size(const enkf_plot_gendata_type *data);
+std::vector<bool>
+enkf_plot_gendata_active_mask(const enkf_plot_gendata_type *data);
 enkf_plot_genvector_type *
 enkf_plot_gendata_iget(const enkf_plot_gendata_type *plot_data, int index);
 void enkf_plot_gendata_load(enkf_plot_gendata_type *plot_data, enkf_fs_type *fs,
@@ -49,7 +52,6 @@ double_vector_type *
 enkf_plot_gendata_get_min_values(enkf_plot_gendata_type *plot_data);
 double_vector_type *
 enkf_plot_gendata_get_max_values(enkf_plot_gendata_type *plot_data);
-
 UTIL_IS_INSTANCE_HEADER(enkf_plot_gendata);
 
 #ifdef __cplusplus

--- a/libres/lib/include/ert/python.hpp
+++ b/libres/lib/include/ert/python.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <ert/enkf/enkf_main.hpp>
+#include <ert/enkf/enkf_plot_gendata.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -55,5 +56,6 @@ enkf_main_type *to_enkf_main_type(py::object obj);
 ert_run_context_type *to_run_context_type(py::object obj);
 enkf_fs_type *to_enkf_fs_type(py::object obj);
 ensemble_config_type *to_ensemble_config_type(py::object obj);
+enkf_plot_gendata_type *to_enkf_plot_gendata_type(py::object obj);
 
 } // namespace py_conversion

--- a/libres/lib/python/enkf_fs_general_data.cpp
+++ b/libres/lib/python/enkf_fs_general_data.cpp
@@ -1,0 +1,61 @@
+#include <ert/enkf/enkf_plot_gendata.hpp>
+#include <ert/python.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+RES_LIB_SUBMODULE("enkf_fs_general_data", m) {
+    m.def(
+        "gendata_get_realizations",
+        [](py::object self, const std::vector<int> &realizations) {
+            auto enkf_plot_gendata =
+                py_conversion::to_enkf_plot_gendata_type(self);
+            const int data_size =
+                enkf_plot_gendata_get_data_size(enkf_plot_gendata);
+            if (data_size < 0) {
+                throw pybind11::value_error(
+                    "No data has been loaded for report step");
+            }
+            auto active_mask = enkf_plot_gendata_active_mask(enkf_plot_gendata);
+            const int realization_size = std::size(realizations);
+            const size_t size = data_size * realization_size;
+
+            double *data = new double[size];
+            std::fill_n(data, size, NAN);
+
+            for (int realization_index = 0;
+                 realization_index < realization_size; realization_index++) {
+                int realization = realizations.at(realization_index);
+                enkf_plot_genvector_type *vector =
+                    enkf_plot_gendata_iget(enkf_plot_gendata, realization);
+                int current_data_size = enkf_plot_genvector_get_size(vector);
+                // Following comment is from orginal code
+                // see: https://github.com/equinor/ert/blob/3f84b979b985376aade9203a6b977b9b541d8c14/res/enkf/export/gen_data_collector.py#L46
+                // Must check because of a bug changing between different case with different states
+                if (current_data_size > 0) {
+                    int data_index;
+                    for (data_index = 0; data_index < current_data_size;
+                         data_index++) {
+                        if (active_mask.at(data_index)) {
+                            data[realization_index +
+                                 realization_size * data_index] =
+                                enkf_plot_genvector_iget(vector, data_index);
+                        }
+                    }
+                }
+            }
+
+            py::capsule free_when_done(data, [](void *f) {
+                double *data = reinterpret_cast<double *>(f);
+                delete[] data;
+            });
+
+            return py::array_t<double>(
+                {data_size, realization_size}, // shape
+                {realization_size * sizeof(double),
+                 sizeof(double)}, // C-style contiguous strides for double
+                data,             // the data pointer
+                free_when_done);  // numpy array references this parent
+        },
+        py::arg("self"), py::arg("realizations"));
+}

--- a/libres/lib/python/py_conversion.cpp
+++ b/libres/lib/python/py_conversion.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <ert/enkf/enkf_main.hpp>
+#include <ert/enkf/enkf_plot_gendata.hpp>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -59,6 +60,19 @@ ensemble_config_type *to_ensemble_config_type(py::object obj) {
     void *pointer = PyLong_AsVoidPtr(address.ptr());
 
     return reinterpret_cast<ensemble_config_type *>(pointer);
+}
+
+enkf_plot_gendata_type *to_enkf_plot_gendata_type(py::object obj) {
+    static py::object class_ =
+        py::module_::import("res.enkf.plot_data.ensemble_plot_gen_data")
+            .attr("EnsemblePlotGenData");
+    if (!py::isinstance(obj, class_))
+        throw py::type_error("Not of type EnsemblePlotGenData");
+
+    py::int_ address = obj.attr("_BaseCClass__c_pointer");
+    void *pointer = PyLong_AsVoidPtr(address.ptr());
+
+    return reinterpret_cast<enkf_plot_gendata_type *>(pointer);
 }
 
 } // namespace py_conversion

--- a/res/enkf/export/gen_data_collector.py
+++ b/res/enkf/export/gen_data_collector.py
@@ -31,23 +31,7 @@ class GenDataCollector:
         gen_data_config = config_node.getModelConfig()
 
         ensemble_data = EnsemblePlotGenData(config_node, fs, report_step)
-        # The data size and active can only be inferred *after* the EnsembleLoad.
-        data_size = gen_data_config.getDataSize(report_step)
-        active_mask = gen_data_config.getActiveMask()
-
-        data_array = numpy.empty(
-            shape=(data_size, len(realizations)), dtype=numpy.float64
-        )
-        data_array.fill(numpy.nan)
-        for realization_index, realization_number in enumerate(realizations):
-            realization_vector = ensemble_data[realization_number]
-            if (
-                len(realization_vector) > 0
-            ):  # Must check because of a bug changing between different case with different states
-                for data_index in range(data_size):
-                    if active_mask[data_index]:
-                        value = realization_vector[data_index]
-                        data_array[data_index][realization_index] = value
+        data_array = ensemble_data.getRealizations(realizations)
 
         realizations = numpy.array(realizations)
         return DataFrame(data=data_array, columns=realizations)

--- a/res/enkf/plot_data/ensemble_plot_gen_data.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_data.py
@@ -17,6 +17,7 @@
 from cwrap import BaseCClass
 from ecl.util.util import BoolVector, DoubleVector
 from res import ResPrototype
+from res import _lib
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums import ErtImplType
@@ -84,6 +85,9 @@ class EnsemblePlotGenData(BaseCClass):
     def getMinValues(self) -> DoubleVector:
         """@rtype: DoubleVector"""
         return self._min_values().setParent(self)
+
+    def getRealizations(self, realizations):
+        return _lib.enkf_fs_general_data.gendata_get_realizations(self, realizations)
 
     def free(self):
         self._free()


### PR DESCRIPTION
**Issue**
Resolves #2649
A cause of performance issues with data collectors is  related to building ndarray by calling across python <-> c++ interface for each array element

**Approach**
Implement populating passed ndarray  in libres code so data can be built using single python<->c++ call instead of one call per array element.


## Pre review checklist

- [ ] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
