### PR TITLE
Bring libres_tests up to flake8 standard

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Lint with flake8
       run: |
-        flake8 ert ert3 tests/ert_tests
+        flake8 ert ert3 tests
 
     - name: Run black
       run: |

--- a/tests/libres_tests/ctest_import.py
+++ b/tests/libres_tests/ctest_import.py
@@ -5,7 +5,7 @@ import sys
 PYTHONPATH = sys.argv[1]
 sys.path.insert(0, PYTHONPATH)
 
-from import_tester import ImportTester
+from import_tester import ImportTester  # noqa
 
 package_name = sys.argv[2]
 package_path = os.path.join(PYTHONPATH, package_name)

--- a/tests/libres_tests/job_runner/test_job_dispatch.py
+++ b/tests/libres_tests/job_runner/test_job_dispatch.py
@@ -269,7 +269,7 @@ def test_job_dispatch_kills_itself_after_unsuccessful_job(unused_tcp_port):
 
     with patch("job_runner.cli.os") as mock_os, patch(
         "job_runner.cli.open", new=mock_open(read_data=jobs_json)
-    ) as mock_file, patch("job_runner.cli.JobRunner") as mock_runner:
+    ), patch("job_runner.cli.JobRunner") as mock_runner:
         mock_runner.return_value.run.return_value = [
             Init([], 0, 0),
             Finish().with_error("overall bad run"),

--- a/tests/libres_tests/libres_utils.py
+++ b/tests/libres_tests/libres_utils.py
@@ -91,9 +91,9 @@ def wait_until(func, interval=0.5, timeout=30):
         except AssertionError:
             if t >= timeout:
                 raise AssertionError(
-                    "Timeout reached in wait_until (function {%s}, timeout {%d}) when waiting for assertion.".format(
-                        func.__name__, timeout
-                    )
+                    "Timeout reached in wait_until "
+                    f"(function {func.__name__}, timeout {timeout:g}) "
+                    "when waiting for assertion."
                 )
 
 
@@ -150,6 +150,7 @@ class ResTest(ExtendedTestCase):
     def createSharePath(cls, path):
         if cls.SHARE_ROOT is None:
             raise Exception(
-                "Trying to create directory rooted in 'SHARE_ROOT' - variable 'SHARE_ROOT' is not set."
+                "Trying to create directory rooted in 'SHARE_ROOT' "
+                "- variable 'SHARE_ROOT' is not set."
             )
         return os.path.realpath(os.path.join(cls.SHARE_ROOT, path))

--- a/tests/libres_tests/res/config/test_config.py
+++ b/tests/libres_tests/res/config/test_config.py
@@ -70,7 +70,7 @@ class ConfigTest(ResTest):
         )
 
     def test_item_types(self):
-        with TestAreaContext("config/types") as test_area:
+        with TestAreaContext("config/types"):
             with open("config", "w") as f:
                 f.write("TYPE_ITEM 10 3.14 TruE  String  file\n")
 
