### PR TITLE
Add extension to error message

### DIFF
--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -335,9 +335,10 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
 
                 return true;
             } else {
-                logger->error("Could not load ECLIPSE summary data from: {}/{}",
-                              run_arg_get_runpath(run_arg),
-                              run_arg_get_job_name(run_arg));
+                logger->error(
+                    "Could not load ECLIPSE summary data from: {}/{}.UNSMRY",
+                    run_arg_get_runpath(run_arg),
+                    run_arg_get_job_name(run_arg));
                 return false;
             }
         }


### PR DESCRIPTION
Because we are only supporting unified summary files now we can add the extension. There is a slight risk that someone will be confused if they are using `.FUNSMRY`, but the chance of that is slim to none.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
