### PR TITLE
clang-format: Remove version check

### DIFF
--- a/script/clang-format
+++ b/script/clang-format
@@ -1,26 +1,52 @@
 #!/usr/bin/env python3
 import sys
-import re
-from typing import Generator
+import shutil
+from typing import Generator, Optional
 from pathlib import Path
 from subprocess import check_output, CalledProcessError, STDOUT
 from argparse import ArgumentParser
 
 
-CLANG_VERSIONS = ("10", "11", "12")
 DIRECTORIES = ["libres"]
 
 
-def check_version(clang_format: str) -> None:
-    version_str = check_output([clang_format, "--version"]).decode()
-    version_res = re.search(r"version (\d+).(\d+).(\d+)", version_str)
-    assert version_res
+def find_clang_format_binary(clang_format: Optional[str]) -> Path:
+    """
+    Looks for clang-format binary by searching the PATH environment
+    variable. Detect if clang-format was installed from PyPI and use the actual
+    binary rather than the incredibly slow Python wrapper.
+    """
+    if clang_format is None:
+        clang_format = shutil.which("clang-format")
+        if clang_format is None:
+            sys.exit("No viable executable 'clang-format' found in PATH")
 
-    major = version_res[1]
-    if major not in CLANG_VERSIONS:
-        sys.exit(
-            f"Version of clang-format ({clang_format}) is {major}, expected it to be one of {', '.join(CLANG_VERSIONS)}"
+    with open(clang_format, "rb") as f:
+        head = f.read(512)
+
+    if head[:2] != b"#!":
+        # File does not contain shebang, assuming real clang-format
+        print(f"Using clang-format: {clang_format}")
+        return Path(clang_format)
+
+    # Extract everything between '#!' and newline
+    python_path = head[2:].split(b"\n")[0].decode().strip()
+
+    # Locate the Python 'clang-format' module path
+    mod_path = (
+        check_output(
+            [python_path, "-c", "import clang_format;print(clang_format.__file__)"]
         )
+        .decode()
+        .strip()
+    )
+
+    # We assume that the location of the actual binary is always in the same
+    # location
+    clang_format_path = Path(mod_path).parent / "data" / "bin" / "clang-format"
+
+    print(f"Using clang-format: {clang_format_path}")
+    return clang_format_path
 
 
 def source_root() -> Path:
@@ -41,7 +67,7 @@ def enumerate_sources() -> Generator[Path, None, None]:
                 yield path
 
 
-def reformat(clang_format: str, dry_run: bool, verbose: bool) -> None:
+def reformat(clang_format: Path, dry_run: bool, verbose: bool) -> None:
     total = 0
     need_reformat = 0
     failed_reformat = 0
@@ -99,7 +125,7 @@ def main() -> None:
     )
     ap.add_argument(
         "--clang-format",
-        default="clang-format",
+        type=str,
         help="Name/path of the clang-format binary",
     )
     ap.add_argument(
@@ -111,8 +137,9 @@ def main() -> None:
     )
 
     args = ap.parse_args()
-    check_version(args.clang_format)
-    reformat(args.clang_format, args.check, args.verbose)
+
+    clang_format = find_clang_format_binary(args.clang_format)
+    reformat(clang_format, args.check, args.verbose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit also speeds up `clang-format` when installed from PyPI. It
detects whether the `clang-format` executable is a Python wrapper and
finds where the actual binary is location.