### PR TITLE
Add maintenance as release notes category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,6 +24,12 @@ changelog:
       exclude:
         labels:
           - release-notes:ert3
+    - title: Maintenance
+      labels:
+        - release-notes:maintenance
+      exclude:
+        labels:
+          - release-notes:ert3
     - title: Dependencies
       labels:
         - release-notes:dependency


### PR DESCRIPTION
**Issue**
Maintenance is an often used category, and many PRs currently does not fit well in other categories.


**Approach**
Add maintenance as category


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
