### PR TITLE
Add record_type graphql endpoint and use it in the _export

### DIFF
--- a/ert/storage/__init__.py
+++ b/ert/storage/__init__.py
@@ -17,6 +17,7 @@ from ert.storage._storage import (
     get_record_storage_transmitters,
     transmit_awaitable_record_collection,
     transmit_record_collection,
+    get_experiment_response_record_types,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "get_record_storage_transmitters",
     "transmit_awaitable_record_collection",
     "transmit_record_collection",
+    "get_experiment_response_record_types",
 ]

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -71,13 +71,17 @@ def _prepare_export_responses(
     outputs = defaultdict(list)
     responses = [elem.record for elem in ensemble.output]
     records_url = ert.storage.get_records_url(workspace_name, experiment_name)
+    record_types = ert.storage.get_experiment_response_record_types(
+        experiment_name=experiment_name
+    )
 
     for record_name in responses:
-        for iens in range(ensemble_size):
-            url = f"{records_url}/{record_name}?realization_index={iens}"
-            future = ert.storage.load_record(url, ert.data.RecordType.LIST_FLOAT)
-            record = get_event_loop().run_until_complete(future)
-            outputs[record_name].append(record.data)
+        if record_types[record_name] == "F64_MATRIX":
+            for iens in range(ensemble_size):
+                url = f"{records_url}/{record_name}?realization_index={iens}"
+                future = ert.storage.load_record(url, ert.data.RecordType.LIST_FLOAT)
+                record = get_event_loop().run_until_complete(future)
+                outputs[record_name].append(record.data)
     return outputs
 
 


### PR DESCRIPTION
**Issue**
Resolves #2715 


**Approach**
Introduce a way to fetch `record_type` without downloading the entire record. Make use of this function when exporting records.


## Pre review checklist

- [x] Added appropriate labels
- [x] write test

