### PR TITLE
Add details view to simulations failed including error logs

### DIFF
--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -331,11 +331,11 @@ class RunDialog(QDialog):
         )
 
         if failed:
-            QMessageBox.critical(
-                self,
-                "Simulations failed!",
-                f"The simulation failed with the following error:\n\n{failed_msg}",
-            )
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Critical)
+            msg.setText("Simulations failed!".center(100))
+            msg.setDetailedText(failed_msg)
+            msg.exec_()
 
     @Slot()
     def _on_ticker(self):

--- a/tests/ert_tests/shared/test_log_capture.py
+++ b/tests/ert_tests/shared/test_log_capture.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+
+from ert_shared.models.base_run_model import captured_logs
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "log_level, expect_propagation",
+    [
+        (logger.debug, False),
+        (logger.info, False),
+        (logger.warning, False),
+        (logger.error, True),
+        (logger.critical, True),
+    ],
+)
+def test_default_log_capture(log_level, expect_propagation):
+    with captured_logs() as logs:
+        log_level("This is not actually an error")
+    if expect_propagation:
+        assert "This is not actually an error" in logs.messages
+    else:
+        assert "This is not actually an error" not in logs.messages
+
+
+@pytest.mark.parametrize(
+    "log_level",
+    [
+        logging.DEBUG,
+        logging.INFO,
+        logging.INFO,
+        logging.ERROR,
+        logging.CRITICAL,
+    ],
+)
+@pytest.mark.parametrize(
+    "log_func, corresponding_level",
+    [
+        (logger.debug, logging.DEBUG),
+        (logger.info, logging.INFO),
+        (logger.warning, logging.WARNING),
+        (logger.error, logging.ERROR),
+        (logger.critical, logging.CRITICAL),
+    ],
+)
+def test_custom_log_capture(log_level, log_func, corresponding_level, caplog):
+    with caplog.at_level(logging.DEBUG):
+        with captured_logs(level=log_level) as logs:
+            log_func("This is a message")
+        if corresponding_level >= logs.level:
+            assert "This is a message" in logs.messages
+        else:
+            assert "This is a message" not in logs.messages


### PR DESCRIPTION
If a simulation fails, all error logs generated during the simulation time are shown to the user in a detailed view.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
