### PR TITLE
Improve error messages in ert3 config validation

### DIFF
--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -142,7 +142,7 @@ async def _get_record_storage_transmitters(
         ):
             raise ert.exceptions.ErtError(
                 f"Ensemble size {ensemble_size} does not match stored record ensemble "
-                + f"size {len(uris)}"
+                + f"for {record_name} of size {len(uris)}"
             )
 
     transmitters = []

--- a/ert3/config/_experiment_run_config.py
+++ b/ert3/config/_experiment_run_config.py
@@ -194,6 +194,18 @@ class ExperimentRunConfig:
             input.record for input in self._ensemble_config.input
         )
         if ensemble_input_names != stage_input_names:
+            msg: str = ""
+
+            missing_in_ensemble = set(stage_input_names) - set(ensemble_input_names)
+            if missing_in_ensemble:
+                msg += (
+                    f"\nMissing record names in ensemble input: {missing_in_ensemble}."
+                )
+
+            missing_in_stage = set(ensemble_input_names) - set(stage_input_names)
+            if missing_in_stage:
+                msg += f"\nMissing record names in stage input: {missing_in_stage}."
+
             raise ert.exceptions.ConfigValidationError(
-                "Ensemble and stage inputs do not match."
+                f"Ensemble and stage inputs do not match.{msg}"
             )

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -238,9 +238,10 @@ def initialize(path: Union[str, Path]) -> Workspace:
         Workspace: A corresponding workspace object.
     """
     path = Path(path)
-    if _locate_root(path) is not None:
+    root = _locate_root(path)
+    if root is not None:
         raise ert.exceptions.IllegalWorkspaceOperation(
-            "Already inside an ERT workspace."
+            f"Already inside an ERT workspace, found {root}/.ert"
         )
     (path / _WORKSPACE_DATA_ROOT).mkdir()
     return Workspace(path)

--- a/tests/ert_tests/ert3/config/test_experiment_run_config.py
+++ b/tests/ert_tests/ert3/config/test_experiment_run_config.py
@@ -57,7 +57,10 @@ def test_experiment_run_config_validate_stage(
 ):
     with pytest.raises(
         ert.exceptions.ConfigValidationError,
-        match="Ensemble and stage inputs do not match.",
+        match=(
+            "Ensemble and stage inputs do not match.\n"
+            "Missing record names in ensemble input: {'other_coefficients'}."
+        ),
     ):
         ert3.config.ExperimentRunConfig(
             ert3.config.ExperimentConfig(type="evaluation"),
@@ -78,6 +81,29 @@ def test_experiment_run_config_validate_stage(
         ert3.config.ExperimentRunConfig(
             ert3.config.ExperimentConfig(type="evaluation"),
             double_stages_config,
+            ert3.config.EnsembleConfig.parse_obj(ensemble_dict),
+            ert3.config.ParametersConfig.parse_obj([]),
+        )
+
+
+def test_experiment_run_config_validate_stage_missing_stage_record(
+    stages_config, base_ensemble_dict
+):
+
+    ensemble_dict = copy.deepcopy(base_ensemble_dict)
+    ensemble_dict["input"].append(
+        {"source": "stochastic.other_coefficients", "record": "other_coefficients"}
+    )
+    with pytest.raises(
+        ert.exceptions.ConfigValidationError,
+        match=(
+            "Ensemble and stage inputs do not match.\n"
+            "Missing record names in stage input: {'other_coefficients'}."
+        ),
+    ):
+        ert3.config.ExperimentRunConfig(
+            ert3.config.ExperimentConfig(type="evaluation"),
+            stages_config,
             ert3.config.EnsembleConfig.parse_obj(ensemble_dict),
             ert3.config.ParametersConfig.parse_obj([]),
         )

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -690,7 +690,10 @@ def test_incompatible_partial_sensitivity_run(
             )
         )
 
-    err_msg = "Ensemble size 6 does not match stored record ensemble size 10"
+    err_msg = (
+        "Ensemble size 6 does not match stored record ensemble "
+        "for other_coefficients of size 10"
+    )
     experiment_run_config = ert3.config.ExperimentRunConfig(
         sensitivity_oat_experiment_config,
         double_stages_config,

--- a/tests/ert_tests/ert3/workspace/test_workspace.py
+++ b/tests/ert_tests/ert3/workspace/test_workspace.py
@@ -18,11 +18,12 @@ def test_workspace_initialize(tmpdir, ert_storage):
     ert3.workspace.initialize(tmpdir)
     ert.storage.init(workspace_name=tmpdir)
 
-    assert (Path(tmpdir) / ert3.workspace._workspace._WORKSPACE_DATA_ROOT).is_dir()
+    data_root = Path(tmpdir) / ert3.workspace._workspace._WORKSPACE_DATA_ROOT
+    assert data_root.is_dir()
 
     with pytest.raises(
         ert.exceptions.IllegalWorkspaceOperation,
-        match="Already inside an ERT workspace.",
+        match=f"Already inside an ERT workspace, found {data_root}",
     ):
         ert3.workspace.initialize(tmpdir)
         ert.storage.init(workspace_name=tmpdir)


### PR DESCRIPTION
* Expose which .ert directory must be deleted for `ert3 init`
* Expose explicitly inconsistencies in stage vs ensemble records

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
