### PR TITLE
Remove enkf_obs instance from local_obsdata

### DIFF
--- a/libres/lib/enkf/local_obsdata.cpp
+++ b/libres/lib/enkf/local_obsdata.cpp
@@ -93,7 +93,11 @@ bool local_obsdata_add_node(local_obsdata_type *data,
 void local_obsdata_del_node(local_obsdata_type *data, const char *key) {
     auto index = data->node_index.at(key);
     data->nodes.erase(data->nodes.begin() + index);
-    data->node_index.erase(key);
+    data->node_index.clear();
+    for (std::size_t i = 0; i < data->nodes.size(); i++) {
+        const auto &node = data->nodes[i];
+        data->node_index.emplace(node.name(), i);
+    }
 }
 
 const LocalObsDataNode *local_obsdata_iget(const local_obsdata_type *data,

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -340,9 +340,7 @@ class _RealEnKFMain(BaseCClass):
     def getLocalConfig(self) -> LocalConfig:
         """@rtype: LocalConfig"""
         config = self._get_local_config().setParent(self)
-        config.initAttributes(
-            self.ensembleConfig(), self.eclConfig().getGrid()
-        )
+        config.initAttributes(self.ensembleConfig(), self.eclConfig().getGrid())
         return config
 
     def siteConfig(self) -> SiteConfig:

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -341,7 +341,7 @@ class _RealEnKFMain(BaseCClass):
         """@rtype: LocalConfig"""
         config = self._get_local_config().setParent(self)
         config.initAttributes(
-            self.ensembleConfig(), self.getObservations(), self.eclConfig().getGrid()
+            self.ensembleConfig(), self.eclConfig().getGrid()
         )
         return config
 

--- a/res/enkf/local_config.py
+++ b/res/enkf/local_config.py
@@ -67,13 +67,9 @@ class LocalConfig(BaseCClass):
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
-    def initAttributes(self, ensemble_config, obs, grid):
+    def initAttributes(self, ensemble_config, grid):
         self.ensemble_config = ensemble_config
-        self.obs = obs
         self.grid = grid
-
-    def __getObservations(self):
-        return self.obs
 
     def __getEnsembleConfig(self):
         return self.ensemble_config
@@ -110,7 +106,6 @@ class LocalConfig(BaseCClass):
 
         self._create_obsdata(obsdata_key)
         obsdata = self.getObsdata(obsdata_key)
-        obsdata.initObservations(self.__getObservations())
         return obsdata
 
     def copyObsdata(self, src_key, target_key):
@@ -121,7 +116,6 @@ class LocalConfig(BaseCClass):
             raise KeyError(f"The observation set {src_key} does not exist")
 
         obsdata = self._copy_obsdata(src_key, target_key)
-        obsdata.initObservations(self.__getObservations())
         return obsdata
 
     def getUpdatestep(self):

--- a/res/enkf/local_config.py
+++ b/res/enkf/local_config.py
@@ -130,6 +130,8 @@ class LocalConfig(BaseCClass):
     def getObsdata(self, obsdata_key):
         """@rtype: Obsdata"""
         assert isinstance(obsdata_key, str)
+        if not self._has_obsdata(obsdata_key):
+            raise KeyError(f"No such local observation key: {obsdata_key}")
         return self._get_obsdata(obsdata_key)
 
     def attachMinistep(self, update_step, mini_step):

--- a/res/enkf/local_obsdata.py
+++ b/res/enkf/local_obsdata.py
@@ -15,38 +15,16 @@ class LocalObsdata(BaseCClass):
     _del_node = ResPrototype("void  local_obsdata_del_node(local_obsdata, char*)")
     _name = ResPrototype("char* local_obsdata_get_name(local_obsdata)")
 
-    def __init__(self, name, obs=None):
-        # The obs instance should be a EnkFObs instance; some circular dependency problems
-        # by importing it right away. It is not really optional, but it is made optional
-        # here to be able to give a decent error message for old call sites which did not
-        # supply the obs argument.
-        if obs is None:
-            msg = """
-
-The LocalObsdata constructor has recently changed, as a second
-argument you should pass the EnkFObs instance with all the
-observations. You can typically get this instance from the ert main
-object as:
-
-    obs = ert.getObservations()
-    local_obs = LocalObsData("YOUR-KEY" , obs)
-
-"""
-            raise Exception(msg)
-
+    def __init__(self, name):
         assert isinstance(name, str)
 
         c_ptr = self._alloc(name)
         if c_ptr:
             super().__init__(c_ptr)
-            self.initObservations(obs)
         else:
             raise ValueError(
                 'Unable to construct LocalObsdata with name "%s" from given obs.' % name
             )
-
-    def initObservations(self, obs):
-        self.obs = obs
 
     def __len__(self):
         """@rtype: int"""
@@ -92,16 +70,11 @@ object as:
     def addNode(self, key):
         """@rtype: LocalObsdataNode"""
         assert isinstance(key, str)
-        if key in self.obs:
-            if key not in self:
-                node = LocalObsdataNode(key)
-                return _lib.local.local_obsdata.add_node(self, node)
-            else:
-                raise KeyError("Tried to add existing observation key:%s " % key)
+        if key not in self:
+            node = LocalObsdataNode(key)
+            return _lib.local.local_obsdata.add_node(self, node)
         else:
-            raise KeyError(
-                "The observation node: %s is not recognized observation key" % key
-            )
+            raise KeyError("Tried to add existing observation key:%s " % key)
 
     def addObsVector(self, obs_vector):
         self.addNode(obs_vector.getObservationKey())

--- a/tests/libres_tests/res/enkf/test_local_config.py
+++ b/tests/libres_tests/res/enkf/test_local_config.py
@@ -24,6 +24,7 @@ from res.enkf.local_obsdata import LocalObsdata
 from res.enkf.local_obsdata_node import LocalObsdataNode
 from res.enkf.active_list import ActiveList
 from res.enkf.local_updatestep import LocalUpdateStep
+from res.enkf.enums import ActiveMode
 from res.test import ErtTestContext
 
 
@@ -77,6 +78,15 @@ class LocalConfigTest(ResTest):
             # Error when adding existing obs node
             with self.assertRaises(KeyError):
                 local_obs_data_1.addNode("GEN_PERLIN_1")
+
+            with self.assertRaises(KeyError):
+                local_config.getObsdata("NO_SUCH_KEY")
+
+            local_obs_data_2 = local_config.getObsdata("OBSSET_1")
+            self.assertEqual(local_obs_data_1, local_obs_data_2)
+            al = local_obs_data_2.getActiveList("GEN_PERLIN_1")
+            al.addActiveIndex(10)
+            self.assertEqual(al.getMode(), ActiveMode.PARTLY_ACTIVE)
 
     def test_get_active_list(self):
         with ErtTestContext(self.local_conf_path, self.config) as test_context:

--- a/tests/libres_tests/res/enkf/test_local_obs_data.py
+++ b/tests/libres_tests/res/enkf/test_local_obs_data.py
@@ -1,0 +1,82 @@
+#  Copyright (C) 2017  Equinor ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import pytest
+from res.enkf.enums import ActiveMode
+from res.enkf.local_obsdata import LocalObsdata
+
+
+def test_empty():
+    local_obs_data = LocalObsdata("LOCAL_OBS")
+    assert len(local_obs_data) == 0
+    assert "NO_SUCH_KEY" not in local_obs_data
+    assert "LOCAL_OBS" == local_obs_data.name()
+
+
+@pytest.mark.parametrize(
+    "index, error, expected_msg",
+    [
+        (10, IndexError, "Invalid index, valid range is"),
+        ("NO_SUCH_KEY", KeyError, 'Unknown key "NO_SUCH_KEY'),
+    ],
+)
+def test_exception(index, error, expected_msg):
+    local_obs_data = LocalObsdata("LOCAL_OBS")
+
+    with pytest.raises(error, match=expected_msg):
+        local_obs_data[index]
+
+
+@pytest.fixture()
+def local_obs_data() -> LocalObsdata:
+    local_obs_data = LocalObsdata("LOCAL_OBS")
+    local_obs_data.addNode("KEY1")
+    local_obs_data.addNode("KEY2")
+    local_obs_data.addNode("KEY3")
+    yield local_obs_data
+
+
+def test_add_nodes(local_obs_data):
+    assert len(local_obs_data) == 3
+    assert "KEY3" in local_obs_data
+
+    for index, key in enumerate(["KEY1", "KEY2", "KEY3"]):
+        index_node = local_obs_data[index]
+        key_node = local_obs_data[key]
+
+        assert index_node == key_node
+
+
+def test_del_node(local_obs_data):
+    assert len(local_obs_data) == 3
+    del local_obs_data["KEY2"]
+    assert len(local_obs_data) == 2
+    for index, key in enumerate(["KEY1", "KEY3"]):
+        index_node = local_obs_data[index]
+        key_node = local_obs_data[key]
+        assert index_node == key_node
+
+
+def test_active_list(local_obs_data):
+    al1 = local_obs_data.getActiveList("KEY1")
+    assert al1.getMode() == ActiveMode.ALL_ACTIVE
+    al1.addActiveIndex(1)
+    al1.addActiveIndex(3)
+    assert al1.getActiveSize(0) == 2
+
+    al2 = local_obs_data.getActiveList("KEY1")
+    assert al2.getMode() == ActiveMode.PARTLY_ACTIVE
+    assert al2.getActiveSize(0) == 2


### PR DESCRIPTION
Add test to `LocalObsData`. Followup of [this comment](https://github.com/equinor/ert/pull/2966#discussion_r820755058) from #2966 

This PR contains some test-code which should be in place before #2966 is merged.

NB: The first commit is a  change of behavior (it is also in #2966, but pulled out here to make it more explicit). The situation is:

1. The C / C++ implementation of `local_obs_data` does not have any knowledge of the true set of observations in an `enkf_obs` instance; i.e. you can in principle add a local observation with an unknown key. This is probably a user error - which will go undetected, but not fatal as such - the unknown key will just be dangling and not used for anything.
2. In the Python implementation `LocalObsData` we have attached a reference to the `enkf_obs` instance while constructing the `LocalObsData` - the purpose of this has been to be able to input check the keys provided by user.

When switching to pybind we do not any longer have separate C and Python implementations - it is all in C++; it is not therefor natural[1] to pimp the python class with respect to the C++ implementation, I therefor suggest to remove this pimping here as a preparation for merging #2966. 

[1]: Yes - it would of course still be possible; but in my opinion not worth it. Some of the user control will be recovered when the localisation is completed with #2981. Furthermore it should be noted that the `local_config` object is decorated with observations, ensemble configuration and grid in Python in the same as described here.
