### PR TITLE
Remove unused function local_ministep_get_obs_data

### DIFF
--- a/libres/lib/enkf/local_ministep.cpp
+++ b/libres/lib/enkf/local_ministep.cpp
@@ -126,11 +126,6 @@ LocalObsData *local_ministep_get_obsdata(const local_ministep_type *ministep) {
     return ministep->observations;
 }
 
-obs_data_type *
-local_ministep_get_obs_data(const local_ministep_type *ministep) {
-    return ministep->obs_data;
-}
-
 const char *local_ministep_get_name(const local_ministep_type *ministep) {
     return ministep->name.data();
 }

--- a/libres/lib/include/ert/enkf/local_ministep.hpp
+++ b/libres/lib/include/ert/enkf/local_ministep.hpp
@@ -129,16 +129,12 @@ extern "C" void local_ministep_add_obsdata(local_ministep_type *ministep,
 extern "C" void local_ministep_add_obsdata_node(local_ministep_type *ministep,
                                                 LocalObsDataNode *obsdatanode);
 LocalObsData *local_ministep_get_obsdata(const local_ministep_type *ministep);
-
 bool local_ministep_data_is_active(const local_ministep_type *ministep,
                                    const char *key);
 
 LocalObsData *local_ministep_get_obsdata(const local_ministep_type *ministep);
 void local_ministep_add_obs_data(local_ministep_type *ministep,
                                  obs_data_type *obs_data);
-extern "C" obs_data_type *
-local_ministep_get_obs_data(const local_ministep_type *ministep);
-
 UTIL_SAFE_CAST_HEADER(local_ministep);
 UTIL_IS_INSTANCE_HEADER(local_ministep);
 


### PR DESCRIPTION
This equivalent function is only called in python, so is never used
from C++

**Issue**
Part of: #2968 



## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
