### PR TITLE
Remove sorting of variables

### DIFF
--- a/ert_gui/ertwidgets/analysismodulevariablespanel.py
+++ b/ert_gui/ertwidgets/analysismodulevariablespanel.py
@@ -52,8 +52,7 @@ class AnalysisModuleVariablesPanel(QWidget):
             analysis_module_variables_model = AnalysisModuleVariablesModel
             self.blockSignals(True)
 
-            variable_names2 = self.sortVariables(variable_names)
-            for variable_name in variable_names2:
+            for variable_name in variable_names:
                 variable_type = analysis_module_variables_model.getVariableType(
                     variable_name
                 )
@@ -131,36 +130,6 @@ class AnalysisModuleVariablesPanel(QWidget):
 
         self.setLayout(layout)
         self.blockSignals(False)
-
-    def sortVariables(self, variable_list):
-        analysis_module_variables_model = AnalysisModuleVariablesModel
-        sorted_list = [
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-            "#",
-        ]
-        result = []
-        for name in variable_list:
-            pos = analysis_module_variables_model.getVariablePosition(name)
-            sorted_list.insert(pos, name)
-            sorted_list.__delitem__(pos + 1)
-
-        for item in sorted_list:
-            if item != "#":
-                result.append(item)
-
-        return result
 
     def createSpinBox(
         self,

--- a/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
+++ b/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
@@ -26,7 +26,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 1.00,
             "step": 0.1,
             "labelname": "Gauss Newton Maximum Steplength",
-            "pos": 0,
         },
         "IES_MIN_STEPLENGTH": {
             "type": float,
@@ -34,7 +33,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 1.00,
             "step": 0.1,
             "labelname": "Gauss Newton Minimum Steplength",
-            "pos": 1,
         },
         "IES_DEC_STEPLENGTH": {
             "type": float,
@@ -42,7 +40,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 10.00,
             "step": 0.1,
             "labelname": "Gauss Newton Steplength Decline",
-            "pos": 2,
         },
         "IES_INVERSION": {
             "type": int,
@@ -50,7 +47,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 3,
             "step": 1,
             "labelname": "Inversion algorithm",
-            "pos": 3,
         },
         "IES_DEBUG": {
             "type": bool,
@@ -61,7 +57,6 @@ class AnalysisModuleVariablesModel(object):
         "IES_AAPROJECTION": {
             "type": bool,
             "labelname": "Include AA projection",
-            "pos": 11,
         },
         "ENKF_TRUNCATION": {
             "type": float,
@@ -69,7 +64,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 1,
             "step": 0.01,
             "labelname": "Singular value truncation",
-            "pos": 9,
         },
         "ENKF_SUBSPACE_DIMENSION": {
             "type": int,
@@ -77,7 +71,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 2147483647,
             "step": 1,
             "labelname": "Number of singular values",
-            "pos": 10,
         },
         "ENKF_NCOMP": {
             "type": int,
@@ -85,7 +78,6 @@ class AnalysisModuleVariablesModel(object):
             "max": 2147483647,
             "step": 1,
             "labelname": "Number of singular values",
-            "pos": 10,
         },
     }
 
@@ -119,10 +111,6 @@ class AnalysisModuleVariablesModel(object):
     @classmethod
     def getVariableLabelName(cls, name):
         return cls._VARIABLE_NAMES[name]["labelname"]
-
-    @classmethod
-    def getVariablePosition(cls, name):
-        return cls._VARIABLE_NAMES[name]["pos"]
 
     @classmethod
     def setVariableValue(


### PR DESCRIPTION
There was no clear reason for sorting the variables, and the implementation was
very error prone, for example there were two variables with position 10, meaning
that one of them was filtered out.


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
