### PR TITLE
Auto-generate documentation for ert3 plugins

### DIFF
--- a/docs/rst/manual/_ext/ert3_plugin_configs.py
+++ b/docs/rst/manual/_ext/ert3_plugin_configs.py
@@ -1,0 +1,125 @@
+import logging
+import sys
+import inspect
+from docutils import nodes, statemachine
+from docutils.parsers.rst import Directive
+from os.path import basename
+from sphinx.application import Sphinx
+
+
+import ert3
+
+HEADER_TMPL = """{name_capitalized}s
+{title_line}-
+
+The default type for this category is: **{default_value}**
+
+The following shows the available {name} configurations:
+
+"""
+
+TMPL = """.. autoclass:: {path}::{config_cls}
+    :members:
+    :undoc-members:
+    :inherited-members: {base_cls}
+
+"""
+
+
+def _load_all_plugins_for_category(category: str):
+    plugin_registry = ert3.config.ConfigPluginRegistry()
+    plugin_registry.register_category(
+        category=category,
+        base_config=ert3.config.plugins.TransformationConfigBase,
+        optional=True,
+    )
+    plugin_manager = ert3.plugins.ErtPluginManager()
+    plugin_manager.collect(registry=plugin_registry)
+    return plugin_registry
+
+
+class ERT3Plugins(Directive):
+    """Load all plugin for the given category (required argument)
+    and render configs for all of them, as well as  the default config for
+    each category.
+    """
+
+    has_content = False
+    required_arguments = 1
+
+    def run(self):
+        category = self.arguments[0]
+        tab_width = self.options.get(
+            "tab-width", self.state.document.settings.tab_width
+        )
+
+        try:
+            plugin_registry = _load_all_plugins_for_category(category)
+            config_base_class = plugin_registry.get_base_config(category=category)
+            category_default = plugin_registry.get_default_for_category(
+                category=category
+            )
+
+            # Find parent of config base class, as we want to document all inherited members
+            # from all base classes up to this class (but NOT including).
+            base_cls = (
+                ""
+                if len(config_base_class.__bases__) == 0
+                else config_base_class.__bases__[0].__name__
+            )
+
+            lines = self._insert_category_header(tab_width, category, category_default)
+            for config_cls in plugin_registry.get_original_configs(category).values():
+                lines.extend(self._insert_configs(tab_width, base_cls, config_cls))
+
+            source = self.state_machine.input_lines.source(
+                self.lineno - self.state_machine.input_offset - 1
+            )
+            self.state_machine.insert_input(lines, source)
+            return []
+        except Exception:
+            logging.exception(
+                f"Failed to produce plugin documentation for category {category} on {basename(source)}:{self.lineno}:"
+            )
+            return [
+                nodes.error(
+                    None,
+                    nodes.paragraph(
+                        text=f"Failed to produce plugin documentation for category {category} on {basename(source)}:{self.lineno}:"
+                    ),
+                    nodes.paragraph(text=str(sys.exc_info()[1])),
+                )
+            ]
+
+    def _insert_configs(self, tab_width, base_cls, config_cls):
+        return statemachine.string2lines(
+            TMPL.format(
+                path=inspect.getmodule(config_cls).__name__,
+                config_cls=config_cls.__name__,
+                base_cls=base_cls,
+            ),
+            tab_width,
+            convert_whitespace=True,
+        )
+
+    def _insert_category_header(self, tab_width, category, default_value):
+        return statemachine.string2lines(
+            HEADER_TMPL.format(
+                name_capitalized=category.capitalize(),
+                title_line="-" * len(category),
+                default_value=default_value,
+                name=category,
+            ),
+            tab_width,
+            convert_whitespace=True,
+        )
+
+
+def setup(app: Sphinx):
+    app.add_directive("ert3_plugins", ERT3Plugins)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/rst/manual/_ext/ert3_plugin_references.py
+++ b/docs/rst/manual/_ext/ert3_plugin_references.py
@@ -1,0 +1,52 @@
+import ert3
+
+
+_modified_classes = {("ert3.config", "StageIO"): ["transformation"]}
+_all_affected_modules = ["ert3.config"]
+
+
+def process_docstring_callback(app, what, name, obj, options, lines):
+    # This sphinx directive will inject plugin information to all class
+    # Specified in _modified_classes. Since the referenced configs are created
+    # dynamically, they cannot be referenced. Hence, the type info is removed,
+    # and we rather show a reference to 'Plugin configuration reference'
+    # where we have generated documentation for each plugin category.
+
+    if what != "module" and name not in _all_affected_modules:
+        return
+
+    for (module, modified_cls), categories in _modified_classes.items():
+        plugin_registry = ert3.config.ConfigPluginRegistry()
+        for category in categories:
+            plugin_registry.register_category(
+                category=category,
+                base_config=ert3.config.plugins.TransformationConfigBase,
+                optional=True,
+            )
+        plugin_manager = ert3.plugins.ErtPluginManager()
+        plugin_manager.collect(registry=plugin_registry)
+
+        if name != module:
+            continue
+
+        base_cls = getattr(obj, modified_cls)
+        cls_transformed = ert3.config.create_plugged_model(
+            model_name=modified_cls,
+            categories=categories,
+            plugin_registry=plugin_registry,
+            model_base=base_cls,
+            model_module=obj.__name__,
+            docs=True,
+        )
+        for category in categories:
+            setattr(
+                cls_transformed,
+                category,
+                f"See section '{category}' under 'Plugin configuration reference' for all valid configs",
+            )
+
+        setattr(obj, modified_cls, cls_transformed)
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", process_docstring_callback)

