### PR TITLE
Remove dependency on semeio

### DIFF
--- a/.github/workflows/run_examples_snake_oil.yml
+++ b/.github/workflows/run_examples_snake_oil.yml
@@ -27,11 +27,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install ERT
+    - name: Install ERT and dependencies
       run: |
         export CC=gcc-10
         export CXX=g++-10
         pip install .
+        pip install semeio  # We need design2params from semeio for this example
 
     - name: Start ert-storage
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,24 +1,24 @@
 black==22.1.0; python_version > '3.6'
-flaky
-pytest>=6.2.0
-pytest-qt
-schemathesis==1.3.4; python_version <= '3.6'
-sphinx
-sphinx-argparse
-sphinx_rtd_theme
-sphinx-autoapi
-pytest-asyncio
-pytest-mock
-pytest-timeout
-requests
-jsonpath_ng
-sphinxcontrib.datatemplates
-decorator
-pylint
 click
+cmake-format
+decorator
+flake8>=4.0.0
+flaky
+jsonpath_ng
+pylint
+pytest-asyncio
+pytest-cov
+pytest-mock
+pytest-qt
+pytest-snapshot
+pytest-timeout
+pytest>=6.2.0
+requests
+schemathesis==1.3.4; python_version <= '3.6'
 scikit-build
 setuptools_scm
-pytest-snapshot
-flake8>=4.0.0
-cmake-format
-pytest-cov
+sphinx
+sphinx_rtd_theme
+sphinx-argparse
+sphinx-autoapi
+sphinxcontrib.datatemplates

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,7 @@ pytest>=6.2.0
 requests
 schemathesis==1.3.4; python_version <= '3.6'
 scikit-build
+semeio
 setuptools_scm
 sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ setup(
         "requests",
         "SALib",
         "scipy",
-        "semeio",
         "sqlalchemy",
         "typing-extensions; python_version < '3.8'",
         "uvicorn < 0.17.0; python_version <= '3.6'",


### PR DESCRIPTION

**Issue**
Circular dependency between ERT and semeio


**Approach**
The dependency on semeio leads to a circular dependency, since semeio
also depends on ert (for good reasons). ERT uses the CSV exporter
functionality from semeio, but code to disable the button in the GUI
if the workflow is not available is already present. Hence semeio is
more of a optional dependency, and can be removed from the
install_requires list.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
