### PR TITLE
Make ert3 log to console when realisations complete

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -7,7 +7,11 @@ from ert_shared.ensemble_evaluator.ensemble.base import Ensemble
 from ert_shared.ensemble_evaluator.entity.identifiers import EVTYPE_EE_TERMINATED
 from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
 
-from ert_shared.status.entity.state import ENSEMBLE_STATE_STOPPED, ENSEMBLE_STATE_FAILED
+from ert_shared.status.entity.state import (
+    ENSEMBLE_STATE_STOPPED,
+    ENSEMBLE_STATE_FAILED,
+    REALIZATION_STATE_FINISHED,
+)
 
 
 def _run(
@@ -15,6 +19,8 @@ def _run(
 ) -> Dict[int, Dict[str, ert.data.RecordTransmitter]]:
     result: Dict[int, Dict[str, ert.data.RecordTransmitter]] = {}
     with ensemble_evaluator.run() as monitor:
+        realization_ids = set()
+        realizations_completed = set()
         for event in monitor.track():
             if isinstance(event.data, dict) and event.data.get("status") in [
                 ENSEMBLE_STATE_STOPPED,
@@ -25,6 +31,19 @@ def _run(
                     raise RuntimeError("Ensemble evaluation failed")
             if event["type"] == EVTYPE_EE_TERMINATED and isinstance(event.data, bytes):
                 result = pickle.loads(event.data)
+            if isinstance(event.data, dict) and "reals" in event.data:
+                for real_id in event.data["reals"]:
+                    realization_ids.add(real_id)
+                    real_status = event.data["reals"][real_id].get("status")
+                    if (
+                        real_status == REALIZATION_STATE_FINISHED
+                        and real_id not in realizations_completed
+                    ):
+                        realizations_completed.add(real_id)
+                        print(
+                            f"Realization {real_id} completed successfully"
+                            f" ({len(realizations_completed)}/{len(realization_ids)})"
+                        )
 
     return result
 


### PR DESCRIPTION
**Approach**
Make `ert3.evaluator` print a message whenever an event with a completing realisation occurs.

The implementation is crude in at least two ways:
- it allows `ert3.evaluator` to print directly to console instead of propagating this as an event to an entity that knows how to present this and
- it inspects the event with no tooling or support code.

## Pre review checklist

- [x] Added appropriate labels