### PR TITLE
Raise meaningful exception when accessing non existing analysis module

### DIFF
--- a/libres/lib/enkf/analysis_config.cpp
+++ b/libres/lib/enkf/analysis_config.cpp
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>
+#include <fmt/format.h>
 
 #include <ert/util/util.h>
 
@@ -252,7 +253,12 @@ void analysis_config_add_module_copy(analysis_config_type *config,
 analysis_module_type *
 analysis_config_get_module(const analysis_config_type *config,
                            const char *module_name) {
-    return config->analysis_modules.at(module_name);
+    if (analysis_config_has_module(config, module_name)) {
+        return config->analysis_modules.at(module_name);
+    } else {
+        throw std::invalid_argument(
+            fmt::format("Analysis module named {} not found", module_name));
+    }
 }
 
 bool analysis_config_has_module(const analysis_config_type *config,
@@ -428,8 +434,12 @@ void analysis_config_init(analysis_config_type *analysis,
                 const char *module_name =
                     config_content_node_iget(assign_node, 0);
                 const char *var_name = config_content_node_iget(assign_node, 1);
-                analysis_module_type *module =
-                    analysis_config_get_module(analysis, module_name);
+                analysis_module_type *module;
+                try {
+                    module = analysis_config_get_module(analysis, module_name);
+                } catch (std::invalid_argument &e) {
+                    util_abort("Error loading config file: %s", e.what());
+                }
                 {
                     char *value = NULL;
 

--- a/libres/tests/enkf/test_analysis_config.cpp
+++ b/libres/tests/enkf/test_analysis_config.cpp
@@ -23,3 +23,20 @@ TEST_CASE("analysis_config_module_names", "[enkf]") {
         }
     }
 }
+
+TEST_CASE("Accessing analysis modules loaded in config", "[enkf]") {
+    GIVEN("A default analysis config with internal modules loaded") {
+        auto analysis_config = analysis_config_alloc_default();
+        WHEN("Internal modules are loaded") {
+            analysis_config_load_internal_modules(analysis_config);
+            THEN("Fetching existing module do not raise exception") {
+                REQUIRE_NOTHROW(
+                    analysis_config_get_module(analysis_config, "STD_ENKF"));
+            }
+            THEN("Fetching non existing module raises exception") {
+                REQUIRE_THROWS(
+                    analysis_config_get_module(analysis_config, "UNKNOWN"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue**
Resolves #2714 

**Approach**
Raise exception when accessing analysis modules which does not exist

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
