### PR TITLE
Remove usage of thread_pool in job_queue

### DIFF
--- a/libres/lib/include/ert/job_queue/job_node.hpp
+++ b/libres/lib/include/ert/job_queue/job_node.hpp
@@ -113,6 +113,7 @@ void *job_queue_node_get_driver_data(job_queue_node_type *node);
 void job_queue_node_set_status(job_queue_node_type *node,
                                job_status_type new_status);
 
+char *job_queue_node_get_name(job_queue_node_type *node);
 UTIL_IS_INSTANCE_HEADER(job_queue_node);
 UTIL_SAFE_CAST_HEADER(job_queue_node);
 

--- a/libres/lib/job_queue/job_node.cpp
+++ b/libres/lib/job_queue/job_node.cpp
@@ -707,3 +707,7 @@ void *job_queue_node_get_driver_data(job_queue_node_type *node) {
 time_t job_queue_node_get_timestamp(const job_queue_node_type *node) {
     return node->progress_timestamp;
 }
+
+char *job_queue_node_get_name(job_queue_node_type *node) {
+    return (node->job_name);
+}


### PR DESCRIPTION
Resolves #2840

**Approach**
The threadpool served two purposes in this module: 1) make handlers run asynchronously i.e. not on the job_queue -thread and 2) it limited the number of concurrently running handlers by the size of the pool. Both these are taken care of using standard C++. Also handling a subtle race-condition present in original code.

## Pre review checklist

- [x] Added appropriate labels