@@ -242,13 +242,13 @@ FIELD    RV            DYNAMIC   MIN:0.0034"""
             self.assertIn("KEY", d)
             item_list = d["KEY"]
             self.assertEqual(len(item_list), 1)
-            l = item_list[0]
-            self.assertEqual(l[0], "VALUE1")
-            self.assertEqual(l[1], "VALUE2")
-            self.assertEqual(l[2], 100)
-            self.assertEqual(l[3], True)
-            self.assertEqual(l[4], 3.14)
-            self.assertEqual(l[5], "../path/file.txt")
+            line = item_list[0]
+            self.assertEqual(line[0], "VALUE1")
+            self.assertEqual(line[1], "VALUE2")
+            self.assertEqual(line[2], 100)
+            self.assertEqual(line[3], True)
+            self.assertEqual(line[4], 3.14)
+            self.assertEqual(line[5], "../path/file.txt")
 
             self.assertFalse("NOT_IN_CONTENT" in content)
             item = content["NOT_IN_CONTENT"]

--- a/tests/libres_tests/res/enkf/data/test_enkf_node.py
+++ b/tests/libres_tests/res/enkf/data/test_enkf_node.py
@@ -14,7 +14,7 @@ class EnkfNodeTest(ResTest):
             config = EnkfConfigNode.create_ext_param("key", keys)
             node = EnkfNode(config)
             ext_node = node.as_ext_param()
-            ext_config = config.getModelConfig()
+            config.getModelConfig()
 
             ext_node.set_vector([1, 2, 3])
             node.ecl_write("path")

--- a/tests/libres_tests/res/enkf/data/test_ext_param.py
+++ b/tests/libres_tests/res/enkf/data/test_ext_param.py
@@ -18,7 +18,7 @@ class ExtParamTest(ResTest):
             self.assertEqual(configkey, input_keys[i])
 
         with self.assertRaises(IndexError):
-            c = config[100]
+            config[100]
 
         keys = []
         for key in config.keys():
@@ -57,10 +57,10 @@ class ExtParamTest(ResTest):
             self.assertIn(configsuffixes, input_suffixes)
 
         with self.assertRaises(IndexError):
-            c = config[100]
+            config[100]
 
         with self.assertRaises(IndexError):
-            c = config["no_such_key"]
+            config["no_such_key"]
 
         self.assertEqual(set(config.keys()), set(input_dict.keys()))
 
@@ -117,15 +117,15 @@ class ExtParamTest(ResTest):
         data = ExtParam(config)
 
         with self.assertRaises(IndexError):
-            d = data[0]  # Cannot use indices when we have suffixes
+            data[0]  # Cannot use indices when we have suffixes
         with self.assertRaises(TypeError):
-            d = data["key1", 1]
+            data["key1", 1]
         with self.assertRaises(KeyError):
-            d = data["NoSuchKey"]
+            data["NoSuchKey"]
         with self.assertRaises(KeyError):
-            d = data["key1"]  # requires a suffix
+            data["key1"]  # requires a suffix
         with self.assertRaises(KeyError):
-            d = data["key1", "no_such_suffix"]
+            data["key1", "no_such_suffix"]
 
         data["key1", "a"] = 1
         data["key1", "b"] = 500.5

--- a/tests/libres_tests/res/enkf/data/test_gen_data_config.py
+++ b/tests/libres_tests/res/enkf/data/test_gen_data_config.py
@@ -14,7 +14,10 @@ class GenDataConfigTest(ResTest):
         "bool_vector_ref gen_data_config_get_active_mask( gen_data_config )", bind=False
     )
     _update_active_mask = ResPrototype(
-        "void gen_data_config_update_active( gen_data_config, forward_load_context , bool_vector)",
+        (
+            "void gen_data_config_update_active( gen_data_config, "
+            "forward_load_context , bool_vector)"
+        ),
         bind=False,
     )
 
@@ -44,7 +47,8 @@ class GenDataConfigTest(ResTest):
             self.assertEqual(second_active_mask_len, 2560)
             self.assertEqual(first_active_mask_length, second_active_mask_len)
 
-            # Setting one element to False, load different case, check, reload, and check.
+            # Setting one element to False, load different case, check, reload,
+            # and check.
             self.assertTrue(active_mask[10])
             active_mask_modified = active_mask.copy()
             active_mask_modified[10] = False
@@ -65,7 +69,8 @@ class GenDataConfigTest(ResTest):
             active_mask = self._get_active_mask(config_node.getDataModelConfig())
             self.assertTrue(active_mask[10])
 
-            # Reload second again, should now be false at 10, due to the update further up
+            # Reload second again, should now be false at 10, due to the update
+            # further up
             data_node = EnkfNode(config_node)
             data_node.tryLoad(fs2, NodeId(60, 0))
             active_mask = self._get_active_mask(config_node.getDataModelConfig())
@@ -75,7 +80,7 @@ class GenDataConfigTest(ResTest):
         self.load_active_masks("missing-active", "default")
 
     def test_create(self):
-        conf = GenDataConfig("KEY")
+        GenDataConfig("KEY")
 
     def updateMask(self, gen_data_config, report_step, fs, active_mask, subst_list):
         run_arg = RunArg.createEnsembleExperimentRunArg(

--- a/tests/libres_tests/res/enkf/data/test_summary.py
+++ b/tests/libres_tests/res/enkf/data/test_summary.py
@@ -11,7 +11,7 @@ class SummaryTest(ResTest):
         self.assertEqual(len(summary), 0)
 
         with self.assertRaises(IndexError):
-            v = summary[100]
+            summary[100]
 
         summary[0] = 75
         self.assertEqual(summary[0], 75)
@@ -20,4 +20,4 @@ class SummaryTest(ResTest):
         self.assertEqual(summary[10], 100)
 
         with self.assertRaises(ValueError):
-            v5 = summary[5]
+            summary[5]

--- a/tests/libres_tests/res/enkf/export/test_design_matrix.py
+++ b/tests/libres_tests/res/enkf/export/test_design_matrix.py
@@ -7,22 +7,22 @@ from res.enkf.export import DesignMatrixReader
 def dumpDesignMatrix1(path):
     with open(path, "w") as dm:
         dm.write(
-            "Case	CORR_SEIS_HEIMDAL	VOL_FRAC_HEIMDAL	AZIM_IND_HEIMDAL	VARIO_PARAL_HEIMDAL	VARIO_NORM_HEIMDAL	VARIO_VERT_HEIMDAL	SEIS_COND_HEIMDAL\n"
+            "Case	CORR_SEIS_HEIMDAL	VOL_FRAC_HEIMDAL	AZIM_IND_HEIMDAL	VARIO_PARAL_HEIMDAL	VARIO_NORM_HEIMDAL	VARIO_VERT_HEIMDAL	SEIS_COND_HEIMDAL\n"  # noqa
         )
-        dm.write("0	0.8			0.08			125			1000			500			25			ON\n")
-        dm.write("1	0.8			0.15			125			2000			1000			25			ON\n")
-        dm.write("2	0.8			0.20			125			4000			2000			25			ON\n")
+        dm.write("0	0.8			0.08			125			1000			500			25			ON\n")  # noqa
+        dm.write("1	0.8			0.15			125			2000			1000			25			ON\n")  # noqa
+        dm.write("2	0.8			0.20			125			4000			2000			25			ON\n")  # noqa
 
 
 def dumpDesignMatrix2(path):
     with open(path, "w") as dm:
         dm.write(
-            "Case	CORR_SEIS_HEIMDAL	VOL_FRAC_HEIMDAL	AZIM_IND_HEIMDAL	VARIO_PARAL_HEIMDAL	VARIO_NORM_HEIMDAL	VARIO_VERT_HEIMDAL	SEIS_COND_HEIMDAL\n"
+            "Case	CORR_SEIS_HEIMDAL	VOL_FRAC_HEIMDAL	AZIM_IND_HEIMDAL	VARIO_PARAL_HEIMDAL	VARIO_NORM_HEIMDAL	VARIO_VERT_HEIMDAL	SEIS_COND_HEIMDAL\n"  # noqa
         )
-        dm.write("0	0.8			0.08			125			1000			500			25			ON\n")
-        dm.write("1	0.8			0.15			125			2000			1000			25			ON\n")
-        dm.write("2	0.8			0.20			125			4000			2000			25			ON\n")
-        dm.write("4	0.8			0.30			125			16000			8000			25			ON\n")
+        dm.write("0	0.8			0.08			125			1000			500			25			ON\n")  # noqa
+        dm.write("1	0.8			0.15			125			2000			1000			25			ON\n")  # noqa
+        dm.write("2	0.8			0.20			125			4000			2000			25			ON\n")  # noqa
+        dm.write("4	0.8			0.30			125			16000			8000			25			ON\n")  # noqa
 
 
 class DesignMatrixTest(ResTest):

--- a/tests/libres_tests/res/enkf/export/test_export_join.py
+++ b/tests/libres_tests/res/enkf/export/test_export_join.py
@@ -102,7 +102,8 @@ class ExportJoinTest(ResTest):
             self.assertFloatEqual(result["MISFIT:TOTAL"][24][last_date], 1714.700855)
 
             with self.assertRaises(KeyError):
-                realization_13 = result.loc[60]
+                # realization 13:
+                result.loc[60]
 
             column_count = len(result.columns)
             self.assertEqual(result.dtypes[0], numpy.float64)

--- a/tests/libres_tests/res/enkf/export/test_gen_data_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_gen_data_collector.py
@@ -12,10 +12,10 @@ class GenDataCollectorTest(ResTest):
             ert = context.getErt()
 
             with self.assertRaises(KeyError):
-                data = GenDataCollector.loadGenData(ert, "default_0", "RFT_XX", 199)
+                GenDataCollector.loadGenData(ert, "default_0", "RFT_XX", 199)
 
             with self.assertRaises(ValueError):
-                data = GenDataCollector.loadGenData(
+                GenDataCollector.loadGenData(
                     ert, "default_0", "SNAKE_OIL_OPR_DIFF", 198
                 )
 

--- a/tests/libres_tests/res/enkf/export/test_gen_kw_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_gen_kw_collector.py
@@ -23,10 +23,12 @@ class GenKwCollectorTest(ResTest):
             self.assertFloatEqual(data["SNAKE_OIL_PARAM:OP1_OFFSET"][0], 0.054539)
             self.assertFloatEqual(data["SNAKE_OIL_PARAM:OP1_OFFSET"][12], 0.057807)
 
-            realization_20 = data.loc[20]
+            # realization 20:
+            data.loc[20]
 
             with self.assertRaises(KeyError):
-                realization_60 = data.loc[60]
+                # realization 60:
+                data.loc[60]
 
             data = GenKwCollector.loadAllGenKwData(
                 ert,

--- a/tests/libres_tests/res/enkf/export/test_misfit_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_misfit_collector.py
@@ -21,7 +21,9 @@ class MisfitCollectorTest(ResTest):
             self.assertFloatEqual(data["MISFIT:TOTAL"][0], 767.008457)
             self.assertFloatEqual(data["MISFIT:TOTAL"][24], 1359.172803)
 
-            realization_20 = data.loc[20]
+            # realization 20:
+            data.loc[20]
 
             with self.assertRaises(KeyError):
-                realization_60 = data.loc[60]
+                # realization 60:
+                data.loc[60]

--- a/tests/libres_tests/res/enkf/export/test_summary_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_summary_collector.py
@@ -31,10 +31,12 @@ class SummaryCollectorTest(ResTest):
             self.assertFloatEqual(data["FOPR"][0]["2010-01-10"], 0.118963)
             self.assertFloatEqual(data["FOPR"][0]["2015-06-23"], 0.133601)
 
-            realization_20 = data.loc[20]
+            # realization 20:
+            data.loc[20]
 
             with self.assertRaises(KeyError):
-                realization_60 = data.loc[60]
+                # realization 60:
+                data.loc[60]
 
             data = SummaryCollector.loadAllSummaryData(
                 ert, "default_0", ["WWCT:OP1", "WWCT:OP2"]

--- a/tests/libres_tests/res/enkf/export/test_summary_observation_collector.py
+++ b/tests/libres_tests/res/enkf/export/test_summary_observation_collector.py
@@ -45,7 +45,7 @@ class SummaryObservationCollectorTest(ResTest):
             self.assertFloatEqual(data["STD_WOPR:OP1"]["2010-03-31"], 0.05)
 
             with self.assertRaises(KeyError):
-                fgir = data["FGIR"]
+                data["FGIR"]
 
             data = SummaryObservationCollector.loadObservationData(
                 ert, "default_0", ["WOPR:OP1"]

--- a/tests/libres_tests/res/enkf/test_analysis_config.py
+++ b/tests/libres_tests/res/enkf/test_analysis_config.py
@@ -38,7 +38,8 @@ class AnalysisConfigTest(ResTest):
             work_area.copy_directory(self.case_directory)
             ac = AnalysisConfig(self.case_file)
 
-            # Unless the MIN_REALIZATIONS is set in config, one is required to have "all" realizations.
+            # Unless the MIN_REALIZATIONS is set in config, one is required to
+            # have "all" realizations.
             self.assertFalse(ac.haveEnoughRealisations(5, 10))
             self.assertTrue(ac.haveEnoughRealisations(10, 10))
 

--- a/tests/libres_tests/res/enkf/test_analysis_iter_config.py
+++ b/tests/libres_tests/res/enkf/test_analysis_iter_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #  Copyright (C) 2014  Equinor ASA, Norway.
 #
-#  The file 'test_analysis_iter_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#  The file 'test_analysis_iter_config.py' is part of ERT
 #
 #  ERT is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/libres_tests/res/enkf/test_ecl_config.py
+++ b/tests/libres_tests/res/enkf/test_ecl_config.py
@@ -84,7 +84,9 @@ class EclConfigTest(ResTest):
             ConfigKeys.GRID: "configuration_tests/input/CASE.EGRID",
             ConfigKeys.REFCASE: "configuration_tests/input/SNAKE_OIL_FIELD",
             ConfigKeys.END_DATE: "2010-10-10",
-            ConfigKeys.SCHEDULE_PREDICTION_FILE: "configuration_tests/input/schedule.sch",
+            ConfigKeys.SCHEDULE_PREDICTION_FILE: (
+                "configuration_tests/input/schedule.sch"
+            ),
         }
 
         self.case_directory = self.createTestPath("local/configuration_tests/")

--- a/tests/libres_tests/res/enkf/test_enkf.py
+++ b/tests/libres_tests/res/enkf/test_enkf.py
@@ -93,7 +93,7 @@ class EnKFTest(ResTest):
 
     @tmpdir()
     def test_site_bootstrap(self):
-        with TestAreaContext("enkf_test", store_area=True) as work_area:
+        with TestAreaContext("enkf_test", store_area=True):
             with self.assertRaises(ValueError):
                 EnKFMain(None)
 
@@ -113,23 +113,21 @@ class EnKFTest(ResTest):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(TypeError):
                 work_area.copy_directory(self.case_directory)
-                main = EnKFMain(res_config="This is not a ResConfig instance")
+                EnKFMain(res_config="This is not a ResConfig instance")
 
     @tmpdir()
     def test_invalid_parameter_count_2_res_config(self):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(ValueError):
                 work_area.copy_directory(self.case_directory)
-                res_config = ResConfig(user_config_file="a", config="b")
+                ResConfig(user_config_file="a", config="b")
 
     @tmpdir()
     def test_invalid_parameter_count_3_res_config(self):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(ValueError):
                 work_area.copy_directory(self.case_directory)
-                res_config = ResConfig(
-                    user_config_file="a", config="b", config_dict="c"
-                )
+                ResConfig(user_config_file="a", config="b", config_dict="c")
 
     @tmpdir()
     def test_enum(self):

--- a/tests/libres_tests/res/enkf/test_enkf_fs.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs.py
@@ -47,4 +47,4 @@ class EnKFFSTest(ResTest):
 
     def test_throws(self):
         with self.assertRaises(Exception):
-            fs = EnkfFs("/does/not/exist")
+            EnkfFs("/does/not/exist")

--- a/tests/libres_tests/res/enkf/test_enkf_fs_manager1.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs_manager1.py
@@ -19,7 +19,7 @@ class EnKFFSManagerTest1(ResTest):
             ert = testContext.getErt()
             fsm = ert.getEnkfFsManager()
 
-            fs = fsm.getCurrentFileSystem()
+            fsm.getCurrentFileSystem()
             self.assertTrue(fsm.isCaseMounted("default_0"))
             self.assertTrue(fsm.caseExists("default_0"))
             self.assertTrue(fsm.caseHasData("default_0"))
@@ -32,7 +32,7 @@ class EnKFFSManagerTest1(ResTest):
             self.assertFalse(fsm.caseHasData("newFS"))
             self.assertFalse(fsm.isCaseRunning("newFS"))
 
-            fs2 = fsm.getFileSystem("newFS")
+            fsm.getFileSystem("newFS")
             self.assertEqual(2, fsm.getFileSystemCount())
 
             self.assertTrue(fsm.isCaseMounted("newFS"))

--- a/tests/libres_tests/res/enkf/test_enkf_library.py
+++ b/tests/libres_tests/res/enkf/test_enkf_library.py
@@ -27,7 +27,7 @@ class EnKFLibraryTest(ResTest):
 
         for cls in classes:
             with self.assertRaises(NotImplementedError):
-                temp = cls()
+                cls()
 
     @tmpdir()
     def test_ecl_config_creation(self):

--- a/tests/libres_tests/res/enkf/test_enkf_load_results_manually.py
+++ b/tests/libres_tests/res/enkf/test_enkf_load_results_manually.py
@@ -54,7 +54,6 @@ class LoadResultsManuallyTest(ResTest):
             ert.getEnkfFsManager().switchFileSystem(load_from)
             realisations = BoolVector(default_value=True, initial_size=25)
             realisations[7] = False
-            iteration = 0
 
             run_context = ert.getRunContextENSEMPLE_EXPERIMENT(load_into, realisations)
 

--- a/tests/libres_tests/res/enkf/test_enkf_runpath.py
+++ b/tests/libres_tests/res/enkf/test_enkf_runpath.py
@@ -45,7 +45,8 @@ class EnKFRunpathTest(ResTest):
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
             main.createRunpath(run_context)
             self.assertFileExists(
-                "snake_oil_no_data/storage/snake_oil/runpath/realization-0/iter-0/parameters.txt"
+                "snake_oil_no_data/storage/snake_oil/"
+                "runpath/realization-0/iter-0/parameters.txt"
             )
             self.assertEqual(
                 len(os.listdir("snake_oil_no_data/storage/snake_oil/runpath")), 1
@@ -79,10 +80,12 @@ class EnKFRunpathTest(ResTest):
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
             main.createRunpath(run_context)
             self.assertDirectoryExists(
-                "snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realization-0/iter-0"
+                "snake_oil_no_data/storage/snake_oil_no_gen_kw/"
+                "runpath/realization-0/iter-0"
             )
             self.assertFileDoesNotExist(
-                "snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realization-0/iter-0/parameters.txt"
+                "snake_oil_no_data/storage/snake_oil_no_gen_kw/"
+                "runpath/realization-0/iter-0/parameters.txt"
             )
             self.assertEqual(
                 len(
@@ -93,7 +96,8 @@ class EnKFRunpathTest(ResTest):
             self.assertEqual(
                 len(
                     os.listdir(
-                        "snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realization-0"
+                        "snake_oil_no_data/storage/snake_oil_no_gen_kw/"
+                        "runpath/realization-0"
                     )
                 ),
                 1,

--- a/tests/libres_tests/res/enkf/test_ensemble_config.py
+++ b/tests/libres_tests/res/enkf/test_ensemble_config.py
@@ -16,7 +16,7 @@ class EnsembleConfigTest(ResTest):
         self.assertFalse("XYZ" in conf)
 
         with self.assertRaises(KeyError):
-            node = conf["KEY"]
+            conf["KEY"]
 
     def test_ensemble_config_constructor(self):
         config_dict = {
@@ -72,7 +72,9 @@ class EnsembleConfigTest(ResTest):
                     ConfigKeys.NAME: "TOP",
                     ConfigKeys.INIT_FILES: "configuration_tests/surface/small.irap",
                     ConfigKeys.OUT_FILE: "configuration_tests/surface/small_out.irap",
-                    ConfigKeys.BASE_SURFACE_KEY: "configuration_tests/surface/small.irap",
+                    ConfigKeys.BASE_SURFACE_KEY: (
+                        "configuration_tests/surface/small.irap"
+                    ),
                     ConfigKeys.MIN_STD: None,
                     ConfigKeys.FORWARD_INIT: False,
                 }

--- a/tests/libres_tests/res/enkf/test_ert_run_context.py
+++ b/tests/libres_tests/res/enkf/test_ert_run_context.py
@@ -24,4 +24,4 @@ from res.enkf import ErtRunContext
 class ErtRunContextTest(ResTest):
     def test_case_init(self):
         mask = BoolVector(default_value=True, initial_size=100)
-        context = ErtRunContext.case_init(None, mask)
+        ErtRunContext.case_init(None, mask)

--- a/tests/libres_tests/res/enkf/test_field_config.py
+++ b/tests/libres_tests/res/enkf/test_field_config.py
@@ -26,10 +26,10 @@ from res.enkf.enums import EnkfFieldFileFormatEnum
 class FieldConfigTest(ResTest):
     def test_create(self):
         grid = EclGridGenerator.create_rectangular((10, 10, 5), (1, 1, 1))
-        field_config = FieldConfig("SWAT", grid)
+        FieldConfig("SWAT", grid)
 
     def test_field_guess_filetype(self):
-        with TestAreaContext("field_config") as test_context:
+        with TestAreaContext("field_config"):
             fname = abspath("test.kw.grdecl")
             with open(fname, "w") as f:
                 f.write("-- my comment\n")

--- a/tests/libres_tests/res/enkf/test_field_export.py
+++ b/tests/libres_tests/res/enkf/test_field_export.py
@@ -46,7 +46,7 @@ class FieldExportTest(ResTest):
             self.assertEqual(grid.get_num_active(), len(field_node))
             with self.assertRaises(IndexError):
                 field_node[grid.get_num_active()]
-            value0 = field_node[0]
+            field_node[0]
 
     def test_field_export(self):
         with ErtTestContext("export_test", self.config_file) as test_context:

--- a/tests/libres_tests/res/enkf/test_hook_manager.py
+++ b/tests/libres_tests/res/enkf/test_hook_manager.py
@@ -38,7 +38,8 @@ class HookManagerTest(ResTest):
             ConfigKeys.CONFIG_DIRECTORY: self.work_area.get_cwd(),
             ConfigKeys.CONFIG_FILE_KEY: "config",
             ConfigKeys.HOOK_WORKFLOW_KEY: [("MAGIC_PRINT", "PRE_SIMULATION")],
-            # these two entries makes the workflow_list load this workflow, but are not needed by hook_manager directly
+            # these two entries makes the workflow_list load this workflow, but
+            # are not needed by hook_manager directly
             ConfigKeys.LOAD_WORKFLOW_JOB: "workflowjobs/MAGIC_PRINT",
             ConfigKeys.LOAD_WORKFLOW: "workflows/MAGIC_PRINT",
         }

--- a/tests/libres_tests/res/enkf/test_model_config.py
+++ b/tests/libres_tests/res/enkf/test_model_config.py
@@ -116,14 +116,19 @@ class ModelConfigTest(ResTest):
                 ConfigKeys.NUM_REALIZATIONS: 10,
                 ConfigKeys.ENSPATH: "configuration_tests/Ensemble",
                 ConfigKeys.TIME_MAP: "configuration_tests/input/refcase/time_map.txt",
-                ConfigKeys.OBS_CONFIG: "configuration_tests/input/observations/observations.txt",
+                ConfigKeys.OBS_CONFIG: (
+                    "configuration_tests/input/observations/observations.txt"
+                ),
                 ConfigKeys.DATAROOT: "configuration_tests/",
                 ConfigKeys.HISTORY_SOURCE: HistorySourceEnum(1),
                 ConfigKeys.GEN_KW_EXPORT_NAME: "parameter_test.json",
                 ConfigKeys.FORWARD_MODEL: [
                     {
                         ConfigKeys.NAME: "COPY_FILE",
-                        ConfigKeys.ARGLIST: "<FROM>=input/schedule.sch, <TO>=output/schedule_copy.sch",
+                        ConfigKeys.ARGLIST: (
+                            "<FROM>=input/schedule.sch, "
+                            "<TO>=output/schedule_copy.sch"
+                        ),
                     },
                     {
                         ConfigKeys.NAME: "SNAKE_OIL_SIMULATOR",
@@ -154,7 +159,9 @@ class ModelConfigTest(ResTest):
             work_area.copy_directory(case_directory)
             with self.assertRaises(ValueError) as cm:
                 ResConfig(
-                    user_config_file="configuration_tests/sched_file_as_history_source.ert"
+                    user_config_file=(
+                        "configuration_tests/sched_file_as_history_source.ert"
+                    )
                 )
 
             # Any assert should per the unittest documentation be outside the

--- a/tests/libres_tests/res/enkf/test_programmatic_res_config.py
+++ b/tests/libres_tests/res/enkf/test_programmatic_res_config.py
@@ -1,6 +1,6 @@
 #  Copyright (C) 2017  Equinor ASA, Norway.
 #
-#  The file 'test_programmatic_res_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#  The file 'test_programmatic_res_config.py' is part of ERT.
 #
 #  ERT is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -248,7 +248,6 @@ class ProgrammaticResConfigTest(ResTest):
 
     def test_no_config_directory(self):
         case_directory = self.createTestPath("local/simple_config")
-        config_file = "simple_config/minimum_config"
 
         with TestAreaContext("res_config_prog_test") as work_area:
             work_area.copy_directory(case_directory)
@@ -258,17 +257,15 @@ class ProgrammaticResConfigTest(ResTest):
 
     def test_errors(self):
         case_directory = self.createTestPath("local/simple_config")
-        config_file = "simple_config/minimum_config"
 
         with TestAreaContext("res_config_prog_test") as work_area:
             work_area.copy_directory(case_directory)
 
             with self.assertRaises(ValueError):
-                res_config = ResConfig(config=self.minimum_config_error)
+                ResConfig(config=self.minimum_config_error)
 
     def test_failed_keys(self):
         case_directory = self.createTestPath("local/simple_config")
-        config_file = "simple_config/minimum_config"
 
         with TestAreaContext("res_config_prog_test") as work_area:
             work_area.copy_directory(case_directory)
@@ -357,7 +354,6 @@ class ProgrammaticResConfigTest(ResTest):
 
     def test_new_config(self):
         case_directory = self.createTestPath("local/simulation_model")
-        config_file = "simulation_model/sim_kw.ert"
 
         with TestAreaContext("res_config_sim_job") as work_area:
             work_area.copy_directory(case_directory)

--- a/tests/libres_tests/res/enkf/test_queue_config.py
+++ b/tests/libres_tests/res/enkf/test_queue_config.py
@@ -34,7 +34,7 @@ class QueueConfigTest(ResTest):
 
             config_file = "simple_config/minimum_config"
             queue_config = QueueConfig(config_file)
-            job_queue = queue_config.create_job_queue()
+            queue_config.create_job_queue()
             queue_config_copy = queue_config.create_local_copy()
 
             self.assertEqual(

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -34,7 +34,6 @@ from res.enkf import (
 )
 from res.job_queue import QueueDriverEnum
 from res.sched import HistorySourceEnum
-from res.util.enums import MessageLevelEnum
 
 # The res_config object should set the environment variable
 # 'DATA_ROOT' to the root directory with the config
@@ -209,7 +208,9 @@ config_data_new = {
     ConfigKeys.ENSPATH: "../output/storage/<CASE_DIR>",  # model
     "PLOT_PATH": "../output/results/plot/<CASE_DIR>",  # removed, previously plot config
     ConfigKeys.UPDATE_LOG_PATH: "../output/update_log/<CASE_DIR>",  # analysis
-    ConfigKeys.RUNPATH_FILE: "../output/run_path_file/.ert-runpath-list_<CASE_DIR>",  # subst
+    ConfigKeys.RUNPATH_FILE: (
+        "../output/run_path_file/.ert-runpath-list_<CASE_DIR>"
+    ),  # subst
     ConfigKeys.DEFINE_KEY: {
         "<USER>": "TEST_USER",
         "<SCRATCH>": "scratch/ert",
@@ -375,8 +376,13 @@ class ResConfigTest(ResTest):
             )
 
     def assert_same_config_file(self, expected_filename, filename, prefix):
-        prefix_path = lambda fn: fn if os.path.isabs(fn) else os.path.join(prefix, fn)
-        canonical_path = lambda fn: os.path.realpath(os.path.abspath(prefix_path(fn)))
+        def prefix_path(filename):
+            if os.path.isabs(filename):
+                return filename
+            return os.path.join(prefix, filename)
+
+        def canonical_path(filename):
+            return os.path.realpath(os.path.abspath(prefix_path(filename)))
 
         self.assertEqual(canonical_path(expected_filename), canonical_path(filename))
 
@@ -608,7 +614,6 @@ class ResConfigTest(ResTest):
     def test_iso_date_format_iso(self):
         self.set_up_simple()
         with TestAreaContext("res_config_init_isodate_test") as work_area:
-            cwd = os.getcwd()
             work_area.copy_directory(self.case_directory)
 
             config_file = "simple_config/minimum_config"
@@ -621,7 +626,6 @@ class ResConfigTest(ResTest):
     def test_legacy_date_format_iso(self):
         self.set_up_simple()
         with TestAreaContext("res_config_init_legacydate_test") as work_area:
-            cwd = os.getcwd()
             work_area.copy_directory(self.case_directory)
 
             config_file = "simple_config/minimum_config"
@@ -653,7 +657,8 @@ class ResConfigTest(ResTest):
             # split config_file to path and filename
             cfg_path, cfg_file = os.path.split(os.path.realpath(self.config_file))
 
-            # replace define keys only in root strings, this should be updated and validated in configsuite instead
+            # replace define keys only in root strings, this should be updated
+            # and validated in configsuite instead
             for define_key in config_data_new[ConfigKeys.DEFINE_KEY]:
                 for data_key in config_data_new:
                     if isinstance(config_data_new[data_key], str):
@@ -672,7 +677,8 @@ class ResConfigTest(ResTest):
             ERT_SHARE_PATH = os.path.dirname(res_config_file.site_config.getLocation())
 
             # update dictionary
-            # commit missing entries, this should be updated and validated in configsuite instead
+            # commit missing entries, this should be updated and validated in
+            # configsuite instead
             config_data_new[ConfigKeys.CONFIG_FILE_KEY] = cfg_file
             config_data_new[ConfigKeys.INSTALL_JOB_DIRECTORY] = [
                 ERT_SHARE_PATH + "/forward-models/res",

--- a/tests/libres_tests/res/enkf/test_row_scaling.py
+++ b/tests/libres_tests/res/enkf/test_row_scaling.py
@@ -63,7 +63,7 @@ def test_basic():
     assert row_scaling[9] == 0.25
 
     with pytest.raises(IndexError):
-        var = row_scaling[10]
+        row_scaling[10]
 
     for i in range(len(row_scaling)):
         r = random.random()
@@ -103,7 +103,7 @@ def test_field_config():
     actnum[10] = 0
 
     grid = EclGridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1), actnum)
-    fc = FieldConfig("PORO", grid)
+    FieldConfig("PORO", grid)
     row_scaling = RowScaling()
     obs_pos = grid.get_xyz(ijk=(5, 5, 1))
     length_scale = (2, 1, 0.50)

--- a/tests/libres_tests/res/enkf/test_row_scaling_case.py
+++ b/tests/libres_tests/res/enkf/test_row_scaling_case.py
@@ -62,8 +62,9 @@ def init_data(main):
     wct = []
     num_realisations = main.getEnsembleSize()
 
-    # The path fields/poro{}.grdecl must be consistent with the INIT_FILES: argument in the
-    # PORO configuration in the configuration file used for the testcase.
+    # The path fields/poro{}.grdecl must be consistent with the INIT_FILES:
+    # argument in the PORO configuration in the configuration file used for the
+    # testcase.
     os.mkdir("fields")
     random.seed(12345)
     for i in range(num_realisations):
@@ -404,7 +405,7 @@ class RowScalingTest(ResTest):
             # The first smoother update without row scaling
             es_update = ESUpdate(main)
             run_context = ErtRunContext.ensemble_smoother_update(init_fs, update_fs1)
-            rng = main.rng()
+            main.rng()
             es_update.smootherUpdate(run_context)
 
             # Configure the local updates
@@ -561,7 +562,8 @@ TIME_MAP timemap.txt
             updatestep.attachMinistep(ministep2)
             update_fs3 = main.getEnkfFsManager().getFileSystem("target3")
             run_context = ErtRunContext.ensemble_smoother_update(init_fs, update_fs3)
-            # Local update with two ministeps - where one observation has been removed from the first
+            # Local update with two ministeps - where one observation has been
+            # removed from the first
             es_update.smootherUpdate(run_context)
 
             ens_config = main.ensembleConfig()

--- a/tests/libres_tests/res/enkf/test_runpath_list_dump.py
+++ b/tests/libres_tests/res/enkf/test_runpath_list_dump.py
@@ -37,7 +37,10 @@ class RunpathListDumpTest(ResTest):
             mask = BoolVector(initial_size=num_realizations, default_value=True)
             mask[13] = False
 
-            runpath_fmt = "simulations/<GEO_ID>/realization-%d/iter-%d/magic-real-<IENS>/magic-iter-<ITER>"
+            runpath_fmt = (
+                "simulations/<GEO_ID>/realization-%d/iter-%d/"
+                "magic-real-<IENS>/magic-iter-<ITER>"
+            )
             jobname_fmt = "SNAKE_OIL_%d"
 
             subst_list = res.resConfig().subst_config.subst_list

--- a/tests/libres_tests/res/enkf/test_runpath_list_ert.py
+++ b/tests/libres_tests/res/enkf/test_runpath_list_ert.py
@@ -15,7 +15,7 @@ class RunpathListTestErt(ResTest):
         # TODO this test is flaky and we need to figure out why.  See #1370
         # enkf_util_assert_buffer_type: wrong target type in file (expected:104 got:0)
         test_path = self.createTestPath("local/snake_oil_field/snake_oil.ert")
-        with ErtTestContext("runpathlist_basic", test_path) as tc:
+        with ErtTestContext("runpathlist_basic", test_path):
             pass
 
     @tmpdir()
@@ -28,7 +28,7 @@ class RunpathListTestErt(ResTest):
             runpath_list = ert.getRunpathList()
             self.assertFalse(os.path.isfile(runpath_list.getExportFile()))
 
-            ens_size = ert.getEnsembleSize()
+            ert.getEnsembleSize()
             runner = ert.getEnkfSimulationRunner()
             fs_manager = ert.getEnkfFsManager()
 

--- a/tests/libres_tests/res/enkf/test_site_config.py
+++ b/tests/libres_tests/res/enkf/test_site_config.py
@@ -90,9 +90,7 @@ class SiteConfigTest(ResTest):
             self.assertEqual(site_config_dict, site_config_user_file)
 
             with self.assertRaises(ValueError):
-                site_config = SiteConfig(
-                    user_config_file=config_file, config_dict=snake_config_dict
-                )
+                SiteConfig(user_config_file=config_file, config_dict=snake_config_dict)
 
     @tmpdir()
     def test_site_config_hook_workflow(self):

--- a/tests/libres_tests/res/enkf/test_state_map.py
+++ b/tests/libres_tests/res/enkf/test_state_map.py
@@ -12,16 +12,16 @@ class StateMapTest(ResTest):
         self.assertEqual(len(state_map), 0)
 
         with self.assertRaises(TypeError):
-            r = state_map["r"]
+            state_map["r"]
 
         with self.assertRaises(IOError):
-            s2 = StateMap("DoesNotExist")
+            StateMap("DoesNotExist")
 
         with self.assertRaises(IOError):
             state_map.load("/file/does/not/exist")
 
         with self.assertRaises(IndexError):
-            v = state_map[0]
+            state_map[0]
 
         with self.assertRaises(TypeError):
             state_map["r"] = RealizationStateEnum.STATE_INITIALIZED
@@ -66,7 +66,7 @@ class StateMapTest(ResTest):
 
         self.assertFalse(state_map.isReadOnly())
 
-        with TestAreaContext("python/state-map/fwrite") as work_area:
+        with TestAreaContext("python/state-map/fwrite"):
             state_map.save("MAP")
             s2 = StateMap("MAP")
             self.assertTrue(state_map == s2)

--- a/tests/libres_tests/res/enkf/test_subst_config.py
+++ b/tests/libres_tests/res/enkf/test_subst_config.py
@@ -104,10 +104,9 @@ class SubstConfigTest(ResTest):
 
     def assertKeyValue(self, subst_config, key, val):
         actual_val = subst_config.__getitem__(key)
-        assert (
-            actual_val == val
-        ), "subst_config does not contain key/value pair ({}, {}). Actual value was: {}".format(
-            key, val, actual_val
+        assert actual_val == val, (
+            f"subst_config does not contain key/value pair ({key}, {val})"
+            f". Actual value was: {actual_val}"
         )
 
     def make_config_file(self, filename):

--- a/tests/libres_tests/res/enkf/test_time_map.py
+++ b/tests/libres_tests/res/enkf/test_time_map.py
@@ -13,7 +13,7 @@ class TimeMapTest(ResTest):
 
         tm = TimeMap()
         with self.assertRaises(IndexError):
-            t = tm[10]
+            tm[10]
 
         pfx = "TimeMap("
         rep = repr(tm)
@@ -43,7 +43,7 @@ class TimeMapTest(ResTest):
         with self.assertRaises(IOError):
             tm.fload("Does/not/exist")
 
-        with TestAreaContext("timemap/fload1") as work_area:
+        with TestAreaContext("timemap/fload1"):
             with open("map.txt", "w") as fileH:
                 fileH.write("2000-10-10\n")
                 fileH.write("2000-10-12\n")
@@ -55,7 +55,7 @@ class TimeMapTest(ResTest):
             self.assertEqual(datetime.date(2000, 10, 10), tm[0])
             self.assertEqual(datetime.date(2000, 10, 16), tm[3])
 
-        with TestAreaContext("timemap/fload2") as work_area:
+        with TestAreaContext("timemap/fload2"):
             with open("map.txt", "w") as fileH:
                 fileH.write("10/10/2000\n")
                 fileH.write("12/10/2000\n")
@@ -67,7 +67,7 @@ class TimeMapTest(ResTest):
             self.assertEqual(datetime.date(2000, 10, 10), tm[0])
             self.assertEqual(datetime.date(2000, 10, 16), tm[3])
 
-        with TestAreaContext("timemap/fload3") as work_area:
+        with TestAreaContext("timemap/fload3"):
             with open("map.txt", "w") as fileH:
                 fileH.write("10/10/200X\n")
 
@@ -78,7 +78,7 @@ class TimeMapTest(ResTest):
             self.assertEqual(datetime.date(2000, 10, 10), tm[0])
             self.assertEqual(datetime.date(2000, 10, 16), tm[3])
 
-        with TestAreaContext("timemap/fload2") as work_area:
+        with TestAreaContext("timemap/fload2"):
             with open("map.txt", "w") as fileH:
                 fileH.write("12/10/2000\n")
                 fileH.write("10/10/2000\n")

--- a/tests/libres_tests/res/fm/test_ecl_run.py
+++ b/tests/libres_tests/res/fm/test_ecl_run.py
@@ -26,8 +26,7 @@ import yaml
 from ecl.summary import EclSum
 from libres_utils import ResTest, tmpdir
 from pytest import MonkeyPatch
-
-from res.fm.ecl import *
+from res.fm.ecl import Ecl100Config, EclRun, FlowConfig, ecl_run, run
 from res.fm.ecl.ecl_run import make_SLURM_machine_list
 
 
@@ -56,6 +55,9 @@ class EclRunTest(ResTest):
         self.monkeypatch.undo()
 
     def init_ecl100_config(self):
+        ecl14_prefix = "/prog/ecl/grid/2014.2/bin/linux_x86_64/"
+        ecl19_prefix = "/prog/res/ecl/grid/2019.3/bin/linux_x86_64/"
+        mpi_prefix = "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/"
         conf = {
             "env": {
                 "F_UFMTENDIAN": "big",
@@ -64,32 +66,28 @@ class EclRunTest(ResTest):
             },
             "versions": {
                 "2014.2": {
-                    "scalar": {
-                        "executable": "/prog/ecl/grid/2014.2/bin/linux_x86_64/eclipse.exe"
-                    },
+                    "scalar": {"executable": ecl14_prefix + "eclipse.exe"},
                     "mpi": {
-                        "executable": "/prog/ecl/grid/2014.2/bin/linux_x86_64/eclipse_ilmpi.exe",
-                        "mpirun": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/bin64/mpirun",
+                        "executable": ecl14_prefix + "eclipse_ilmpi.exe",
+                        "mpirun": mpi_prefix + "bin64/mpirun",
                         "env": {
-                            "I_MPI_ROOT": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/",
+                            "I_MPI_ROOT": mpi_prefix,
                             "P4_RSHCOMMAND": "ssh",
-                            "LD_LIBRARY_PATH": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/lib64:$LD_LIBRARY_PATH",
-                            "PATH": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/bin64:$PATH",
+                            "LD_LIBRARY_PATH": mpi_prefix + "lib64:$LD_LIBRARY_PATH",
+                            "PATH": mpi_prefix + "bin64:$PATH",
                         },
                     },
                 },
                 "2019.3": {
-                    "scalar": {
-                        "executable": "/prog/res/ecl/grid/2019.3/bin/linux_x86_64/eclipse.exe"
-                    },
+                    "scalar": {"executable": ecl19_prefix + "eclipse.exe"},
                     "mpi": {
-                        "executable": "/prog/res/ecl/grid/2019.3/bin/linux_x86_64/eclipse_ilmpi.exe",
-                        "mpirun": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/bin64/mpirun",
+                        "executable": ecl19_prefix + "eclipse_ilmpi.exe",
+                        "mpirun": mpi_prefix + "bin64/mpirun",
                         "env": {
-                            "I_MPI_ROOT": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044",
+                            "I_MPI_ROOT": mpi_prefix,
                             "P4_RSHCOMMAND": "ssh",
-                            "LD_LIBRARY_PATH": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/lib64:$LD_LIBRARY_PATH",
-                            "PATH": "/prog/ecl/grid/tools/linux_x86_64/intel/mpi/5.0.2.044/bin64:$PATH",
+                            "LD_LIBRARY_PATH": mpi_prefix + "lib64:$LD_LIBRARY_PATH",
+                            "PATH": mpi_prefix + "bin64:$PATH",
                         },
                     },
                 },
@@ -315,7 +313,7 @@ class EclRunTest(ResTest):
         self.assertEqual(lines[1].strip(), "VAL2")
 
     @tmpdir()
-    def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables_will_overwrite(
+    def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables_will_overwrite(  # noqa
         self,
     ):
         version = "1111.11"
@@ -575,10 +573,10 @@ class EclRunTest(ResTest):
         error0 = """ @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):
  @           UNABLE TO OPEN INCLUDED FILE                                    
  @           /private/joaho/ERT/git/Gurbat/XXexample_grid_sim.GRDECL         
