### PR TITLE
Make AutorunTestEnsemble cancellable

### DIFF
--- a/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -222,3 +222,9 @@ class AutorunTestEnsemble(TestEnsemble):
         )
 
         self._eval_thread.start()
+
+    def cancel(self):
+        pass
+
+    def is_cancellable(self):
+        return True


### PR DESCRIPTION
**Issue**
Resolves #2785

**Approach**
In order to prevent flakyness in testing of
run_and_get_successful_realizations, we need to ensure that all events
are sent before the evaluator shuts down. This commits makes the
ensemble cancellable, but does nothing when asked to cancel. This way
all events will be propagated before the evaluator is done, and
run_and_get_successful_realizations proceeds to check the number of
successful realizations.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
