### PR TITLE
Remove deprecated (py38) loop parameter

### DIFF
--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -46,9 +46,7 @@ class EnsembleEvaluator:
         self._done = self._loop.create_future()
 
         self._clients: Set[WebSocketServerProtocol] = set()
-        self._dispatchers_connected: asyncio.Queue[None] = asyncio.Queue(
-            loop=self._loop
-        )
+        self._dispatchers_connected: asyncio.Queue[None] = asyncio.Queue()
         self._batcher = Batcher(timeout=2, loop=self._loop)
         self._dispatcher = Dispatcher(
             ensemble=self._ensemble,


### PR DESCRIPTION
**Issue**
Resolves deprecation warnings
`...../ert/ert_shared/ensemble_evaluator/evaluator.py:49: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
`  

**Approach**
Removed the argument at selected places in the source, and looking for test failures.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
