### PR TITLE
Make port range larger in test

### DIFF
--- a/ert3/evaluator/_evaluator.py
+++ b/ert3/evaluator/_evaluator.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Dict
+from typing import Dict, Optional
 
 import ert
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
@@ -50,8 +50,9 @@ def _run(
 
 def evaluate(
     ensemble: Ensemble,
+    custom_port_range: Optional[range] = None,
 ) -> Dict[int, Dict[str, ert.data.RecordTransmitter]]:
-    config = EvaluatorServerConfig()
+    config = EvaluatorServerConfig(custom_port_range=custom_port_range)
     ee = EnsembleEvaluator(ensemble=ensemble, config=config, iter_=0)
     result = _run(ee)
     return result

--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -137,7 +137,7 @@ the asyncio code to also close the underlying socket:
 class EvaluatorServerConfig:
     def __init__(
         self,
-        custom_port_range: range = None,
+        custom_port_range: typing.Optional[range] = None,
         use_token: bool = True,
         generate_cert: bool = True,
     ) -> None:

--- a/tests/ert_tests/ert3/evaluator/test_evaluator.py
+++ b/tests/ert_tests/ert3/evaluator/test_evaluator.py
@@ -93,7 +93,7 @@ def test_evaluator(
         stage, ensemble_config.forward_model.driver, ensemble_config.size, step_builder
     )
 
-    evaluation_records = ert3.evaluator.evaluate(ensemble)
+    evaluation_records = ert3.evaluator.evaluate(ensemble, range(1024, 65535))
 
     for _, transmitter_map in evaluation_records.items():
         record = asyncio.get_event_loop().run_until_complete(


### PR DESCRIPTION
Test was not working when many workers running, as no ports were available.
https://ci.equinor.com/scout/job/komodo_testing/job/ert-custom-script-pr/9340/console