### PR TITLE
Replace deprecated `..index.is_all_dates` in plottery

### DIFF
--- a/ert_gui/plottery/plots/ensemble.py
+++ b/ert_gui/plottery/plots/ensemble.py
@@ -1,5 +1,6 @@
 from .observations import plotObservations
 from .plot_tools import PlotTools
+from .plot_tools import index_is_datetime
 from ert_gui.plottery.plots.history import plotHistory
 from ert_gui.plottery.plots.refcase import plotRefcase
 
@@ -24,7 +25,7 @@ class EnsemblePlot(object):
             data = data.T
 
             if not data.empty:
-                if not data.index.is_all_dates:
+                if not index_is_datetime(data):
                     plot_context.deactivateDateSupport()
                     plot_context.x_axis = plot_context.INDEX_AXIS
 

--- a/ert_gui/plottery/plots/plot_tools.py
+++ b/ert_gui/plottery/plots/plot_tools.py
@@ -1,3 +1,6 @@
+import pandas as pd
+
+
 class PlotTools(object):
     @staticmethod
     def showGrid(axes, plot_context):
@@ -104,3 +107,7 @@ class PlotTools(object):
             # unit = ert.eclConfig().getRefcase().unit(key)
             # if unit != "":
             # config.setYLabel(unit)
+
+
+def index_is_datetime(data: pd.DataFrame):
+    return data.index.inferred_type == "datetime64"

--- a/ert_gui/plottery/plots/statistics.py
+++ b/ert_gui/plottery/plots/statistics.py
@@ -4,6 +4,7 @@ from pandas import DataFrame
 
 from .observations import plotObservations
 from .plot_tools import PlotTools
+from .plot_tools import index_is_datetime
 from ert_gui.plottery.plots.history import plotHistory
 from ert_gui.plottery.plots.refcase import plotRefcase
 
@@ -26,7 +27,7 @@ class StatisticsPlot(object):
         for case, data in case_to_data_map.items():
             data = data.T
             if not data.empty:
-                if not data.index.is_all_dates:
+                if not index_is_datetime(data):
                     plot_context.deactivateDateSupport()
                     plot_context.x_axis = plot_context.INDEX_AXIS
 

--- a/tests/ert_tests/gui/plottery/plots/test_plot_tools.py
+++ b/tests/ert_tests/gui/plottery/plots/test_plot_tools.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import numpy as np
+from ert_gui.plottery.plots.plot_tools import index_is_datetime
+
+
+def test_index_is_datetime_empty():
+    df = pd.DataFrame()
+    is_datetime = index_is_datetime(data=df)
+
+    assert not is_datetime
+
+
+def test_index_is_datetime_int():
+    ints = np.random.randint(0, 30, size=10)
+    df = pd.DataFrame(ints, columns=["Random"], index=ints)
+    is_datetime = index_is_datetime(data=df)
+
+    assert not is_datetime
+
+
+def test_index_is_datetime():
+    df = pd.DataFrame(
+        np.random.randint(0, 30, size=10),
+        columns=["Random"],
+        index=pd.date_range("20220101", periods=10),
+    )
+    is_datetime = index_is_datetime(data=df)
+
+    assert is_datetime


### PR DESCRIPTION
**Issue**
`..index.is_all_dates` is deprecated and needs to be replaced. 


**Approach**
Extracted functionality making the check and verified the behavior with test.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
