### PR TITLE
Use lowercase letters when specifying psb resources

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/prefect.py
+++ b/ert_shared/ensemble_evaluator/ensemble/prefect.py
@@ -88,8 +88,8 @@ def _get_executor(custom_port_range, name="local"):
             "project": "ERT-TEST",
             "local_directory": "$TMPDIR",
             "cores": 4,
-            "memory": "16GB",
-            "resource_spec": "select=1:ncpus=4:mem=16GB",
+            "memory": "16gb",
+            "resource_spec": "select=1:ncpus=4:mem=16gb",
         }
         return DaskExecutor(
             cluster_class="dask_jobqueue.PBSCluster",


### PR DESCRIPTION
**Issue**

Using uppercase letters causes problem on PSB clusters in Azure.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
