### PR TITLE
Remove usage of threadpool in block_fs_driver

### DIFF
--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -365,7 +365,15 @@ static enkf_fs_type *enkf_fs_mount_block_fs(FILE *fstab_stream,
 enkf_fs_type *enkf_fs_create_fs(const char *mount_point,
                                 fs_driver_impl driver_id, void *arg,
                                 bool mount) {
+    /*
+	 * NOTE: This value is the (maximum) number of concurrent files
+	 * used by ert::block_fs_driver -objects. These objects will
+	 * occasionally schedule one std::future for each file, hence
+	 * this is sometimes the number of concurrently executing futures.
+	 * (In other words - don't set it to 100000...)
+	 */
     const int num_drivers = 32;
+
     FILE *stream = fs_driver_open_fstab(mount_point, true);
     if (stream != NULL) {
         fs_driver_init_fstab(stream, driver_id);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import os
 import pkg_resources
+import shutil
 
 import pytest
 
 from utils import SOURCE_DIR
+from res.enkf import ResConfig
 
 
 @pytest.fixture(scope="session")
@@ -32,3 +34,14 @@ def env_save():
     ]
     set_xor = set(environment_pre).symmetric_difference(set(environment_post))
     assert len(set_xor) == 0, f"Detected differences in environment: {set_xor}"
+
+
+@pytest.fixture()
+def setup_case(tmpdir, source_root):
+    def copy_case(path, config_file):
+        shutil.copytree(os.path.join(source_root, "test-data", path), "test_data")
+        os.chdir("test_data")
+        return ResConfig(config_file)
+
+    with tmpdir.as_cwd():
+        yield copy_case

--- a/tests/performance_tests/enkf/test_enkf_fs.py
+++ b/tests/performance_tests/enkf/test_enkf_fs.py
@@ -1,0 +1,19 @@
+import pytest
+
+from res.enkf import EnKFMain
+
+
+def mount_and_umount(ert, case_name):
+    fs_manager = ert.getEnkfFsManager()
+    assert not fs_manager.isCaseMounted(case_name)
+    mount_point = fs_manager.getFileSystem(case_name)
+    assert fs_manager.isCaseMounted(case_name)
+    del mount_point
+    fs_manager.umount()
+
+
+def test_mount_fs(setup_case, benchmark):
+    res_config = setup_case("local/snake_oil", "snake_oil.ert")
+
+    ert = EnKFMain(res_config)
+    benchmark(mount_and_umount, ert, "default_1")


### PR DESCRIPTION
**Issue**
Resolves #2843

**Approach**
Replaced thread-pool by std::future. Manual testing shows that on large testcases this is more efficient than both thread-pool and sequential execution. Added explanation to the constant 32.

Simple benchmark-test, moved fixture from test_es_update.py to conftest in order to make it generally available.
