### PR TITLE
rejoin lines that were split on whitespace with spaces

### DIFF
--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -436,7 +436,7 @@ void model_config_init(model_config_type *model_config,
 
         if (util_string_equal(config_content_node_get_kw(node),
                               FORWARD_MODEL_KEY)) {
-            const char *arg = config_content_node_get_full_string(node, "");
+            const char *arg = config_content_node_get_full_string(node, " ");
             forward_model_parse_job_deprecated_args(model_config->forward_model,
                                                     arg, define_list);
         }


### PR DESCRIPTION
**Issue**
Resolves #2766


**Approach**
Somewhere early during parsing of the config, lines are split by whitespace. These are later joined again, but incorrectly. This makes sure that arguments that were split on whitespace are joined by spaces again.

Considering the state of all this code, I fully expect this to break something else in a horrible way.

## Pre review checklist

- [ ] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
