### PR TITLE
Fix timing in test batch sim

### DIFF
--- a/tests/libres_tests/res/simulator/test_batch_sim.py
+++ b/tests/libres_tests/res/simulator/test_batch_sim.py
@@ -550,6 +550,7 @@ class BatchSimulatorTest(ResTest):
                 JobStatusType.JOB_QUEUE_UNKNOWN,
                 JobStatusType.JOB_QUEUE_EXIT,
                 JobStatusType.JOB_QUEUE_DONE,
+                None,  # job is not submitted yet but ok for this test
             )
         )
 


### PR DESCRIPTION
Should resolve #2436

See https://github.com/equinor/ert/issues/2436#issuecomment-1065223397. This patch allows the loop to continue also when `batch_ctx.job_status()` returns None.