### PR TITLE
Ignore errors in rmtree

### DIFF
--- a/tests/ert_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert_tests/gui/tools/plot/test_plot_api.py
@@ -219,7 +219,7 @@ class PlotApiTest(TestCase):
 
 
 def test_key_def_structure(api):
-    shutil.rmtree("storage")
+    shutil.rmtree("storage", ignore_errors=True)
     key_defs = api.all_data_type_keys()
     fopr = next(x for x in key_defs if x["key"] == "FOPR")
 


### PR DESCRIPTION
Resolves #3153

This fails sometimes due to the suspected/known race where block_fs removes lockfiles on GC, which may or may not run in parallel with rmtree.
