### PR TITLE
Make image cache singleton

### DIFF
--- a/ert_gui/simulation/view/realization.py
+++ b/ert_gui/simulation/view/realization.py
@@ -61,11 +61,14 @@ class RealizationWidget(QWidget):
         self._real_view.clearSelection()
 
 
+# This singleton is shared among all instances of RealizationDelegate
+_image_cache = {}
+
+
 class RealizationDelegate(QStyledItemDelegate):
     def __init__(self, width, height, parent=None) -> None:
         super(RealizationDelegate, self).__init__(parent)
         self._size = QSize(width, height)
-        self._image_cache = {}
 
     def paint(self, painter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         text = index.data(RealLabelHint)
@@ -123,7 +126,7 @@ class RealizationDelegate(QStyledItemDelegate):
         k = 0
 
         colors_hash = hash(tuple([color.name() for color in colors]))
-        if colors_hash not in self._image_cache:
+        if colors_hash not in _image_cache:
             foreground_image = QImage(grid_dim, grid_dim, QImage.Format_ARGB32)
             foreground_image.fill(QColorConstants.Gray)
 
@@ -135,9 +138,9 @@ class RealizationDelegate(QStyledItemDelegate):
                         color = colors[k]
                     foreground_image.setPixel(x, y, color.rgb())
                     k += 1
-            self._image_cache[colors_hash] = foreground_image
+            _image_cache[colors_hash] = foreground_image
         else:
-            foreground_image = self._image_cache[colors_hash]
+            foreground_image = _image_cache[colors_hash]
 
         painter.drawImage(rect, foreground_image)
 


### PR DESCRIPTION
Might resolve #3223 but will improve performance in any case.

The current code has an per-instance cache of images in RealizationDelegate. These images can safely be shared among all instances. In addition to improve performance this also ensures that images are not removed together with instaces of RealizationDelegate, which is the suspected cause of #3223.

The potential race if two instances construct the same image is not a problem as the images will be identical and the last will persist in the cache.