### PR TITLE
Remove dependency on BLAS and LAPACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ updating is the Ensemble Smoother (ES).
 
 ## Prerequisites
 
-The following is needed to run ert properly
-- libblas
-- lapack
-
-MacOS already ships with BLAS and LAPACK implementations in its [vecLib](https://developer.apple.com/documentation/accelerate/veclib) framework.
+Python 3.6+ with development headers.
 
 ## Installation
 

--- a/ci/github/build_linux_wheel.sh
+++ b/ci/github/build_linux_wheel.sh
@@ -12,9 +12,6 @@ case "$1" in
         ;;
 esac
 
-# Install dependencies
-yum install -y lapack-devel blas-devel
-
 # Build wheel
 cd /github/workspace
 /opt/python/$pyver/bin/pip wheel . --no-deps -w wheelhouse

--- a/libres/lib/CMakeLists.txt
+++ b/libres/lib/CMakeLists.txt
@@ -165,16 +165,8 @@ pybind11_add_module(
   enkf/subst_config.cpp)
 # -----------------------------------------------------------------
 
-find_package(LAPACK REQUIRED)
-target_link_libraries(
-  _lib
-  PUBLIC ${ECL}
-         ${LAPACK_LIBRARIES}
-         ${LAPACK_LINKER_FLAGS}
-         std::filesystem
-         cJSON::cJSON
-         fmt::fmt
-         Eigen3::Eigen)
+target_link_libraries(_lib PUBLIC ${ECL} std::filesystem cJSON::cJSON fmt::fmt
+                                  Eigen3::Eigen)
 target_include_directories(
   _lib
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
The functionality that previously required BLAS and LAPACK have been
replaced with Eigen3.

Eigen3 may compile down to code that calls BLAS or LAPACK procedures if
enable, but that is something that we should consider doing only after
major refactoring is done and we have a need for it.