### PR TITLE
Fix dependecy issues

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,8 +32,8 @@ jobs:
 
     - name: Install with dependencies
       run: |
-        pip install -r dev-requirements.txt
         pip install .
+        pip install -r dev-requirements.txt
 
     - name: Run ert tests
       if: matrix.system-under-test == 'ert'

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.12.0",
-        "ert-storage >= 0.3.7",
+        "ert-storage >= 0.3.11",
         "fastapi==0.70.1",
         "graphene",
         "graphlib_backport; python_version < '3.9'",


### PR DESCRIPTION

**Issue**
Ert is not compatible with ert-storage<3.11. Also the install order in the coverage workflow is slightly unusual, and could cause problems.

**Approach**
- Pin ert-storage>=0.3.11
- Flip install order in coverage workflow



## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
