### PR TITLE
Pin pytest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 black==21.12b0
 flaky
-pytest>=6.2.0
+pytest>=6.2.0; python_version != '3.9'
+pytest>=6.2.0,<7.0.0; python_version == '3.9'
 pytest-qt
 schemathesis==1.3.4; python_version <= '3.6'
 sphinx


### PR DESCRIPTION
**Issue**
Pytest 7.0.0 throws an error on Python 3.9, see https://github.com/pytest-dev/pytest/issues/9608

**Approach**
Pin pytest for Python 3.9

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
