### PR TITLE
Remove unused functions in enkf_state.cpp

### DIFF
--- a/libres/lib/include/ert/enkf/enkf_state.hpp
+++ b/libres/lib/include/ert/enkf/enkf_state.hpp
@@ -77,10 +77,6 @@ extern "C" void enkf_state_free(enkf_state_type *);
 extern "C" const ensemble_config_type *
 enkf_state_get_ensemble_config(const enkf_state_type *enkf_state);
 
-bool enkf_state_complete_forward_modelOK__(void *arg);
-bool enkf_state_complete_forward_modelRETRY__(void *arg);
-bool enkf_state_complete_forward_modelEXIT__(void *arg);
-
 extern "C" bool
 enkf_state_complete_forward_modelOK(const res_config_type *res_config,
                                     run_arg_type *run_arg);


### PR DESCRIPTION
After changing to calling from python a few functions are no longer
called.