### PR TITLE
Remove leftover dd/mm/yyyy mention in docs

### DIFF
--- a/docs/rst/manual/reference/configuration/keywords.rst
+++ b/docs/rst/manual/reference/configuration/keywords.rst
@@ -1500,14 +1500,14 @@ but required when installing ERT at a new site.
                 TIME_MAP time_map.txt
 
         The format of the TIME_MAP file should just be a list of dates formatted as
-        dd/mm/yyyy. The example file below has four dates:
+        YYYY-MM-DD. The example file below has four dates:
 
         ::
 
-                01/01/2000
-                01/07/2000
-                01/01/2001
-                01/07/2001
+                2000-01-01
+                2000-07-01
+                2001-01-01
+                2001-07-01
 
 
 

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -840,7 +840,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
 
         const char *help_item_spec_date =
             "The DATE item gives the observation time as the date date it "
-            "occured. Format is dd/mm/yyyy.";
+            "occured. Format is YYYY-MM-DD.";
         conf_item_spec_type *item_spec_date =
             conf_item_spec_alloc("DATE", false, DT_DATE, help_item_spec_date);
 
@@ -935,7 +935,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
 
         const char *help_item_spec_date =
             "The DATE item gives the observation time as the date date it "
-            "occured. Format is dd/mm/yyyy.";
+            "occured. Format is YYYY-MM-DD.";
         conf_item_spec_type *item_spec_date =
             conf_item_spec_alloc("DATE", false, DT_DATE, help_item_spec_date);
 
@@ -1062,7 +1062,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "The item DATA gives the observed GEN_DATA instance.";
         const char *help_item_spec_date =
             "The DATE item gives the observation time as the date date it "
-            "occured. Format is dd/mm/yyyy.";
+            "occured. Format is YYYY-MM-DD.";
         const char *help_item_spec_days =
             "The DAYS item gives the observation time as days after simulation "
             "start.";


### PR DESCRIPTION
**Issue**
Resolves mention soon-deprecated date formats in docs. Reported by @asnyv

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
