### PR TITLE
Force GC to avoid conflict with running C++ dtors later

### DIFF
--- a/tests/ert_tests/dark_storage/conftest.py
+++ b/tests/ert_tests/dark_storage/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import os
 import shutil
 import py
+import gc
 
 from starlette.testclient import TestClient
 
@@ -76,6 +77,7 @@ def reset_enkf():
     enkf._config = None
     enkf._ert = None
     enkf._libres_facade = None
+    gc.collect()
 
 
 def new_storage_client(monkeypatch, ert_storage_client):


### PR DESCRIPTION
Likely to resolve #3084 and similar.

This line
https://github.com/equinor/ert/blob/0d8b973d2341f0c39ca467bfcf0cdd2ae1656215/tests/ert_tests/dark_storage/conftest.py#L77
releases a global instance of `EnkfMain`. We know that releasing an `EnkfMain`-instance causes some C++ dtors to run (in particular `ert::block_fs_driver::~block_fs_driver()`) , and we suspect this sometimes conflicts with immediately creating new `EnkfMain` instances.

This patch just makes sure GC runs immediately, triggering dtors before new `EnkfMain`-instances are created. It is thus only useful for the _create-release-create-release_ -pattern which exposes these conflicts in the dtors. Afaik, production-code does not apply this pattern, is not likely subject to these conflicts, and does not need a similar patch.