### PR TITLE
Add Python 3.10 to list of classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],


### PR DESCRIPTION

**Issue**
After commit 0a06beff3 ert now supports Python 3.10, so we should also
add it to the list of classifiers so it displays correct on PyPi.

**Approach**
Add Python 3.10 to list of classifiers

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
