### PR TITLE
Modify ModelConfig.enspath to hold an absolute file-path

### DIFF
--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -253,7 +253,7 @@ void model_config_set_max_internal_submit(model_config_type *model_config,
     model_config->max_internal_submit = max_resample;
 }
 
-UTIL_IS_INSTANCE_FUNCTION(model_config, MODEL_CONFIG_TYPE_ID)
+UTIL_IS_INSTANCE_FUNCTION(model_config, MODEL_CONFIG_TYPE_ID);
 
 model_config_type *model_config_alloc_empty() {
     model_config_type *model_config =
@@ -497,8 +497,9 @@ void model_config_init(model_config_type *model_config,
   */
 
     if (config_content_has_item(config, ENSPATH_KEY))
-        model_config_set_enspath(model_config, config_content_get_value_as_path(
-                                                   config, ENSPATH_KEY));
+        model_config_set_enspath(
+            model_config,
+            config_content_get_value_as_abspath(config, ENSPATH_KEY));
 
     if (config_content_has_item(config, DATA_ROOT_KEY))
         model_config_set_data_root(

--- a/res/test/ert_test_context.py
+++ b/res/test/ert_test_context.py
@@ -40,7 +40,7 @@ class ErtTestContext:
             self._ert = EnKFMain(self._res_config, strict=True)
         except Exception:
             os.chdir(self._dir_before)
-            shutil.rmtree(self._tmp_dir)
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)
             raise
         return self
 
@@ -48,7 +48,7 @@ class ErtTestContext:
         self._ert = None
         self._res_config = None
         os.chdir(self._dir_before)
-        shutil.rmtree(self._tmp_dir)
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
 
     def getErt(self):
         return self._ert

--- a/tests/libres_tests/res/enkf/test_enkf.py
+++ b/tests/libres_tests/res/enkf/test_enkf.py
@@ -251,7 +251,7 @@ class EnKFTest(ResTest):
             )
             self.assertIsInstance(main.getMemberRunningState(0), EnKFState)
 
-            self.assertEqual("simple_config/Ensemble", main.getMountPoint())
+            self.assertTrue(main.getMountPoint().endswith("simple_config/Ensemble"))
 
     @tmpdir()
     def test_run_context(self):

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -382,7 +382,8 @@ class ResConfigTest(ResTest):
 
     def assert_path(self, rel_path, config_path, model_path):
         self.assertEqual(
-            os.path.normpath(os.path.join(rel_path, config_path)), model_path
+            os.path.realpath(os.path.join(rel_path, config_path)),
+            os.path.realpath(model_path),
         )
 
     def assert_model_config(self, model_config, config_data, working_dir):


### PR DESCRIPTION
Filenames in `block_fs_driver` are derived from this field, which currently is relative to the directory in which the config-file resides. If a process changes directory after instantiating `ModelConfig`, existing `block_fs_driver`-instances refer to wrong filenames on disk.

1. The `block_fs_driver` dtor currently modifies / remove files which may (currently) happen on Python GC, i.e. outside of our control

2. Our Python-based tests run in separate tmp-directories with no guarantee of GC between

Combining 1 and 2 above with relative paths opens up for flakiness in the tests. By using absolute paths we avoid this.