### PR TITLE
Fix to circumvent pylint bug

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ decorator
 flake8>=4.0.0
 jsonpath_ng
 mock; python_version <= '3.7' # missing AsyncMock added in py38
-pylint<2.13.0
+pylint
 pytest-asyncio
 pytest-cov
 pytest-mock

--- a/ert3/config/_config_plugin_registry.py
+++ b/ert3/config/_config_plugin_registry.py
@@ -104,7 +104,9 @@ class ConfigPluginRegistry:
         if name in self._registry[category]:
             raise ValueError(f"{name} is already registered")
 
-        field_definitions: Any = {self._descriminator[category]: (Literal[name], ...)}
+        field_definitions: Any = {
+            self._descriminator[category]: (Literal[name], Ellipsis)
+        }
         config_name = f"Full{config.__name__}"
         full_config = create_model(
             config_name, __base__=config, __module__=__name__, **field_definitions


### PR DESCRIPTION
**Issue**
Resolves #3162

**Approach**
Replace a `...` with `Ellipsis`. It is a bug in `pylint`, but the fix is still appropriate.

## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