--- a/docs/rst/manual/_ext/ert3_plugin_references.py
+++ b/docs/rst/manual/_ext/ert3_plugin_references.py
@@ -1,7 +1,10 @@
 import ert3
 
 
-_modified_classes = {("ert3.config", "StageIO"): ["transformation"]}
+_modified_classes = {
+    ("ert3.config", "StageIO"): ["transformation"],
+    ("ert3.config", "EnsembleInput"): ["transformation"],
+}
 _all_affected_modules = ["ert3.config"]
 
 

--- a/docs/rst/manual/api_reference/config.rst
+++ b/docs/rst/manual/api_reference/config.rst
@@ -9,10 +9,10 @@ Configuration reference
     :members:
     :undoc-members:
 
-.. autoclass:: ert3.config._ensemble_config::Input
+.. autoclass:: ert3.config._ensemble_config::EnsembleInput
     :members:
     :undoc-members:
 
-.. autoclass:: ert3.config._ensemble_config::Output
+.. autoclass:: ert3.config._ensemble_config::EnsembleOutput
     :members:
     :undoc-members:

--- a/docs/rst/manual/api_reference/config_plugins.rst
+++ b/docs/rst/manual/api_reference/config_plugins.rst
@@ -1,0 +1,5 @@
+Plugin configuration reference
+==============================
+
+.. ert3_plugins:: transformation
+

--- a/docs/rst/manual/api_reference/index.rst
+++ b/docs/rst/manual/api_reference/index.rst
@@ -4,5 +4,6 @@
 
   exceptions
   config
