### PR TITLE
Update algorithm GUI config

### DIFF
--- a/ert_gui/ertwidgets/analysismoduleselector.py
+++ b/ert_gui/ertwidgets/analysismoduleselector.py
@@ -1,5 +1,3 @@
-import sys
-
 from qtpy.QtCore import QMargins, Qt
 from qtpy.QtWidgets import QWidget, QHBoxLayout, QComboBox, QToolButton
 

--- a/ert_gui/ertwidgets/analysismodulevariablespanel.py
+++ b/ert_gui/ertwidgets/analysismodulevariablespanel.py
@@ -80,7 +80,6 @@ class AnalysisModuleVariablesPanel(QWidget):
                     spinner = self.createSpinBox(
                         variable_name,
                         variable_value,
-                        variable_type,
                         analysis_module_variables_model,
                     )
 
@@ -123,14 +122,36 @@ class AnalysisModuleVariablesPanel(QWidget):
                     )
                     layout.addRow(label, None)
 
+        # Truncation of the eigenvalue spectrum is not possible when using exact inversion,
+        # hence the spinners for setting the amount of truncation are deactivated for exact inversion.
+        inversion_spinner = self.widget_from_layout(layout, "IES_INVERSION")
+        truncation_spinner = self.widget_from_layout(layout, "ENKF_TRUNCATION")
+        self.update_truncation_spinners(inversion_spinner.value(), truncation_spinner)
+        inversion_spinner.valueChanged.connect(
+            lambda value: self.update_truncation_spinners(value, truncation_spinner)
+        )
+
         self.setLayout(layout)
         self.blockSignals(False)
+
+    def update_truncation_spinners(
+        self, value: int, truncation_spinner: QDoubleSpinBox
+    ) -> None:
+        if value == 0:  # Exact inversion
+            truncation_spinner.setEnabled(False)
+        else:
+            truncation_spinner.setEnabled(True)
+
+    def widget_from_layout(self, layout: QFormLayout, widget_name: str) -> QWidget:
+        for i in range(layout.count()):
+            widget = layout.itemAt(i).widget()
+            if widget.objectName() == widget_name:
+                return widget
 
     def createSpinBox(
         self,
         variable_name,
         variable_value,
-        variable_type,
         analysis_module_variables_model,
     ):
         spinner = QSpinBox()
@@ -144,11 +165,9 @@ class AnalysisModuleVariablesPanel(QWidget):
         spinner.setSingleStep(
             analysis_module_variables_model.getVariableStepValue(variable_name)
         )
+        spinner.setObjectName(variable_name)
         if variable_value is not None:
             spinner.setValue(variable_value)
-        spinner.valueChanged.connect(
-            partial(self.valueChanged, variable_name, variable_type, spinner)
-        )
         return spinner
 
     def createCheckBox(self, variable_name, variable_value, variable_type):
@@ -179,6 +198,7 @@ class AnalysisModuleVariablesPanel(QWidget):
             analysis_module_variables_model.getVariableStepValue(variable_name)
         )
         spinner.setValue(variable_value)
+        spinner.setObjectName(variable_name)
         spinner.valueChanged.connect(
             partial(self.valueChanged, variable_name, variable_type, spinner)
         )

--- a/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
+++ b/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
@@ -14,71 +14,18 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import logging
+from typing import List
+
 from ert_shared.libres_facade import LibresFacade
 from res.analysis.analysis_module import AnalysisModule
 
 
-class AnalysisModuleVariablesModel(object):
+class AnalysisModuleVariablesModel:
 
-    _VARIABLE_NAMES = {
-        "IES_MAX_STEPLENGTH": {
-            "type": float,
-            "min": 0.1,
-            "max": 1.00,
-            "step": 0.1,
-            "labelname": "Gauss–Newton maximum steplength",
-        },
-        "IES_MIN_STEPLENGTH": {
-            "type": float,
-            "min": 0.1,
-            "max": 1.00,
-            "step": 0.1,
-            "labelname": "Gauss–Newton minimum steplength",
-        },
-        "IES_DEC_STEPLENGTH": {
-            "type": float,
-            "min": 1.1,
-            "max": 10.00,
-            "step": 0.1,
-            "labelname": "Gauss–Newton steplength decline",
-        },
-        "IES_INVERSION": {
-            "type": int,
-            "min": 0,
-            "max": 3,
-            "step": 1,
-            "labelname": "Inversion algorithm",
-        },
-        "IES_AAPROJECTION": {
-            "type": bool,
-            "labelname": "Include AA projection",
-        },
-        "ENKF_TRUNCATION": {
-            "type": float,
-            "min": -2.0,
-            "max": 1,
-            "step": 0.01,
-            "labelname": "Singular value truncation",
-        },
-        "ENKF_SUBSPACE_DIMENSION": {
-            "type": int,
-            "min": -2,
-            "max": 2147483647,
-            "step": 1,
-            "labelname": "Number of singular values",
-        },
-        "ENKF_NCOMP": {
-            "type": int,
-            "min": -2,
-            "max": 2147483647,
-            "step": 1,
-            "labelname": "Number of singular values",
-        },
-    }
+    _VARIABLE_NAMES = AnalysisModule.VARIABLE_NAMES
 
     @classmethod
