### PR TITLE
Fix scaling of ESMDA weights

### DIFF
--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -186,12 +186,16 @@ class MultipleDataAssimilation(BaseRunModel):
 
     @staticmethod
     def normalizeWeights(weights: List[float]) -> List[float]:
+        """Scale weights such that their reciprocals sum to 1.0,
+        i.e., sum(1.0 / x for x in weights) == 1.0.
+        See for example Equation 38 of evensen2018 - Analysis of iterative
+        ensemble smoothers for solving inverse problems.
+        """
         if not weights:
             return []
         weights = [weight for weight in weights if abs(weight) != 0.0]
-        from math import sqrt
 
-        length = sqrt(sum((1.0 / x) * (1.0 / x) for x in weights))
+        length = sum(1.0 / x for x in weights)
         return [x * length for x in weights]
 
     @staticmethod

--- a/libres/lib/analysis/update.cpp
+++ b/libres/lib/analysis/update.cpp
@@ -402,8 +402,11 @@ make_update_data(enkf_fs_type *source_fs, enkf_fs_type *target_fs,
     meas_data_free(meas_data);
 
     Eigen::VectorXd observation_values = obs_data_values_as_vector(obs_data);
+    // Inflating measurement errors by a factor sqrt(global_std_scaling) as shown
+    // in for example evensen2018 - Analysis of iterative ensemble smoothers for solving inverse problems.
+    // `global_std_scaling` is 1.0 for ES.
     Eigen::VectorXd observation_errors =
-        obs_data_errors_as_vector(obs_data) * global_std_scaling;
+        obs_data_errors_as_vector(obs_data) * sqrt(global_std_scaling);
     std::vector<bool> obs_mask = obs_data_get_active_mask(obs_data);
 
     if (S.rows() == 0) {

--- a/tests/ert_tests/gui/test_multiple_data_assimilation.py
+++ b/tests/ert_tests/gui/test_multiple_data_assimilation.py
@@ -1,66 +1,33 @@
-from ert_utils import ErtTest
+from multiprocessing.sharedctypes import Value
+import numpy as np
+import pytest
 
 from ert_shared.models import MultipleDataAssimilation as mda
 
 
-class MDAWeightsTest(ErtTest):
-    def test_weights(self):
+def test_normalized_weights():
+    weights = mda.normalizeWeights([1])
+    assert weights == [1.0]
 
-        weights = mda.parseWeights("2, 2, 2, 2")
-        print(weights)
-        self.assertAlmostEqualList([2, 2, 2, 2], weights)
+    weights = mda.normalizeWeights([1, 1])
+    assert weights == [2.0, 2.0]
 
-        weights = mda.parseWeights("1, 2, 3, ")
-        self.assertAlmostEqualList([1, 2, 3], weights)
+    weights = np.array(mda.normalizeWeights([8, 4, 2, 1]))
+    assert np.reciprocal(weights).sum() == 1.0
 
-        weights = mda.parseWeights("1, 0, 1")
-        self.assertAlmostEqualList([1, 1], weights)
 
-        weights = mda.parseWeights("1.414213562373095, 1.414213562373095")
-        self.assertAlmostEqualList([1.414213562373095, 1.414213562373095], weights)
+def test_weights():
+    weights = mda.parseWeights("2, 2, 2, 2")
+    assert weights == [2, 2, 2, 2]
 
-        with self.assertRaises(ValueError):
-            mda.parseWeights("2, error, 2, 2")
+    weights = mda.parseWeights("1, 2, 3, ")
+    assert weights == [1, 2, 3]
 
-    def test_normalized_weights(self):
+    weights = mda.parseWeights("1, 0, 1")
+    assert weights == [1, 1]
 
-        weights = mda.normalizeWeights([1])
-        self.assertAlmostEqualList([1.0], weights)
+    weights = mda.parseWeights("1.414213562373095, 1.414213562373095")
+    assert weights == [1.414213562373095, 1.414213562373095]
 
-        weights = mda.normalizeWeights([1, 1])
-        self.assertAlmostEqualList([1.414214, 1.414214], weights)
-
-        weights = mda.normalizeWeights([1, 0, 1])
-        self.assertAlmostEqualList([1.414214, 1.414214], weights)
-
-        weights = mda.normalizeWeights([1, 1, 1])
-        self.assertAlmostEqualList([1.732051, 1.732051, 1.732051], weights)
-
-        weights = mda.normalizeWeights([8, 4, 2, 1])
-        self.assertAlmostEqualList(
-            [
-                9.219544457292887,
-                4.6097722286464435,
-                2.3048861143232218,
-                1.1524430571616109,
-            ],
-            weights,
-        )
-
-        weights = mda.normalizeWeights(
-            [
-                9.219544457292887,
-                4.6097722286464435,
-                2.3048861143232218,
-                1.1524430571616109,
-            ]
-        )
-        self.assertAlmostEqualList(
-            [
-                9.219544457292887,
-                4.6097722286464435,
-                2.3048861143232218,
-                1.1524430571616109,
-            ],
-            weights,
-        )
+    with pytest.raises(ValueError):
+        mda.parseWeights("2, error, 2, 2")


### PR DESCRIPTION
ESMDA requires that inverses of scaled weights sum to 1.0,
which is not always the case with the current implementation.

**Issue**
Resolves #3239


**Approach**

```python
import numpy as np
from math import sqrt

def current(weights):
    length = sqrt(sum((1.0 / x) * (1.0 / x) for x in weights))
    return np.array([x * length for x in weights])

def new(weights):
    length = sum(1.0 / x for x in weights)
    return np.array([x * length for x in weights])

weights = [1, 1]
print(current(weights))
print(np.sqrt(new(weights)))

# >> [1.4142135623730951, 1.4142135623730951]
# >> [1.41421356 1.41421356]

weights = [4, 2, 1]
print(current(weights))
print(np.sqrt(new(weights)))

# >> [4.58257569495584, 2.29128784747792, 1.14564392373896]
# >> [2.64575131 1.87082869 1.32287566]
```

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).






