### PR TITLE
Add missing EnKFMain in workflow runner

### DIFF
--- a/ert_gui/tools/workflows/workflows_tool.py
+++ b/ert_gui/tools/workflows/workflows_tool.py
@@ -7,6 +7,7 @@ from ert_gui.tools.workflows import RunWorkflowWidget
 class WorkflowsTool(Tool):
     def __init__(self, ert, notifier):
         self.notifier = notifier
+        self.ert = ert
         enabled = len(ert.getWorkflowList().getWorkflowNames()) > 0
         super().__init__(
             "Run Workflow",
@@ -16,7 +17,7 @@ class WorkflowsTool(Tool):
         )
 
     def trigger(self):
-        run_workflow_widget = RunWorkflowWidget()
+        run_workflow_widget = RunWorkflowWidget(self.ert)
         dialog = ClosableDialog("Run workflow", run_workflow_widget, self.parent())
         dialog.exec_()
         self.notifier.emitErtChange()  # workflow may have added new cases.


### PR DESCRIPTION
**Issue**
EnKFMain was missing in the workflow widget, causing it to fail.


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
