### PR TITLE
Speed up snake_oil_diff

### DIFF
--- a/test-data/local/snake_oil/jobs/snake_oil_diff.py
+++ b/test-data/local/snake_oil/jobs/snake_oil_diff.py
@@ -8,7 +8,7 @@ def writeDiff(filename, vector1, vector2):
             node1 = vector1[index]
             node2 = vector2[index]
 
-            diff = node1.value - node2.value
+            diff = node1 - node2
             f.write("%f\n" % diff)
 
 
@@ -18,16 +18,16 @@ if __name__ == "__main__":
     report_step = 199
     writeDiff(
         "snake_oil_opr_diff_%d.txt" % report_step,
-        ecl_sum["WOPR:OP1"],
-        ecl_sum["WOPR:OP2"],
+        ecl_sum.numpy_vector("WOPR:OP1"),
+        ecl_sum.numpy_vector("WOPR:OP2"),
     )
     writeDiff(
         "snake_oil_wpr_diff_%d.txt" % report_step,
-        ecl_sum["WWPR:OP1"],
-        ecl_sum["WWPR:OP2"],
+        ecl_sum.numpy_vector("WWPR:OP1"),
+        ecl_sum.numpy_vector("WWPR:OP2"),
     )
     writeDiff(
         "snake_oil_gpr_diff_%d.txt" % report_step,
-        ecl_sum["WGPR:OP1"],
-        ecl_sum["WGPR:OP2"],
+        ecl_sum.numpy_vector("WGPR:OP1"),
+        ecl_sum.numpy_vector("WGPR:OP2"),
     )

--- a/test-data/local/snake_oil_no_data/jobs/snake_oil_diff.py
+++ b/test-data/local/snake_oil_no_data/jobs/snake_oil_diff.py
@@ -8,7 +8,7 @@ def writeDiff(filename, vector1, vector2):
             node1 = vector1[index]
             node2 = vector2[index]
 
-            diff = node1.value - node2.value
+            diff = node1 - node2
             f.write("%f\n" % diff)
 
 
@@ -18,16 +18,16 @@ if __name__ == "__main__":
     report_step = 199
     writeDiff(
         "snake_oil_opr_diff_%d.txt" % report_step,
-        ecl_sum["WOPR:OP1"],
-        ecl_sum["WOPR:OP2"],
+        ecl_sum.numpy_vector("WOPR:OP1"),
+        ecl_sum.numpy_vector("WOPR:OP2"),
     )
     writeDiff(
         "snake_oil_wpr_diff_%d.txt" % report_step,
-        ecl_sum["WWPR:OP1"],
-        ecl_sum["WWPR:OP2"],
+        ecl_sum.numpy_vector("WWPR:OP1"),
+        ecl_sum.numpy_vector("WWPR:OP2"),
     )
     writeDiff(
         "snake_oil_gpr_diff_%d.txt" % report_step,
-        ecl_sum["WGPR:OP1"],
-        ecl_sum["WGPR:OP2"],
+        ecl_sum.numpy_vector("WGPR:OP1"),
+        ecl_sum.numpy_vector("WGPR:OP2"),
     )


### PR DESCRIPTION
By using EclSum.numpy_vector() the speed of fetching data is
greatly improved, which makes snake_oil run a lot faster.
