### PR TITLE
Avoid BoolVector in Python code

### DIFF
--- a/ert/ensemble_evaluator/activerange.py
+++ b/ert/ensemble_evaluator/activerange.py
@@ -12,7 +12,7 @@ from typing import Collection, List, Optional, Tuple, Union
 
 
 def mask_to_rangestring(mask: Collection[Union[bool, int]]) -> str:
-    """Convert a mask (ordered collection of booleans) into a range string
+    """Convert a mask (ordered collection of booleans or int) into a rangestring.
     For instance, `0 1 0 1 1 1` would be converted to `1, 3-5`.
 
     The length of the collection is not encoded in the resulting string and

--- a/ert_gui/ertwidgets/models/activerealizationsmodel.py
+++ b/ert_gui/ertwidgets/models/activerealizationsmodel.py
@@ -1,35 +1,9 @@
+from typing import List
+
 from ecl.util.util import BoolVector
+from ert.ensemble_evaluator.activerange import ActiveRange, mask_to_rangestring
 from ert_gui.ertwidgets.models.valuemodel import ValueModel
 from ert_shared.libres_facade import LibresFacade
-
-
-def mask_to_rangestring(mask):
-    """Convert a mask (ordered collection of booleans) into a range string
-
-    For instance, `0 1 0 1 1 1` would be converted to `1, 3-5`
-    """
-    ranges = []
-
-    def store_range(begin, end):
-        if end - begin == 1:
-            ranges.append("{}".format(begin))
-        else:
-            ranges.append("{}-{}".format(begin, end - 1))
-
-    start = None
-    for i, is_active in enumerate(mask):
-        if is_active:
-            if start is None:  # begin tracking a range
-                start = i
-            assert start is not None
-        else:
-            if start is not None:  # store the range and stop tracking
-                store_range(start, i)
-                start = None
-            assert start is None
-    if start is not None:  # complete the last range if any
-        store_range(start, len(mask))
-    return ",".join(ranges)
 
 
 class ActiveRealizationsModel(ValueModel):
@@ -57,14 +31,7 @@ class ActiveRealizationsModel(ValueModel):
         size = self.facade.get_ensemble_size()
         return "0-%d" % (size - 1)
 
-    def getActiveRealizationsMask(self):
-        count = self.facade.get_ensemble_size()
-
-        mask = BoolVector(default_value=False, initial_size=count)
-        if not mask.updateActiveMask(self.getValue()):
-            raise ValueError('Error while parsing range string "%s"!' % self.getValue())
-
-        if len(mask) != count:
-            raise ValueError("Mask size changed %d != %d!" % (count, len(mask)))
-
-        return mask
+    def getActiveRealizationsMask(self) -> List[bool]:
+        return ActiveRange(
+            rangestring=self.getValue(), length=self.facade.get_ensemble_size()
+        ).mask

--- a/ert_gui/ertwidgets/models/ertmodel.py
+++ b/ert_gui/ertwidgets/models/ertmodel.py
@@ -3,7 +3,7 @@ from typing import List
 from ert_shared.libres_facade import LibresFacade
 from res.enkf import EnKFMain, RealizationStateEnum
 from res.enkf import ErtRunContext
-from ecl.util.util import BoolVector, StringList
+from ecl.util.util import StringList
 from ert_gui.ertwidgets import showWaitCursorWhileWaiting
 
 
@@ -45,7 +45,7 @@ def initializeCurrentCaseFromScratch(
     parameters: List[str], members: List[str], ert: EnKFMain
 ):
     selected_parameters = StringList(parameters)
-    mask = BoolVector(initial_size=ert.getEnsembleSize(), default_value=False)
+    mask = [False] * ert.getEnsembleSize()
     for member in members:
         member = int(member.strip())
         mask[member] = True
@@ -71,7 +71,11 @@ def initializeCurrentCaseFromExisting(
     ):
         total_member_count = ert.getEnsembleSize()
 
