### PR TITLE
Set proper timeout for Storage.start_server()

### DIFF
--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -135,7 +135,7 @@ def workspace_integration(tmpdir):
     workspace_dir.mkdir()
     with chdir(workspace_dir):
 
-        with Storage.start_server():
+        with Storage.start_server(timeout=120):
             workspace_obj = ert3.workspace.initialize(workspace_dir)
             ert.storage.init(workspace_name=workspace_obj.name)
             yield workspace_obj

--- a/tests/ert_tests/ert3/console/integration/test_cli.py
+++ b/tests/ert_tests/ert3/console/integration/test_cli.py
@@ -601,7 +601,7 @@ def test_check_service(tmpdir, monkeypatch):
         with patch.object(
             sys, "argv", ["ert3", "service", "check", "storage", "--timeout", "10"]
         ):
-            with Storage.start_server():
+            with Storage.start_server(timeout=120):
                 ert3.console._console._main()
 
 


### PR DESCRIPTION
Resolve #2429 by specifying a reasonable timeout
