### PR TITLE
Refactor `StateMap` into C++ & pybind11

### DIFF
--- a/src/libres/lib/analysis/update.cpp
+++ b/src/libres/lib/analysis/update.cpp
@@ -108,8 +108,7 @@ void deserialize_node(enkf_fs_type *fs,
     // deserialize the matrix into the node (and writes it to the fs)
     enkf_node_deserialize(node, fs, node_id, active_list, A, row_offset,
                           column);
-    state_map_update_undefined(enkf_fs_get_state_map(fs), iens,
-                               STATE_INITIALIZED);
+    enkf_fs_get_state_map(fs).update_undefined(iens, STATE_INITIALIZED);
     enkf_node_free(node);
 }
 
@@ -268,10 +267,9 @@ void copy_parameters(enkf_fs_type *source_fs, enkf_fs_type *target_fs,
             enkf_node_free(data_node);
         }
 
-        state_map_type *target_state_map = enkf_fs_get_state_map(target_fs);
-        state_map_set_from_inverted_mask(target_state_map, ens_mask,
-                                         STATE_PARENT_FAILURE);
-        state_map_set_from_mask(target_state_map, ens_mask, STATE_INITIALIZED);
+        auto &target_state_map = enkf_fs_get_state_map(target_fs);
+        target_state_map.set_from_inverted_mask(ens_mask, STATE_PARENT_FAILURE);
+        target_state_map.set_from_mask(ens_mask, STATE_INITIALIZED);
         enkf_fs_fsync(target_fs);
     }
 }

--- a/src/libres/lib/enkf/enkf_main_manage_fs.cpp
+++ b/src/libres/lib/enkf/enkf_main_manage_fs.cpp
@@ -76,7 +76,7 @@ static void enkf_main_copy_ensemble(const ensemble_config_type *ensemble_config,
                                     enkf_fs_type *target_case_fs,
                                     const std::vector<bool> &iens_mask,
                                     const std::vector<std::string> &node_list) {
-    state_map_type *target_state_map = enkf_fs_get_state_map(target_case_fs);
+    auto &target_state_map = enkf_fs_get_state_map(target_case_fs);
 
     for (auto &node : node_list) {
         enkf_config_node_type *config_node =
@@ -95,7 +95,7 @@ static void enkf_main_copy_ensemble(const ensemble_config_type *ensemble_config,
                     enkf_node_copy(config_node, source_case_fs, target_case_fs,
                                    src_id, target_id);
 
-                state_map_iset(target_state_map, src_iens, STATE_INITIALIZED);
+                target_state_map.set(src_iens, STATE_INITIALIZED);
             }
             src_iens++;
         }
@@ -486,11 +486,10 @@ bool enkf_main_fs_exists(const enkf_main_type *enkf_main,
     return exists;
 }
 
-state_map_type *
-enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
-                                   const char *case_path) {
+StateMap enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
+                                            const char *case_path) {
     char *mount_point = enkf_main_alloc_mount_point(enkf_main, case_path);
-    state_map_type *state_map = enkf_fs_alloc_readonly_state_map(mount_point);
+    auto state_map = enkf_fs_alloc_readonly_state_map(mount_point);
     free(mount_point);
     return state_map;
 }

