### PR TITLE
Pin black formatter to 21.12b0

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install flake8 black pylint cmake-format
+        pip install -r dev-requirements.txt
 
     - name: Clang Format
       run: ./script/clang-format --check

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ black
 flaky
 pytest>=6.2.0
 pytest-qt
-schemathesis==1.3.4
+schemathesis==1.3.4; python_version <= '3.6'
 sphinx
 sphinx-argparse
 sphinx_rtd_theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-black
+black==21.12b0
 flaky
 pytest>=6.2.0
 pytest-qt


### PR DESCRIPTION
**Issue**
The internal documentation deploy failed with:

```
The conflict is caused by:
    The user requested click
     schemathesis 1.3.4 depends on click<8.0 and >=7.0
     black 22.1.0 depends on click>=8.0.0

To fix this you could try to:
    1. loosen the range of package versions you've specified
    2. remove package versions to allow pip attempt to solve the dependency conflict
```

Link to [build](https://github.com/equinor/fmu-docs/runs/5000126769?check_suite_focus=true).

**Approach**
The documentation build is ran in a Python 3.8 environment, where the latest version of black requires a version of `schemathesis` that is not supported by Python 3.6. Instead of pinning `schemathesis` for all Python versions this PR only pins it for Python 3.6 and lower.

There is always a cost attached to a conditional pin, but in this case this is not a direct dependency of us and hence the effort should be rather low.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