- @           SYSTEM ERROR CODE IS       29                                   """
+ @           SYSTEM ERROR CODE IS       29                                   """  # noqa
 
         error1 = """ @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):
- @           INCLUDE FILES MISSING.                                          """
+ @           INCLUDE FILES MISSING.                                          """  # noqa
 
         self.assertEqual(error_list[0], error0)
         self.assertEqual(error_list[1], error1)

--- a/tests/libres_tests/res/fm/test_ecl_versioning_config.py
+++ b/tests/libres_tests/res/fm/test_ecl_versioning_config.py
@@ -54,7 +54,6 @@ class EclConfigTest(ResTest):
             with self.assertRaises(ValueError):
                 conf = Ecl100Config()
 
-            scalar_path = "scalar"
             scalar_exe = "bin/scalar_exe"
             mpi_exe = "bin/mpi_exe"
             mpi_run = "bin/mpi_run"
@@ -117,11 +116,13 @@ class EclConfigTest(ResTest):
             with self.assertRaises(OSError):
                 sim = conf.sim("2016")
 
-            # Fails because the 2016 mpi version points to a non existing mpi executable
+            # Fails because the 2016 mpi version points to a non existing mpi
+            # executable
             with self.assertRaises(OSError):
                 sim = conf.mpi_sim("2016")
 
-            # Fails because the 2017 mpi version mpirun points to a non existing mpi executable
+            # Fails because the 2017 mpi version mpirun points to a non existing
+            # mpi executable
             with self.assertRaises(OSError):
                 sim = conf.mpi_sim("2017")
 

--- a/tests/libres_tests/res/fm/test_fm_config.py
+++ b/tests/libres_tests/res/fm/test_fm_config.py
@@ -10,11 +10,11 @@ class TestFMValidity(ResTest):
         pass
 
     def _extract_executable(self, filename):
-        with open(filename, "r") as f:
-            for line in f.readlines():
-                l = line.strip().split()
-                if len(l) > 1 and l[0] == "EXECUTABLE":
-                    return l[1]
+        with open(filename, "r") as filehandle:
+            for line in filehandle.readlines():
+                splitline = line.strip().split()
+                if len(splitline) > 1 and splitline[0] == "EXECUTABLE":
+                    return splitline[1]
         return None
 
     def _file_exist_and_is_executable(self, file_path):

--- a/tests/libres_tests/res/fm/test_rms_config.py
+++ b/tests/libres_tests/res/fm/test_rms_config.py
@@ -41,7 +41,7 @@ class RMSConfigTest(ResTest):
         conf = RMSConfig()
 
         with self.assertRaises(OSError):
-            exe = conf.executable
+            conf.executable
 
         with TestAreaContext("yaml"):
             with open("file.yml", "w") as f:

--- a/tests/libres_tests/res/fm/test_rms_run.py
+++ b/tests/libres_tests/res/fm/test_rms_run.py
@@ -41,7 +41,8 @@ then
     exit 1
 fi
 PYPATH_EXPECTED={expected_pythonpath}
-if [[ $PYTHONPATH != $PYPATH_EXPECTED ]] # first user defined, then config defined, then rest
+# first user defined, then config defined, then rest:
+if [[ $PYTHONPATH != $PYPATH_EXPECTED ]]
 then
     echo "PYTHONPATH set incorrectly"
     echo $PYTHONPATH should be $PYPATH_EXPECTED
@@ -99,11 +100,11 @@ class RMSRunTest(ResTest):
 
     def test_create(self):
         with self.assertRaises(OSError):
-            r = RMSRun(0, "/project/does/not/exist", "workflow")
+            RMSRun(0, "/project/does/not/exist", "workflow")
 
         with TestAreaContext("test_create"):
             os.mkdir("rms")
-            r = RMSRun(0, "rms", "workflow")
+            RMSRun(0, "rms", "workflow")
 
     def test_run_class(self):
         with TestAreaContext("test_run"):
@@ -597,7 +598,6 @@ env:
 
     def test_run_allow_no_env(self):
         with TestAreaContext("test_run"):
-            wrapper_file_name = f"{os.getcwd()}/bin/rms_wrapper"
             with open("rms_config.yml", "w") as f:
                 f.write(
                     f"""\

