### PR TITLE
Active list simplifications

### DIFF
--- a/libres/lib/enkf/active_list.cpp
+++ b/libres/lib/enkf/active_list.cpp
@@ -129,9 +129,6 @@ int active_list_get_active_size(const active_list_type *active_list,
     case PARTLY_ACTIVE:
         active_size = int_vector_size(active_list->index_list);
         break;
-    case INACTIVE:
-        active_size = 0;
-        break;
     case ALL_ACTIVE:
         active_size = total_size;
         break;
@@ -163,8 +160,6 @@ const int *active_list_get_active(const active_list_type *active_list) {
 bool active_list_iget(const active_list_type *active_list, int index) {
     if (active_list->mode == ALL_ACTIVE)
         return true;
-    else if (active_list->mode == INACTIVE)
-        return false;
     else
         return int_vector_iget(active_list->index_list, index);
 }

--- a/libres/lib/enkf/active_list.cpp
+++ b/libres/lib/enkf/active_list.cpp
@@ -157,13 +157,6 @@ const int *active_list_get_active(const active_list_type *active_list) {
         return NULL;
 }
 
-bool active_list_iget(const active_list_type *active_list, int index) {
-    if (active_list->mode == ALL_ACTIVE)
-        return true;
-    else
-        return int_vector_iget(active_list->index_list, index);
-}
-
 void active_list_summary_fprintf(const active_list_type *active_list,
                                  const char *dataset_key, const char *key,
                                  FILE *stream) {

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -318,10 +318,7 @@ static void enkf_obs_get_obs_and_measure_summary(
             break;
 
         if (local_obsdata_node_tstep_active(obs_node, step) &&
-            obs_vector_iget_active(obs_vector, step) &&
-            active_list_iget(
-                active_list,
-                0 /* Index into the scalar summary observation */)) {
+            obs_vector_iget_active(obs_vector, step)) {
             const summary_obs_type *summary_obs =
                 (const summary_obs_type *)obs_vector_iget_node(obs_vector,
                                                                step);
@@ -367,10 +364,7 @@ static void enkf_obs_get_obs_and_measure_summary(
                 break;
 
             if (local_obsdata_node_tstep_active(obs_node, step) &&
-                obs_vector_iget_active(obs_vector, step) &&
-                active_list_iget(
-                    active_list,
-                    0 /* Index into the scalar summary observation */)) {
+                obs_vector_iget_active(obs_vector, step)) {
                 for (int iens_index = 0; iens_index < active_size;
                      iens_index++) {
                     const int iens =

--- a/libres/lib/include/ert/enkf/active_list.hpp
+++ b/libres/lib/include/ert/enkf/active_list.hpp
@@ -39,7 +39,6 @@ active_list_type *active_list_alloc_copy(const active_list_type *src);
 void active_list_summary_fprintf(const active_list_type *active_list,
                                  const char *dataset_key, const char *key,
                                  FILE *stream);
-bool active_list_iget(const active_list_type *active_list, int index);
 bool active_list_equal(const active_list_type *active_list1,
                        const active_list_type *active_list2);
 void active_list_copy(active_list_type *target, const active_list_type *src);

--- a/libres/lib/include/ert/enkf/enkf_types.hpp
+++ b/libres/lib/include/ert/enkf/enkf_types.hpp
@@ -167,7 +167,6 @@ typedef enum {
 typedef enum {
     ALL_ACTIVE =
         1, /* The variable/observation is fully active, i.e. all cells/all faults/all .. */
-    INACTIVE = 2, /* Fully inactive */
     PARTLY_ACTIVE =
         3 /* Partly active - must supply additonal type spesific information on what is active.*/
 } active_mode_type;

--- a/res/enkf/active_list.py
+++ b/res/enkf/active_list.py
@@ -29,7 +29,6 @@ class ActiveList(BaseCClass):
     _asize = ResPrototype("int   active_list_get_active_size(active_list, int)")
     _get_mode = ResPrototype("active_mode_enum active_list_get_mode(active_list)")
     _get_active_index_list = ResPrototype("int*  active_list_get_active(active_list)")
-    _is_active = ResPrototype("bool active_list_iget(active_list, int)")
 
     def __init__(self):
         c_ptr = self._alloc()

--- a/res/enkf/active_list.py
+++ b/res/enkf/active_list.py
@@ -57,15 +57,13 @@ class ActiveList(BaseCClass):
         self._add_index(index)
 
     def getActiveSize(self, default_value):
-        """In mode PARTLY_ACTIVE, we return the size of the active set; In mode
-        INACTIVE 0 is returned and if the mode is ALL_ACTIVE, the input
-        default_value is returned.
+        """In mode PARTLY_ACTIVE, we return the size of the active set; if the mode is
+        ALL_ACTIVE, the input default_value is returned.
+
         """
         mode = self.getMode()
         if mode == ActiveMode.PARTLY_ACTIVE:
             return self._asize(0)
-        if mode == ActiveMode.INACTIVE:
-            return 0
         return default_value
 
     def free(self):

--- a/res/enkf/enums/active_mode_enum.py
+++ b/res/enkf/enums/active_mode_enum.py
@@ -19,10 +19,8 @@ from cwrap import BaseCEnum
 class ActiveMode(BaseCEnum):
     TYPE_NAME = "active_mode_enum"
     ALL_ACTIVE = None
-    INACTIVE = None
     PARTLY_ACTIVE = None
 
 
 ActiveMode.addEnum("ALL_ACTIVE", 1)
-ActiveMode.addEnum("INACTIVE", 2)
 ActiveMode.addEnum("PARTLY_ACTIVE", 3)

--- a/tests/libres_tests/res/enkf/test_active_list.py
+++ b/tests/libres_tests/res/enkf/test_active_list.py
@@ -22,10 +22,8 @@ from res.enkf import ActiveList, ActiveMode
 class ActiveListTest(ResTest):
     def test_active_mode_enum(self):
         self.assertEqual(ActiveMode.ALL_ACTIVE, 1)
-        self.assertEqual(ActiveMode.INACTIVE, 2)
         self.assertEqual(ActiveMode.PARTLY_ACTIVE, 3)
         self.assertEqual(ActiveMode(1).name, "ALL_ACTIVE")
-        self.assertEqual(ActiveMode(2).name, "INACTIVE")
         self.assertEqual(ActiveMode(3).name, "PARTLY_ACTIVE")
 
     def test_active_size(self):
@@ -51,7 +49,6 @@ class ActiveListTest(ResTest):
         al = ActiveList()
         rep = repr(al)
         self.assertFalse("PARTLY_ACTIVE" in rep)
-        self.assertFalse("INACTIVE" in rep)
         self.assertTrue("ALL_ACTIVE" in rep)
         pfx = "ActiveList("
         self.assertEqual(pfx, rep[: len(pfx)])
@@ -60,7 +57,6 @@ class ActiveListTest(ResTest):
         rep = repr(al)
         self.assertTrue("150" in rep)
         self.assertTrue("PARTLY_ACTIVE" in rep)
-        self.assertFalse("INACTIVE" in rep)
         self.assertFalse("ALL_ACTIVE" in rep)
 
 


### PR DESCRIPTION
Currently working on moving the `ies::data::Data` instances to be managed by the `local_ministep` type. This is approaching a situation where C-linkage and C++ linkage and different ways to expose in Python is becoming a challenge. The desired direction is obviously C++ & pybind11 - but I was vary of letting the changes spread to one gigantic change essentially permeating "all the code".

Current PR is just a minor simplification which is always a good thing.