### PR TITLE
Make `block_fs` append-only + other refactorings

### DIFF
--- a/libres/lib/res_util/block_fs.cpp
+++ b/libres/lib/res_util/block_fs.cpp
@@ -30,7 +30,7 @@
 
 #include <fmt/ostream.h>
 
-#include <ert/util/buffer.hpp>
+#include <ert/python.hpp>
 #include <ert/util/hash.hpp>
 #include <ert/util/vector.hpp>
 
@@ -61,7 +61,6 @@ namespace fs = std::filesystem;
 */
 
 #define NODE_IN_USE_BYTE 85 /* Binary(85)  =  01010101 */
-#define NODE_FREE_BYTE 170  /* Binary(170) =  10101010 */
 #define WRITE_START__ 77162
 
 static const int NODE_END_TAG =
@@ -72,30 +71,11 @@ static const int NODE_WRITE_ACTIVE_END = 776512;
 typedef enum {
     NODE_IN_USE =
         1431655765, /* NODE_IN_USE_BYTE * ( 1 + 256 + 256**2 + 256**3) => Binary 01010101010101010101010101010101 */
-    NODE_FREE =
-        -1431655766, /* NODE_FREE_BYTE   * ( 1 + 256 + 256**2 + 256**3) => Binary 10101010101010101010101010101010 */
     NODE_WRITE_ACTIVE = WRITE_START__, /* This */
     NODE_INVALID = 13 /* This should __never__ be written to disk */
 } node_status_type;
 
-/*
-   The free_node_struct is used to implement a doubly linked list of
-   free nodes; i.e. holes in the file which are available for other use.
-*/
 typedef struct file_node_struct file_node_type;
