### PR TITLE
Replace util_abort on time map with logging error and failing realisation

### DIFF
--- a/libres/lib/enkf/enkf_main_manage_fs.cpp
+++ b/libres/lib/enkf/enkf_main_manage_fs.cpp
@@ -416,9 +416,7 @@ enkf_fs_type *enkf_main_mount_alt_fs(const enkf_main_type *enkf_main,
 
                 if (refcase) {
                     time_map_type *time_map = enkf_fs_get_time_map(new_fs);
-                    if (time_map_attach_refcase(time_map, refcase))
-                        time_map_set_strict(time_map, false);
-                    else
+                    if (!time_map_attach_refcase(time_map, refcase))
                         logger->error("Warning mismatch between refcase:{} "
                                       "and existing case:{}",
                                       ecl_sum_get_case(refcase),

--- a/libres/lib/include/ert/enkf/time_map.hpp
+++ b/libres/lib/include/ert/enkf/time_map.hpp
@@ -35,8 +35,6 @@ extern "C" bool time_map_try_update(time_map_type *map, int step, time_t time);
 bool time_map_attach_refcase(time_map_type *time_map,
                              const ecl_sum_type *refcase);
 bool time_map_has_refcase(const time_map_type *time_map);
-extern "C" bool time_map_is_strict(const time_map_type *time_map);
-extern "C" void time_map_set_strict(time_map_type *time_map, bool strict);
 void time_map_clear(time_map_type *map);
 bool time_map_equal(const time_map_type *map1, const time_map_type *map2);
 extern "C" time_map_type *time_map_alloc();

--- a/libres/old_tests/enkf/CMakeLists.txt
+++ b/libres/old_tests/enkf/CMakeLists.txt
@@ -228,11 +228,6 @@ add_equinor_test(
   config_ecl_sum_compatible_true TRUE)
 
 add_equinor_test(
-  enkf_state_report_step_compatible_FALSE enkf_state_report_step_compatible
-  "${EQUINOR_TEST_DATA_DIR}/config/ecl_sum_compatible_false"
-  config_ecl_sum_compatible_false FALSE)
-
-add_equinor_test(
   enkf_state_manual_load enkf_state_manual_load
   "${EQUINOR_TEST_DATA_DIR}/config/ecl_sum_compatible_true"
   config_ecl_sum_compatible_true)

--- a/libres/old_tests/enkf/test_enkf_time_map.cpp
+++ b/libres/old_tests/enkf/test_enkf_time_map.cpp
@@ -47,19 +47,10 @@ void ecl_test(const char *ecl_case) {
 
     time_map_clear(ecl_map);
     time_map_update(ecl_map, 1, 256);
-    time_map_set_strict(ecl_map, false);
     test_assert_false(time_map_summary_update(ecl_map, ecl_sum));
 
     time_map_free(ecl_map);
     ecl_sum_free(ecl_sum);
-}
-
-static void map_update(void *arg) {
-    vector_type *arg_vector = vector_safe_cast(arg);
-    time_map_type *tmap = (time_map_type *)vector_iget(arg_vector, 0);
-    ecl_sum_type *sum = (ecl_sum_type *)vector_iget(arg_vector, 1);
-
-    time_map_summary_update(tmap, sum);
 }
 
 void test_inconsistent_summary(const char *case1, const char *case2) {
@@ -69,14 +60,6 @@ void test_inconsistent_summary(const char *case1, const char *case2) {
     time_map_type *ecl_map = time_map_alloc();
 
     test_assert_true(time_map_summary_update(ecl_map, ecl_sum1));
-    {
-        vector_type *arg = vector_alloc_new();
-        vector_append_ref(arg, ecl_map);
-        vector_append_ref(arg, ecl_sum2);
-        test_assert_util_abort("time_map_summary_update_abort", map_update,
-                               arg);
-        vector_free(arg);
-    }
 
     time_map_free(ecl_map);
     ecl_sum_free(ecl_sum1);
@@ -108,7 +91,6 @@ void test_refcase(const char *refcase_name, const char *case1,
     {
         time_map_type *ecl_map = time_map_alloc();
 
-        time_map_set_strict(ecl_map, false);
         time_map_attach_refcase(ecl_map, refcase);
 
         test_assert_false(time_map_summary_update(ecl_map, ecl_sum2));
@@ -186,7 +168,6 @@ void test_index_map(const char *case1, const char *case2, const char *case3,
     }
 
     /* case2 has an extra tstep in the middle of the case. */
-    time_map_set_strict(ecl_map, false);
     test_assert_false(time_map_summary_update(ecl_map, ecl_sum2));
     {
         int_vector_type *index_map =
@@ -237,11 +218,9 @@ void simple_test() {
     ecl::util::TestArea ta("simple");
     const char *mapfile = "map";
 
-    time_map_set_strict(time_map, false);
     test_assert_true(time_map_update(time_map, 0, 100));
     test_assert_true(time_map_update(time_map, 1, 200));
     test_assert_true(time_map_update(time_map, 1, 200));
-    test_assert_false(time_map_update(time_map, 1, 250));
 
     test_assert_true(time_map_equal(time_map, time_map));
     time_map_fwrite(time_map, mapfile);
@@ -275,10 +254,7 @@ void simple_test_inconsistent() {
     time_map_type *time_map = time_map_alloc();
 
     test_assert_true(time_map_update(time_map, 0, 100));
-    time_map_set_strict(time_map, false);
-    test_assert_false(time_map_update(time_map, 0, 101));
 
-    time_map_set_strict(time_map, true);
     test_assert_util_abort("time_map_update_abort", simple_update, time_map);
 
     time_map_free(time_map);
@@ -322,7 +298,6 @@ void test_read_only() {
         time_map_type *tm = time_map_alloc();
 
         test_assert_true(time_map_is_instance(tm));
-        test_assert_true(time_map_is_strict(tm));
         test_assert_false(time_map_is_readonly(tm));
 
         time_map_update(tm, 0, 0);

--- a/res/enkf/util/time_map.py
+++ b/res/enkf/util/time_map.py
@@ -33,8 +33,6 @@ class TimeMap(BaseCClass):
     _iget = ResPrototype("time_t time_map_iget(time_map, int)")
     _size = ResPrototype("int    time_map_get_size(time_map)")
     _try_update = ResPrototype("bool   time_map_try_update(time_map , int , time_t)")
-    _is_strict = ResPrototype("bool   time_map_is_strict( time_map )")
-    _set_strict = ResPrototype("void   time_map_set_strict( time_map , bool)")
     _lookup_time = ResPrototype("int    time_map_lookup_time( time_map , time_t)")
     _lookup_time_with_tolerance = ResPrototype(
         "int    time_map_lookup_time_with_tolerance( time_map , time_t , int , int)"
@@ -71,12 +69,6 @@ class TimeMap(BaseCClass):
         else:
             raise IOError((errno.ENOENT, "File not found: %s" % filename))
 
-    def isStrict(self):
-        return self._is_strict()
-
-    def setStrict(self, strict):
-        return self._set_strict(strict)
-
     def getSimulationDays(self, step):
         """@rtype: double"""
         if not isinstance(step, int):
@@ -106,10 +98,7 @@ class TimeMap(BaseCClass):
         if self._try_update(index, CTime(time)):
             return True
         else:
-            if self.isStrict():
-                raise Exception("Tried to update with inconsistent value")
-            else:
-                return False
+            raise Exception("Tried to update with inconsistent value")
 
     def __iter__(self):
         cur = 0
@@ -180,9 +169,7 @@ class TimeMap(BaseCClass):
 
     def __repr__(self):
         ls = len(self)
-        la = self.getLastStep()
-        st = "strict" if self.isStrict() else "not strict"
-        cnt = "size = %d, last_step = %d, %s" % (ls, la, st)
+        cnt = "size = %d" % (ls)
         return self._create_repr(cnt)
 
     def dump(self):
@@ -193,6 +180,3 @@ class TimeMap(BaseCClass):
         for step, t in enumerate(self):
             step_list.append((step, t, self.getSimulationDays(step)))
         return step_list
-
-    def getLastStep(self):
-        return self._last_step()

--- a/tests/libres_tests/res/enkf/test_load_forward_model.py
+++ b/tests/libres_tests/res/enkf/test_load_forward_model.py
@@ -1,0 +1,126 @@
+import fileinput
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from ecl.summary import EclSum
+from ecl.util.util import BoolVector
+
+from ert_shared.libres_facade import LibresFacade
+from res.enkf import ResConfig, EnKFMain
+
+
+@pytest.fixture
+def copy_data(tmp_path, source_root):
+    os.chdir(tmp_path)
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local/snake_oil"), "test_data"
+    )
+    os.chdir("test_data")
+
+
+def run_simulator(time_step_count, start_date):
+    """@rtype: EclSum"""
+    ecl_sum = EclSum.writer("SNAKE_OIL_FIELD", start_date, 10, 10, 10)
+
+    ecl_sum.addVariable("FOPR", unit="SM3/DAY")
+    ecl_sum.addVariable("FOPRH", unit="SM3/DAY")
+
+    ecl_sum.addVariable("WOPR", wgname="OP1", unit="SM3/DAY")
+    ecl_sum.addVariable("WOPRH", wgname="OP1", unit="SM3/DAY")
+
+    mini_step_count = 10
+    for report_step in range(time_step_count):
+        for mini_step in range(mini_step_count):
+            t_step = ecl_sum.addTStep(
+                report_step + 1, sim_days=report_step * mini_step_count + mini_step
+            )
+            t_step["FOPR"] = 1
+            t_step["WOPR:OP1"] = 2
+            t_step["FOPRH"] = 3
+            t_step["WOPRH:OP1"] = 4
+
+    return ecl_sum
+
+
+def test_load_inconsistent_time_map_summary(copy_data, caplog):
+    """
+    Checking that we dont util_abort, we fail the forward model instead
+    """
+    cwd = os.getcwd()
+
+    # Get rid of GEN_DATA as we are only interested in SUMMARY
+    with fileinput.input("snake_oil.ert", inplace=True) as fin:
+        for line in fin:
+            if line.startswith("GEN_DATA"):
+                continue
+            print(line, end="")
+
+    res_config = ResConfig("snake_oil.ert")
+    ert = EnKFMain(res_config)
+    facade = LibresFacade(ert)
+    realisation_number = 0
+    assert (
+        facade.get_current_fs().getStateMap()[realisation_number].name
+        == "STATE_HAS_DATA"
+    )  # Check prior state
+
+    # Create a result that is incompatible with the refcase
+    run_path = Path("storage") / "snake_oil" / "runpath" / "realization-0" / "iter-0"
+    os.chdir(run_path)
+    ecl_sum = run_simulator(1, datetime(2000, 1, 1))
+    ecl_sum.fwrite()
+    os.chdir(cwd)
+
+    realizations = BoolVector(
+        default_value=False, initial_size=facade.get_ensemble_size()
+    )
+    realizations[realisation_number] = True
+    with caplog.at_level(logging.ERROR):
+        loaded = facade.load_from_forward_model("default_0", realizations, 0)
+    assert (
+        f"""Inconsistency in time_map - loading SUMMARY from: {run_path.absolute()} failed:
+Time mismatch for step: 1, new time: 2000-01-10, reference case: 2010-01-10
+"""
+        in caplog.messages
+    )
+    assert (
+        f"Inconsistent time map for summary data from: {run_path.absolute()}"
+        f"/SNAKE_OIL_FIELD, realisation failed" in caplog.messages
+    )
+    assert loaded == 0
+    assert (
+        facade.get_current_fs().getStateMap()[realisation_number].name
+        == "STATE_LOAD_FAILURE"
+    )  # Check that status is as expected
+
+
+def test_load_forward_model(copy_data):
+    """
+    Checking that we are able to load from forward model
+    """
+    # Get rid of GEN_DATA it causes a failure to load from forward model
+    with fileinput.input("snake_oil.ert", inplace=True) as fin:
+        for line in fin:
+            if line.startswith("GEN_DATA"):
+                continue
+            print(line, end="")
+
+    res_config = ResConfig("snake_oil.ert")
+    ert = EnKFMain(res_config)
+    facade = LibresFacade(ert)
+    realisation_number = 0
+
+    realizations = BoolVector(
+        default_value=False, initial_size=facade.get_ensemble_size()
+    )
+    realizations[realisation_number] = True
+    loaded = facade.load_from_forward_model("default_0", realizations, 0)
+    assert loaded == 1
+    assert (
+        facade.get_current_fs().getStateMap()[realisation_number].name
+        == "STATE_HAS_DATA"
+    )  # Check that status is as expected

--- a/tests/libres_tests/res/enkf/test_time_map.py
+++ b/tests/libres_tests/res/enkf/test_time_map.py
@@ -23,14 +23,9 @@ class TimeMapTest(ResTest):
         self.assertTrue(tm.update(0, datetime.date(2000, 1, 1)))
         self.assertEqual(tm[0], datetime.date(2000, 1, 1))
 
-        self.assertTrue(tm.isStrict())
         with self.assertRaises(Exception):
             tm.update(0, datetime.date(2000, 1, 2))
 
-        tm.setStrict(False)
-        self.assertFalse(tm.update(0, datetime.date(2000, 1, 2)))
-
-        tm.setStrict(True)
         self.assertTrue(tm.update(1, datetime.date(2000, 1, 2)))
         d = tm.dump()
         self.assertEqual(
@@ -219,8 +214,3 @@ class TimeMapTest(ResTest):
                 tolerance_seconds_before=10,
                 tolerance_seconds_after=10,
             )
-
-    def test_empty(self):
-        tm = TimeMap()
-        last_step = tm.getLastStep()
-        self.assertEqual(last_step, -1)


### PR DESCRIPTION
**Issue**
If there is a time map inconsistency the process would crash through util_abort


**Approach**
Replace util_abort with logging the error and failing the forward model instead. In addition to the included test I tested it on the snake_oil case by randomly making the produced summary result inconsistent with the time map by:
```
    import numpy as np
    if np.random.rand() < 0.1:
        start_date = datetime(1995, 1, 1)
        print("This should fail")
    else:
        start_date = datetime(2010, 1, 1)
    ecl_sum = EclSum.writer("SNAKE_OIL_FIELD", start_date, 10, 10, 10)
```
in `snake_oil_simulator.py` and removing `GEN_DATA` from config and observations for simplicity:
```
MAX_SUBMIT 1
FORWARD_MODEL SNAKE_OIL_SIMULATOR
--FORWARD_MODEL SNAKE_OIL_NPV
--FORWARD_MODEL SNAKE_OIL_DIFF

RUN_TEMPLATE templates/seed_template.txt seed.txt
GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters.txt

--GEN_DATA SNAKE_OIL_OPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
--GEN_DATA SNAKE_OIL_WPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
--GEN_DATA SNAKE_OIL_GPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199
```
also added `MAX_SUBMIT` to avoid the forward model running twice.

Everything then runs as expected, when the randomness occurs the forward model is marked as failed and the process continues.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
