### PR TITLE
Use std variant

### DIFF
--- a/libres/lib/include/ert/analysis/enkf_linalg.hpp
+++ b/libres/lib/include/ert/analysis/enkf_linalg.hpp
@@ -1,14 +1,11 @@
 #ifndef ERT_ENKF_LINALG_H
 #define ERT_ENKF_LINALG_H
+#include <variant>
 
 #include <ert/util/double_vector.hpp>
 
 #include <ert/res_util/matrix_lapack.hpp>
 #include <ert/res_util/matrix.hpp>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 void enkf_linalg_init_stdX(matrix_type *X, const matrix_type *S,
                            const matrix_type *D, const matrix_type *W,
@@ -22,7 +19,8 @@ void enkf_linalg_init_sqrtX(matrix_type *X5, const matrix_type *S,
 void enkf_linalg_Cee(matrix_type *B, int nrens, const matrix_type *R,
                      const matrix_type *U0, const double *inv_sig0);
 
-int enkf_linalg_svdS(const matrix_type *S, double truncation, int ncomp,
+int enkf_linalg_svdS(const matrix_type *S,
+                     const std::variant<double, int> &truncation,
                      dgesvd_vector_enum jobVT, double *sig0, matrix_type *U0,
                      matrix_type *V0T);
 
@@ -31,13 +29,14 @@ matrix_type *enkf_linalg_alloc_innov(const matrix_type *dObs,
 
 void enkf_linalg_lowrankCinv__(const matrix_type *S, const matrix_type *R,
                                matrix_type *V0T, matrix_type *Z, double *eig,
-                               matrix_type *U0, double truncation, int ncomp);
+                               matrix_type *U0,
+                               const std::variant<double, int> &truncation);
 
 void enkf_linalg_lowrankCinv(
     const matrix_type *S, const matrix_type *R,
     matrix_type *W, /* Corresponding to X1 from Eq. 14.29 */
     double *eig,    /* Corresponding to 1 / (1 + Lambda_1) (14.29) */
-    double truncation, int ncomp);
+    const std::variant<double, int> &truncation);
 
 void enkf_linalg_lowrankE(
     const matrix_type *S, /* (nrobs x nrens) */
@@ -46,7 +45,7 @@ void enkf_linalg_lowrankE(
         *W, /* (nrobs x nrmin) Corresponding to X1 from Eqs. 14.54-14.55 */
     double
         *eig, /* (nrmin)         Corresponding to 1 / (1 + Lambda1^2) (14.54) */
-    double truncation, int ncomp);
+    const std::variant<double, int> &truncation);
 
 void enkf_linalg_genX2(matrix_type *X2, const matrix_type *S,
                        const matrix_type *W, const double *eig);
@@ -64,7 +63,4 @@ matrix_type *enkf_linalg_alloc_mp_randrot(int ens_size, rng_type *rng);
 void enkf_linalg_set_randrot(matrix_type *Q, rng_type *rng);
 void enkf_linalg_checkX(const matrix_type *X, bool bootstrap);
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/libres/lib/include/ert/analysis/ies/ies.hpp
+++ b/libres/lib/include/ert/analysis/ies/ies.hpp
@@ -18,6 +18,7 @@
 
 #ifndef IES_ENKF_H
 #define IES_ENKF_H
+#include <variant>
 
 #include <ert/util/bool_vector.hpp>
 #include <ert/util/rng.hpp>
@@ -38,7 +39,7 @@ void init_update(void *arg, const bool_vector_type *ens_mask,
                  const matrix_type *R, const matrix_type *dObs,
                  const matrix_type *E, const matrix_type *D, rng_type *rng);
 
-void initX(double truncation, int subspace_dimension,
+void initX(const std::variant<double, int> &truncation,
            config::inversion_type ies_inversion, const matrix_type *Y0,
            const matrix_type *R, const matrix_type *E, const matrix_type *D,
            matrix_type *X);

--- a/libres/lib/include/ert/analysis/ies/ies_config.hpp
+++ b/libres/lib/include/ert/analysis/ies/ies_config.hpp
@@ -20,6 +20,7 @@
 #define IES_CONFIG_H
 
 #include <ert/analysis/analysis_module.hpp>
+#include <variant>
 
 namespace ies {
 namespace config {
@@ -36,11 +37,9 @@ typedef struct config_struct config_type;
 config_type *alloc();
 void free(config_type *config);
 
-int get_subspace_dimension(const config_type *config);
-void set_subspace_dimension(config_type *config, int subspace_dimension);
-
-double get_truncation(const config_type *config);
+const std::variant<double, int> &get_truncation(const config_type *config);
 void set_truncation(config_type *config, double truncation);
+void set_subspace_dimension(config_type *config, int subspace_dimension);
 
 void set_option_flags(config_type *config, long flags);
 long get_option_flags(const config_type *config);

--- a/libres/lib/include/ert/analysis/std_enkf.hpp
+++ b/libres/lib/include/ert/analysis/std_enkf.hpp
@@ -1,5 +1,6 @@
 #ifndef ERT_STD_ENKF_H
 #define ERT_STD_ENKF_H
+#include <variant>
 
 #include <ert/res_util/matrix.hpp>
 #include <ert/util/rng.hpp>
@@ -20,8 +21,6 @@
 typedef struct std_enkf_data_struct std_enkf_data_type;
 
 bool std_enkf_set_double(void *arg, const char *var_name, double value);
-
-int std_enkf_get_subspace_dimension(std_enkf_data_type *data);
 void std_enkf_set_truncation(std_enkf_data_type *data, double truncation);
 void std_enkf_set_subspace_dimension(std_enkf_data_type *data,
                                      int subspace_dimension);
@@ -29,7 +28,8 @@ bool std_enkf_has_var(const void *arg, const char *var_name);
 ies::config::inversion_type
 std_enkf_data_get_inversion(const std_enkf_data_type *data);
 
-double std_enkf_get_truncation(std_enkf_data_type *data);
+const std::variant<double, int> &
+std_enkf_get_truncation(std_enkf_data_type *data);
 void *std_enkf_data_alloc();
 void std_enkf_data_free(void *module_data);
 

--- a/libres/tests/analysis/test_compare_initX.cpp
+++ b/libres/tests/analysis/test_compare_initX.cpp
@@ -73,7 +73,6 @@ TEST_CASE("compare_initX", "[analysis]") {
             std_enkf_initX(std_enkf_data, X1, nullptr, S, R, nullptr, E, D,
                            rng);
             ies::initX(std_enkf_get_truncation(std_enkf_data),
-                       std_enkf_get_subspace_dimension(std_enkf_data),
                        std_enkf_data_get_inversion(std_enkf_data), S, R, E, D,
                        X2);
 
@@ -97,7 +96,6 @@ TEST_CASE("compare_initX", "[analysis]") {
             std_enkf_initX(std_enkf_data, X1, nullptr, S, R, nullptr, E, D,
                            rng);
             ies::initX(std_enkf_get_truncation(std_enkf_data),
-                       std_enkf_get_subspace_dimension(std_enkf_data),
                        std_enkf_data_get_inversion(std_enkf_data), S, R, E, D,
                        X2);
 


### PR DESCRIPTION
All the SVD routines can specify the number of singular values to retain in two different ways - either as an integer specifying the number of singular values directly, or as a floating point number specifying the amount variation explained.

With this PR this is implemented with `std::variant<double, int>`

On top of #2681