### PR TITLE
Disable lazy_loading of summary-data by default

### DIFF
--- a/tests/libres_tests/res/enkf/conftest.py
+++ b/tests/libres_tests/res/enkf/conftest.py
@@ -1,0 +1,16 @@
+import os
+import shutil
+import pytest
+
+from res.enkf import ResConfig
+
+
+@pytest.fixture()
+def setup_case(tmpdir, source_root):
+    def copy_case(path, config_file):
+        shutil.copytree(os.path.join(source_root, "test-data", path), "test_data")
+        os.chdir("test_data")
+        return ResConfig(config_file)
+
+    with tmpdir.as_cwd():
+        yield copy_case

--- a/tests/libres_tests/res/enkf/test_enkf_load_results_manually2.py
+++ b/tests/libres_tests/res/enkf/test_enkf_load_results_manually2.py
@@ -1,0 +1,25 @@
+import logging
+import pytest
+
+from ecl.util.util import BoolVector
+from res.enkf import EnKFMain
+
+
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_load_results_manually(setup_case, caplog, monkeypatch, lazy_load):
+    """
+    This little test does not depend on Equinor-data and only verifies
+    the lazy_load flag in forward_load_context plus memory-logging
+    """
+    if lazy_load:
+        monkeypatch.setenv("ERT_LAZY_LOAD_SUMMARYDATA", str(lazy_load))
+    res_config = setup_case("local/snake_oil", "snake_oil.ert")
+    ert = EnKFMain(res_config)
+    load_from = ert.getEnkfFsManager().getFileSystem("default_0")
+    ert.getEnkfFsManager().switchFileSystem(load_from)
+    realisations = BoolVector(default_value=False, initial_size=25)
+    realisations[0] = True  # only need one to test what we want
+    with caplog.at_level(logging.INFO):
+        loaded = ert.loadFromForwardModel(realisations, 0, load_from)
+        assert 0 == loaded  # they will  in fact all fail, but that's ok
+        assert f"lazy={lazy_load}".lower() in caplog.text

--- a/tests/libres_tests/res/enkf/test_es_update.py
+++ b/tests/libres_tests/res/enkf/test_es_update.py
@@ -1,23 +1,10 @@
-import os
-import shutil
 import sys
 
 import pytest
 
 from ecl.util.util import BoolVector
 
-from res.enkf import EnkfNode, ErtRunContext, ESUpdate, NodeId, ResConfig, EnKFMain
-
-
-@pytest.fixture()
-def setup_case(tmpdir, source_root):
-    def copy_case(path, config_file):
-        shutil.copytree(os.path.join(source_root, "test-data", path), "test_data")
-        os.chdir("test_data")
-        return ResConfig(config_file)
-
-    with tmpdir.as_cwd():
-        yield copy_case
+from res.enkf import EnkfNode, ErtRunContext, ESUpdate, NodeId, EnKFMain
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Lazy-loading can be re-enabled by setting the environment variable ERT_LAZY_LOAD_SUMMARYDATA to anything. Added logging of memory-usage for this piece of code to prepare for removing the entire lazy-load mechanism.

**Issue**
Resolves #2972

## Pre review checklist
- [x] Added appropriate labels
  * `documentation` to document the environment-variable
  * `enhancement` because this really speeds up loading
