### PR TITLE
Make fixtures cleanup after themselves

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y valgrind
-        
+
     - name: Install Conan
       run: |
         python3 -m pip install conan
@@ -185,6 +185,12 @@ jobs:
         pushd tests
         pytest ert_tests performance_tests -sv --durations=0 -m "integration_test"
 
+    - name: Test for a clean repository
+      run: |
+        # Run this before the 'Test CLI' entry below, which produces a few files that are accepted for now. Exclude the wheel.
+        git status --porcelain | sed '/ert.*.whl$/d'
+        test -z "$(git status --porcelain | sed '/ert.*.whl$/d')"
+
     - name: Test CLI
       run: |
         ert --help
@@ -279,6 +285,8 @@ jobs:
         # Run tests
         pushd tests
         pytest libres_tests --durations=0
+        git status --porcelain | sed '/ert.*.whl$/d'
+        test -z "$(git status --porcelain | sed '/ert.*.whl$/d')"
 
 
   publish:

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -271,6 +271,8 @@ def stages_config(stages_config_list, plugin_registry):
         stages_config_list, plugin_registry=plugin_registry
     )
 
+    script_file.unlink()
+
 
 @pytest.fixture()
 def double_stages_config_list():
@@ -337,6 +339,8 @@ def double_stages_config(double_stages_config_list, plugin_registry):
         double_stages_config_list, plugin_registry=plugin_registry
     )
 
+    script_file.unlink()
+
 
 @pytest.fixture()
 def x_uncertainty_stages_config(plugin_registry):
@@ -386,6 +390,8 @@ def x_uncertainty_stages_config(plugin_registry):
     os.chmod(script_file, st.st_mode | stat.S_IEXEC)
 
     yield ert3.config.load_stages_config(config_list, plugin_registry=plugin_registry)
+
+    script_file.unlink()
 
 
 @pytest.fixture()


### PR DESCRIPTION
**Issue**
Resolves #3279


**Approach**
Make sure that fixtures that create the `poly.py` file clean it up after yielding.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