-    def getVariableNames(cls, analysis_module: AnalysisModule):
-        """@rtype: list of str"""
+    def getVariableNames(cls, analysis_module: AnalysisModule) -> List[str]:
         assert isinstance(analysis_module, AnalysisModule)
         items = []
         for name in cls._VARIABLE_NAMES:
@@ -111,7 +58,7 @@ class AnalysisModuleVariablesModel(object):
         cls, facade: LibresFacade, analysis_module_name: str, name: str, value: str
     ):
         analysis_module = facade.get_analysis_module(analysis_module_name)
-        result = analysis_module.setVar(name, str(value))
+        analysis_module.setVar(name, str(value))
 
     @classmethod
     def getVariableValue(

--- a/ert_shared/libres_facade.py
+++ b/ert_shared/libres_facade.py
@@ -1,7 +1,8 @@
 import logging
 
-from ecl.util.util import BoolVector
 from pandas import DataFrame
+
+from ecl.util.util import BoolVector
 from res.analysis.analysis_module import AnalysisModule
 from res.analysis.enums.analysis_module_options_enum import AnalysisModuleOptionsEnum
 from res.enkf.export import (
@@ -30,7 +31,7 @@ class LibresFacade:
     def get_analysis_config(self):
         return self._enkf_main.analysisConfig()
 
-    def get_analysis_module(self, module_name):
+    def get_analysis_module(self, module_name: str) -> AnalysisModule:
         return self._enkf_main.analysisConfig().getModule(module_name)
 
     def get_analysis_modules(self, iterable=False):

--- a/libres/lib/analysis/analysis_module.cpp
+++ b/libres/lib/analysis/analysis_module.cpp
@@ -45,6 +45,7 @@ struct analysis_module_struct {
         user_name; /* String used to identify this module for the user; not used in
                                                    the linking process. */
     analysis_mode_enum mode;
+    std::unordered_set<std::string> keys;
 };
 
 analysis_mode_enum
@@ -73,12 +74,37 @@ analysis_module_type *analysis_module_alloc_named(int ens_size,
 
 analysis_module_type *analysis_module_alloc(int ens_size,
                                             analysis_mode_enum mode) {
-    if (mode == ENSEMBLE_SMOOTHER)
-        return analysis_module_alloc_named(ens_size, mode, "STD_ENKF");
-    else if (mode == ITERATED_ENSEMBLE_SMOOTHER)
-        return analysis_module_alloc_named(ens_size, mode, "IES_ENKF");
-    else
-        throw std::logic_error("Undandled enum value");
+    if (mode == ENSEMBLE_SMOOTHER) {
+        analysis_module_type *module = new analysis_module_type();
+        module->mode = mode;
+        module->user_name = util_alloc_string_copy("STD_ENKF");
+        module->module_config = std::make_unique<ies::config::Config>(false);
+        module->module_data = std::make_unique<ies::data::Data>(ens_size);
+        module->keys = {ies::data::ITER_KEY,
+                        ies::config::IES_INVERSION_KEY,
+                        ies::config::IES_LOGFILE_KEY,
+                        ies::config::IES_DEBUG_KEY,
+                        ies::config::IES_AAPROJECTION_KEY,
+                        ies::config::ENKF_TRUNCATION_KEY};
+        return module;
+    } else if (mode == ITERATED_ENSEMBLE_SMOOTHER) {
+        analysis_module_type *module = new analysis_module_type();
+        module->mode = mode;
+        module->user_name = util_alloc_string_copy("IES_ENKF");
+        module->module_config = std::make_unique<ies::config::Config>(true);
+        module->module_data = std::make_unique<ies::data::Data>(ens_size);
+        module->keys = {ies::data::ITER_KEY,
+                        ies::config::IES_MAX_STEPLENGTH_KEY,
+                        ies::config::IES_MIN_STEPLENGTH_KEY,
+                        ies::config::IES_DEC_STEPLENGTH_KEY,
+                        ies::config::IES_INVERSION_KEY,
+                        ies::config::IES_LOGFILE_KEY,
+                        ies::config::IES_DEBUG_KEY,
+                        ies::config::IES_AAPROJECTION_KEY,
+                        ies::config::ENKF_TRUNCATION_KEY};
+        return module;
+    } else
+        throw std::logic_error("Unhandled enum value");
 }
 
 const char *analysis_module_get_name(const analysis_module_type *module) {
@@ -268,21 +294,7 @@ bool analysis_module_check_option(const analysis_module_type *module,
 
 bool analysis_module_has_var(const analysis_module_type *module,
                              const char *var) {
-
-    static const std::unordered_set<std::string> keys = {
-        ies::data::ITER_KEY,
-        ies::config::IES_MAX_STEPLENGTH_KEY,
-        ies::config::IES_MIN_STEPLENGTH_KEY,
-        ies::config::IES_DEC_STEPLENGTH_KEY,
-        ies::config::IES_INVERSION_KEY,
-        ies::config::IES_LOGFILE_KEY,
-        ies::config::IES_DEBUG_KEY,
-        ies::config::IES_AAPROJECTION_KEY,
-        ies::config::ENKF_TRUNCATION_KEY,
-        ies::config::ENKF_SUBSPACE_DIMENSION_KEY,
-        ies::config::ENKF_NCOMP_KEY};
-
-    return (keys.count(var) == 1);
+    return module->keys.count(var);
 }
 
 bool analysis_module_get_bool(const analysis_module_type *module,

--- a/res/analysis/analysis_module.py
+++ b/res/analysis/analysis_module.py
@@ -14,6 +14,8 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from typing import List
+
 from cwrap import BaseCClass
 
 from res import ResPrototype
@@ -45,27 +47,43 @@ class AnalysisModule(BaseCClass):
     VARIABLE_NAMES = {
         "IES_MAX_STEPLENGTH": {
             "type": float,
-            "description": "Max step Length of Gauss Newton Iteration",
+            "min": 0.1,
+            "max": 1.00,
+            "step": 0.1,
+            "labelname": "Gauss–Newton maximum steplength",
         },
         "IES_MIN_STEPLENGTH": {
             "type": float,
-            "description": "Min step Length of Gauss Newton Iteration",
+            "min": 0.1,
+            "max": 1.00,
+            "step": 0.1,
+            "labelname": "Gauss–Newton minimum steplength",
         },
         "IES_DEC_STEPLENGTH": {
             "type": float,
-            "description": "Decline of step Length in Gauss Newton Iteration",
+            "min": 1.1,
+            "max": 10.00,
+            "step": 0.1,
+            "labelname": "Gauss–Newton steplength decline",
         },
-        "IES_INVERSION": {"type": int, "description": "Inversion algorithm"},
-        "IES_AAPROJECTION": {
-            "type": str,
-            "description": "Include projection Y (A^+A) for n<N-1",
-        },
-        "ENKF_TRUNCATION": {"type": float, "description": "Singular value truncation"},
-        "ENKF_SUBSPACE_DIMENSION": {
+        "IES_INVERSION": {
             "type": int,
-            "description": "Number of singular values",
+            "min": 0,
+            "max": 3,
+            "step": 1,
+            "labelname": "Inversion algorithm",
         },
-        "ENKF_NCOMP": {"type": int, "description": "Number of singular values"},
+        "IES_AAPROJECTION": {
+            "type": bool,
+            "labelname": "Include AA projection",
+        },
+        "ENKF_TRUNCATION": {
+            "type": float,
+            "min": -2.0,
+            "max": 1,
+            "step": 0.01,
+            "labelname": "Singular value truncation",
+        },
     }
 
     def __init__(self, ens_size, name):
@@ -75,8 +93,7 @@ class AnalysisModule(BaseCClass):
 
         super().__init__(c_ptr)
 
-    def getVariableNames(self):
-        """@rtype: list of str"""
+    def getVariableNames(self) -> List[str]:
         items = []
         for name in AnalysisModule.VARIABLE_NAMES:
             if self.hasVar(name):
@@ -124,8 +141,7 @@ class AnalysisModule(BaseCClass):
     def checkOption(self, flag: AnalysisModuleOptionsEnum):
         return self._check_option(flag)
 
-    def hasVar(self, var):
-        """:rtype: bool"""
+    def hasVar(self, var: str) -> bool:
         return self._has_var(var)
 
     def getDouble(self, var):

--- a/tests/ert_tests/gui/ertwidgets/test_analysismodulevariablespanel.py
+++ b/tests/ert_tests/gui/ertwidgets/test_analysismodulevariablespanel.py
@@ -19,6 +19,5 @@ def test_createSpinBox(qtbot):
                 variable_dialog.createSpinBox(
                     variable_name,
                     variable_value,
-                    int,
                     analysis_module_variables_model,
                 )


### PR DESCRIPTION
Remove ENKF_SUBSPACE_DIMENSION from GUI as it is covered
by ENKF_NCOMP

**Issue**
Resolves #3179


**Approach**
_Short description of the approach_

Setting step-sizes not possible for ES (and for MDA).
Truncation-spinners deactivated by default since exact inversion is used.

![es_edit_variables](https://user-images.githubusercontent.com/45088507/161977468-1d817dcd-f4e1-4450-9e11-1d76cdc3c037.png)

Changing inversion type activates truncation-spinners.

![es_edit_variables_truncation](https://user-images.githubusercontent.com/45088507/161977492-4bd2331e-cc30-49cb-9caa-a24f50737680.png)

Still possible to set step-lengths for IES.

![ies_edit_variables](https://user-images.githubusercontent.com/45088507/161977499-9d1fbbcd-2d6f-49f7-86f7-b11157e3e628.png)

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
