### PR TITLE
Revert "Make state_map_select_matching return instead of mutating"

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,6 +41,7 @@ jobs:
 
     - name: Run black
       run: |
+        pip install black==22.1.0
         black . --check
 
     - name: Run pylint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ pytest-timeout
 jsonpath_ng
 sphinxcontrib.datatemplates
 decorator
-pylint
+pylint<2.13.0
 scikit-build
 setuptools_scm
 pytest-snapshot

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-black==22.1.0; python_version > '3.6'
+click==8.0.2; python_version > '3.6'
+click<8; python_version <= '3.6'
 flaky
 pytest>=6.2.0
 pytest-qt
@@ -14,7 +15,6 @@ jsonpath_ng
 sphinxcontrib.datatemplates
 decorator
 pylint
-click
 scikit-build
 setuptools_scm
 pytest-snapshot

--- a/ert_shared/share/ert/workflows/jobs/internal-gui/scripts/export_misfit_data.py
+++ b/ert_shared/share/ert/workflows/jobs/internal-gui/scripts/export_misfit_data.py
@@ -70,5 +70,8 @@ class ExportMisfitDataJob(ErtScript):
 
     def createActiveList(self, fs):
         state_map = fs.getStateMap()
-        ens_mask = state_map.selectMatching(RealizationStateEnum.STATE_HAS_DATA)
-        return [index for index, element in enumerate(ens_mask) if element]
+        ens_mask = [False] * self.ert().getEnsembleSize()
+        state_map.selectMatching(ens_mask, RealizationStateEnum.STATE_HAS_DATA)
+        index_list = [index for index, element in enumerate(ens_mask) if element]
+        bool_vec = BoolVector.createFromList(len(index_list), index_list)
+        return bool_vec.createActiveList()

