### PR TITLE
Pretty print json for human readable files

### DIFF
--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -33,6 +33,7 @@ class _json_serializer(Serializer):
     def encode(
         self, obj: Any, *args: Any, indent: Optional[int] = 4, **kwargs: Any
     ) -> str:
+        # pylint: disable=arguments-differ
         return json.dumps(obj, *args, indent=indent, **kwargs)
 
     def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:

--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import aiofiles
 import yaml
@@ -30,10 +30,10 @@ class Serializer(ABC):
 
 
 class _json_serializer(Serializer):
-    def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
-        if "indent" not in kwargs:
-            kwargs["indent"] = 4
-        return json.dumps(obj, *args, **kwargs)
+    def encode(
+        self, obj: Any, *args: Any, indent: Optional[int] = 4, **kwargs: Any
+    ) -> str:
+        return json.dumps(obj, *args, indent=indent, **kwargs)
 
     def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
         return json.loads(series, *args, **kwargs)

--- a/ert/serialization/_serializer.py
+++ b/ert/serialization/_serializer.py
@@ -31,6 +31,8 @@ class Serializer(ABC):
 
 class _json_serializer(Serializer):
     def encode(self, obj: Any, *args: Any, **kwargs: Any) -> str:
+        if "indent" not in kwargs:
+            kwargs["indent"] = 4
         return json.dumps(obj, *args, **kwargs)
 
     def decode(self, series: str, *args: Any, **kwargs: Any) -> Any:
@@ -40,7 +42,7 @@ class _json_serializer(Serializer):
         self, obj: Any, path: Union[str, Path], *args: Any, **kwargs: Any
     ) -> None:
         async with aiofiles.open(path, mode="wt", encoding="utf-8") as filehandle:
-            await filehandle.write(json.dumps(obj))
+            await filehandle.write(json.dumps(obj, indent=4))
 
     async def decode_from_path(
         self, path: Union[str, Path], *args: Any, **kwargs: Any

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -199,7 +199,7 @@ class Workspace:
             output_file = "data.json"
         self.assert_experiment_exists(experiment_name)
         with open(experiment_root / output_file, "w", encoding="utf-8") as f:
-            json.dump(data, f)
+            json.dump(data, f, indent=4, sort_keys=True)
 
     def _validate_resources(self, ensemble_config: ert3.config.EnsembleConfig) -> None:
         resource_inputs = [

--- a/ert3_examples/polynomial/poly.py
+++ b/ert3_examples/polynomial/poly.py
@@ -61,7 +61,7 @@ def _main():
     args = parser.parse_args()
     result = _evaluate_polynomial(args.coefficients, args.x_uncertainties)
     with open(args.output, "w") as f:
-        json.dump(result, f)
+        json.dump(result, f, indent=4)
 
 
 if __name__ == "__main__":

--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -346,7 +346,7 @@ class BaseService:
 
         if isinstance(info, Mapping):
             with open(f"{self.service_name}_server.json", "w") as f:
-                json.dump(info, f)
+                json.dump(info, f, indent=4)
 
         self._conn_info_event.set()
 

--- a/job_runner/job.py
+++ b/job_runner/job.py
@@ -70,7 +70,7 @@ class Job:
                 os.path.basename(self.job_data.get("executable"))
             )
             with open("{}_exec_env.json".format(exec_name), "w") as f:
-                f.write(json.dumps(exec_env))
+                f.write(json.dumps(exec_env, indent=4))
 
         max_running_minutes = self.job_data.get("max_running_minutes")
         run_start_time = dt.now()

--- a/job_runner/reporting/file.py
+++ b/job_runner/reporting/file.py
@@ -198,4 +198,4 @@ class File(Reporter):
 
     def _dump_status_json(self):
         with open(self.STATUS_json, "w") as fp:
-            json.dump(self.status_dict, fp, indent=1)
+            json.dump(self.status_dict, fp, indent=4)

--- a/tests/ert_tests/ert3/data/test_serializer.py
+++ b/tests/ert_tests/ert3/data/test_serializer.py
@@ -16,10 +16,18 @@ def test_json_serializer_encode_decode(obj, obj_json):
     assert json.loads(json_serializer.encode(obj)) == json.loads(obj_json)
     assert json_serializer.decode(obj_json) == obj
 
-    # Test that keyword arguments are passed through
-    assert json_serializer.decode(json_serializer.encode(obj, indent=True)) == obj
+    # Test that indent actually makes a differences:
+    if obj:
+        assert len(json_serializer.encode(obj, indent=2)) > len(
+            json_serializer.encode(obj, indent=1)
+        )
 
-    # Most compact json serialization:
+    # Test default indent:
+    assert len(json_serializer.encode(obj, indent=4)) == len(
+        json_serializer.encode(obj)
+    )
+
+    # Test ability to reach the most compact json serialization:
     assert json_serializer.encode(
         obj, indent=None, separators=(",", ":")
     ) == obj_json.replace(" ", "")

--- a/tests/ert_tests/ert3/data/test_serializer.py
+++ b/tests/ert_tests/ert3/data/test_serializer.py
@@ -1,9 +1,6 @@
-import datetime
-import os
+import json
 
-import numpy as np
 import pytest
-
 from ert.serialization import _serializer
 
 OBJECTS = [None, {}, {"foo": "bar"}]
@@ -16,14 +13,16 @@ assert len(OBJECTS) == len(OBJECTS_JSON) == len(OBJECTS_YAML)
 def test_json_serializer_encode_decode(obj, obj_json):
     json_serializer = _serializer._json_serializer()
 
-    assert json_serializer.encode(obj) == obj_json
+    assert json.loads(json_serializer.encode(obj)) == json.loads(obj_json)
     assert json_serializer.decode(obj_json) == obj
 
     # Test that keyword arguments are passed through
     assert json_serializer.decode(json_serializer.encode(obj, indent=True)) == obj
-    assert json_serializer.encode(obj, separators=(",", ":")) == obj_json.replace(
-        " ", ""
-    )
+
+    # Most compact json serialization:
+    assert json_serializer.encode(
+        obj, indent=None, separators=(",", ":")
+    ) == obj_json.replace(" ", "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Issue**
Resolves #318 once more..


**Approach**
Add `indent=4` to occurences of `json.dump()` whenever it writes to a file that a human might read.


~~There are some occurences of `indent=1` already in the code base, not sure if consistency with that is important, or if we should try to be consistent with how `black` would format the same dictionaries in source code~~

Changed existing `indent=1` into `indent=4`.

Considered to add `sort_keys=True` also, but skipped it, might confuse.

Occurences of `json.dump()` in tests are not touched.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
