### PR TITLE
Automatically increase softlimit for max open files while running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import resource
 import pkg_resources
 import shutil
 from pathlib import Path
@@ -35,6 +36,19 @@ def env_save():
     ]
     set_xor = set(environment_pre).symmetric_difference(set(environment_post))
     assert len(set_xor) == 0, f"Detected differences in environment: {set_xor}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def maximize_ulimits():
+    """
+    Bumps the soft-limit for max number of files up to its max-value
+    since we know that the tests may open lots of files simultaneously.
+    Resets to original when session ends.
+    """
+    limits = resource.getrlimit(resource.RLIMIT_NOFILE)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (limits[1], limits[1]))
+    yield
+    resource.setrlimit(resource.RLIMIT_NOFILE, limits)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Far too often, the testsuite fails because default `ulimit -n` in the shell is too low. This patch uses an autouse-fixture and the Python resource-API to temporarily bump this value to max for the test-session.