### PR TITLE
Ensure JobQueue responds properly to CancelledError

### DIFF
--- a/ert_shared/ensemble_evaluator/ensemble/legacy.py
+++ b/ert_shared/ensemble_evaluator/ensemble/legacy.py
@@ -196,8 +196,6 @@ class _LegacyEnsemble(_Ensemble):
         asyncio.set_event_loop(asyncio.new_event_loop())
         logger.debug("cancelling, waiting for wakeup...")
         self._allow_cancel.wait()
-        logger.debug("got wakeup, killing all jobs...")
-        self._job_queue.kill_all_jobs()
         logger.debug("cancelling futures...")
         if self._aggregate_future.cancelled():
             logger.debug("aggregate future was already cancelled")

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -42,7 +42,7 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
     num_reals = 10
     custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():
-        ensemble = make_ensemble_builder(tmpdir, num_reals, 2, job_sleep=5).build()
+        ensemble = make_ensemble_builder(tmpdir, num_reals, 2, job_sleep=30).build()
         config = EvaluatorServerConfig(
             custom_port_range=custom_port_range, custom_host="127.0.0.1"
         )


### PR DESCRIPTION
**Issue**
Probably resolves #2844. See comments in issue for a description of the problem.

The `job_sleep` parameter in the test is increased to ensure no jobs finish before the test gets around to kill them.
