### PR TITLE
Add upper limit for ERT Storage dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.12.0",
-        "ert-storage >= 0.3.7",
+        "ert-storage >= 0.3.7, < 0.4",
         "fastapi==0.70.1",
         "graphene",
         "graphlib_backport; python_version < '3.9'",


### PR DESCRIPTION
We need to allow breaking changes to happen in ERT Storage.
