### PR TITLE
Filter out comments from logged configuration

### DIFF
--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -441,13 +441,28 @@ def start_ert_server(mode: str):
         yield
 
 
-def log_config(args: ArgumentParser, logger: logging.Logger) -> None:
-    if args.config is not None and os.path.isfile(args.config):
-        with open(args.config, "r", encoding="utf-8") as file_obj:
-            content = file_obj.read()
-            logger.info(
-                f"Content of the configuration file ({args.config}):\n" + content
-            )
+def log_config(config_path: str, logger: logging.Logger) -> None:
+    """
+    Logs what configuration was used to start ert. Because the config
+    parsing is quite convoluted we are not able to remove all the comments,
+    but the easy ones are filtered out.
+    """
+    if config_path is not None and os.path.isfile(config_path):
+        config_context = ""
+        with open(config_path, "r", encoding="utf-8") as file_obj:
+            for line in file_obj:
+                line = line.strip()
+                if not line or line.startswith("--"):
+                    continue
+                if "--" in line:
+                    # There might be a comment in this line, but it could
+                    # also be an argument to a job, so we do a quick check
+                    if not any(x in line for x in ['"', "'"]):
+                        line = line.split("--")[0].rstrip()
+                config_context += line + "\n"
+        logger.info(
+            f"Content of the configuration file ({config_path}):\n" + config_context
+        )
 
 
 def main():
@@ -468,7 +483,7 @@ def main():
         with start_ert_server(args.mode), ErtPluginContext() as context:
             context.plugin_manager.add_logging_handle_to_root(logging.getLogger())
             logger.info("Running ert with {}".format(str(args)))
-            log_config(args, logger)
+            log_config(args.config, logger)
             args.func(args)
     except ErtCliError as err:
         logger.exception(str(err))

--- a/tests/ert_tests/shared/test_main_entry.py
+++ b/tests/ert_tests/shared/test_main_entry.py
@@ -1,11 +1,14 @@
 import os
 import sys
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
 
 from ert_shared import main
+from ert_shared.main import log_config
+
+from utils import SOURCE_DIR
 
 
 def test_main_logging(monkeypatch, caplog):
@@ -37,18 +40,18 @@ def test_main_logging_argparse(monkeypatch, caplog):
 
 
 def test_main_logging_config(monkeypatch, caplog, tmp_path):
-    os.chdir(tmp_path)
     content = "Content of config.ert\nMore content."
-    with open("config.ert", "w", encoding="utf-8") as file_obj:
+    ert_config = tmp_path / "config.ert"
+    with open(ert_config, "w", encoding="utf-8") as file_obj:
         file_obj.write(content)
     monkeypatch.setattr(logging.config, "dictConfig", MagicMock())
     monkeypatch.setattr(main, "run_cli", MagicMock())
     monkeypatch.setattr(main, "start_ert_server", MagicMock())
     monkeypatch.setattr(main, "ErtPluginContext", MagicMock())
-    monkeypatch.setattr(sys, "argv", ["ert", "test_run", "config.ert"])
+    monkeypatch.setattr(sys, "argv", ["ert", "test_run", str(ert_config)])
     with caplog.at_level(logging.INFO):
         main.main()
-    assert "Content of the configuration file (config.ert):" in caplog.text
+    assert f"Content of the configuration file ({str(ert_config)}):" in caplog.text
     assert content in caplog.text
 
 
@@ -119,4 +122,104 @@ def test_vis_database_url_forwarded(monkeypatch):
     main.main()
     mocked_connect_or_start_server.assert_called_once_with(
         res_config=None, database_url="TEST_DATABASE_URL"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="mock_open is not iterable")
