### PR TITLE
Adjust test in extraction due to changes in API

### DIFF
--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -94,7 +94,8 @@ def test_add_experiments(tmpdir, ert_storage):
         parameters = ert.storage.get_experiment_parameters(
             experiment_name=experiment_name
         )
-        assert experiment_parameter_records == parameters
+        parameter_names = [entry["name"] for entry in parameters]
+        assert experiment_parameter_records == parameter_names
 
 
 @pytest.mark.requires_ert_storage

--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -242,11 +242,13 @@ def test_parameters(client):
 
     # Compare parameters (+ 2 due to the two log10_ coeffs)
     parameters = client.get(f"/ensembles/{ensemble_id}/parameters").json()
+    parameter_names = [entry["name"] for entry in parameters]
+    assert len(parameters) == len(parameter_names)
     assert len(parameters) == len(priors) + 2
     for name, _, prior in priors:
-        assert f"COEFFS:{name}" in parameters
+        assert f"COEFFS:{name}" in parameter_names
         if prior["function"] in ("lognormal", "loguniform"):
-            assert f"LOG10_COEFFS:{name}" in parameters
+            assert f"LOG10_COEFFS:{name}" in parameter_names
 
     # Compare records (+ 2 due to the two log10_ coeffs)
     records = client.get(f"/ensembles/{ensemble_id}/records").json()


### PR DESCRIPTION
The API is now bundling parameter names with labels in a dict.
The test in test_extraction needed to be adjusted to reflect those changes. 
