### PR TITLE
make tests ert-storage 0.3.9 compatible

### DIFF
--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -94,7 +94,8 @@ def test_add_experiments(tmpdir, ert_storage):
         parameters = ert.storage.get_experiment_parameters(
             experiment_name=experiment_name
         )
-        assert experiment_parameter_records == parameters
+        parameter_names = [p["name"] for p in parameters]
+        assert experiment_parameter_records == parameter_names
 
 
 @pytest.mark.requires_ert_storage

--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -242,11 +242,12 @@ def test_parameters(client):
 
     # Compare parameters (+ 2 due to the two log10_ coeffs)
     parameters = client.get(f"/ensembles/{ensemble_id}/parameters").json()
+    parameter_names = [p["name"] for p in parameters]
     assert len(parameters) == len(priors) + 2
     for name, _, prior in priors:
-        assert f"COEFFS:{name}" in parameters
+        assert f"COEFFS:{name}" in parameter_names
         if prior["function"] in ("lognormal", "loguniform"):
-            assert f"LOG10_COEFFS:{name}" in parameters
+            assert f"LOG10_COEFFS:{name}" in parameter_names
 
     # Compare records (+ 2 due to the two log10_ coeffs)
     records = client.get(f"/ensembles/{ensemble_id}/records").json()


### PR DESCRIPTION
ert3 does not use get_parameters. Making tests work for current ert-storage api
