### PR TITLE
Do not build vanilla step on unexpected step type

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/builder.py
+++ b/ert_shared/ensemble_evaluator/ensemble/builder.py
@@ -687,19 +687,26 @@ class _StepBuilder(_StageBuilder):
                 self._job_name,
                 self._run_arg,
             )
-        cls = _Step
         if self._type == "function":
-            cls = _FunctionStep
+            return _FunctionStep(
+                stage.get_id(),
+                stage.get_inputs(),
+                stage.get_outputs(),
+                jobs,
+                stage.get_name(),
+                source,
+            )
         elif self._type == "unix":
-            cls = _UnixStep
-        return cls(
-            stage.get_id(),
-            stage.get_inputs(),
-            stage.get_outputs(),
-            jobs,
-            stage.get_name(),
-            source,
-        )
+            return _UnixStep(
+                stage.get_id(),
+                stage.get_inputs(),
+                stage.get_outputs(),
+                jobs,
+                stage.get_name(),
+                source,
+            )
+        else:
+            raise ValueError("Unexpected type while building step: {self._type}")
 
 
 def create_step_builder() -> _StepBuilder:

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
@@ -21,6 +21,7 @@ def test_build_ensemble():
             .set_id("0")
             .set_name("some_step")
             .set_dummy_io()
+            .set_type("unix")
         )
         .active(True)
     )
@@ -172,7 +173,12 @@ def test_topological_sort(steps, expected, ambiguous):
     non_transmitted_factory = MagicMock().return_value = MagicMock()
     non_transmitted_factory.return_value.is_transmitted.return_value = False
     for step_def in steps:
-        step = ee.create_step_builder().set_id("0").set_name(step_def["name"])
+        step = (
+            ee.create_step_builder()
+            .set_id("0")
+            .set_name(step_def["name"])
+            .set_type("unix")
+        )
         for input_ in step_def["inputs"]:
             step.add_input(
                 ee.create_input_builder()


### PR DESCRIPTION
During my work in #2755 I discovered that the step builder will build a vanilla step if the type is neither `unix` nor `function`. I think it should fail instead...

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