-        member_mask = BoolVector.createFromList(total_member_count, members)
+        if set(members) != set("0", "1"):
+            raise ValueError(
+                f"Wrong member set, only 0 and 1 as strings are allowed, got {set(members)}"
+            )
+        member_mask = [bool(int(string)) for string in members]
 
         ert.getEnkfFsManager().customInitializeCurrentFromExistingCase(
             source_case, source_report_step, member_mask, parameters

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -3,7 +3,6 @@ import asyncio
 from threading import Thread
 from PyQt5.QtWidgets import QAbstractItemView
 
-from ecl.util.util import BoolVector
 from ert_gui.ertwidgets import resourceMovie
 from ert_gui.model.job_list import JobListProxyModel
 from ert_gui.model.snapshot import RealIens, SnapshotModel, FileRole

--- a/ert_gui/simulation/single_test_run_panel.py
+++ b/ert_gui/simulation/single_test_run_panel.py
@@ -5,7 +5,6 @@ from ert_gui.ertwidgets.caseselector import CaseSelector
 from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert_shared.models import SingleTestRun
 from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
-from ecl.util.util import BoolVector
 
 from ert_shared.libres_facade import LibresFacade
 
@@ -33,4 +32,4 @@ class SingleTestRunPanel(SimulationConfigPanel):
 
     def getSimulationArguments(self):
 
-        return {"active_realizations": BoolVector(default_value=True, initial_size=1)}
+        return {"active_realizations": [True]}

--- a/ert_shared/ide/keywords/definitions/range_string_argument.py
+++ b/ert_shared/ide/keywords/definitions/range_string_argument.py
@@ -1,80 +1,45 @@
 import re
+
+from ert.ensemble_evaluator.activerange import ActiveRange
+from ert_shared.ide.keywords.data import ValidationStatus
 from ert_shared.ide.keywords.definitions import ArgumentDefinition
 
 
 class RangeStringArgument(ArgumentDefinition):
 
-    NOT_A_VALID_RANGE_STRING = "The input should be of the type: <b><pre>\n\t1,3-5,9,17\n</pre></b>i.e. integer values separated by commas, and dashes to represent ranges."
+    NOT_A_VALID_RANGE_STRING = (
+        "The input should be of the type: "
+        "<b><pre>\n\t1,3-5,9,17\n</pre></b>"
+        "i.e. integer values separated by commas, and dashes to represent ranges."
+    )
     VALUE_NOT_IN_RANGE = "A value must be in the range from 0 to %d."
-
-    PATTERN = re.compile(r"^[0-9\-, \t]+$")
-    RANGE_PATTERN = re.compile(r"^[ \t]*([0-9]+)[ \t]*-[ \t]*([0-9]+)[ \t]*$")
-    NUMBER_PATTERN = re.compile(r"^[ \t]*([0-9]+)[ \t]*$")
 
     def __init__(self, max_value=None, **kwargs):
         super(RangeStringArgument, self).__init__(**kwargs)
         self.__max_value = max_value
 
-    def validate(self, token):
+    def validate(self, token: str) -> ValidationStatus:
+
         validation_status = super(RangeStringArgument, self).validate(token)
 
         if not validation_status:
             return validation_status
-        else:
-            match = RangeStringArgument.PATTERN.match(token)
 
-            if match is None:
+        try:
+            ActiveRange.validate_rangestring(token)
+        except ValueError:
+            validation_status.setFailed()
+            validation_status.addToMessage(RangeStringArgument.NOT_A_VALID_RANGE_STRING)
+
+        if self.__max_value is not None:
+            try:
+                ActiveRange.validate_rangestring_vs_length(token, self.__max_value)
+            except ValueError:
                 validation_status.setFailed()
                 validation_status.addToMessage(
-                    RangeStringArgument.NOT_A_VALID_RANGE_STRING
+                    RangeStringArgument.VALUE_NOT_IN_RANGE % (self.__max_value - 1)
                 )
-            else:
 
-                groups = token.split(",")
+        validation_status.setValue(token)
 
-                for group in groups:
-                    range_match = RangeStringArgument.RANGE_PATTERN.match(group)
-                    number_match = RangeStringArgument.NUMBER_PATTERN.match(group)
-
-                    if range_match is None and number_match is None:
-                        validation_status.setFailed()
-                        validation_status.addToMessage(
-                            RangeStringArgument.NOT_A_VALID_RANGE_STRING
-                        )
-                        break
-
-                    if range_match:
-                        num_1 = int(range_match.group(1))
-                        num_2 = int(range_match.group(2))
-
-                        if not num_2 > num_1:
-                            validation_status.setFailed()
-                            validation_status.addToMessage(
-                                RangeStringArgument.NOT_A_VALID_RANGE_STRING
-                            )
-                            break
-
-                        if self.__max_value is not None and (
-                            num_1 >= self.__max_value or num_2 >= self.__max_value
-                        ):
-                            validation_status.setFailed()
-                            validation_status.addToMessage(
-                                RangeStringArgument.VALUE_NOT_IN_RANGE
-                                % (self.__max_value - 1)
-                            )
-                            break
-
-                    if number_match and self.__max_value is not None:
-                        num = int(number_match.group(1))
-
-                        if num >= self.__max_value:
-                            validation_status.setFailed()
-                            validation_status.addToMessage(
-                                RangeStringArgument.VALUE_NOT_IN_RANGE
-                                % (self.__max_value - 1)
-                            )
-                            break
-
-                validation_status.setValue(token)
-
-            return validation_status
+        return validation_status

--- a/ert_shared/libres_facade.py
+++ b/ert_shared/libres_facade.py
@@ -1,8 +1,9 @@
+from typing import List
+
 import logging
 
 from pandas import DataFrame
 
-from ecl.util.util import BoolVector
 from res.analysis.analysis_module import AnalysisModule
 from res.analysis.enums.analysis_module_options_enum import AnalysisModuleOptionsEnum
 from res.enkf.export import (
@@ -83,7 +84,7 @@ class LibresFacade:
         return self._enkf_main.getModelConfig().getRunpathAsString()
 
     def load_from_forward_model(
-        self, case: str, realisations: BoolVector, iteration: int
+        self, case: str, realisations: List[bool], iteration: int
     ) -> int:
         fs = self._enkf_main.getEnkfFsManager().getFileSystem(case)
         return self._enkf_main.loadFromForwardModel(realisations, iteration, fs)

--- a/ert_shared/models/ensemble_smoother.py
+++ b/ert_shared/models/ensemble_smoother.py
@@ -122,11 +122,10 @@ class EnsembleSmoother(BaseRunModel):
             itr = 1
             sim_fs = prior_context.get_target_fs()
             target_fs = None
-            state = (
+            mask = sim_fs.getStateMap().createMask(
                 RealizationStateEnum.STATE_HAS_DATA
                 | RealizationStateEnum.STATE_INITIALIZED
             )
-            mask = sim_fs.getStateMap().createMask(state)
 
         run_context = ErtRunContext.ensemble_smoother(
             sim_fs, target_fs, mask, runpath_fmt, jobname_fmt, subst_list, itr

--- a/ert_shared/models/iterated_ensemble_smoother.py
+++ b/ert_shared/models/iterated_ensemble_smoother.py
@@ -171,8 +171,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
         if prior_context is None:
             mask = self._simulation_arguments["active_realizations"]
         else:
-            state = (
-                RealizationStateEnum.STATE_HAS_DATA
+            state: RealizationStateEnum = (
+                RealizationStateEnum.STATE_HAS_DATA  # type: ignore
                 | RealizationStateEnum.STATE_INITIALIZED
             )
             mask = sim_fs.getStateMap().createMask(state)

--- a/ert_shared/models/multiple_data_assimilation.py
+++ b/ert_shared/models/multiple_data_assimilation.py
@@ -254,11 +254,10 @@ class MultipleDataAssimilation(BaseRunModel):
         if initialize_mask_from_arguments:
             mask = self._simulation_arguments["active_realizations"]
         else:
-            state = (
+            mask = sim_fs.getStateMap().createMask(
                 RealizationStateEnum.STATE_HAS_DATA
                 | RealizationStateEnum.STATE_INITIALIZED
             )
-            mask = sim_fs.getStateMap().createMask(state)
             # Make sure to only run the realizations which was passed in as argument
             for idx, (valid_state, run_realization) in enumerate(
                 zip(mask, self._initial_realizations_mask)

--- a/ert_shared/share/ert/workflows/jobs/internal-gui/scripts/export_misfit_data.py
+++ b/ert_shared/share/ert/workflows/jobs/internal-gui/scripts/export_misfit_data.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import os
 from res.enkf import ErtScript, RealizationStateEnum
-from ecl.util.util import BoolVector
 
 """
 This job exports misfit data into a chosen file or to the default gen_kw export file (parameters.txt)

--- a/res/enkf/enkf_fs_manager.py
+++ b/res/enkf/enkf_fs_manager.py
@@ -5,7 +5,7 @@ import warnings
 from typing import List
 
 from cwrap import BaseCClass
-from ecl.util.util import BoolVector, StringList
+from ecl.util.util import StringList
 
 from res import ResPrototype
 from res import _lib
@@ -224,28 +224,22 @@ class EnkfFsManager(BaseCClass):
         self,
         source_case,
         source_report_step,
-        member_mask: List[str],
+        member_mask: List[bool],
         node_list: List[str],
     ):
         """
         @type source_case: str
         @type source_report_step: int
-        @type member_mask: ecl.util.BoolVector
+        @type member_mask: list
         @type node_list: ecl.util.StringList
         """
         if source_case not in self.getCaseList():
             raise KeyError(
                 f"No such source case: {source_case} in {self.getCaseList()}"
             )
-        if isinstance(member_mask, BoolVector):
-            warnings.warn(
-                "Using BoolVector for member_mask is deprecated, use a python list of bool",
-                DeprecationWarning,
-            )
-            member_mask = list(member_mask)
         if isinstance(node_list, StringList):
             warnings.warn(
-                "Using StringList for node_list is deprecated, use a python list of bool",
+                "Using StringList for node_list is deprecated, use a python list of strings",
                 DeprecationWarning,
             )
             node_list = list(node_list)
@@ -274,7 +268,7 @@ class EnkfFsManager(BaseCClass):
     ):
         if isinstance(parameter_list, StringList):
             warnings.warn(
-                "Using StringList for node_list is deprecated, use a python list of bools instead",
+                "Using StringList for node_list is deprecated, use a python list of strings",
                 DeprecationWarning,
             )
             parameter_list = list(parameter_list)

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -14,8 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from typing import List
+
 from cwrap import BaseCClass
-from ecl.util.util import RandomNumberGenerator
+from ecl.util.util import BoolVector, RandomNumberGenerator
 
 from res import ResPrototype
 from res.enkf.analysis_config import AnalysisConfig
@@ -434,9 +436,13 @@ class _RealEnKFMain(BaseCClass):
             keyword, path, iactive, file_type, report_step, state, enkfFs
         )
 
-    def loadFromForwardModel(self, realization, iteration, fs):
+    def loadFromForwardModel(self, realization: List[bool], iteration: int, fs):
         """Returns the number of loaded realizations"""
-        return self._load_from_forward_model(iteration, realization, fs)
+        true_indices = [idx for idx, value in enumerate(realization) if value]
+        bool_vector = BoolVector.createFromList(
+            size=len(realization), source_list=true_indices
+        )
+        return self._load_from_forward_model(iteration, bool_vector, fs)
 
     def loadFromRunContext(self, run_context, fs):
         """Returns the number of loaded realizations"""
@@ -448,8 +454,14 @@ class _RealEnKFMain(BaseCClass):
     def createRunpath(self, run_context):
         self._create_run_path(run_context)
 
-    def getRunContextENSEMPLE_EXPERIMENT(self, fs, iactive, iteration=0):
-        return self._alloc_run_context_ENSEMBLE_EXPERIMENT(fs, iactive, iteration)
+    def getRunContextENSEMPLE_EXPERIMENT(
+        self, fs, iactive: List[bool], iteration: int = 0
+    ):
+        true_indices = [idx for idx, value in enumerate(iactive) if value]
+        bool_vector = BoolVector.createFromList(
+            size=len(iactive), source_list=true_indices
+        )
+        return self._alloc_run_context_ENSEMBLE_EXPERIMENT(fs, bool_vector, iteration)
 
     def create_runpath_list(self):
         return self._create_runpath_list()

--- a/res/enkf/ert_run_context.py
+++ b/res/enkf/ert_run_context.py
@@ -13,6 +13,8 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from typing import List
+
 from cwrap import BaseCClass
 from ecl.util.util import BoolVector, StringList
 
@@ -21,6 +23,11 @@ from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums import EnkfInitModeEnum
 from res.enkf.run_arg import RunArg
 from res.util import PathFormat, SubstitutionList
+
+
+def boolvector_from_boollist(bool_list: List[bool]) -> BoolVector:
+    true_indices = [idx for idx, value in enumerate(bool_list) if value]
+    return BoolVector.createFromList(size=len(bool_list), source_list=true_indices)
 
 
 class ErtRunContext(BaseCClass):
@@ -104,7 +111,7 @@ class ErtRunContext(BaseCClass):
         run_type,
         sim_fs: EnkfFs,
         target_fs: EnkfFs,
-        mask,
+        mask: List[bool],
         path_fmt: PathFormat,
         jobname_fmt,
         subst_list: SubstitutionList,
@@ -116,7 +123,7 @@ class ErtRunContext(BaseCClass):
             init_mode,
             sim_fs,
             target_fs,
-            mask,
+            boolvector_from_boollist(mask),
             path_fmt,
             jobname_fmt,
             subst_list,
@@ -126,25 +133,30 @@ class ErtRunContext(BaseCClass):
 
         # The C object ert_run_context uses a shared object for the
         # path_fmt and subst_list objects. We therefore hold on
-        # to a reference here - to inhibt Python GC of these objects.
+        # to a reference here - to inhibit Python GC of these objects.
         self._path_fmt = path_fmt
         self._subst_list = subst_list
 
     @classmethod
     def case_init(cls, sim_fs, mask):
-        return cls._alloc_case_init(sim_fs, mask)
+        return cls._alloc_case_init(sim_fs, boolvector_from_boollist(mask))
 
     @classmethod
     def ensemble_experiment(
-        cls, sim_fs, mask, path_fmt, jobname_fmt, subst_list, itr
+        cls, sim_fs, mask: List[bool], path_fmt, jobname_fmt, subst_list, itr
     ) -> "ErtRunContext":
         run_context = cls._alloc_ensemble_experiment(
-            sim_fs, mask, path_fmt, jobname_fmt, subst_list, itr
+            sim_fs,
+            boolvector_from_boollist(mask),
+            path_fmt,
+            jobname_fmt,
+            subst_list,
+            itr,
         )
 
         # The C object ert_run_context uses a shared object for the
         # path_fmt and subst_list objects. We therefore hold on
-        # to a reference here - to inhibt Python GC of these objects.
+        # to a reference here - to inhibit Python GC of these objects.
         run_context._path_fmt = path_fmt
         run_context._subst_list = subst_list
 
@@ -152,15 +164,21 @@ class ErtRunContext(BaseCClass):
 
     @classmethod
     def ensemble_smoother(
-        cls, sim_fs, target_fs, mask, path_fmt, jobname_fmt, subst_list, itr
+        cls, sim_fs, target_fs, mask: List[bool], path_fmt, jobname_fmt, subst_list, itr
     ) -> "ErtRunContext":
         run_context = cls._alloc_ensemble_smoother(
-            sim_fs, target_fs, mask, path_fmt, jobname_fmt, subst_list, itr
+            sim_fs,
+            target_fs,
+            boolvector_from_boollist(mask),
+            path_fmt,
+            jobname_fmt,
+            subst_list,
+            itr,
         )
 
         # The C object ert_run_context uses a shared object for the
         # path_fmt and subst_list objects. We therefore hold on
-        # to a reference here - to inhibt Python GC of these objects.
+        # to a reference here - to inhibit Python GC of these objects.
         run_context._path_fmt = path_fmt
         run_context._subst_list = subst_list
 
@@ -183,7 +201,7 @@ class ErtRunContext(BaseCClass):
 
     def __getitem__(self, index) -> RunArg:
         if not isinstance(index, int):
-            raise TypeError("Invalid type - expetected integer")
+            raise TypeError("Invalid type - expected integer")
 
         if 0 <= index < len(self):
             run_arg = self._iget(index)
@@ -202,13 +220,15 @@ class ErtRunContext(BaseCClass):
     @classmethod
     def createRunpathList(
         cls,
-        mask: BoolVector,
+        mask: List[bool],
         runpath_fmt: PathFormat,
         subst_list: SubstitutionList,
         iter=0,
     ) -> StringList:
         """@rtype: ecl.util.stringlist.StringList"""
-        return cls._alloc_runpath_list(mask, runpath_fmt, subst_list, iter)
+        return cls._alloc_runpath_list(
+            boolvector_from_boollist(mask), runpath_fmt, subst_list, iter
+        )
 
     @classmethod
     def createRunpath(
@@ -220,8 +240,8 @@ class ErtRunContext(BaseCClass):
     def get_id(self):
         return self._get_id()
 
-    def get_mask(self) -> BoolVector:
-        return self._get_mask()
+    def get_mask(self) -> List[bool]:
+        return list(self._get_mask())
 
     def get_iter(self) -> int:
         return self._get_iter()

--- a/res/enkf/export/gen_kw_collector.py
+++ b/res/enkf/export/gen_kw_collector.py
@@ -1,5 +1,6 @@
+from typing import List
+
 from res import _lib
-from ecl.util.util import BoolVector
 from pandas import DataFrame
 from res.enkf import EnKFMain
 from res.enkf.enums import RealizationStateEnum
@@ -7,15 +8,12 @@ from res.enkf.enums import RealizationStateEnum
 
 class GenKwCollector:
     @staticmethod
-    def createActiveList(ert, fs):
-        state_map = fs.getStateMap()
-        ens_mask = state_map.selectMatching(
+    def createActiveList(ert, fs) -> List[int]:
+        ens_mask = fs.getStateMap().selectMatching(
             RealizationStateEnum.STATE_INITIALIZED
             | RealizationStateEnum.STATE_HAS_DATA,
         )
-        index_list = [index for index, element in enumerate(ens_mask) if element]
-        bool_vec = BoolVector.createFromList(len(index_list), index_list)
-        return bool_vec.createActiveList()
+        return [index for index, active in enumerate(ens_mask) if active]
 
     @staticmethod
     def getAllGenKwKeys(ert):

--- a/res/enkf/plot_data/ensemble_plot_gen_kw.py
+++ b/res/enkf/plot_data/ensemble_plot_gen_kw.py
@@ -14,7 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from typing import Optional
+from typing import List, Optional
 
 from cwrap import BaseCClass
 from ecl.util.util import BoolVector
@@ -58,12 +58,14 @@ class EnsemblePlotGenKW(BaseCClass):
 
         self.__load(file_system, input_mask)
 
-    def __load(self, file_system: EnkfFs, input_mask: Optional[BoolVector] = None):
+    def __load(self, file_system: EnkfFs, input_mask: Optional[List[bool]] = None):
         assert isinstance(file_system, EnkfFs)
-        if input_mask is not None:
-            assert isinstance(input_mask, BoolVector)
-
-        self._load(file_system, True, 0, input_mask)
+        if input_mask is None:
+            mask = None
+        else:
+            mask_indices = [idx for idx, value in enumerate(input_mask) if value]
+            mask = BoolVector.createFromList(mask_indices)
+        self._load(file_system, True, 0, mask)
 
     def __len__(self):
         """@rtype: int"""

--- a/res/enkf/state_map.py
+++ b/res/enkf/state_map.py
@@ -13,8 +13,9 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from typing import List
+
 from cwrap import BaseCClass
-from ecl.util.util import BoolVector
 
 from res import ResPrototype, _lib
 from res.enkf.enums import RealizationStateEnum
@@ -102,40 +103,24 @@ class StateMap(BaseCClass):
         """@rtype: bool"""
         return self._is_read_only()
 
-    def selectMatching(self, select_mask):
-        """
-        @type select_mask: RealizationStateEnum
-        """
+    def selectMatching(self, select_mask: RealizationStateEnum) -> List[bool]:
         assert isinstance(select_mask, RealizationStateEnum)
-        return _lib.state_map.select_matching(self, select_mask.value, True)
+        return list(_lib.state_map.select_matching(self, select_mask.value, True))
 
-    def deselectMatching(self, select_mask):
-        """
-        @type select_mask: RealizationStateEnum
-        """
+    def deselectMatching(self, select_mask: RealizationStateEnum) -> List[bool]:
         assert isinstance(select_mask, RealizationStateEnum)
-        return _lib.state_map.select_matching(self, select_mask.value, False)
+        return list(_lib.state_map.select_matching(self, select_mask.value, False))
 
-    def realizationList(self, state_value):
-        """
-        Will create a list of all realisations with state equal to state_value.
-
-        @type state_value: RealizationStateEnum
-        @rtype: ecl.util.IntVector
-        """
+    def realizationList(self, state_value: RealizationStateEnum) -> List[int]:
+        """Will create an integer list of all realisations with state equal to
+        state_value."""
         mask = self.createMask(state_value)
-        return BoolVector.createActiveList(mask)
+        return [idx for idx, value in enumerate(mask) if value]
 
-    def createMask(self, state_value):
-        """
-        Will create a bool vector of all realisations with state equal to state_value.
-
-        @type state_value: RealizationStateEnum
-        @rtype: ecl.util.BoolVector
-        """
-        mask = self.selectMatching(state_value)
-        index_list = [index for index, element in enumerate(mask) if element]
-        return BoolVector.createFromList(len(mask), index_list)
+    def createMask(self, state_value: RealizationStateEnum) -> List[bool]:
+        """Will create a bool list of all realisations with state equal to
+        state_value."""
+        return self.selectMatching(state_value)
 
     def free(self):
         self._free()

--- a/res/simulator/batch_simulator.py
+++ b/res/simulator/batch_simulator.py
@@ -1,5 +1,3 @@
-from ecl.util.util import BoolVector
-
 from res.enkf import EnKFMain, NodeId, ResConfig
 from res.enkf.config import EnkfConfigNode
 from res.enkf.data import EnkfNode
@@ -199,7 +197,7 @@ class BatchSimulator:
         # started, and things will typically be in a quite sorry state if an
         # exception occurs.
         itr = 0
-        mask = BoolVector(default_value=True, initial_size=len(case_data))
+        mask = [True] * len(case_data)
         sim_context = BatchContext(
             self.result_keys, self.ert, file_system, mask, itr, case_data
         )

--- a/res/simulator/simulation_context.py
+++ b/res/simulator/simulation_context.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from res.job_queue import JobQueueManager, ForwardModelStatus
 from res.enkf import ErtRunContext, EnkfSimulationRunner
 from res.enkf.enums import EnkfRunType, HookRuntime
@@ -6,7 +8,7 @@ from time import sleep
 
 
 class SimulationContext:
-    def __init__(self, ert, sim_fs, mask, itr, case_data):
+    def __init__(self, ert, sim_fs, mask: List[bool], itr, case_data):
         self._ert = ert
         """ :type: res.enkf.EnKFMain """
         max_runtime = ert.analysisConfig().get_max_runtime()
@@ -66,8 +68,8 @@ class SimulationContext:
         sim_thread.start()
         return sim_thread
 
-    def __len__(self):
-        return self._mask.count()
+    def __len__(self) -> int:
+        return len(self._mask)
 
     def isRunning(self):
         # TODO: Should separate between running jobs and having loaded all data

--- a/tests/ert_tests/cli/test_model_factory.py
+++ b/tests/ert_tests/cli/test_model_factory.py
@@ -1,10 +1,9 @@
-import os
 from argparse import Namespace
 
 from _pytest.tmpdir import tmp_path
-from ecl.util.util import BoolVector
 from ert_utils import ErtTest
 
+from ert.ensemble_evaluator.activerange import ActiveRange
 import ert_shared.cli.model_factory as model_factory
 from ert_shared.libres_facade import LibresFacade
 from ert_shared.models.ensemble_experiment import EnsembleExperiment
@@ -62,9 +61,7 @@ class ModelFactoryTest(ErtTest):
             args = Namespace(realizations=None)
             ensemble_size = ert.getEnsembleSize()
             res = model_factory._realizations(args, ensemble_size)
-            mask = BoolVector(default_value=False, initial_size=ensemble_size)
-            mask.updateActiveMask("0-99")
-            self.assertEqual(mask, res)
+            self.assertEqual([True] * 100, res)
 
     def test_init_iteration_number(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")
@@ -86,9 +83,9 @@ class ModelFactoryTest(ErtTest):
             args = Namespace(realizations="0-4,7,8")
             ensemble_size = ert.getEnsembleSize()
             res = model_factory._realizations(args, ensemble_size)
-            mask = BoolVector(default_value=False, initial_size=ensemble_size)
-            mask.updateActiveMask("0-4,7,8")
-            self.assertEqual(mask, res)
+            self.assertEqual(
+                ActiveRange(rangestring="0-4,7,8", length=ensemble_size).mask, res
+            )
 
     def test_setup_single_test_run(self):
         config_file = self.createTestPath("local/poly_example/poly.ert")

--- a/tests/ert_tests/gui/conftest.py
+++ b/tests/ert_tests/gui/conftest.py
@@ -1,7 +1,7 @@
 import copy
 import time
 from datetime import datetime as dt
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -127,8 +127,9 @@ def small_snapshot() -> Snapshot:
 
 @pytest.fixture
 def active_realizations() -> Mock:
-    active_reals = Mock()
+    active_reals = MagicMock()
     active_reals.count = Mock(return_value=10)
+    active_reals.__iter__.return_value = [True] * 10
     return active_reals
 
 

--- a/tests/ert_tests/gui/ide/test_range_string_argument.py
+++ b/tests/ert_tests/gui/ide/test_range_string_argument.py
@@ -1,7 +1,8 @@
 from ert_utils import ErtTest
 
-from ert_shared.ide.keywords.definitions.range_string_argument import \
-    RangeStringArgument
+from ert_shared.ide.keywords.definitions.range_string_argument import (
+    RangeStringArgument,
+)
 
 
 class RangeStringArgumentTest(ErtTest):

--- a/tests/ert_tests/gui/ide/test_range_string_argument.py
+++ b/tests/ert_tests/gui/ide/test_range_string_argument.py
@@ -1,8 +1,7 @@
 from ert_utils import ErtTest
 
-from ert_shared.ide.keywords.definitions.range_string_argument import (
-    RangeStringArgument,
-)
+from ert_shared.ide.keywords.definitions.range_string_argument import \
+    RangeStringArgument
 
 
 class RangeStringArgumentTest(ErtTest):

--- a/tests/ert_tests/gui/models/test_active_realizations_model.py
+++ b/tests/ert_tests/gui/models/test_active_realizations_model.py
@@ -1,6 +1,6 @@
 from ert_utils import ErtTest
 
-from ert_gui.ertwidgets.models.activerealizationsmodel import mask_to_rangestring
+from ert.ensemble_evaluator.activerange import mask_to_rangestring
 
 
 class ActiveRealizationsModelTest(ErtTest):

--- a/tests/ert_tests/gui/test_gui_load.py
+++ b/tests/ert_tests/gui/test_gui_load.py
@@ -53,10 +53,12 @@ def patch_enkf_main(monkeypatch, tmpdir):
         Mock(return_value=["test"]),
     )
 
+    def patched_mask_to_rangestring(mask):
+        return ""
+
     monkeypatch.setattr(
-        ert_gui.ertwidgets.models.activerealizationsmodel,
-        "mask_to_rangestring",
-        Mock(return_value=""),
+        "ert.ensemble_evaluator.activerange.mask_to_rangestring.__code__",
+        patched_mask_to_rangestring.__code__,
     )
 
     monkeypatch.setattr(

--- a/tests/ert_tests/models/test_base_run_model.py
+++ b/tests/ert_tests/models/test_base_run_model.py
@@ -78,7 +78,7 @@ def test_failed_realizations(initials, completed, any_failed, failures):
     brm._initial_realizations_mask = initials
     brm._completed_realizations_mask = completed
 
-    assert list(brm._create_mask_from_failed_realizations()) == failures
+    assert brm._create_mask_from_failed_realizations() == failures
     assert brm._count_successful_realizations() == sum(completed)
 
     assert brm.has_failed_realizations() == any_failed

--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -10,7 +10,6 @@ from typing import List, Tuple
 import numpy as np
 import pandas as pd
 import pytest
-from ecl.util.util import BoolVector
 from numpy.testing import assert_almost_equal, assert_array_equal
 
 from ert_shared.libres_facade import LibresFacade
@@ -569,7 +568,7 @@ def _create_runpath(ert: LibresFacade, iteration: int = 0) -> ErtRunContext:
     run_context = ErtRunContext.ensemble_smoother(
         result_fs,
         target_fs,
-        BoolVector(default_value=True, initial_size=ert.get_ensemble_size()),
+        [True] * ert.get_ensemble_size(),
         runpath_fmt,
         jobname_fmt,
         subst_list,

--- a/tests/libres_tests/res/enkf/test_enkf.py
+++ b/tests/libres_tests/res/enkf/test_enkf.py
@@ -18,7 +18,6 @@ import os
 import os.path
 
 from ecl.util.test import TestAreaContext
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import (
@@ -259,7 +258,7 @@ class EnKFTest(ResTest):
             main = EnKFMain(res_config)
             fs_manager = main.getEnkfFsManager()
             fs = fs_manager.getCurrentFileSystem()
-            iactive = BoolVector(initial_size=10, default_value=True)
+            iactive = [True] * 10
             iactive[0] = False
             iactive[1] = False
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
@@ -293,7 +292,7 @@ class EnKFTest(ResTest):
             fs_manager = main.getEnkfFsManager()
             fs = fs_manager.getCurrentFileSystem()
 
-            mask = BoolVector(default_value=False, initial_size=10)
+            mask = [False] * 10
             mask[0] = True
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, mask)
 

--- a/tests/libres_tests/res/enkf/test_enkf_fs_manager_init.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs_manager_init.py
@@ -2,7 +2,7 @@ import shutil
 import os
 import pytest
 from res.enkf import ResConfig, EnKFMain, ErtRunContext
-from ecl.util.util import BoolVector, StringList
+from ecl.util.util import StringList
 from ert_shared import __version__
 from packaging import version
 
@@ -35,12 +35,10 @@ def fail_if_not_removed():
 def test_custom_init_runs(state_mask, expected_length):
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)
-    new_fs = ert.getEnkfFsManager().getFileSystem("new_case")  # new case
+    new_fs = ert.getEnkfFsManager().getFileSystem("new_case")
     ert.getEnkfFsManager().switchFileSystem(new_fs)
-    index_list = [i for i, flag in enumerate(state_mask) if flag]
-    bool_vector = BoolVector.createFromList(len(state_mask), index_list)
     ert.getEnkfFsManager().customInitializeCurrentFromExistingCase(
-        "default_0", 0, bool_vector, StringList(["SNAKE_OIL_PARAM"])
+        "default_0", 0, state_mask, StringList(["SNAKE_OIL_PARAM"])
     )
     assert len(ert.getEnkfFsManager().getStateMapForCase("new_case")) == expected_length
 
@@ -49,8 +47,8 @@ def test_custom_init_runs(state_mask, expected_length):
 def test_fs_init_from_scratch():
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)
-    sim_fs = ert.getEnkfFsManager().getFileSystem("new_case")  # new case
-    mask = BoolVector.createFromList(25, [0, 1, 2, 3, 4, 5])
+    sim_fs = ert.getEnkfFsManager().getFileSystem("new_case")
+    mask = [True] * 6 + [False] * 19
     run_context = ErtRunContext.case_init(sim_fs, mask)
 
     ert.getEnkfFsManager().initializeFromScratch(
@@ -67,13 +65,11 @@ def test_fs_init_from_scratch():
 def test_custom_init_runs_deprecated(state_mask, expected_length):
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)
-    new_fs = ert.getEnkfFsManager().getFileSystem("new_case")  # new case
+    new_fs = ert.getEnkfFsManager().getFileSystem("new_case")
     ert.getEnkfFsManager().switchFileSystem(new_fs)
-    index_list = [i for i, flag in enumerate(state_mask) if flag]
-    bool_vector = BoolVector.createFromList(len(state_mask), index_list)
     with pytest.warns(DeprecationWarning):
         ert.getEnkfFsManager().customInitializeCurrentFromExistingCase(
-            "default_0", 0, bool_vector, StringList(["SNAKE_OIL_PARAM"])
+            "default_0", 0, state_mask, StringList(["SNAKE_OIL_PARAM"])
         )
     assert len(ert.getEnkfFsManager().getStateMapForCase("new_case")) == expected_length
 
@@ -82,8 +78,8 @@ def test_custom_init_runs_deprecated(state_mask, expected_length):
 def test_fs_init_from_scratch_deprecated():
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)
-    sim_fs = ert.getEnkfFsManager().getFileSystem("new_case")  # new case
-    mask = BoolVector.createFromList(25, [0, 1, 2, 3, 4, 5])
+    sim_fs = ert.getEnkfFsManager().getFileSystem("new_case")
+    mask = [True] * 6 + [False] * 19
     run_context = ErtRunContext.case_init(sim_fs, mask)
     with pytest.warns(DeprecationWarning):
         ert.getEnkfFsManager().initializeFromScratch(

--- a/tests/libres_tests/res/enkf/test_enkf_load_results_manually.py
+++ b/tests/libres_tests/res/enkf/test_enkf_load_results_manually.py
@@ -1,5 +1,4 @@
 import pytest
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
@@ -23,7 +22,7 @@ class LoadResultsManuallyTest(ResTest):
             load_from = ert.getEnkfFsManager().getFileSystem(load_from_case)
 
             ert.getEnkfFsManager().switchFileSystem(load_from)
-            realisations = BoolVector(default_value=True, initial_size=25)
+            realisations = [True] * 25
             realisations[7] = False
             iteration = 0
 
@@ -52,7 +51,7 @@ class LoadResultsManuallyTest(ResTest):
             load_from = ert.getEnkfFsManager().getFileSystem(load_from_case)
 
             ert.getEnkfFsManager().switchFileSystem(load_from)
-            realisations = BoolVector(default_value=True, initial_size=25)
+            realisations = [True] * 25
             realisations[7] = False
 
             run_context = ert.getRunContextENSEMPLE_EXPERIMENT(load_into, realisations)

--- a/tests/libres_tests/res/enkf/test_enkf_load_results_manually2.py
+++ b/tests/libres_tests/res/enkf/test_enkf_load_results_manually2.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
 
-from ecl.util.util import BoolVector
 from res.enkf import EnKFMain
 
 
@@ -18,9 +17,9 @@ def test_load_results_manually2(setup_case, caplog, monkeypatch, lazy_load):
     ert = EnKFMain(res_config, strict=True)
     load_from = ert.getEnkfFsManager().getFileSystem("default_0")
     ert.getEnkfFsManager().switchFileSystem(load_from)
-    realisations = BoolVector(default_value=False, initial_size=25)
+    realisations = [False] * 25
     realisations[0] = True  # only need one to test what we want
     with caplog.at_level(logging.INFO):
         loaded = ert.loadFromForwardModel(realisations, 0, load_from)
-        assert 0 == loaded  # they will  in fact all fail, but that's ok
+        assert 0 == loaded  # they will in fact all fail, but that's ok
         assert f"lazy={lazy_load}".lower() in caplog.text

--- a/tests/libres_tests/res/enkf/test_enkf_runpath.py
+++ b/tests/libres_tests/res/enkf/test_enkf_runpath.py
@@ -18,7 +18,6 @@ import os
 
 import pytest
 from ecl.util.test import TestAreaContext
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import ResConfig
@@ -37,9 +36,7 @@ class EnKFRunpathTest(ResTest):
             work_area.copy_directory(case_directory)
             res_config = ResConfig("snake_oil_no_data/snake_oil.ert")
             main = EnKFMain(res_config)
-            iactive = BoolVector(
-                initial_size=main.getEnsembleSize(), default_value=False
-            )
+            iactive = [False] * main.getEnsembleSize()
             iactive[0] = True
             fs = main.getEnkfFsManager().getCurrentFileSystem()
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
@@ -72,9 +69,7 @@ class EnKFRunpathTest(ResTest):
             work_area.copy_directory(case_directory)
             res_config = ResConfig("snake_oil_no_data/snake_oil_no_gen_kw.ert")
             main = EnKFMain(res_config)
-            iactive = BoolVector(
-                initial_size=main.getEnsembleSize(), default_value=False
-            )
+            iactive = [False] * main.getEnsembleSize()
             iactive[0] = True
             fs = main.getEnkfFsManager().getCurrentFileSystem()
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)

--- a/tests/libres_tests/res/enkf/test_enkf_sim_model.py
+++ b/tests/libres_tests/res/enkf/test_enkf_sim_model.py
@@ -19,7 +19,6 @@ import os
 
 import pytest
 from ecl.util.test import TestAreaContext
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf.ert_run_context import ErtRunContext
@@ -93,7 +92,7 @@ class EnKFTestSimModel(ResTest):
 
                 subst_list = ert.getDataKW()
                 itr = 0
-                mask = BoolVector(default_value=True, initial_size=1)
+                mask = [True]
 
                 run_context = ErtRunContext.ensemble_experiment(
                     result_fs, mask, runpath_fmt, jobname_fmt, subst_list, itr

--- a/tests/libres_tests/res/enkf/test_enkf_transfer_env.py
+++ b/tests/libres_tests/res/enkf/test_enkf_transfer_env.py
@@ -19,7 +19,6 @@ import os
 
 import pytest
 from ecl.util.test import TestAreaContext
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf.ert_run_context import ErtRunContext
@@ -55,7 +54,7 @@ class EnKFTestTransferEnv(ResTest):
                 jobname_fmt = model_config.getJobnameFormat()
                 subst_list = ert.getDataKW()
                 itr = 0
-                mask = BoolVector(default_value=True, initial_size=1)
+                mask = [True]
                 run_context = ErtRunContext.ensemble_experiment(
                     result_fs, mask, runpath_fmt, jobname_fmt, subst_list, itr
                 )

--- a/tests/libres_tests/res/enkf/test_ert_run_context.py
+++ b/tests/libres_tests/res/enkf/test_ert_run_context.py
@@ -15,7 +15,6 @@
 #  for more details.
 
 
-from ecl.util.util import BoolVector
 from libres_utils import ResTest
 
 from res.enkf import ErtRunContext
@@ -23,5 +22,5 @@ from res.enkf import ErtRunContext
 
 class ErtRunContextTest(ResTest):
     def test_case_init(self):
-        mask = BoolVector(default_value=True, initial_size=100)
+        mask = [True] * 100
         ErtRunContext.case_init(None, mask)

--- a/tests/libres_tests/res/enkf/test_es_update.py
+++ b/tests/libres_tests/res/enkf/test_es_update.py
@@ -2,8 +2,6 @@ import sys
 
 import pytest
 
-from ecl.util.util import BoolVector
-
 from res.enkf import EnkfNode, ErtRunContext, ESUpdate, NodeId, EnKFMain
 
 
@@ -238,8 +236,8 @@ def test_localization(setup_case, expected_target_gen_kw):
     updatestep = local_config.getUpdatestep()
     updatestep.attachMinistep(ministep)
 
-    # Run enseble smoother
-    mask = BoolVector(initial_size=ert.getEnsembleSize(), default_value=True)
+    # Run ensemble smoother
+    mask = [True] * ert.getEnsembleSize()
     model_config = ert.getModelConfig()
     path_fmt = model_config.getRunpathFormat()
     jobname_fmt = model_config.getJobnameFormat()

--- a/tests/libres_tests/res/enkf/test_row_scaling_case.py
+++ b/tests/libres_tests/res/enkf/test_row_scaling_case.py
@@ -21,7 +21,6 @@ import shutil
 
 import numpy as np
 from ecl.grid import EclGridGenerator
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import EnKFMain, EnkfNode, ErtRunContext, ESUpdate, NodeId, ResConfig
@@ -80,7 +79,7 @@ def init_data(main):
         bhp.append(poro * 1000 + random.gauss(0, bhp_std))
         wct.append(poro * 4 + random.gauss(0, wct_std))
 
-    mask = BoolVector(initial_size=main.getEnsembleSize(), default_value=True)
+    mask = [True] * main.getEnsembleSize()
     init_context = ErtRunContext.case_init(init_fs, mask)
     main.initRun(init_context)
 

--- a/tests/libres_tests/res/enkf/test_run_context.py
+++ b/tests/libres_tests/res/enkf/test_run_context.py
@@ -1,5 +1,4 @@
 from ecl.util.test import TestAreaContext
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import EnkfFs, ErtRunContext
@@ -15,7 +14,7 @@ class ErtRunContextTest(ResTest):
             sim_fs = EnkfFs.createFileSystem("sim_fs")
             target_fs = None
 
-            mask = BoolVector(initial_size=100, default_value=True)
+            mask = [True] * 100
             mask[50] = False
             runpath_fmt = PathFormat("path/to/sim%d")
             subst_list = SubstitutionList()

--- a/tests/libres_tests/res/enkf/test_runpath_list_dump.py
+++ b/tests/libres_tests/res/enkf/test_runpath_list_dump.py
@@ -1,6 +1,5 @@
 import os
 
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import ErtRunContext
@@ -34,7 +33,7 @@ class RunpathListDumpTest(ResTest):
             sim_fs = fs_manager.getFileSystem("sim_fs")
 
             num_realizations = 25
-            mask = BoolVector(initial_size=num_realizations, default_value=True)
+            mask = [True] * num_realizations
             mask[13] = False
 
             runpath_fmt = (

--- a/tests/libres_tests/res/enkf/test_runpath_list_ert.py
+++ b/tests/libres_tests/res/enkf/test_runpath_list_ert.py
@@ -1,6 +1,5 @@
 import os
 
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import ErtRunContext
@@ -33,7 +32,7 @@ class RunpathListTestErt(ResTest):
             fs_manager = ert.getEnkfFsManager()
 
             init_fs = fs_manager.getFileSystem("init_fs")
-            mask = BoolVector(initial_size=25, default_value=True)
+            mask = [True] * 25
             runpath_fmt = ert.getModelConfig().getRunpathFormat()
             subst_list = SubstitutionList()
             itr = 0
@@ -67,7 +66,7 @@ class RunpathListTestErt(ResTest):
 
             ens_size = ert.getEnsembleSize()
             runner = ert.getEnkfSimulationRunner()
-            mask = BoolVector(initial_size=ens_size, default_value=True)
+            mask = [True] * ens_size
             fs_manager = ert.getEnkfFsManager()
             init_fs = fs_manager.getFileSystem("init_fs")
 

--- a/tests/libres_tests/res/enkf/test_simulation_batch.py
+++ b/tests/libres_tests/res/enkf/test_simulation_batch.py
@@ -1,4 +1,3 @@
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir
 
 from res.enkf import EnkfConfigNode, EnkfNode, ErtRunContext, NodeId
@@ -62,7 +61,7 @@ class SimulationBatchTest(ResTest):
                 injection_node.save(sim_fs, node_id)
                 state_map[iens] = RealizationStateEnum.STATE_INITIALIZED
 
-            mask = BoolVector(default_value=True, initial_size=batch_size)
+            mask = [True] * batch_size
             model_config = ert.getModelConfig()
             runpath_fmt = model_config.getRunpathFormat()
             jobname_fmt = model_config.getJobnameFormat()

--- a/tests/libres_tests/res/simulator/test_simulation_context.py
+++ b/tests/libres_tests/res/simulator/test_simulation_context.py
@@ -1,4 +1,3 @@
-from ecl.util.util import BoolVector
 from libres_utils import ResTest, tmpdir, wait_until
 
 from res.enkf.enums import RealizationStateEnum
@@ -14,15 +13,8 @@ class SimulationContextTest(ResTest):
             ert = test_context.getErt()
 
             size = 4
-            even_mask = BoolVector(initial_size=size)
-            odd_mask = BoolVector(initial_size=size)
-
-            for iens_2 in range(size // 2):
-                even_mask[2 * iens_2] = True
-                even_mask[2 * iens_2 + 1] = False
-
-                odd_mask[2 * iens_2] = False
-                odd_mask[2 * iens_2 + 1] = True
+            even_mask = [True, False] * (size // 2)
+            odd_mask = [False, True] * (size // 2)
 
             fs_manager = ert.getEnkfFsManager()
             even_half = fs_manager.getFileSystem("even_half")

--- a/tests/libres_tests/test_integration_config.py
+++ b/tests/libres_tests/test_integration_config.py
@@ -1,5 +1,4 @@
 import pytest
-from ecl.util.util import BoolVector
 from res.enkf import ErtRunContext
 from res.enkf.enkf_main import EnKFMain
 from res.enkf.res_config import ResConfig
@@ -19,7 +18,7 @@ def _create_runpath(enkf_main: EnKFMain) -> ErtRunContext:
     run_context = ErtRunContext.ensemble_smoother(
         result_fs,
         None,
-        BoolVector(default_value=True, initial_size=1),
+        [True],
         runpath_fmt,
         jobname_fmt,
         subst_list,

--- a/tests/performance_tests/enkf/test_load_state.py
+++ b/tests/performance_tests/enkf/test_load_state.py
@@ -1,7 +1,5 @@
-import time
 import pytest
 
-from ecl.util.util import BoolVector
 from res.test import ErtTestSharedContext
 
 
@@ -16,7 +14,7 @@ class TestLoadState:
             load_into = ctx.ert.getEnkfFsManager().getFileSystem("A1")
             ctx.ert.getEnkfFsManager().getFileSystem("default")
 
-            realisations = BoolVector(default_value=True, initial_size=25)
+            realisations = [True] * 25
 
             run_context = ctx.ert.getRunContextENSEMPLE_EXPERIMENT(
                 load_into, realisations
@@ -30,6 +28,6 @@ class TestLoadState:
             self.TESTDATA_ROOT / "Equinor/config/with_data/config_GEN_DATA"
         ) as ctx:
             load_from = ctx.ert.getEnkfFsManager().getFileSystem("default")
-            realisations = BoolVector(default_value=True, initial_size=25)
+            realisations = [True] * 25
             loaded = benchmark(ctx.ert.loadFromForwardModel, realisations, 0, load_from)
             assert loaded == 25, f"Loaded {loaded} realizations, expected 25"


### PR DESCRIPTION
**Issue**
Resolves #3121
Resolves #3141


**Approach**
Replace usage of `BoolVector` with `List[bool]`except for the final call to wrapped C-code. Use new Python object `ActiveRange` for interpreting range strings.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
