### PR TITLE
Propagate logs from ensemble_evaluator, storage and status

### DIFF
--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -32,11 +32,7 @@ loggers:
   ert_shared.ensemble_evaluator:
     level: DEBUG
     handlers: [eefile]
-    propagate: yes
-  ert_shared.ensemble_evaluator.prefect_ensemble:
-    level: DEBUG
-    handlers: [eefile]
-    propagate: yes
+    propagate: no
   websockets.server:
     level: ERROR
     handlers: [eefile]

--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -24,23 +24,23 @@ loggers:
   ert_shared.storage:
     level: DEBUG
     handlers: [apifile]
-    propagate: no
+    propagate: yes
   ert_shared.status:
     level: DEBUG
     handlers: [file]
-    propagate: no
+    propagate: yes
   ert_shared.ensemble_evaluator:
     level: DEBUG
     handlers: [eefile]
-    propagate: no
+    propagate: yes
   ert_shared.ensemble_evaluator.prefect_ensemble:
     level: DEBUG
     handlers: [eefile]
-    propagate: no
+    propagate: yes
   websockets.server:
     level: ERROR
     handlers: [eefile]
-    propagate: no
+    propagate: yes
   res:
     level: DEBUG
     propagate: yes


### PR DESCRIPTION
This was most likely set to false because there was a stream handler
at the time which was pushing logs to the terminal.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
