### PR TITLE
Avoid DeprecationWarning from qtbot

### DIFF
--- a/tests/ert_tests/gui/logging/test_logging_tool.py
+++ b/tests/ert_tests/gui/logging/test_logging_tool.py
@@ -24,7 +24,6 @@ def test_logging_widget(qtbot, caplog, log_func, expected):
     widget.show()
     qtbot.addWidget(widget)
 
-    qtbot.waitForWindowShown(widget)
-    with caplog.at_level(logging.DEBUG):
+    with qtbot.waitExposed(widget), caplog.at_level(logging.DEBUG):
         log_func("Writing some text")
-    assert widget.text_box.toPlainText() == expected
+        assert widget.text_box.toPlainText() == expected

--- a/tests/ert_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert_tests/gui/simulation/test_run_dialog.py
@@ -25,10 +25,10 @@ def test_success(runmodel, qtbot, mock_tracker):
         tracker.return_value = mock_tracker([EndEvent(failed=False, failed_msg="")])
         widget.startSimulation()
 
-    qtbot.waitForWindowShown(widget)
-    qtbot.waitUntil(lambda: widget._total_progress_bar.value() == 100)
-    assert widget.done_button.isVisible()
-    assert widget.done_button.text() == "Done"
+    with qtbot.waitExposed(widget, timeout=30000):
+        qtbot.waitUntil(lambda: widget._total_progress_bar.value() == 100)
+        assert widget.done_button.isVisible()
+        assert widget.done_button.text() == "Done"
 
 
 def test_large_snapshot(runmodel, large_snapshot, qtbot, mock_tracker):
@@ -60,10 +60,10 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot, mock_tracker):
         )
         widget.startSimulation()
 
-    qtbot.waitForWindowShown(widget)
-    qtbot.waitUntil(lambda: widget._total_progress_bar.value() == 100, timeout=5000)
-    qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
-    qtbot.waitUntil(lambda: widget._tab_widget.count() == 2, timeout=5000)
+    with qtbot.waitExposed(widget, timeout=30000):
+        qtbot.waitUntil(lambda: widget._total_progress_bar.value() == 100, timeout=5000)
+        qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(lambda: widget._tab_widget.count() == 2, timeout=5000)
 
 
 @pytest.mark.parametrize(
@@ -284,9 +284,9 @@ def test_run_dialog(events, tab_widget_count, runmodel, qtbot, mock_tracker):
         tracker.return_value = mock_tracker(events)
         widget.startSimulation()
 
-    qtbot.waitForWindowShown(widget)
-    qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
-    qtbot.waitUntil(
-        lambda: widget._tab_widget.count() == tab_widget_count, timeout=5000
-    )
-    qtbot.waitUntil(lambda: widget.done_button.isVisible(), timeout=5000)
+    with qtbot.waitExposed(widget, timeout=30000):
+        qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(
+            lambda: widget._tab_widget.count() == tab_widget_count, timeout=5000
+        )
+        qtbot.waitUntil(lambda: widget.done_button.isVisible(), timeout=5000)


### PR DESCRIPTION
Avoids this warning:

`DeprecationWarning: waitForWindowShown is deprecated, as the underlying Qt method was obsoleted in Qt 5.0 and removed in Qt 6.0. Its name is imprecise and the pytest-qt wrapper does not raise TimeoutError if the window wasn't shown. Please use the qtbot.waitExposed context manager instead.`