### PR TITLE
Add event viewer tool to gui

### DIFF
--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -30,6 +30,8 @@ from ert_gui.main_window import GertMainWindow
 from ert_gui.simulation.simulation_panel import SimulationPanel
 from ert_gui.tools.export import ExportTool
 from ert_gui.tools.load_results import LoadResultsTool
+from ert_gui.tools.event_viewer import EventViewerTool
+from ert_gui.tools.event_viewer import GUILogHandler
 from ert_gui.tools.manage_cases import ManageCasesTool
 from ert_gui.tools.plot import PlotTool
 from ert_gui.tools.plugins import PluginHandler, PluginsTool
@@ -126,6 +128,8 @@ def _setup_main_window(ert: EnKFMain, notifier: ErtNotifier, args: argparse.Name
     config_file = args.config
     window = GertMainWindow(config_file)
     window.setWidget(SimulationPanel(ert, notifier, config_file))
+    gui_log_handler = GUILogHandler()
+    logging.getLogger().addHandler(gui_log_handler)
     plugin_handler = PluginHandler(ert, ert.getWorkflowList().getPluginJobs(), window)
 
     window.addDock(
@@ -138,5 +142,6 @@ def _setup_main_window(ert: EnKFMain, notifier: ErtNotifier, args: argparse.Name
     window.addTool(PluginsTool(plugin_handler, notifier))
     window.addTool(RunAnalysisTool(ert, notifier))
     window.addTool(LoadResultsTool(facade))
+    window.addTool(EventViewerTool(gui_log_handler))
     window.adjustSize()
     return window

--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -112,7 +112,7 @@ def _check_locale():
 ** WARNING: You are using a locale with decimalpoint: '{}' - the ert application is
             written with the assumption that '.' is used as decimalpoint, and chances
             are that something will break if you continue with this locale. It is highly
-            reccomended that you set the decimalpoint to '.' using one of the environment
+            recommended that you set the decimalpoint to '.' using one of the environment
             variables 'LANG', LC_ALL', or 'LC_NUMERIC' to either the 'C' locale or
             alternatively a locale which uses '.' as decimalpoint.\n""".format(
             decimal_point

--- a/ert_gui/tools/event_viewer/__init__.py
+++ b/ert_gui/tools/event_viewer/__init__.py
@@ -1,0 +1,3 @@
+from .panel import EventViewerPanel
+from .panel import GUILogHandler
+from .tool import EventViewerTool

--- a/ert_gui/tools/event_viewer/panel.py
+++ b/ert_gui/tools/event_viewer/panel.py
@@ -1,0 +1,50 @@
+from qtpy.QtWidgets import QVBoxLayout, QPlainTextEdit
+
+from qtpy import QtCore
+import logging
+
+
+class GUILogHandler(logging.Handler, QtCore.QObject):
+    """
+    Log handler which will emit a qt signal every time a
+    log is emitted
+    """
+
+    append_log_statement = QtCore.Signal(str)
+
+    def __init__(self):
+        super().__init__()
+        self.setFormatter(logging.Formatter("%(levelname)-8s %(message)s"))
+        self.setLevel(logging.INFO)
+
+        QtCore.QObject.__init__(self)
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.append_log_statement.emit(msg)
+
+
+class EventViewerPanel(QPlainTextEdit):
+    def __init__(self, log_handler: GUILogHandler):
+        self.log_handler = log_handler
+        QPlainTextEdit.__init__(self)
+
+        self.setMinimumWidth(500)
+        self.setMinimumHeight(200)
+        self._dynamic = False
+
+        self.setWindowTitle("Event viewer")
+        self.activateWindow()
+
+        layout = QVBoxLayout()
+        self.text_box = QPlainTextEdit()
+        self.text_box.setReadOnly(True)
+        self.text_box.setMaximumBlockCount(1000)
+        layout.addWidget(self.text_box)
+
+        self.setLayout(layout)
+        log_handler.append_log_statement.connect(self.val_changed)
+
+    @QtCore.Slot(str)
+    def val_changed(self, value):
+        self.text_box.appendPlainText(value)

--- a/ert_gui/tools/event_viewer/tool.py
+++ b/ert_gui/tools/event_viewer/tool.py
@@ -1,0 +1,18 @@
+from ert_gui.ertwidgets import resourceIcon
+from ert_gui.tools import Tool
+from ert_gui.tools.event_viewer import EventViewerPanel
+
+
+class EventViewerTool(Tool):
+    def __init__(self, gui_handler):
+        super().__init__(
+            "Event viewer",
+            "tools/event_viewer",
+            resourceIcon("notifications.svg"),
+        )
+        self.log_handler = gui_handler
+        self.logging_window = EventViewerPanel(self.log_handler)
+        self.setEnabled(True)
+
+    def trigger(self):
+        self.logging_window.show()

--- a/tests/ert_tests/gui/logging/test_logging_tool.py
+++ b/tests/ert_tests/gui/logging/test_logging_tool.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+
+from ert_gui.tools.event_viewer import GUILogHandler, EventViewerPanel
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "log_func, expected",
+    [
+        (logger.debug, ""),
+        (logger.info, "INFO     Writing some text"),
+        (logger.warning, "WARNING  Writing some text"),
+        (logger.error, "ERROR    Writing some text"),
+    ],
+)
+def test_logging_widget(qtbot, caplog, log_func, expected):
+    logging_handle = GUILogHandler()
+    logger.addHandler(logging_handle)
+
+    widget = EventViewerPanel(logging_handle)
+    widget.show()
+    qtbot.addWidget(widget)
+
+    qtbot.waitForWindowShown(widget)
+    with caplog.at_level(logging.DEBUG):
+        log_func("Writing some text")
+    assert widget.text_box.toPlainText() == expected


### PR DESCRIPTION
**Issue**
Partially adresses #608


**Approach**
Adds a logging tab in the gui, which will show the logs. Currently limited to the 1k last entries, but can be increased.

Edit:
Example of how this looks:
![Skjermbilde 2022-03-25 kl  11 09 48](https://user-images.githubusercontent.com/44577479/160100928-9ffd9298-7993-451f-9644-6e11c74e57ee.png)

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