--- a/tests/libres_tests/res/fm/test_shell.py
+++ b/tests/libres_tests/res/fm/test_shell.py
@@ -6,8 +6,16 @@ import unittest
 from ecl.util.test import TestAreaContext
 from libres_utils import ResTest
 from pytest import MonkeyPatch
-
-from res.fm.shell import *
+from res.fm.shell import (
+    careful_copy_file,
+    copy_directory,
+    copy_file,
+    delete_directory,
+    delete_file,
+    mkdir,
+    move_file,
+    symlink,
+)
 
 
 @contextlib.contextmanager

--- a/tests/libres_tests/res/fm/test_templating.py
+++ b/tests/libres_tests/res/fm/test_templating.py
@@ -12,11 +12,11 @@ from res.fm.templating import load_parameters, render_template
 
 class TemplatingTest(ResTest):
     well_drill_tmpl = (
-        'PROD1 takes value {{ well_drill.PROD1 }}, implying {{ "on" if well_drill.PROD1 >= 0.5 else "off" }}\n'
-        'PROD2 takes value {{ well_drill.PROD2 }}, implying {{ "on" if well_drill.PROD2 >= 0.5 else "off" }}\n'
+        'PROD1 takes value {{ well_drill.PROD1 }}, implying {{ "on" if well_drill.PROD1 >= 0.5 else "off" }}\n'  # noqa
+        'PROD2 takes value {{ well_drill.PROD2 }}, implying {{ "on" if well_drill.PROD2 >= 0.5 else "off" }}\n'  # noqa
         "---------------------------------- \n"
         "{%- for well in well_drill.INJ %}\n"
-        '{{ well.name }} takes value {{  well.value|round(1) }}, implying {{ "on" if  well.value >= 0.5 else "off"}}\n'
+        '{{ well.name }} takes value {{  well.value|round(1) }}, implying {{ "on" if  well.value >= 0.5 else "off"}}\n'  # noqa
         "{%- endfor %}"
     )
 
