### PR TITLE
Remove option of loading from non-unified summary files

### DIFF
--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -69,34 +69,12 @@ forward_load_context_load_ecl_sum(forward_load_context_type *load_context) {
             run_path, eclbase, ECL_UNIFIED_SUMMARY_FILE, fmt_file, -1);
         stringlist_type *data_files = stringlist_alloc_new();
 
-        /* Should we load from a unified summary file, or from several non-unified files? */
         if (unified_file != NULL)
-            /* Use unified file: */
             stringlist_append_copy(data_files, unified_file);
-        else {
-            /* Use several non unified files. */
-            /* Bypassing the query to model_config_load_results() */
-            int report_step = run_arg_get_load_start(run_arg);
-            if (report_step == 0)
-                report_step++; // Ignore looking for the .S0000 summary file (it does not exist).
-            while (true) {
-                char *summary_file = ecl_util_alloc_exfilename(
-                    run_arg_get_runpath(run_arg), eclbase, ECL_SUMMARY_FILE,
-                    fmt_file, report_step);
-
-                if (summary_file != NULL) {
-                    stringlist_append_copy(data_files, summary_file);
-                    free(summary_file);
-                } else
-                    /*
-             We stop the loading at first 'hole' in the series of summary files;
-             the internalize layer must report failure if we are missing data.
-          */
-                    break;
-
-                report_step++;
-            }
-        }
+        else
+            logger->error("Could not find SUMMARY file at: {}/{} or using non "
+                          "unified SUMMARY file",
+                          run_path, eclbase);
 
         if ((header_file != NULL) && (stringlist_get_size(data_files) > 0)) {
             bool include_restart = false;

--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -69,14 +69,9 @@ forward_load_context_load_ecl_sum(forward_load_context_type *load_context) {
             run_path, eclbase, ECL_UNIFIED_SUMMARY_FILE, fmt_file, -1);
         stringlist_type *data_files = stringlist_alloc_new();
 
-        if (unified_file != NULL)
+        if ((unified_file != NULL) && (header_file != NULL)) {
             stringlist_append_copy(data_files, unified_file);
-        else
-            logger->error("Could not find SUMMARY file at: {}/{} or using non "
-                          "unified SUMMARY file",
-                          run_path, eclbase);
 
-        if ((header_file != NULL) && (stringlist_get_size(data_files) > 0)) {
             bool include_restart = false;
 
             /*
@@ -139,7 +134,11 @@ forward_load_context_load_ecl_sum(forward_load_context_type *load_context) {
                     summary = NULL;
                 }
             }
-        }
+        } else
+            logger->error("Could not find SUMMARY file at: {}/{} or using non "
+                          "unified SUMMARY file",
+                          run_path, eclbase);
+
         stringlist_free(data_files);
         free(header_file);
         free(unified_file);


### PR DESCRIPTION
If we are not able to find the expected unified summary file in the callback we assume it is a non-unified summary file. However that is very unlikely as hardly anyone uses that anymore. It is more likely that the expected summary file is not there. This notifies the user that we are not able to load, and it will be set as failed in the state map.  

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
