### PR TITLE
Backport: Pin schemathesis only for Python<=3.6

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ black==21.12b0
 flaky
 pytest>=6.2.0
 pytest-qt
-schemathesis==1.3.4
+schemathesis==1.3.4; python_version <= '3.6'
 sphinx
 sphinx-argparse
 sphinx_rtd_theme


### PR DESCRIPTION
**Issue**
Backport of 695ee0673


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
