### PR TITLE
Correct exception name typo

### DIFF
--- a/ert/exceptions/__init__.py
+++ b/ert/exceptions/__init__.py
@@ -5,7 +5,7 @@ from ert.exceptions._exceptions import (
     ErtError,
     IllegalWorkspaceOperation,
     IllegalWorkspaceState,
-    NonExistantExperiment,
+    NonExistentExperiment,
     StorageError,
     ExperimentError,
 )
@@ -18,7 +18,7 @@ __all__ = [
     "ElementMissingError",
     "IllegalWorkspaceOperation",
     "IllegalWorkspaceState",
-    "NonExistantExperiment",
+    "NonExistentExperiment",
     "ConfigValidationError",
     "ExperimentError",
 ]

--- a/ert/exceptions/_exceptions.py
+++ b/ert/exceptions/_exceptions.py
@@ -17,7 +17,7 @@ class IllegalWorkspaceState(ErtError):
         self.message = message
 
 
-class NonExistantExperiment(IllegalWorkspaceOperation):
+class NonExistentExperiment(IllegalWorkspaceOperation):
     def __init__(self, message: str) -> None:
         self.message = message
 

--- a/ert/storage/_storage.py
+++ b/ert/storage/_storage.py
@@ -434,7 +434,7 @@ def get_records_url(workspace_name: str, experiment_name: Optional[str] = None) 
         experiment_name = f"{workspace_name}.{_ENSEMBLE_RECORDS}"
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise ert.exceptions.NonExistantExperiment(
+        raise ert.exceptions.NonExistentExperiment(
             f"Experiment {experiment_name} does not exist"
         )
 
@@ -517,7 +517,7 @@ async def _get_ensemble_id_async(
     experiment = experiments.get(experiment_name, None)
     if experiment is not None:
         return str(experiment["ensemble_ids"][0])
-    raise ert.exceptions.NonExistantExperiment(
+    raise ert.exceptions.NonExistentExperiment(
         f"Experiment {experiment_name} does not exist"
     )
 
@@ -624,7 +624,7 @@ def get_experiment_names(*, workspace_name: str) -> Set[str]:
 def _get_experiment_parameters(experiment_name: str) -> Iterable[str]:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise ert.exceptions.NonExistantExperiment(
+        raise ert.exceptions.NonExistentExperiment(
             f"Cannot get parameters from non-existing experiment: {experiment_name}"
         )
 
@@ -685,7 +685,7 @@ def get_ensemble_record_names(
         experiment_name = f"{workspace_name}.{_ENSEMBLE_RECORDS}"
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise ert.exceptions.NonExistantExperiment(
+        raise ert.exceptions.NonExistentExperiment(
             f"Cannot get record names of non-existing experiment: {experiment_name}"
         )
 
@@ -707,7 +707,7 @@ def get_experiment_parameters(*, experiment_name: str) -> Iterable[str]:
 def get_experiment_responses(*, experiment_name: str) -> Iterable[str]:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise ert.exceptions.NonExistantExperiment(
+        raise ert.exceptions.NonExistentExperiment(
             f"Cannot get responses from non-existing experiment: {experiment_name}"
         )
 
@@ -729,7 +729,7 @@ def get_experiment_responses(*, experiment_name: str) -> Iterable[str]:
 def delete_experiment(*, experiment_name: str) -> None:
     experiment = _get_experiment_by_name(experiment_name)
     if experiment is None:
-        raise ert.exceptions.NonExistantExperiment(
+        raise ert.exceptions.NonExistentExperiment(
             f"Experiment does not exist: {experiment_name}"
         )
     response = _delete_on_server(path=f"experiments/{experiment['id']}")

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -433,7 +433,7 @@ def test_cli_clean_one(workspace):
 
 
 @pytest.mark.requires_ert_storage
-def test_cli_clean_non_existant_experiment(workspace, capsys):
+def test_cli_clean_non_Existent_experiment(workspace, capsys):
     experiments_folder = workspace._path / _EXPERIMENTS_BASE
     experiments = {"E0", " E1"}
     for experiment in experiments:
@@ -453,7 +453,7 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
 
     deleted_experiment = experiments.pop()
 
-    args = ["ert3", "clean", deleted_experiment, "non_existant_experiment"]
+    args = ["ert3", "clean", deleted_experiment, "non_Existent_experiment"]
     with patch.object(sys, "argv", args):
         ert3.console.main()
 
@@ -464,7 +464,7 @@ def test_cli_clean_non_existant_experiment(workspace, capsys):
     captured = capsys.readouterr()
     assert (
         captured.out.strip() == "Following experiment(s) did not exist:\n"
-        "    non_existant_experiment\n"
+        "    non_Existent_experiment\n"
         "Perhaps you mistyped an experiment name?"
     )
 

--- a/tests/ert_tests/ert3/storage/test_storage.py
+++ b/tests/ert_tests/ert3/storage/test_storage.py
@@ -103,7 +103,7 @@ def test_get_parameters_unknown_experiment(tmpdir, ert_storage):
     ert.storage.init(workspace_name=tmpdir)
 
     with pytest.raises(
-        ert.exceptions.NonExistantExperiment,
+        ert.exceptions.NonExistentExperiment,
         match="Cannot get parameters from non-existing experiment: unknown-experiment",
     ):
         ert.storage.get_experiment_parameters(experiment_name="unknown-experiment")
@@ -283,7 +283,7 @@ def test_add_ensemble_record_to_non_existing_experiment(
 ):
     ert.storage.init(workspace_name=tmpdir)
     with pytest.raises(
-        ert.exceptions.NonExistantExperiment,
+        ert.exceptions.NonExistentExperiment,
         match="Experiment non_existing_experiment does not exist",
     ):
         get_event_loop().run_until_complete(
@@ -302,7 +302,7 @@ def test_add_ensemble_record_to_non_existing_experiment(
 def test_get_ensemble_record_to_non_existing_experiment(tmpdir, ert_storage):
     ert.storage.init(workspace_name=tmpdir)
     with pytest.raises(
-        ert.exceptions.NonExistantExperiment,
+        ert.exceptions.NonExistentExperiment,
         match="Experiment non_existing_experiment does not exist",
     ):
         ert.storage.get_ensemble_record(
@@ -354,7 +354,7 @@ def test_get_record_names_unknown_experiment(tmpdir, ert_storage):
     ert.storage.init(workspace_name=tmpdir)
 
     with pytest.raises(
-        ert.exceptions.NonExistantExperiment,
+        ert.exceptions.NonExistentExperiment,
         match="Cannot get record names of non-existing experiment: unknown-experiment",
     ):
         ert.storage.get_ensemble_record_names(
@@ -375,7 +375,7 @@ def test_delete_experiment(tmpdir, ert_storage):
     assert "test" in ert.storage.get_experiment_names(workspace_name=tmpdir)
 
     with pytest.raises(
-        ert.exceptions.NonExistantExperiment,
+        ert.exceptions.NonExistentExperiment,
         match="Experiment does not exist: does_not_exist",
     ):
         ert.storage.delete_experiment(experiment_name="does_not_exist")


### PR DESCRIPTION
Existant -> Existent

**Issue**
Resolves (probable?) typo in the list of ERT exceptions. Existant is usually a misspelling of existent, but there seems to be some legit use of the term, as in https://wikidiff.com/existant/existent, which does not seem to apply to the usage of the exception in question in ERT.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