@@ -44,7 +44,7 @@ class TemplatingTest(ResTest):
 
     @tmpdir()
     def test_render_invalid(self):
-        with TestAreaContext("templating") as tac:
+        with TestAreaContext("templating"):
 
             prod_wells = {"PROD%d" % idx: 0.3 * idx for idx in range(4)}
             prod_in = "well_drill.json"
@@ -179,7 +179,7 @@ class TemplatingTest(ResTest):
 
     @tmpdir()
     def test_template_executable(self):
-        with TestAreaContext("templating") as tac:
+        with TestAreaContext("templating"):
             with open("template", "w") as template_file:
                 template_file.write(
                     "FILENAME\n"
@@ -198,7 +198,11 @@ class TemplatingTest(ResTest):
                 }
                 json_file.write(json.dumps(parameters))
 
-            params = " --output_file out_file --template_file template --input_files other.json"
+            params = (
+                " --output_file out_file "
+                "--template_file template "
+                "--input_files other.json"
+            )
             template_render_exec = pkg_resources.resource_filename(
                 "ert_shared",
                 "share/ert/forward-models/templating/script/template_render",
@@ -215,7 +219,7 @@ class TemplatingTest(ResTest):
     @tmpdir()
     def test_load_parameters(self):
 
-        with TestAreaContext("templating") as tac:
+        with TestAreaContext("templating"):
             with open("parameters.json", "w") as json_file:
                 json_file.write(json.dumps(self.default_parameters))
 

--- a/tests/libres_tests/res/job_queue/test_ert_plugin.py
+++ b/tests/libres_tests/res/job_queue/test_ert_plugin.py
@@ -36,18 +36,6 @@ class CanceledPlugin(ErtPlugin):
         raise CancelPluginException("Cancel test!")
 
 
-# class GUIPlugin(ErtPlugin):
-#     def getArguments(self, parent=None):
-#         value1 = QInputDialog.getInt(parent, "Enter a number!", "Enter a nice number (nothing else than 5):", value=0, min=0, max=10)
-#         value2 = QInputDialog.getInt(parent, "Enter a number!", "Enter a nice number (nothing else than 6):", value=0, min=0, max=10)
-#         print(value1, value2)
-#         return [value1[0], value2[0]]
-#
-#     def run(self, arg1, arg2, arg3=None):
-#         assert arg1 == 5
-#         assert arg2 == 6
-
-
 class ErtPluginTest(ResTest):
     def test_simple_ert_plugin(self):
 

--- a/tests/libres_tests/res/job_queue/test_ert_script.py
+++ b/tests/libres_tests/res/job_queue/test_ert_script.py
@@ -56,10 +56,10 @@ class ErtScriptTest(ResTest):
 
     def test_ert_script_failed_implementation(self):
         with self.assertRaises(UserWarning):
-            script = FailScript("ert")
+            FailScript("ert")
 
     def test_ert_script_from_file(self):
-        with TestAreaContext("python/job_queue/ert_script") as work_area:
+        with TestAreaContext("python/job_queue/ert_script"):
             ErtScriptTest.createScripts()
 
             script_object = ErtScript.loadScriptFromFile("subtract_script.py")

--- a/tests/libres_tests/res/job_queue/test_forward_model_formatted_print.py
+++ b/tests/libres_tests/res/job_queue/test_forward_model_formatted_print.py
@@ -179,8 +179,8 @@ def _generate_job(
     return ext_job
 
 
-def empty_list_if_none(l):
-    return [] if l is None else l
+def empty_list_if_none(_list):
+    return [] if _list is None else _list
 
 
 def default_name_if_none(name):
@@ -228,7 +228,10 @@ class ForwardModelFormattedPrintTest(ResTest):
     JOBS_JSON_FILE = "jobs.json"
 
     def validate_ext_job(self, ext_job, ext_job_config):
-        zero_if_none = lambda x: 0 if x is None else x
+        def zero_if_none(x):
+            if x is None:
+                return 0
+            return x
 
         self.assertEqual(ext_job.name(), default_name_if_none(ext_job_config["name"]))
         self.assertEqual(ext_job.get_executable(), ext_job_config["executable"])
@@ -332,7 +335,7 @@ class ForwardModelFormattedPrintTest(ResTest):
                         create_std_file(job, std=key, job_index=job_index),
                         loaded_job[key],
                     )
-                elif key is "executable":
+                elif key == "executable":
                     assert job[key] in loaded_job[key]
                 else:
                     self.assertEqual(job[key], loaded_job[key])
@@ -424,7 +427,7 @@ class ForwardModelFormattedPrintTest(ResTest):
             self.assertEqual(first_value, env_config[first])
             self.assertEqual(second_value, env_config[second])
             self.assertEqual(third_value_correct, env_config[third])
-            update_config = config[update_string]
+            config[update_string]
 
     def test_repr(self):
         with TestAreaContext("python/job_queue/forward_model_one_job"):
@@ -505,7 +508,12 @@ class ForwardModelFormattedPrintTest(ResTest):
                 run_id, os.getcwd(), "data_root", global_args, umask, varlist
             )
 
