### PR TITLE
Add additional information on failure in test_http_response

### DIFF
--- a/tests/ert_tests/dark_storage/conftest.py
+++ b/tests/ert_tests/dark_storage/conftest.py
@@ -26,15 +26,16 @@ def poly_example_tmp_dir_shared(
         os.path.join(source_root, "test-data", "local", "poly_example"),
         poly_dir,
     )
-
     with poly_dir.as_cwd():
         parser = ArgumentParser(prog="test_main")
         parsed = ert_parser(
             parser,
             [
                 ENSEMBLE_SMOOTHER_MODE,
+                "--current-case",
+                "alpha",
                 "--target-case",
-                "poly_runpath_file",
+                "beta",
                 "--realizations",
                 "1,2,4",
                 "poly.ert",

--- a/tests/ert_tests/dark_storage/test_graphql_queries.py
+++ b/tests/ert_tests/dark_storage/test_graphql_queries.py
@@ -26,7 +26,7 @@ def test_get_experiment(poly_example_tmp_dir, dark_storage_client):
     assert "COEFF_C" == priors["COEFFS"][2]["key"]
 
 
-def test_get_enesembles(poly_example_tmp_dir, dark_storage_client):
+def test_get_ensembles(poly_example_tmp_dir, dark_storage_client):
 
     resp: Response = dark_storage_client.post(
         "/gql", json={"query": "{experiments{ensembles{userdata}}}"}
@@ -36,21 +36,21 @@ def test_get_enesembles(poly_example_tmp_dir, dark_storage_client):
     assert len(answer_json["data"]["experiments"]) == 1
 
     assert "ensembles" in answer_json["data"]["experiments"][0]
-    assert len(answer_json["data"]["experiments"][0]["ensembles"]) == 2
+    assert len(answer_json["data"]["experiments"][0]["ensembles"]) == 3
 
     assert "userdata" in answer_json["data"]["experiments"][0]["ensembles"][0]
     userdata = json.loads(
         answer_json["data"]["experiments"][0]["ensembles"][0]["userdata"]
     )
     assert "name" in userdata
-    assert userdata["name"] == "default"
+    assert userdata["name"] == "alpha"
 
     assert "userdata" in answer_json["data"]["experiments"][0]["ensembles"][1]
     userdata = json.loads(
         answer_json["data"]["experiments"][0]["ensembles"][1]["userdata"]
     )
     assert "name" in userdata
-    assert userdata["name"] == "poly_runpath_file"
+    assert userdata["name"] == "beta"
 
 
 def test_get_response_names(poly_example_tmp_dir, dark_storage_client):


### PR DESCRIPTION
The result in https://github.com/equinor/ert/issues/2824 is difficult to reproduce.

A hypothesis for the failures is that there could be remnants of previously ran tests in memory which interferes with this test. This PR changes variable names to non-default values and adds some additional output on failures. Also disproving our hypothesis would be helpful.
