### PR TITLE
Increase timeout from run_examples_polynomial CI

### DIFF
--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-ert3-polynomial-local:
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
         popd
 
   run-ert3-polynomial-postgres:
-    timeout-minutes: 20
+    timeout-minutes: 60
     services:
       postgres:
         image: postgres:10.8


### PR DESCRIPTION
This keeps timing out constantly, impeding other work. The default on
Github Actions is six hours, so this should finish within that time.
