### PR TITLE
Undo pinning of click in dev-requirements

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run black
       run: |
-        pip install black[jupyter]==22.1.0
+        pip install black[jupyter]
         black . --check
 
     - name: Run pylint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
-click==8.0.2; python_version > '3.6'
-click<8; python_version <= '3.6'
+click
 cmake-format
 decorator
 flake8>=4.0.0


### PR DESCRIPTION
Black 22.3 resolves the issue.

Partially reverts bf8ed59b5dfcacb6c2ee0d6c9f54bd851d317d82