### PR TITLE
Retrieve responses for _export via the dedicated endpoint

### DIFF
--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -710,11 +710,18 @@ def get_experiment_responses(*, experiment_name: str) -> Iterable[str]:
         )
 
     ensemble_id = experiment["ensemble_ids"][0]  # currently just one ens per exp
-    response = _get_from_server(f"ensembles/{ensemble_id}")
+    response = _get_from_server(f"ensembles/{ensemble_id}/responses")
 
     if response.status_code != 200:
         raise ert.exceptions.StorageError(response.text)
-    return list(response.json()["response_names"])
+
+    # The ensemble responses are sent in the following form:
+    #     {
+    #         "polynomial_output": {"id": id, "name": name, "userdata": {}}
+    #     }
+    # therefore we extract only the keys
+
+    return list(response.json().keys())
 
 
 def delete_experiment(*, experiment_name: str) -> None:

--- a/ert3/engine/_export.py
+++ b/ert3/engine/_export.py
@@ -69,8 +69,8 @@ def _prepare_export_responses(
     ensemble_size: int,
 ) -> Dict[str, List[ert.data.record_data]]:
     outputs = defaultdict(list)
-    responses = [elem.record for elem in ensemble.output]
     records_url = ert.storage.get_records_url(workspace_name, experiment_name)
+    responses = ert.storage.get_experiment_responses(experiment_name=experiment_name)
 
     for record_name in responses:
         for iens in range(ensemble_size):


### PR DESCRIPTION
**Issue**
Resolves #2715 


**Approach**
Instead of using `ensemble.output` as a source to response names when exporting experiment we can use directly the dedicated endpoint (`ens_id/responses`) which filters out automatically only `NumericalRecord` types records.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
