### PR TITLE
Remove deprecated parameter 'loop' in Queues 

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/legacy.py
+++ b/ert_shared/ensemble_evaluator/ensemble/legacy.py
@@ -105,7 +105,7 @@ class _LegacyEnsemble(_Ensemble):
 
             self._job_queue = self._queue_config.create_job_queue()
 
-            timeout_queue = asyncio.Queue(loop=get_event_loop())
+            timeout_queue = asyncio.Queue()
             on_timeout, send_timeout_future = self.setup_timeout_callback(timeout_queue)
 
             for real in self.get_active_reals():


### PR DESCRIPTION
**Issue**
Python 3.10 have deprecated the loop keyword when creating asyncio
queues. Instead it will use the currently running loop.

**Approach**
Remove the loop parameter. However, in the evaluator, this will bind to the wrong
loop, so we delay the creation of the queue until it is actually needed and we are
in the context of the "correct" thread. This definitely shows that our usage of
asyncio and threads is not optimal, but this is a bigger design discussion that
needs to happen.

Originally part of #2834 

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
