### PR TITLE
Add timeout message when starting services

### DIFF
--- a/ert_shared/services/_base_service.py
+++ b/ert_shared/services/_base_service.py
@@ -188,6 +188,9 @@ class _Proc(threading.Thread):
 
             # Timeout reached, exit with a failure
             if ready == ([], [], []):
+                print(
+                    f"Service {self._service_name} startup exceeded defined timeout {self._timeout}s, initiating shutdown"
+                )
                 self._do_shutdown()
                 self._ensure_delete_conn_info()
                 return None


### PR DESCRIPTION
**Issue**
When starting ert api there is a timeout associated with starting services. If the timeout is exceeded the ert process is shut down without any indication of the cause. This causes confusion when determining the cause of the shutdown

**Approach**
Print simple message. There may be a need to have a more robust handling of this situation in future

