### PR TITLE
Explicit mime type to avoid warning

### DIFF
--- a/ert3_examples/polynomial/experiments/doe/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/doe/ensemble.yml
@@ -4,6 +4,7 @@ input:
   -
     source: storage.designed_coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/evaluation/ensemble.yml
@@ -4,6 +4,7 @@ input:
   -
     source: stochastic.coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/fast_sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/fast_sensitivity/ensemble.yml
@@ -2,6 +2,7 @@ input:
   -
     source: stochastic.uniform_coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/function_evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/function_evaluation/ensemble.yml
@@ -4,6 +4,7 @@ input:
   -
     source: stochastic.coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/partial_sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/partial_sensitivity/ensemble.yml
@@ -2,9 +2,11 @@ input:
   -
     source: stochastic.coefficients
     record: coefficients
+    mime: application/json
   -
     source: storage.coefficients
     record: other_coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/sensitivity/ensemble.yml
@@ -2,6 +2,7 @@ input:
   -
     source: stochastic.coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/uniform_evaluation/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/uniform_evaluation/ensemble.yml
@@ -4,6 +4,7 @@ input:
   -
     source: stochastic.uniform_coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/uniform_sensitivity/ensemble.yml
@@ -2,6 +2,7 @@ input:
   -
     source: stochastic.uniform_coefficients
     record: coefficients
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/polynomial/experiments/x_uncertainty/ensemble.yml
+++ b/ert3_examples/polynomial/experiments/x_uncertainty/ensemble.yml
@@ -4,9 +4,11 @@ input:
   -
     source: stochastic.coefficients
     record: coefficients
+    mime: application/json
   -
     source: stochastic.x_normals
     record: x_uncertainties
+    mime: application/json
 
 output:
   -

--- a/ert3_examples/spe1/experiments/doe/ensemble.yml
+++ b/ert3_examples/spe1/experiments/doe/ensemble.yml
@@ -4,6 +4,7 @@ input:
   -
     source: storage.designed_field_properties
     record: field_properties
+    mime: application/json
   -
     source: resources.wells.json
     record: wells

--- a/ert3_examples/spe1/experiments/evaluation/ensemble.yml
+++ b/ert3_examples/spe1/experiments/evaluation/ensemble.yml
@@ -4,9 +4,11 @@ input:
   -
     source: stochastic.field_properties
     record: field_properties
+    mime: application/json
   -
     source: stochastic.wells_no_delay
     record: wells
+    mime: application/json
   -
     source: resources.case
     record: spe1_template

--- a/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
+++ b/ert3_examples/spe1/experiments/sensitivity/ensemble.yml
@@ -2,10 +2,12 @@ input:
   -
     source: stochastic.field_properties
     record: field_properties
+    mime: application/json
   -
     source: stochastic.wells
     record: wells
-  
+    mime: application/json
+
   - source: resources.case
     record: spe1_template
 


### PR DESCRIPTION
**Issue**
Resolves warnings on mime inconsistencies when running ert3, example:

`Warning: Conflicting ensemble mime 'application/octet-stream' and stage mime 'application/json' for input 'coefficients'.`

**Approach**
Explicitly set the mime type in each experiments `ensemble.yml`. There is a hunch that this is a workaround, so maybe not something we want to leak into this file.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
