### PR TITLE
Add RES_LIB_SUBMODULE to pybind11 code

### DIFF
--- a/libres/lib/enkf/config_keys.cpp
+++ b/libres/lib/enkf/config_keys.cpp
@@ -2,7 +2,7 @@
 #include <ert/enkf/config_keys.hpp>
 #include <pybind11/pytypes.h>
 
-void init_config_keys(py::module_ m) {
+RES_LIB_SUBMODULE("config_keys", m) {
     struct ConfigKeys {};
 
     py::class_<ConfigKeys> cls(m, "ConfigKeys");

--- a/libres/lib/include/ert/python.hpp
+++ b/libres/lib/include/ert/python.hpp
@@ -1,22 +1,54 @@
-#ifndef RES_PYTHON_HPP
-#define RES_PYTHON_HPP
+/**
+ * This header contains utilities for interacting with Python via pybind11
+ */
+
+#pragma once
 
 #include <ert/enkf/enkf_main.hpp>
-
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <ert/logging.hpp>
 
 namespace py = pybind11;
-/**
- * This header contains utilities for interacting with Python via pybind11
- */
-#endif
+
+namespace ert::detail {
+struct Submodule {
+    using init_type = void(py::module_);
+    const char *path;
+    init_type &init;
+
+    Submodule(const char *, init_type &);
+};
+} // namespace ert::detail
 
 /**
- * Create a namespace for converting cwrap`ed python objects to c++
+ * Define a submodule path within the Python package 'res._lib'
+ *
+ * This is macro is similar to Pybind11's PYBIND11_MODULE macro. The first
+ * argument is the Python submodule path, and the second is the name of the
+ * py::module_ parameter (eg. 'm').
+ *
+ * For example, the following will create the Python module 'res._lib.foo.bar'
+ * which contains an object named 'baz' whose value is the string 'quz'.
+ *
+ *     RES_LIB_SUBMODULE("foo.bar", m) {
+ *         m.add_object("baz", py::str{"quz"});
+ *     }
+ *
+ * Multiple initialisation functions can be defined for the same submodule.
+ * However, the order in which each function is called is undefined.
+ *
+ * Note: The name of this macro should reflect the module path of this libres
+ * library. At the moment it is 'res._lib', so the macro is prefixed with
+ * RES_LIB.
  */
+#define RES_LIB_SUBMODULE(_Path, _ModuleParam)                                 \
+    static void _python_submodule_init(py::module_);                           \
+    static ::ert::detail::Submodule _python_submodule{_Path,                   \
+                                                      _python_submodule_init}; \
+    void _python_submodule_init(py::module_ _ModuleParam)
+
 namespace py_conversion {
 
 enkf_main_type *to_enkf_main_type(py::object obj);

--- a/libres/lib/include/ert/res_util/string.hpp
+++ b/libres/lib/include/ert/res_util/string.hpp
@@ -30,7 +30,7 @@ void split(std::string_view str, char delimiter, Func &&func) {
  *
  * Equivalent to Python's: `s.split(delim)[-1]`
  */
-std::string_view back_element(std::string_view str, char delimiter) {
+inline std::string_view back_element(std::string_view str, char delimiter) {
     auto pos = str.rfind(delimiter);
     return pos == str.npos ? str : str.substr(pos + 1);
 }

--- a/libres/lib/python/enkf_defaults.cpp
+++ b/libres/lib/python/enkf_defaults.cpp
@@ -1,11 +1,7 @@
 #include <ert/enkf/enkf_defaults.hpp>
 #include <ert/python.hpp>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
-namespace py = pybind11;
-
-void enkf_defaults(py::module_ m) {
+RES_LIB_SUBMODULE("enkf_defaults", m) {
     m.add_object("DEFAULT_GEN_KW_EXPORT_NAME",
                  py::str(DEFAULT_GEN_KW_EXPORT_NAME));
 }

--- a/libres/lib/python/enkf_fs_manager.cpp
+++ b/libres/lib/python/enkf_fs_manager.cpp
@@ -1,11 +1,7 @@
 #include <ert/enkf/enkf_main.hpp>
 #include <ert/python.hpp>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
-namespace py = pybind11;
-
-void enkf_fs_manager(py::module_ m) {
+RES_LIB_SUBMODULE("enkf_fs_manager", m) {
     m.def(
         "initialize_from_scratch",
         [](py::object self, std::vector<std::string> param_list,

--- a/libres/lib/python/ensemble_config.cpp
+++ b/libres/lib/python/ensemble_config.cpp
@@ -5,7 +5,7 @@
 
 namespace py = pybind11;
 
-void ensemble_config(py::module_ m) {
+RES_LIB_SUBMODULE("ensemble_config", m) {
     m.def(
         "ensemble_config_keylist_from_var_type",
         [](py::object self, int var_mask) {

--- a/libres/lib/python/init.cpp
+++ b/libres/lib/python/init.cpp
@@ -6,8 +6,20 @@
 #include <ert/enkf/obs_vector.hpp>
 #include <ert/enkf/analysis_config.hpp>
 #include <ert/enkf/ensemble_config.hpp>
+#include <ert/python.hpp>
+#include <ert/res_util/string.hpp>
 
-namespace py = pybind11;
+namespace {
+auto &submodules() {
+    static std::vector<ert::detail::Submodule *> submodules;
+    return submodules;
+}
+} // namespace
+
+ert::detail::Submodule::Submodule(const char *path, init_type &init)
+    : path(path), init(init) {
+    submodules().push_back(this);
+}
 
 obs_vector_type *to_obs_vector_type(py::object obj) {
     py::object address = obj.attr("_BaseCClass__c_pointer");
@@ -27,6 +39,21 @@ analysis_config_type *to_analysis_config_type(py::object obj) {
 }
 
 PYBIND11_MODULE(_lib, m) {
+    /* Initialise submodules */
+    for (auto submodule : submodules()) {
+        py::module_ node = m;
+        ert::split(submodule->path, '.', [&node](auto name) {
+            std::string sname{name};
+            if (hasattr(node, sname.c_str())) {
+                node = node.attr(sname.c_str());
+            } else {
+                node = node.def_submodule(sname.c_str());
+            }
+        });
+
+        submodule->init(node);
+    }
+
     m.def(
         "obs_vector_get_step_list",
         [](py::object self) {
@@ -41,15 +68,4 @@ PYBIND11_MODULE(_lib, m) {
             return analysis_config_module_names(analysis_config);
         },
         py::arg("self"));
-    void init_logging(py::module_ m);
-    init_logging(m);
-    void ensemble_config(py::module_);
-    ensemble_config(m.def_submodule("ensemble_config"));
-    void enkf_fs_manager(py::module_);
-    enkf_fs_manager(m.def_submodule("enkf_fs_manager"));
-
-    void init_config_keys(py::module_ m);
-    init_config_keys(m.def_submodule("config_keys"));
-    void enkf_defaults(py::module_ m);
-    enkf_defaults(m.def_submodule("enkf_defaults"));
 }

--- a/libres/lib/python/logging.cpp
+++ b/libres/lib/python/logging.cpp
@@ -118,7 +118,7 @@ std::shared_ptr<ert::ILogger> ert::get_logger(const std::string &name) {
     return logger;
 }
 
-void init_logging(py::module_ m) {
+RES_LIB_SUBMODULE("", m) {
     has_init_logging = true;
 
     // Initialise all loggers that were created before Python initialised


### PR DESCRIPTION
This is a macro that:
1. Creates a submodule (if needed)
2. Calls the init function with the module object

Registration of submodules can then be done implicitly by using
`RES_LIB_SUBMODULE` in a `.cpp` file without having to add it to
`lib/python/init.cpp`.

---

My goal was to use pybind11's [custom type casting](https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html) functionality to remove the entirety of `py_conversion::*` and the wrapper classes, but alas it wasn't possible with the current state of our codebase. Pybind11 uses C++'s `typeid`, which cannot be used with forward-declared types.