### PR TITLE
Handle error publish changes

### DIFF
--- a/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 from http import HTTPStatus
+import logging
 
 import pytest
 import websockets
@@ -10,20 +11,24 @@ from ert_shared.async_utils import get_event_loop
 from ert_shared.ensemble_evaluator.utils import wait_for_evaluator
 
 
-async def mock_ws(host, port, done):
+async def mock_ws(host, port, done, close_on_first_attempt=False):
     events = []
+    been_closed = False
 
     async def process_request(path, request_headers):
         if path == "/healthcheck":
             return HTTPStatus.OK, {}, b""
 
     async def _handler(websocket, path):
-        while True:
-            event = await websocket.recv()
+        nonlocal been_closed
+        nonlocal close_on_first_attempt
+        if close_on_first_attempt and not been_closed:
+            await websocket.close(code=1001, reason="expected close")
+            been_closed = True
+            return
+
+        async for event in websocket:
             events.append(event)
-            cloud_event = from_json(event)
-            if cloud_event["type"] == "com.equinor.ert.forward_model_stage.success":
-                break
 
     async with websockets.serve(_handler, host, port, process_request=process_request):
         await done
@@ -60,6 +65,68 @@ async def test_happy_path(
 
     assert mock_ws_task.done()
 
+    event_0 = from_json(mock_ws_task.result()[0])
+    assert event_0["source"] == "/ert/ee/ee_0/real/0/step/0"
+    assert event_0["type"] == "com.equinor.ert.forward_model_step.waiting"
+    assert event_0.data == {"queue_event_type": "JOB_QUEUE_WAITING"}
+
+    end_event_index = len(mock_ws_task.result()) - 1
+    end_event = from_json(mock_ws_task.result()[end_event_index])
+    assert end_event["type"] == "com.equinor.ert.forward_model_step.success"
+    assert end_event.data == {"queue_event_type": "JOB_QUEUE_SUCCESS"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_retry_on_close(
+    tmpdir, unused_tcp_port, event_loop, make_ensemble_builder, queue_config, caplog
+):
+    caplog.set_level(logging.INFO)
+    asyncio.set_event_loop(event_loop)
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+
+    done = get_event_loop().create_future()
+    mock_ws_task = get_event_loop().create_task(
+        mock_ws(
+            host,
+            unused_tcp_port,
+            done,
+            close_on_first_attempt=True,
+        )
+    )
+    await wait_for_evaluator(base_url=url, timeout=5)
+
+    ensemble = make_ensemble_builder(tmpdir, 1, 1).build()
+    queue = queue_config.create_job_queue()
+    for real in ensemble.get_reals():
+        queue.add_ee_stage(real.get_steps()[0], None)
+    queue.submit_complete()
+
+    await queue.execute_queue_async(
+        url,
+        "ee_0",
+        threading.BoundedSemaphore(value=10),
+        None,
+    )
+    done.set_result(None)
+
+    await mock_ws_task
+
+    mock_ws_task.result()
+
+    assert mock_ws_task.done()
+
+    # Verify that the test inflicts the expected ConnectionClosed exception
+    assert any(
+        [
+            record
+            for record in caplog.records
+            if "code=1001, reason='expected close'" in str(record.exc_info)
+        ]
+    )
+
+    # And that we should still be able to reconnect and provide the information
     event_0 = from_json(mock_ws_task.result()[0])
     assert event_0["source"] == "/ert/ee/ee_0/real/0/step/0"
     assert event_0["type"] == "com.equinor.ert.forward_model_step.waiting"

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -18,7 +18,7 @@ def dummy_exit_callback(args):
     print(args)
 
 
-dummy_config = {
+DUMMY_CONFIG = {
     "job_script": "job_script.py",
     "num_cpu": 1,
     "job_name": "dummy_job_{}",
@@ -27,17 +27,17 @@ dummy_config = {
     "exit_callback": dummy_exit_callback,
 }
 
-simple_script = """#!/usr/bin/env python
+SIMPLE_SCRIPT = """#!/usr/bin/env python
 print('hello')
 """
 
-never_ending_script = """#!/usr/bin/env python
+NEVER_ENDING_SCRIPT = """#!/usr/bin/env python
 import time
 while True:
     time.sleep(0.5)
 """
 
-failing_script = """#!/usr/bin/env python
+FAILING_SCRIPT = """#!/usr/bin/env python
 import sys
 sys.exit(1)
 """
@@ -46,21 +46,21 @@ sys.exit(1)
 def create_queue(script, max_submit=1, max_runtime=None, callback_timeout=None):
     driver = Driver(driver_type=QueueDriverEnum.LOCAL_DRIVER, max_running=5)
     job_queue = JobQueue(driver, max_submit=max_submit)
-    with open(dummy_config["job_script"], "w") as f:
+    with open(DUMMY_CONFIG["job_script"], "w") as f:
         f.write(script)
-    os.chmod(dummy_config["job_script"], stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
+    os.chmod(DUMMY_CONFIG["job_script"], stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
     for i in range(10):
-        os.mkdir(dummy_config["run_path"].format(i))
+        os.mkdir(DUMMY_CONFIG["run_path"].format(i))
         job = JobQueueNode(
-            job_script=dummy_config["job_script"],
-            job_name=dummy_config["job_name"].format(i),
-            run_path=dummy_config["run_path"].format(i),
-            num_cpu=dummy_config["num_cpu"],
+            job_script=DUMMY_CONFIG["job_script"],
+            job_name=DUMMY_CONFIG["job_name"].format(i),
+            run_path=DUMMY_CONFIG["run_path"].format(i),
+            num_cpu=DUMMY_CONFIG["num_cpu"],
             status_file=job_queue.status_file,
             ok_file=job_queue.ok_file,
             exit_file=job_queue.exit_file,
-            done_callback_function=dummy_config["ok_callback"],
-            exit_callback_function=dummy_config["exit_callback"],
+            done_callback_function=DUMMY_CONFIG["ok_callback"],
+            exit_callback_function=DUMMY_CONFIG["exit_callback"],
             callback_arguments=[{"job_number": i}],
             max_runtime=max_runtime,
             callback_timeout=callback_timeout,
@@ -85,7 +85,7 @@ class JobQueueTest(ResTest):
 
     def test_kill_jobs(self):
         with TestAreaContext("job_queue_test_kill") as work_area:
-            job_queue = create_queue(never_ending_script)
+            job_queue = create_queue(NEVER_ENDING_SCRIPT)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -115,7 +115,7 @@ class JobQueueTest(ResTest):
 
     def test_add_jobs(self):
         with TestAreaContext("job_queue_test_add") as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -134,7 +134,7 @@ class JobQueueTest(ResTest):
 
     def test_failing_jobs(self):
         with TestAreaContext("job_queue_test_add") as work_area:
-            job_queue = create_queue(failing_script, max_submit=1)
+            job_queue = create_queue(FAILING_SCRIPT, max_submit=1)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -167,7 +167,7 @@ class JobQueueTest(ResTest):
                 job_numbers.add(arg[0]["job_number"])
 
             job_queue = create_queue(
-                never_ending_script,
+                NEVER_ENDING_SCRIPT,
                 max_submit=1,
                 max_runtime=5,
                 callback_timeout=callback,
@@ -200,14 +200,14 @@ class JobQueueTest(ResTest):
 
     def test_add_ensemble_evaluator_info(self):
         with TestAreaContext("job_queue_add_ensemble_evaluator_info") as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"
             cert = "My very nice cert"
             token = "my_super_secret_token"
             cert_file = ".ee.pem"
             runpaths = [
-                pathlib.Path(dummy_config["run_path"].format(i)) for i in range(10)
+                pathlib.Path(DUMMY_CONFIG["run_path"].format(i)) for i in range(10)
             ]
             for runpath in runpaths:
                 with open(runpath / "jobs.json", "w") as f:
@@ -235,14 +235,14 @@ class JobQueueTest(ResTest):
         with TestAreaContext(
             "job_queue_add_ensemble_evaluator_info_cert_none"
         ) as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"
             cert = None
             token = None
             cert_file = ".ee.pem"
             runpaths = [
-                pathlib.Path(dummy_config["run_path"].format(i)) for i in range(10)
+                pathlib.Path(DUMMY_CONFIG["run_path"].format(i)) for i in range(10)
             ]
             for runpath in runpaths:
                 with open(runpath / "jobs.json", "w") as f:


### PR DESCRIPTION
**Issue**
Resolves #2781 

**Approach**

Use the suggested approach from websockets to handle connection closing and automatically reopen:

> If an error occurs while establishing the connection, [connect()](https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.connect) retries with exponential backoff. The backoff delay starts at three seconds and increases up to one minute.

https://websockets.readthedocs.io/en/stable/reference/client.html#opening-a-connection

The current number of retries is simply a suggestion, we could very well add more. Note that adding too many will result in blocking start (and cancel?) jobs. 

Will work a bit more on getting a test to run
