### PR TITLE
All content must be included in testkomodo file

### DIFF
--- a/ci/jenkins/testkomodo-repeat-flaky.sh
+++ b/ci/jenkins/testkomodo-repeat-flaky.sh
@@ -1,6 +1,25 @@
-# It is only necessary to change the start_tests function
-SCRIPT_DIR=$(dirname "$0")
-source $SCRIPT_DIR/testkomodo.sh
+copy_test_files () {
+    cp -r ${CI_SOURCE_ROOT}/tests ${CI_TEST_ROOT}
+
+    #ert
+    ln -s ${CI_SOURCE_ROOT}/test-data ${CI_TEST_ROOT}/test-data
+    ln -s ${CI_SOURCE_ROOT}/ert3_examples ${CI_TEST_ROOT}/ert3_examples
+
+    # Trick ERT to find a fake source root
+    mkdir ${CI_TEST_ROOT}/.git
+
+    # libres
+    mkdir -p ${CI_TEST_ROOT}/libres/res/fm/rms
+    ln -s ${CI_SOURCE_ROOT}/res/fm/rms/rms_config.yml ${CI_TEST_ROOT}/libres/res/fm/rms/rms_config.yml
+    ln -s {$CI_SOURCE_ROOT,$CI_TEST_ROOT}/libres/lib
+    ln -s {$CI_SOURCE_ROOT,$CI_TEST_ROOT}/libres/bin
+
+    ln -s ${CI_SOURCE_ROOT}/share ${CI_TEST_ROOT}/share
+}
+
+install_test_dependencies () {
+    pip install -r dev-requirements.txt
+}
 
 start_tests () {
     export NO_PROXY=localhost,127.0.0.1
@@ -10,4 +29,5 @@ start_tests () {
     pytest --count=100 -x  tests/ert_tests/ensemble_evaluator
     pytest --count=100 -x  tests/ert_tests/ert3
     popd
+
 }


### PR DESCRIPTION
The testkomodo script is copied, and thus other files in the same directory is not accessible. Include all contents of the test script in order to run