### PR TITLE
Improve error handling around ert3 initialization

### DIFF
--- a/ert/storage/__init__.py
+++ b/ert/storage/__init__.py
@@ -17,6 +17,7 @@ from ert.storage._storage import (
     get_record_storage_transmitters,
     transmit_awaitable_record_collection,
     transmit_record_collection,
+    assert_storage_initialized,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "get_record_storage_transmitters",
     "transmit_awaitable_record_collection",
     "transmit_record_collection",
+    "assert_storage_initialized",
 ]

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -544,6 +544,17 @@ def init(*, workspace_name: str) -> None:
         )
 
 
+def assert_storage_initialized(workspace_name: str) -> None:
+    response = _get_from_server(path="experiments")
+    experiment_names = {exp["name"]: exp["ensemble_ids"] for exp in response.json()}
+
+    for special_key in _SPECIAL_KEYS:
+        if f"{workspace_name}.{special_key}" not in experiment_names:
+            raise ert.exceptions.StorageError(
+                "Storage is not initialized properly. The workspace needs to be reinitialized"
+            )
+
+
 def init_experiment(
     *,
     experiment_name: str,

--- a/ert3/workspace/_workspace.py
+++ b/ert3/workspace/_workspace.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union, cast
@@ -201,6 +202,9 @@ class Workspace:
         with open(experiment_root / output_file, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4, sort_keys=True)
 
+    def delete(self) -> None:
+        shutil.rmtree(self._path / _WORKSPACE_DATA_ROOT)
+
     def _validate_resources(self, ensemble_config: ert3.config.EnsembleConfig) -> None:
         resource_inputs = [
             item
@@ -225,7 +229,7 @@ class Workspace:
 
 
 def initialize(path: Union[str, Path]) -> Workspace:
-    """Initalize a workspace directory
+    """Initialize a workspace directory
 
     Args:
         path (Union[str, pathlib.Path]): Path to the workspace to initialize.
@@ -241,7 +245,7 @@ def initialize(path: Union[str, Path]) -> Workspace:
     root = _locate_root(path)
     if root is not None:
         raise ert.exceptions.IllegalWorkspaceOperation(
-            f"Already inside an ERT workspace, found {root}/.ert"
+            f"Already inside an ERT workspace, found {root}/{_WORKSPACE_DATA_ROOT}"
         )
     (path / _WORKSPACE_DATA_ROOT).mkdir()
     return Workspace(path)


### PR DESCRIPTION
**Issue**
Resolves #2760


**Approach**
- Add error handling for the case that `ert3 init` fails to connect to the storage.
- Add error handling for the case that ert3 tries to use a storage that not has been initialized properly.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
