### PR TITLE
Update labels for automatic release notes generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,8 @@ _Short description of the approach_
 
 ## Pre review checklist
 
-- [ ] Added appropriate labels
+- [ ] Added appropriate release note label
+- [ ] PR title captures the intent of the changes, and is fitting for release notes.
+- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
 
-Adding labels helps the maintainers when writing release notes, see sections and the
-corresponding labels here: https://github.com/equinor/ert/blob/main/.github/release.yml
+Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,25 +2,38 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - breaking-change
+        - release-notes:breaking-change
       exclude:
         labels:
-          - ert3
+          - release-notes:ert3
     - title: New Features 🎉
       labels:
-        - enhancement
+        - release-notes:new-feature
       exclude:
         labels:
-          - ert3
+          - release-notes:ert3
+    - title: Improvements
+      labels:
+        - release-notes:improvement
+      exclude:
+        labels:
+          - release-notes:ert3
     - title: Bug Fixes
       labels:
-        - bug
+        - release-notes:bug-fix
       exclude:
         labels:
-          - ert3
+          - release-notes:ert3
+    - title: Dependencies
+      labels:
+        - release-notes:dependency
+      exclude:
+        labels:
+          - release-notes:ert3
     - title: ert3
       labels:
-        - ert3
+        - release-notes:ert3
     - title: Other Changes
       labels:
+        - release-notes:misc
         - "*"


### PR DESCRIPTION
**Issue**
It's currently difficult for maintainers and contributors to label PRs with relevant labels, as it is not obvious what effect different labels have in the resulting release notes. This PR aims to create specific labels for automatic release notes. If merged, I will update PRs two months back with relevant labels.


**Approach**
Update the template for release note generation and pull request
template with release note specific labels.
