### PR TITLE
Pin pylint to version <2.13.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ decorator
 flake8>=4.0.0
 jsonpath_ng
 mock; python_version <= '3.7' # missing AsyncMock added in py38
-pylint
+pylint<2.13.0
 pytest-asyncio
 pytest-cov
 pytest-mock


### PR DESCRIPTION
**Issue**
Version 2.13.0 introduces changes that makes our testing pipelines fail.

**Approach**
This commits pins the version until a fix is implemented.

See also follow up issue: https://github.com/equinor/ert/issues/3162

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