-            s = '{"start_time": null, "jobs": [{"status": "Success", "start_time": 1519653419.0, "end_time": 1519653419.0, "name": "SQUARE_PARAMS", "error": null, "current_memory_usage": 2000, "max_memory_usage": 3000}], "end_time": null, "run_id": ""}'
+            s = (
+                '{"start_time": null, "jobs": [{"status": "Success", '
+                '"start_time": 1519653419.0, "end_time": 1519653419.0, '
+                '"name": "SQUARE_PARAMS", "error": null, "current_memory_usage": 2000, '
+                '"max_memory_usage": 3000}], "end_time": null, "run_id": ""}'
+            )
 
             with open("status.json", "w") as f:
                 f.write(s)

--- a/tests/libres_tests/res/job_queue/test_function_ert_script.py
+++ b/tests/libres_tests/res/job_queue/test_function_ert_script.py
@@ -7,7 +7,7 @@ from res.job_queue import WorkflowJob
 
 class FunctionErtScriptTest(ResTest):
     def test_compare(self):
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createInternalFunctionJob()
 
             parser = WorkflowJob.configParser()
@@ -23,7 +23,8 @@ class FunctionErtScriptTest(ResTest):
             self.assertNotEqual(result, 0)
 
             result = workflow_job.run(None, ["String", "String"])