-typedef struct free_node_struct free_node_type;
-
-struct free_node_struct {
-    free_node_type *next;
-    free_node_type *prev;
-    file_node_type *file_node;
-};
-
-/*
-  Datastructure representing one 'block' in the datafile. The block
-  can either refer to a file (status == NODE_IN_USE) or to an empty
-  slot in the datafile (status == NODE_FREE).
-*/
 
 struct file_node_struct {
     long int
@@ -104,14 +84,8 @@ struct file_node_struct {
     int node_size; /* The size in bytes of this node - must be >= data_size. NEVER Changed. */
     int data_size; /* The size of the data stored in this node - in addition the node might need to store header information. */
     node_status_type
-        status; /* This should be: NODE_IN_USE | NODE_FREE; in addition the disk can have NODE_WRITE_ACTIVE for incomplete writes. */
+        status; /* This should be: NODE_IN_USE; in addition the disk can have NODE_WRITE_ACTIVE for incomplete writes. */
 };
-
-/*
-   data_size   : manipulated in block_fs_fwrite__() and block_fs_insert_free_node().
-   status      : manipulated in block_fs_fwrite__() and block_fs_unlink_file__();
-   data_offset : manipulated in block_fs_fwrite__() and block_fs_insert_free_node().
-*/
 
 struct block_fs_struct {
     UTIL_TYPE_ID_DECLARATION;
@@ -120,18 +94,16 @@ struct block_fs_struct {
     FILE *data_stream;
 
     long int data_file_size; /* The total number of bytes in the data_file. */
-    long int free_size;      /* Size of 'holes' in the data file. */
     int block_size;          /* The size of blocks in bytes. */
 
     std::mutex mutex;
 
-    int num_free_nodes;
     hash_type *
         index; /* THE HASH table of all the nodes/files which have been stored. */
-    free_node_type *free_nodes;
-    vector_type *
-        file_nodes; /* This vector owns all the file_node instances - the index and free_nodes structures
-                                       only contain pointers to the objects stored in this vector. */
+    vector_type
+        *file_nodes; /* This vector owns all the file_node instances - the index
+                       structure only contain pointers to the objects stored in
+                       this vector. */
     int write_count; /* This just counts the number of writes since the file system was mounted. */
     bool data_owner;
     int fsync_interval; /* 0: never  n: every nth iteration. */
@@ -198,14 +170,9 @@ static file_node_type *file_node_fread_alloc(FILE *stream, char **key) {
     node_status_type status;
     long int node_offset = ftell(stream);
     if (fread(&status, sizeof status, 1, stream) == 1) {
-        if ((status == NODE_IN_USE) || (status == NODE_FREE)) {
+        if (status == NODE_IN_USE) {
             int node_size;
-            if (status == NODE_IN_USE)
-                *key = util_fread_realloc_string(*key, stream);
-            else {
-                free(*key); /* Explicitly set to NULL for free nodes. */
-                *key = NULL;
-            }
+            *key = util_fread_realloc_string(*key, stream);
 
             node_size = util_fread_int(stream);
             if (node_size <= 0)
@@ -356,112 +323,10 @@ static file_node_type *file_node_index_buffer_fread_alloc(buffer_type *buffer) {
     }
 }
 
-static free_node_type *free_node_alloc(file_node_type *file_node) {
-    free_node_type *free_node =
-        (free_node_type *)util_malloc(sizeof *free_node);
-
-    free_node->file_node = file_node;
-    free_node->next = NULL;
-    free_node->prev = NULL;
-
-    return free_node;
-}
-
-static void free_node_free(free_node_type *free_node) { free(free_node); }
-
-static void free_node_free_list(free_node_type *head) {
-    free_node_type *current = head;
-    free_node_type *next;
-    while (current != NULL) {
-        next = current->next;
-        free_node_free(current);
-        current = next;
-    }
-}
-
 static void block_fs_insert_index_node(block_fs_type *block_fs,
                                        const char *filename,
                                        const file_node_type *file_node) {
     hash_insert_ref(block_fs->index, filename, file_node);
-}
-
-/*
-   Looks through the list of free nodes - looking for a node with
-   offset 'node_offset'. If no such node can be found, NULL will be
-   returned.
-*/
-
-static file_node_type *block_fs_lookup_free_node(const block_fs_type *block_fs,
-                                                 long int node_offset) {
-    free_node_type *current = block_fs->free_nodes;
-    while (current != NULL && (current->file_node->node_offset != node_offset))
-        current = current->next;
-
-    if (current == NULL)
-        return NULL;
-    else
-        return current->file_node;
-}
-
-/*
-   Inserts a file_node instance in the linked list of free nodes. The
-   list is sorted in order of increasing node size.
-*/
-
-static void block_fs_insert_free_node(block_fs_type *block_fs,
-                                      file_node_type *file_node) {
-    free_node_type *_new = free_node_alloc(file_node);
-
-    /* Special case: starting with a empty list. */
-    if (block_fs->free_nodes == NULL) {
-        _new->next = NULL;
-        _new->prev = NULL;
-        block_fs->free_nodes = _new;
-    } else {
-        free_node_type *current = block_fs->free_nodes;
-        free_node_type *prev = NULL;
-
-        while (current != NULL &&
-               (current->file_node->node_size < file_node->node_size)) {
-            prev = current;
-            current = current->next;
-        }
-
-        if (current == NULL) {
-            /*
-         The new node should be added at the end of the list - i.e. it
-         will not have a next node.
-      */
-            _new->next = NULL;
-            _new->prev = prev;
-            prev->next = _new;
-        } else {
-            /*
-        The new node should be placed BEFORE the current node.
-      */
-            if (prev == NULL) {
-                /* The new node should become the new list head. */
-                block_fs->free_nodes = _new;
-                _new->prev = NULL;
-            } else {
-                prev->next = _new;
-                _new->prev = prev;
-            }
-            current->prev = _new;
-            _new->next = current;
-        }
-        if (_new != NULL)
-            if (_new->next == _new)
-                util_abort("%s: broken LIST1 \n", __func__);
-        if (prev != NULL)
-            if (prev->next == prev)
-                util_abort("%s: broken LIST2 \n", __func__);
-        if (current != NULL)
-            if (current->next == current)
-                util_abort("%s: Broken LIST3 \n", __func__);
-    }
-    block_fs->num_free_nodes++;
-    block_fs->free_size += _new->file_node->node_size;
 }
 
 /*
@@ -480,11 +345,8 @@ static void block_fs_install_node(block_fs_type *block_fs,
 static void block_fs_reinit(block_fs_type *block_fs) {
     block_fs->index = hash_alloc();
     block_fs->file_nodes = vector_alloc_new();
-    block_fs->free_nodes = NULL;
-    block_fs->num_free_nodes = 0;
     block_fs->write_count = 0;
     block_fs->data_file_size = 0;
-    block_fs->free_size = 0;
 }
 
 static block_fs_type *block_fs_alloc_empty(const fs::path &mount_file,
@@ -541,10 +403,10 @@ static void block_fs_fseek_node_data(block_fs_type *block_fs,
 }
 
 /*
-   This function will read through the datafile seeking for one of the
-   identifiers: NODE_IN_USE | NODE_FREE. If one of the valid status
-   identifiers is found the stream is repositioned at the beginning of
-   the valid node, so the calling scope can continue with a
+   This function will read through the datafile seeking for the identifier:
+   NODE_IN_USE. If the valid status identifiers is found the stream is
+   repositioned at the beginning of the valid node, so the calling scope can
+   continue with a
 
       file_node = file_node_date_fread_alloc()
 
@@ -557,7 +419,7 @@ static bool block_fs_fseek_valid_node(block_fs_type *block_fs) {
     int status;
     while (true) {
         if (fread(&byte, sizeof byte, 1, block_fs->data_stream) == 1) {
-            if (byte == NODE_IN_USE_BYTE || byte == NODE_FREE_BYTE) {
+            if (byte == NODE_IN_USE_BYTE) {
                 long int pos = ftell(block_fs->data_stream);
                 /*
            OK - we found one interesting byte; let us try to read the
@@ -566,7 +428,7 @@ static bool block_fs_fseek_valid_node(block_fs_type *block_fs) {
                 fseek__(block_fs->data_stream, -1, SEEK_CUR);
                 if (fread(&status, sizeof status, 1, block_fs->data_stream) ==
                     1) {
-                    if (status == NODE_IN_USE || status == NODE_FREE_BYTE) {
+                    if (status == NODE_IN_USE) {
                         /*
                OK - we have found a valid identifier. We reposition to
                the start of this valid status id and return true.
@@ -658,15 +520,9 @@ static void block_fs_fix_nodes(block_fs_type *block_fs,
                     file_node->node_size = node_end - node_offset;
                 }
 
-                file_node->status = NODE_FREE;
+                file_node->status = NODE_INVALID;
                 file_node->data_size = 0;
                 file_node->data_offset = 0;
-                if (block_fs_lookup_free_node(block_fs, node_offset) == NULL) {
-                    /* The node is already on the free list - we just change some metadata. */
-                    new_node = true;
-                    block_fs_install_node(block_fs, file_node);
-                    block_fs_insert_free_node(block_fs, file_node);
-                }
 
                 block_fs_fseek(block_fs, node_offset);
                 file_node_fwrite(file_node, NULL, block_fs->data_stream);
@@ -713,15 +569,10 @@ static void block_fs_build_index(block_fs_type *block_fs,
                                              block_fs->data_stream)) {
                     block_fs_fseek_node_end(block_fs, file_node);
                     block_fs_install_node(block_fs, file_node);
-                    switch (file_node->status) {
-                    case (NODE_IN_USE):
+                    if (file_node->status == NODE_IN_USE) {
                         block_fs_insert_index_node(block_fs, filename,
                                                    file_node);
-                        break;
-                    case (NODE_FREE):
-                        block_fs_insert_free_node(block_fs, file_node);
-                        break;
-                    default:
+                    } else {
                         util_abort("%s: node status flag:%d not recognized - "
                                    "error in data file \n",
                                    __func__, file_node->status);
@@ -783,73 +634,28 @@ block_fs_type *block_fs_mount(const fs::path &mount_file, int block_size,
     return block_fs;
 }
 
-static void block_fs_unlink_free_node(block_fs_type *block_fs,
-                                      free_node_type *node) {
-    free_node_type *prev = node->prev;
-    free_node_type *next = node->next;
-
-    if (prev == NULL)
-        /* Special case: popping off the head of the list. */
-        block_fs->free_nodes = next;
-    else
-        prev->next = next;
-
-    if (next != NULL)
-        next->prev = prev;
-
-    block_fs->num_free_nodes--;
-    block_fs->free_size -= node->file_node->node_size;
-    free_node_free(node);
-}
-
-/*
-   This function first checks the free nodes if any of them can be
-   used, otherwise a new node is created.
-*/
-
 static file_node_type *block_fs_get_new_node(block_fs_type *block_fs,
                                              const char *filename,
                                              size_t min_size) {
 
-    free_node_type *current = block_fs->free_nodes;
+    long int offset;
+    int node_size;
+    file_node_type *new_node;
 
-    while (current != NULL && (current->file_node->node_size < min_size)) {
-        current = current->next;
+    {
+        div_t d = div(min_size, block_fs->block_size);
+        node_size = d.quot * block_fs->block_size;
+        if (d.rem)
+            node_size += block_fs->block_size;
     }
-    if (current != NULL) {
-        /*
-       Current points to a file_node which can be used. Before we return current we must:
 
-       1. Remove current from the free_nodes list.
-       2. Add current to the index hash.
+    /* Must lock the total size here ... */
+    offset = block_fs->data_file_size;
+    new_node = file_node_alloc(NODE_IN_USE, offset, node_size);
+    block_fs_install_node(
+        block_fs, new_node); /* <- This will update the total file size. */
 
-    */
-        file_node_type *file_node = current->file_node;
-        block_fs_unlink_free_node(block_fs, current);
-
-        return file_node;
-    } else {
-        /* No usable nodes in the free nodes list - must allocate a brand new one. */
-
-        long int offset;
-        int node_size;
-        file_node_type *new_node;
-
-        {
-            div_t d = div(min_size, block_fs->block_size);
-            node_size = d.quot * block_fs->block_size;
-            if (d.rem)
-                node_size += block_fs->block_size;
-        }
-
-        /* Must lock the total size here ... */
-        offset = block_fs->data_file_size;
-        new_node = file_node_alloc(NODE_IN_USE, offset, node_size);
-        block_fs_install_node(
-            block_fs, new_node); /* <- This will update the total file size. */
-
-        return new_node;
-    }
+    return new_node;
 }
 
 bool block_fs_has_file__(const block_fs_type *block_fs, const char *filename) {
@@ -859,23 +665,6 @@ bool block_fs_has_file__(const block_fs_type *block_fs, const char *filename) {
 bool block_fs_has_file(block_fs_type *block_fs, const char *filename) {
     std::lock_guard guard{block_fs->mutex};
     return block_fs_has_file__(block_fs, filename);
-}
-
-static void block_fs_unlink_file__(block_fs_type *block_fs,
-                                   const char *filename) {
-    file_node_type *node =
-        (file_node_type *)hash_pop(block_fs->index, filename);
-
-    node->status = NODE_FREE;
-    node->data_offset = 0;
-    node->data_size = 0;
-    if (block_fs->data_stream != NULL) {
-        fsync(block_fs->data_fd);
-        block_fs_fseek(block_fs, node->node_offset);
-        file_node_fwrite(node, NULL, block_fs->data_stream);
-        fsync(block_fs->data_fd);
-    }
-    block_fs_insert_free_node(block_fs, node);
 }
 
 /*
@@ -948,24 +737,7 @@ void block_fs_fwrite_file(block_fs_type *block_fs, const char *filename,
     bool new_node = true;
     size_t min_size = data_size + file_node_header_size(filename);
 
-    if (block_fs_has_file__(block_fs, filename)) {
-        file_node = (file_node_type *)hash_get(block_fs->index, filename);
-        if (file_node->node_size < min_size) {
-            /*
-         The current node is too small for the new content:
-
-         1. Remove the existing node, from the index and insert it
-         into the free_nodes list.
-
-         2. Get a new node.
-
-      */
-            block_fs_unlink_file__(block_fs, filename);
-            file_node = block_fs_get_new_node(block_fs, filename, min_size);
-        } else
-            new_node = false; /* We are reusing the existing node. */
-    } else
-        file_node = block_fs_get_new_node(block_fs, filename, min_size);
+    file_node = block_fs_get_new_node(block_fs, filename, min_size);
 
     /* The actual writing ... */
     block_fs_fwrite__(block_fs, filename, file_node, ptr, data_size);
@@ -1011,7 +783,6 @@ void block_fs_close(block_fs_type *block_fs) {
     if (block_fs->data_stream != NULL)
         fclose(block_fs->data_stream);
 
-    free_node_free_list(block_fs->free_nodes);
     hash_free(block_fs->index);
     vector_free(block_fs->file_nodes);
     delete block_fs;


### PR DESCRIPTION
Block FS has support for data deletion, as well as data replacement. The
deletion part via the function `enkf_fs_unlink` was removed a while ago
since the functionality was unused. It is also possible for data to be
replaced. I don't believe this functionality is actually used, but it's
been difficult to prove it due to the amount of locations from which the
`block_fs` writing function can be accessed (including from Python).

The places that are of interest, namely writing of parameters to
PARAMETER and response data to RESPONSE after a successful ERT run are
written once and only once. That is, by the time ERT knows about FOPR
from a forward-model, it has already internalised all of the data, and
thus won't need to rewrite the data. Essentially, as far as I can tell,
ERT doesn't make use of this "partial" data writing functionality.
However, due to the breadth of sources from which the writing
function can be called, I can't say this for certain.

However, by making `block_fs` append-only, we make it easy to discover
new data as it's being written. It makes it possible to poll the
file (by eg. dark storage) and if the file has been updated, one only
has to look at the end of the file to find out what's new. This could
potentially make it easier to update visualisations before all forward
models complete.

Compatibility with older ERTs are kept: Should I be incorrect in my
assumption that no data is being rewritten, storages generated by older
ERTs could have gaps in the data file marked with `NODE_FREE`, which is
safe to ignore. If this append-only variant has data that is rewritten,
it'll appear twice in the file as `NODE_IN_USE`. Older ERT would read
both, but due to the current one appearing last, that'll be the one that
ERT will internalise in its dictionary.