### PR TITLE
Remove utility functions of the legacy tracker

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -293,7 +293,6 @@ class RunDialog(QDialog):
 
         tracker = create_tracker(
             self._run_model,
-            num_realizations=self._simulation_arguments["active_realizations"].count(),
             ee_config=evaluator_server_config,
         )
 

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -72,9 +72,7 @@ def run_cli(args):
         )
         thread.start()
 
-        tracker = create_tracker(
-            model, detailed_interval=0, ee_config=evaluator_server_config
-        )
+        tracker = create_tracker(model, ee_config=evaluator_server_config)
 
         out = open(os.devnull, "w") if args.disable_monitoring else sys.stderr
         monitor = Monitor(out=out, color_always=args.color_always)

--- a/ert_shared/status/tracker/evaluator.py
+++ b/ert_shared/status/tracker/evaluator.py
@@ -38,8 +38,6 @@ class EvaluatorTracker:
         model: BaseRunModel,
         host,
         port,
-        general_interval,
-        detailed_interval,
         token=None,
         cert=None,
         next_ensemble_evaluator_wait_time=5,
@@ -63,7 +61,6 @@ class EvaluatorTracker:
         self._drainer_thread.start()
 
         self._iter_snapshot = {}
-        self._general_interval = general_interval
 
     def _drain_monitor(self):
         asyncio.set_event_loop(asyncio.new_event_loop())

--- a/ert_shared/status/tracker/factory.py
+++ b/ert_shared/status/tracker/factory.py
@@ -1,36 +1,21 @@
 from ert_shared.status.tracker.evaluator import EvaluatorTracker
-from ert_shared.status.utils import scale_intervals
 
 
 def create_tracker(
     model,
-    general_interval=5,
-    detailed_interval=10,
-    num_realizations=None,
     ee_config=None,
 ):
     """Creates a tracker tracking a @model. The provided model
-    is updated either purely event-driven, or in two tiers: @general_interval,
-    @detailed_interval. Whether updates are continuous or periodic depends on
-    invocation. In the case of periodic updates, setting an interval to <=0
-    disables update.
-
-    If @num_realizations is defined, then the intervals are scaled
-    according to some affine transformation such that it is tractable to
-    do tracking. This only applies to periodic updates.
+    is updated purely event-driven.
 
     If @ee_host_port_tuple then the factory will produce something that can
     track an ensemble evaluator and emit events appropriately.
     """
-    if num_realizations is not None:
-        general_interval, detailed_interval = scale_intervals(num_realizations)
 
     return EvaluatorTracker(
         model,
         ee_config.host,
         ee_config.port,
-        general_interval,
-        detailed_interval,
         token=ee_config.token,
         cert=ee_config.cert,
     )

--- a/ert_shared/status/utils.py
+++ b/ert_shared/status/utils.py
@@ -82,26 +82,3 @@ def format_running_time(runtime: int) -> str:
         layout = "Running time: {s} seconds"
 
     return layout.format(d=days, h=hours, m=minutes, s=seconds)
-
-
-def scale_intervals(reals):
-    scaled_gen = _scale(reals, min_time=5, max_time=10)
-    scaled_det = _scale(reals, min_time=10, max_time=20)
-    return math.trunc(scaled_gen), math.trunc(scaled_det)
-
-
-def _scale(nr_realizations, min_time=5, max_time=15, min_real=1, max_real=500):
-    nr_realizations = min(max_real, nr_realizations)
-    nr_realizations = max(min_real, nr_realizations)
-    norm_real = _norm(min_real, max_real, nr_realizations)
-
-    scaling_factor = _norm(_func(0), _func(1), _func(norm_real))
-    return min_time + scaling_factor * (max_time - min_time)
-
-
-def _norm(min_val, max_val, val):
-    return (val - min_val) / (max_val - min_val)
-
-
-def _func(val):
-    return 1.0 * (1.0 + 500.0) ** val

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -158,8 +158,6 @@ def test_tracking(
 
             tracker = create_tracker(
                 model,
-                general_interval=1,
-                detailed_interval=2,
                 ee_config=evaluator_server_config,
             )
 

--- a/tests/ert_tests/status/test_utils.py
+++ b/tests/ert_tests/status/test_utils.py
@@ -3,7 +3,6 @@ import unittest
 from ert_shared.status.utils import (
     _calculate_progress,
     format_running_time,
-    scale_intervals,
 )
 
 
@@ -29,33 +28,6 @@ class TrackerUtilsTest(unittest.TestCase):
 
         for t in tests:
             self.assertEqual(t["expected"], format_running_time(t["seconds"]))
-
-    def test_scale_intervals(self):
-        tests = [
-            {"reals": 1, "expected_gen": 5, "expected_det": 10},
-            {"reals": 100, "expected_gen": 5, "expected_det": 10},
-            {"reals": 200, "expected_gen": 5, "expected_det": 10},
-            {"reals": 500, "expected_gen": 10, "expected_det": 20},
-            {"reals": 900, "expected_gen": 10, "expected_det": 20},
-            {"reals": 1000, "expected_gen": 10, "expected_det": 20},
-        ]
-
-        for t in tests:
-            actual_gen, actual_det = scale_intervals(t["reals"])
-            self.assertEqual(
-                t["expected_gen"],
-                actual_gen,
-                "failed to scale general to {} (was: {}) for {} reals".format(
-                    t["expected_gen"], actual_gen, t["reals"]
-                ),
-            )
-            self.assertEqual(
-                t["expected_det"],
-                actual_det,
-                "failed to scale detailed to {} (was: {}) for {} reals".format(
-                    t["expected_det"], actual_det, t["reals"]
-                ),
-            )
 
     def test_calculate_progress(self):
         tests = [


### PR DESCRIPTION
**Issue**
Legacy utility functions for legacy tracker should be removed


**Approach**
Remove utility functions

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