-            # result is returned as c_void_p -> automatic conversion to None if value is 0
+            # result is returned as c_void_p -> automatic conversion to None if
+            # value is 0
             self.assertIsNone(result)
 
             workflow_job = WorkflowJob.fromFile("compare_job")

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -92,7 +92,7 @@ class JobQueueTest(ResTest):
         self.assertEnumIsFullyDefined(JobStatusType, "job_status_type", source_path)
 
     def test_kill_jobs(self):
-        with TestAreaContext("job_queue_test_kill") as work_area:
+        with TestAreaContext("job_queue_test_kill"):
             job_queue = create_queue(NEVER_ENDING_SCRIPT)
 
             assert job_queue.queue_size == 10
@@ -122,7 +122,7 @@ class JobQueueTest(ResTest):
                 job.wait_for()
 
     def test_add_jobs(self):
-        with TestAreaContext("job_queue_test_add") as work_area:
+        with TestAreaContext("job_queue_test_add"):
             job_queue = create_queue(SIMPLE_SCRIPT)
 
             assert job_queue.queue_size == 10
@@ -141,7 +141,7 @@ class JobQueueTest(ResTest):
                 job.wait_for()
 
     def test_failing_jobs(self):
-        with TestAreaContext("job_queue_test_add") as work_area:
+        with TestAreaContext("job_queue_test_add"):
             job_queue = create_queue(FAILING_SCRIPT, max_submit=1)
 
             assert job_queue.queue_size == 10
@@ -167,7 +167,7 @@ class JobQueueTest(ResTest):
                 assert job_queue.snapshot()[iens] == str(JobStatusType.JOB_QUEUE_FAILED)
 
     def test_timeout_jobs(self):
-        with TestAreaContext("job_queue_test_kill") as work_area:
+        with TestAreaContext("job_queue_test_kill"):
             job_numbers = set()
 
             def callback(arg):
@@ -207,7 +207,7 @@ class JobQueueTest(ResTest):
                 job.wait_for()
 
     def test_add_ensemble_evaluator_info(self):
-        with TestAreaContext("job_queue_add_ensemble_evaluator_info") as work_area:
+        with TestAreaContext("job_queue_add_ensemble_evaluator_info"):
             job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"
@@ -240,9 +240,7 @@ class JobQueueTest(ResTest):
                     assert f.read() == cert
 
     def test_add_ensemble_evaluator_info_cert_none(self):
-        with TestAreaContext(
-            "job_queue_add_ensemble_evaluator_info_cert_none"
-        ) as work_area:
+        with TestAreaContext("job_queue_add_ensemble_evaluator_info_cert_none"):
             job_queue = create_queue(SIMPLE_SCRIPT)
             ee_id = "some_id"
             dispatch_url = "wss://some_url.com"

--- a/tests/libres_tests/res/job_queue/test_job_queue_manager.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue_manager.py
@@ -146,7 +146,7 @@ class JobQueueManagerTest(ResTest):
 
     def test_execute_queue(self):
 
-        with TestAreaContext("job_queue_manager_test") as work_area:
+        with TestAreaContext("job_queue_manager_test"):
             job_queue = create_queue(simple_script)
             manager = JobQueueManager(job_queue)
             manager.execute_queue()
@@ -160,7 +160,7 @@ class JobQueueManagerTest(ResTest):
                     assert f.read() == "success"
 
     def test_max_submit_reached(self):
-        with TestAreaContext("job_queue_manager_test") as work_area:
+        with TestAreaContext("job_queue_manager_test"):
             max_submit_num = 5
             job_queue = create_queue(failing_script, max_submit=max_submit_num)
             manager = JobQueueManager(job_queue)
@@ -176,7 +176,7 @@ class JobQueueManagerTest(ResTest):
                 assert job.submit_attempt == job_queue.max_submit
 
     def test_kill_queue(self):
-        with TestAreaContext("job_queue_manager_test") as work_area:
+        with TestAreaContext("job_queue_manager_test"):
             max_submit_num = 5
             job_queue = create_queue(simple_script, max_submit=max_submit_num)
             manager = JobQueueManager(job_queue)

--- a/tests/libres_tests/res/job_queue/test_workflow.py
+++ b/tests/libres_tests/res/job_queue/test_workflow.py
@@ -8,7 +8,7 @@ from res.util.substitution_list import SubstitutionList
 
 class WorkflowTest(ResTest):
     def test_workflow(self):
-        with TestAreaContext("python/job_queue/workflow") as work_area:
+        with TestAreaContext("python/job_queue/workflow"):
             WorkflowCommon.createExternalDumpJob()
 
             joblist = WorkflowJoblist()
@@ -32,7 +32,7 @@ class WorkflowTest(ResTest):
             self.assertEqual(job, joblist["DUMP"])
 
     def test_workflow_run(self):
-        with TestAreaContext("python/job_queue/workflow") as work_area:
+        with TestAreaContext("python/job_queue/workflow"):
             WorkflowCommon.createExternalDumpJob()
 
             joblist = WorkflowJoblist()
@@ -55,7 +55,7 @@ class WorkflowTest(ResTest):
                 self.assertEqual(f.read(), "dump_text_2")
 
     def test_failing_workflow_run(self):