+@pytest.mark.parametrize(
+    "config_content, expected",
+    [
+        pytest.param("--Comment", "", id="Line comment"),
+        pytest.param(" --Comment", "", id="Line comment with whitespace"),
+        pytest.param("\t--Comment", "", id="Line comment with whitespace"),
+        pytest.param("KEY VALUE", "KEY VALUE\n", id="Config line"),
+        pytest.param("KEY VALUE --Comment", "KEY VALUE\n", id="Inline comment"),
+        pytest.param(
+            'FORWARD_MODEL("--argument_or_comment")',
+            'FORWARD_MODEL("--argument_or_comment")\n',
+            id="Not able to determine inline comment or part of config",
+        ),
+    ],
+)
+def test_logging_config(caplog, config_content, expected):
+    base_content = "Content of the configuration file (file_name):\n{}"
+    logger = logging.getLogger(__name__)
+    config_path = "file_name"
+    with patch("builtins.open", mock_open(read_data=config_content)), patch(
+        "os.path.isfile", MagicMock(return_value=True)
+    ):
+        with caplog.at_level(logging.INFO):
+            log_config(config_path, logger)
+    expected = base_content.format(expected)
+    assert expected in caplog.messages
+
+
+def test_logging_snake_oil_config(caplog):
+    """
+    Run logging on an actual config file with line comments
+    and inline comments to check the result
+    """
+    logger = logging.getLogger(__name__)
+    config_path = os.path.join(
+        SOURCE_DIR,
+        "test-data",
+        "local",
+        "snake_oil_structure",
+        "ert",
+        "model",
+        "user_config.ert",
+    )
+    with caplog.at_level(logging.INFO):
+        log_config(config_path, logger)
+    assert (
+        """
+JOBNAME SNAKE_OIL_STRUCTURE_%d
+DEFINE  <USER>          TEST_USER
+DEFINE  <SCRATCH>       scratch/ert
+DEFINE  <CASE_DIR>      the_extensive_case
+DEFINE  <ECLIPSE_NAME>  XYZ
+DATA_FILE           ../../eclipse/model/SNAKE_OIL.DATA
+GRID                ../../eclipse/include/grid/CASE.EGRID
+RUNPATH             <SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d
+ECLBASE             eclipse/model/<ECLIPSE_NAME>-%d
+ENSPATH             ../output/storage/<CASE_DIR>
+RUNPATH_FILE        ../output/run_path_file/.ert-runpath-list_<CASE_DIR>
+REFCASE             ../input/refcase/SNAKE_OIL_FIELD
+UPDATE_LOG_PATH     ../output/update_log/<CASE_DIR>
+RANDOM_SEED 3593114179000630026631423308983283277868
+NUM_REALIZATIONS              10
+MAX_RUNTIME                   23400
+MIN_REALIZATIONS              50%
+QUEUE_SYSTEM                  LSF
+QUEUE_OPTION LSF MAX_RUNNING  100
+QUEUE_OPTION LSF LSF_RESOURCE select[x86_64Linux] same[type:model]
+QUEUE_OPTION LSF LSF_SERVER   simulacrum
+QUEUE_OPTION LSF LSF_QUEUE    mr
+MAX_SUBMIT                    13
+UMASK                         007
+GEN_DATA super_data INPUT_FORMAT:ASCII RESULT_FILE:super_data_%d  REPORT_STEPS:1
+GEN_KW SIGMA          ../input/templates/sigma.tmpl          coarse.sigma              ../input/distributions/sigma.dist
+RUN_TEMPLATE             ../input/templates/seed_template.txt     seed.txt
+INSTALL_JOB SNAKE_OIL_SIMULATOR ../../snake_oil/jobs/SNAKE_OIL_SIMULATOR
+INSTALL_JOB SNAKE_OIL_NPV ../../snake_oil/jobs/SNAKE_OIL_NPV
+INSTALL_JOB SNAKE_OIL_DIFF ../../snake_oil/jobs/SNAKE_OIL_DIFF
+FORWARD_MODEL SNAKE_OIL_SIMULATOR
+FORWARD_MODEL SNAKE_OIL_NPV
+FORWARD_MODEL SNAKE_OIL_DIFF
+HISTORY_SOURCE REFCASE_HISTORY
+OBS_CONFIG ../input/observations/obsfiles/observations.txt
+TIME_MAP   ../input/refcase/time_map.txt
+SUMMARY WOPR:PROD
+SUMMARY WOPT:PROD
+SUMMARY WWPR:PROD
+SUMMARY WWCT:PROD
+SUMMARY WWPT:PROD
+SUMMARY WBHP:PROD
+SUMMARY WWIR:INJ
+SUMMARY WWIT:INJ
+SUMMARY WBHP:INJ
+SUMMARY ROE:1
+LOAD_WORKFLOW_JOB ../bin/workflows/workflowjobs/UBER_PRINT
+LOAD_WORKFLOW     ../bin/workflows/MAGIC_PRINT"""  # noqa: E501
+        in caplog.text
     )


### PR DESCRIPTION
**Issue**
Resolves #3248


**Approach**
Do some checks to filter out comments, it will not get rid of everything, but should get rid of most comments. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
