### PR TITLE
Don't ask for storage as an extras in CI

### DIFF
--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install ERT
       run: |
-        pip install .[storage]
+        pip install .
 
     - name: Start ert-storage
       run: |
@@ -84,7 +84,7 @@ jobs:
 
     - name: Install ERT
       run: |
-        pip install .[storage]
+        pip install .
 
     - name: Start postgres ert-storage
       env:

--- a/.github/workflows/run_examples_spe1.yml
+++ b/.github/workflows/run_examples_spe1.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         export CC=gcc-10
         export CXX=g++-10
-        pip install .[storage]
+        pip install .
 
     - name: Install spe1 dependencies
       run: |


### PR DESCRIPTION
**Issue**
Resolves warning in CI on missing extas in ERT.

This is a followup to https://github.com/equinor/ert/commit/28d777d4999185a80ca42015e0cd2af6c2e65a3f#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7


**Approach**
rm.  `ert-storage` is an explicit requirement now.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
