### PR TITLE
Enhancing test to verify whether the actual jobs finished or not

### DIFF
--- a/tests/ert_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert_tests/ensemble_evaluator/conftest.py
@@ -95,6 +95,7 @@ def make_ensemble_builder(queue_config):
                         'if __name__ == "__main__":\n'
                         f'    print("stdout from {job_index}")\n'
                         f"    time.sleep({job_sleep})\n"
+                        f"    with open('status.txt', 'a'): pass\n"
                     )
                 mode = os.stat(ext_job_exec).st_mode
                 mode |= stat.S_IXUSR | stat.S_IXGRP

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +32,10 @@ def test_run_legacy_ensemble(tmpdir, make_ensemble_builder):
         assert evaluator._ensemble.get_status() == state.ENSEMBLE_STATE_STOPPED
         assert evaluator._ensemble.get_successful_realizations() == num_reals
 
+        # realisations should finish, each creating a status-file
+        for i in range(num_reals):
+            assert os.path.isfile(f"real_{i}/status.txt")
+
 
 @pytest.mark.timeout(60)
 def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
@@ -53,6 +58,10 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
 
         assert evaluator._ensemble.get_status() == state.ENSEMBLE_STATE_CANCELLED
 
+        # realisations should not finish, thus not creating a status-file
+        for i in range(num_reals):
+            assert not os.path.isfile(f"real_{i}/status.txt")
+
 
 @pytest.mark.timeout(60)
 def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
@@ -74,3 +83,7 @@ def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
                     ]:
                         monitor.signal_done()
             assert evaluator._ensemble.get_status() == state.ENSEMBLE_STATE_FAILED
+
+        # realisations should not finish, thus not creating a status-file
+        for i in range(num_reals):
+            assert not os.path.isfile(f"real_{i}/status.txt")


### PR DESCRIPTION
Let the "jobs" touch a file upon normal exit, use existence of this file as robust indication of whether jobs succeded or not.