### PR TITLE
Add support for log-uniform distribution

### DIFF
--- a/ert3/stats/__init__.py
+++ b/ert3/stats/__init__.py
@@ -1,4 +1,11 @@
-from ert3.stats._stats import Constant, Discrete, Distribution, Gaussian, Uniform
+from ert3.stats._stats import (
+    Constant,
+    Discrete,
+    Distribution,
+    Gaussian,
+    Uniform,
+    LogUniform,
+)
 
 __all__ = [
     "Constant",
@@ -6,4 +13,5 @@ __all__ = [
     "Distribution",
     "Gaussian",
     "Uniform",
+    "LogUniform",
 ]

--- a/ert3/stats/_stats.py
+++ b/ert3/stats/_stats.py
@@ -163,6 +163,50 @@ class Uniform(Distribution):
         return "uniform"
 
 
+class LogUniform(Distribution):
+    def __init__(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+        *,
+        size: Optional[int] = None,
+        index: Optional[ert.data.RecordIndex] = None,
+    ) -> None:
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+
+        def rvs(size: int) -> np.ndarray:  # type: ignore
+            return np.array(
+                scipy.stats.loguniform.rvs(
+                    a=self._lower_bound, b=self._upper_bound, size=self._size
+                )
+            )
+
+        def ppf(x: np.ndarray) -> np.ndarray:  # type: ignore
+            return np.array(
+                scipy.stats.loguniform.ppf(x, a=self._lower_bound, b=self._upper_bound)
+            )
+
+        super().__init__(
+            size=size,
+            index=index,
+            rvs=rvs,
+            ppf=ppf,
+        )
+
+    @property
+    def lower_bound(self) -> float:
+        return self._lower_bound
+
+    @property
+    def upper_bound(self) -> float:
+        return self._upper_bound
+
+    @property
+    def type(self) -> str:
+        return "loguniform"
+
+
 class Discrete(Distribution):
     """Draw a NumericalRecord of specified size (or with specified index) from
     a discrete list of values. Each value has equal weight.

--- a/tests/ert_tests/ert3/stats/test_distributions.py
+++ b/tests/ert_tests/ert3/stats/test_distributions.py
@@ -344,3 +344,118 @@ def test_discrete_ppf(values, q, expected_val):
                 assert np.isnan(ppf_result.data[idx])
             else:
                 assert ppf_result.data[idx] == e
+
+
+@pytest.mark.parametrize(
+    ("size", "lower_bound", "upper_bound"),
+    (
+        (10000, 0.001, 1),
+        (20000, 10, 20),
+    ),
+)
+def test_loguniform_samples_unique(size, lower_bound, upper_bound):
+    loguniform = ert3.stats.Uniform(lower_bound, upper_bound, size=size)
+
+    assert loguniform.lower_bound == lower_bound
+    assert loguniform.upper_bound == upper_bound
+
+    # Essentially tests that samples drawn from Uniform are unique
+    prev_samples = set()
+    for _ in range(100):
+        sample = loguniform.sample()
+
+        assert loguniform.index == tuple(range(size)), "Indices should be identical"
+        assert tuple(sample.data) not in prev_samples, "Samples should be different"
+
+        prev_samples.add(tuple(sample.data))
+
+
+@pytest.mark.parametrize(
+    ("size", "lower_bound", "upper_bound"),
+    (
+        (10000, 0.001, 1),
+        (20000, 10, 20),
+    ),
+)
+def test_loguniform_samples_comesfromscipy(size, lower_bound, upper_bound):
+    with patch("scipy.stats.loguniform.rvs") as scipy:
+        retval = np.array(range(100))
+        scipy.return_value = retval  # never mind the content
+
+        loguniform = ert3.stats.LogUniform(lower_bound, upper_bound, size=size)
+        data = loguniform.sample().data
+
+        scipy.assert_called_once_with(a=lower_bound, b=upper_bound, size=size)
+        assert np.array_equal(
+            retval, data
+        ), "Samples should be identical to rvs from Scipy"
+
+
+@pytest.mark.parametrize(
+    ("index", "lower_bound", "upper_bound"),
+    (
+        (("a", "b", "c"), 0, 1),
+        (tuple("a" * i for i in range(1, 10)), 2, 5),
+    ),
+)
+def test_loguniform_index(index, lower_bound, upper_bound):
+    with patch("scipy.stats.loguniform.rvs") as scipy:
+        loguniform = ert3.stats.LogUniform(lower_bound, upper_bound, index=index)
+
+        assert loguniform.lower_bound == lower_bound
+        assert loguniform.upper_bound == upper_bound
+
+        samples = {idx: [] for idx in index}
+        for i in range(100):
+
+            scipy.return_value = [i] * len(index)
+            sample = loguniform.sample()
+            scipy.assert_called_once_with(a=lower_bound, b=upper_bound, size=len(index))
+            scipy.reset_mock()
+
+            assert sorted(loguniform.index) == sorted(
+                index
+            ), "Indices should be the same"
+            assert sorted(sample.index) == sorted(index), "Indices should be the same"
+            for key in index:
+                samples[key].append(sample.data[key])
+
+    for key in index:
+        s = np.array(samples[key])
+        assert np.alltrue(s == range(100)), f"Wrong samples for key {key}"
+
+
+def test_loguniform_distribution_invalid():
+    err_msg_neither = "Cannot create distribution with neither size nor index"
+    with pytest.raises(ValueError, match=err_msg_neither):
+        ert3.stats.LogUniform(0.001, 1)
+
+    err_msg_both = "Cannot create distribution with both size and index"
+    with pytest.raises(ValueError, match=err_msg_both):
+        ert3.stats.LogUniform(0.001, 1, size=10, index=list(range(10)))
+
+
+@pytest.mark.parametrize(
+    ("lower", "upper", "q", "size", "index"),
+    (
+        (0.001, 2, 0.5, 1, None),
+        (2, 5, 0.1, 5, None),
+        (1, 2, 0.7, 10, None),
+        (0.001, 1, 0.005, None, ("a", "b", "c")),
+        (0.001, 1, 0.995, None, tuple(index_len * "x" for index_len in range(1, 10))),
+        (2, 5, 0.1, None, ("x", "y")),
+        (1, 2, 0.7, None, ("single_key",)),
+    ),
+)
+def test_loguniform_ppf(lower, upper, q, size, index):
+    if size is not None:
+        dist = ert3.stats.LogUniform(lower, upper, size=size)
+    else:
+        dist = ert3.stats.LogUniform(lower, upper, index=index)
+
+    expected_value = scipy.stats.loguniform.ppf(q, a=lower, b=upper)
+    ppf_result = dist.ppf(q)
+    assert len(dist.index) == len(ppf_result.data)
+    assert sorted(dist.index) == sorted(ppf_result.index)
+    for idx in dist.index:
+        assert ppf_result.data[idx] == pytest.approx(expected_value)


### PR DESCRIPTION
**Issue**
Resolves #2925


**Approach**
Duplicate mostly the code for the uniform distribution, translating upper and lower bound to the shape parameters of the loguniform distribution, taking into account that the lower bound must be > 0.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
