### PR TITLE
Refactor RunDialog to depend less on RunModel

### DIFF
--- a/ert_gui/simulation/simulation_panel.py
+++ b/ert_gui/simulation/simulation_panel.py
@@ -131,8 +131,7 @@ class SimulationPanel(QWidget):
             arguments = self.getSimulationArguments()
             dialog = RunDialog(
                 self._config_file,
-                run_model(self.ert, self.ert.get_queue_config()),
-                arguments,
+                run_model(arguments, self.ert, self.ert.get_queue_config()),
             )
             dialog.startSimulation()
             dialog.exec_()

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -42,7 +42,7 @@ def run_cli(args):
     if args.mode == WORKFLOW_MODE:
         execute_workflow(ert, args.name)
         return
-    model, argument = create_model(
+    model = create_model(
         ert,
         facade.get_analysis_module_names,
         facade.get_ensemble_size(),
@@ -69,7 +69,7 @@ def run_cli(args):
     thread = threading.Thread(
         name="ert_cli_simulation_thread",
         target=model.start_simulations_thread,
-        args=(argument, evaluator_server_config),
+        args=(evaluator_server_config,),
     )
     thread.start()
 

--- a/ert_shared/models/single_test_run.py
+++ b/ert_shared/models/single_test_run.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, Any
 
 from ert_shared.models import ErtRunError, EnsembleExperiment
 from ert_shared.models.types import Argument
@@ -9,9 +9,13 @@ from res.enkf.enkf_main import EnKFMain
 
 
 class SingleTestRun(EnsembleExperiment):
-    def __init__(self, ert: EnKFMain, *_: Any):
+    def __init__(self, simulation_arguments: Dict[str, Any], ert: EnKFMain, *_: Any):
         local_queue_config = ert.get_queue_config().create_local_copy()
-        super().__init__(ert, local_queue_config)
+        super().__init__(
+            simulation_arguments,
+            ert,
+            local_queue_config,
+        )
 
     def checkHaveSufficientRealizations(self, num_successful_realizations: int) -> None:
         # Should only have one successful realization
@@ -19,10 +23,10 @@ class SingleTestRun(EnsembleExperiment):
             raise ErtRunError("Simulation failed!")
 
     def runSimulations(
-        self, arguments: Argument, evaluator_server_config: EvaluatorServerConfig
+        self, evaluator_server_config: EvaluatorServerConfig
     ) -> ErtRunContext:
         return self.runSimulations__(
-            arguments, "Running single realisation test ...", evaluator_server_config
+            "Running single realisation test ...", evaluator_server_config
         )
 
     @classmethod

--- a/tests/ert_tests/cli/test_model_factory.py
+++ b/tests/ert_tests/cli/test_model_factory.py
@@ -71,11 +71,11 @@ class ModelFactoryTest(ErtTest):
         with ErtTestContext("test_init_iteration_number", config_file) as work_area:
             ert = work_area.getErt()
             args = Namespace(iter_num=10, realizations=None)
-            model, argument = model_factory._setup_ensemble_experiment(
+            model = model_factory._setup_ensemble_experiment(
                 ert, args, ert.getEnsembleSize()
             )
-            run_context = model.create_context(argument)
-            self.assertEqual(argument["iter_num"], 10)
+            run_context = model.create_context()
+            self.assertEqual(model._simulation_arguments["iter_num"], 10)
             self.assertEqual(run_context.get_iter(), 10)
 
     def test_custom_realizations(self):
@@ -95,22 +95,22 @@ class ModelFactoryTest(ErtTest):
         with ErtTestContext("test_single_test_run", config_file) as work_area:
             ert = work_area.getErt()
 
-            model, argument = model_factory._setup_single_test_run(ert)
+            model = model_factory._setup_single_test_run(ert)
             self.assertTrue(isinstance(model, SingleTestRun))
-            self.assertEqual(1, len(argument.keys()))
-            self.assertTrue("active_realizations" in argument)
-            model.create_context(argument)
+            self.assertEqual(1, len(model._simulation_arguments.keys()))
+            self.assertTrue("active_realizations" in model._simulation_arguments)
+            model.create_context()
 
     def test_setup_ensemble_experiment(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")
         with ErtTestContext("test_single_test_run", config_file) as work_area:
             ert = work_area.getErt()
 
-            model, argument = model_factory._setup_single_test_run(ert)
+            model = model_factory._setup_single_test_run(ert)
             self.assertTrue(isinstance(model, EnsembleExperiment))
-            self.assertEqual(1, len(argument.keys()))
-            self.assertTrue("active_realizations" in argument)
-            model.create_context(argument)
+            self.assertEqual(1, len(model._simulation_arguments.keys()))
+            self.assertTrue("active_realizations" in model._simulation_arguments)
+            model.create_context()
 
     def test_setup_ensemble_smoother(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")
@@ -119,7 +119,7 @@ class ModelFactoryTest(ErtTest):
             facade = LibresFacade(ert)
             args = Namespace(realizations="0-4,7,8", target_case="test_case")
 
-            model, argument = model_factory._setup_ensemble_smoother(
+            model = model_factory._setup_ensemble_smoother(
                 ert,
                 facade.get_analysis_module_names,
                 args,
@@ -127,11 +127,11 @@ class ModelFactoryTest(ErtTest):
                 facade.get_current_case_name(),
             )
             self.assertTrue(isinstance(model, EnsembleSmoother))
-            self.assertEqual(3, len(argument.keys()))
-            self.assertTrue("active_realizations" in argument)
-            self.assertTrue("target_case" in argument)
-            self.assertTrue("analysis_module" in argument)
-            model.create_context(argument)
+            self.assertEqual(3, len(model._simulation_arguments.keys()))
+            self.assertTrue("active_realizations" in model._simulation_arguments)
+            self.assertTrue("target_case" in model._simulation_arguments)
+            self.assertTrue("analysis_module" in model._simulation_arguments)
+            model.create_context()
 
     def test_setup_multiple_data_assimilation(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")
@@ -145,7 +145,7 @@ class ModelFactoryTest(ErtTest):
                 start_iteration="0",
             )
 
-            model, argument = model_factory._setup_multiple_data_assimilation(
+            model = model_factory._setup_multiple_data_assimilation(
                 ert,
                 facade.get_analysis_module_names,
                 args,
@@ -153,13 +153,13 @@ class ModelFactoryTest(ErtTest):
                 facade.get_current_case_name(),
             )
             self.assertTrue(isinstance(model, MultipleDataAssimilation))
-            self.assertEqual(5, len(argument.keys()))
-            self.assertTrue("active_realizations" in argument)
-            self.assertTrue("target_case" in argument)
-            self.assertTrue("analysis_module" in argument)
-            self.assertTrue("weights" in argument)
-            self.assertTrue("start_iteration" in argument)
-            model.create_context(argument, 0)
+            self.assertEqual(5, len(model._simulation_arguments.keys()))
+            self.assertTrue("active_realizations" in model._simulation_arguments)
+            self.assertTrue("target_case" in model._simulation_arguments)
+            self.assertTrue("analysis_module" in model._simulation_arguments)
+            self.assertTrue("weights" in model._simulation_arguments)
+            self.assertTrue("start_iteration" in model._simulation_arguments)
+            model.create_context(0)
 
     def test_setup_iterative_ensemble_smoother(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")
@@ -174,7 +174,7 @@ class ModelFactoryTest(ErtTest):
                 num_iterations="10",
             )
 
-            model, argument = model_factory._setup_iterative_ensemble_smoother(
+            model = model_factory._setup_iterative_ensemble_smoother(
                 ert,
                 facade.get_analysis_module_names,
                 args,
@@ -182,13 +182,13 @@ class ModelFactoryTest(ErtTest):
                 facade.get_current_case_name(),
             )
             self.assertTrue(isinstance(model, IteratedEnsembleSmoother))
-            self.assertEqual(4, len(argument.keys()))
-            self.assertTrue("active_realizations" in argument)
-            self.assertTrue("target_case" in argument)
-            self.assertTrue("analysis_module" in argument)
-            self.assertTrue("num_iterations" in argument)
+            self.assertEqual(4, len(model._simulation_arguments.keys()))
+            self.assertTrue("active_realizations" in model._simulation_arguments)
+            self.assertTrue("target_case" in model._simulation_arguments)
+            self.assertTrue("analysis_module" in model._simulation_arguments)
+            self.assertTrue("num_iterations" in model._simulation_arguments)
             self.assertTrue(facade.get_number_of_iterations() == 10)
-            model.create_context(argument, 0)
+            model.create_context(0)
 
     def test_analysis_module_name_iterable(self):
 

--- a/tests/ert_tests/cli/test_model_hook_order.py
+++ b/tests/ert_tests/cli/test_model_hook_order.py
@@ -26,17 +26,17 @@ def test_hook_call_order_ensemble_smoother(monkeypatch):
     across different models.
     """
     ert_mock = MagicMock()
-    test_class = EnsembleSmoother(ert_mock, MagicMock())
+    minimum_args = MagicMock()
+    test_class = EnsembleSmoother(minimum_args, ert_mock, MagicMock())
     test_class.create_context = MagicMock()
     test_class.run_ensemble_evaluator = MagicMock(return_value=1)
     mock_parent = MagicMock()
     mock_sim_runner = MagicMock()
     mock_parent.runWorkflows = mock_sim_runner
-    minimum_args = MagicMock()
     evaluator_server_config_mock = MagicMock()
     test_module = inspect.getmodule(test_class)
     monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
-    test_class.runSimulations(minimum_args, evaluator_server_config_mock)
+    test_class.runSimulations(evaluator_server_config_mock)
 
     expected_calls = [
         call(expected_call, ert=ert_mock) for expected_call in EXPECTED_CALL_ORDER
@@ -59,7 +59,7 @@ def test_hook_call_order_es_mda(monkeypatch):
         custom_port_range=range(1024, 65535)
     )
     ert_mock = MagicMock()
-    test_class = test_class(ert_mock, MagicMock())
+    test_class = test_class(minimum_args, ert_mock, MagicMock())
     mock_sim_runner = MagicMock()
     mock_parent = MagicMock()
     mock_parent.runWorkflows = mock_sim_runner
@@ -67,14 +67,14 @@ def test_hook_call_order_es_mda(monkeypatch):
     monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
 
     test_class.create_context = MagicMock()
-    test_class.checkMinimumActiveRealizations = MagicMock()
+    test_class._checkMinimumActiveRealizations = MagicMock()
     test_class.parseWeights = MagicMock(return_value=[1])
     test_class.setAnalysisModule = MagicMock()
     test_class.facade.get_number_of_iterations = MagicMock(return_value=-1)
 
     test_class.run_ensemble_evaluator = MagicMock(return_value=1)
 
-    test_class.runSimulations(minimum_args, evaluator_server_config)
+    test_class.runSimulations(evaluator_server_config)
 
     expected_calls = [
         call(expected_call, ert=ert_mock) for expected_call in EXPECTED_CALL_ORDER
@@ -97,14 +97,14 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
     monkeypatch.setattr(test_module, "EnkfSimulationRunner", mock_parent)
 
     test_class.create_context = MagicMock()
-    test_class.checkMinimumActiveRealizations = MagicMock()
+    test_class._checkMinimumActiveRealizations = MagicMock()
     test_class.parseWeights = MagicMock(return_value=[1])
     test_class.setAnalysisModule = MagicMock()
     ert_mock = MagicMock()
     ert_mock.return_value.analysisConfig.return_value.getAnalysisIterConfig.return_value.getNumRetries.return_value = (
         1
     )
-    test_class = test_class(MagicMock(), MagicMock())
+    test_class = test_class(MagicMock(), MagicMock(), MagicMock())
     monkeypatch.setattr(test_class, "ert", ert_mock)
     test_class.setAnalysisModule = MagicMock()
     test_class.setAnalysisModule.return_value.getInt.return_value = 1
@@ -112,7 +112,7 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
 
     test_class.setPhase = MagicMock()
     test_class.facade.get_number_of_iterations = MagicMock(return_value=1)
-    test_class.runSimulations(MagicMock(), MagicMock())
+    test_class.runSimulations(MagicMock())
 
     expected_calls = [
         call(expected_call, ert=ert_mock()) for expected_call in EXPECTED_CALL_ORDER

--- a/tests/ert_tests/gui/conftest.py
+++ b/tests/ert_tests/gui/conftest.py
@@ -127,20 +127,22 @@ def small_snapshot() -> Snapshot:
 
 
 @pytest.fixture
-def runmodel() -> Mock:
+def active_realizations() -> Mock:
+    active_reals = Mock()
+    active_reals.count = Mock(return_value=10)
+    return active_reals
+
+
+@pytest.fixture
+def runmodel(active_realizations) -> Mock:
     brm = Mock()
     brm.get_runtime = Mock(return_value=100)
     brm.hasRunFailed = Mock(return_value=False)
     brm.getFailMessage = Mock(return_value="")
     brm.support_restart = True
+    brm._simulation_arguments = {"active_realizations": active_realizations}
+    brm.has_failed_realizations = lambda: False
     return brm
-
-
-@pytest.fixture
-def active_realizations() -> Mock:
-    active_reals = Mock()
-    active_reals.count = Mock(return_value=10)
-    return active_reals
 
 
 class MockTracker:

--- a/tests/ert_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert_tests/gui/simulation/test_run_dialog.py
@@ -16,11 +16,8 @@ from ert_shared.status.entity.event import (
 from qtpy.QtCore import Qt
 
 
-def test_success(runmodel, active_realizations, qtbot, mock_tracker):
-    widget = RunDialog(
-        "poly.ert", runmodel, {"active_realizations": active_realizations}
-    )
-    widget.has_failed_realizations = lambda: False
+def test_success(runmodel, qtbot, mock_tracker):
+    widget = RunDialog("poly.ert", runmodel)
     widget.show()
     qtbot.addWidget(widget)
 
@@ -36,13 +33,8 @@ def test_success(runmodel, active_realizations, qtbot, mock_tracker):
     assert widget.done_button.text() == "Done"
 
 
-def test_large_snapshot(
-    runmodel, active_realizations, large_snapshot, qtbot, mock_tracker
-):
-    widget = RunDialog(
-        "poly.ert", runmodel, {"active_realizations": active_realizations}
-    )
-    widget.has_failed_realizations = lambda: False
+def test_large_snapshot(runmodel, large_snapshot, qtbot, mock_tracker):
+    widget = RunDialog("poly.ert", runmodel)
     widget.show()
     qtbot.addWidget(widget)
 
@@ -285,13 +277,8 @@ def test_large_snapshot(
         ),
     ],
 )
-def test_run_dialog(
-    events, tab_widget_count, runmodel, active_realizations, qtbot, mock_tracker
-):
-    widget = RunDialog(
-        "poly.ert", runmodel, {"active_realizations": active_realizations}
-    )
-    widget.has_failed_realizations = lambda: False
+def test_run_dialog(events, tab_widget_count, runmodel, qtbot, mock_tracker):
+    widget = RunDialog("poly.ert", runmodel)
     widget.show()
     qtbot.addWidget(widget)
 

--- a/tests/ert_tests/models/test_base_run_model.py
+++ b/tests/ert_tests/models/test_base_run_model.py
@@ -11,7 +11,7 @@ class BaseRunModelTest(ErtTest):
         config_file = self.createTestPath("local/simple_config/minimum_config")
         with ErtTestContext("kjell", config_file) as work_area:
             ert = work_area.getErt()
-            brm = BaseRunModel(ert, ert.get_queue_config())
+            brm = BaseRunModel(None, ert, ert.get_queue_config())
             assert brm.support_restart
 
 

--- a/tests/ert_tests/status/test_evaluator_tracker.py
+++ b/tests/ert_tests/status/test_evaluator_tracker.py
@@ -378,7 +378,7 @@ def test_tracking_progress(
     if issubclass(run_model, ERT3RunModel):
         brm = run_model()
     else:
-        brm = run_model(None, None)
+        brm = run_model(None, None, None)
     ee_config = EvaluatorServerConfig(
         custom_port_range=range(1024, 65535), custom_host="127.0.0.1"
     )

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -141,7 +141,7 @@ def test_tracking(
         ert = EnKFMain(res_config, strict=True, verbose=parsed.verbose)
         facade = LibresFacade(ert)
 
-        model, argument = create_model(
+        model = create_model(
             ert,
             facade.get_analysis_module_names,
             facade.get_ensemble_size(),
@@ -156,7 +156,7 @@ def test_tracking(
         thread = threading.Thread(
             name="ert_cli_simulation_thread",
             target=model.start_simulations_thread,
-            args=(argument, evaluator_server_config),
+            args=(evaluator_server_config,),
         )
         thread.start()
 


### PR DESCRIPTION
**Issue**
Resolves #3024 


**Approach**
- [x] Refactor `RunDialog` by migrating simulation running info into `BaseRunModel`
- [x] Move more processing logic into RunModel
~~- [ ] Make `EvaluatorTracker` as a proxy for `BaseRunModel`~~ this might be affected by #2132 so left it for now


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