--- a/src/libres/lib/enkf/enkf_plot_data.cpp
+++ b/src/libres/lib/enkf/enkf_plot_data.cpp
@@ -92,11 +92,10 @@ int enkf_plot_data_get_size(const enkf_plot_data_type *plot_data) {
 
 void enkf_plot_data_load(enkf_plot_data_type *plot_data, enkf_fs_type *fs,
                          const char *index_key) {
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    int ens_size = state_map_get_size(state_map);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    int ens_size = state_map.size();
 
-    std::vector<bool> mask =
-        state_map_select_matching(state_map, STATE_HAS_DATA, true);
+    std::vector<bool> mask = state_map.select_matching(STATE_HAS_DATA, true);
     enkf_plot_data_resize(plot_data, ens_size);
     enkf_plot_data_reset(plot_data);
     {

--- a/src/libres/lib/enkf/enkf_plot_gen_kw.cpp
+++ b/src/libres/lib/enkf/enkf_plot_gen_kw.cpp
@@ -100,8 +100,8 @@ void enkf_plot_gen_kw_load(enkf_plot_gen_kw_type *plot_gen_kw, enkf_fs_type *fs,
                            bool transform_data, int report_step,
                            const bool_vector_type *input_mask) {
 
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    int ens_size = state_map_get_size(state_map);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    int ens_size = state_map.size();
     bool_vector_type *mask;
 
     if (input_mask)

--- a/src/libres/lib/enkf/enkf_plot_gendata.cpp
+++ b/src/libres/lib/enkf/enkf_plot_gendata.cpp
@@ -131,11 +131,10 @@ static void enkf_plot_gendata_resize(enkf_plot_gendata_type *plot_gendata,
 void enkf_plot_gendata_load(enkf_plot_gendata_type *plot_data, enkf_fs_type *fs,
                             int report_step) {
 
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    int ens_size = state_map_get_size(state_map);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    int ens_size = state_map.size();
 
-    const auto &mask =
-        state_map_select_matching(state_map, STATE_HAS_DATA, true);
+    const auto &mask = state_map.select_matching(STATE_HAS_DATA, true);
     enkf_plot_gendata_resize(plot_data, ens_size);
     plot_data->report_step = report_step;
 

--- a/src/libres/lib/enkf/enkf_state.cpp
+++ b/src/libres/lib/enkf/enkf_state.cpp
@@ -102,8 +102,8 @@ void enkf_state_initialize(enkf_state_type *enkf_state, rng_type *rng,
                            const std::vector<std::string> &param_list,
                            init_mode_type init_mode) {
     int iens = enkf_state->__iens;
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    realisation_state_enum current_state = state_map_iget(state_map, iens);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    realisation_state_enum current_state = state_map.get(iens);
     if ((current_state == STATE_PARENT_FAILURE) && (init_mode != INIT_FORCE))
         return;
     else {
@@ -124,8 +124,7 @@ void enkf_state_initialize(enkf_state_type *enkf_state, rng_type *rng,
 
             enkf_node_free(param_node);
         }
-        state_map_update_matching(state_map, iens,
-                                  STATE_UNDEFINED | STATE_LOAD_FAILURE,
+        state_map.update_matching(iens, STATE_UNDEFINED | STATE_LOAD_FAILURE,
                                   STATE_INITIALIZED);
         enkf_fs_fsync(fs);
     }
@@ -460,13 +459,12 @@ enkf_state_load_from_forward_model__(ensemble_config_type *ens_config,
         result = enkf_state_internalize_results(ens_config, model_config,
                                                 ecl_config, run_arg);
     }
-    state_map_type *state_map =
-        enkf_fs_get_state_map(run_arg_get_sim_fs(run_arg));
+    auto &state_map = enkf_fs_get_state_map(run_arg_get_sim_fs(run_arg));
     int iens = run_arg_get_iens(run_arg);
     if (result.first != LOAD_SUCCESSFUL)
-        state_map_iset(state_map, iens, STATE_LOAD_FAILURE);
+        state_map.set(iens, STATE_LOAD_FAILURE);
     else
-        state_map_iset(state_map, iens, STATE_HAS_DATA);
+        state_map.set(iens, STATE_HAS_DATA);
 
     return result;
 }
@@ -531,9 +529,8 @@ bool enkf_state_complete_forward_model_EXIT_handler__(run_arg_type *run_arg) {
     if (run_arg_get_run_status(run_arg) != JOB_LOAD_FAILURE)
         run_arg_set_run_status(run_arg, JOB_RUN_FAILURE);
 
-    state_map_type *state_map =
-        enkf_fs_get_state_map(run_arg_get_sim_fs(run_arg));
-    state_map_iset(state_map, run_arg_get_iens(run_arg), STATE_LOAD_FAILURE);
+    auto &state_map = enkf_fs_get_state_map(run_arg_get_sim_fs(run_arg));
+    state_map.set(run_arg_get_iens(run_arg), STATE_LOAD_FAILURE);
     return false;
 }
 

--- a/src/libres/lib/enkf/state_map.cpp
+++ b/src/libres/lib/enkf/state_map.cpp
@@ -15,9 +15,13 @@
    for more details.
 */
 #include <algorithm>
+#include <cstdint>
 #include <filesystem>
 
+#include <fstream>
+#include <mutex>
 #include <pthread.h>
+#include <stdexcept>
 #include <stdlib.h>
 
 #include <ert/python.hpp>
@@ -29,92 +33,66 @@
 
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/state_map.hpp>
+#include <system_error>
 
 namespace fs = std::filesystem;
 
-#define STATE_MAP_TYPE_ID 500672132
+namespace {
+void read_libecl_vector(std::istream &s, std::vector<int> &v) {
+    std::int32_t length{};
+    s.read(reinterpret_cast<char *>(&length), sizeof(length));
 
-struct state_map_struct {
-    UTIL_TYPE_ID_DECLARATION;
-    int_vector_type *state;
-    pthread_rwlock_t mutable rw_lock;
-    bool read_only;
-};
+    /* default_value is used by libecl's auto-resizeable vector_type to fill in
+     * the gaps. We don't do that here, but we still have to read the value. */
+    std::int32_t default_value{};
+    s.read(reinterpret_cast<char *>(&default_value), sizeof(default_value));
 
-UTIL_IS_INSTANCE_FUNCTION(state_map, STATE_MAP_TYPE_ID)
-
-state_map_type *state_map_alloc() {
-    state_map_type *map = (state_map_type *)util_malloc(sizeof *map);
-    UTIL_TYPE_ID_INIT(map, STATE_MAP_TYPE_ID);
-    map->state = int_vector_alloc(0, STATE_UNDEFINED);
-    pthread_rwlock_init(&map->rw_lock, NULL);
-    map->read_only = false;
-    return map;
+    v.resize(length);
+    s.read(reinterpret_cast<char *>(&v[0]), sizeof(v[0]) * v.size());
 }
 
-state_map_type *state_map_fread_alloc(const char *filename) {
-    state_map_type *map = state_map_alloc();
-    if (fs::exists(filename)) {
-        FILE *stream = util_fopen(filename, "r");
-        int_vector_fread(map->state, stream);
-        fclose(stream);
-    }
-    return map;
+void write_libecl_vector(std::ostream &s, const std::vector<int> &v) {
+    std::int32_t length = v.size();
+    s.write(reinterpret_cast<const char *>(&length), sizeof(length));
+
+    /* default_value is used by libecl's auto-resizeable vector_type to fill in
+     * the gaps. We don't do that here, but we still have to write the value. */
+    std::int32_t default_value{};
+    s.write(reinterpret_cast<const char *>(&default_value),
+            sizeof(default_value));
+
+    s.write(reinterpret_cast<const char *>(&v[0]), sizeof(v[0]) * v.size());
+}
+} // namespace
+
+StateMap::StateMap(const fs::path &filename, bool read_only) {
+    read(filename, read_only);
 }
 
-state_map_type *state_map_fread_alloc_readonly(const char *filename) {
-    state_map_type *map = state_map_fread_alloc(filename);
-    map->read_only = true;
-    return map;
+StateMap::StateMap(const StateMap &other) {
+    std::lock_guard guard{other.m_mutex};
+    m_state = other.m_state;
 }
 
-state_map_type *state_map_alloc_copy(const state_map_type *map) {
-    state_map_type *copy = state_map_alloc();
-    pthread_rwlock_rdlock(&map->rw_lock);
-    { int_vector_memcpy(copy->state, map->state); }
-    pthread_rwlock_unlock(&map->rw_lock);
-    return copy;
+int StateMap::size() const {
+    std::lock_guard guard{m_mutex};
+    return m_state.size();
 }
 
-void state_map_free(state_map_type *map) {
-    int_vector_free(map->state);
-    free(map);
+bool StateMap::operator==(const StateMap &other) const {
+    std::scoped_lock lock{m_mutex, other.m_mutex};
+    return m_state == other.m_state;
 }
 
-int state_map_get_size(const state_map_type *map) {
-    int size;
-    pthread_rwlock_rdlock(&map->rw_lock);
-    { size = int_vector_size(map->state); }
-    pthread_rwlock_unlock(&map->rw_lock);
-    return size;
+realisation_state_enum StateMap::get(int index) const {
+    std::lock_guard guard{m_mutex};
+    if (index < m_state.size())
+        return static_cast<realisation_state_enum>(m_state.at(index));
+    return realisation_state_enum::STATE_UNDEFINED;
 }
 
-bool state_map_equal(const state_map_type *map1, const state_map_type *map2) {
-    bool equal = true;
-    pthread_rwlock_rdlock(&map1->rw_lock);
-    pthread_rwlock_rdlock(&map2->rw_lock);
-    {
-        if (int_vector_size(map1->state) != int_vector_size(map2->state))
-            equal = false;
-
-        if (equal)
-            equal = int_vector_equal(map1->state, map2->state);
-    }
-    pthread_rwlock_unlock(&map1->rw_lock);
-    pthread_rwlock_unlock(&map2->rw_lock);
-    return equal;
-}
-
-realisation_state_enum state_map_iget(const state_map_type *map, int index) {
-    realisation_state_enum state;
-    pthread_rwlock_rdlock(&map->rw_lock);
-    { state = (realisation_state_enum)int_vector_safe_iget(map->state, index); }
-    pthread_rwlock_unlock(&map->rw_lock);
-    return state;
-}
-
-bool state_map_legal_transition(realisation_state_enum state1,
-                                realisation_state_enum state2) {
+bool StateMap::is_legal_transition(realisation_state_enum state1,
+                                   realisation_state_enum state2) {
     int target_mask = 0;
 
     if (state1 == STATE_UNDEFINED)
@@ -136,140 +114,147 @@ bool state_map_legal_transition(realisation_state_enum state1,
         return false;
 }
 
-static void state_map_assert_writable(const state_map_type *map) {
-    if (map->read_only)
+void StateMap::m_assert_writable() const {
+    if (m_read_only)
         util_abort("%s: tried to modify read_only state_map - aborting \n",
                    __func__);
 }
 
-static void state_map_iset__(state_map_type *map, int index,
-                             realisation_state_enum new_state) {
-    realisation_state_enum current_state =
-        (realisation_state_enum)int_vector_safe_iget(map->state, index);
+void StateMap::set(int index, realisation_state_enum new_state) {
+    m_assert_writable();
+    std::lock_guard lock{m_mutex};
 
-    if (state_map_legal_transition(current_state, new_state))
-        int_vector_iset(map->state, index, new_state);
+    if (index < 0)
+        index += m_state.size();
+    if (index < 0)
+        throw std::out_of_range(
+            fmt::format("index out of range: {} < 0", index));
+    if (index >= m_state.size())
+        m_state.resize(index + 1, STATE_UNDEFINED);
+
+    auto current_state = static_cast<realisation_state_enum>(m_state.at(index));
+
+    if (is_legal_transition(current_state, new_state))
+        m_state[index] = new_state;
     else
         util_abort(
             "%s: illegal state transition for realisation:%d %d -> %d \n",
             __func__, index, current_state, new_state);
 }
 
-void state_map_iset(state_map_type *map, int index,
-                    realisation_state_enum state) {
-    state_map_assert_writable(map);
-    pthread_rwlock_wrlock(&map->rw_lock);
-    { state_map_iset__(map, index, state); }
-    pthread_rwlock_unlock(&map->rw_lock);
-}
-
-void state_map_update_matching(state_map_type *map, int index, int state_mask,
+void StateMap::update_matching(size_t index, int state_mask,
                                realisation_state_enum new_state) {
-    realisation_state_enum current_state = state_map_iget(map, index);
+    realisation_state_enum current_state = get(index);
     if (current_state & state_mask)
-        state_map_iset(map, index, new_state);
+        set(index, new_state);
 }
 
-void state_map_update_undefined(state_map_type *map, int index,
-                                realisation_state_enum new_state) {
-    state_map_update_matching(map, index, STATE_UNDEFINED, new_state);
+void StateMap::write(const fs::path &path) const {
+    std::lock_guard lock{m_mutex};
+
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec /* Error-code is ignored */);
+    std::ofstream stream{path};
+
+    if (!stream.is_open())
+        util_abort("%s: failed to open:%s for writing \n", __func__,
+                   path.c_str());
+
+    stream.exceptions(stream.failbit);
+    write_libecl_vector(stream, m_state);
 }
 
-void state_map_fwrite(const state_map_type *map, const char *filename) {
-    pthread_rwlock_rdlock(&map->rw_lock);
-    {
-        auto stream = mkdir_fopen(fs::path(filename), "w");
-        if (stream) {
-            int_vector_fwrite(map->state, stream);
-            fclose(stream);
-        } else
-            util_abort("%s: failed to open:%s for writing \n", __func__,
-                       filename);
+bool StateMap::read(const fs::path &filename) {
+    return read(filename, m_read_only);
+}
+
+bool StateMap::read(const fs::path &filename, bool read_only) {
+    m_read_only = read_only;
+    std::lock_guard lock{m_mutex};
+    std::ifstream stream{filename};
+    try {
+        stream.exceptions(stream.failbit);
+        read_libecl_vector(stream, m_state);
+        return true;
+    } catch (std::ios_base::failure &) {
+        m_state.clear();
+        return false;
     }
-    pthread_rwlock_unlock(&map->rw_lock);
 }
 
-bool state_map_fread(state_map_type *map, const char *filename) {
-    bool file_exists = false;
-    pthread_rwlock_wrlock(&map->rw_lock);
-    {
-        if (fs::exists(filename)) {
-            FILE *stream = util_fopen(filename, "r");
-            if (stream) {
-                int_vector_fread(map->state, stream);
-                fclose(stream);
-            } else
-                util_abort("%s: failed to open:%s for reading \n", __func__,
-                           filename);
-            file_exists = true;
-        } else
-            int_vector_reset(map->state);
+std::vector<bool> StateMap::select_matching(int select_mask,
+                                            bool select) const {
+    std::lock_guard lock{m_mutex};
+    std::vector<bool> select_target(m_state.size(), false);
+    for (size_t i{}; i < m_state.size(); ++i) {
+        auto state_value = m_state[i];
+        if (state_value & select_mask)
+            select_target[i] = select;
     }
-    pthread_rwlock_unlock(&map->rw_lock);
-    return file_exists;
-}
-
-std::vector<bool> state_map_select_matching(const state_map_type *map,
-                                            int select_mask, bool select) {
-    std::vector<bool> select_target(int_vector_size(map->state), false);
-    pthread_rwlock_rdlock(&map->rw_lock);
-    {
-        const int *map_ptr = int_vector_get_ptr(map->state);
-        for (size_t i = 0; i < select_target.size(); i++) {
-            int state_value = map_ptr[i];
-            if (state_value & select_mask)
-                select_target[i] = select;
-        }
-    }
-    pthread_rwlock_unlock(&map->rw_lock);
     return select_target;
 }
 
-static void state_map_set_from_mask__(state_map_type *map,
-                                      const std::vector<bool> &mask,
-                                      realisation_state_enum state,
-                                      bool invert) {
-    for (int i = 0; i < mask.size(); i++) {
-        if (mask[i] != invert)
-            state_map_iset(map, i, state);
-    }
-}
-
-void state_map_set_from_inverted_mask(state_map_type *state_map,
-                                      const std::vector<bool> &mask,
+void StateMap::set_from_inverted_mask(const std::vector<bool> &mask,
                                       realisation_state_enum state) {
-    state_map_set_from_mask__(state_map, mask, state, true);
+    for (size_t i{}; i < mask.size(); ++i)
+        if (!mask[i])
+            set(i, state);
 }
 
-void state_map_set_from_mask(state_map_type *state_map,
-                             const std::vector<bool> &mask,
+void StateMap::set_from_mask(const std::vector<bool> &mask,
                              realisation_state_enum state) {
-    state_map_set_from_mask__(state_map, mask, state, false);
+    for (size_t i{}; i < mask.size(); ++i)
+        if (mask[i])
+            set(i, state);
 }
 
-bool state_map_is_readonly(const state_map_type *state_map) {
-    return state_map->read_only;
+size_t StateMap::count_matching(int mask) const {
+    std::lock_guard lock{m_mutex};
+    return std::count_if(m_state.begin(), m_state.end(),
+                         [mask](int value) { return value & mask; });
 }
 
-int state_map_count_matching(const state_map_type *state_map, int mask) {
-    int count = 0;
-    pthread_rwlock_rdlock(&state_map->rw_lock);
-    {
-        const int *map_ptr = int_vector_get_ptr(state_map->state);
-        for (int i = 0; i < int_vector_size(state_map->state); i++) {
-            int state_value = map_ptr[i];
-            if (state_value & mask)
-                count++;
-        }
-    }
-    pthread_rwlock_unlock(&state_map->rw_lock);
-    return count;
-}
+RES_LIB_SUBMODULE("state_map", m) {
+    using namespace py::literals;
 
-std::vector<bool> select_matching(py::object map, int select_mask,
-                                  bool select) {
-    auto map_ = ert::from_cwrap<state_map_type>(map);
-    return state_map_select_matching(map_, select_mask, select);
-}
+    const auto init_with_exception = [](const fs::path &path,
+                                        bool readonly) -> StateMap {
+        StateMap sm;
+        if (!sm.read(path, readonly))
+            throw std::ios_base::failure{"StateMap::StateMap"};
+        return sm;
+    };
 
-RES_LIB_SUBMODULE("state_map", m) { m.def("select_matching", select_matching); }
+    const auto load_with_exception = [](StateMap &sm, const fs::path &path) {
+        if (!sm.read(path))
+            throw std::ios_base::failure{"StateMap::load"};
+    };
+
+    py::enum_<realisation_state_enum>(m, "RealizationStateEnum",
+                                      py::arithmetic{})
+        .value("STATE_UNDEFINED", STATE_UNDEFINED)
+        .value("STATE_INITIALIZED", STATE_INITIALIZED)
+        .value("STATE_HAS_DATA", STATE_HAS_DATA)
+        .value("STATE_LOAD_FAILURE", STATE_LOAD_FAILURE)
+        .value("STATE_PARENT_FAILURE", STATE_PARENT_FAILURE)
+        .export_values();
+
+    py::class_<StateMap, std::shared_ptr<StateMap>>(m, "StateMap")
+        .def_static("isLegalTransition", &StateMap::is_legal_transition)
+        .def(py::init<>())
+        .def(py::init(init_with_exception), "path"_a, "readonly"_a = false)
+        .def(py::self == py::self)
+        .def("__len__", &StateMap::size)
+        .def("_get", &StateMap::get, "index"_a)
+        .def("__setitem__", &StateMap::set, "index"_a, "value"_a)
+        .def("isReadOnly", &StateMap::is_readonly)
+        .def("load", load_with_exception, "path"_a)
+        .def("save", &StateMap::write, "path"_a)
+        .def("selectMatching",
+             [](const StateMap &x, int mask) {
+                 return x.select_matching(mask, true);
+             })
+        .def("deselectMatching", [](const StateMap &x, int mask) {
+            return x.select_matching(mask, false);
+        });
+}

--- a/src/libres/lib/include/ert/enkf/enkf_fs.hpp
+++ b/src/libres/lib/include/ert/enkf/enkf_fs.hpp
@@ -89,8 +89,8 @@ FILE *enkf_fs_open_excase_file(const enkf_fs_type *fs, const char *input_name);
 FILE *enkf_fs_open_excase_tstep_file(const enkf_fs_type *fs,
                                      const char *input_name, int tstep);
 
-state_map_type *enkf_fs_alloc_readonly_state_map(const char *mount_point);
-extern "C" state_map_type *enkf_fs_get_state_map(const enkf_fs_type *fs);
+StateMap enkf_fs_alloc_readonly_state_map(const char *mount_point);
+StateMap &enkf_fs_get_state_map(enkf_fs_type *fs);
 extern "C" time_map_type *enkf_fs_get_time_map(const enkf_fs_type *fs);
 misfit_ensemble_type *enkf_fs_get_misfit_ensemble(const enkf_fs_type *fs);
 extern "C" summary_key_set_type *

--- a/src/libres/lib/include/ert/enkf/enkf_main.hpp
+++ b/src/libres/lib/include/ert/enkf/enkf_main.hpp
@@ -158,9 +158,8 @@ bool enkf_main_fs_exists(const enkf_main_type *enkf_main,
 extern "C" const char *
 enkf_main_get_mount_root(const enkf_main_type *enkf_main);
 
-extern "C" state_map_type *
-enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
-                                   const char *case_path);
+StateMap enkf_main_alloc_readonly_state_map(const enkf_main_type *enkf_main,
+                                            const char *case_path);
 
 extern "C" queue_config_type *
 enkf_main_get_queue_config(enkf_main_type *enkf_main);

--- a/src/libres/lib/include/ert/enkf/state_map.hpp
+++ b/src/libres/lib/include/ert/enkf/state_map.hpp
@@ -1,62 +1,47 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-   The file 'state_map.c' is part of ERT - Ensemble based Reservoir Tool.
+#pragma once
 
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
-#ifndef ERT_STATE_MAP_H
-#define ERT_STATE_MAP_H
-
-#include <ert/util/bool_vector.h>
-#include <ert/util/type_macros.h>
+#include <filesystem>
+#include <mutex>
 #include <vector>
 
 #include <ert/enkf/enkf_types.hpp>
 
-typedef struct state_map_struct state_map_type;
+class StateMap {
+    std::vector<int> m_state;
+    mutable std::mutex m_mutex;
+    bool m_read_only{};
 
-extern "C" state_map_type *state_map_alloc();
-state_map_type *state_map_fread_alloc(const char *filename);
-state_map_type *state_map_fread_alloc_readonly(const char *filename);
-state_map_type *state_map_alloc_copy(const state_map_type *map);
-extern "C" bool state_map_is_readonly(const state_map_type *state_map);
-extern "C" void state_map_free(state_map_type *map);
-extern "C" int state_map_get_size(const state_map_type *map);
-extern "C" realisation_state_enum state_map_iget(const state_map_type *map,
-                                                 int index);
-void state_map_update_undefined(state_map_type *map, int index,
-                                realisation_state_enum new_state);
-void state_map_update_matching(state_map_type *map, int index, int state_mask,
-                               realisation_state_enum new_state);
-extern "C" void state_map_iset(state_map_type *map, int index,
-                               realisation_state_enum state);
-extern "C" bool state_map_equal(const state_map_type *map1,
-                                const state_map_type *map2);
-extern "C" void state_map_fwrite(const state_map_type *map,
-                                 const char *filename);
-extern "C" bool state_map_fread(state_map_type *map, const char *filename);
-std::vector<bool> state_map_select_matching(const state_map_type *map,
-                                            int select_mask, bool select);
-void state_map_set_from_inverted_mask(state_map_type *map,
-                                      const std::vector<bool> &mask,
-                                      realisation_state_enum state);
-void state_map_set_from_mask(state_map_type *map, const std::vector<bool> &mask,
-                             realisation_state_enum state);
-int state_map_count_matching(const state_map_type *state_map, int mask);
-extern "C" bool state_map_legal_transition(realisation_state_enum state1,
-                                           realisation_state_enum state2);
+    void m_assert_writable() const;
 
-UTIL_IS_INSTANCE_HEADER(state_map);
+public:
+    StateMap() = default;
+    StateMap(const std::filesystem::path &filename, bool read_only = true);
+    StateMap(const StateMap &other);
 
-#endif
+    int size() const;
+    bool operator==(const StateMap &) const;
+
+    bool is_readonly() const { return m_read_only; };
+
+    void set(int index, realisation_state_enum new_state);
+    realisation_state_enum get(int index) const;
+    void update_matching(size_t index, int state_mask,
+                         realisation_state_enum new_state);
+    void update_undefined(size_t index, realisation_state_enum new_state) {
+        update_matching(index, STATE_UNDEFINED, new_state);
+    }
+
+    void write(const std::filesystem::path &path) const;
+    bool read(const std::filesystem::path &path);
+    bool read(const std::filesystem::path &path, bool read_only);
+
+    std::vector<bool> select_matching(int select_mask, bool select) const;
+    void set_from_inverted_mask(const std::vector<bool> &mask,
+                                realisation_state_enum state);
+    void set_from_mask(const std::vector<bool> &mask,
+                       realisation_state_enum state);
+    size_t count_matching(int mask) const;
+
+    static bool is_legal_transition(realisation_state_enum state1,
+                                    realisation_state_enum state2);
+};

--- a/src/libres/lib/include/ert/python.hpp
+++ b/src/libres/lib/include/ert/python.hpp
@@ -11,6 +11,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 #include <pybind11/stl_bind.h>
 
 #include <ert/logging.hpp>

--- a/src/libres/lib/python/init.cpp
+++ b/src/libres/lib/python/init.cpp
@@ -8,6 +8,7 @@
 #include <ert/enkf/obs_vector.hpp>
 #include <ert/python.hpp>
 #include <ert/res_util/string.hpp>
+#include <pyerrors.h>
 
 namespace {
 auto &submodules() {
@@ -22,6 +23,18 @@ ert::detail::Submodule::Submodule(const char *path, init_type &init)
 }
 
 PYBIND11_MODULE(_lib, m) {
+    py::register_exception_translator([](std::exception_ptr p) {
+        if (!p)
+            return;
+
+        try {
+            std::rethrow_exception(p);
+        } catch (const std::ios_base::failure &e) {
+            PyErr_SetString(PyExc_OSError, e.what());
+            return;
+        }
+    });
+
     /* Initialise submodules */
     for (auto submodule : submodules()) {
         py::module_ node = m;

--- a/src/libres/old_tests/enkf/test_enkf_main_fs.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_main_fs.cpp
@@ -51,12 +51,9 @@ int main(int argc, char **argv) {
         }
 
         {
-            state_map_type *map1 =
-                enkf_fs_get_state_map(enkf_main_get_fs(enkf_main));
-            state_map_type *map2 =
-                enkf_main_alloc_readonly_state_map(enkf_main, "enkf");
-            test_assert_true(state_map_equal(map1, map2));
-            state_map_free(map2);
+            auto &map1 = enkf_fs_get_state_map(enkf_main_get_fs(enkf_main));
+            auto map2 = enkf_main_alloc_readonly_state_map(enkf_main, "enkf");
+            test_assert_true(map1 == map2);
         }
         {
             enkf_fs_type *fs1 =

--- a/src/libres/old_tests/enkf/test_enkf_state_manual_load.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_state_manual_load.cpp
@@ -37,8 +37,8 @@ int test_load_manually_to_new_case(enkf_main_type *enkf_main) {
         "run_id", fs, iens, iter, "simulations/run0", job_name);
     {
 
-        state_map_type *state_map = enkf_fs_get_state_map(fs);
-        state_map_update_undefined(state_map, 0, STATE_INITIALIZED);
+        auto &state_map = enkf_fs_get_state_map(fs);
+        state_map.update_undefined(0, STATE_INITIALIZED);
 
         enkf_state_load_from_forward_model(enkf_main_iget_state(enkf_main, 0),
                                            run_arg);

--- a/src/libres/old_tests/enkf/test_enkf_state_map.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_state_map.cpp
@@ -26,158 +26,144 @@
 #include <ert/enkf/state_map.hpp>
 
 void create_test() {
-    state_map_type *state_map = state_map_alloc();
-    test_assert_true(state_map_is_instance(state_map));
-    test_assert_int_equal(0, state_map_get_size(state_map));
-    test_assert_false(state_map_is_readonly(state_map));
-    state_map_free(state_map);
+    StateMap state_map;
+    test_assert_int_equal(0, state_map.size());
+    test_assert_false(state_map.is_readonly());
 }
 
 void get_test() {
-    state_map_type *state_map = state_map_alloc();
-    test_assert_int_equal(STATE_UNDEFINED, state_map_iget(state_map, 0));
-    test_assert_int_equal(STATE_UNDEFINED, state_map_iget(state_map, 100));
-    state_map_free(state_map);
+    StateMap state_map;
+    test_assert_int_equal(STATE_UNDEFINED, state_map.get(0));
+    test_assert_int_equal(STATE_UNDEFINED, state_map.get(100));
 }
 
 void set_test() {
-    state_map_type *state_map = state_map_alloc();
-    state_map_iset(state_map, 0, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(state_map, 0));
+    StateMap state_map;
+    state_map.set(0, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(0));
 
-    state_map_iset(state_map, 100, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(state_map, 100));
+    state_map.set(100, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(100));
 
-    test_assert_int_equal(STATE_UNDEFINED, state_map_iget(state_map, 50));
-    test_assert_int_equal(101, state_map_get_size(state_map));
-    state_map_free(state_map);
+    test_assert_int_equal(STATE_UNDEFINED, state_map.get(50));
+    test_assert_int_equal(101, state_map.size());
 }
 
 void load_empty_test() {
-    state_map_type *state_map = state_map_fread_alloc("File/does/not/exists");
-    test_assert_true(state_map_is_instance(state_map));
-    test_assert_int_equal(0, state_map_get_size(state_map));
-    state_map_free(state_map);
+    StateMap state_map("File/does/not/exists");
+    test_assert_int_equal(0, state_map.size());
 }
 
 void test_equal() {
-    state_map_type *state_map1 = state_map_alloc();
-    state_map_type *state_map2 = state_map_alloc();
+    StateMap state_map1;
+    StateMap state_map2;
 
-    test_assert_true(state_map_equal(state_map1, state_map2));
+    test_assert_true(state_map1 == state_map2);
     for (int i = 0; i < 25; i++) {
-        state_map_iset(state_map1, i, STATE_INITIALIZED);
-        state_map_iset(state_map2, i, STATE_INITIALIZED);
+        state_map1.set(i, STATE_INITIALIZED);
+        state_map2.set(i, STATE_INITIALIZED);
     }
-    test_assert_true(state_map_equal(state_map1, state_map2));
+    test_assert_true(state_map1 == state_map2);
 
-    state_map_iset(state_map2, 15, STATE_HAS_DATA);
-    test_assert_false(state_map_equal(state_map1, state_map2));
-    state_map_iset(state_map2, 15, STATE_LOAD_FAILURE);
-    state_map_iset(state_map2, 15, STATE_INITIALIZED);
-    test_assert_true(state_map_equal(state_map1, state_map2));
+    state_map2.set(15, STATE_HAS_DATA);
+    test_assert_false(state_map1 == state_map2);
+    state_map2.set(15, STATE_LOAD_FAILURE);
+    state_map2.set(15, STATE_INITIALIZED);
+    test_assert_true(state_map1 == state_map2);
 
-    state_map_iset(state_map2, 150, STATE_INITIALIZED);
-    test_assert_false(state_map_equal(state_map1, state_map2));
+    state_map2.set(150, STATE_INITIALIZED);
+    test_assert_false(state_map1 == state_map2);
 }
 
 void test_copy() {
-    state_map_type *state_map = state_map_alloc();
-    state_map_iset(state_map, 0, STATE_INITIALIZED);
-    state_map_iset(state_map, 100, STATE_INITIALIZED);
+    StateMap state_map;
+    state_map.set(0, STATE_INITIALIZED);
+    state_map.set(100, STATE_INITIALIZED);
     {
-        state_map_type *copy = state_map_alloc_copy(state_map);
-        test_assert_true(state_map_equal(copy, state_map));
+        StateMap copy = state_map;
+        test_assert_true(copy == state_map);
 
-        state_map_iset(state_map, 10, STATE_INITIALIZED);
-        test_assert_false(state_map_equal(copy, state_map));
-
-        state_map_free(copy);
+        state_map.set(10, STATE_INITIALIZED);
+        test_assert_false(copy == state_map);
     }
-    state_map_free(state_map);
 }
 
 void test_io() {
     ecl::util::TestArea ta("state_map_io");
     {
-        state_map_type *state_map = state_map_alloc();
-        state_map_type *copy1, *copy2;
-        state_map_iset(state_map, 0, STATE_INITIALIZED);
-        state_map_iset(state_map, 100, STATE_INITIALIZED);
-        state_map_fwrite(state_map, "map");
+        StateMap state_map;
+        state_map.set(0, STATE_INITIALIZED);
+        state_map.set(100, STATE_INITIALIZED);
+        state_map.write("map");
 
-        copy1 = state_map_fread_alloc("map");
-        test_assert_true(state_map_equal(state_map, copy1));
+        StateMap copy1("map");
+        test_assert_true(state_map == copy1);
 
-        copy2 = state_map_alloc();
-        test_assert_true(state_map_fread(copy2, "map"));
-        test_assert_true(state_map_equal(state_map, copy2));
+        StateMap copy2;
+        test_assert_true(copy2.read("map"));
+        test_assert_true(state_map == copy2);
 
-        state_map_iset(copy2, 67, STATE_INITIALIZED);
-        test_assert_false(state_map_equal(state_map, copy2));
+        copy2.set(67, STATE_INITIALIZED);
+        test_assert_false(state_map == copy2);
 
-        state_map_fread(copy2, "map");
-        test_assert_true(state_map_equal(state_map, copy2));
+        copy2.read("map");
+        test_assert_true(state_map == copy2);
 
-        test_assert_false(state_map_fread(copy2, "DoesNotExist"));
-        test_assert_int_equal(0, state_map_get_size(copy2));
+        test_assert_false(copy2.read("DoesNotExist"));
+        test_assert_int_equal(0, copy2.size());
     }
 }
 
 void test_update_undefined() {
-    state_map_type *map = state_map_alloc();
+    StateMap state_map;
 
-    state_map_iset(map, 10, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_UNDEFINED, state_map_iget(map, 5));
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 10));
+    state_map.set(10, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_UNDEFINED, state_map.get(5));
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(10));
 
-    state_map_update_undefined(map, 5, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 5));
+    state_map.update_undefined(5, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(5));
 
-    state_map_update_undefined(map, 10, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 10));
-
-    state_map_free(map);
+    state_map.update_undefined(10, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(10));
 }
 
 void test_update_matching() {
-    state_map_type *map = state_map_alloc();
+    StateMap state_map;
 
-    state_map_iset(map, 10, STATE_INITIALIZED);
-    state_map_iset(map, 3, STATE_PARENT_FAILURE);
-    test_assert_int_equal(STATE_UNDEFINED, state_map_iget(map, 5));
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 10));
+    state_map.set(10, STATE_INITIALIZED);
+    state_map.set(3, STATE_PARENT_FAILURE);
+    test_assert_int_equal(STATE_UNDEFINED, state_map.get(5));
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(10));
 
-    state_map_update_matching(map, 5, STATE_UNDEFINED | STATE_LOAD_FAILURE,
+    state_map.update_matching(5, STATE_UNDEFINED | STATE_LOAD_FAILURE,
                               STATE_INITIALIZED);
-    state_map_update_matching(map, 10, STATE_UNDEFINED | STATE_LOAD_FAILURE,
+    state_map.update_matching(10, STATE_UNDEFINED | STATE_LOAD_FAILURE,
                               STATE_INITIALIZED);
-    state_map_update_matching(map, 3, STATE_UNDEFINED | STATE_LOAD_FAILURE,
+    state_map.update_matching(3, STATE_UNDEFINED | STATE_LOAD_FAILURE,
                               STATE_INITIALIZED);
 
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 5));
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 10));
-    test_assert_int_equal(STATE_PARENT_FAILURE, state_map_iget(map, 3));
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(5));
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(10));
+    test_assert_int_equal(STATE_PARENT_FAILURE, state_map.get(3));
 
-    state_map_update_undefined(map, 10, STATE_INITIALIZED);
-    test_assert_int_equal(STATE_INITIALIZED, state_map_iget(map, 10));
-
-    state_map_free(map);
+    state_map.update_undefined(10, STATE_INITIALIZED);
+    test_assert_int_equal(STATE_INITIALIZED, state_map.get(10));
 }
 
 void test_select_matching() {
-    state_map_type *map = state_map_alloc();
+    StateMap state_map;
 
-    state_map_iset(map, 10, STATE_INITIALIZED);
-    state_map_iset(map, 10, STATE_HAS_DATA);
-    state_map_iset(map, 20, STATE_INITIALIZED);
-    std::vector<bool> mask = state_map_select_matching(
-        map, STATE_HAS_DATA | STATE_INITIALIZED, true);
+    state_map.set(10, STATE_INITIALIZED);
+    state_map.set(10, STATE_HAS_DATA);
+    state_map.set(20, STATE_INITIALIZED);
+    auto mask =
+        state_map.select_matching(STATE_HAS_DATA | STATE_INITIALIZED, true);
     test_assert_int_equal(mask.size(), 21);
     test_assert_true(mask[10]);
     test_assert_true(mask[20]);
 
-    mask = state_map_select_matching(map, STATE_HAS_DATA, true);
+    mask = state_map.select_matching(STATE_HAS_DATA, true);
 
     for (size_t i; i < mask.size(); i++) {
         if (i == 10)
@@ -187,23 +173,20 @@ void test_select_matching() {
         }
     }
 
-    state_map_iset(map, 50, STATE_INITIALIZED);
-    mask = state_map_select_matching(map, STATE_HAS_DATA | STATE_INITIALIZED,
-                                     true);
+    state_map.set(50, STATE_INITIALIZED);
+    mask = state_map.select_matching(STATE_HAS_DATA | STATE_INITIALIZED, true);
     test_assert_int_equal(mask.size(), 51);
-
-    state_map_free(map);
 }
 
 void test_deselect_matching() {
-    state_map_type *map = state_map_alloc();
+    StateMap state_map;
 
-    state_map_iset(map, 10, STATE_HAS_DATA);
-    state_map_iset(map, 20, STATE_INITIALIZED);
-    std::vector<bool> mask = state_map_select_matching(
-        map, STATE_HAS_DATA | STATE_INITIALIZED, false);
+    state_map.set(10, STATE_HAS_DATA);
+    state_map.set(20, STATE_INITIALIZED);
+    auto mask =
+        state_map.select_matching(STATE_HAS_DATA | STATE_INITIALIZED, false);
 
-    test_assert_int_equal(state_map_get_size(map), mask.size());
+    test_assert_int_equal(state_map.size(), mask.size());
 
     for (int i = 0; i < mask.size(); i++) {
         if ((i == 10) | (i == 20))
@@ -212,29 +195,25 @@ void test_deselect_matching() {
             test_assert_true(mask[i]);
         }
     }
-
-    state_map_free(map);
 }
 
 void test_count_matching() {
-    state_map_type *map1 = state_map_alloc();
-    state_map_iset(map1, 10, STATE_INITIALIZED);
+    StateMap state_map;
+    state_map.set(10, STATE_INITIALIZED);
 
-    state_map_iset(map1, 15, STATE_INITIALIZED);
-    state_map_iset(map1, 15, STATE_HAS_DATA);
+    state_map.set(15, STATE_INITIALIZED);
+    state_map.set(15, STATE_HAS_DATA);
 
-    state_map_iset(map1, 16, STATE_INITIALIZED);
-    state_map_iset(map1, 16, STATE_HAS_DATA);
-    state_map_iset(map1, 16, STATE_LOAD_FAILURE);
+    state_map.set(16, STATE_INITIALIZED);
+    state_map.set(16, STATE_HAS_DATA);
+    state_map.set(16, STATE_LOAD_FAILURE);
 
-    test_assert_int_equal(1, state_map_count_matching(map1, STATE_HAS_DATA));
+    test_assert_int_equal(1, state_map.count_matching(STATE_HAS_DATA));
     test_assert_int_equal(
-        2, state_map_count_matching(map1, STATE_HAS_DATA | STATE_LOAD_FAILURE));
-    test_assert_int_equal(
-        3, state_map_count_matching(map1, STATE_HAS_DATA | STATE_LOAD_FAILURE |
-                                              STATE_INITIALIZED));
-
-    state_map_free(map1);
+        2, state_map.count_matching(STATE_HAS_DATA | STATE_LOAD_FAILURE));
+    test_assert_int_equal(3, state_map.count_matching(STATE_HAS_DATA |
+                                                      STATE_LOAD_FAILURE |
+                                                      STATE_INITIALIZED));
 }
 
 // Probably means that the target should be explicitly set to
@@ -242,87 +221,83 @@ void test_count_matching() {
 void test_transitions() {
 
     test_assert_false(
-        state_map_legal_transition(STATE_UNDEFINED, STATE_UNDEFINED));
+        StateMap::is_legal_transition(STATE_UNDEFINED, STATE_UNDEFINED));
     test_assert_true(
-        state_map_legal_transition(STATE_UNDEFINED, STATE_INITIALIZED));
+        StateMap::is_legal_transition(STATE_UNDEFINED, STATE_INITIALIZED));
     test_assert_false(
-        state_map_legal_transition(STATE_UNDEFINED, STATE_HAS_DATA));
+        StateMap::is_legal_transition(STATE_UNDEFINED, STATE_HAS_DATA));
     test_assert_false(
-        state_map_legal_transition(STATE_UNDEFINED, STATE_LOAD_FAILURE));
+        StateMap::is_legal_transition(STATE_UNDEFINED, STATE_LOAD_FAILURE));
     test_assert_true(
-        state_map_legal_transition(STATE_UNDEFINED, STATE_PARENT_FAILURE));
+        StateMap::is_legal_transition(STATE_UNDEFINED, STATE_PARENT_FAILURE));
 
     test_assert_false(
-        state_map_legal_transition(STATE_INITIALIZED, STATE_UNDEFINED));
+        StateMap::is_legal_transition(STATE_INITIALIZED, STATE_UNDEFINED));
     test_assert_true(
-        state_map_legal_transition(STATE_INITIALIZED, STATE_INITIALIZED));
+        StateMap::is_legal_transition(STATE_INITIALIZED, STATE_INITIALIZED));
     test_assert_true(
-        state_map_legal_transition(STATE_INITIALIZED, STATE_HAS_DATA));
+        StateMap::is_legal_transition(STATE_INITIALIZED, STATE_HAS_DATA));
     test_assert_true(
-        state_map_legal_transition(STATE_INITIALIZED, STATE_LOAD_FAILURE));
-    test_assert_true(state_map_legal_transition(
+        StateMap::is_legal_transition(STATE_INITIALIZED, STATE_LOAD_FAILURE));
+    test_assert_true(StateMap::is_legal_transition(
         STATE_INITIALIZED,
         STATE_PARENT_FAILURE)); // Should maybe false - if the commenta baove is taken into account.
 
     test_assert_false(
-        state_map_legal_transition(STATE_HAS_DATA, STATE_UNDEFINED));
+        StateMap::is_legal_transition(STATE_HAS_DATA, STATE_UNDEFINED));
     test_assert_true(
-        state_map_legal_transition(STATE_HAS_DATA, STATE_INITIALIZED));
+        StateMap::is_legal_transition(STATE_HAS_DATA, STATE_INITIALIZED));
     test_assert_true(
-        state_map_legal_transition(STATE_HAS_DATA, STATE_HAS_DATA));
+        StateMap::is_legal_transition(STATE_HAS_DATA, STATE_HAS_DATA));
     test_assert_true(
-        state_map_legal_transition(STATE_HAS_DATA, STATE_LOAD_FAILURE));
-    test_assert_true(state_map_legal_transition(STATE_HAS_DATA,
-                                                STATE_PARENT_FAILURE)); // Rerun
+        StateMap::is_legal_transition(STATE_HAS_DATA, STATE_LOAD_FAILURE));
+    test_assert_true(
+        StateMap::is_legal_transition(STATE_HAS_DATA,
+                                      STATE_PARENT_FAILURE)); // Rerun
 
     test_assert_false(
-        state_map_legal_transition(STATE_LOAD_FAILURE, STATE_UNDEFINED));
+        StateMap::is_legal_transition(STATE_LOAD_FAILURE, STATE_UNDEFINED));
     test_assert_true(
-        state_map_legal_transition(STATE_LOAD_FAILURE, STATE_INITIALIZED));
+        StateMap::is_legal_transition(STATE_LOAD_FAILURE, STATE_INITIALIZED));
     test_assert_true(
-        state_map_legal_transition(STATE_LOAD_FAILURE, STATE_HAS_DATA));
+        StateMap::is_legal_transition(STATE_LOAD_FAILURE, STATE_HAS_DATA));
     test_assert_true(
-        state_map_legal_transition(STATE_LOAD_FAILURE, STATE_LOAD_FAILURE));
-    test_assert_false(
-        state_map_legal_transition(STATE_LOAD_FAILURE, STATE_PARENT_FAILURE));
+        StateMap::is_legal_transition(STATE_LOAD_FAILURE, STATE_LOAD_FAILURE));
+    test_assert_false(StateMap::is_legal_transition(STATE_LOAD_FAILURE,
+                                                    STATE_PARENT_FAILURE));
 
     test_assert_false(
-        state_map_legal_transition(STATE_PARENT_FAILURE, STATE_UNDEFINED));
+        StateMap::is_legal_transition(STATE_PARENT_FAILURE, STATE_UNDEFINED));
     test_assert_true(
-        state_map_legal_transition(STATE_PARENT_FAILURE, STATE_INITIALIZED));
+        StateMap::is_legal_transition(STATE_PARENT_FAILURE, STATE_INITIALIZED));
     test_assert_false(
-        state_map_legal_transition(STATE_PARENT_FAILURE, STATE_HAS_DATA));
-    test_assert_false(
-        state_map_legal_transition(STATE_PARENT_FAILURE, STATE_LOAD_FAILURE));
-    test_assert_true(
-        state_map_legal_transition(STATE_PARENT_FAILURE, STATE_PARENT_FAILURE));
+        StateMap::is_legal_transition(STATE_PARENT_FAILURE, STATE_HAS_DATA));
+    test_assert_false(StateMap::is_legal_transition(STATE_PARENT_FAILURE,
+                                                    STATE_LOAD_FAILURE));
+    test_assert_true(StateMap::is_legal_transition(STATE_PARENT_FAILURE,
+                                                   STATE_PARENT_FAILURE));
 }
 
 void test_readonly() {
     {
-        state_map_type *map1 =
-            state_map_fread_alloc_readonly("FileDoesNotExist");
+        StateMap state_map("FileDoesNotExist", true);
 
-        test_assert_true(state_map_is_instance(map1));
-        test_assert_int_equal(0, state_map_get_size(map1));
-        test_assert_true(state_map_is_readonly(map1));
-        state_map_free(map1);
+        test_assert_int_equal(0, state_map.size());
+        test_assert_true(state_map.is_readonly());
     }
     {
         ecl::util::TestArea ta("ro");
-        state_map_type *map1 = state_map_alloc();
+        StateMap state_map;
 
-        state_map_iset(map1, 5, STATE_INITIALIZED);
-        state_map_iset(map1, 9, STATE_INITIALIZED);
+        state_map.set(5, STATE_INITIALIZED);
+        state_map.set(9, STATE_INITIALIZED);
 
-        state_map_fwrite(map1, "map1");
+        state_map.write("map1");
         {
-            state_map_type *map2 = state_map_fread_alloc_readonly("map1");
+            StateMap map2("map1", true);
 
-            test_assert_true(state_map_equal(map1, map2));
-            state_map_free(map2);
+            test_assert_true(state_map == map2);
         }
-        state_map_free(map1);
     }
 }
 

--- a/src/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
@@ -31,8 +31,8 @@ bool check_ecl_sum_compatible(const enkf_main_type *enkf_main) {
     run_arg_type *run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT(
         "run_id", fs, 0, 0, "simulations/run0", job_name);
 
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    state_map_iset(state_map, 0, STATE_INITIALIZED);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    state_map.set(0, STATE_INITIALIZED);
 
     auto error = enkf_state_load_from_forward_model(state, run_arg);
 

--- a/src/libres/old_tests/enkf/test_enkf_state_skip_summary_load.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_state_skip_summary_load.cpp
@@ -33,12 +33,12 @@ bool check_ecl_sum_loaded(const enkf_main_type *enkf_main) {
     run_arg_type *run_arg2 = run_arg_alloc_ENSEMBLE_EXPERIMENT(
         "run_id", fs, 0, 0, "simulations/run1", job_name);
 
-    state_map_type *state_map = enkf_fs_get_state_map(fs);
-    state_map_iset(state_map, 0, STATE_INITIALIZED);
+    auto &state_map = enkf_fs_get_state_map(fs);
+    state_map.set(0, STATE_INITIALIZED);
 
     auto error = enkf_state_load_from_forward_model(state1, run_arg1);
 
-    state_map_iset(state_map, 1, STATE_INITIALIZED);
+    state_map.set(1, STATE_INITIALIZED);
     error = enkf_state_load_from_forward_model(state2, run_arg2);
 
     free(job_name);

--- a/src/libres/old_tests/enkf/test_enkf_workflow_job.cpp
+++ b/src/libres/old_tests/enkf/test_enkf_workflow_job.cpp
@@ -148,11 +148,11 @@ void test_init_case_job(ert_test_context_type *test_context,
 
         enkf_fs_type *default_fs =
             enkf_main_mount_alt_fs(enkf_main, "default", true);
-        state_map_type *default_state_map = enkf_fs_get_state_map(default_fs);
-        state_map_type *current_state_map =
+        auto &default_state_map = enkf_fs_get_state_map(default_fs);
+        auto &current_state_map =
             enkf_fs_get_state_map(enkf_main_get_fs(enkf_main));
-        test_assert_int_equal(state_map_get_size(default_state_map),
-                              state_map_get_size(current_state_map));
+        test_assert_int_equal(default_state_map.size(),
+                              current_state_map.size());
         enkf_fs_decref(default_fs);
     }
 
@@ -172,10 +172,9 @@ void test_init_case_job(ert_test_context_type *test_context,
 
         enkf_fs_type *default_fs =
             enkf_main_mount_alt_fs(enkf_main, "default", true);
-        state_map_type *default_state_map = enkf_fs_get_state_map(default_fs);
-        state_map_type *new_state_map = enkf_fs_get_state_map(fs);
-        test_assert_int_equal(state_map_get_size(default_state_map),
-                              state_map_get_size(new_state_map));
+        auto &default_state_map = enkf_fs_get_state_map(default_fs);
+        auto &new_state_map = enkf_fs_get_state_map(fs);
+        test_assert_int_equal(default_state_map.size(), new_state_map.size());
         enkf_fs_decref(fs);
     }
 

--- a/src/res/enkf/enkf_fs.py
+++ b/src/res/enkf/enkf_fs.py
@@ -25,6 +25,7 @@ from res.enkf.enums import EnKFFSType
 from res.enkf.state_map import StateMap
 from res.enkf.summary_key_set import SummaryKeySet
 from res.enkf.util import TimeMap
+from res import _lib
 
 from res._lib import update
 
@@ -46,7 +47,6 @@ class EnkfFs(BaseCClass):
         bind=False,
     )
     _get_time_map = ResPrototype("time_map_ref  enkf_fs_get_time_map(enkf_fs)")
-    _get_state_map = ResPrototype("state_map_ref enkf_fs_get_state_map(enkf_fs)")
     _summary_key_set = ResPrototype(
         "summary_key_set_ref enkf_fs_get_summary_key_set(enkf_fs)"
     )
@@ -75,7 +75,7 @@ class EnkfFs(BaseCClass):
 
     def getStateMap(self) -> StateMap:
         """@rtype: StateMap"""
-        return self._get_state_map().setParent(self)
+        return _lib.enkf_fs.get_state_map(self)
 
     def getCaseName(self):
         """@rtype: str"""

--- a/src/res/enkf/enkf_fs_manager.py
+++ b/src/res/enkf/enkf_fs_manager.py
@@ -100,10 +100,6 @@ class EnkfFsManager(BaseCClass):
         "void enkf_main_init_current_case_from_existing(enkf_fs_manager, enkf_fs, int)"
     )
 
-    _alloc_readonly_state_map = ResPrototype(
-        "state_map_obj enkf_main_alloc_readonly_state_map(enkf_fs_manager, char*)"
-    )
-
     DEFAULT_CAPACITY = 5
 
     def __init__(self, enkf_main: "EnKFMain", capacity: int = DEFAULT_CAPACITY):
@@ -262,7 +258,7 @@ class EnkfFsManager(BaseCClass):
             fs = self.getFileSystem(case)
             return fs.getStateMap()
         else:
-            return self._alloc_readonly_state_map(case)
+            return _lib.enkf_fs.alloc_readonly_state_map(case)
 
     def isCaseHidden(self, case_name: str) -> bool:
         return case_name.startswith(".")

--- a/src/res/enkf/enums/realization_state_enum.py
+++ b/src/res/enkf/enums/realization_state_enum.py
@@ -1,32 +1,4 @@
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'ert_impl_type_enum.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-from cwrap import BaseCEnum
+from res._lib.state_map import RealizationStateEnum
 
 
-class RealizationStateEnum(BaseCEnum):
-    TYPE_NAME = "realisation_state_enum"
-    STATE_UNDEFINED = 1
-    STATE_INITIALIZED = 2
-    STATE_HAS_DATA = 4
-    STATE_LOAD_FAILURE = 8
-    STATE_PARENT_FAILURE = 16
-
-
-RealizationStateEnum.addEnum("STATE_UNDEFINED", 1)
-RealizationStateEnum.addEnum("STATE_INITIALIZED", 2)
-RealizationStateEnum.addEnum("STATE_HAS_DATA", 4)
-RealizationStateEnum.addEnum("STATE_LOAD_FAILURE", 8)
-RealizationStateEnum.addEnum("STATE_PARENT_FAILURE", 16)
+__all__ = ["RealizationStateEnum"]

--- a/src/res/enkf/state_map.py
+++ b/src/res/enkf/state_map.py
@@ -1,137 +1,44 @@
-#  Copyright (C) 2012  Equinor ASA, Norway.
-#
-#  The file 'enkf_fs.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from typing import List
-
-from cwrap import BaseCClass
-
-from res import ResPrototype, _lib
+from res._lib.state_map import StateMap
 from res.enkf.enums import RealizationStateEnum
 
 
-class StateMap(BaseCClass):
-    TYPE_NAME = "state_map"
+def __getitem__(self, iens: int) -> RealizationStateEnum:
+    if iens < len(self):
+        return self._get(iens)
+    raise IndexError(f"StateMap index out of range: {iens} not in [0, {len(self)})")
 
-    _alloc = ResPrototype("void* state_map_alloc()", bind=False)
-    _fread = ResPrototype("bool  state_map_fread(state_map , char*)")
-    _fwrite = ResPrototype("void  state_map_fwrite(state_map , char*)")
-    _equal = ResPrototype("bool  state_map_equal(state_map , state_map)")
-    _free = ResPrototype("void  state_map_free(state_map)")
-    _size = ResPrototype("int   state_map_get_size(state_map)")
-    _iget = ResPrototype("realisation_state_enum state_map_iget(state_map, int)")
-    _iset = ResPrototype("void  state_map_iset(state_map, int, realisation_state_enum)")
-    _is_read_only = ResPrototype("bool  state_map_is_readonly(state_map)")
-    _is_legal_transition = ResPrototype(
-        "bool  state_map_legal_transition(realisation_state_enum, realisation_state_enum)",  # noqa
-        bind=False,
-    )
 
-    def __init__(self, filename=None):
-        c_ptr = self._alloc()
-        super().__init__(c_ptr)
-        if filename:
-            self.load(filename)
+def __iter__(self):
+    index = 0
+    size = len(self)
 
-    def __len__(self):
-        """@rtype: int"""
-        return self._size()
+    while index < size:
+        yield self[index]
+        index += 1
 
-    def __iter__(self):
-        index = 0
-        size = len(self)
 
-        while index < size:
-            yield self[index]
-            index += 1
+def realizationList(self, state_value: RealizationStateEnum) -> List[int]:
+    """Will create an integer list of all realisations with state equal to
+    state_value."""
+    mask = self.createMask(state_value)
+    return [idx for idx, value in enumerate(mask) if value]
 
-    def __eq__(self, other):
-        return self._equal(other)
 
-    def __getitem__(self, index):
-        """@rtype: RealizationStateEnum"""
-        if not isinstance(index, int):
-            raise TypeError("Expected an integer")
+def createMask(self, state_value: RealizationStateEnum) -> List[bool]:
+    """Will create a bool list of all realisations with state equal to
+    state_value."""
+    return self.selectMatching(state_value)
 
-        size = len(self)
-        if index < 0:
-            index += size
-        if 0 <= index < size:
-            return self._iget(index)
-        raise IndexError(f"Invalid index. Valid range: [0, {size})")
 
-    def __setitem__(self, index, value):
-        if self.isReadOnly():
-            raise UserWarning("This State Map is read only!")
+StateMap.__getitem__ = __getitem__
+StateMap.__iter__ = __iter__
+StateMap.realizationList = realizationList
+StateMap.createMask = createMask
 
-        if not isinstance(index, int):
-            raise TypeError("Expected an integer")
+del __getitem__
+del __iter__
+del realizationList
+del createMask
 
-        if not isinstance(value, RealizationStateEnum):
-            raise TypeError("Expected a RealizationStateEnum")
-
-        if index < 0:
-            index += len(self)
-        if index < 0:
-            raise IndexError(f"Index out of range: {index} < 0")
-
-        self._iset(index, value)
-
-    @classmethod
-    def isLegalTransition(cls, realization_state1, realization_state2):
-        """@rtype: bool"""
-
-        if not isinstance(realization_state1, RealizationStateEnum) or not isinstance(
-            realization_state2, RealizationStateEnum
-        ):
-            raise TypeError("Expected a RealizationStateEnum")
-
-        return cls._is_legal_transition(realization_state1, realization_state2)
-
-    def isReadOnly(self):
-        """@rtype: bool"""
-        return self._is_read_only()
-
-    def selectMatching(self, select_mask) -> List[bool]:
-        assert isinstance(select_mask, RealizationStateEnum)
-        return list(_lib.state_map.select_matching(self, select_mask.value, True))
-
-    def deselectMatching(self, select_mask: RealizationStateEnum) -> List[bool]:
-        assert isinstance(select_mask, RealizationStateEnum)
-        return list(_lib.state_map.select_matching(self, select_mask.value, False))
-
-    def realizationList(self, state_value: RealizationStateEnum) -> List[int]:
-        """Will create an integer list of all realisations with state equal to
-        state_value."""
-        mask = self.createMask(state_value)
-        return [idx for idx, value in enumerate(mask) if value]
-
-    def createMask(self, state_value: RealizationStateEnum) -> List[bool]:
-        """Will create a bool list of all realisations with state equal to
-        state_value."""
-        return self.selectMatching(state_value)
-
-    def free(self):
-        self._free()
-
-    def __repr__(self):
-        ro = "read only" if self.isReadOnly() else "read/write"
-        return f"StateMap(size = {len(self)}, {ro}) {self._ad_str()}"
-
-    def load(self, filename):
-        if not self._fread(filename):
-            raise IOError(f"Failed to load state map from:{filename}")
-
-    def save(self, filename):
-        self._fwrite(filename)
+__all__ = ["StateMap", "RealizationStateEnum"]


### PR DESCRIPTION
WIP on the way to turning `EnkfFs` into a C++ & pybind11 class. The next mini step is to convert `TimeMap`, which should be enough to convert the rest of `EnkfFs` into something more manageable. The end goal is to get rid of this ref/deref stuff and use `std::shared_ptr` with a well-behaved C++ binding. The other end goal is to allow for a better `EnkfFs` API. Basically, reduce all of the complexity down to `storage.load_parameters("FOPR")`[^1] which returns a `np.ndarray`.

[^1]: I think `BlockStorage` is a more descriptive name than `EnkfFs`, considering that the latter is neither a filesystem but a less advanced DOOM (1993) WAD, and also there is no ensemble kalman filter anymore so the prefix makes little sense.