### PR TITLE
Stop using a Client instance over long time spans

### DIFF
--- a/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -24,7 +24,9 @@ def _mock_ws(host, port, messages, delay_startup=0):
 
     async def _run_server():
         await asyncio.sleep(delay_startup)
-        async with websockets.serve(_handler, host, port):
+        async with websockets.serve(
+            _handler, host, port, ping_timeout=1, ping_interval=1
+        ):
             await done
 
     loop.run_until_complete(_run_server())

--- a/tests/ert_tests/ensemble_evaluator/prefect/scripts/unix_test_script.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/scripts/unix_test_script.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import json
+import time
 
 
 def parse_args(args=None):
@@ -18,5 +19,11 @@ def write_to_file(file, data):
 
 if __name__ == "__main__":
     options = parse_args()
+
+    # this sleep prevents regressions like https://github.com/equinor/ert/issues/2756
+    # in conjunction with aggressive ping_interval and ping_timout in the evaluation
+    # server
+    time.sleep(2)
+
     data = [1, 2, 3]
     write_to_file("output.out", data)

--- a/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
@@ -171,12 +171,21 @@ def test_unix_task(
         jobs=[("script", Path("unix_test_script.py"), job_args)],
         type_="unix",
     )
-    result, flow_run, _ = prefect_flow_run(
+    result, flow_run, messages = prefect_flow_run(
         ws_monitor=mock_ws_monitor,
         step=step,
         input_map=input_map,
         output_map=output_map,
     )
+
+    if not error_test:
+        assert [
+            msg for msg in messages if ids.EVTYPE_FM_JOB_SUCCESS in msg
+        ], "no job success event"
+        assert [
+            msg for msg in messages if ids.EVTYPE_FM_STEP_SUCCESS in msg
+        ], "no step success event"
+
     assert_prefect_flow_run(
         result=result,
         flow_run=flow_run,


### PR DESCRIPTION
**Issue**
Resolves #2756 


**Approach**
If Client's loop doesn't run in <20 second intervals, the WS connection
will time out and #2756 will happen for unix steps running longer than
20 seconds. Hence we make all Client usage single-use.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
