### PR TITLE
Fix index out of bounds for active realizations < ensemble size in ESMDA

### DIFF
--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -256,8 +256,10 @@ class MultipleDataAssimilation(BaseRunModel):
             )
             mask = sim_fs.getStateMap().createMask(state)
             # Make sure to only run the realizations which was passed in as argument
-            for index, run_realization in enumerate(self._initial_realizations_mask):
-                mask[index] = mask[index] and run_realization
+            for idx, (valid_state, run_realization) in enumerate(
+                zip(mask, self._initial_realizations_mask)
+            ):
+                mask[idx] = valid_state and run_realization
 
         run_context = ErtRunContext.ensemble_smoother(
             sim_fs, target_fs, mask, runpath_fmt, jobname_fmt, subst_list, itr

--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 
 import ert_shared
-from ert_shared.cli import ENSEMBLE_SMOOTHER_MODE, TEST_RUN_MODE
+from ert_shared.cli import ENSEMBLE_SMOOTHER_MODE, ES_MDA_MODE, TEST_RUN_MODE
 from ert_shared.cli.main import run_cli, ErtCliError
 from ert_shared.feature_toggling import FeatureToggling
 from ert_shared.main import ert_parser
@@ -109,6 +109,36 @@ def test_ensemble_evaluator(tmpdir, source_root):
                 "poly_example/poly.ert",
                 "--port-range",
                 "1024-65535",
+            ],
+        )
+        FeatureToggling.update_from_args(parsed)
+
+        run_cli(parsed)
+        FeatureToggling.reset()
+
+
+@pytest.mark.integration_test
+def test_es_mda(tmpdir, source_root):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+
+    with tmpdir.as_cwd():
+        parser = ArgumentParser(prog="test_main")
+        parsed = ert_parser(
+            parser,
+            [
+                ES_MDA_MODE,
+                "--target-case",
+                "iter-%d",
+                "--realizations",
+                "1,2,4,8,16",
+                "poly_example/poly.ert",
+                "--port-range",
+                "1024-65535",
+                "--weights",
+                "1",
             ],
         )
         FeatureToggling.update_from_args(parsed)


### PR DESCRIPTION
**Issue**
Resolves #3191

**Approach**
The mask retrieved from getStateMap.createMask has the size has the
length of active realisations list. Looping through the
initial_realizations_mask may result in index out of bounds.

The PR adds an integration test that likely hasn't been added before due to time consumption (the simple test takes 17 seconds on my mac to pass). There are however no cli tests with es_mda mode, so one could argue that it's fair to add. Tests fails on main.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