-        with TestAreaContext("python/job_queue/workflow") as work_area:
+        with TestAreaContext("python/job_queue/workflow"):
             WorkflowCommon.createExternalDumpJob()
 
             joblist = WorkflowJoblist()

--- a/tests/libres_tests/res/job_queue/test_workflow_job.py
+++ b/tests/libres_tests/res/job_queue/test_workflow_job.py
@@ -27,7 +27,7 @@ class WorkflowJobTest(ResTest):
         self.assertEqual(workflow_job.name(), "Test")
 
     def test_read_internal_function(self):
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createInternalFunctionJob()
             WorkflowCommon.createErtScriptsJob()
 
@@ -56,7 +56,7 @@ class WorkflowJobTest(ResTest):
             )
 
     def test_arguments(self):
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createInternalFunctionJob()
 
             config = self._alloc_config()
@@ -77,7 +77,7 @@ class WorkflowJobTest(ResTest):
 
     def test_run_external_job(self):
 
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createExternalDumpJob()
 
             config = self._alloc_config()
@@ -94,19 +94,19 @@ class WorkflowJobTest(ResTest):
 
     def test_error_handling_external_job(self):
 
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createExternalDumpJob()
 
             config = self._alloc_config()
             job = self._alloc_from_file("DUMP", config, "dump_failing_job")
 
             self.assertFalse(job.isInternal())
-            argTypes = job.argumentTypes()
+            job.argumentTypes()
             self.assertIsNone(job.run(None, []))
             self.assertTrue(job.stderrdata().startswith("Traceback"))
 
     def test_run_internal_script(self):
-        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+        with TestAreaContext("python/job_queue/workflow_job"):
             WorkflowCommon.createErtScriptsJob()
 
             config = self._alloc_config()

--- a/tests/libres_tests/res/job_queue/test_workflow_joblist.py
+++ b/tests/libres_tests/res/job_queue/test_workflow_joblist.py
@@ -21,7 +21,7 @@ class WorkflowJoblistTest(ResTest):
         self.assertEqual(job.name(), job_ref.name())
 
     def test_workflow_joblist_with_files(self):
-        with TestAreaContext("python/job_queue/workflow_joblist") as work_area:
+        with TestAreaContext("python/job_queue/workflow_joblist"):
             WorkflowCommon.createErtScriptsJob()
             WorkflowCommon.createExternalDumpJob()
             WorkflowCommon.createInternalFunctionJob()

--- a/tests/libres_tests/res/job_queue/test_workflow_runner.py
+++ b/tests/libres_tests/res/job_queue/test_workflow_runner.py
@@ -10,9 +10,7 @@ from res.util.substitution_list import SubstitutionList
 
 class WorkflowRunnerTest(ResTest):
     def test_workflow_thread_cancel_ert_script(self):
-        with TestAreaContext(
-            "python/job_queue/workflow_runner_ert_script"
-        ) as work_area:
+        with TestAreaContext("python/job_queue/workflow_runner_ert_script"):
             WorkflowCommon.createWaitJob()
 
             joblist = WorkflowJoblist()
@@ -49,7 +47,7 @@ class WorkflowRunnerTest(ResTest):
             self.assertFileDoesNotExist("wait_finished_2")
 
     def test_workflow_thread_cancel_external(self):
-        with TestAreaContext("python/job_queue/workflow_runner_external") as work_area:
+        with TestAreaContext("python/job_queue/workflow_runner_external"):
             WorkflowCommon.createWaitJob()
 
             joblist = WorkflowJoblist()
@@ -80,7 +78,7 @@ class WorkflowRunnerTest(ResTest):
             self.assertFileDoesNotExist("wait_finished_2")
 
     def test_workflow_failed_job(self):
-        with TestAreaContext("python/job_queue/workflow_runner_fails") as work_area:
+        with TestAreaContext("python/job_queue/workflow_runner_fails"):
             WorkflowCommon.createExternalDumpJob()
 
             joblist = WorkflowJoblist()
@@ -100,7 +98,7 @@ class WorkflowRunnerTest(ResTest):
                 self.assertNotEqual(workflow_runner.exception(), None)
 
     def test_workflow_success(self):
-        with TestAreaContext("python/job_queue/workflow_runner_fast") as work_area:
+        with TestAreaContext("python/job_queue/workflow_runner_fast"):
             WorkflowCommon.createWaitJob()
 
             joblist = WorkflowJoblist()

--- a/tests/libres_tests/res/run/test_run.py
+++ b/tests/libres_tests/res/run/test_run.py
@@ -10,7 +10,7 @@ class RunTest(ResTest):
         # Slightly weird - tests need existing file,
         # but it can be empty ....
         self.testConfig = "/tmp/config-%06d" % random.randint(100000, 999999)
-        with open(self.testConfig, "w") as f:
+        with open(self.testConfig, "w"):
             pass
 
     def test_init(self):
@@ -62,4 +62,4 @@ class RunTest(ResTest):
             tr.add_check(25, "arg")
 
         with self.assertRaises(Exception):
-            tr.add_check(func_does_not_exist, "arg")
+            tr.add_check(func_does_not_exist, "arg")  # noqa

--- a/tests/libres_tests/res/simulator/test_batch_sim.py
+++ b/tests/libres_tests/res/simulator/test_batch_sim.py
@@ -533,8 +533,9 @@ class BatchSimulatorTest(ResTest):
             self.assertEqual(status.complete, 0)
             self.assertEqual(status.running, 0)
             for idx, _ in enumerate(case_data):
-                path = "storage/batch_sim/runpath/{}/realization-{}/iter-0/realization.number".format(
-                    case_name, idx
+                path = (
+                    f"storage/batch_sim/runpath/{case_name}"
+                    f"/realization-{idx}/iter-0/realization.number"
                 )
                 self.assertTrue(os.path.isfile(path))
                 with open(path, "r") as f:

--- a/tests/libres_tests/res/testcase/test_mini_config.py
+++ b/tests/libres_tests/res/testcase/test_mini_config.py
@@ -12,10 +12,10 @@ class MiniConfigTest(ResTest):
         #
         # 0 OK
         # 1 GenData report step 1 missing
-        # 2 GenData report step 2 missing, Forward Model Component Target File not found.
-        # 3 GenData report step 3 missing, Forward Model Component Target File not found.
+        # 2 GenData report step 2 missing, Forward Model Component Target File not found
+        # 3 GenData report step 3 missing, Forward Model Component Target File not found
         # 4 GenData report step 1 missing
-        # 5 GenData report step 2 missing, Forward Model Component Target File not found.
+        # 5 GenData report step 2 missing, Forward Model Component Target File not found
         # 6 GenData report step 3 missing
         # 7 Forward Model Target File not found.
         # 8 OK

--- a/tests/libres_tests/res/util/test_subprocess.py
+++ b/tests/libres_tests/res/util/test_subprocess.py
@@ -23,9 +23,10 @@ from libres_utils import tmpdir
 
 from res.util.subprocess import await_process_tee
 
-# This method finds the limit of the system pipe-buffer which
-# might be taken into account when using subprocesses with pipes
+
 def _find_system_pipe_max_size():
+    """This method finds the limit of the system pipe-buffer which
+    might be taken into account when using subprocesses with pipes."""
     p = Popen(["dd", "if=/dev/zero", "bs=1"], stdin=PIPE, stdout=PIPE)
     try:
         p.wait(timeout=1)

--- a/tests/libres_tests/res/util/test_substitution_list.py
+++ b/tests/libres_tests/res/util/test_substitution_list.py
@@ -12,13 +12,13 @@ class SubstitutionListTest(ResTest):
         self.assertEqual(len(subst_list), 1)
 
         with self.assertRaises(KeyError):
-            item = subst_list[2]
+            subst_list[2]
 
         with self.assertRaises(KeyError):
-            item = subst_list["NoSuchKey"]
+            subst_list["NoSuchKey"]
 
         with self.assertRaises(KeyError):
-            item = subst_list.doc("NoSuchKey")
+            subst_list.doc("NoSuchKey")
 
         self.assertTrue("Key" in subst_list)
         self.assertEqual(subst_list["Key"], "Value")

--- a/tests/libres_tests/share/test_synthesizer.py
+++ b/tests/libres_tests/share/test_synthesizer.py
@@ -5,7 +5,7 @@ from libres_utils import ResTest
 
 try:
     from res.test.synthesizer import OilSimulator
-except ImportError as e:
+except ImportError:
     share_lib_path = os.path.join(ResTest.createSharePath("lib"))
 
     sys.path.insert(0, share_lib_path)

--- a/tests/performance_tests/enkf/test_load_state.py
+++ b/tests/performance_tests/enkf/test_load_state.py
@@ -14,7 +14,7 @@ class TestLoadState:
             self.TESTDATA_ROOT / "Equinor/config/with_data/config_GEN_DATA"
         ) as ctx:
             load_into = ctx.ert.getEnkfFsManager().getFileSystem("A1")
-            load_from = ctx.ert.getEnkfFsManager().getFileSystem("default")
+            ctx.ert.getEnkfFsManager().getFileSystem("default")
 
             realisations = BoolVector(default_value=True, initial_size=25)
 


### PR DESCRIPTION
**Issue**
Resolves missing flake8 compliance in tests/libres_tests

**Approach**
Fix all flake8 complaints.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
