### PR TITLE
Remove unused function local_obsdata_node_copy_active_list()

### DIFF
--- a/libres/lib/enkf/local_obsdata_node.cpp
+++ b/libres/lib/enkf/local_obsdata_node.cpp
@@ -62,11 +62,6 @@ local_obsdata_node_alloc_copy(const local_obsdata_node_type *src) {
     return target;
 }
 
-void local_obsdata_node_copy_active_list(local_obsdata_node_type *node,
-                                         const active_list_type *active_list) {
-    active_list_copy(node->active_list, active_list);
-}
-
 const char *local_obsdata_node_get_key(const local_obsdata_node_type *node) {
     return node->obs_key;
 }

--- a/libres/lib/include/ert/enkf/local_obsdata_node.hpp
+++ b/libres/lib/include/ert/enkf/local_obsdata_node.hpp
@@ -41,9 +41,6 @@ active_list_type *
 local_obsdata_node_get_active_list(const local_obsdata_node_type *node);
 active_list_type *
 local_obsdata_node_get_copy_active_list(const local_obsdata_node_type *node);
-extern "C++" void
-local_obsdata_node_copy_active_list(local_obsdata_node_type *node,
-                                    const active_list_type *active_list);
 UTIL_IS_INSTANCE_HEADER(local_obsdata_node);
 UTIL_SAFE_CAST_HEADER(local_obsdata_node);
 

--- a/libres/old_tests/enkf/test_enkf_local_obsdata_node.cpp
+++ b/libres/old_tests/enkf/test_enkf_local_obsdata_node.cpp
@@ -35,9 +35,6 @@ void test_content(local_obsdata_node_type *node) {
 
         test_assert_false(active_list_equal(
             new_active_list, local_obsdata_node_get_active_list(node)));
-        local_obsdata_node_copy_active_list(node, new_active_list);
-        test_assert_true(active_list_equal(
-            new_active_list, local_obsdata_node_get_active_list(node)));
     }
 }
 


### PR DESCRIPTION
Remove unused function; small part of #2906
