### PR TITLE
Log the contents of the ERT2 configuration file

### DIFF
--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -441,6 +441,15 @@ def start_ert_server(mode: str):
         yield
 
 
+def log_config(args: ArgumentParser, logger: logging.Logger) -> None:
+    if args.config is not None and os.path.isfile(args.config):
+        with open(args.config, "r", encoding="utf-8") as file_obj:
+            content = file_obj.read()
+            logger.info(
+                f"Content of the configuration file ({args.config}):\n" + content
+            )
+
+
 def main():
     with open(LOGGING_CONFIG, encoding="utf-8") as conf_file:
         logging.config.dictConfig(yaml.safe_load(conf_file))
@@ -459,6 +468,7 @@ def main():
         with start_ert_server(args.mode), ErtPluginContext() as context:
             context.plugin_manager.add_logging_handle_to_root(logging.getLogger())
             logger.info("Running ert with {}".format(str(args)))
+            log_config(args, logger)
             args.func(args)
     except ErtCliError as err:
         logger.exception(str(err))

--- a/tests/ert_tests/shared/test_main_entry.py
+++ b/tests/ert_tests/shared/test_main_entry.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import logging
 from unittest.mock import MagicMock
@@ -33,6 +34,22 @@ def test_main_logging_argparse(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         main.main()
     assert "mode='test_run'" in caplog.text
+
+
+def test_main_logging_config(monkeypatch, caplog, tmp_path):
+    os.chdir(tmp_path)
+    content = "Content of config.ert\nMore content."
+    with open("config.ert", "w", encoding="utf-8") as file_obj:
+        file_obj.write(content)
+    monkeypatch.setattr(logging.config, "dictConfig", MagicMock())
+    monkeypatch.setattr(main, "run_cli", MagicMock())
+    monkeypatch.setattr(main, "start_ert_server", MagicMock())
+    monkeypatch.setattr(main, "ErtPluginContext", MagicMock())
+    monkeypatch.setattr(sys, "argv", ["ert", "test_run", "config.ert"])
+    with caplog.at_level(logging.INFO):
+        main.main()
+    assert "Content of the configuration file (config.ert):" in caplog.text
+    assert content in caplog.text
 
 
 def test_api_database_default(monkeypatch):


### PR DESCRIPTION
**Issue**
Resolves #3180


**Approach**
Log the content of the configuration file before starting the evaluation

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