+  config_plugins
   workspace
   data

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -54,6 +54,8 @@ extensions = [
     "sphinxcontrib.datatemplates",
     "ert_jobs",
     "ert_narratives",
+    "ert3_plugin_configs",
+    "ert3_plugin_references",
 ]
 
 # Autodoc settings:

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -4,6 +4,7 @@ from ._ensemble_config import (
     EnsembleConfig,
     create_ensemble_config,
     SourceNS,
+    EnsembleInput,
 )
 from ._stages_config import (
     load_stages_config,
@@ -44,4 +45,5 @@ __all__ = [
     "create_stages_config",
     "create_plugged_model",
     "StageIO",
+    "EnsembleInput",
 ]

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -1,4 +1,4 @@
-from ._config_plugin_registry import ConfigPluginRegistry
+from ._config_plugin_registry import ConfigPluginRegistry, create_plugged_model
 from ._ensemble_config import (
     load_ensemble_config,
     EnsembleConfig,
@@ -14,7 +14,6 @@ from ._stages_config import (
     TransportableCommand,
     Step,
     create_stages_config,
-    create_plugged_model,
     StageIO,
 )
 from ._validator import DEFAULT_RECORD_MIME_TYPE

--- a/ert3/config/__init__.py
+++ b/ert3/config/__init__.py
@@ -14,6 +14,8 @@ from ._stages_config import (
     TransportableCommand,
     Step,
     create_stages_config,
+    create_plugged_model,
+    StageIO,
 )
 from ._validator import DEFAULT_RECORD_MIME_TYPE
 from ._experiment_config import load_experiment_config, ExperimentConfig
@@ -41,4 +43,6 @@ __all__ = [
     "ExperimentRunConfig",
     "ConfigPluginRegistry",
     "create_stages_config",
+    "create_plugged_model",
+    "StageIO",
 ]

--- a/ert3/config/_config_plugin_registry.py
+++ b/ert3/config/_config_plugin_registry.py
@@ -131,7 +131,7 @@ class ConfigPluginRegistry:
         """Return the discriminator for this category."""
         return self._descriminator[category]
 
-    def get_base_config(self, category: str) -> str:
+    def get_base_config(self, category: str) -> Type[BaseModel]:
         """Return the base config class for this category."""
         return self._base_configs[category]
 

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -102,8 +102,8 @@ class EnsembleInput(_EnsembleConfig):
 
     @no_type_check
     def __init__(self, **data: Any) -> None:
-        # isinstance is too lenient for this case, needs to specifically check
-        # for type EnsembleInput, specifically not subclasses. So C0123 must be disabled.
+        # isinstance is too lenient for this case, needs to specifically check for
+        # type EnsembleInput, specifically not subclasses. So C0123 must be disabled.
         # If this instance is an EnsembleInput, it means no plugins which is no deal.
         if type(self) is EnsembleInput:  # pylint: disable=C0123
             raise RuntimeError(

--- a/ert3/config/_ensemble_config.py
+++ b/ert3/config/_ensemble_config.py
@@ -84,7 +84,17 @@ def _validate_transformation(
     return _validator
 
 
-class Input(_EnsembleConfig):
+class EnsembleInput(_EnsembleConfig):
+    """:class:`EnsembleInput` defines inputs over the ensemble. Use it in conjunction
+    with :class:`ert3.config.SourceNS` to load resources or sample parameters.
+
+    :class:`EnsembleInput` is the basis for :class:`ert3.config.EnsembleInput` which
+    is the plugged-in version of it. Using this model directly will raise a
+    :class:`RuntimeError`. Instantiate instead this model using either
+    :py:func:`ert3.config.load_ensemble_config` or
+    :py:func:`ert3.config.create_ensemble_config`.
+    """
+
     _namespace: SourceNS
     _location: str
     record: str
@@ -93,9 +103,9 @@ class Input(_EnsembleConfig):
     @no_type_check
     def __init__(self, **data: Any) -> None:
         # isinstance is too lenient for this case, needs to specifically check
-        # for type Input, specifically not subclasses. So C0123 must be disabled.
-        # If this instance is an Input, it means no plugins which is no deal.
-        if type(self) is Input:  # pylint: disable=C0123
+        # for type EnsembleInput, specifically not subclasses. So C0123 must be disabled.
+        # If this instance is an EnsembleInput, it means no plugins which is no deal.
+        if type(self) is EnsembleInput:  # pylint: disable=C0123
             raise RuntimeError(
                 "this configuration must be obtained from 'create_ensemble_config'."
             )
@@ -119,14 +129,14 @@ class Input(_EnsembleConfig):
         return ert.data.TransformationDirection.TO_RECORD
 
 
-class Output(_EnsembleConfig):
+class EnsembleOutput(_EnsembleConfig):
     record: str
 
 
 class EnsembleConfig(_EnsembleConfig):
     forward_model: ForwardModel
-    input: Tuple[Input, ...]
-    output: Tuple[Output, ...]
+    input: Tuple[EnsembleInput, ...]
+    output: Tuple[EnsembleOutput, ...]
     size: Optional[int] = None
     storage_type: str = "ert_storage"
 
@@ -140,10 +150,10 @@ def create_ensemble_config(
     default_discriminator = plugin_registry.get_default_for_category("transformation")
 
     input_config = create_plugged_model(
-        model_name="PluggedInput",
+        model_name="PluggedEnsembleInput",
         categories=["transformation"],
         plugin_registry=plugin_registry,
-        model_base=Input,
+        model_base=EnsembleInput,
         model_module=__name__,
         validators={
             "validate_transformation": root_validator(pre=True, allow_reuse=True)(

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -450,7 +450,11 @@ def _main() -> None:
     workspace = Workspace(pathlib.Path.cwd())
 
     plugin_registry = ert3.config.ConfigPluginRegistry()
-    plugin_registry.register_category(category="transformation", optional=True)
+    plugin_registry.register_category(
+        category="transformation",
+        optional=True,
+        base_config=ert3.config.plugins.TransformationConfigBase,
+    )
     plugin_manager = ert3.plugins.ErtPluginManager()
     plugin_manager.collect(registry=plugin_registry)
 

--- a/tests/ert_tests/ert3/config/test_stages_config.py
+++ b/tests/ert_tests/ert3/config/test_stages_config.py
@@ -567,7 +567,11 @@ def test_transformations(
 
 def test_required_plugged_in_configuration_errors():
     plugin_registry = ert3.config.ConfigPluginRegistry()
-    plugin_registry.register_category(category="transformation", optional=False)
+    plugin_registry.register_category(
+        category="transformation",
+        optional=False,
+        base_config=ert3.config.plugins.TransformationConfigBase,
+    )
     plugin_manager = ert3.plugins.ErtPluginManager(
         plugins=[ert3.config.plugins.implementations]
     )
@@ -596,7 +600,11 @@ def test_required_plugged_in_configuration_errors():
 
 def test_optional_plugged_in_configuration():
     plugin_registry = ert3.config.ConfigPluginRegistry()
-    plugin_registry.register_category(category="transformation", optional=True)
+    plugin_registry.register_category(
+        category="transformation",
+        optional=True,
+        base_config=ert3.config.plugins.TransformationConfigBase,
+    )
     plugin_manager = ert3.plugins.ErtPluginManager(
         plugins=[ert3.config.plugins.implementations]
     )

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -459,7 +459,10 @@ def raw_ensrec_to_records():
 def plugin_registry():
     plugin_registry = ert3.config.ConfigPluginRegistry()
     plugin_registry.register_category(
-        category="transformation", descriminator="type", optional=True
+        category="transformation",
+        descriminator="type",
+        optional=True,
+        base_config=ert3.config.plugins.TransformationConfigBase,
     )
     plugin_manager = ert3.plugins.ErtPluginManager(
         plugins=[ert3.config.plugins.implementations]


### PR DESCRIPTION
**Issue**
Resolves #3133


**Approach**
Inject the plugin fields when generating documentation for configurations.
Add separate section with auto-generated documentation for each plugin category.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
