### PR TITLE
Allow inline shell script in stages

### DIFF
--- a/ert3/evaluator/_builder.py
+++ b/ert3/evaluator/_builder.py
@@ -1,4 +1,5 @@
 import pathlib
+import shlex
 from functools import partial
 from typing import Callable, Dict, Tuple, Type, cast
 
@@ -161,7 +162,7 @@ def build_ensemble(
             )
 
         for script in stage.script:
-            name, *args = script.split()
+            name, *args = shlex.split(script)
             step_builder.add_job(
                 create_job_builder()
                 .set_name(name)


### PR DESCRIPTION
**Issue**
Resolves the need for making and transporting a wrapper script in order for more fancy commands in `stages.yml`, like e.g.

```yaml
script:
  - sh -c "cd rms/model; rms -project foo"
```

**Approach**
Change `str.split()` to `shlex.split()` which will not split inside quotations.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
