### PR TITLE
Improve failure behaviour from ert client to storage

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,8 +8,9 @@ sphinx-argparse
 sphinx_rtd_theme
 sphinx-autoapi
 pytest-asyncio
-requests
+pytest-mock
 pytest-timeout
+requests
 jsonpath_ng
 sphinxcontrib.datatemplates
 decorator

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -535,7 +535,9 @@ def init(*, workspace_name: str) -> None:
 
     for special_key in _SPECIAL_KEYS:
         if f"{workspace_name}.{special_key}" in experiment_names:
-            raise ValueError("Storage already initialized")
+            raise RuntimeError(
+                f"Workspace {workspace_name} already registered in storage"
+            )
         _init_experiment(
             experiment_name=f"{workspace_name}.{special_key}",
             parameters={},

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -224,8 +224,11 @@ def _init(args: Any) -> None:
         ert.storage.init(workspace_name=workspace.name)
     except TimeoutError as err:
         workspace.delete()
+        raise ert.exceptions.StorageError(f"Failed to contact storage: {err}") from err
+    except ValueError as err:
+        workspace.delete()
         raise ert.exceptions.StorageError(
-            "Failed to contact storage. Is it running?"
+            f"Could not initialize storage: {err}"
         ) from err
 
 

--- a/ert_shared/services/storage_service.py
+++ b/ert_shared/services/storage_service.py
@@ -52,7 +52,9 @@ class Storage(BaseService):
             except requests.ConnectionError:
                 pass
 
-        raise RuntimeError("Server started, but none of the URLs provided worked")
+        raise TimeoutError(
+            "None of the URLs provided for the ert storage server worked."
+        )
 
     @classmethod
     def session(cls, timeout=None) -> Client:

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -14,7 +14,7 @@ def test_init(tmpdir, ert_storage):
 @pytest.mark.requires_ert_storage
 def test_double_init(tmpdir, ert_storage):
     ert.storage.init(workspace_name=tmpdir)
-    with pytest.raises(ValueError, match="Storage already initialized"):
+    with pytest.raises(RuntimeError, match="already registered in storage"):
         ert.storage.init(workspace_name=tmpdir)
 
 


### PR DESCRIPTION
**Issue**
Resolves #2953 


**Approach**
The console already has functionality for removing the `.ert` directory, but only if it catches a TimeoutError. The storage initialization raises a RuntimeError. I chose to change the exception raised instead of catching one  more exception.

https://github.com/equinor/ert/blob/main/ert3/console/_console.py#L223-L229

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
