### PR TITLE
Introduce read-only info class derived from EvaluatorServerConfig

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -292,7 +292,7 @@ class RunDialog(QDialog):
 
         tracker = create_tracker(
             self._run_model,
-            ee_config=evaluator_server_config,
+            ee_con_info=evaluator_server_config.get_connection_info(),
         )
 
         worker = TrackerWorker(tracker)

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -72,7 +72,9 @@ def run_cli(args):
         )
         thread.start()
 
-        tracker = create_tracker(model, ee_config=evaluator_server_config)
+        tracker = create_tracker(
+            model, ee_con_info=evaluator_server_config.get_connection_info()
+        )
 
         out = open(os.devnull, "w") if args.disable_monitoring else sys.stderr
         monitor = Monitor(out=out, color_always=args.color_always)

--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -109,6 +109,29 @@ def _generate_certificate(
     return cert_str, key_bytes, pw
 
 
+class EvaluatorConnectionInfo:
+    """Read only server-info"""
+
+    def __init__(self, host: str, port: int, cert: str, token: str, url: str) -> None:
+        self.host = host
+        self.port = port
+        self.cert = cert
+        self.token = token
+        self.url = url
+
+    @property
+    def dispatch_uri(self) -> str:
+        return f"{self.url}/dispatch"
+
+    @property
+    def client_uri(self) -> str:
+        return f"{self.url}/client"
+
+    @property
+    def result_uri(self) -> str:
+        return f"{self.url}/result"
+
+
 """
 This class is responsible for identifying a host:port-combo and then provide
 low-level sockets bound to said combo. The problem is that these sockets may
@@ -167,6 +190,11 @@ class EvaluatorServerConfig:
             dispatch_uri=self.dispatch_uri, token=self.token, cert=self.cert
         )
 
+    def get_connection_info(self) -> EvaluatorConnectionInfo:
+        return EvaluatorConnectionInfo(
+            self.host, self.port, self.cert, self.token, self.url
+        )
+
     def get_server_ssl_context(
         self, protocol: int = ssl.PROTOCOL_TLS_SERVER
     ) -> typing.Optional[ssl.SSLContext]:
@@ -189,10 +217,3 @@ class EvaluatorServerConfig:
                 return context
         finally:
             tempfile.tempdir = backup_default_tmp
-
-
-class EvaluatorServerConfigInfo:
-    def __init__(self, dispatch_uri: str, token: str, cert: str):
-        self.dispatch_uri = dispatch_uri
-        self.token = token
-        self.cert = cert

--- a/ert_shared/ensemble_evaluator/ensemble/prefect.py
+++ b/ert_shared/ensemble_evaluator/ensemble/prefect.py
@@ -150,7 +150,7 @@ class PrefectEnsemble(_Ensemble):
             _get_executor, custom_port_range, executor
         )
 
-        self._ee_config = None
+        self._ee_con_info = None
         self._eval_proc = None
         self._ee_id: Optional[str] = None
         self._iens_to_task = {}
@@ -205,7 +205,7 @@ class PrefectEnsemble(_Ensemble):
 
     def evaluate(self, config: EvaluatorServerConfig, ee_id: str):
         self._ee_id = ee_id
-        self._ee_config = config.get_info()
+        self._ee_con_info = config.get_connection_info()
 
         # everything in self will be pickled since we bind a member function in target
         ctx = self._get_multiprocessing_context()
@@ -219,9 +219,9 @@ class PrefectEnsemble(_Ensemble):
         get_event_loop()
         try:
             with Client(
-                self._ee_config.dispatch_uri,
-                self._ee_config.token,
-                self._ee_config.cert,
+                self._ee_con_info.dispatch_uri,
+                self._ee_con_info.token,
+                self._ee_con_info.cert,
             ) as c:
                 event = CloudEvent(
                     {
@@ -231,16 +231,16 @@ class PrefectEnsemble(_Ensemble):
                 )
                 c.send(to_json(event).decode())
             with prefect.context(
-                url=self._ee_config.dispatch_uri,
-                token=self._ee_config.token,
-                cert=self._ee_config.cert,
+                url=self._ee_con_info.dispatch_uri,
+                token=self._ee_con_info.token,
+                cert=self._ee_con_info.cert,
             ):
                 self.run_flow(self._ee_id)
 
             with Client(
-                self._ee_config.dispatch_uri,
-                self._ee_config.token,
-                self._ee_config.cert,
+                self._ee_con_info.dispatch_uri,
+                self._ee_con_info.token,
+                self._ee_con_info.cert,
             ) as c:
                 event = CloudEvent(
                     {
@@ -257,9 +257,9 @@ class PrefectEnsemble(_Ensemble):
                 exc_info=True,
             )
             with Client(
-                self._ee_config.dispatch_uri,
-                self._ee_config.token,
-                self._ee_config.cert,
+                self._ee_con_info.dispatch_uri,
+                self._ee_con_info.token,
+                self._ee_con_info.cert,
             ) as c:
                 event = CloudEvent(
                     {
@@ -325,10 +325,10 @@ class PrefectEnsemble(_Ensemble):
         loop = asyncio.new_event_loop()
         loop.run_until_complete(
             self.send_cloudevent(
-                self._ee_config.dispatch_uri,
+                self._ee_con_info.dispatch_uri,
                 event,
-                token=self._ee_config.token,
-                cert=self._ee_config.cert,
+                token=self._ee_con_info.token,
+                cert=self._ee_con_info.cert,
             )
         )
         loop.close()

--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -224,13 +224,7 @@ class EnsembleEvaluator:
     def run(self) -> ee_monitor._Monitor:
         self._ws_thread.start()
         self._ensemble.evaluate(self._config, self._ee_id)
-        return ee_monitor.create(
-            self._config.host,
-            self._config.port,
-            self._config.protocol,
-            self._config.cert,
-            self._config.token,
-        )
+        return ee_monitor.create(self._config.get_connection_info())
 
     def _stop(self):
         if not self._done.done():

--- a/ert_shared/status/tracker/factory.py
+++ b/ert_shared/status/tracker/factory.py
@@ -3,7 +3,7 @@ from ert_shared.status.tracker.evaluator import EvaluatorTracker
 
 def create_tracker(
     model,
-    ee_config=None,
+    ee_con_info,
 ):
     """Creates a tracker tracking a @model. The provided model
     is updated purely event-driven.
@@ -14,8 +14,5 @@ def create_tracker(
 
     return EvaluatorTracker(
         model,
-        ee_config.host,
-        ee_config.port,
-        token=ee_config.token,
-        cert=ee_config.cert,
+        ee_con_info,
     )

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -101,7 +101,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             assert snapshot.get_job("1", "0", "1").status == JOB_STATE_FAILURE
 
         # a second monitor connects
-        with ee_monitor.create(host, port, "wss", cert, token) as monitor2:
+        with ee_monitor.create(evaluator._config.get_connection_info()) as monitor2:
             events2 = monitor2.track()
             full_snapshot_event = next(events2)
             assert full_snapshot_event["type"] == identifiers.EVTYPE_EE_SNAPSHOT

--- a/tests/ert_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert_tests/ensemble_evaluator/test_monitor.py
@@ -26,7 +26,7 @@ def test_monitor_successful_ensemble(make_ee_config):
 
     ee.run()
     with NarrativeProxy(monitor_successful_ensemble()).proxy(ee_config.url) as port:
-        with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
+        with ee_monitor.create(ee_config.get_connection_info()) as monitor:
             for event in monitor.track():
                 if event["type"] == identifiers.EVTYPE_EE_SNAPSHOT:
                     ensemble.start()
@@ -54,7 +54,7 @@ def test_monitor_failing_evaluation(make_ee_config):
     with NarrativeProxy(
         monitor_failing_evaluation().on_uri(f"ws://localhost:{ee_config.port}")
     ).proxy(ee_config.url) as port:
-        with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
+        with ee_monitor.create(ee_config.get_connection_info()) as monitor:
             for event in monitor.track():
                 if event["type"] == identifiers.EVTYPE_EE_SNAPSHOT:
                     ensemble.start()
@@ -83,7 +83,7 @@ def test_monitor_failing_ensemble(make_ee_config):
     with NarrativeProxy(
         monitor_failing_ensemble().on_uri(f"ws://localhost:{ee_config.port}")
     ).proxy(ee_config.url) as port:
-        with ee_monitor.create("localhost", port, "ws", None, None) as monitor:
+        with ee_monitor.create(ee_config.get_connection_info()) as monitor:
             for event in monitor.track():
                 if event["type"] == identifiers.EVTYPE_EE_SNAPSHOT:
                     ensemble.start()

--- a/tests/ert_tests/status/test_evaluator_tracker.py
+++ b/tests/ert_tests/status/test_evaluator_tracker.py
@@ -10,6 +10,7 @@ from ert_shared.ensemble_evaluator.entity.snapshot import (
     SnapshotBuilder,
     Step,
 )
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert_shared.models.base_run_model import BaseRunModel
 from ert_shared.status.entity import state
 from ert_shared.status.entity.event import EndEvent, SnapshotUpdateEvent
@@ -278,12 +279,13 @@ def test_tracking_progress(
     discarded. The test asserts that the state of the world is correct only for
     the final update event."""
     brm = BaseRunModel(None, None)
+    ee_config = EvaluatorServerConfig()
     with patch("ert_shared.status.tracker.evaluator.create_ee_monitor") as mock_ee:
         mock_ee.return_value.__enter__.return_value = make_mock_ee_monitor(
             monitor_events.copy()
         )
         tracker = EvaluatorTracker(
-            brm, "host", "port", 0, 0, next_ensemble_evaluator_wait_time=0.1
+            brm, ee_config.get_connection_info(), next_ensemble_evaluator_wait_time=0.1
         )
         for attr, val in brm_mutations:
             setattr(brm, attr, val)

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -158,7 +158,7 @@ def test_tracking(
 
             tracker = create_tracker(
                 model,
-                ee_config=evaluator_server_config,
+                ee_con_info=evaluator_server_config.get_connection_info(),
             )
 
             snapshots = {}


### PR DESCRIPTION
**Issue**
Resolves #3044 

**Approach**
~~Utilize `EvaluatorServerConfig` and make sure references are okay~~
- [x] Create a new read-only information class derived from `EvaluatorServerConfig`.
- [x] Employ the new class (called `EvaluatorConnectionInfo`)

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
