### PR TITLE
Remove UTIL_TYPE_ID and everything related to it

### DIFF
--- a/libres/lib/config/config_content.cpp
+++ b/libres/lib/config/config_content.cpp
@@ -30,10 +30,8 @@
 #include <ert/config/config_path_stack.hpp>
 #include <ert/config/config_content.hpp>
 
-#define CONFIG_CONTENT_TYPE_ID 6612520
 
 struct config_content_struct {
-    UTIL_TYPE_ID_DECLARATION;
     std::set<std::string> *
         parsed_files; /* A set of config files whcih have been parsed - to protect against circular includes. */
 
@@ -51,12 +49,10 @@ struct config_content_struct {
     bool valid;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(config_content, CONFIG_CONTENT_TYPE_ID)
 
 config_content_type *config_content_alloc(const char *filename) {
     config_content_type *content =
         (config_content_type *)util_malloc(sizeof *content);
-    UTIL_TYPE_ID_INIT(content, CONFIG_CONTENT_TYPE_ID);
     content->parsed_files = new std::set<std::string>();
 
     content->valid = false;

--- a/libres/lib/config/config_content_item.cpp
+++ b/libres/lib/config/config_content_item.cpp
@@ -25,7 +25,6 @@
 
 #define CONFIG_CONTENT_ITEM_ID 8876752
 struct config_content_item_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const config_schema_item_type *schema;
     vector_type *nodes;
     const config_path_elm_type *path_elm;
@@ -146,11 +145,9 @@ void config_content_item_free(config_content_item_type *item) {
     free(item);
 }
 
-UTIL_SAFE_CAST_FUNCTION(config_content_item, CONFIG_CONTENT_ITEM_ID)
-UTIL_IS_INSTANCE_FUNCTION(config_content_item, CONFIG_CONTENT_ITEM_ID)
 
 void config_content_item_free__(void *arg) {
-    config_content_item_type *content_item = config_content_item_safe_cast(arg);
+    config_content_item_type *content_item = reinterpret_cast<config_content_item_type*>(arg);
     config_content_item_free(content_item);
 }
 
@@ -159,7 +156,6 @@ config_content_item_alloc(const config_schema_item_type *schema,
                           const config_path_elm_type *path_elm) {
     config_content_item_type *content_item =
         (config_content_item_type *)util_malloc(sizeof *content_item);
-    UTIL_TYPE_ID_INIT(content_item, CONFIG_CONTENT_ITEM_ID);
     content_item->schema = schema;
     content_item->nodes = vector_alloc_new();
     content_item->path_elm = path_elm;

--- a/libres/lib/config/config_content_node.cpp
+++ b/libres/lib/config/config_content_node.cpp
@@ -32,21 +32,18 @@ namespace fs = std::filesystem;
 
 #define CONFIG_CONTENT_NODE_ID 6752887
 struct config_content_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const config_schema_item_type *schema;
     stringlist_type *stringlist; /* The values which have been set. */
     const config_path_elm_type *cwd;
     stringlist_type *string_storage;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(config_content_node, CONFIG_CONTENT_NODE_ID)
 
     config_content_node_type *config_content_node_alloc(
         const config_schema_item_type *schema,
         const config_path_elm_type *cwd) {
     config_content_node_type *node =
         (config_content_node_type *)util_malloc(sizeof *node);
-    UTIL_TYPE_ID_INIT(node, CONFIG_CONTENT_NODE_ID);
     node->stringlist = stringlist_alloc_new();
     node->cwd = cwd;
     node->schema = schema;
@@ -81,7 +78,7 @@ void config_content_node_free(config_content_node_type *node) {
 }
 
 void config_content_node_free__(void *arg) {
-    config_content_node_type *node = config_content_node_safe_cast(arg);
+    config_content_node_type *node = reinterpret_cast<config_content_node_type*>(arg);
     config_content_node_free(node);
 }
 

--- a/libres/lib/config/config_path_elm.cpp
+++ b/libres/lib/config/config_path_elm.cpp
@@ -23,23 +23,19 @@
 #include <ert/config/config_root_path.hpp>
 #include <ert/config/config_path_elm.hpp>
 
-#define CONFIG_PATH_ELM_TYPE_ID 7100063
 
 struct config_path_elm_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *abs_path; // This will always be absolute
     char *rel_path; // This will always be relative to the root path.
     const config_root_path_type *root_path;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(config_path_elm, CONFIG_PATH_ELM_TYPE_ID)
 
     config_path_elm_type *config_path_elm_alloc(
         const config_root_path_type *root_path, const char *path) {
     if (root_path != NULL) {
         config_path_elm_type *path_elm =
             (config_path_elm_type *)util_malloc(sizeof *path_elm);
-        UTIL_TYPE_ID_INIT(path_elm, CONFIG_PATH_ELM_TYPE_ID);
         path_elm->root_path = root_path;
         if (path == NULL) {
             path_elm->rel_path = NULL;
@@ -75,7 +71,7 @@ void config_path_elm_free(config_path_elm_type *path_elm) {
 }
 
 void config_path_elm_free__(void *arg) {
-    config_path_elm_type *path_elm = config_path_elm_safe_cast(arg);
+    config_path_elm_type *path_elm = reinterpret_cast<config_path_elm_type*>(arg);
     config_path_elm_free(path_elm);
 }
 

--- a/libres/lib/config/config_path_stack.cpp
+++ b/libres/lib/config/config_path_stack.cpp
@@ -23,10 +23,8 @@
 #include <ert/config/config_path_elm.hpp>
 #include <ert/config/config_path_stack.hpp>
 
-#define CONFIG_PATH_STACK_TYPE_ID 86751520
 
 struct config_path_stack_struct {
-    UTIL_TYPE_ID_DECLARATION;
     vector_type *storage;
     vector_type *stack;
 };
@@ -34,7 +32,6 @@ struct config_path_stack_struct {
 config_path_stack_type *config_path_stack_alloc() {
     config_path_stack_type *path_stack =
         (config_path_stack_type *)util_malloc(sizeof *path_stack);
-    UTIL_TYPE_ID_INIT(path_stack, CONFIG_PATH_STACK_TYPE_ID);
     path_stack->storage = vector_alloc_new();
     path_stack->stack = vector_alloc_new();
     return path_stack;

--- a/libres/lib/config/config_schema_item.cpp
+++ b/libres/lib/config/config_schema_item.cpp
@@ -86,7 +86,6 @@ struct validate_struct {
 
 #define CONFIG_SCHEMA_ITEM_ID 6751
 struct config_schema_item_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *kw; /* The kw which identifies this item */
 
     bool required_set;
@@ -194,7 +193,6 @@ static void validate_set_indexed_selection_set(validate_type *validate,
         set.insert(stringlist_iget(argv, i));
 }
 
-static UTIL_SAFE_CAST_FUNCTION(config_schema_item, CONFIG_SCHEMA_ITEM_ID)
 
     void config_schema_item_assure_type(const config_schema_item_type *item,
                                         int index, int type_mask) {
@@ -211,7 +209,6 @@ config_schema_item_type *config_schema_item_alloc(const char *kw,
                                                   bool required) {
     config_schema_item_type *item =
         (config_schema_item_type *)util_malloc(sizeof *item);
-    UTIL_TYPE_ID_INIT(item, CONFIG_SCHEMA_ITEM_ID);
     item->kw = util_alloc_string_copy(kw);
 
     item->required_set = required;
@@ -509,7 +506,7 @@ void config_schema_item_free(config_schema_item_type *item) {
 }
 
 void config_schema_item_free__(void *void_item) {
-    config_schema_item_type *item = config_schema_item_safe_cast(void_item);
+    config_schema_item_type *item = reinterpret_cast<config_schema_item_type*>(void_item);
     config_schema_item_free(item);
 }
 

--- a/libres/lib/config/config_settings.cpp
+++ b/libres/lib/config/config_settings.cpp
@@ -24,10 +24,8 @@
 #include <ert/config/config_schema_item.hpp>
 #include <ert/config/config_settings.hpp>
 
-#define SETTING_NODE_TYPE_ID 76254096
 
 struct config_settings_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *root_key;
     hash_type *settings;
 };
@@ -35,7 +33,6 @@ struct config_settings_struct {
 typedef struct setting_node_struct setting_node_type;
 
 struct setting_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     config_item_types value_type;
     char *key;
     char *string_value;
@@ -48,7 +45,6 @@ static void setting_node_assert_type(const setting_node_type *node,
                    __func__, expected_type, node->value_type);
 }
 
-UTIL_SAFE_CAST_FUNCTION(setting_node, SETTING_NODE_TYPE_ID)
 
 static setting_node_type *setting_node_alloc(const char *key,
                                              config_item_types value_type,
@@ -59,7 +55,6 @@ static setting_node_type *setting_node_alloc(const char *key,
     {
         setting_node_type *node =
             (setting_node_type *)util_malloc(sizeof *node);
-        UTIL_TYPE_ID_INIT(node, SETTING_NODE_TYPE_ID);
         node->value_type = value_type;
         node->string_value = util_alloc_string_copy(initial_value);
         node->key = util_alloc_string_copy(key);
@@ -74,7 +69,7 @@ static void setting_node_free(setting_node_type *node) {
 }
 
 static void setting_node_free__(void *arg) {
-    setting_node_type *node = setting_node_safe_cast(arg);
+    setting_node_type *node = reinterpret_cast<setting_node_type*>(arg);
     setting_node_free(node);
 }
 

--- a/libres/lib/enkf/analysis_config.cpp
+++ b/libres/lib/enkf/analysis_config.cpp
@@ -41,10 +41,8 @@
 #define UPDATE_ENKF_ALPHA_KEY "ENKF_ALPHA"
 #define UPDATE_STD_CUTOFF_KEY "STD_CUTOFF"
 
-#define ANALYSIS_CONFIG_TYPE_ID 64431306
 
 struct analysis_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     std::unordered_map<std::string, analysis_module_type *> analysis_modules;
     analysis_module_type *analysis_module;
     char *log_path; /* Points to directory with update logs. */
@@ -64,7 +62,6 @@ struct analysis_config_struct {
     double global_std_scaling;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(analysis_config, ANALYSIS_CONFIG_TYPE_ID)
 
 /*
 
@@ -488,7 +485,6 @@ analysis_config_alloc_full(int ens_size, double alpha, bool rerun,
                            bool single_node_update, double global_std_scaling,
                            int max_runtime, int min_realisations) {
     analysis_config_type *config = new analysis_config_type();
-    UTIL_TYPE_ID_INIT(config, ANALYSIS_CONFIG_TYPE_ID);
 
     config->log_path = NULL;
     config->update_settings = config_settings_alloc(UPDATE_SETTING_KEY);
@@ -516,7 +512,6 @@ analysis_config_alloc_full(int ens_size, double alpha, bool rerun,
 
 analysis_config_type *analysis_config_alloc_default(void) {
     analysis_config_type *config = new analysis_config_type();
-    UTIL_TYPE_ID_INIT(config, ANALYSIS_CONFIG_TYPE_ID);
 
     config->update_settings = config_settings_alloc(UPDATE_SETTING_KEY);
     config_settings_add_double_setting(

--- a/libres/lib/enkf/block_fs_driver.cpp
+++ b/libres/lib/enkf/block_fs_driver.cpp
@@ -45,10 +45,8 @@ struct bfs_config_struct {
     bool bfs_lock;
 };
 
-#define BFS_TYPE_ID 5510643
 
 struct bfs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     block_fs_type *block_fs;
     char *
         mountfile; // The full path to the file mounted by the block_fs layer - including extension.
@@ -75,7 +73,6 @@ bfs_config_type *bfs_config_alloc(bool read_only, bool bfs_lock) {
 
 void bfs_config_free(bfs_config_type *config) { free(config); }
 
-static UTIL_SAFE_CAST_FUNCTION(bfs, BFS_TYPE_ID);
 
 static void bfs_close(bfs_type *bfs) {
     if (bfs->block_fs != NULL)
@@ -86,7 +83,6 @@ static void bfs_close(bfs_type *bfs) {
 
 static bfs_type *bfs_alloc(const bfs_config_type *config) {
     bfs_type *fs = (bfs_type *)util_malloc(sizeof *fs);
-    UTIL_TYPE_ID_INIT(fs, BFS_TYPE_ID);
     fs->config = config;
 
     // New init

--- a/libres/lib/enkf/callback_arg.cpp
+++ b/libres/lib/enkf/callback_arg.cpp
@@ -19,17 +19,13 @@
 
 #include <ert/enkf/callback_arg.hpp>
 
-#define CALLBACK_ARG_TYPE_ID 7814509
 
 callback_arg_type *callback_arg_alloc(const res_config_type *res_config,
                                       run_arg_type *run_arg, rng_type *rng) {
     callback_arg_type *cb = (callback_arg_type *)util_malloc(sizeof *cb);
-    UTIL_TYPE_ID_INIT(cb, CALLBACK_ARG_TYPE_ID);
     cb->run_arg = run_arg;
     cb->rng = rng;
     cb->res_config = res_config;
     return cb;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(callback_arg, CALLBACK_ARG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(callback_arg, CALLBACK_ARG_TYPE_ID)

--- a/libres/lib/enkf/container.cpp
+++ b/libres/lib/enkf/container.cpp
@@ -32,7 +32,6 @@ struct container_struct {
 C_USED container_type *container_alloc(const container_config_type *config) {
     container_type *container =
         (container_type *)util_malloc(sizeof *container);
-    UTIL_TYPE_ID_INIT(container, CONTAINER);
     container->config = config;
     container->nodes = vector_alloc_new();
     return container;
@@ -63,8 +62,5 @@ void container_assert_size(const container_type *container) {
                    container_config_get_size(container->config));
 }
 
-UTIL_IS_INSTANCE_FUNCTION(container, CONTAINER)
-UTIL_SAFE_CAST_FUNCTION(container, CONTAINER)
-UTIL_SAFE_CAST_FUNCTION_CONST(container, CONTAINER)
 VOID_ALLOC(container)
 VOID_FREE(container)

--- a/libres/lib/enkf/container_config.cpp
+++ b/libres/lib/enkf/container_config.cpp
@@ -22,19 +22,15 @@
 
 #include <ert/enkf/container_config.hpp>
 
-#define CONTAINER_CONFIG_TYPE_ID 51330852
 
 struct container_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     vector_type *nodes;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(container_config, CONTAINER_CONFIG_TYPE_ID);
 
 container_config_type *container_config_alloc(const char *key) {
     container_config_type *container =
         (container_config_type *)util_malloc(sizeof *container);
-    UTIL_TYPE_ID_INIT(container, CONTAINER_CONFIG_TYPE_ID);
     container->nodes = vector_alloc_new();
     return container;
 }
@@ -59,7 +55,5 @@ int container_config_get_data_size(
     return 0;
 }
 
-UTIL_SAFE_CAST_FUNCTION(container_config, CONTAINER_CONFIG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(container_config, CONTAINER_CONFIG_TYPE_ID)
 VOID_GET_DATA_SIZE(container)
 VOID_CONFIG_FREE(container)

--- a/libres/lib/enkf/ecl_refcase_list.cpp
+++ b/libres/lib/enkf/ecl_refcase_list.cpp
@@ -57,10 +57,8 @@
          will get NULL.
  */
 
-#define SUM_PAIR_TYPE_ID 665109971
 
 typedef struct sum_pair_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *case_name; // This  should be (path)/basename - no extension
     ecl_sum_type *ecl_sum;
 } sum_pair_type;
@@ -93,7 +91,6 @@ static sum_pair_type *sum_pair_alloc(const char *case_name, bool strict_load) {
 
         {
             sum_pair_type *pair = (sum_pair_type *)util_malloc(sizeof *pair);
-            UTIL_TYPE_ID_INIT(pair, SUM_PAIR_TYPE_ID);
             pair->case_name = use_case;
             pair->ecl_sum = ecl_sum;
             return pair;
@@ -105,8 +102,6 @@ static sum_pair_type *sum_pair_alloc(const char *case_name, bool strict_load) {
     }
 }
 
-static UTIL_SAFE_CAST_FUNCTION(sum_pair, SUM_PAIR_TYPE_ID);
-static UTIL_SAFE_CAST_FUNCTION_CONST(sum_pair, SUM_PAIR_TYPE_ID);
 
 const ecl_sum_type *sum_pair_get_ecl_sum(sum_pair_type *sum_pair) {
     if (sum_pair->ecl_sum == NULL)
@@ -122,13 +117,13 @@ static void sum_pair_free(sum_pair_type *sum_pair) {
 }
 
 static void sum_pair_free__(void *arg) {
-    sum_pair_type *pair = sum_pair_safe_cast(arg);
+    sum_pair_type *pair = reinterpret_cast<sum_pair_type*>(arg);
     sum_pair_free(pair);
 }
 
 static int sum_pair_cmp(const void *arg1, const void *arg2) {
-    const sum_pair_type *pair1 = sum_pair_safe_cast_const(arg1);
-    const sum_pair_type *pair2 = sum_pair_safe_cast_const(arg2);
+    const sum_pair_type *pair1 = reinterpret_cast<sum_pair_type*>_const(arg1);
+    const sum_pair_type *pair2 = reinterpret_cast<sum_pair_type*>_const(arg2);
 
     return util_strcmp_int(pair1->case_name, pair2->case_name);
 }

--- a/libres/lib/enkf/enkf_config_node.cpp
+++ b/libres/lib/enkf/enkf_config_node.cpp
@@ -43,10 +43,8 @@
 
 namespace fs = std::filesystem;
 
-#define ENKF_CONFIG_NODE_TYPE_ID 776104
 
 struct enkf_config_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     ert_impl_type impl_type;
     enkf_var_type var_type;
     bool vector_storage;
@@ -77,7 +75,6 @@ struct enkf_config_node_struct {
     config_free_ftype *freef;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_config_node, ENKF_CONFIG_NODE_TYPE_ID)
 
 static bool enkf_config_node_has_container(const enkf_config_node_type *node,
                                            enkf_fs_type *fs,
@@ -123,7 +120,6 @@ static enkf_config_node_type *enkf_config_node_alloc__(enkf_var_type var_type,
                                                        bool forward_init) {
     enkf_config_node_type *node =
         (enkf_config_node_type *)util_malloc(sizeof *node);
-    UTIL_TYPE_ID_INIT(node, ENKF_CONFIG_NODE_TYPE_ID);
     node->forward_init = forward_init;
     node->var_type = var_type;
     node->impl_type = impl_type;
@@ -1104,5 +1100,4 @@ enkf_config_node_type *enkf_config_node_alloc_SURFACE_full(
 
     return config_node;
 }
-UTIL_SAFE_CAST_FUNCTION(enkf_config_node, ENKF_CONFIG_NODE_TYPE_ID)
 VOID_FREE(enkf_config_node)

--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -133,7 +133,6 @@ static auto logger = ert::get_logger("enkf");
   foolprof.
 */
 
-#define ENKF_FS_TYPE_ID 1089763
 #define ENKF_MOUNT_MAP "enkf_mount_info"
 #define SUMMARY_KEY_SET_FILE "summary-key-set"
 #define TIME_MAP_FILE "time-map"
@@ -142,7 +141,6 @@ static auto logger = ert::get_logger("enkf");
 #define CASE_CONFIG_FILE "case_config"
 
 struct enkf_fs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *case_name;
     char *root_path;
     char *
@@ -175,8 +173,6 @@ struct enkf_fs_struct {
         // be able to answer the question: Is this case currently 'running'?
 };
 
-UTIL_SAFE_CAST_FUNCTION(enkf_fs, ENKF_FS_TYPE_ID)
-UTIL_IS_INSTANCE_FUNCTION(enkf_fs, ENKF_FS_TYPE_ID)
 
 void enkf_fs_umount(enkf_fs_type *fs);
 
@@ -215,7 +211,6 @@ enkf_fs_type *enkf_fs_get_ref(enkf_fs_type *fs) {
 
 enkf_fs_type *enkf_fs_alloc_empty(const char *mount_point) {
     enkf_fs_type *fs = new enkf_fs_type;
-    UTIL_TYPE_ID_INIT(fs, ENKF_FS_TYPE_ID);
     fs->time_map = time_map_alloc();
     fs->cases_config = cases_config_alloc();
     fs->state_map = state_map_alloc();

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -88,7 +88,6 @@ static auto logger = ert::get_logger("enkf");
 #define ENKF_MAIN_ID 8301
 
 struct enkf_main_struct {
-    UTIL_TYPE_ID_DECLARATION;
     enkf_fs_type *dbase; /* The internalized information. */
 
     const res_config_type *res_config;
@@ -111,8 +110,6 @@ static void enkf_main_init_fs(enkf_main_type *enkf_main);
 static void enkf_main_user_select_initial_fs(enkf_main_type *enkf_main);
 static void enkf_main_free_ensemble(enkf_main_type *enkf_main);
 
-UTIL_SAFE_CAST_FUNCTION(enkf_main, ENKF_MAIN_ID)
-UTIL_IS_INSTANCE_FUNCTION(enkf_main, ENKF_MAIN_ID)
 
 const analysis_config_type *
 enkf_main_get_analysis_config(const enkf_main_type *enkf_main) {
@@ -365,7 +362,6 @@ void enkf_main_clear_data_kw(enkf_main_type *enkf_main) {
 
 static enkf_main_type *enkf_main_alloc_empty() {
     enkf_main_type *enkf_main = new enkf_main_type;
-    UTIL_TYPE_ID_INIT(enkf_main, ENKF_MAIN_ID);
     enkf_main->ensemble = NULL;
     enkf_main->rng_manager = NULL;
     enkf_main->shared_rng = NULL;

--- a/libres/lib/enkf/enkf_main_jobs.cpp
+++ b/libres/lib/enkf/enkf_main_jobs.cpp
@@ -47,7 +47,7 @@ alloc_iactive_vector_from_range(const stringlist_type *range, int startindex,
 // Internal workflow job
 extern "C" C_USED void *enkf_main_exit_JOB(void *self,
                                            const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     enkf_main_exit(enkf_main);
     return NULL;
 }
@@ -58,7 +58,7 @@ extern "C" C_USED void *enkf_main_exit_JOB(void *self,
 // Internal workflow job
 extern "C" C_USED void *enkf_main_select_case_JOB(void *self,
                                                   const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     const char *new_case = stringlist_iget(args, 0);
     enkf_main_select_fs(enkf_main, new_case);
     return NULL;
@@ -67,7 +67,7 @@ extern "C" C_USED void *enkf_main_select_case_JOB(void *self,
 // Internal workflow job
 extern "C" C_USED void *enkf_main_create_case_JOB(void *self,
                                                   const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     const char *new_case = stringlist_iget(args, 0);
     enkf_fs_type *fs = enkf_main_mount_alt_fs(enkf_main, new_case, true);
     enkf_fs_decref(fs);
@@ -77,7 +77,7 @@ extern "C" C_USED void *enkf_main_create_case_JOB(void *self,
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_init_case_from_existing_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
 
     const char *source_case = stringlist_iget(args, 0);
     enkf_fs_type *source_fs =
@@ -142,7 +142,7 @@ static void *enkf_main_load_results_JOB__(enkf_main_type *enkf_main, int iter,
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_load_results_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     int iter = 0;
     {
         const model_config_type *model_config =
@@ -160,7 +160,7 @@ enkf_main_load_results_JOB(void *self, const stringlist_type *args) {
 // Internal Workflow job
 extern "C" C_USED void *
 enkf_main_load_results_iter_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     stringlist_type *iens_args = stringlist_alloc_new();
     int iter;
 
@@ -198,7 +198,7 @@ enkf_main_export_field_JOB(void *self, const stringlist_type *args) {
         field_config_default_export_format(file_name);
 
     if ((RMS_ROFF_FILE == file_type) || (ECL_GRDECL_FILE == file_type)) {
-        enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+        enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
         enkf_main_jobs_export_field(enkf_main, args, file_type);
     } else
         printf("EXPORT_FIELD filename argument: File extension must be either "
@@ -210,7 +210,7 @@ enkf_main_export_field_JOB(void *self, const stringlist_type *args) {
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_export_field_to_RMS_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     enkf_main_jobs_export_field(enkf_main, args, RMS_ROFF_FILE);
     return NULL;
 }
@@ -218,7 +218,7 @@ enkf_main_export_field_to_RMS_JOB(void *self, const stringlist_type *args) {
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_export_field_to_ECL_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     enkf_main_jobs_export_field(enkf_main, args, ECL_GRDECL_FILE);
     return NULL;
 }
@@ -226,7 +226,7 @@ enkf_main_export_field_to_ECL_JOB(void *self, const stringlist_type *args) {
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_init_misfit_table_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     int history_length = enkf_main_get_history_length(enkf_main);
     enkf_obs_type *enkf_obs = enkf_main_get_obs(enkf_main);
     int ens_size = enkf_main_get_ensemble_size(enkf_main);
@@ -288,7 +288,7 @@ static void enkf_main_export_runpath_file(enkf_main_type *enkf_main,
 // Internal workflow job
 extern "C" C_USED void *
 enkf_main_export_runpath_file_JOB(void *self, const stringlist_type *args) {
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     int ensemble_size = enkf_main_get_ensemble_size(enkf_main);
     const analysis_config_type *analysis_config =
         enkf_main_get_analysis_config(enkf_main);
@@ -351,7 +351,7 @@ enkf_main_pre_simulation_copy_JOB(void *self, const stringlist_type *args) {
         return NULL;
     }
 
-    enkf_main_type *enkf_main = enkf_main_safe_cast(self);
+    enkf_main_type *enkf_main = reinterpret_cast<enkf_main_type*>(self);
     model_config_type *model_config = enkf_main_get_model_config(enkf_main);
     if (!model_config_data_root_is_set(model_config)) {
         logger->error(

--- a/libres/lib/enkf/enkf_node.cpp
+++ b/libres/lib/enkf/enkf_node.cpp
@@ -179,10 +179,8 @@
    whole exercise.
 */
 
-#define ENKF_NODE_TYPE_ID 71043086
 
 struct enkf_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     alloc_ftype *alloc;
     ecl_write_ftype *ecl_write;
     forward_load_ftype *forward_load;
@@ -214,7 +212,6 @@ struct enkf_node_struct {
     vector_type *container_nodes;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_node, ENKF_NODE_TYPE_ID)
 
 const enkf_config_node_type *enkf_node_get_config(const enkf_node_type *node) {
     return node->config;
@@ -828,7 +825,6 @@ bool enkf_node_has_func(const enkf_node_type *node,
 
 enkf_node_type *enkf_node_alloc(const enkf_config_node_type *config) {
     enkf_node_type *node = enkf_node_alloc_empty(config);
-    UTIL_TYPE_ID_INIT(node, ENKF_NODE_TYPE_ID);
     enkf_node_alloc_domain_object(node);
     return node;
 }

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -162,9 +162,7 @@ In the following example we have two observations
 
  */
 
-#define ENKF_OBS_TYPE_ID 637297
 struct enkf_obs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     /* A hash of obs_vector_types indexed by user provided keys. */
     vector_type *obs_vector;
     hash_type *obs_hash;
@@ -190,7 +188,6 @@ static int enkf_obs_get_last_restart(const enkf_obs_type *enkf_obs) {
     return time_map_get_size(enkf_obs->obs_time) - 1;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_obs, ENKF_OBS_TYPE_ID)
 
 enkf_obs_type *enkf_obs_alloc(const history_type *history,
                               time_map_type *external_time_map,
@@ -198,7 +195,6 @@ enkf_obs_type *enkf_obs_alloc(const history_type *history,
                               const ecl_sum_type *refcase,
                               ensemble_config_type *ensemble_config) {
     enkf_obs_type *enkf_obs = (enkf_obs_type *)util_malloc(sizeof *enkf_obs);
-    UTIL_TYPE_ID_INIT(enkf_obs, ENKF_OBS_TYPE_ID);
     enkf_obs->obs_hash = hash_alloc();
     enkf_obs->obs_vector = vector_alloc_new();
     enkf_obs->obs_time = time_map_alloc();

--- a/libres/lib/enkf/enkf_plot_data.cpp
+++ b/libres/lib/enkf/enkf_plot_data.cpp
@@ -19,10 +19,8 @@
 #include <ert/enkf/enkf_plot_tvector.hpp>
 #include <ert/enkf/enkf_plot_data.hpp>
 
-#define ENKF_PLOT_DATA_TYPE_ID 3331063
 
 struct enkf_plot_data_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const enkf_config_node_type *config_node;
     int size;
     enkf_plot_tvector_type **ensemble;
@@ -68,13 +66,11 @@ void enkf_plot_data_free(enkf_plot_data_type *plot_data) {
     free(plot_data);
 }
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_data, ENKF_PLOT_DATA_TYPE_ID);
 
 enkf_plot_data_type *
 enkf_plot_data_alloc(const enkf_config_node_type *config_node) {
     enkf_plot_data_type *plot_data =
         (enkf_plot_data_type *)util_malloc(sizeof *plot_data);
-    UTIL_TYPE_ID_INIT(plot_data, ENKF_PLOT_DATA_TYPE_ID);
     plot_data->config_node = config_node;
     plot_data->size = 0;
     plot_data->ensemble = NULL;

--- a/libres/lib/enkf/enkf_plot_gen_kw.cpp
+++ b/libres/lib/enkf/enkf_plot_gen_kw.cpp
@@ -23,23 +23,19 @@
 #include <ert/enkf/enkf_plot_gen_kw.hpp>
 #include <ert/enkf/gen_kw_config.hpp>
 
-#define ENKF_PLOT_GEN_KW_TYPE_ID 88362063
 
 struct enkf_plot_gen_kw_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const enkf_config_node_type *config_node;
     int size;                                /* Number of ensembles. */
     enkf_plot_gen_kw_vector_type **ensemble; /* One vector for each ensemble. */
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_gen_kw, ENKF_PLOT_GEN_KW_TYPE_ID)
 
 enkf_plot_gen_kw_type *
 enkf_plot_gen_kw_alloc(const enkf_config_node_type *config_node) {
     if (enkf_config_node_get_impl_type(config_node) == GEN_KW) {
         enkf_plot_gen_kw_type *plot_gen_kw =
             (enkf_plot_gen_kw_type *)util_malloc(sizeof *plot_gen_kw);
-        UTIL_TYPE_ID_INIT(plot_gen_kw, ENKF_PLOT_GEN_KW_TYPE_ID);
         plot_gen_kw->config_node = config_node;
         plot_gen_kw->size = 0;
         plot_gen_kw->ensemble = NULL;

--- a/libres/lib/enkf/enkf_plot_gen_kw_vector.cpp
+++ b/libres/lib/enkf/enkf_plot_gen_kw_vector.cpp
@@ -23,16 +23,13 @@
 #include <ert/enkf/enkf_plot_gen_kw_vector.hpp>
 #include <ert/enkf/gen_kw.hpp>
 
-#define ENKF_PLOT_GEN_KW_VECTOR_TYPE_ID 88362064
 
 struct enkf_plot_gen_kw_vector_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int iens;
     double_vector_type *data;
     const enkf_config_node_type *config_node;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_gen_kw_vector,
                           ENKF_PLOT_GEN_KW_VECTOR_TYPE_ID)
 
 enkf_plot_gen_kw_vector_type *
@@ -40,7 +37,6 @@ enkf_plot_gen_kw_vector_alloc(const enkf_config_node_type *config_node,
                               int iens) {
     enkf_plot_gen_kw_vector_type *vector =
         (enkf_plot_gen_kw_vector_type *)util_malloc(sizeof *vector);
-    UTIL_TYPE_ID_INIT(vector, ENKF_PLOT_GEN_KW_VECTOR_TYPE_ID);
     vector->config_node = config_node;
     vector->data = double_vector_alloc(0, 0);
     vector->iens = iens;

--- a/libres/lib/enkf/enkf_plot_gendata.cpp
+++ b/libres/lib/enkf/enkf_plot_gendata.cpp
@@ -25,10 +25,8 @@
 #include <ert/enkf/obs_vector.hpp>
 #include <ert/enkf/enkf_plot_gendata.hpp>
 
-#define ENKF_PLOT_GENDATA_TYPE_ID 377626666
 
 struct enkf_plot_gendata_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int size;
     int report_step;
     const enkf_config_node_type *enkf_config_node;
@@ -38,14 +36,12 @@ struct enkf_plot_gendata_struct {
     double_vector_type *min_values;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_gendata, ENKF_PLOT_GENDATA_TYPE_ID)
 
 enkf_plot_gendata_type *
 enkf_plot_gendata_alloc(const enkf_config_node_type *enkf_config_node) {
     if (enkf_config_node_get_impl_type(enkf_config_node) == GEN_DATA) {
         enkf_plot_gendata_type *data =
             (enkf_plot_gendata_type *)util_malloc(sizeof *data);
-        UTIL_TYPE_ID_INIT(data, ENKF_PLOT_GENDATA_TYPE_ID);
         data->size = 0;
         data->enkf_config_node = enkf_config_node;
         data->work_arg = NULL;

--- a/libres/lib/enkf/enkf_plot_genvector.cpp
+++ b/libres/lib/enkf/enkf_plot_genvector.cpp
@@ -24,22 +24,18 @@
 #include <ert/enkf/gen_data.hpp>
 #include <ert/enkf/enkf_plot_genvector.hpp>
 
-#define ENKF_PLOT_GENVECTOR_TYPE_ID 66862669
 
 struct enkf_plot_genvector_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int iens;
     double_vector_type *data;
     const enkf_config_node_type *config_node;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_genvector, ENKF_PLOT_GENVECTOR_TYPE_ID)
 
 enkf_plot_genvector_type *
 enkf_plot_genvector_alloc(const enkf_config_node_type *config_node, int iens) {
     enkf_plot_genvector_type *vector =
         (enkf_plot_genvector_type *)util_malloc(sizeof *vector);
-    UTIL_TYPE_ID_INIT(vector, ENKF_PLOT_GENVECTOR_TYPE_ID);
     vector->config_node = config_node;
     vector->data = double_vector_alloc(0, 0);
     vector->iens = iens;
@@ -75,7 +71,7 @@ void enkf_plot_genvector_load(enkf_plot_genvector_type *vector,
 }
 
 void *enkf_plot_genvector_load__(void *arg) {
-    arg_pack_type *arg_pack = arg_pack_safe_cast(arg);
+    arg_pack_type *arg_pack = reinterpret_cast<arg_pack_type*>(arg);
     enkf_plot_genvector_type *vector =
         (enkf_plot_genvector_type *)arg_pack_iget_ptr(arg_pack, 0);
     enkf_fs_type *fs = (enkf_fs_type *)arg_pack_iget_ptr(arg_pack, 1);

--- a/libres/lib/enkf/enkf_plot_tvector.cpp
+++ b/libres/lib/enkf/enkf_plot_tvector.cpp
@@ -26,7 +26,6 @@
 #define ENKF_PLOT_TVECTOR_ID 6111861
 
 struct enkf_plot_tvector_struct {
-    UTIL_TYPE_ID_DECLARATION;
     double_vector_type *data;
     double_vector_type *work;
     time_t_vector_type *time;
@@ -36,8 +35,6 @@ struct enkf_plot_tvector_struct {
     bool summary_mode;
 };
 
-UTIL_SAFE_CAST_FUNCTION(enkf_plot_tvector, ENKF_PLOT_TVECTOR_ID)
-UTIL_IS_INSTANCE_FUNCTION(enkf_plot_tvector, ENKF_PLOT_TVECTOR_ID)
 
 void enkf_plot_tvector_reset(enkf_plot_tvector_type *plot_tvector) {
     double_vector_reset(plot_tvector->data);
@@ -49,7 +46,6 @@ enkf_plot_tvector_type *
 enkf_plot_tvector_alloc(const enkf_config_node_type *config_node, int iens) {
     enkf_plot_tvector_type *plot_tvector =
         (enkf_plot_tvector_type *)util_malloc(sizeof *plot_tvector);
-    UTIL_TYPE_ID_INIT(plot_tvector, ENKF_PLOT_TVECTOR_ID);
 
     plot_tvector->data = double_vector_alloc(0, 0);
     plot_tvector->time = time_t_vector_alloc(-1, 0);

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -40,7 +40,6 @@
 #include <ert/enkf/callback_arg.hpp>
 
 static auto logger = ert::get_logger("enkf");
-#define ENKF_STATE_TYPE_ID 78132
 
 /*
    This struct contains various objects which the enkf_state needs
@@ -65,7 +64,6 @@ typedef struct shared_info_struct {
 } shared_info_type;
 
 struct enkf_state_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hash_type *node_hash;
     ensemble_config_type *
         ensemble_config; /* The config nodes for the enkf_node objects contained in node_hash. */
@@ -74,7 +72,6 @@ struct enkf_state_struct {
     int __iens;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(enkf_state, ENKF_STATE_TYPE_ID)
 
     static shared_info_type *shared_info_alloc(
         const site_config_type *site_config, model_config_type *model_config,
@@ -178,7 +175,6 @@ enkf_state_type *enkf_state_alloc(int iens, rng_type *rng,
 
     enkf_state_type *enkf_state =
         (enkf_state_type *)util_malloc(sizeof *enkf_state);
-    UTIL_TYPE_ID_INIT(enkf_state, ENKF_STATE_TYPE_ID);
 
     enkf_state->ensemble_config = ensemble_config;
     enkf_state->shared_info =
@@ -650,7 +646,7 @@ bool enkf_state_complete_forward_modelOK(const res_config_type *res_config,
 }
 
 bool enkf_state_complete_forward_modelOK__(void *arg) {
-    callback_arg_type *cb_arg = callback_arg_safe_cast(arg);
+    callback_arg_type *cb_arg = reinterpret_cast<callback_arg_type*>(arg);
 
     return enkf_state_complete_forward_modelOK(cb_arg->res_config,
                                                cb_arg->run_arg);
@@ -671,7 +667,7 @@ bool enkf_state_complete_forward_model_EXIT_handler__(run_arg_type *run_arg) {
 }
 
 static bool enkf_state_complete_forward_model_EXIT_handler(void *arg) {
-    callback_arg_type *callback_arg = callback_arg_safe_cast(arg);
+    callback_arg_type *callback_arg = reinterpret_cast<callback_arg_type*>(arg);
     run_arg_type *run_arg = callback_arg->run_arg;
     return enkf_state_complete_forward_model_EXIT_handler__(run_arg);
 }
@@ -725,7 +721,7 @@ static void enkf_state_internal_retry(const res_config_type *res_config,
 }
 
 bool enkf_state_complete_forward_modelRETRY__(void *arg) {
-    callback_arg_type *cb_arg = callback_arg_safe_cast(arg);
+    callback_arg_type *cb_arg = reinterpret_cast<callback_arg_type*>(arg);
 
     if (run_arg_can_retry(cb_arg->run_arg)) {
         enkf_state_internal_retry(cb_arg->res_config, cb_arg->run_arg,

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -46,7 +46,6 @@
 
 namespace fs = std::filesystem;
 
-#define ENSEMBLE_CONFIG_TYPE_ID 8825306
 
 namespace {
 
@@ -82,7 +81,6 @@ get_string(const std::unordered_map<std::string, std::string> &opt_map,
 } // namespace
 
 struct ensemble_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     pthread_mutex_t mutex;
     char *
         gen_kw_format_string; /* format string used when creating gen_kw search/replace strings. */
@@ -94,8 +92,6 @@ struct ensemble_config_struct {
     summary_key_matcher_type *summary_key_matcher;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID)
 
 /*
    setting the format string used to 'mangle' the string in the gen_kw
@@ -156,7 +152,6 @@ ensemble_config_get_trans_table(const ensemble_config_type *ensemble_config) {
 static ensemble_config_type *ensemble_config_alloc_empty(void) {
     ensemble_config_type *ensemble_config = new ensemble_config_type();
 
-    UTIL_TYPE_ID_INIT(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID);
     ensemble_config->field_trans_table = field_trans_table_alloc();
     ensemble_config->gen_kw_format_string =
         util_alloc_string_copy(DEFAULT_GEN_KW_TAG_FORMAT);

--- a/libres/lib/enkf/ert_run_context.cpp
+++ b/libres/lib/enkf/ert_run_context.cpp
@@ -30,10 +30,8 @@
 #include <ert/enkf/run_arg.hpp>
 #include <ert/enkf/ert_run_context.hpp>
 
-#define ERT_RUN_CONTEXT_TYPE_ID 55534132
 
 struct ert_run_context_struct {
-    UTIL_TYPE_ID_DECLARATION;
     vector_type *run_args;
     run_mode_type run_mode;
     init_mode_type init_mode;
@@ -145,7 +143,6 @@ ert_run_context_alloc__(const bool_vector_type *iactive, run_mode_type run_mode,
                         enkf_fs_type *update_target_fs, int iter) {
     ert_run_context_type *context =
         (ert_run_context_type *)util_malloc(sizeof *context);
-    UTIL_TYPE_ID_INIT(context, ERT_RUN_CONTEXT_TYPE_ID);
 
     if (iactive != NULL) {
         context->iactive = bool_vector_alloc_copy(iactive);
@@ -295,7 +292,6 @@ ert_run_context_alloc(run_mode_type run_mode, init_mode_type init_mode,
     return NULL;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(ert_run_context, ERT_RUN_CONTEXT_TYPE_ID);
 
 const char *ert_run_context_get_id(const ert_run_context_type *context) {
     return context->run_id;

--- a/libres/lib/enkf/ert_template.cpp
+++ b/libres/lib/enkf/ert_template.cpp
@@ -23,19 +23,15 @@
 #include <ert/enkf/ert_template.hpp>
 #include <ert/enkf/config_keys.hpp>
 
-#define ERT_TEMPLATE_TYPE_ID 7731963
-#define ERT_TEMPLATES_TYPE_ID 6677330
 
 /* Singular - one template. */
 struct ert_template_struct {
-    UTIL_TYPE_ID_DECLARATION;
     template_type *tmpl;
     char *target_file;
 };
 
 /* Plural - many templates. */
 struct ert_templates_struct {
-    UTIL_TYPE_ID_DECLARATION;
     subst_list_type *parent_subst;
     hash_type *templates;
 };
@@ -66,7 +62,6 @@ ert_template_type *ert_template_alloc(const char *template_file,
                                       subst_list_type *parent_subst) {
     ert_template_type *ert_template =
         (ert_template_type *)util_malloc(sizeof *ert_template);
-    UTIL_TYPE_ID_INIT(ert_template, ERT_TEMPLATE_TYPE_ID);
     ert_template->tmpl = template_alloc(
         template_file, false,
         parent_subst); /* The templates are instantiated with internalize_template == false;
@@ -107,16 +102,14 @@ void ert_template_set_args_from_string(ert_template_type *ert_template,
     template_add_args_from_string(ert_template->tmpl, arg_string);
 }
 
-UTIL_SAFE_CAST_FUNCTION(ert_template, ERT_TEMPLATE_TYPE_ID)
 
 void ert_template_free__(void *arg) {
-    ert_template_free(ert_template_safe_cast(arg));
+    ert_template_free(reinterpret_cast<ert_template_type*>(arg));
 }
 
 ert_templates_type *ert_templates_alloc_default(subst_list_type *parent_subst) {
     ert_templates_type *templates =
         (ert_templates_type *)util_malloc(sizeof *templates);
-    UTIL_TYPE_ID_INIT(templates, ERT_TEMPLATES_TYPE_ID);
     templates->templates = hash_alloc();
     templates->parent_subst = parent_subst;
     return templates;

--- a/libres/lib/enkf/ert_test_context.cpp
+++ b/libres/lib/enkf/ert_test_context.cpp
@@ -30,16 +30,13 @@
 
 namespace fs = std::filesystem;
 
-#define ERT_TEST_CONTEXT_TYPE_ID 99671055
 struct ert_test_context_struct {
-    UTIL_TYPE_ID_DECLARATION;
     enkf_main_type *enkf_main;
     test_work_area_type *work_area;
     res_config_type *res_config;
     rng_type *rng;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(ert_test_context, ERT_TEST_CONTEXT_TYPE_ID)
 
 static ert_test_context_type *
 ert_test_context_alloc_internal(test_work_area_type *work_area,
@@ -47,7 +44,6 @@ ert_test_context_alloc_internal(test_work_area_type *work_area,
                                 const char *ui_mode) {
     ert_test_context_type *test_context =
         (ert_test_context_type *)util_malloc(sizeof *test_context);
-    UTIL_TYPE_ID_INIT(test_context, ERT_TEST_CONTEXT_TYPE_ID);
 
     /*
     This environment variable is set to ensure that test context will

--- a/libres/lib/enkf/ert_workflow_list.cpp
+++ b/libres/lib/enkf/ert_workflow_list.cpp
@@ -43,10 +43,8 @@
 namespace fs = std::filesystem;
 static auto logger = ert::get_logger("enkf");
 
-#define ERT_WORKFLOW_LIST_TYPE_ID 8856275
 
 struct ert_workflow_list_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hash_type *workflows;
     hash_type *alias_map;
     workflow_joblist_type *joblist;
@@ -62,7 +60,6 @@ ert_workflow_list_type *
 ert_workflow_list_alloc_empty(const subst_list_type *context) {
     ert_workflow_list_type *workflow_list =
         (ert_workflow_list_type *)util_malloc(sizeof *workflow_list);
-    UTIL_TYPE_ID_INIT(workflow_list, ERT_WORKFLOW_LIST_TYPE_ID);
     workflow_list->workflows = hash_alloc();
     workflow_list->alias_map = hash_alloc();
     workflow_list->joblist = workflow_joblist_alloc();
@@ -112,7 +109,6 @@ ert_workflow_list_alloc_full(const subst_list_type *context,
     return workflow_list;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(ert_workflow_list, ERT_WORKFLOW_LIST_TYPE_ID)
 
 void ert_workflow_list_set_verbose(ert_workflow_list_type *workflow_list,
                                    bool verbose) {

--- a/libres/lib/enkf/ext_param.cpp
+++ b/libres/lib/enkf/ext_param.cpp
@@ -230,8 +230,6 @@ ext_param_config_type const *ext_param_get_config(const ext_param_type *param) {
     return param->config;
 }
 
-UTIL_SAFE_CAST_FUNCTION(ext_param, EXT_PARAM)
-UTIL_SAFE_CAST_FUNCTION_CONST(ext_param, EXT_PARAM)
 VOID_ALLOC(ext_param)
 VOID_FREE(ext_param)
 VOID_ECL_WRITE(ext_param)

--- a/libres/lib/enkf/ext_param_config.cpp
+++ b/libres/lib/enkf/ext_param_config.cpp
@@ -30,14 +30,11 @@
 
 #define EXT_PARAM_CONFIG_ID 97124451
 struct ext_param_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     std::string key;
     std::vector<std::string> keys;
     std::vector<std::vector<std::string>> suffixes;
 };
 
-UTIL_SAFE_CAST_FUNCTION(ext_param_config, EXT_PARAM_CONFIG_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(ext_param_config, EXT_PARAM_CONFIG_ID)
 
 void ext_param_config_free(ext_param_config_type *config) { delete config; }
 
@@ -72,7 +69,6 @@ ext_param_config_type *ext_param_config_alloc(const char *key,
         return NULL;
 
     ext_param_config_type *config = new ext_param_config_type();
-    UTIL_TYPE_ID_INIT(config, EXT_PARAM_CONFIG_ID);
     config->key = key;
 
     for (int i = 0; i < stringlist_get_size(keys); i++) {

--- a/libres/lib/enkf/field.cpp
+++ b/libres/lib/enkf/field.cpp
@@ -777,7 +777,7 @@ void field_ecl_write(const field_type *field, const char *run_path,
         field_config_get_export_format(field->config);
 
     if (export_format == ECL_FILE) {
-        fortio_type *restart_fortio = fortio_safe_cast(filestream);
+        fortio_type *restart_fortio = reinterpret_cast<fortio_type*>(filestream);
         field_export(field, NULL, restart_fortio, export_format, true, NULL);
         return;
     }
@@ -1194,9 +1194,6 @@ C_USED bool field_user_get(const field_type *field, const char *index_key,
 
   MATH_OPS(field)
 */
-UTIL_SAFE_CAST_FUNCTION(field, FIELD)
-UTIL_SAFE_CAST_FUNCTION_CONST(field, FIELD)
-UTIL_IS_INSTANCE_FUNCTION(field, FIELD)
 VOID_ALLOC(field)
 VOID_FREE(field)
 VOID_ECL_WRITE(field)

--- a/libres/lib/enkf/field_config.cpp
+++ b/libres/lib/enkf/field_config.cpp
@@ -117,7 +117,6 @@ _______________/                     \___________/       |  with EnKF.          
 #define FIELD_CONFIG_ID 78269
 
 struct field_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
 
     char *ecl_kw_name; /* Name/key ... */
     int data_size, nx, ny,
@@ -155,7 +154,6 @@ struct field_config_struct {
     char *input_transform_name;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(field_config, FIELD_CONFIG_ID)
 
 void field_config_set_ecl_data_type(field_config_type *config,
                                     ecl_data_type data_type) {
@@ -314,7 +312,6 @@ field_config_type *field_config_alloc_empty(const char *ecl_kw_name,
 
     field_config_type *config =
         (field_config_type *)util_malloc(sizeof *config);
-    UTIL_TYPE_ID_INIT(config, FIELD_CONFIG_ID);
 
     config->keep_inactive_cells = keep_inactive_cells;
     config->ecl_kw_name = util_alloc_string_copy(ecl_kw_name);
@@ -809,8 +806,6 @@ void field_config_fprintf_config(const field_config_type *config,
         fprintf(stream, CONFIG_FLOAT_OPTION_FORMAT, MAX_KEY, config->max_value);
 }
 
-UTIL_SAFE_CAST_FUNCTION(field_config, FIELD_CONFIG_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(field_config, FIELD_CONFIG_ID)
 CONFIG_GET_ECL_KW_NAME(field);
 GET_DATA_SIZE(field)
 VOID_GET_DATA_SIZE(field)

--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -26,12 +26,10 @@
 #include <ert/res_util/memory.hpp>
 #include <fmt/format.h>
 
-#define FORWARD_LOAD_CONTEXT_TYPE_ID 644239127
 
 static auto logger = ert::get_logger("enkf.forward_load_context");
 
 struct forward_load_context_struct {
-    UTIL_TYPE_ID_DECLARATION;
     // Everyuthing can be NULL here ... - when created from gen_data.
 
     ecl_sum_type *ecl_sum;
@@ -49,7 +47,6 @@ struct forward_load_context_struct {
     bool ecl_active;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(forward_load_context, FORWARD_LOAD_CONTEXT_TYPE_ID);
 
 static void
 forward_load_context_load_ecl_sum(forward_load_context_type *load_context) {
@@ -179,7 +176,6 @@ forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,
                            stringlist_type *messages) {
     forward_load_context_type *load_context =
         (forward_load_context_type *)util_malloc(sizeof *load_context);
-    UTIL_TYPE_ID_INIT(load_context, FORWARD_LOAD_CONTEXT_TYPE_ID);
 
     load_context->ecl_active = false;
     load_context->ecl_sum = NULL;

--- a/libres/lib/enkf/fs_driver.cpp
+++ b/libres/lib/enkf/fs_driver.cpp
@@ -47,7 +47,7 @@ void fs_driver_init(fs_driver_type *driver) {
     driver->fsync_driver = NULL;
 }
 
-fs_driver_type *fs_driver_safe_cast(void *__driver) {
+fs_driver_type *reinterpret_cast<fs_driver_type*>(void *__driver) {
     fs_driver_type *driver = (fs_driver_type *)__driver;
     if (driver->type_id != FS_DRIVER_ID)
         util_abort("%s: runtime cast failed. \n", __func__);

--- a/libres/lib/enkf/gen_data.cpp
+++ b/libres/lib/enkf/gen_data.cpp
@@ -573,8 +573,6 @@ void gen_data_copy_to_double_vector(const gen_data_type *gen_data,
     }
 }
 
-UTIL_SAFE_CAST_FUNCTION_CONST(gen_data, GEN_DATA)
-UTIL_SAFE_CAST_FUNCTION(gen_data, GEN_DATA)
 VOID_USER_GET(gen_data)
 VOID_ALLOC(gen_data)
 VOID_FREE(gen_data)

--- a/libres/lib/enkf/gen_data_config.cpp
+++ b/libres/lib/enkf/gen_data_config.cpp
@@ -49,7 +49,6 @@ static auto logger = ert::get_logger("enkf");
 
 #define GEN_DATA_CONFIG_ID 90051
 struct gen_data_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *
         key; /* The key this gen_data instance is known under - needed for debugging. */
     ecl_data_type
@@ -83,9 +82,6 @@ struct gen_data_config_struct {
     int active_report_step;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(gen_data_config, GEN_DATA_CONFIG_ID)
-UTIL_SAFE_CAST_FUNCTION(gen_data_config, GEN_DATA_CONFIG_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(gen_data_config, GEN_DATA_CONFIG_ID)
 
 gen_data_file_format_type
 gen_data_config_get_input_format(const gen_data_config_type *config) {
@@ -156,7 +152,6 @@ static gen_data_config_type *gen_data_config_alloc(const char *key,
                                                    bool dynamic) {
     gen_data_config_type *config =
         (gen_data_config_type *)util_malloc(sizeof *config);
-    UTIL_TYPE_ID_INIT(config, GEN_DATA_CONFIG_ID);
 
     config->key = util_alloc_string_copy(key);
 

--- a/libres/lib/enkf/gen_kw.cpp
+++ b/libres/lib/enkf/gen_kw.cpp
@@ -410,8 +410,6 @@ C_USED bool gen_kw_user_get(const gen_kw_type *gen_kw, const char *key,
     }
 }
 
-UTIL_SAFE_CAST_FUNCTION(gen_kw, GEN_KW);
-UTIL_SAFE_CAST_FUNCTION_CONST(gen_kw, GEN_KW);
 VOID_ALLOC(gen_kw);
 VOID_INITIALIZE(gen_kw);
 VOID_COPY(gen_kw)

--- a/libres/lib/enkf/gen_kw_config.cpp
+++ b/libres/lib/enkf/gen_kw_config.cpp
@@ -36,18 +36,14 @@
 
 namespace fs = std::filesystem;
 
-#define GEN_KW_CONFIG_TYPE_ID 550761
-#define GEN_KW_PARAMETER_TYPE_ID 886201
 
 typedef struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *name;
     char *tagged_name;
     trans_func_type *trans_func;
 } gen_kw_parameter_type;
 
 struct gen_kw_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *key;
     vector_type *parameters; /* Vector of gen_kw_parameter_type instances. */
     char *template_file;
@@ -56,11 +52,7 @@ struct gen_kw_config_struct {
         tag_fmt; /* Pointer to the tag_format owned by the ensemble config object. */
 };
 
-UTIL_SAFE_CAST_FUNCTION(gen_kw_parameter, GEN_KW_PARAMETER_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(gen_kw_parameter, GEN_KW_PARAMETER_TYPE_ID)
 
-UTIL_SAFE_CAST_FUNCTION(gen_kw_config, GEN_KW_CONFIG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(gen_kw_config, GEN_KW_CONFIG_TYPE_ID)
 
 static void
 gen_kw_parameter_update_tagged_name(gen_kw_parameter_type *parameter,
@@ -74,7 +66,6 @@ static gen_kw_parameter_type *gen_kw_parameter_alloc(const char *parameter_name,
                                                      const char *tag_fmt) {
     gen_kw_parameter_type *parameter =
         (gen_kw_parameter_type *)util_malloc(sizeof *parameter);
-    UTIL_TYPE_ID_INIT(parameter, GEN_KW_PARAMETER_TYPE_ID);
     parameter->name = util_alloc_string_copy(parameter_name);
     parameter->tagged_name = NULL;
     parameter->trans_func = NULL;
@@ -91,7 +82,7 @@ static void gen_kw_parameter_free(gen_kw_parameter_type *parameter) {
 }
 
 static void gen_kw_parameter_free__(void *__parameter) {
-    gen_kw_parameter_type *parameter = gen_kw_parameter_safe_cast(__parameter);
+    gen_kw_parameter_type *parameter = reinterpret_cast<gen_kw_parameter_type*>(__parameter);
     gen_kw_parameter_free(parameter);
 }
 
@@ -185,7 +176,6 @@ gen_kw_config_type *gen_kw_config_alloc_empty(const char *key,
                                               const char *tag_fmt) {
     gen_kw_config_type *gen_kw_config =
         (gen_kw_config_type *)util_malloc(sizeof *gen_kw_config);
-    UTIL_TYPE_ID_INIT(gen_kw_config, GEN_KW_CONFIG_TYPE_ID);
 
     gen_kw_config->key = NULL;
     gen_kw_config->template_file = NULL;

--- a/libres/lib/enkf/gen_obs.cpp
+++ b/libres/lib/enkf/gen_obs.cpp
@@ -55,10 +55,8 @@
   std_scaling will be incorporated in the result.
 */
 
-#define GEN_OBS_TYPE_ID 77619
 
 struct gen_obs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int obs_size; /* This is the total size of the observation vector. */
     int *
         data_index_list; /* The indexes which are observed in the corresponding gen_data instance - of length obs_size. */
@@ -77,8 +75,6 @@ struct gen_obs_struct {
     gen_data_config_type *data_config;
 };
 
-static UTIL_SAFE_CAST_FUNCTION_CONST(
-    gen_obs, GEN_OBS_TYPE_ID) static UTIL_SAFE_CAST_FUNCTION(gen_obs,
                                                              GEN_OBS_TYPE_ID)
 
     void gen_obs_free(gen_obs_type *gen_obs) {
@@ -190,7 +186,6 @@ void gen_obs_parse_data_index(gen_obs_type *obs,
 gen_obs_type *gen_obs_alloc__(const gen_data_config_type *data_config,
                               const char *obs_key) {
     gen_obs_type *obs = (gen_obs_type *)util_malloc(sizeof *obs);
-    UTIL_TYPE_ID_INIT(obs, GEN_OBS_TYPE_ID);
     obs->obs_data = NULL;
     obs->obs_std = NULL;
     obs->std_scaling = NULL;
@@ -542,7 +537,6 @@ int gen_obs_get_obs_index(const gen_obs_type *gen_obs, int index) {
     }
 }
 
-UTIL_IS_INSTANCE_FUNCTION(gen_obs, GEN_OBS_TYPE_ID)
 VOID_FREE(gen_obs)
 VOID_GET_OBS(gen_obs)
 VOID_MEASURE(gen_obs, gen_data)

--- a/libres/lib/enkf/hook_workflow.cpp
+++ b/libres/lib/enkf/hook_workflow.cpp
@@ -33,21 +33,17 @@
 #define RUN_MODE_PRE_UPDATE_NAME "PRE_UPDATE"
 #define RUN_MODE_POST_UPDATE_NAME "POST_UPDATE"
 
-#define HOOK_WORKFLOW_TYPE_ID 7321780
 
 struct hook_workflow_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hook_run_mode_enum run_mode;
     workflow_type *workflow;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(hook_workflow, HOOK_WORKFLOW_TYPE_ID);
 
 hook_workflow_type *hook_workflow_alloc(workflow_type *workflow,
                                         hook_run_mode_enum run_mode) {
     hook_workflow_type *hook_workflow =
         (hook_workflow_type *)util_malloc(sizeof *hook_workflow);
-    UTIL_TYPE_ID_INIT(hook_workflow, HOOK_WORKFLOW_TYPE_ID);
     hook_workflow->run_mode = run_mode;
     hook_workflow->workflow = workflow;
     return hook_workflow;
@@ -58,7 +54,7 @@ void hook_workflow_free(hook_workflow_type *hook_workflow) {
 }
 
 void hook_workflow_free__(void *arg) {
-    hook_workflow_type *hook_workflow = hook_workflow_safe_cast(arg);
+    hook_workflow_type *hook_workflow = reinterpret_cast<hook_workflow_type*>(arg);
     hook_workflow_free(hook_workflow);
 }
 

--- a/libres/lib/enkf/local_ministep.cpp
+++ b/libres/lib/enkf/local_ministep.cpp
@@ -39,8 +39,6 @@
    to the internals of the underlying enkf_node / obs_node objects.
 */
 
-UTIL_SAFE_CAST_FUNCTION(local_ministep, LOCAL_MINISTEP_TYPE_ID);
-UTIL_IS_INSTANCE_FUNCTION(local_ministep, LOCAL_MINISTEP_TYPE_ID);
 
 local_ministep_type *local_ministep_alloc(const char *name) {
     return new local_ministep_type(name);
@@ -49,7 +47,7 @@ local_ministep_type *local_ministep_alloc(const char *name) {
 void local_ministep_free(local_ministep_type *ministep) { delete ministep; }
 
 void local_ministep_free__(void *arg) {
-    local_ministep_type *ministep = local_ministep_safe_cast(arg);
+    local_ministep_type *ministep = reinterpret_cast<local_ministep_type*>(arg);
     local_ministep_free(ministep);
 }
 

--- a/libres/lib/enkf/local_updatestep.cpp
+++ b/libres/lib/enkf/local_updatestep.cpp
@@ -31,21 +31,17 @@
    contain several.
 */
 
-#define LOCAL_UPDATESTEP_TYPE_ID 77159
 
 struct local_updatestep_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *name;
     vector_type *ministep;
 };
 
-UTIL_SAFE_CAST_FUNCTION(local_updatestep, LOCAL_UPDATESTEP_TYPE_ID)
 
 local_updatestep_type *local_updatestep_alloc(const char *name) {
     local_updatestep_type *updatestep =
         (local_updatestep_type *)util_malloc(sizeof *updatestep);
 
-    UTIL_TYPE_ID_INIT(updatestep, LOCAL_UPDATESTEP_TYPE_ID);
     updatestep->name = util_alloc_string_copy(name);
     updatestep->ministep = vector_alloc_new();
 
@@ -59,7 +55,7 @@ void local_updatestep_free(local_updatestep_type *updatestep) {
 }
 
 void local_updatestep_free__(void *arg) {
-    local_updatestep_type *updatestep = local_updatestep_safe_cast(arg);
+    local_updatestep_type *updatestep = reinterpret_cast<local_updatestep_type*>(arg);
     local_updatestep_free(updatestep);
 }
 

--- a/libres/lib/enkf/meas_data.cpp
+++ b/libres/lib/enkf/meas_data.cpp
@@ -36,11 +36,8 @@
 
 #include <ert/enkf/meas_data.hpp>
 
-#define MEAS_BLOCK_TYPE_ID 661936407
-#define MEAS_DATA_TYPE_ID 561000861
 
 struct meas_data_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int active_ens_size;
     vector_type *data;
     pthread_mutex_t data_mutex;
@@ -49,7 +46,6 @@ struct meas_data_struct {
 };
 
 struct meas_block_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int active_ens_size;
     int obs_size;
     int ens_stride;
@@ -63,7 +59,6 @@ struct meas_block_struct {
     int_vector_type *index_map;
 };
 
-UTIL_SAFE_CAST_FUNCTION(meas_block, MEAS_BLOCK_TYPE_ID)
 
 /*
    Observe that meas_block instance must be allocated with a correct
@@ -95,7 +90,6 @@ meas_block_type *meas_block_alloc(const char *obs_key,
                                   const std::vector<bool> &ens_mask,
                                   int obs_size) {
     auto meas_block = new meas_block_type;
-    UTIL_TYPE_ID_INIT(meas_block, MEAS_BLOCK_TYPE_ID);
     meas_block->active_ens_size =
         std::count(ens_mask.begin(), ens_mask.end(), true);
     meas_block->ens_mask = ens_mask;
@@ -128,7 +122,7 @@ void meas_block_free(meas_block_type *meas_block) {
 }
 
 static void meas_block_free__(void *arg) {
-    meas_block_type *meas_block = meas_block_safe_cast(arg);
+    meas_block_type *meas_block = reinterpret_cast<meas_block_type*>(arg);
     meas_block_free(meas_block);
 }
 
@@ -273,11 +267,9 @@ int meas_block_get_total_ens_size(const meas_block_type *meas_block) {
     return meas_block->ens_mask.size();
 }
 
-UTIL_IS_INSTANCE_FUNCTION(meas_data, MEAS_DATA_TYPE_ID)
 
 meas_data_type *meas_data_alloc(const std::vector<bool> &ens_mask) {
     auto meas = new meas_data_type;
-    UTIL_TYPE_ID_INIT(meas, MEAS_DATA_TYPE_ID);
 
     meas->data = vector_alloc_new();
     meas->blocks = hash_alloc();

--- a/libres/lib/enkf/misfit_ensemble.cpp
+++ b/libres/lib/enkf/misfit_ensemble.cpp
@@ -38,7 +38,6 @@
 */
 
 struct misfit_ensemble_struct {
-    UTIL_TYPE_ID_DECLARATION;
     bool initialized;
     int history_length;
     vector_type *

--- a/libres/lib/enkf/misfit_member.cpp
+++ b/libres/lib/enkf/misfit_member.cpp
@@ -23,17 +23,14 @@
 
 #include <ert/enkf/misfit_member.hpp>
 
-#define MISFIT_MEMBER_TYPE_ID 541066
 
 struct misfit_member_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int my_iens;
     hash_type *
         obs; /* hash table of misfit_ts_type instances - indexed by observation keys. The structure
                                  of this hash table is duplicated for each ensemble member.*/
 };
 
-static UTIL_SAFE_CAST_FUNCTION(misfit_member, MISFIT_MEMBER_TYPE_ID);
 
 static void misfit_member_free(misfit_member_type *node) {
     hash_free(node->obs);
@@ -41,12 +38,11 @@ static void misfit_member_free(misfit_member_type *node) {
 }
 
 void misfit_member_free__(void *node) {
-    misfit_member_free(misfit_member_safe_cast(node));
+    misfit_member_free(reinterpret_cast<misfit_member_type*>(node));
 }
 
 misfit_member_type *misfit_member_alloc(int iens) {
     misfit_member_type *node = (misfit_member_type *)util_malloc(sizeof *node);
-    UTIL_TYPE_ID_INIT(node, MISFIT_MEMBER_TYPE_ID);
     node->my_iens = iens;
     node->obs = hash_alloc();
     return node;

--- a/libres/lib/enkf/misfit_ranking.cpp
+++ b/libres/lib/enkf/misfit_ranking.cpp
@@ -35,10 +35,8 @@
    misfit_ranking. I.e. all the RFT measurements.
 */
 
-#define MISFIT_RANKING_TYPE_ID 671108
 
 struct misfit_ranking_struct {
-    UTIL_TYPE_ID_DECLARATION;
     vector_type *
         ensemble; /* An ensemble of hash instances. Each hash instance is populated like this: hash_insert_double(hash , "WGOR" , 1.09); */
     double_vector_type *
@@ -48,8 +46,6 @@ struct misfit_ranking_struct {
     int ens_size;
 };
 
-UTIL_SAFE_CAST_FUNCTION(misfit_ranking, MISFIT_RANKING_TYPE_ID)
-UTIL_IS_INSTANCE_FUNCTION(misfit_ranking, MISFIT_RANKING_TYPE_ID)
 
 void misfit_ranking_display(const misfit_ranking_type *misfit_ranking,
                             FILE *stream) {
@@ -111,7 +107,6 @@ void misfit_ranking_display(const misfit_ranking_type *misfit_ranking,
 static misfit_ranking_type *misfit_ranking_alloc_empty(int ens_size) {
     misfit_ranking_type *misfit_ranking =
         (misfit_ranking_type *)util_malloc(sizeof *misfit_ranking);
-    UTIL_TYPE_ID_INIT(misfit_ranking, MISFIT_RANKING_TYPE_ID);
     misfit_ranking->sort_permutation = NULL;
     misfit_ranking->ensemble = vector_alloc_new();
     misfit_ranking->total = double_vector_alloc(0, INVALID_RANKING_VALUE);
@@ -174,7 +169,7 @@ void misfit_ranking_free(misfit_ranking_type *misfit_ranking) {
 }
 
 void misfit_ranking_free__(void *arg) {
-    misfit_ranking_type *misfit_ranking = misfit_ranking_safe_cast(arg);
+    misfit_ranking_type *misfit_ranking = reinterpret_cast<misfit_ranking_type*>(arg);
     misfit_ranking_free(misfit_ranking);
 }
 

--- a/libres/lib/enkf/misfit_ts.cpp
+++ b/libres/lib/enkf/misfit_ts.cpp
@@ -25,20 +25,16 @@
 
 #include <ert/enkf/misfit_ts.hpp>
 
-#define MISFIT_TS_TYPE_ID 641066
 
 struct misfit_ts_struct {
-    UTIL_TYPE_ID_DECLARATION;
     double_vector_type *
         data; /* A double vector of length 'history_length' with actual misfit values. */
 };
 
-static UTIL_SAFE_CAST_FUNCTION(misfit_ts, MISFIT_TS_TYPE_ID);
 
 misfit_ts_type *misfit_ts_alloc(int history_length) {
     misfit_ts_type *misfit_ts =
         (misfit_ts_type *)util_malloc(sizeof *misfit_ts);
-    UTIL_TYPE_ID_INIT(misfit_ts, MISFIT_TS_TYPE_ID);
 
     if (history_length > 0)
         misfit_ts->data = double_vector_alloc(history_length + 1, 0);
@@ -66,7 +62,7 @@ static void misfit_ts_free(misfit_ts_type *misfit_ts) {
 }
 
 void misfit_ts_free__(void *vector) {
-    misfit_ts_free(misfit_ts_safe_cast(vector));
+    misfit_ts_free(reinterpret_cast<misfit_ts_type*>(vector));
 }
 
 void misfit_ts_iset(misfit_ts_type *vector, int time_index, double value) {

--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -67,9 +67,7 @@ static auto logger = ert::get_logger("enkf");
   This semantically predefined runpath is the only option visible to the user.
  */
 
-#define MODEL_CONFIG_TYPE_ID 661053
 struct model_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     forward_model_type *
         forward_model; /* The forward_model - as loaded from the config file. Each enkf_state object internalizes its private copy of the forward_model. */
     time_map_type *external_time_map;
@@ -253,7 +251,6 @@ void model_config_set_max_internal_submit(model_config_type *model_config,
     model_config->max_internal_submit = max_resample;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(model_config, MODEL_CONFIG_TYPE_ID)
 
 model_config_type *model_config_alloc_empty() {
     model_config_type *model_config =
@@ -266,7 +263,6 @@ model_config_type *model_config_alloc_empty() {
      3. Initialize with user supplied values.
 
   */
-    UTIL_TYPE_ID_INIT(model_config, MODEL_CONFIG_TYPE_ID);
     model_config->enspath = NULL;
     model_config->rftpath = NULL;
     model_config->data_root = NULL;

--- a/libres/lib/enkf/obs_data.cpp
+++ b/libres/lib/enkf/obs_data.cpp
@@ -72,10 +72,8 @@ Matrices: S, D, E and various internal variables.
 #include <ert/enkf/obs_data.hpp>
 #include <ert/enkf/enkf_util.hpp>
 
-#define OBS_BLOCK_TYPE_ID 995833
 
 struct obs_block_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *obs_key;
     int size;
     double *value;
@@ -95,7 +93,6 @@ struct obs_data_struct {
     double global_std_scaling;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(obs_block, OBS_BLOCK_TYPE_ID)
 
     obs_block_type *obs_block_alloc(const char *obs_key, int obs_size,
                                     matrix_type *error_covar,
@@ -104,7 +101,6 @@ static UTIL_SAFE_CAST_FUNCTION(obs_block, OBS_BLOCK_TYPE_ID)
     obs_block_type *obs_block =
         (obs_block_type *)util_malloc(sizeof *obs_block);
 
-    UTIL_TYPE_ID_INIT(obs_block, OBS_BLOCK_TYPE_ID);
     obs_block->size = obs_size;
     obs_block->obs_key = util_alloc_string_copy(obs_key);
     obs_block->value =
@@ -132,7 +128,7 @@ void obs_block_free(obs_block_type *obs_block) {
 }
 
 static void obs_block_free__(void *arg) {
-    obs_block_type *obs_block = obs_block_safe_cast(arg);
+    obs_block_type *obs_block = reinterpret_cast<obs_block_type*>(arg);
     obs_block_free(obs_block);
 }
 

--- a/libres/lib/enkf/obs_vector.cpp
+++ b/libres/lib/enkf/obs_vector.cpp
@@ -47,10 +47,8 @@
 #include <ert/enkf/local_obsdata_node.hpp>
 #include <ert/enkf/active_list.hpp>
 
-#define OBS_VECTOR_TYPE_ID 120086
 
 struct obs_vector_struct {
-    UTIL_TYPE_ID_DECLARATION;
     obs_free_ftype *freef;  /* Function used to free an observation node. */
     obs_get_ftype *get_obs; /* Function used to build the 'd' vector. */
     obs_meas_ftype *
@@ -72,8 +70,6 @@ struct obs_vector_struct {
     std::vector<int> step_list;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(obs_vector, OBS_VECTOR_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(obs_vector, OBS_VECTOR_TYPE_ID)
 
 static void obs_vector_prefer_RESTART_warning() {
     // clang-format off
@@ -161,7 +157,6 @@ obs_vector_type *obs_vector_alloc(obs_impl_type obs_type, const char *obs_key,
                                   int num_reports) {
     auto vector = new obs_vector_type;
 
-    UTIL_TYPE_ID_INIT(vector, OBS_VECTOR_TYPE_ID);
     vector->freef = NULL;
     vector->measure = NULL;
     vector->get_obs = NULL;
@@ -239,32 +234,8 @@ void obs_vector_free(obs_vector_type *obs_vector) {
     delete obs_vector;
 }
 
-static void obs_vector_assert_node_type(const obs_vector_type *obs_vector,
-                                        const void *node) {
-    bool type_OK;
-    switch (obs_vector->obs_type) {
-    case (SUMMARY_OBS):
-        type_OK = summary_obs_is_instance(node);
-        break;
-    case (BLOCK_OBS):
-        type_OK = block_obs_is_instance(node);
-        break;
-    case (GEN_OBS):
-        type_OK = gen_obs_is_instance(node);
-        break;
-    default:
-        util_abort("%s: Error in type check: \n", __func__);
-        type_OK = false;
-    }
-    if (!type_OK)
-        util_abort("%s: Type mismatch when trying to add observation node to "
-                   "observation vector \n",
-                   __func__);
-}
-
 void obs_vector_install_node(obs_vector_type *obs_vector, int index,
                              void *node) {
-    obs_vector_assert_node_type(obs_vector, node);
     {
         if (vector_iget_const(obs_vector->nodes, index) == NULL) {
             obs_vector->num_active++;

--- a/libres/lib/enkf/rng_manager.cpp
+++ b/libres/lib/enkf/rng_manager.cpp
@@ -29,10 +29,8 @@
 namespace fs = std::filesystem;
 static auto logger = ert::get_logger("enkf");
 
-#define RNG_MANAGER_TYPE_ID 77250451
 
 struct rng_manager_struct {
-    UTIL_TYPE_ID_DECLARATION;
     rng_alg_type rng_alg;
     rng_type *
         internal_seed_rng; /* This is used to seed the RNG's which are managed. */
@@ -41,12 +39,10 @@ struct rng_manager_struct {
     vector_type *rng_list;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(rng_manager, RNG_MANAGER_TYPE_ID)
 
 static rng_manager_type *rng_manager_alloc__(rng_init_mode init_mode) {
     rng_manager_type *rng_manager =
         (rng_manager_type *)util_malloc(sizeof *rng_manager);
-    UTIL_TYPE_ID_INIT(rng_manager, RNG_MANAGER_TYPE_ID);
     rng_manager->rng_list = vector_alloc_new();
     rng_manager->rng_alg = MZRAN;
     rng_manager->internal_seed_rng = rng_alloc(rng_manager->rng_alg, init_mode);

--- a/libres/lib/enkf/run_arg.cpp
+++ b/libres/lib/enkf/run_arg.cpp
@@ -23,11 +23,9 @@
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/run_arg.hpp>
 
-#define RUN_ARG_TYPE_ID 66143287
 #define INVALID_QUEUE_INDEX -99
 
 struct run_arg_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int iens;
     int max_internal_submit; /* How many times the enkf_state object should try to resubmit when the queueu has said everything is OK - but the load fails. */
     int num_internal_submit;
@@ -50,8 +48,6 @@ struct run_arg_struct {
     char *run_id;
 };
 
-UTIL_SAFE_CAST_FUNCTION(run_arg, RUN_ARG_TYPE_ID)
-UTIL_IS_INSTANCE_FUNCTION(run_arg, RUN_ARG_TYPE_ID)
 
 static void run_arg_update_subst(run_arg_type *run_arg);
 
@@ -67,7 +63,6 @@ static run_arg_type *run_arg_alloc(const char *run_id, enkf_fs_type *sim_fs,
             __func__);
     {
         run_arg_type *run_arg = (run_arg_type *)util_malloc(sizeof *run_arg);
-        UTIL_TYPE_ID_INIT(run_arg, RUN_ARG_TYPE_ID);
         run_arg->run_id = util_alloc_string_copy(run_id);
         run_arg->sim_fs = sim_fs;
         run_arg->update_target_fs = update_target_fs;
@@ -127,7 +122,7 @@ void run_arg_free(run_arg_type *run_arg) {
 }
 
 void run_arg_free__(void *arg) {
-    run_arg_type *run_arg = run_arg_safe_cast(arg);
+    run_arg_type *run_arg = reinterpret_cast<run_arg_type*>(arg);
     run_arg_free(run_arg);
 }
 

--- a/libres/lib/enkf/runpath_list.cpp
+++ b/libres/lib/enkf/runpath_list.cpp
@@ -39,23 +39,18 @@ struct runpath_list_struct {
     char *export_file;
 };
 
-#define RUNPATH_NODE_TYPE_ID 661400541
 struct runpath_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int iens;
     int iter;
     char *runpath;
     char *basename;
 };
 
-UTIL_SAFE_CAST_FUNCTION(runpath_node, RUNPATH_NODE_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(runpath_node, RUNPATH_NODE_TYPE_ID)
 
 static runpath_node_type *runpath_node_alloc(int iens, int iter,
                                              const char *runpath,
                                              const char *basename) {
     runpath_node_type *node = (runpath_node_type *)util_malloc(sizeof *node);
-    UTIL_TYPE_ID_INIT(node, RUNPATH_NODE_TYPE_ID);
 
     node->iens = iens;
     node->iter = iter;
@@ -72,7 +67,7 @@ static void runpath_node_free(runpath_node_type *node) {
 }
 
 static void runpath_node_free__(void *arg) {
-    runpath_node_type *node = runpath_node_safe_cast(arg);
+    runpath_node_type *node = reinterpret_cast<runpath_node_type*>(arg);
     runpath_node_free(node);
 }
 
@@ -81,8 +76,8 @@ static void runpath_node_free__(void *arg) {
 */
 
 static int runpath_node_cmp(const void *arg1, const void *arg2) {
-    const runpath_node_type *node1 = runpath_node_safe_cast_const(arg1);
-    const runpath_node_type *node2 = runpath_node_safe_cast_const(arg2);
+    const runpath_node_type *node1 = reinterpret_cast<runpath_node_type*>_const(arg1);
+    const runpath_node_type *node2 = reinterpret_cast<runpath_node_type*>_const(arg2);
     {
         if (node1->iter > node2->iter)
             return 1;

--- a/libres/lib/enkf/state_map.cpp
+++ b/libres/lib/enkf/state_map.cpp
@@ -32,20 +32,16 @@
 
 namespace fs = std::filesystem;
 
-#define STATE_MAP_TYPE_ID 500672132
 
 struct state_map_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int_vector_type *state;
     pthread_rwlock_t mutable rw_lock;
     bool read_only;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(state_map, STATE_MAP_TYPE_ID)
 
 state_map_type *state_map_alloc() {
     state_map_type *map = (state_map_type *)util_malloc(sizeof *map);
-    UTIL_TYPE_ID_INIT(map, STATE_MAP_TYPE_ID);
     map->state = int_vector_alloc(0, STATE_UNDEFINED);
     pthread_rwlock_init(&map->rw_lock, NULL);
     map->read_only = false;

--- a/libres/lib/enkf/summary.cpp
+++ b/libres/lib/enkf/summary.cpp
@@ -296,8 +296,6 @@ bool summary_forward_load_vector(summary_type *summary,
     return true;
 }
 
-UTIL_SAFE_CAST_FUNCTION(summary, SUMMARY)
-UTIL_SAFE_CAST_FUNCTION_CONST(summary, SUMMARY)
 VOID_ALLOC(summary)
 VOID_FREE(summary)
 VOID_COPY(summary)

--- a/libres/lib/enkf/summary_config.cpp
+++ b/libres/lib/enkf/summary_config.cpp
@@ -27,7 +27,6 @@
 
 #include <ert/enkf/summary_config.hpp>
 
-#define SUMMARY_CONFIG_TYPE_ID 63106
 
 struct summary_config_struct {
     int __type_id;
@@ -40,7 +39,6 @@ struct summary_config_struct {
         obs_set; /* Set of keys (which fit in enkf_obs) which are observations of this node. */
 };
 
-UTIL_IS_INSTANCE_FUNCTION(summary_config, SUMMARY_CONFIG_TYPE_ID)
 
 const char *summary_config_get_var(const summary_config_type *config) {
     return config->var;
@@ -100,7 +98,5 @@ int summary_config_get_data_size(const summary_config_type *config) {
     return 1;
 }
 
-UTIL_SAFE_CAST_FUNCTION(summary_config, SUMMARY_CONFIG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(summary_config, SUMMARY_CONFIG_TYPE_ID)
 VOID_GET_DATA_SIZE(summary)
 VOID_CONFIG_FREE(summary)

--- a/libres/lib/enkf/summary_key_matcher.cpp
+++ b/libres/lib/enkf/summary_key_matcher.cpp
@@ -4,19 +4,15 @@
 
 #include <ert/util/hash.h>
 
-#define SUMMARY_KEY_MATCHER_TYPE_ID 700672137
 
 struct summary_key_matcher_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hash_type *key_set;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(summary_key_matcher, SUMMARY_KEY_MATCHER_TYPE_ID)
 
 summary_key_matcher_type *summary_key_matcher_alloc() {
     summary_key_matcher_type *matcher =
         (summary_key_matcher_type *)util_malloc(sizeof *matcher);
-    UTIL_TYPE_ID_INIT(matcher, SUMMARY_KEY_MATCHER_TYPE_ID);
     matcher->key_set = hash_alloc();
     return matcher;
 }

--- a/libres/lib/enkf/summary_key_set.cpp
+++ b/libres/lib/enkf/summary_key_set.cpp
@@ -28,21 +28,17 @@
 
 namespace fs = std::filesystem;
 
-#define SUMMARY_KEY_SET_TYPE_ID 700672133
 
 struct summary_key_set_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hash_type *key_set;
     pthread_rwlock_t rw_lock;
     bool read_only;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(summary_key_set, SUMMARY_KEY_SET_TYPE_ID)
 
 summary_key_set_type *summary_key_set_alloc() {
     summary_key_set_type *set =
         (summary_key_set_type *)util_malloc(sizeof *set);
-    UTIL_TYPE_ID_INIT(set, SUMMARY_KEY_SET_TYPE_ID);
     set->key_set = hash_alloc();
     pthread_rwlock_init(&set->rw_lock, NULL);
     set->read_only = false;

--- a/libres/lib/enkf/summary_obs.cpp
+++ b/libres/lib/enkf/summary_obs.cpp
@@ -27,11 +27,9 @@
 
 #include "ert/python.hpp"
 
-#define SUMMARY_OBS_TYPE_ID 66103
 #define OBS_SIZE 1
 
 struct summary_obs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *
         summary_key; /* The observation, in summary.x syntax, e.g. GOPR:FIELD.    */
     char *obs_key;
@@ -57,7 +55,6 @@ summary_obs_type *summary_obs_alloc(const char *summary_key,
                                     double std) {
 
     summary_obs_type *obs = (summary_obs_type *)util_malloc(sizeof *obs);
-    UTIL_TYPE_ID_INIT(obs, SUMMARY_OBS_TYPE_ID)
 
     obs->summary_key = util_alloc_string_copy(summary_key);
     obs->obs_key = util_alloc_string_copy(obs_key);
@@ -68,9 +65,6 @@ summary_obs_type *summary_obs_alloc(const char *summary_key,
     return obs;
 }
 
-static UTIL_SAFE_CAST_FUNCTION_CONST(summary_obs, SUMMARY_OBS_TYPE_ID);
-static UTIL_SAFE_CAST_FUNCTION(summary_obs, SUMMARY_OBS_TYPE_ID);
-UTIL_IS_INSTANCE_FUNCTION(summary_obs, SUMMARY_OBS_TYPE_ID);
 
 void summary_obs_free(summary_obs_type *summary_obs) {
     free(summary_obs->summary_key);

--- a/libres/lib/enkf/surface.cpp
+++ b/libres/lib/enkf/surface.cpp
@@ -140,8 +140,6 @@ bool surface_user_get(const surface_type *surface, const char *index_key,
     return false;
 }
 
-UTIL_SAFE_CAST_FUNCTION(surface, SURFACE)
-UTIL_SAFE_CAST_FUNCTION_CONST(surface, SURFACE)
 VOID_ALLOC(surface)
 VOID_FREE(surface)
 VOID_ECL_WRITE(surface)

--- a/libres/lib/enkf/surface_config.cpp
+++ b/libres/lib/enkf/surface_config.cpp
@@ -22,17 +22,14 @@
 
 #include <ert/enkf/surface_config.hpp>
 
-#define SURFACE_CONFIG_TYPE_ID 853317
 
 struct surface_config_struct {
-    UTIL_TYPE_ID_DECLARATION;
     geo_surface_type *base_surface;
 };
 
 surface_config_type *surface_config_alloc_empty() {
     surface_config_type *config =
         (surface_config_type *)util_malloc(sizeof *config);
-    UTIL_TYPE_ID_INIT(config, SURFACE_CONFIG_TYPE_ID);
     config->base_surface = NULL;
     return config;
 }
@@ -66,7 +63,5 @@ void surface_config_ecl_write(const surface_config_type *config,
                                              zcoord);
 }
 
-UTIL_SAFE_CAST_FUNCTION(surface_config, SURFACE_CONFIG_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(surface_config, SURFACE_CONFIG_TYPE_ID)
 VOID_GET_DATA_SIZE(surface)
 VOID_CONFIG_FREE(surface)

--- a/libres/lib/enkf/time_map.cpp
+++ b/libres/lib/enkf/time_map.cpp
@@ -40,9 +40,7 @@ static void time_map_update_abort(time_map_type *map, int step, time_t time);
 static void time_map_summary_update_abort(time_map_type *map,
                                           const ecl_sum_type *ecl_sum);
 
-#define TIME_MAP_TYPE_ID 7751432
 struct time_map_struct {
-    UTIL_TYPE_ID_DECLARATION;
     time_t_vector_type *map;
     pthread_rwlock_t rw_lock;
     bool modified;
@@ -51,12 +49,9 @@ struct time_map_struct {
     const ecl_sum_type *refcase;
 };
 
-UTIL_SAFE_CAST_FUNCTION(time_map, TIME_MAP_TYPE_ID)
-UTIL_IS_INSTANCE_FUNCTION(time_map, TIME_MAP_TYPE_ID)
 
 time_map_type *time_map_alloc() {
     time_map_type *map = (time_map_type *)util_malloc(sizeof *map);
-    UTIL_TYPE_ID_INIT(map, TIME_MAP_TYPE_ID);
 
     map->map = time_t_vector_alloc(0, DEFAULT_TIME);
     map->modified = false;

--- a/libres/lib/enkf/value_export.cpp
+++ b/libres/lib/enkf/value_export.cpp
@@ -34,10 +34,8 @@
 
 namespace fs = std::filesystem;
 
-#define VALUE_EXPORT_TYPE_ID 5741761
 
 struct value_export_struct {
-    UTIL_TYPE_ID_DECLARATION;
     std::string directory;
     std::string base_name;
     std::map<std::string, std::map<std::string, double>> values;
@@ -78,7 +76,6 @@ value_export_type *value_export_alloc(std::string directory,
                                       std::string base_name) {
 
     value_export_type *value = new value_export_type;
-    UTIL_TYPE_ID_INIT(value, VALUE_EXPORT_TYPE_ID);
     value->directory = directory;
     value->base_name = base_name;
     return value;
@@ -205,4 +202,3 @@ void value_export_append(value_export_type *value, const std::string key,
     value->values[key][subkey] = double_value;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(value_export, VALUE_EXPORT_TYPE_ID)

--- a/libres/lib/include/ert/config/config_content.hpp
+++ b/libres/lib/include/ert/config/config_content.hpp
@@ -113,6 +113,5 @@ void config_content_pop_path_stack(config_content_type *content);
 extern "C" stringlist_type *
 config_content_alloc_keys(const config_content_type *content);
 
-UTIL_IS_INSTANCE_HEADER(config_content);
 
 #endif

--- a/libres/lib/include/ert/config/config_content_item.hpp
+++ b/libres/lib/include/ert/config/config_content_item.hpp
@@ -63,6 +63,5 @@ config_content_item_get_schema(const config_content_item_type *item);
 const config_path_elm_type *
 config_content_item_get_path_elm(const config_content_item_type *item);
 
-UTIL_IS_INSTANCE_HEADER(config_content_item);
 
 #endif

--- a/libres/lib/include/ert/enkf/analysis_config.hpp
+++ b/libres/lib/include/ert/enkf/analysis_config.hpp
@@ -121,6 +121,5 @@ analysis_config_add_module_copy(analysis_config_type *config,
 void analysis_config_load_internal_modules(int ens_size,
                                            analysis_config_type *config);
 
-UTIL_IS_INSTANCE_HEADER(analysis_config);
 
 #endif

--- a/libres/lib/include/ert/enkf/block_obs.hpp
+++ b/libres/lib/include/ert/enkf/block_obs.hpp
@@ -75,7 +75,6 @@ extern "C" void block_obs_append_summary_obs(block_obs_type *block_obs, int i,
 
 VOID_FREE_HEADER(block_obs);
 VOID_GET_OBS_HEADER(block_obs);
-UTIL_IS_INSTANCE_HEADER(block_obs);
 VOID_MEASURE_HEADER(block_obs);
 VOID_USER_GET_OBS_HEADER(block_obs);
 VOID_CHI2_HEADER(block_obs);

--- a/libres/lib/include/ert/enkf/callback_arg.hpp
+++ b/libres/lib/include/ert/enkf/callback_arg.hpp
@@ -28,7 +28,6 @@
 typedef struct callback_arg_struct callback_arg_type;
 
 struct callback_arg_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const res_config_type *res_config;
     run_arg_type *run_arg;
     rng_type *rng;
@@ -37,7 +36,5 @@ struct callback_arg_struct {
 callback_arg_type *callback_arg_alloc(const res_config_type *res_config,
                                       run_arg_type *run_arg, rng_type *rng);
 
-UTIL_IS_INSTANCE_HEADER(callback_arg);
-UTIL_SAFE_CAST_HEADER(callback_arg);
 
 #endif

--- a/libres/lib/include/ert/enkf/container.hpp
+++ b/libres/lib/include/ert/enkf/container.hpp
@@ -30,7 +30,5 @@ void container_assert_size(const container_type *container);
 
 VOID_ALLOC_HEADER(container);
 VOID_FREE_HEADER(container);
-UTIL_IS_INSTANCE_HEADER(container);
-UTIL_SAFE_CAST_HEADER_CONST(container);
 
 #endif

--- a/libres/lib/include/ert/enkf/container_config.hpp
+++ b/libres/lib/include/ert/enkf/container_config.hpp
@@ -30,8 +30,6 @@ void container_config_add_node(container_config_type *container,
                                const enkf_config_node_type *config_node);
 int container_config_get_size(const container_config_type *container_config);
 
-UTIL_IS_INSTANCE_HEADER(container_config);
-UTIL_SAFE_CAST_HEADER_CONST(container_config);
 GET_DATA_SIZE_HEADER(container);
 VOID_GET_DATA_SIZE_HEADER(container);
 VOID_CONFIG_FREE_HEADER(container);

--- a/libres/lib/include/ert/enkf/enkf_config_node.hpp
+++ b/libres/lib/include/ert/enkf/enkf_config_node.hpp
@@ -206,7 +206,5 @@ extern "C" PY_USED enkf_config_node_type *enkf_config_node_alloc_SURFACE_full(
     const char *base_surface, const char *min_std_file,
     const char *init_file_fmt);
 
-UTIL_IS_INSTANCE_HEADER(enkf_config_node);
-UTIL_SAFE_CAST_HEADER(enkf_config_node);
 VOID_FREE_HEADER(enkf_config_node);
 #endif

--- a/libres/lib/include/ert/enkf/enkf_fs.hpp
+++ b/libres/lib/include/ert/enkf/enkf_fs.hpp
@@ -107,7 +107,5 @@ void enkf_fs_increase_run_count(enkf_fs_type *fs);
 void enkf_fs_decrease_run_count(enkf_fs_type *fs);
 extern "C" PY_USED bool enkf_fs_is_running(const enkf_fs_type *fs);
 
-UTIL_SAFE_CAST_HEADER(enkf_fs);
-UTIL_IS_INSTANCE_HEADER(enkf_fs);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_macros.hpp
+++ b/libres/lib/include/ert/enkf/enkf_macros.hpp
@@ -55,7 +55,7 @@
 #define VOID_GET_DATA_SIZE(prefix)                                             \
     int prefix##_config_get_data_size__(const void *arg) {                     \
         const prefix##_config_type *config =                                   \
-            prefix##_config_safe_cast_const(arg);                              \
+            reinterpret_cast<const prefix##_config_type*>(arg);                \
         return prefix##_config_get_data_size(config);                          \
     }
 #define VOID_GET_DATA_SIZE_HEADER(prefix)                                      \
@@ -64,7 +64,7 @@
 #define VOID_ALLOC(prefix)                                                     \
     void *prefix##_alloc__(const void *void_config) {                          \
         const prefix##_config_type *config =                                   \
-            prefix##_config_safe_cast_const(void_config);                      \
+            reinterpret_cast<const prefix##_config_type*>(void_config);        \
         return prefix##_alloc(config);                                         \
     }
 
@@ -72,7 +72,8 @@
 
 #define VOID_HAS_DATA(prefix)                                                  \
     bool prefix##_has_data__(const void *void_arg, int report_step) {          \
-        const prefix##_type *arg = prefix##_safe_cast_const(void_arg);         \
+        const prefix##_type *arg =                                             \
+            reinterpret_cast<const prefix##_type*>(void_arg);                  \
         return prefix##_has_data(arg, report_step);                            \
     }
 
@@ -82,14 +83,16 @@
 #define VOID_WRITE_TO_BUFFER(prefix)                                           \
     bool prefix##_write_to_buffer__(const void *void_arg, buffer_type *buffer, \
                                     int report_step) {                         \
-        const prefix##_type *arg = prefix##_safe_cast_const(void_arg);         \
+        const prefix##_type *arg =                                             \
+            reinterpret_cast<const prefix##_type*>(void_arg);                  \
         return prefix##_write_to_buffer(arg, buffer, report_step);             \
     }
 
 #define VOID_READ_FROM_BUFFER(prefix)                                          \
     void prefix##_read_from_buffer__(void *void_arg, buffer_type *buffer,      \
                                      enkf_fs_type *fs, int report_step) {      \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                                   \
+            reinterpret_cast<prefix##_type*>(void_arg);                        \
         prefix##_read_from_buffer(arg, buffer, fs, report_step);               \
     }
 
@@ -101,7 +104,8 @@
 
 #define VOID_FLOAD(prefix)                                                     \
     bool prefix##_fload__(void *void_arg, const char *filename) {              \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         return prefix##_fload(arg, filename);                                  \
     }
 #define VOID_FLOAD_HEADER(prefix) bool prefix##_fload__(void *, const char *);
@@ -110,7 +114,8 @@
     void prefix##_ecl_write__(const void *void_arg, const char *path,          \
                               const char *file,                                \
                               value_export_type *export_value) {               \
-        const prefix##_type *arg = prefix##_safe_cast_const(void_arg);         \
+        const prefix##_type *arg =                                             \
+            reinterpret_cast<const prefix##_type*>(void_arg);                  \
         prefix##_ecl_write(arg, path, file, export_value);                     \
     }
 
@@ -122,7 +127,8 @@
     bool prefix##_forward_load__(                                              \
         void *void_arg, const char *ecl_file,                                  \
         const forward_load_context_type *load_context) {                       \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         return prefix##_forward_load(arg, ecl_file, load_context);             \
     }
 
@@ -135,7 +141,8 @@
         void *void_arg, const char *ecl_file,                                  \
         const forward_load_context_type *load_context,                         \
         const int_vector_type *time_index) {                                   \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         return prefix##_forward_load_vector(arg, ecl_file, load_context,       \
                                             time_index);                       \
     }
@@ -147,7 +154,8 @@
 
 #define VOID_FREE(prefix)                                                      \
     void prefix##_free__(void *void_arg) {                                     \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         prefix##_free(arg);                                                    \
     }
 
@@ -156,7 +164,8 @@
 #define VOID_USER_GET(prefix)                                                  \
     bool prefix##_user_get__(void *void_arg, const char *key, int report_step, \
                              double *value) {                                  \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        const prefix##_type *arg =                                             \
+            reinterpret_cast<const prefix##_type*>(void_arg);                  \
         return prefix##_user_get(arg, key, report_step, value);                \
     }
 
@@ -166,7 +175,8 @@
 #define VOID_USER_GET_VECTOR(prefix)                                           \
     void prefix##_user_get_vector__(void *void_arg, const char *key,           \
                                     double_vector_type *value) {               \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         prefix##_user_get_vector(arg, key, value);                             \
     }
 
@@ -184,8 +194,10 @@
 
 #define VOID_COPY(prefix)                                                      \
     void prefix##_copy__(const void *void_src, void *void_target) {            \
-        const prefix##_type *src = prefix##_safe_cast_const(void_src);         \
-        prefix##_type *target = prefix##_safe_cast(void_target);               \
+        const prefix##_type *src =                                             \
+            reinterpret_cast<const prefix##_type*>(void_src);                  \
+        prefix##_type *target =                                          \
+            reinterpret_cast<prefix##_type*>(void_target);               \
         prefix##_copy(src, target);                                            \
     }
 #define VOID_COPY_HEADER(prefix) void prefix##_copy__(const void *, void *);
@@ -202,7 +214,8 @@
     void prefix##_serialize__(const void *void_arg, node_id_type node_id,      \
                               const ActiveList *active_list, matrix_type *A,   \
                               int row_offset, int column) {                    \
-        const prefix##_type *arg = prefix##_safe_cast_const(void_arg);         \
+        const prefix##_type *arg =                                             \
+            reinterpret_cast<const prefix##_type*>(void_arg);                  \
         prefix##_serialize(arg, node_id, active_list, A, row_offset, column);  \
     }
 #define VOID_SERIALIZE_HEADER(prefix)                                          \
@@ -213,7 +226,8 @@
     void prefix##_deserialize__(                                               \
         void *void_arg, node_id_type node_id, const ActiveList *active_list,   \
         const matrix_type *A, int row_offset, int column) {                    \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         prefix##_deserialize(arg, node_id, active_list, A, row_offset,         \
                              column);                                          \
     }
@@ -224,7 +238,8 @@
 #define VOID_INITIALIZE(prefix)                                                \
     bool prefix##_initialize__(void *void_arg, int iens,                       \
                                const char *init_file, rng_type *rng) {         \
-        prefix##_type *arg = prefix##_safe_cast(void_arg);                     \
+        prefix##_type *arg =                                             \
+            reinterpret_cast<prefix##_type*>(void_arg);                  \
         return prefix##_initialize(arg, iens, init_file, rng);                 \
     }
 #define VOID_INITIALIZE_HEADER(prefix)                                         \
@@ -267,7 +282,8 @@
 #define VOID_UPDATE_STD_SCALE(prefix)                                          \
     void prefix##_update_std_scale__(void *void_obs, double std_multiplier,    \
                                      const ActiveList *active_list) {          \
-        prefix##_type *obs = prefix##_safe_cast(void_obs);                     \
+        prefix##_type *obs =                                             \
+            reinterpret_cast<prefix##_type*>(void_obs);                  \
         prefix##_update_std_scale(obs, std_multiplier, active_list);           \
     }
 
@@ -278,7 +294,8 @@
 #define VOID_CHI2(obs_prefix, state_prefix)                                    \
     double obs_prefix##_chi2__(const void *void_obs, const void *void_state,   \
                                node_id_type node_id) {                         \
-        const obs_prefix##_type *obs = obs_prefix##_safe_cast_const(void_obs); \
+        const prefix##_type *obs =                                             \
+            reinterpret_cast<const prefix##_type*>(void_obs);                  \
         const state_prefix##_type *state =                                     \
             (const state_prefix##_type *)void_state;                           \
         return obs_prefix##_chi2(obs, state, node_id);                         \
@@ -295,7 +312,7 @@
 
 #define VOID_CLEAR(prefix)                                                     \
     void prefix##_clear__(void *void_arg) {                                    \
-        prefix##_clear(prefix##_safe_cast(void_arg));                          \
+        prefix##_clear(reinterpret_cast<prefix##_type*>(void_arg));                          \
     }
 #define VOID_CLEAR_HEADER(prefix) void prefix##_clear__(void *)
 #endif

--- a/libres/lib/include/ert/enkf/enkf_main.hpp
+++ b/libres/lib/include/ert/enkf/enkf_main.hpp
@@ -225,7 +225,5 @@ extern "C" void enkf_main_add_data_kw(enkf_main_type *enkf_main,
 extern "C" const res_config_type *
 enkf_main_get_res_config(const enkf_main_type *enkf_main);
 
-UTIL_SAFE_CAST_HEADER(enkf_main);
-UTIL_IS_INSTANCE_HEADER(enkf_main);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_node.hpp
+++ b/libres/lib/include/ert/enkf/enkf_node.hpp
@@ -166,6 +166,5 @@ extern "C" const char *enkf_node_get_key(const enkf_node_type *);
 bool enkf_node_has_func(const enkf_node_type *, node_function_type);
 bool enkf_node_internalize(const enkf_node_type *, int);
 
-UTIL_IS_INSTANCE_HEADER(enkf_node);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_obs.hpp
+++ b/libres/lib/include/ert/enkf/enkf_obs.hpp
@@ -90,6 +90,5 @@ void enkf_obs_add_local_nodes_with_data(const enkf_obs_type *enkf_obs,
                                         enkf_fs_type *fs,
                                         const bool_vector_type *ens_mask);
 conf_class_type *enkf_obs_get_obs_conf_class();
-UTIL_IS_INSTANCE_HEADER(enkf_obs);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_data.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_data.hpp
@@ -40,6 +40,5 @@ extern "C" int enkf_plot_data_get_size(const enkf_plot_data_type *plot_data);
 extern "C" enkf_plot_tvector_type *
 enkf_plot_data_iget(const enkf_plot_data_type *plot_data, int index);
 
-UTIL_IS_INSTANCE_HEADER(enkf_plot_data);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_gen_kw.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_gen_kw.hpp
@@ -49,6 +49,5 @@ extern "C" bool
 enkf_plot_gen_kw_should_use_log_scale(const enkf_plot_gen_kw_type *gen_kw,
                                       int index);
 
-UTIL_IS_INSTANCE_HEADER(enkf_plot_gen_kw);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_gen_kw_vector.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_gen_kw_vector.hpp
@@ -40,6 +40,5 @@ extern "C" double
 enkf_plot_gen_kw_vector_iget(const enkf_plot_gen_kw_vector_type *vector,
                              int index);
 
-UTIL_IS_INSTANCE_HEADER(enkf_plot_gen_kw_vector);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_gendata.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_gendata.hpp
@@ -47,6 +47,5 @@ extern "C" double_vector_type *
 enkf_plot_gendata_get_min_values(enkf_plot_gendata_type *plot_data);
 extern "C" double_vector_type *
 enkf_plot_gendata_get_max_values(enkf_plot_gendata_type *plot_data);
-UTIL_IS_INSTANCE_HEADER(enkf_plot_gendata);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_genvector.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_genvector.hpp
@@ -35,6 +35,5 @@ void *enkf_plot_genvector_load__(void *arg);
 extern "C" double
 enkf_plot_genvector_iget(const enkf_plot_genvector_type *vector, int index);
 
-UTIL_IS_INSTANCE_HEADER(enkf_plot_genvector);
 
 #endif

--- a/libres/lib/include/ert/enkf/enkf_plot_tvector.hpp
+++ b/libres/lib/include/ert/enkf/enkf_plot_tvector.hpp
@@ -30,8 +30,6 @@
 
 typedef struct enkf_plot_tvector_struct enkf_plot_tvector_type;
 
-UTIL_SAFE_CAST_HEADER(enkf_plot_tvector);
-UTIL_IS_INSTANCE_HEADER(enkf_plot_tvector);
 
 void enkf_plot_tvector_reset(enkf_plot_tvector_type *plot_tvector);
 enkf_plot_tvector_type *

--- a/libres/lib/include/ert/enkf/ensemble_config.hpp
+++ b/libres/lib/include/ert/enkf/ensemble_config.hpp
@@ -124,7 +124,5 @@ ensemble_config_get_size(const ensemble_config_type *ensemble_config);
 int ensemble_config_forward_init(const ensemble_config_type *ens_config,
                                  const run_arg_type *run_arg);
 
-UTIL_IS_INSTANCE_HEADER(ensemble_config);
-UTIL_SAFE_CAST_HEADER(ensemble_config);
 
 #endif

--- a/libres/lib/include/ert/enkf/ert_run_context.hpp
+++ b/libres/lib/include/ert/enkf/ert_run_context.hpp
@@ -105,6 +105,5 @@ ert_run_context_get_update_target_fs(const ert_run_context_type *run_context);
 extern "C" bool ert_run_context_iactive(const ert_run_context_type *context,
                                         int iens);
 
-UTIL_IS_INSTANCE_HEADER(ert_run_context);
 
 #endif

--- a/libres/lib/include/ert/enkf/ert_test_context.hpp
+++ b/libres/lib/include/ert/enkf/ert_test_context.hpp
@@ -52,6 +52,5 @@ bool ert_test_context_run_worklow(ert_test_context_type *test_context,
                                   const char *workflow_name);
 const char *ert_test_context_get_cwd(const ert_test_context_type *test_context);
 
-UTIL_IS_INSTANCE_HEADER(ert_test_context);
 
 #endif

--- a/libres/lib/include/ert/enkf/ert_workflow_list.hpp
+++ b/libres/lib/include/ert/enkf/ert_workflow_list.hpp
@@ -83,6 +83,5 @@ extern "C" const subst_list_type *
 ert_workflow_list_get_context(const ert_workflow_list_type *workflow_list);
 int ert_workflow_list_get_size(const ert_workflow_list_type *workflow_list);
 
-UTIL_IS_INSTANCE_HEADER(ert_workflow_list);
 
 #endif

--- a/libres/lib/include/ert/enkf/ext_param.hpp
+++ b/libres/lib/include/ert/enkf/ext_param.hpp
@@ -45,8 +45,6 @@ extern "C" ext_param_type *ext_param_alloc(const ext_param_config_type *config);
 extern "C" ext_param_config_type const *
 ext_param_get_config(const ext_param_type *param);
 
-UTIL_SAFE_CAST_HEADER(ext_param);
-UTIL_SAFE_CAST_HEADER_CONST(ext_param);
 VOID_FREE_HEADER(ext_param);
 VOID_ALLOC_HEADER(ext_param);
 VOID_ECL_WRITE_HEADER(ext_param);

--- a/libres/lib/include/ert/enkf/ext_param_config.hpp
+++ b/libres/lib/include/ert/enkf/ext_param_config.hpp
@@ -48,8 +48,6 @@ ext_param_config_ikey_iget_suffix(const ext_param_config_type *config,
 int ext_param_config_ikey_get_suffix_index(const ext_param_config_type *config,
                                            int key_id, const char *suffix);
 
-UTIL_SAFE_CAST_HEADER(ext_param_config);
-UTIL_SAFE_CAST_HEADER_CONST(ext_param_config);
 VOID_FREE_HEADER(ext_param_config);
 VOID_GET_DATA_SIZE_HEADER(ext_param);
 

--- a/libres/lib/include/ert/enkf/field.hpp
+++ b/libres/lib/include/ert/enkf/field.hpp
@@ -53,8 +53,6 @@ extern "C" int field_get_size(const field_type *field);
 
 void field_inplace_output_transform(field_type *field);
 
-UTIL_IS_INSTANCE_HEADER(field);
-UTIL_SAFE_CAST_HEADER_CONST(field);
 VOID_ALLOC_HEADER(field);
 VOID_FREE_HEADER(field);
 VOID_COPY_HEADER(field);

--- a/libres/lib/include/ert/enkf/field_config.hpp
+++ b/libres/lib/include/ert/enkf/field_config.hpp
@@ -179,9 +179,6 @@ extern "C" field_type_enum
 field_config_get_type(const field_config_type *config);
 
 /*Generated headers */
-UTIL_IS_INSTANCE_HEADER(field_config);
-UTIL_SAFE_CAST_HEADER(field_config);
-UTIL_SAFE_CAST_HEADER_CONST(field_config);
 CONFIG_GET_ECL_KW_NAME_HEADER(field);
 VOID_FREE_HEADER(field_config);
 VOID_GET_DATA_SIZE_HEADER(field);

--- a/libres/lib/include/ert/enkf/forward_load_context.hpp
+++ b/libres/lib/include/ert/enkf/forward_load_context.hpp
@@ -61,6 +61,5 @@ extern "C" void
 forward_load_context_select_step(forward_load_context_type *load_context,
                                  int report_step);
 
-UTIL_IS_INSTANCE_HEADER(forward_load_context);
 
 #endif

--- a/libres/lib/include/ert/enkf/fs_driver.hpp
+++ b/libres/lib/include/ert/enkf/fs_driver.hpp
@@ -207,7 +207,6 @@ struct fs_driver_struct {
 };
 
 void fs_driver_init(fs_driver_type *);
-fs_driver_type *fs_driver_safe_cast(void *);
 
 void fs_driver_init_fstab(FILE *stream, fs_driver_impl driver_id);
 char *fs_driver_alloc_fstab_file(const char *path);

--- a/libres/lib/include/ert/enkf/gen_data.hpp
+++ b/libres/lib/include/ert/enkf/gen_data.hpp
@@ -51,8 +51,6 @@ bool gen_data_fload_with_report_step(
     gen_data_type *gen_data, const char *filename,
     const forward_load_context_type *load_context);
 
-UTIL_SAFE_CAST_HEADER(gen_data);
-UTIL_SAFE_CAST_HEADER_CONST(gen_data);
 VOID_USER_GET_HEADER(gen_data);
 VOID_ALLOC_HEADER(gen_data);
 VOID_FREE_HEADER(gen_data);

--- a/libres/lib/include/ert/enkf/gen_data_config.hpp
+++ b/libres/lib/include/ert/enkf/gen_data_config.hpp
@@ -119,9 +119,6 @@ extern "C" int
 gen_data_config_get_data_size__(const gen_data_config_type *config,
                                 int report_step);
 
-UTIL_IS_INSTANCE_HEADER(gen_data_config);
-UTIL_SAFE_CAST_HEADER(gen_data_config);
-UTIL_SAFE_CAST_HEADER_CONST(gen_data_config);
 VOID_FREE_HEADER(gen_data_config)
 
 #endif

--- a/libres/lib/include/ert/enkf/gen_kw.hpp
+++ b/libres/lib/include/ert/enkf/gen_kw.hpp
@@ -49,8 +49,6 @@ void gen_kw_filter_file(const gen_kw_type *, const char *);
 extern "C" void gen_kw_ecl_write_template(const gen_kw_type *gen_kw,
                                           const char *file_name);
 
-UTIL_SAFE_CAST_HEADER(gen_kw);
-UTIL_SAFE_CAST_HEADER_CONST(gen_kw);
 VOID_ECL_WRITE_HEADER(gen_kw)
 VOID_COPY_HEADER(gen_kw);
 VOID_INITIALIZE_HEADER(gen_kw);

--- a/libres/lib/include/ert/enkf/gen_kw_config.hpp
+++ b/libres/lib/include/ert/enkf/gen_kw_config.hpp
@@ -69,8 +69,6 @@ extern "C" stringlist_type *
 gen_kw_config_iget_function_parameter_names(const gen_kw_config_type *config,
                                             int index);
 
-UTIL_SAFE_CAST_HEADER_CONST(gen_kw_config);
-UTIL_SAFE_CAST_HEADER(gen_kw_config);
 VOID_FREE_HEADER(gen_kw_config);
 VOID_GET_DATA_SIZE_HEADER(gen_kw);
 #endif

--- a/libres/lib/include/ert/enkf/gen_obs.hpp
+++ b/libres/lib/include/ert/enkf/gen_obs.hpp
@@ -62,7 +62,6 @@ void gen_obs_parse_data_index(gen_obs_type *obs, const char *data_index_string);
 extern "C" void gen_obs_free(gen_obs_type *gen_obs);
 
 VOID_CHI2_HEADER(gen_obs);
-UTIL_IS_INSTANCE_HEADER(gen_obs);
 VOID_FREE_HEADER(gen_obs);
 VOID_GET_OBS_HEADER(gen_obs);
 VOID_MEASURE_HEADER(gen_obs);

--- a/libres/lib/include/ert/enkf/local_ministep.hpp
+++ b/libres/lib/include/ert/enkf/local_ministep.hpp
@@ -31,11 +31,9 @@
 #include <ert/enkf/obs_data.hpp>
 #include <ert/enkf/row_scaling.hpp>
 
-#define LOCAL_MINISTEP_TYPE_ID 661066
 
 class local_ministep_type {
 public:
-    UTIL_TYPE_ID_DECLARATION;
     std::string
         name; /* A name used for this ministep - string is also used as key in a hash table holding this instance. */
     LocalObsData *observations;
@@ -46,7 +44,6 @@ public:
 
     explicit local_ministep_type(const char *name)
         : name(strdup(name)), obs_data(nullptr) {
-        UTIL_TYPE_ID_INIT(this, LOCAL_MINISTEP_TYPE_ID);
         this->observations = new LocalObsData("OBSDATA_" + this->name);
     }
 
@@ -139,7 +136,5 @@ void local_ministep_add_obs_data(local_ministep_type *ministep,
 extern "C" obs_data_type *
 local_ministep_get_obs_data(const local_ministep_type *ministep);
 
-UTIL_SAFE_CAST_HEADER(local_ministep);
-UTIL_IS_INSTANCE_HEADER(local_ministep);
 
 #endif

--- a/libres/lib/include/ert/enkf/meas_data.hpp
+++ b/libres/lib/include/ert/enkf/meas_data.hpp
@@ -32,8 +32,6 @@
 typedef struct meas_data_struct meas_data_type;
 typedef struct meas_block_struct meas_block_type;
 
-UTIL_IS_INSTANCE_HEADER(meas_data);
-UTIL_SAFE_CAST_HEADER(meas_block);
 meas_block_type *meas_block_alloc(const char *obs_key,
                                   const std::vector<bool> &ens_mask,
                                   int obs_size);

--- a/libres/lib/include/ert/enkf/misfit_ranking.hpp
+++ b/libres/lib/include/ert/enkf/misfit_ranking.hpp
@@ -29,8 +29,6 @@
 
 typedef struct misfit_ranking_struct misfit_ranking_type;
 
-UTIL_IS_INSTANCE_HEADER(misfit_ranking);
-UTIL_SAFE_CAST_HEADER(misfit_ranking);
 
 void misfit_ranking_display(const misfit_ranking_type *misfit_ranking,
                             FILE *stream);

--- a/libres/lib/include/ert/enkf/model_config.hpp
+++ b/libres/lib/include/ert/enkf/model_config.hpp
@@ -127,6 +127,5 @@ void model_config_init_config_parser(config_parser_type *config_parser);
 bool model_config_report_step_compatible(const model_config_type *model_config,
                                          const ecl_sum_type *ecl_sum_simulated);
 
-UTIL_IS_INSTANCE_HEADER(model_config);
 
 #endif

--- a/libres/lib/include/ert/enkf/obs_vector.hpp
+++ b/libres/lib/include/ert/enkf/obs_vector.hpp
@@ -130,8 +130,6 @@ obs_vector_get_obs_key(const obs_vector_type *obs_vector);
 LocalObsDataNode *
 obs_vector_alloc_local_node(const obs_vector_type *obs_vector);
 
-UTIL_IS_INSTANCE_HEADER(obs_vector);
-UTIL_SAFE_CAST_HEADER(obs_vector);
 VOID_FREE_HEADER(obs_vector);
 
 #endif

--- a/libres/lib/include/ert/enkf/queue_config.hpp
+++ b/libres/lib/include/ert/enkf/queue_config.hpp
@@ -86,7 +86,5 @@ extern "C" PY_USED const char *queue_config_lsf_server();
 extern "C" PY_USED const char *queue_config_lsf_resource();
 extern "C" PY_USED const char *queue_config_lsf_driver_name();
 
-UTIL_SAFE_CAST_HEADER(queue_config);
-UTIL_IS_INSTANCE_HEADER(queue_config);
 
 #endif

--- a/libres/lib/include/ert/enkf/rng_manager.hpp
+++ b/libres/lib/include/ert/enkf/rng_manager.hpp
@@ -49,6 +49,5 @@ void rng_manager_save_state(const rng_manager_type *rng_manager,
                             const char *seed_file);
 void rng_manager_log_state(const rng_manager_type *rng_manager);
 
-UTIL_IS_INSTANCE_HEADER(rng_manager);
 
 #endif

--- a/libres/lib/include/ert/enkf/run_arg.hpp
+++ b/libres/lib/include/ert/enkf/run_arg.hpp
@@ -27,8 +27,6 @@
 #include <ert/enkf/enkf_fs.hpp>
 #include <ert/enkf/run_arg_type.hpp>
 
-UTIL_SAFE_CAST_HEADER(run_arg);
-UTIL_IS_INSTANCE_HEADER(run_arg);
 
 extern "C" run_arg_type *
 run_arg_alloc_ENSEMBLE_EXPERIMENT(const char *run_id, enkf_fs_type *sim_fs,

--- a/libres/lib/include/ert/enkf/state_map.hpp
+++ b/libres/lib/include/ert/enkf/state_map.hpp
@@ -57,6 +57,5 @@ int state_map_count_matching(const state_map_type *state_map, int mask);
 extern "C" bool state_map_legal_transition(realisation_state_enum state1,
                                            realisation_state_enum state2);
 
-UTIL_IS_INSTANCE_HEADER(state_map);
 
 #endif

--- a/libres/lib/include/ert/enkf/summary.hpp
+++ b/libres/lib/include/ert/enkf/summary.hpp
@@ -38,8 +38,6 @@ extern "C" int summary_length(const summary_type *summary);
 extern "C" double summary_undefined_value();
 
 VOID_HAS_DATA_HEADER(summary);
-UTIL_SAFE_CAST_HEADER(summary);
-UTIL_SAFE_CAST_HEADER_CONST(summary);
 VOID_ALLOC_HEADER(summary);
 VOID_FREE_HEADER(summary);
 VOID_COPY_HEADER(summary);

--- a/libres/lib/include/ert/enkf/summary_config.hpp
+++ b/libres/lib/include/ert/enkf/summary_config.hpp
@@ -59,9 +59,6 @@ extern "C" summary_config_type *summary_config_alloc(const char *,
                                                      load_fail_type load_fail);
 extern "C" void summary_config_free(summary_config_type *);
 
-UTIL_IS_INSTANCE_HEADER(summary_config);
-UTIL_SAFE_CAST_HEADER(summary_config);
-UTIL_SAFE_CAST_HEADER_CONST(summary_config);
 GET_DATA_SIZE_HEADER(summary);
 VOID_GET_DATA_SIZE_HEADER(summary);
 VOID_CONFIG_FREE_HEADER(summary);

--- a/libres/lib/include/ert/enkf/summary_key_matcher.hpp
+++ b/libres/lib/include/ert/enkf/summary_key_matcher.hpp
@@ -23,6 +23,5 @@ extern "C" bool summary_key_matcher_summary_key_is_required(
 extern "C" stringlist_type *
 summary_key_matcher_get_keys(const summary_key_matcher_type *matcher);
 
-UTIL_IS_INSTANCE_HEADER(summary_key_matcher);
 
 #endif

--- a/libres/lib/include/ert/enkf/summary_key_set.hpp
+++ b/libres/lib/include/ert/enkf/summary_key_set.hpp
@@ -25,6 +25,5 @@ extern "C" void summary_key_set_fwrite(summary_key_set_type *set,
                                        const char *filename);
 bool summary_key_set_fread(summary_key_set_type *set, const char *filename);
 
-UTIL_IS_INSTANCE_HEADER(summary_key_set);
 
 #endif

--- a/libres/lib/include/ert/enkf/summary_obs.hpp
+++ b/libres/lib/include/ert/enkf/summary_obs.hpp
@@ -61,7 +61,6 @@ extern "C" void summary_obs_set_std_scale(summary_obs_type *summary_obs,
 VOID_FREE_HEADER(summary_obs);
 VOID_GET_OBS_HEADER(summary_obs);
 VOID_MEASURE_HEADER(summary_obs);
-UTIL_IS_INSTANCE_HEADER(summary_obs);
 VOID_USER_GET_OBS_HEADER(summary_obs);
 VOID_CHI2_HEADER(summary_obs);
 VOID_UPDATE_STD_SCALE_HEADER(summary_obs);

--- a/libres/lib/include/ert/enkf/surface.hpp
+++ b/libres/lib/include/ert/enkf/surface.hpp
@@ -25,8 +25,6 @@
 
 typedef struct surface_struct surface_type;
 
-UTIL_SAFE_CAST_HEADER(surface);
-UTIL_SAFE_CAST_HEADER_CONST(surface);
 VOID_ALLOC_HEADER(surface);
 VOID_FREE_HEADER(surface);
 VOID_ECL_WRITE_HEADER(surface);

--- a/libres/lib/include/ert/enkf/surface_config.hpp
+++ b/libres/lib/include/ert/enkf/surface_config.hpp
@@ -35,8 +35,6 @@ surface_config_type *surface_config_alloc_empty();
 void surface_config_set_base_surface(surface_config_type *config,
                                      const char *base_surface);
 
-UTIL_SAFE_CAST_HEADER(surface_config);
-UTIL_SAFE_CAST_HEADER_CONST(surface_config);
 GET_DATA_SIZE_HEADER(surface);
 VOID_GET_DATA_SIZE_HEADER(surface);
 VOID_CONFIG_FREE_HEADER(surface);

--- a/libres/lib/include/ert/enkf/time_map.hpp
+++ b/libres/lib/include/ert/enkf/time_map.hpp
@@ -26,8 +26,6 @@
 
 typedef struct time_map_struct time_map_type;
 
-UTIL_SAFE_CAST_HEADER(time_map);
-UTIL_IS_INSTANCE_HEADER(time_map);
 
 bool time_map_try_summary_update(time_map_type *map,
                                  const ecl_sum_type *ecl_sum);

--- a/libres/lib/include/ert/enkf/value_export.hpp
+++ b/libres/lib/include/ert/enkf/value_export.hpp
@@ -36,6 +36,5 @@ void value_export(const value_export_type *value);
 void value_export_append(value_export_type *value, const std::string key,
                          const std::string subkey, double double_value);
 
-UTIL_IS_INSTANCE_HEADER(value_export);
 
 #endif

--- a/libres/lib/include/ert/job_queue/job_list.hpp
+++ b/libres/lib/include/ert/job_queue/job_list.hpp
@@ -39,7 +39,5 @@ void job_list_reader_wait(job_list_type *list, int usleep_time1,
                           int usleep_time2);
 void job_list_unlock(job_list_type *list);
 
-UTIL_SAFE_CAST_HEADER(job_list);
-UTIL_IS_INSTANCE_HEADER(job_list);
 
 #endif

--- a/libres/lib/include/ert/job_queue/job_node.hpp
+++ b/libres/lib/include/ert/job_queue/job_node.hpp
@@ -113,7 +113,5 @@ extern "C" void job_queue_node_set_status(job_queue_node_type *node,
                                           job_status_type new_status);
 
 char *job_queue_node_get_name(job_queue_node_type *node);
-UTIL_IS_INSTANCE_HEADER(job_queue_node);
-UTIL_SAFE_CAST_HEADER(job_queue_node);
 
 #endif

--- a/libres/lib/include/ert/job_queue/job_queue.hpp
+++ b/libres/lib/include/ert/job_queue/job_queue.hpp
@@ -101,6 +101,5 @@ extern "C" PY_USED char *job_queue_get_status_file(const job_queue_type *queue);
 extern "C" PY_USED int job_queue_add_job_node(job_queue_type *queue,
                                               job_queue_node_type *node);
 
-UTIL_SAFE_CAST_HEADER(job_queue);
 
 #endif

--- a/libres/lib/include/ert/job_queue/job_queue_status.hpp
+++ b/libres/lib/include/ert/job_queue/job_queue_status.hpp
@@ -38,7 +38,5 @@ bool job_queue_status_transition(job_queue_status_type *status_count,
                                  job_status_type target_status);
 int job_queue_status_get_total_count(const job_queue_status_type *status);
 
-UTIL_IS_INSTANCE_HEADER(job_queue_status);
-UTIL_SAFE_CAST_HEADER(job_queue_status);
 
 #endif

--- a/libres/lib/include/ert/job_queue/lsf_driver.hpp
+++ b/libres/lib/include/ert/job_queue/lsf_driver.hpp
@@ -92,6 +92,5 @@ int lsf_job_parse_bsub_stdout(const char *bsub_cmd, const char *stdout_file);
 char *lsf_job_write_bjobs_to_file(const char *bjobs_cmd,
                                   lsf_driver_type *driver, const long jobid);
 
-UTIL_SAFE_CAST_HEADER(lsf_driver);
 
 #endif

--- a/libres/lib/include/ert/job_queue/queue_driver.hpp
+++ b/libres/lib/include/ert/job_queue/queue_driver.hpp
@@ -106,6 +106,5 @@ typedef enum {
                                              because of pause or it is going down. */
 submit_status_type;
 
-UTIL_IS_INSTANCE_HEADER(queue_driver);
 
 #endif

--- a/libres/lib/include/ert/job_queue/slurm_driver.hpp
+++ b/libres/lib/include/ert/job_queue/slurm_driver.hpp
@@ -49,6 +49,5 @@ job_status_type slurm_driver_get_job_status(void *__driver, void *__job);
 void slurm_driver_kill_job(void *__driver, void *__job);
 void slurm_driver_free_job(void *__job);
 
-UTIL_SAFE_CAST_HEADER(slurm_driver);
 
 #endif

--- a/libres/lib/include/ert/job_queue/torque_driver.hpp
+++ b/libres/lib/include/ert/job_queue/torque_driver.hpp
@@ -75,6 +75,5 @@ FILE *torque_driver_get_debug_stream(const torque_driver_type *driver);
 job_status_type torque_driver_parse_status(const char *qstat_file,
                                            const char *jobnr);
 
-UTIL_SAFE_CAST_HEADER(torque_driver);
 
 #endif /* TORQUE_DRIVER_H */

--- a/libres/lib/include/ert/job_queue/workflow.hpp
+++ b/libres/lib/include/ert/job_queue/workflow.hpp
@@ -49,6 +49,5 @@ workflow_iget_arguments(const workflow_type *workflow, int index);
 extern "C" bool workflow_try_compile(workflow_type *script,
                                      const subst_list_type *context);
 
-UTIL_IS_INSTANCE_HEADER(workflow);
 
 #endif

--- a/libres/lib/include/ert/res_util/arg_pack.hpp
+++ b/libres/lib/include/ert/res_util/arg_pack.hpp
@@ -30,9 +30,6 @@ typedef void(arg_node_free_ftype)(void *);
 typedef void *(arg_node_copyc_ftype)(const void *);
 
 arg_pack_type *arg_pack_alloc();
-UTIL_SAFE_CAST_HEADER(arg_pack);
-UTIL_SAFE_CAST_HEADER_CONST(arg_pack);
-UTIL_IS_INSTANCE_HEADER(arg_pack);
 
 void arg_pack_free(arg_pack_type *);
 void arg_pack_clear(arg_pack_type *);

--- a/libres/lib/include/ert/res_util/block_fs.hpp
+++ b/libres/lib/include/ert/res_util/block_fs.hpp
@@ -49,6 +49,4 @@ vector_type *block_fs_alloc_filelist(block_fs_type *block_fs,
                                      block_fs_sort_type sort_mode,
                                      bool include_free_nodes);
 
-UTIL_IS_INSTANCE_HEADER(block_fs);
-UTIL_SAFE_CAST_HEADER(block_fs);
 #endif

--- a/libres/lib/include/ert/res_util/subst_func.hpp
+++ b/libres/lib/include/ert/res_util/subst_func.hpp
@@ -38,7 +38,6 @@ subst_func_type *subst_func_pool_get_func(const subst_func_pool_type *pool,
                                           const char *func_name);
 bool subst_func_pool_has_func(const subst_func_pool_type *pool,
                               const char *func_name);
-UTIL_IS_INSTANCE_HEADER(subst_func_pool);
 
 char *subst_func_add(const stringlist_type *args, void *arg);
 char *subst_func_mul(const stringlist_type *args, void *arg);

--- a/libres/lib/include/ert/res_util/subst_list.hpp
+++ b/libres/lib/include/ert/res_util/subst_list.hpp
@@ -67,5 +67,4 @@ extern "C" bool subst_list_has_key(const subst_list_type *subst_list,
 void subst_list_add_from_string(subst_list_type *subst_list,
                                 const char *arg_string, bool append);
 
-UTIL_IS_INSTANCE_HEADER(subst_list);
 #endif

--- a/libres/lib/include/ert/res_util/template_type.hpp
+++ b/libres/lib/include/ert/res_util/template_type.hpp
@@ -9,10 +9,8 @@
 #include <regex.h>
 #endif //ERT_HAVE_REGEXP
 
-#define TEMPLATE_TYPE_ID 7781045
 
 struct template_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *
         template_file; /* The template file - if internalize_template == false this filename can contain keys which will be replaced at instantiation time. */
     char *

--- a/libres/lib/include/ert/res_util/ui_return.hpp
+++ b/libres/lib/include/ert/res_util/ui_return.hpp
@@ -46,6 +46,5 @@ ui_return_get_help(const ui_return_type *ui_return);
 extern "C" const char *ui_return_iget_error(const ui_return_type *ui_return,
                                             int index);
 
-UTIL_IS_INSTANCE_HEADER(ui_return);
 
 #endif

--- a/libres/lib/include/ert/sched/history.hpp
+++ b/libres/lib/include/ert/sched/history.hpp
@@ -57,6 +57,5 @@ time_t history_get_time_t_from_restart_nr(const history_type *history,
                                           int restart_nr);
 history_source_type history_get_source(const history_type *history);
 
-UTIL_IS_INSTANCE_HEADER(history);
 
 #endif

--- a/libres/lib/job_queue/ext_job.cpp
+++ b/libres/lib/job_queue/ext_job.cpp
@@ -101,7 +101,6 @@ jobList = [
      "stdin"     : "eclipse.stdin"}]
 */
 
-#define EXT_JOB_TYPE_ID 763012
 
 #define EXT_JOB_STDOUT "stdout"
 #define EXT_JOB_STDERR "stderr"
@@ -109,7 +108,6 @@ jobList = [
     "null" //Setting STDOUT null or STDERR null in forward model directs output to screen
 
 struct ext_job_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *name;
     char *executable;
     char *target_file;
@@ -148,14 +146,12 @@ struct ext_job_struct {
         __valid; /* Temporary variable consulted during the bootstrap - when the ext_job is completely initialized this should NOT be consulted anymore. */
 };
 
-static UTIL_SAFE_CAST_FUNCTION(ext_job, EXT_JOB_TYPE_ID)
 
     static ext_job_type *ext_job_alloc__(const char *name,
                                          const char *license_root_path,
                                          bool private_job) {
     ext_job_type *ext_job = (ext_job_type *)util_malloc(sizeof *ext_job);
 
-    UTIL_TYPE_ID_INIT(ext_job, EXT_JOB_TYPE_ID);
     ext_job->name = util_alloc_string_copy(name);
     ext_job->license_root_path = util_alloc_string_copy(license_root_path);
     ext_job->executable = NULL;
@@ -334,7 +330,7 @@ void ext_job_free(ext_job_type *ext_job) {
 }
 
 void ext_job_free__(void *__ext_job) {
-    ext_job_free(ext_job_safe_cast(__ext_job));
+    ext_job_free(reinterpret_cast<ext_job_type*>(__ext_job));
 }
 
 /*

--- a/libres/lib/job_queue/job_list.cpp
+++ b/libres/lib/job_queue/job_list.cpp
@@ -27,22 +27,17 @@
 #include <ert/job_queue/job_node.hpp>
 #include <ert/job_queue/job_list.hpp>
 
-#define JOB_LIST_TYPE_ID 8154222
 
 struct job_list_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int active_size;
     int alloc_size;
     job_queue_node_type **jobs;
     pthread_rwlock_t lock;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(job_list, JOB_LIST_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(job_list, JOB_LIST_TYPE_ID)
 
 job_list_type *job_list_alloc() {
     job_list_type *job_list = (job_list_type *)util_malloc(sizeof *job_list);
-    UTIL_TYPE_ID_INIT(job_list, JOB_LIST_TYPE_ID);
     job_list->active_size = 0;
     job_list->alloc_size = 0;
     job_list->jobs = NULL;

--- a/libres/lib/job_queue/job_node.cpp
+++ b/libres/lib/job_queue/job_node.cpp
@@ -33,11 +33,9 @@
 namespace fs = std::filesystem;
 static auto logger = ert::get_logger("job_queue");
 
-#define JOB_QUEUE_NODE_TYPE_ID 3315299
 #define INVALID_QUEUE_INDEX -999
 
 struct job_queue_node_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int num_cpu; /* How many cpu's will this job need - the driver is free to ignore if not relevant. */
     char *run_cmd; /* The path to the actual executable. */
     char *
@@ -164,8 +162,6 @@ void job_queue_node_fscanf_EXIT(job_queue_node_type *node) {
     }
 }
 
-UTIL_IS_INSTANCE_FUNCTION(job_queue_node, JOB_QUEUE_NODE_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(job_queue_node, JOB_QUEUE_NODE_TYPE_ID)
 
 int job_queue_node_get_queue_index(const job_queue_node_type *node) {
     if (node->queue_index == INVALID_QUEUE_INDEX)
@@ -261,7 +257,6 @@ job_queue_node_alloc(const char *job_name, const char *run_path,
         (job_queue_node_type *)util_malloc(sizeof *node);
     node->confirmed_running = false;
     node->progress_timestamp = time(NULL);
-    UTIL_TYPE_ID_INIT(node, JOB_QUEUE_NODE_TYPE_ID);
 
     /* The data initialized in this block should *NEVER* change. */
     std::string path = job_name;

--- a/libres/lib/job_queue/job_queue.cpp
+++ b/libres/lib/job_queue/job_queue.cpp
@@ -69,7 +69,6 @@ static auto logger = ert::get_logger("job_queue");
         this:
 
         struct some_driver {
-            UTIL_TYPE_ID_DECLARATION
             QUEUE_DRIVER_FUNCTIONS
             ....
             ....
@@ -80,7 +79,6 @@ static auto logger = ert::get_logger("job_queue");
         queue_driver_type instance which is a struct like this:
 
         struct queue_driver_struct {
-            UTIL_TYPE_ID_DECLARATION
             QUEUE_DRIVER_FIELDS
         }
 
@@ -204,10 +202,8 @@ static auto logger = ert::get_logger("job_queue");
 
 */
 
-#define JOB_QUEUE_TYPE_ID 665210
 
 struct job_queue_struct {
-    UTIL_TYPE_ID_DECLARATION;
     job_list_type *job_list;
     job_queue_status_type *status;
     char *
@@ -960,7 +956,7 @@ void job_queue_run_jobs(job_queue_type *queue, int num_total_run,
 }
 
 void *job_queue_run_jobs__(void *__arg_pack) {
-    arg_pack_type *arg_pack = arg_pack_safe_cast(__arg_pack);
+    arg_pack_type *arg_pack = reinterpret_cast<arg_pack_type*>(__arg_pack);
     job_queue_type *queue = (job_queue_type *)arg_pack_iget_ptr(arg_pack, 0);
     int num_total_run = arg_pack_iget_int(arg_pack, 1);
     bool verbose = arg_pack_iget_bool(arg_pack, 2);
@@ -1053,7 +1049,6 @@ int job_queue_add_job(job_queue_type *queue, const char *run_cmd,
         return -1;
 }
 
-UTIL_SAFE_CAST_FUNCTION(job_queue, JOB_QUEUE_TYPE_ID)
 
 /*
    Observe that the job_queue returned by this function is NOT ready
@@ -1066,7 +1061,6 @@ job_queue_type *job_queue_alloc(int max_submit, const char *ok_file,
                                 const char *exit_file) {
 
     job_queue_type *queue = (job_queue_type *)util_malloc(sizeof *queue);
-    UTIL_TYPE_ID_INIT(queue, JOB_QUEUE_TYPE_ID);
     queue->usleep_time = 250000; /* 1000000 : 1 second */
     queue->max_ok_wait_time = 60;
     queue->max_duration = 0;

--- a/libres/lib/job_queue/job_queue_status.cpp
+++ b/libres/lib/job_queue/job_queue_status.cpp
@@ -22,10 +22,8 @@
 #include <ert/job_queue/queue_driver.hpp>
 #include <ert/job_queue/job_queue_status.hpp>
 
-#define JOB_QUEUE_STATUS_TYPE_ID 777620306
 
 struct job_queue_status_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int status_list[JOB_QUEUE_MAX_STATE];
     pthread_rwlock_t rw_lock;
     int status_index[JOB_QUEUE_MAX_STATE];
@@ -48,13 +46,10 @@ static int STATUS_INDEX(const job_queue_status_type *status_count,
     return 0;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(job_queue_status, JOB_QUEUE_STATUS_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION(job_queue_status, JOB_QUEUE_STATUS_TYPE_ID)
 
 job_queue_status_type *job_queue_status_alloc() {
     job_queue_status_type *status =
         (job_queue_status_type *)util_malloc(sizeof *status);
-    UTIL_TYPE_ID_INIT(status, JOB_QUEUE_STATUS_TYPE_ID);
     pthread_rwlock_init(&status->rw_lock, NULL);
     job_queue_status_clear(status);
     status->timestamp = time(NULL);

--- a/libres/lib/job_queue/queue_driver.cpp
+++ b/libres/lib/job_queue/queue_driver.cpp
@@ -56,7 +56,6 @@
 #define QUEUE_DRIVER_ID 86516032
 
 struct queue_driver_struct {
-    UTIL_TYPE_ID_DECLARATION;
     /*
      Function pointers - pointing to low level functions in the implementations of
      e.g. lsf_driver.
@@ -85,7 +84,6 @@ struct queue_driver_struct {
                                         will (try) to send an unlimited number of jobs to the driver. */
 };
 
-UTIL_IS_INSTANCE_FUNCTION(queue_driver, QUEUE_DRIVER_ID)
 
 void queue_driver_set_max_running(queue_driver_type *driver, int max_running) {
     driver->max_running_string =
@@ -201,7 +199,6 @@ bool queue_driver_unset_option(queue_driver_type *driver,
 static queue_driver_type *queue_driver_alloc_empty() {
     queue_driver_type *driver =
         (queue_driver_type *)util_malloc(sizeof *driver);
-    UTIL_TYPE_ID_INIT(driver, QUEUE_DRIVER_ID);
     driver->driver_type = NULL_DRIVER;
     driver->submit = NULL;
     driver->get_status = NULL;
@@ -220,7 +217,6 @@ static queue_driver_type *queue_driver_alloc_empty() {
     return driver;
 }
 
-static UTIL_SAFE_CAST_FUNCTION(queue_driver, QUEUE_DRIVER_ID)
 
     /*
    The driver created in this function has all the function pointers
@@ -411,6 +407,6 @@ void queue_driver_free(queue_driver_type *driver) {
 }
 
 void queue_driver_free__(void *driver) {
-    queue_driver_type *queue_driver = queue_driver_safe_cast(driver);
+    queue_driver_type *queue_driver = reinterpret_cast<queue_driver_type*>(driver);
     queue_driver_free(queue_driver);
 }

--- a/libres/lib/job_queue/slurm_driver.cpp
+++ b/libres/lib/job_queue/slurm_driver.cpp
@@ -122,7 +122,6 @@ private:
     mutable pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
 };
 
-#define SLURM_DRIVER_TYPE_ID 70555081
 #define DEFAULT_SBATCH_CMD "sbatch"
 #define DEFAULT_SCANCEL_CMD "scancel"
 #define DEFAULT_SQUEUE_CMD "squeue"
@@ -138,7 +137,6 @@ private:
 #define SLURM_CONFIGURING_STATUS "CONFIGURING"
 
 struct slurm_driver_struct {
-    UTIL_TYPE_ID_DECLARATION;
 
     std::string sbatch_cmd;
     std::string scancel_cmd;
@@ -217,12 +215,9 @@ template <typename C> static std::string join_string(const C &strings) {
     return full_string;
 }
 
-UTIL_SAFE_CAST_FUNCTION(slurm_driver, SLURM_DRIVER_TYPE_ID)
-static UTIL_SAFE_CAST_FUNCTION_CONST(slurm_driver, SLURM_DRIVER_TYPE_ID)
 
     void *slurm_driver_alloc() {
     slurm_driver_type *driver = new slurm_driver_type();
-    UTIL_TYPE_ID_INIT(driver, SLURM_DRIVER_TYPE_ID);
     driver->sbatch_cmd = DEFAULT_SBATCH_CMD;
     driver->scancel_cmd = DEFAULT_SCANCEL_CMD;
     driver->squeue_cmd = DEFAULT_SQUEUE_CMD;
@@ -237,13 +232,13 @@ static UTIL_SAFE_CAST_FUNCTION_CONST(slurm_driver, SLURM_DRIVER_TYPE_ID)
 void slurm_driver_free(slurm_driver_type *driver) { delete driver; }
 
 void slurm_driver_free__(void *__driver) {
-    slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
+    slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>(__driver);
     slurm_driver_free(driver);
 }
 
 const void *slurm_driver_get_option(const void *__driver,
                                     const char *option_key) {
-    const slurm_driver_type *driver = slurm_driver_safe_cast_const(__driver);
+    const slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>_const(__driver);
     if (strcmp(option_key, SLURM_SBATCH_OPTION) == 0)
         return driver->sbatch_cmd.c_str();
 
@@ -282,7 +277,7 @@ const void *slurm_driver_get_option(const void *__driver,
 
 bool slurm_driver_set_option(void *__driver, const char *option_key,
                              const void *value) {
-    slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
+    slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>(__driver);
     if (strcmp(option_key, SLURM_SBATCH_OPTION) == 0) {
         driver->sbatch_cmd = static_cast<const char *>(value);
         return true;
@@ -433,7 +428,7 @@ static std::string make_submit_script(const slurm_driver_type *driver,
 void *slurm_driver_submit_job(void *__driver, const char *cmd, int num_cpu,
                               const char *run_path, const char *job_name,
                               int argc, const char **argv) {
-    slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
+    slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>(__driver);
 
     auto submit_script =
         make_submit_script(driver, cmd, job_name, num_cpu, argc, argv);
@@ -599,7 +594,7 @@ static void slurm_driver_update_status_cache(const slurm_driver_type *driver) {
 */
 
 job_status_type slurm_driver_get_job_status(void *__driver, void *__job) {
-    slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
+    slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>(__driver);
     const auto *job = static_cast<const SlurmJob *>(__job);
     auto update_cache = difftime(time(nullptr), driver->status_timestamp) >
                         driver->status_timeout;
@@ -610,7 +605,7 @@ job_status_type slurm_driver_get_job_status(void *__driver, void *__job) {
 }
 
 void slurm_driver_kill_job(void *__driver, void *__job) {
-    slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
+    slurm_driver_type *driver = reinterpret_cast<slurm_driver_type*>(__driver);
     const auto *job = static_cast<const SlurmJob *>(__job);
     const char **argv =
         static_cast<const char **>(util_calloc(1, sizeof *argv));

--- a/libres/lib/job_queue/torque_driver.cpp
+++ b/libres/lib/job_queue/torque_driver.cpp
@@ -30,11 +30,8 @@
 
 namespace fs = std::filesystem;
 
-#define TORQUE_DRIVER_TYPE_ID 34873653
-#define TORQUE_JOB_TYPE_ID 12312312
 
 struct torque_driver_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *queue_name;
     char *qsub_cmd;
     char *qstat_cmd;
@@ -51,22 +48,17 @@ struct torque_driver_struct {
 };
 
 struct torque_job_struct {
-    UTIL_TYPE_ID_DECLARATION;
     long int torque_jobnr;
     char *torque_jobnr_char;
 };
 
-UTIL_SAFE_CAST_FUNCTION(torque_driver, TORQUE_DRIVER_TYPE_ID);
 
-static UTIL_SAFE_CAST_FUNCTION_CONST(
     torque_driver,
-    TORQUE_DRIVER_TYPE_ID) static UTIL_SAFE_CAST_FUNCTION(torque_job,
                                                           TORQUE_JOB_TYPE_ID)
 
     void *torque_driver_alloc() {
     torque_driver_type *torque_driver =
         (torque_driver_type *)util_malloc(sizeof *torque_driver);
-    UTIL_TYPE_ID_INIT(torque_driver, TORQUE_DRIVER_TYPE_ID);
 
     torque_driver->queue_name = NULL;
     torque_driver->qsub_cmd = NULL;
@@ -192,7 +184,7 @@ torque_driver_set_num_cpus_per_node(torque_driver_type *driver,
 bool torque_driver_set_option(void *__driver, const char *option_key,
                               const void *value_) {
     const char *value = (const char *)value_;
-    torque_driver_type *driver = torque_driver_safe_cast(__driver);
+    torque_driver_type *driver = reinterpret_cast<torque_driver_type*>(__driver);
     bool option_set = true;
     {
         if (strcmp(TORQUE_QSUB_CMD, option_key) == 0)
@@ -225,7 +217,7 @@ bool torque_driver_set_option(void *__driver, const char *option_key,
 
 const void *torque_driver_get_option(const void *__driver,
                                      const char *option_key) {
-    const torque_driver_type *driver = torque_driver_safe_cast_const(__driver);
+    const torque_driver_type *driver = reinterpret_cast<torque_driver_type*>_const(__driver);
     {
         if (strcmp(TORQUE_QSUB_CMD, option_key) == 0)
             return driver->qsub_cmd;
@@ -270,7 +262,6 @@ torque_job_type *torque_job_alloc() {
     job = (torque_job_type *)util_malloc(sizeof *job);
     job->torque_jobnr_char = NULL;
     job->torque_jobnr = 0;
-    UTIL_TYPE_ID_INIT(job, TORQUE_JOB_TYPE_ID);
 
     return job;
 }
@@ -466,7 +457,7 @@ void torque_job_free(torque_job_type *job) {
 
 void torque_driver_free_job(void *__job) {
 
-    torque_job_type *job = torque_job_safe_cast(__job);
+    torque_job_type *job = reinterpret_cast<torque_job_type*>(__job);
     torque_job_free(job);
 }
 
@@ -474,7 +465,7 @@ void *torque_driver_submit_job(void *__driver, const char *submit_cmd,
                                int num_cpu, const char *run_path,
                                const char *job_name, int argc,
                                const char **argv) {
-    torque_driver_type *driver = torque_driver_safe_cast(__driver);
+    torque_driver_type *driver = reinterpret_cast<torque_driver_type*>(__driver);
     torque_job_type *job = torque_job_alloc();
 
     torque_debug(driver, "Submitting job in:%s", run_path);
@@ -612,15 +603,15 @@ job_status_type torque_driver_parse_status(const char *qstat_file,
 }
 
 job_status_type torque_driver_get_job_status(void *__driver, void *__job) {
-    torque_driver_type *driver = torque_driver_safe_cast(__driver);
-    torque_job_type *job = torque_job_safe_cast(__job);
+    torque_driver_type *driver = reinterpret_cast<torque_driver_type*>(__driver);
+    torque_job_type *job = reinterpret_cast<torque_job_type*>(__job);
     return torque_driver_get_qstat_status(driver, job->torque_jobnr_char);
 }
 
 void torque_driver_kill_job(void *__driver, void *__job) {
 
-    torque_driver_type *driver = torque_driver_safe_cast(__driver);
-    torque_job_type *job = torque_job_safe_cast(__job);
+    torque_driver_type *driver = reinterpret_cast<torque_driver_type*>(__driver);
+    torque_job_type *job = reinterpret_cast<torque_job_type*>(__job);
     util_spawn_blocking(driver->qdel_cmd, 1,
                         (const char **)&job->torque_jobnr_char, NULL, NULL);
 }
@@ -640,7 +631,7 @@ void torque_driver_free(torque_driver_type *driver) {
 }
 
 void torque_driver_free__(void *__driver) {
-    torque_driver_type *driver = torque_driver_safe_cast(__driver);
+    torque_driver_type *driver = reinterpret_cast<torque_driver_type*>(__driver);
     torque_driver_free(driver);
 }
 

--- a/libres/lib/job_queue/workflow.cpp
+++ b/libres/lib/job_queue/workflow.cpp
@@ -31,21 +31,17 @@
 
 namespace fs = std::filesystem;
 
-#define CMD_TYPE_ID 66153
-#define WORKFLOW_TYPE_ID 6762081
 #define WORKFLOW_COMMENT_STRING "--"
 #define WORKFLOW_INCLUDE "INCLUDE"
 
 typedef struct cmd_struct cmd_type;
 
 struct cmd_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const workflow_job_type *workflow_job;
     stringlist_type *arglist;
 };
 
 struct workflow_struct {
-    UTIL_TYPE_ID_DECLARATION;
     time_t compile_time;
     bool compiled;
     char *src_file;
@@ -58,13 +54,11 @@ struct workflow_struct {
 static cmd_type *cmd_alloc(const workflow_job_type *workflow_job,
                            const stringlist_type *arglist) {
     cmd_type *cmd = (cmd_type *)util_malloc(sizeof *cmd);
-    UTIL_TYPE_ID_INIT(cmd, CMD_TYPE_ID);
     cmd->workflow_job = workflow_job;
     cmd->arglist = stringlist_alloc_deep_copy(arglist);
     return cmd;
 }
 
-static UTIL_SAFE_CAST_FUNCTION(cmd, CMD_TYPE_ID);
 
 static void cmd_free(cmd_type *cmd) {
     stringlist_free(cmd->arglist);
@@ -72,7 +66,7 @@ static void cmd_free(cmd_type *cmd) {
 }
 
 static void cmd_free__(void *arg) {
-    cmd_type *cmd = cmd_safe_cast(arg);
+    cmd_type *cmd = reinterpret_cast<cmd_type*>(arg);
     cmd_free(cmd);
 }
 
@@ -209,7 +203,6 @@ void *workflow_pop_stack(workflow_type *workflow) {
 workflow_type *workflow_alloc(const char *src_file,
                               workflow_joblist_type *joblist) {
     workflow_type *script = (workflow_type *)util_malloc(sizeof *script);
-    UTIL_TYPE_ID_INIT(script, WORKFLOW_TYPE_ID);
 
     script->src_file = util_alloc_string_copy(src_file);
     script->joblist = joblist;
@@ -222,8 +215,6 @@ workflow_type *workflow_alloc(const char *src_file,
     return script;
 }
 
-static UTIL_SAFE_CAST_FUNCTION(workflow, WORKFLOW_TYPE_ID)
-    UTIL_IS_INSTANCE_FUNCTION(workflow, WORKFLOW_TYPE_ID)
 
         void workflow_free(workflow_type *workflow) {
     free(workflow->src_file);
@@ -237,7 +228,7 @@ static UTIL_SAFE_CAST_FUNCTION(workflow, WORKFLOW_TYPE_ID)
 }
 
 void workflow_free__(void *arg) {
-    workflow_type *workflow = workflow_safe_cast(arg);
+    workflow_type *workflow = reinterpret_cast<workflow_type*>(arg);
     workflow_free(workflow);
 }
 

--- a/libres/lib/job_queue/workflow_job.cpp
+++ b/libres/lib/job_queue/workflow_job.cpp
@@ -36,10 +36,8 @@
 
 #define NULL_STRING "NULL"
 
-#define WORKFLOW_JOB_TYPE_ID 614441
 
 struct workflow_job_struct {
-    UTIL_TYPE_ID_DECLARATION;
     bool internal;
     int min_arg;
     int max_arg;
@@ -108,7 +106,6 @@ config_parser_type *workflow_job_alloc_config() {
     return config;
 }
 
-static UTIL_SAFE_CAST_FUNCTION(workflow_job, WORKFLOW_JOB_TYPE_ID);
 
 void workflow_job_update_config_compiler(const workflow_job_type *workflow_job,
                                          config_parser_type *config_compiler) {
@@ -133,7 +130,6 @@ void workflow_job_update_config_compiler(const workflow_job_type *workflow_job,
 workflow_job_type *workflow_job_alloc(const char *name, bool internal) {
     workflow_job_type *workflow_job =
         (workflow_job_type *)util_malloc(sizeof *workflow_job);
-    UTIL_TYPE_ID_INIT(workflow_job, WORKFLOW_JOB_TYPE_ID);
     workflow_job->internal = internal; // this can not be changed run-time.
     workflow_job->min_arg = CONFIG_DEFAULT_ARG_MIN;
     workflow_job->max_arg = CONFIG_DEFAULT_ARG_MAX;
@@ -372,7 +368,7 @@ void workflow_job_free(workflow_job_type *workflow_job) {
 }
 
 void workflow_job_free__(void *arg) {
-    workflow_job_type *workflow_job = workflow_job_safe_cast(arg);
+    workflow_job_type *workflow_job = reinterpret_cast<workflow_job_type*>(arg);
     workflow_job_free(workflow_job);
 }
 

--- a/libres/lib/res_util/arg_pack.cpp
+++ b/libres/lib/res_util/arg_pack.cpp
@@ -60,7 +60,7 @@
 
 
    void some_function__(void * __arg_pack) {
-      arg_pack_type * arg_pack = arg_pack_safe_cast( __arg_pack );
+      arg_pack_type * arg_pack = reinterpret_cast<arg_pack_type*>( __arg_pack );
       const char * arg1 = arg_pack_iget_ptr( arg_pack , 0);
       int          arg2 = arg_pack_iget_int( arg_pack , 1);
 
@@ -78,7 +78,6 @@
 
 */
 
-#define ARG_PACK_TYPE_ID 668268
 
 typedef struct {
     void *
@@ -91,7 +90,6 @@ typedef struct {
 } arg_node_type;
 
 struct arg_pack_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int size; /* The number of arguments appended to this arg_pack instance. */
     int alloc_size; /* The number of nodes allocated to this arg_pack - will in general be greater than size. */
     bool
@@ -254,9 +252,6 @@ static void arg_node_free(arg_node_type *node) {
     free(node);
 }
 
-UTIL_SAFE_CAST_FUNCTION(arg_pack, ARG_PACK_TYPE_ID)
-UTIL_SAFE_CAST_FUNCTION_CONST(arg_pack, ARG_PACK_TYPE_ID)
-UTIL_IS_INSTANCE_FUNCTION(arg_pack, ARG_PACK_TYPE_ID)
 
 static void __arg_pack_assert_index(const arg_pack_type *arg, int iarg) {
     if (iarg < 0 || iarg >= arg->size)
@@ -323,7 +318,6 @@ static arg_node_type *arg_pack_get_append_node(arg_pack_type *arg_pack) {
 
 arg_pack_type *arg_pack_alloc() {
     arg_pack_type *arg_pack = (arg_pack_type *)util_malloc(sizeof *arg_pack);
-    UTIL_TYPE_ID_INIT(arg_pack, ARG_PACK_TYPE_ID);
     arg_pack->nodes = NULL;
     arg_pack->alloc_size = 0;
     arg_pack->locked = false;

--- a/libres/lib/res_util/block_fs.cpp
+++ b/libres/lib/res_util/block_fs.cpp
@@ -36,7 +36,6 @@
 namespace fs = std::filesystem;
 
 #define MOUNT_MAP_MAGIC_INT 8861290
-#define BLOCK_FS_TYPE_ID 7100652
 #define INDEX_MAGIC_INT 1213775
 #define INDEX_FORMAT_VERSION 1
 
@@ -113,7 +112,6 @@ struct file_node_struct {
 */
 
 struct block_fs_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *
         mount_file; /* The full path to a file with some mount information - input to the mount routine. */
     char *path;
@@ -154,7 +152,6 @@ struct block_fs_struct {
 
 static void block_fs_rotate__(block_fs_type *block_fs);
 
-UTIL_SAFE_CAST_FUNCTION(block_fs, BLOCK_FS_TYPE_ID)
 
 static inline void fseek__(FILE *stream, long int arg, int whence) {
     if (fseek(stream, arg, whence) != 0) {
@@ -558,7 +555,6 @@ static block_fs_type *block_fs_alloc_empty(const char *mount_file,
                                            int fsync_interval, bool read_only,
                                            bool use_lockfile) {
     block_fs_type *block_fs = (block_fs_type *)util_malloc(sizeof *block_fs);
-    UTIL_TYPE_ID_INIT(block_fs, BLOCK_FS_TYPE_ID);
 
     block_fs->mount_file = util_alloc_string_copy(mount_file);
     block_fs->fsync_interval = fsync_interval;
@@ -607,7 +603,6 @@ static block_fs_type *block_fs_alloc_empty(const char *mount_file,
     return block_fs;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(block_fs, BLOCK_FS_TYPE_ID);
 
 static void block_fs_fwrite_mount_info__(const char *mount_file, int version) {
     FILE *stream = util_fopen(mount_file, "w");

--- a/libres/lib/res_util/path_fmt.cpp
+++ b/libres/lib/res_util/path_fmt.cpp
@@ -55,13 +55,11 @@ char * path = path_fmt_alloc(path_fmt , "BaseCase" , 67);
 #define PATH_FMT_ID 7519200
 
 struct path_fmt_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *fmt;
     char *file_fmt;
     bool is_directory;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(path_fmt, PATH_FMT_ID)
 
     void path_fmt_reset_fmt(path_fmt_type *path, const char *fmt) {
     path->fmt = util_realloc_string_copy(path->fmt, fmt);
@@ -71,7 +69,6 @@ static UTIL_SAFE_CAST_FUNCTION(path_fmt, PATH_FMT_ID)
 
 static path_fmt_type *path_fmt_alloc__(const char *fmt, bool is_directory) {
     path_fmt_type *path = (path_fmt_type *)util_malloc(sizeof *path);
-    UTIL_TYPE_ID_INIT(path, PATH_FMT_ID);
     path->fmt = NULL;
     path->file_fmt = NULL;
     path->is_directory = is_directory;
@@ -273,6 +270,6 @@ void path_fmt_free(path_fmt_type *path) {
 }
 
 void path_fmt_free__(void *arg) {
-    path_fmt_type *path_fmt = path_fmt_safe_cast(arg);
+    path_fmt_type *path_fmt = reinterpret_cast<path_fmt_type*>(arg);
     path_fmt_free(path_fmt);
 }

--- a/libres/lib/res_util/subst_func.cpp
+++ b/libres/lib/res_util/subst_func.cpp
@@ -24,16 +24,12 @@
 
 #include <ert/res_util/subst_func.hpp>
 
-#define SUBST_FUNC_TYPE_ID 646781
-#define SUBST_FUNC_POOL_TYPE_ID 7641
 
 struct subst_func_pool_struct {
-    UTIL_TYPE_ID_DECLARATION;
     hash_type *func_table;
 };
 
 struct subst_func_struct {
-    UTIL_TYPE_ID_DECLARATION;
     subst_func_ftype *func;
     char *name;
     char *doc_string; /* doc_string for this function - can be NULL. */
@@ -69,7 +65,6 @@ subst_func_type *subst_func_alloc(const char *func_name, const char *doc_string,
                                   int argc_min, int argc_max, void *arg) {
     subst_func_type *subst_func =
         (subst_func_type *)util_malloc(sizeof *subst_func);
-    UTIL_TYPE_ID_INIT(subst_func, SUBST_FUNC_TYPE_ID);
     subst_func->func = func;
     subst_func->name = util_alloc_string_copy(func_name);
     subst_func->vararg = vararg;
@@ -86,18 +81,15 @@ void subst_func_free(subst_func_type *subst_func) {
     free(subst_func);
 }
 
-UTIL_SAFE_CAST_FUNCTION(subst_func, SUBST_FUNC_TYPE_ID);
 
 static void subst_func_free__(void *arg) {
-    subst_func_free(subst_func_safe_cast(arg));
+    subst_func_free(reinterpret_cast<subst_func_type*>(arg));
 }
 
-UTIL_IS_INSTANCE_FUNCTION(subst_func_pool, SUBST_FUNC_POOL_TYPE_ID);
 
 subst_func_pool_type *subst_func_pool_alloc() {
     subst_func_pool_type *pool =
         (subst_func_pool_type *)util_malloc(sizeof *pool);
-    UTIL_TYPE_ID_INIT(pool, SUBST_FUNC_POOL_TYPE_ID);
     pool->func_table = hash_alloc();
     return pool;
 }

--- a/libres/lib/res_util/subst_list.cpp
+++ b/libres/lib/res_util/subst_list.cpp
@@ -81,10 +81,8 @@ typedef enum {
     SUBST_SHARED_REF = 3
 } subst_insert_type; /* Mode used in the subst_list_insert__() function */
 
-#define SUBST_LIST_TYPE_ID 6614320
 
 struct subst_list_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const subst_list_type *
         parent; /* A parent subst_list instance - can be NULL - no destructor is called for the parent. */
     vector_type *string_data; /* The string substitutions we should do. */
@@ -239,7 +237,6 @@ subst_list_insert_new_node(subst_list_type *subst_list, const char *key,
     return new_node;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(subst_list, SUBST_LIST_TYPE_ID)
 
 /*
    Observe that this function sets both the subst parent, and the pool
@@ -275,7 +272,6 @@ bool subst_list_has_key(const subst_list_type *subst_list, const char *key) {
 subst_list_type *subst_list_alloc(const void *input_arg) {
     subst_list_type *subst_list =
         (subst_list_type *)util_malloc(sizeof *subst_list);
-    UTIL_TYPE_ID_INIT(subst_list, SUBST_LIST_TYPE_ID);
     subst_list->parent = NULL;
     subst_list->func_pool = NULL;
     subst_list->map = hash_alloc();

--- a/libres/lib/res_util/template.cpp
+++ b/libres/lib/res_util/template.cpp
@@ -88,7 +88,6 @@ template_type *template_alloc(const char *template_file,
                               bool internalize_template,
                               subst_list_type *parent_subst) {
     template_type *_template = (template_type *)util_malloc(sizeof *_template);
-    UTIL_TYPE_ID_INIT(_template, TEMPLATE_TYPE_ID);
     _template->arg_list = subst_list_alloc(parent_subst);
     _template->template_buffer = NULL;
     _template->template_file = NULL;

--- a/libres/lib/res_util/thread_pool.cpp
+++ b/libres/lib/res_util/thread_pool.cpp
@@ -115,9 +115,7 @@ typedef struct {
     bool running;  /* Is the job_slot running now?? */
 } thread_pool_job_slot_type;
 
-#define THREAD_POOL_TYPE_ID 71443207
 struct thread_pool_struct {
-    UTIL_TYPE_ID_DECLARATION;
     thread_pool_arg_type
         *queue;      /* The jobs to be executed are appended in this vector. */
     int queue_index; /* The index of the next job to run. */
@@ -136,7 +134,6 @@ struct thread_pool_struct {
     pthread_rwlock_t queue_lock;
 };
 
-static UTIL_SAFE_CAST_FUNCTION(thread_pool, THREAD_POOL_TYPE_ID)
 
     /*
    This function will grow the queue. It is called by the main thread
@@ -205,7 +202,7 @@ static void *thread_pool_start_job(void *arg) {
 */
 
 static void *thread_pool_main_loop(void *arg) {
-    thread_pool_type *tp = thread_pool_safe_cast(arg);
+    thread_pool_type *tp = reinterpret_cast<thread_pool_type*>(arg);
     {
         const int usleep_init =
             1000; /* The sleep time when there are free slots available - but no jobs wanting to run. */
@@ -411,7 +408,6 @@ bool thread_pool_try_join(thread_pool_type *pool, int timeout_seconds) {
 
 thread_pool_type *thread_pool_alloc(int max_running, bool start_queue) {
     thread_pool_type *pool = (thread_pool_type *)util_malloc(sizeof *pool);
-    UTIL_TYPE_ID_INIT(pool, THREAD_POOL_TYPE_ID);
     pool->job_slots = (thread_pool_job_slot_type *)util_calloc(
         max_running, sizeof *pool->job_slots);
     pool->max_running = max_running;

--- a/libres/lib/res_util/ui_return.cpp
+++ b/libres/lib/res_util/ui_return.cpp
@@ -28,21 +28,17 @@
 
 #include <ert/res_util/ui_return.hpp>
 
-#define UI_RETURN_TYPE_ID 6122209
 
 struct ui_return_struct {
-    UTIL_TYPE_ID_DECLARATION;
     ui_return_status_enum status;
     stringlist_type *error_list;
     char *help_text;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(ui_return, UI_RETURN_TYPE_ID)
 
 ui_return_type *ui_return_alloc(ui_return_status_enum status) {
     ui_return_type *ui_return =
         (ui_return_type *)util_malloc(sizeof *ui_return);
-    UTIL_TYPE_ID_INIT(ui_return, UI_RETURN_TYPE_ID);
     ui_return->status = status;
     ui_return->help_text = NULL;
     ui_return->error_list = stringlist_alloc_new();

--- a/libres/lib/rms/rms_tag.cpp
+++ b/libres/lib/rms/rms_tag.cpp
@@ -34,10 +34,8 @@ static const char *rms_endtag_string = "endtag";
 #define OWNED_REF 1
 #define COPY 2
 
-#define RMS_TAG_TYPE_ID 4431296
 
 struct rms_tag_struct {
-    UTIL_TYPE_ID_DECLARATION;
     char *name;
     vector_type *key_list;
     hash_type *key_hash; /* Hash of tagkey instances */
@@ -45,7 +43,6 @@ struct rms_tag_struct {
 
 rms_tag_type *rms_tag_alloc(const char *name) {
     rms_tag_type *tag = (rms_tag_type *)malloc(sizeof *tag);
-    UTIL_TYPE_ID_INIT(tag, RMS_TAG_TYPE_ID)
     tag->name = NULL;
     tag->key_hash = hash_alloc();
     tag->key_list = vector_alloc_new();
@@ -54,7 +51,6 @@ rms_tag_type *rms_tag_alloc(const char *name) {
     return tag;
 }
 
-static UTIL_SAFE_CAST_FUNCTION(rms_tag, RMS_TAG_TYPE_ID)
 
     void rms_tag_free(rms_tag_type *tag) {
     free(tag->name);
@@ -64,7 +60,7 @@ static UTIL_SAFE_CAST_FUNCTION(rms_tag, RMS_TAG_TYPE_ID)
 }
 
 void rms_tag_free__(void *arg) {
-    rms_tag_type *tag = rms_tag_safe_cast(arg);
+    rms_tag_type *tag = reinterpret_cast<rms_tag_type*>(arg);
     rms_tag_free(tag);
 }
 

--- a/libres/lib/sched/history.cpp
+++ b/libres/lib/sched/history.cpp
@@ -26,10 +26,8 @@
 
 #include <ert/sched/history.hpp>
 
-#define HISTORY_TYPE_ID 66143109
 
 struct history_struct {
-    UTIL_TYPE_ID_DECLARATION;
     const ecl_sum_type *
         refcase; /* ecl_sum instance used when the data are taken from a summary instance. Observe that this is NOT owned by history instance.*/
     history_source_type source;
@@ -63,11 +61,9 @@ const char *history_get_source_string(history_source_type history_source) {
     }
 }
 
-UTIL_IS_INSTANCE_FUNCTION(history, HISTORY_TYPE_ID)
 
 static history_type *history_alloc_empty() {
     history_type *history = (history_type *)util_malloc(sizeof *history);
-    UTIL_TYPE_ID_INIT(history, HISTORY_TYPE_ID);
     history->refcase = NULL;
     return history;
 }

--- a/libres/old_tests/enkf/test_enkf_ensemble_config.cpp
+++ b/libres/old_tests/enkf/test_enkf_ensemble_config.cpp
@@ -23,7 +23,7 @@
 #include <ert/enkf/ensemble_config.hpp>
 
 void add_NULL_node(void *arg) {
-    ensemble_config_type *ens_config = ensemble_config_safe_cast(arg);
+    ensemble_config_type *ens_config = reinterpret_cast<ensemble_config_type*>(arg);
     ensemble_config_add_node(ens_config, NULL);
 }
 

--- a/libres/old_tests/enkf/test_enkf_fs.cpp
+++ b/libres/old_tests/enkf/test_enkf_fs.cpp
@@ -122,7 +122,7 @@ void createFS() {
 }
 
 void test_fwrite_readonly(void *arg) {
-    enkf_fs_type *fs = enkf_fs_safe_cast(arg);
+    enkf_fs_type *fs = reinterpret_cast<enkf_fs_type*>(arg);
     /*
      The arguments here are completely bogus; the important thing is
      that this fwrite call should be intercepted by a util_abort()

--- a/libres/old_tests/enkf/test_enkf_meas_data.cpp
+++ b/libres/old_tests/enkf/test_enkf_meas_data.cpp
@@ -25,12 +25,12 @@
 #include <ert/enkf/meas_data.hpp>
 
 void meas_block_iset_abort(void *arg) {
-    meas_block_type *block = meas_block_safe_cast(arg);
+    meas_block_type *block = reinterpret_cast<meas_block_type*>(arg);
     meas_block_iset(block, 0, 0, 100);
 }
 
 void meas_block_iget_abort(void *arg) {
-    meas_block_type *block = meas_block_safe_cast(arg);
+    meas_block_type *block = reinterpret_cast<meas_block_type*>(arg);
     meas_block_iget(block, 0, 0);
 }
 

--- a/libres/old_tests/enkf/test_enkf_run_arg.cpp
+++ b/libres/old_tests/enkf/test_enkf_run_arg.cpp
@@ -24,12 +24,12 @@
 #include <ert/enkf/ert_run_context.hpp>
 
 void call_get_queue_index(void *arg) {
-    run_arg_type *run_arg = run_arg_safe_cast(arg);
+    run_arg_type *run_arg = reinterpret_cast<run_arg_type*>(arg);
     run_arg_get_queue_index(run_arg);
 }
 
 void call_set_queue_index(void *arg) {
-    run_arg_type *run_arg = run_arg_safe_cast(arg);
+    run_arg_type *run_arg = reinterpret_cast<run_arg_type*>(arg);
     run_arg_set_queue_index(run_arg, 88);
 }
 
@@ -62,12 +62,12 @@ void test_queue_index() {
 }
 
 void call_get_sim_fs(void *arg) {
-    run_arg_type *run_arg = run_arg_safe_cast(arg);
+    run_arg_type *run_arg = reinterpret_cast<run_arg_type*>(arg);
     run_arg_get_sim_fs(run_arg);
 }
 
 void call_get_update_target_fs(void *arg) {
-    run_arg_type *run_arg = run_arg_safe_cast(arg);
+    run_arg_type *run_arg = reinterpret_cast<run_arg_type*>(arg);
     run_arg_get_update_target_fs(run_arg);
 }
 

--- a/libres/old_tests/enkf/test_enkf_runpath_list.cpp
+++ b/libres/old_tests/enkf/test_enkf_runpath_list.cpp
@@ -29,7 +29,7 @@
 #include <ert/enkf/ert_test_context.hpp>
 
 void *add_pathlist(void *arg) {
-    arg_pack_type *arg_pack = arg_pack_safe_cast(arg);
+    arg_pack_type *arg_pack = reinterpret_cast<arg_pack_type*>(arg);
     runpath_list_type *list =
         (runpath_list_type *)arg_pack_iget_ptr(arg_pack, 0);
     int offset = arg_pack_iget_int(arg_pack, 1);

--- a/libres/old_tests/enkf/test_enkf_time_map.cpp
+++ b/libres/old_tests/enkf/test_enkf_time_map.cpp
@@ -55,7 +55,7 @@ void ecl_test(const char *ecl_case) {
 }
 
 static void map_update(void *arg) {
-    vector_type *arg_vector = vector_safe_cast(arg);
+    vector_type *arg_vector = reinterpret_cast<vector_type*>(arg);
     time_map_type *tmap = (time_map_type *)vector_iget(arg_vector, 0);
     ecl_sum_type *sum = (ecl_sum_type *)vector_iget(arg_vector, 1);
 
@@ -84,7 +84,7 @@ void test_inconsistent_summary(const char *case1, const char *case2) {
 }
 
 static void alloc_index_map(void *arg) {
-    arg_pack_type *arg_pack = arg_pack_safe_cast(arg);
+    arg_pack_type *arg_pack = reinterpret_cast<arg_pack_type*>(arg);
     time_map_type *map = (time_map_type *)arg_pack_iget_ptr(arg_pack, 0);
     ecl_sum_type *sum = (ecl_sum_type *)arg_pack_iget_ptr(arg_pack, 1);
 
@@ -269,7 +269,7 @@ void simple_test() {
 }
 
 static void simple_update(void *arg) {
-    time_map_type *tmap = time_map_safe_cast(arg);
+    time_map_type *tmap = reinterpret_cast<time_map_type*>(arg);
 
     time_map_update(tmap, 0, 101);
 }
@@ -290,7 +290,7 @@ void simple_test_inconsistent() {
 #define MAP_SIZE 10000
 
 void *update_time_map(void *arg) {
-    time_map_type *time_map = time_map_safe_cast(arg);
+    time_map_type *time_map = reinterpret_cast<time_map_type*>(arg);
     int i;
     for (i = 0; i < MAP_SIZE; i++)
         time_map_update(time_map, i, i);

--- a/libres/old_tests/enkf/test_gen_kw.cpp
+++ b/libres/old_tests/enkf/test_gen_kw.cpp
@@ -52,7 +52,7 @@ void test_write_gen_kw_export_file(enkf_main_type *enkf_main) {
 }
 
 static void read_erroneous_gen_kw_file(void *arg) {
-    vector_type *arg_vector = vector_safe_cast(arg);
+    vector_type *arg_vector = reinterpret_cast<vector_type*>(arg);
     gen_kw_config_type *gen_kw_config =
         (gen_kw_config_type *)vector_iget(arg_vector, 0);
     const char *filename = (const char *)vector_iget_const(arg_vector, 1);

--- a/libres/old_tests/job_queue/test_job_list.cpp
+++ b/libres/old_tests/job_queue/test_job_list.cpp
@@ -32,7 +32,7 @@ void test_create() {
 }
 
 void call_add_job(void *arg) {
-    arg_pack_type *arg_pack = arg_pack_safe_cast(arg);
+    arg_pack_type *arg_pack = reinterpret_cast<arg_pack_type*>(arg);
     job_list_type *job_list = (job_list_type *)arg_pack_iget_ptr(arg_pack, 0);
     job_queue_node_type *node =
         (job_queue_node_type *)arg_pack_iget_ptr(arg_pack, 1);
@@ -40,7 +40,7 @@ void call_add_job(void *arg) {
 }
 
 void call_iget_job(void *arg) {
-    job_list_type *job_list = job_list_safe_cast(arg);
+    job_list_type *job_list = reinterpret_cast<job_list_type*>(arg);
     job_list_iget_job(job_list, 10);
 }
 

--- a/libres/old_tests/job_queue/test_job_node.cpp
+++ b/libres/old_tests/job_queue/test_job_node.cpp
@@ -28,7 +28,7 @@ void test_create() {
 }
 
 void call_get_queue_index(void *arg) {
-    job_queue_node_type *node = job_queue_node_safe_cast(arg);
+    job_queue_node_type *node = reinterpret_cast<job_queue_node_type*>(arg);
     job_queue_node_get_queue_index(node);
 }
 

--- a/libres/old_tests/job_queue/test_job_status.cpp
+++ b/libres/old_tests/job_queue/test_job_status.cpp
@@ -24,7 +24,7 @@
 #include <ert/util/test_util.hpp>
 
 void call_get_status(void *arg) {
-    job_queue_status_type *job_status = job_queue_status_safe_cast(arg);
+    job_queue_status_type *job_status = reinterpret_cast<job_queue_status_type*>(arg);
     job_queue_status_get_count(
         job_status,
         pow(2,
@@ -42,20 +42,20 @@ void test_create() {
 }
 
 void *add_sim(void *arg) {
-    job_queue_status_type *job_status = job_queue_status_safe_cast(arg);
+    job_queue_status_type *job_status = reinterpret_cast<job_queue_status_type*>(arg);
     job_queue_status_inc(job_status, JOB_QUEUE_WAITING);
     return NULL;
 }
 
 void *user_exit(void *arg) {
-    job_queue_status_type *job_status = job_queue_status_safe_cast(arg);
+    job_queue_status_type *job_status = reinterpret_cast<job_queue_status_type*>(arg);
     job_queue_status_transition(job_status, JOB_QUEUE_WAITING,
                                 JOB_QUEUE_DO_KILL);
     return NULL;
 }
 
 void *user_done(void *arg) {
-    job_queue_status_type *job_status = job_queue_status_safe_cast(arg);
+    job_queue_status_type *job_status = reinterpret_cast<job_queue_status_type*>(arg);
     job_queue_status_transition(job_status, JOB_QUEUE_WAITING, JOB_QUEUE_DONE);
     return NULL;
 }

--- a/libres/old_tests/res_util/test_ert_util_block_fs.cpp
+++ b/libres/old_tests/res_util/test_ert_util_block_fs.cpp
@@ -33,7 +33,7 @@ void test_assert_util_abort(const char *function_name, void call_func(void *),
                             void *arg);
 
 void violating_fwrite(void *arg) {
-    block_fs_type *bfs = block_fs_safe_cast(arg);
+    block_fs_type *bfs = reinterpret_cast<block_fs_type*>(arg);
     block_fs_fwrite_file(bfs, "name", NULL, 100);
 }
 


### PR DESCRIPTION
The usage of the following macros has been removed:
- `UTIL_TYPE_ID_INIT`
- `UTIL_TYPD_ID_DECLARATION`
- `UTIL_IS_INSTANCE_HEADER`
- `UTIL_IS_INSTANCE_FUNCTION`
- `UTIL_SAFE_CAST_HEADER`
- `UTIL_SAFE_CAST_HEADER_CONST`
- `UTIL_SAFE_CAST_FUNCTION`
- `UTIL_SAFE_CAST_FUNCTION_CONST`

The invocations of `_safe_cast` and `_safe_cast_const` have been
replaced with an equivalent `reinterpret_cast<T>` "call", and the
invocations for `_is_instance` are assumed to be `true` in all instances
and removed.

This system is both technically unsafe and superfluous due to the
existence of C++ functionality that achieves the same thing. It is
unsafe because each function assumes that a `void*` can be turned into a
`int*` for type-identification. This may not always be the case, where
either the `void*` is pointing to empty memory (eg. by `malloc(0)`) or
the first four bytes may not be correct aligned to `int`'s alignment,
potentially causing load errors (on CPUs that are not supported by ERT,
but still). Other systems work around this by having a dedicated type
which does have the necessary properties, like eg. Python's `PyObject*`,
but we didn't do this. As it stands currently, it's more appropriate
long-term to get rid of this mechanism entirely rather than fixing it.

Resolves: #2625 