### PR TITLE
Handle error publish changes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ cmake-format
 decorator
 flake8>=4.0.0
 jsonpath_ng
+mock; python_version <= '3.7' # missing AsyncMock added in py38
 pylint
 pytest-asyncio
 pytest-cov

--- a/res/job_queue/queue.py
+++ b/res/job_queue/queue.py
@@ -24,6 +24,7 @@ import logging
 import ssl
 import time
 import typing
+from collections import deque
 
 import websockets
 from cloudevents.http import CloudEvent, to_json
@@ -35,6 +36,7 @@ from res.job_queue.job_status_type_enum import JobStatusType
 from res.job_queue.queue_differ import QueueDiffer
 from res.job_queue.thread_status_type_enum import ThreadStatus
 from websockets.datastructures import Headers
+from websockets.exceptions import ConnectionClosedError
 
 logger = logging.getLogger(__name__)
 
@@ -418,13 +420,44 @@ class JobQueue(BaseCClass):
         )
 
     @staticmethod
-    async def _publish_changes(ee_id, changes, websocket):
-        events = [
-            JobQueue._translate_change_to_cloudevent(ee_id, real_id, status)
-            for real_id, status in changes.items()
-        ]
-        for event in events:
-            await websocket.send(to_json(event))
+    async def _publish_changes(ee_id, changes, ws_uri, ssl_context, headers):
+        events = deque(
+            [
+                JobQueue._translate_change_to_cloudevent(ee_id, real_id, status)
+                for real_id, status in changes.items()
+            ]
+        )
+        retries = 0
+        while True:
+            try:
+                async with websockets.connect(
+                    ws_uri, ssl=ssl_context, extra_headers=headers
+                ) as websocket:
+                    while events:
+                        await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
+                        events.popleft()
+                    return
+            except (ConnectionClosedError, asyncio.TimeoutError) as e:
+                if retries >= 10:
+                    logger.exception(
+                        "Connection to websocket %s failed, "
+                        + "unable to publish changes",
+                        ws_uri,
+                    )
+                    raise
+
+                # websockets for python > 3.6 comes with builtin backoff, implement a
+                # crude one here
+                retries += 1
+                backoff = max(3, min(60, 2**retries))
+                logger.info(
+                    "Connection to websocket %s was closed, retry in %d seconds.",
+                    ws_uri,
+                    backoff,
+                    exc_info=e,
+                )
+
+                await asyncio.sleep(backoff)
 
     async def execute_queue_async(
         self, ws_uri, ee_id, pool_sema, evaluators, cert=None, token=None
@@ -437,41 +470,41 @@ class JobQueue(BaseCClass):
         headers = Headers()
         if token is not None:
             headers["token"] = token
-        async with websockets.connect(
-            ws_uri, ssl=ssl_context, extra_headers=headers
-        ) as websocket:
-            await JobQueue._publish_changes(ee_id, self._differ.snapshot(), websocket)
+        await JobQueue._publish_changes(
+            ee_id, self._differ.snapshot(), ws_uri, ssl_context, headers
+        )
+        try:
+            while True:
+                self.launch_jobs(pool_sema)
 
-            try:
-                while True:
-                    self.launch_jobs(pool_sema)
+                await asyncio.sleep(1)
 
-                    await asyncio.sleep(1)
+                if evaluators is not None:
+                    for func in evaluators:
+                        func()
 
-                    if evaluators is not None:
-                        for func in evaluators:
-                            func()
+                await JobQueue._publish_changes(
+                    ee_id, self.changes_after_transition(), ws_uri, ssl_context, headers
+                )
+                if not self.is_active() or self.stopped:
+                    break
+        except asyncio.CancelledError:
+            self.kill_all_jobs()  # make available_capacity() return false
+            logger.debug("queue cancelled, stopping jobs...")
+            await self.stop_jobs_async()
+            logger.debug("jobs stopped, re-raising CancelledError")
+            raise
 
-                    await JobQueue._publish_changes(
-                        ee_id, self.changes_after_transition(), websocket
-                    )
-                    if not self.is_active() or self.stopped:
-                        break
-            except asyncio.CancelledError:
-                self.kill_all_jobs()  # make available_capacity() return false
-                logger.debug("queue cancelled, stopping jobs...")
-                await self.stop_jobs_async()
-                logger.debug("jobs stopped, re-raising CancelledError")
-                raise
+        if self.stopped:
+            logger.debug("observed that the queue had stopped, stopping jobs...")
+            await self.stop_jobs_async()
+            logger.debug("jobs now stopped")
 
-            if self.stopped:
-                logger.debug("observed that the queue had stopped, stopping jobs...")
-                await self.stop_jobs_async()
-                logger.debug("jobs now stopped")
-
-            self.assert_complete()
-            self._differ.transition(self.job_list)
-            await JobQueue._publish_changes(ee_id, self._differ.snapshot(), websocket)
+        self.assert_complete()
+        self._differ.transition(self.job_list)
+        await JobQueue._publish_changes(
+            ee_id, self._differ.snapshot(), ws_uri, ssl_context, headers
+        )
 
     def add_job_from_run_arg(self, run_arg, res_config, max_runtime, ok_cb, exit_cb):
         job_name = run_arg.job_name

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -18,7 +18,7 @@ def dummy_exit_callback(args):
     print(args)
 
 
-dummy_config = {
+DUMMY_CONFIG = {
     "job_script": "job_script.py",
     "num_cpu": 1,
     "job_name": "dummy_job_{}",
@@ -27,17 +27,17 @@ dummy_config = {
     "exit_callback": dummy_exit_callback,
 }
 
-simple_script = """#!/usr/bin/env python
+SIMPLE_SCRIPT = """#!/usr/bin/env python
 print('hello')
 """
 
-never_ending_script = """#!/usr/bin/env python
+NEVER_ENDING_SCRIPT = """#!/usr/bin/env python
 import time
 while True:
     time.sleep(0.5)
 """
 
-failing_script = """#!/usr/bin/env python
+FAILING_SCRIPT = """#!/usr/bin/env python
 import sys
 sys.exit(1)
 """
@@ -46,21 +46,21 @@ sys.exit(1)
 def create_queue(script, max_submit=1, max_runtime=None, callback_timeout=None):
     driver = Driver(driver_type=QueueDriverEnum.LOCAL_DRIVER, max_running=5)
     job_queue = JobQueue(driver, max_submit=max_submit)
-    with open(dummy_config["job_script"], "w") as f:
+    with open(DUMMY_CONFIG["job_script"], "w") as f:
         f.write(script)
-    os.chmod(dummy_config["job_script"], stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
+    os.chmod(DUMMY_CONFIG["job_script"], stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
     for i in range(10):
-        os.mkdir(dummy_config["run_path"].format(i))
+        os.mkdir(DUMMY_CONFIG["run_path"].format(i))
         job = JobQueueNode(
-            job_script=dummy_config["job_script"],
-            job_name=dummy_config["job_name"].format(i),
-            run_path=dummy_config["run_path"].format(i),
-            num_cpu=dummy_config["num_cpu"],
+            job_script=DUMMY_CONFIG["job_script"],
+            job_name=DUMMY_CONFIG["job_name"].format(i),
+            run_path=DUMMY_CONFIG["run_path"].format(i),
+            num_cpu=DUMMY_CONFIG["num_cpu"],
             status_file=job_queue.status_file,
             ok_file=job_queue.ok_file,
             exit_file=job_queue.exit_file,
-            done_callback_function=dummy_config["ok_callback"],
-            exit_callback_function=dummy_config["exit_callback"],
+            done_callback_function=DUMMY_CONFIG["ok_callback"],
+            exit_callback_function=DUMMY_CONFIG["exit_callback"],
             callback_arguments=[{"job_number": i}],
             max_runtime=max_runtime,
             callback_timeout=callback_timeout,
@@ -85,7 +85,7 @@ class JobQueueTest(ResTest):
 
     def test_kill_jobs(self):
         with TestAreaContext("job_queue_test_kill") as work_area:
-            job_queue = create_queue(never_ending_script)
+            job_queue = create_queue(NEVER_ENDING_SCRIPT)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -115,7 +115,7 @@ class JobQueueTest(ResTest):
 
     def test_add_jobs(self):
         with TestAreaContext("job_queue_test_add") as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -134,7 +134,7 @@ class JobQueueTest(ResTest):
 
     def test_failing_jobs(self):
         with TestAreaContext("job_queue_test_add") as work_area:
-            job_queue = create_queue(failing_script, max_submit=1)
+            job_queue = create_queue(FAILING_SCRIPT, max_submit=1)
 
             assert job_queue.queue_size == 10
             assert job_queue.is_active()
@@ -167,7 +167,7 @@ class JobQueueTest(ResTest):
                 job_numbers.add(arg[0]["job_number"])
 
             job_queue = create_queue(
-                never_ending_script,
+                NEVER_ENDING_SCRIPT,
                 max_submit=1,
                 max_runtime=5,
                 callback_timeout=callback,
@@ -200,14 +200,14 @@ class JobQueueTest(ResTest):
 
     def test_add_ensemble_evaluator_info(self):
         with TestAreaContext("job_queue_add_ensemble_evaluator_info") as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"
             cert = "My very nice cert"
             token = "my_super_secret_token"
             cert_file = ".ee.pem"
             runpaths = [
-                pathlib.Path(dummy_config["run_path"].format(i)) for i in range(10)
+                pathlib.Path(DUMMY_CONFIG["run_path"].format(i)) for i in range(10)
             ]
             for runpath in runpaths:
                 with open(runpath / "jobs.json", "w") as f:
@@ -235,14 +235,14 @@ class JobQueueTest(ResTest):
         with TestAreaContext(
             "job_queue_add_ensemble_evaluator_info_cert_none"
         ) as work_area:
-            job_queue = create_queue(simple_script)
+            job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"
             cert = None
             token = None
             cert_file = ".ee.pem"
             runpaths = [
-                pathlib.Path(dummy_config["run_path"].format(i)) for i in range(10)
+                pathlib.Path(DUMMY_CONFIG["run_path"].format(i)) for i in range(10)
             ]
             for runpath in runpaths:
                 with open(runpath / "jobs.json", "w") as f:


### PR DESCRIPTION
**Issue**
Resolves #2781
Resolves #3113

**Approach**

Use the suggested approach from websockets to handle connection closing and automatically reopen:

> If an error occurs while establishing the connection, [connect()](https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.connect) retries with exponential backoff. The backoff delay starts at three seconds and increases up to one minute.

https://websockets.readthedocs.io/en/stable/reference/client.html#opening-a-connection

The current number of retries is simply a suggestion, we could very well add more. Note that adding too many will result in blocking start (and cancel?) jobs. 

Supersedes https://github.com/equinor/ert/pull/2907