### PR TITLE
Remove pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "websockets >= 9.0.1",
         "httpx",
     ],
-    setup_requires=["pytest-runner", "setuptools_scm"],
+    setup_requires=["setuptools_scm"],
     entry_points={
         "console_scripts": [
             "ert3=ert3.console:main",
@@ -140,5 +140,4 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    test_suite="tests",
 )


### PR DESCRIPTION
**Issue**
Resolves #657


**Approach**
remove `pytest-runner` and `test_suite` from `setup.py`.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