--- a/libres/lib/analysis/update.cpp
+++ b/libres/lib/analysis/update.cpp
@@ -588,8 +588,8 @@ bool smoother_update(const local_updatestep_type *updatestep,
 
     ert::utils::scoped_memory_logger memlogger(logger, "smoother_update");
 
-    auto ens_mask =
-        state_map_select_matching(source_state_map, STATE_HAS_DATA, true);
+    std::vector<bool> ens_mask(total_ens_size, false);
+    state_map_select_matching(source_state_map, ens_mask, STATE_HAS_DATA, true);
 
     copy_parameters(source_fs, target_fs, ensemble_config, ens_mask);
 

--- a/libres/lib/enkf/enkf_plot_data.cpp
+++ b/libres/lib/enkf/enkf_plot_data.cpp
@@ -95,8 +95,9 @@ void enkf_plot_data_load(enkf_plot_data_type *plot_data, enkf_fs_type *fs,
     state_map_type *state_map = enkf_fs_get_state_map(fs);
     int ens_size = state_map_get_size(state_map);
 
-    std::vector<bool> mask =
-        state_map_select_matching(state_map, STATE_HAS_DATA, true);
+    std::vector<bool> mask(ens_size, false);
+
+    state_map_select_matching(state_map, mask, STATE_HAS_DATA, true);
     enkf_plot_data_resize(plot_data, ens_size);
     enkf_plot_data_reset(plot_data);
     {

--- a/libres/lib/enkf/enkf_plot_gendata.cpp
+++ b/libres/lib/enkf/enkf_plot_gendata.cpp
@@ -152,8 +152,9 @@ void enkf_plot_gendata_load(enkf_plot_gendata_type *plot_data, enkf_fs_type *fs,
     state_map_type *state_map = enkf_fs_get_state_map(fs);
     int ens_size = state_map_get_size(state_map);
 
-    const auto &mask =
-        state_map_select_matching(state_map, STATE_HAS_DATA, true);
+    std::vector<bool> mask(ens_size, false);
+
+    state_map_select_matching(state_map, mask, STATE_HAS_DATA, true);
     enkf_plot_gendata_resize(plot_data, ens_size);
     enkf_plot_gendata_reset(plot_data, report_step);
     plot_data->report_step = report_step;

--- a/libres/lib/enkf/state_map.cpp
+++ b/libres/lib/enkf/state_map.cpp
@@ -209,20 +209,25 @@ bool state_map_fread(state_map_type *map, const char *filename) {
     return file_exists;
 }
 
-std::vector<bool> state_map_select_matching(const state_map_type *map,
-                                            int select_mask, bool select) {
-    std::vector<bool> select_target(int_vector_size(map->state), false);
+/*
+  NB: This function does *not* resize select_target vector; i.e. realizations
+  beyond the size of the select_target vector will not be selected.
+*/
+void state_map_select_matching(const state_map_type *map,
+                               std::vector<bool> &select_target,
+                               int select_mask, bool select) {
     pthread_rwlock_rdlock(&map->rw_lock);
     {
         const int *map_ptr = int_vector_get_ptr(map->state);
-        for (size_t i = 0; i < select_target.size(); i++) {
+        size_t size =
+            std::min((size_t)int_vector_size(map->state), select_target.size());
+        for (size_t i = 0; i < size; i++) {
             int state_value = map_ptr[i];
             if (state_value & select_mask)
                 select_target[i] = select;
         }
     }
     pthread_rwlock_unlock(&map->rw_lock);
-    return select_target;
 }
 
 static void state_map_set_from_mask__(state_map_type *map,
@@ -266,10 +271,15 @@ int state_map_count_matching(const state_map_type *state_map, int mask) {
     return count;
 }
 
-std::vector<bool> select_matching(py::object map, int select_mask,
-                                  bool select) {
+void select_matching(py::object map, py::list my_list, int select_mask,
+                     bool select) {
     auto map_ = ert::from_cwrap<state_map_type>(map);
-    return state_map_select_matching(map_, select_mask, select);
+    std::vector<bool> select_target;
+    for (auto item : my_list)
+        select_target.push_back(item.cast<bool>());
+    state_map_select_matching(map_, select_target, select_mask, select);
+    for (size_t i = 0; i < select_target.size(); i++)
+        my_list[i] = py::bool_(select_target[i]);
 }
 
 RES_LIB_SUBMODULE("state_map", m) { m.def("select_matching", select_matching); }

--- a/libres/lib/include/ert/enkf/state_map.hpp
+++ b/libres/lib/include/ert/enkf/state_map.hpp
@@ -48,9 +48,9 @@ void state_map_iset(state_map_type *map, int index,
 bool state_map_equal(const state_map_type *map1, const state_map_type *map2);
 void state_map_fwrite(const state_map_type *map, const char *filename);
 bool state_map_fread(state_map_type *map, const char *filename);
-extern "C++" std::vector<bool>
-state_map_select_matching(const state_map_type *map, int select_mask,
-                          bool select);
+extern "C++" void state_map_select_matching(const state_map_type *map,
+                                            std::vector<bool> &select_target,
+                                            int select_mask, bool select);
 void state_map_set_from_inverted_mask(state_map_type *map,
                                       const std::vector<bool> &mask,
                                       realisation_state_enum state);

--- a/libres/old_tests/enkf/test_enkf_state_map.cpp
+++ b/libres/old_tests/enkf/test_enkf_state_map.cpp
@@ -167,49 +167,59 @@ void test_update_matching() {
 
 void test_select_matching() {
     state_map_type *map = state_map_alloc();
+    std::vector<bool> mask1(21, false);
+    std::vector<bool> mask2(1000, true);
 
     state_map_iset(map, 10, STATE_INITIALIZED);
     state_map_iset(map, 10, STATE_HAS_DATA);
     state_map_iset(map, 20, STATE_INITIALIZED);
-    std::vector<bool> mask = state_map_select_matching(
-        map, STATE_HAS_DATA | STATE_INITIALIZED, true);
-    test_assert_int_equal(mask.size(), 21);
-    test_assert_true(mask[10]);
-    test_assert_true(mask[20]);
+    state_map_select_matching(map, mask1, STATE_HAS_DATA | STATE_INITIALIZED,
+                              true);
+    state_map_select_matching(map, mask2, STATE_HAS_DATA | STATE_INITIALIZED,
+                              true);
 
-    mask = state_map_select_matching(map, STATE_HAS_DATA, true);
-
-    for (size_t i; i < mask.size(); i++) {
+    for (int i = 0; i < mask1.size(); i++) {
         if (i == 10)
-            test_assert_true(mask[i]);
+            test_assert_true(mask1[i]);
+        else if (i == 20)
+            test_assert_true(mask1[i]);
         else {
-            test_assert_false(mask[0]);
+            test_assert_false(mask1[i]);
+            test_assert_true(mask2[i]);
         }
     }
 
     state_map_iset(map, 50, STATE_INITIALIZED);
-    mask = state_map_select_matching(map, STATE_HAS_DATA | STATE_INITIALIZED,
-                                     true);
-    test_assert_int_equal(mask.size(), 51);
+    state_map_select_matching(map, mask1, STATE_HAS_DATA | STATE_INITIALIZED,
+                              true);
+    test_assert_int_equal(mask1.size(), 21);
 
     state_map_free(map);
 }
 
 void test_deselect_matching() {
     state_map_type *map = state_map_alloc();
+    std::vector<bool> mask1(0, false);
+    std::vector<bool> mask2(1000, true);
 
+    state_map_iset(map, 10, STATE_INITIALIZED);
     state_map_iset(map, 10, STATE_HAS_DATA);
     state_map_iset(map, 20, STATE_INITIALIZED);
-    std::vector<bool> mask = state_map_select_matching(
-        map, STATE_HAS_DATA | STATE_INITIALIZED, false);
+    state_map_select_matching(map, mask1, STATE_HAS_DATA | STATE_INITIALIZED,
+                              false);
+    state_map_select_matching(map, mask2, STATE_HAS_DATA | STATE_INITIALIZED,
+                              false);
 
-    test_assert_int_equal(state_map_get_size(map), mask.size());
+    test_assert_int_equal(state_map_get_size(map), mask1.size());
 
-    for (int i = 0; i < mask.size(); i++) {
-        if ((i == 10) | (i == 20))
-            test_assert_false(mask[i]);
+    for (int i = 0; i < mask1.size(); i++) {
+        if (i == 10)
+            test_assert_false(mask1[1]);
+        else if (i == 20)
+            test_assert_false(mask2[1]);
         else {
-            test_assert_true(mask[i]);
+            test_assert_false(mask1[1]);
+            test_assert_true(mask2[1]);
         }
     }
 

--- a/res/enkf/export/gen_kw_collector.py
+++ b/res/enkf/export/gen_kw_collector.py
@@ -10,7 +10,9 @@ class GenKwCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()
-        ens_mask = state_map.selectMatching(
+        ens_mask = [False] * ert.getEnsembleSize()
+        state_map.selectMatching(
+            ens_mask,
             RealizationStateEnum.STATE_INITIALIZED
             | RealizationStateEnum.STATE_HAS_DATA,
         )

--- a/res/enkf/export/misfit_collector.py
+++ b/res/enkf/export/misfit_collector.py
@@ -10,7 +10,8 @@ class MisfitCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()
-        ens_mask = state_map.selectMatching(RealizationStateEnum.STATE_HAS_DATA)
+        ens_mask = [False] * ert.getEnsembleSize()
+        state_map.selectMatching(ens_mask, RealizationStateEnum.STATE_HAS_DATA)
 
         return [index for index, element in enumerate(ens_mask) if element]
 

--- a/res/enkf/export/summary_collector.py
+++ b/res/enkf/export/summary_collector.py
@@ -9,7 +9,8 @@ class SummaryCollector:
     @staticmethod
     def createActiveList(ert, fs):
         state_map = fs.getStateMap()
-        ens_mask = state_map.selectMatching(RealizationStateEnum.STATE_HAS_DATA)
+        ens_mask = [False] * ert.getEnsembleSize()
+        state_map.selectMatching(ens_mask, RealizationStateEnum.STATE_HAS_DATA)
         return [index for index, element in enumerate(ens_mask) if element]
 
     @staticmethod

--- a/res/enkf/plot_data/plot_block_data_loader.py
+++ b/res/enkf/plot_data/plot_block_data_loader.py
@@ -1,4 +1,4 @@
-from ecl.util.util import DoubleVector, ThreadPool
+from ecl.util.util import BoolVector, DoubleVector, ThreadPool
 
 from res.enkf import NodeId
 from res.enkf.data import EnkfNode
@@ -35,17 +35,23 @@ class PlotBlockDataLoader:
 
         return depth
 
-    def load(self, fs, report_step):
+    def load(self, fs, report_step, input_mask=None):
         """
         @type fs: EnkfFs
         @type report_step: int
+        @type input_mask: BoolVector
         @rtype: PlotBlockData
         """
 
         state_map = fs.getStateMap()
         ensemble_size = len(state_map)
 
-        ens_mask = state_map.selectMatching(RealizationStateEnum.STATE_HAS_DATA)
+        if input_mask is not None:
+            mask = list(BoolVector.copy(input_mask))
+        else:
+            mask = [False] * ensemble_size
+
+        state_map.selectMatching(mask, RealizationStateEnum.STATE_HAS_DATA)
 
         depth = self.getDepthValues(report_step)
 
@@ -55,8 +61,8 @@ class PlotBlockDataLoader:
         plot_block_data = PlotBlockData(depth)
 
         thread_pool = ThreadPool()
-        for index, mask in enumerate(ens_mask):
-            if mask:
+        for index in range(ensemble_size):
+            if mask[index]:
                 thread_pool.addTask(
                     self.loadVector, plot_block_data, fs, report_step, index
                 )

--- a/res/enkf/state_map.py
+++ b/res/enkf/state_map.py
@@ -102,19 +102,26 @@ class StateMap(BaseCClass):
         """@rtype: bool"""
         return self._is_read_only()
 
-    def selectMatching(self, select_mask):
+    def selectMatching(self, select_target, select_mask):
         """
+        @type select_target: BoolVector
         @type select_mask: RealizationStateEnum
         """
+        if not isinstance(select_target, list):
+            raise TypeError("Select target must be of type list")
         assert isinstance(select_mask, RealizationStateEnum)
-        return _lib.state_map.select_matching(self, select_mask, True)
+        _lib.state_map.select_matching(self, select_target, select_mask, True)
 
-    def deselectMatching(self, select_mask):
+    def deselectMatching(self, select_target, select_mask):
         """
+        @type select_target: BoolVector
         @type select_mask: RealizationStateEnum
         """
+        if not isinstance(select_target, list):
+            raise TypeError("Select target must be of type list")
         assert isinstance(select_mask, RealizationStateEnum)
-        return _lib.state_map.select_matching(self, select_mask, False)
+
+        _lib.state_map.select_matching(self, select_target, select_mask, False)
 
     def realizationList(self, state_value):
         """
@@ -133,7 +140,8 @@ class StateMap(BaseCClass):
         @type state_value: RealizationStateEnum
         @rtype: ecl.util.BoolVector
         """
-        mask = self.selectMatching(state_value)
+        mask = [False] * len(self)
+        self.selectMatching(mask, state_value)
         index_list = [index for index, element in enumerate(mask) if element]
         return BoolVector.createFromList(len(mask), index_list)
 


### PR DESCRIPTION
**Issue**
User reported error with setting the number of realizations lower than the ensemble size in the GUI, and bisecting revealed this commit to be the problem, and reverting it solves the issue. The commit has no critical features for the 2.33 version, so reverting the commit is ab OK solution, while a proper fix will implemented for the main branch and backported to 2.34.  

**Approach**
This reverts commit e871dd6bc59d16c26b659382dbc81b1b0e3b94fb.


## Pre review checklist

- [x] Added appropriate labels

Adding labels helps the maintainers when writing release notes, see sections and the
corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
