### PR TITLE
Remove the current parameter group concept

### DIFF
--- a/ert3/config/_parameters_config.py
+++ b/ert3/config/_parameters_config.py
@@ -148,7 +148,7 @@ class _VariablesConfig(_ParametersConfig):
             return variables
 
         raise ValueError(
-            "Parameter group cannot have empty variable list.\n"
+            "A parameter cannot have an empty variable list.\n"
             "Avoid specifying variables to get scalars."
         )
 
@@ -189,15 +189,15 @@ class _ParameterConfig(_ParametersConfig):
     @root_validator
     def _ensure_variables_or_size(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if values.get("variables") and values.get("size"):
-            raise ValueError("Parameter group cannot have both variables and size")
+            raise ValueError("Parameters cannot have both variables and size")
         return values
 
     @validator("name")
-    def _ensure_valid_group_name(cls, value: Any) -> str:
+    def _ensure_valid_parameter_name(cls, value: Any) -> str:
         return _ensure_valid_name(value)
 
     @validator("size")
-    def _ensure_valid_group_size(cls, value: Any) -> Optional[int]:
+    def _ensure_valid_parameter_size(cls, value: Any) -> Optional[int]:
         return _ensure_valid_size(value)
 
     def as_distribution(self) -> ert3.stats.Distribution:
@@ -269,10 +269,10 @@ class ParametersConfig(_ParametersConfig):
         if isinstance(item, int):
             return self.__root__[item]
         elif isinstance(item, str):
-            for group in self:
-                if group.name == item:
-                    return group
-            raise ValueError(f"No parameter group found named: {item}")
+            for param in self:
+                if param.name == item:
+                    return param
+            raise ValueError(f"No parameter found named: {item}")
         raise TypeError(f"Item should be int or str, not {type(item)}")
 
     def __len__(self) -> int:

--- a/ert3/console/_console.py
+++ b/ert3/console/_console.py
@@ -110,7 +110,7 @@ def _build_record_argparser(subparsers: Any) -> None:
         "sample", help="Sample stochastic parameter into a record"
     )
     sample_parser.add_argument(
-        "parameter_group", help="Name of the distribution group in parameters.yml"
+        "parameter", help="Name of the parameter in parameters.yml"
     )
     sample_parser.add_argument("record_name", help="Name of the resulting record")
     sample_parser.add_argument(
@@ -357,7 +357,7 @@ def _record(workspace: Workspace, args: Any) -> None:
         parameters_config = workspace.load_parameters_config()
         collection = ert3.engine.sample_record(
             parameters_config,
-            args.parameter_group,
+            args.parameter,
             args.ensemble_size,
         )
         future = ert.storage.transmit_record_collection(

--- a/ert3/engine/_record.py
+++ b/ert3/engine/_record.py
@@ -17,10 +17,10 @@ async def load_record(
 
 def sample_record(
     parameters_config: ert3.config.ParametersConfig,
-    parameter_group_name: str,
+    parameter_name: str,
     ensemble_size: int,
 ) -> ert.data.RecordCollection:
-    distribution = parameters_config[parameter_group_name].as_distribution()
+    distribution = parameters_config[parameter_name].as_distribution()
     return ert.data.RecordCollection(
         records=tuple(distribution.sample() for _ in range(ensemble_size))
     )

--- a/ert3/engine/_sensitivity.py
+++ b/ert3/engine/_sensitivity.py
@@ -75,8 +75,8 @@ def _load_sensitivity_parameters(
 
     sensitivity_parameters = {}
     for input_ in stochastic_inputs:
-        group_name = input_.source_location
-        sensitivity_parameters[input_.name] = all_distributions[group_name]
+        parameter_name = input_.source_location
+        sensitivity_parameters[input_.name] = all_distributions[parameter_name]
     return sensitivity_parameters
 
 

--- a/ert3_examples/spe1/README.md
+++ b/ert3_examples/spe1/README.md
@@ -15,9 +15,9 @@ that highlights the features of ert3 in a reservoir context.
 
 #### Parameters
 The available parameterizations of the model resides within
-[parameters.yml](parameters.yml). In general a parameter group is given a name,
-which can be referenced later in experiments, a distribution (`uniform` or
-`gauss`) and a list of variables that are drawn from the distribution.
+[parameters.yml](parameters.yml). In general a parameter is given a name,
+which can be referenced later in experiments and a distribution (`uniform`,
+`gauss`, etc.).
 
 #### Stages
 The forward model in ert3 is a stage and is described in
@@ -77,7 +77,7 @@ evaluation of the model described in the respective `ensembles.yml`. The
 evaluation. The `ensemble.yml` describes the size of the ensemble, maps data
 sources to input records and specifies the stage that is the forward model
 together with the queue system that is to be used. Notice in particular that by
-`stochastic.field_properties` one is pointing at the parameter group named
+`stochastic.field_properties` one is pointing at the parameter named
 `field_properties` in `parameters.yml`.
 
 The experiment can be executed by `ert3 run evaluation`. And the data can

--- a/tests/ert_tests/ert3/algorithms/test_one_at_a_time.py
+++ b/tests/ert_tests/ert3/algorithms/test_one_at_a_time.py
@@ -158,7 +158,7 @@ def test_uni_and_norm():
                 assert e == pytest.approx(r)
 
 
-def test_multi_parameter_groups():
+def test_multi_parameters():
     records = {}
 
     size = 10

--- a/tests/ert_tests/ert3/config/test_parameters_config.py
+++ b/tests/ert_tests/ert3/config/test_parameters_config.py
@@ -42,7 +42,7 @@ def test_valid_gauss(mean, std):
 def test_valid_gauss_variables():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_coordinate",
             "type": "stochastic",
             "distribution": {
                 "type": "gaussian",
@@ -68,7 +68,7 @@ def test_valid_gauss_variables():
 def test_valid_gauss_size():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_list_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "gaussian",
@@ -85,7 +85,7 @@ def test_valid_gauss_size():
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_list_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "gaussian"
     assert param.distribution.input.mean == 0
@@ -112,7 +112,7 @@ def test_valid_gauss_size():
 def test_invalid_gauss(input_):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "gaussian",
@@ -131,7 +131,7 @@ def test_invalid_gauss(input_):
 def test_valid_uniform(lower_bound, upper_bound):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -146,7 +146,7 @@ def test_valid_uniform(lower_bound, upper_bound):
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "uniform"
     assert param.distribution.input.lower_bound == lower_bound
@@ -161,7 +161,7 @@ def test_valid_uniform(lower_bound, upper_bound):
 def test_valid_uniform_variables():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_coordinate",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -183,7 +183,7 @@ def test_valid_uniform_variables():
 def test_valid_uniform_size():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_list_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -199,7 +199,7 @@ def test_valid_uniform_size():
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_list_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "uniform"
     assert param.distribution.input.lower_bound == 0
@@ -226,7 +226,7 @@ def test_valid_uniform_size():
 def test_invalid_uniform(input_):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -245,7 +245,7 @@ def test_invalid_uniform(input_):
 def test_valid_loguniform(lower_bound, upper_bound):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_coordinate",
             "type": "stochastic",
             "distribution": {
                 "type": "loguniform",
@@ -261,7 +261,7 @@ def test_valid_loguniform(lower_bound, upper_bound):
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_coordinate"
     assert param.type == "stochastic"
     assert param.distribution.type == "loguniform"
     assert param.distribution.input.lower_bound == lower_bound
@@ -278,7 +278,7 @@ def test_valid_loguniform(lower_bound, upper_bound):
 def test_valid_loguniform_size():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_list_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "loguniform",
@@ -294,7 +294,7 @@ def test_valid_loguniform_size():
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_list_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "loguniform"
     assert param.distribution.input.lower_bound == 0.1
@@ -323,7 +323,7 @@ def test_valid_loguniform_size():
 def test_invalid_loguniform(input_):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_coordinate",
             "type": "stochastic",
             "distribution": {
                 "type": "loguniform",
@@ -349,7 +349,7 @@ def test_invalid_loguniform(input_):
 def test_valid_discrete(values):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "discrete",
@@ -362,7 +362,7 @@ def test_valid_discrete(values):
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "discrete"
     assert param.distribution.input.values == values
@@ -383,7 +383,7 @@ def test_valid_discrete(values):
 def test_invalid_discrete(input_):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "discrete",
@@ -408,7 +408,7 @@ def test_invalid_discrete(input_):
 def test_valid_constant(value):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "constant",
@@ -423,7 +423,7 @@ def test_valid_constant(value):
     assert len(parameters_config) == 1
     param = parameters_config[0]
 
-    assert param.name == "my_parameter_group"
+    assert param.name == "my_parameter"
     assert param.type == "stochastic"
     assert param.distribution.type == "constant"
     assert param.distribution.input.value == value
@@ -443,7 +443,7 @@ def test_valid_constant(value):
 def test_invalid_constant(input_):
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "constant",
@@ -571,7 +571,7 @@ def test_empty_variables():
     ]
 
     err_msg = (
-        "Parameter group cannot have empty variable list.\n"
+        "A parameter cannot have an empty variable list.\n"
         "Avoid specifying variables to get scalars. "
     )
     with pytest.raises(ert.exceptions.ConfigValidationError, match=err_msg):
@@ -605,7 +605,7 @@ def test_invalid_size(size):
 
 @pytest.mark.parametrize(
     ("variables", "size", "err_msg"),
-    ((["x", "y", "z"], 3, "Parameter group cannot have both variables and size"),),
+    ((["x", "y", "z"], 3, "Parameters cannot have both variables and size"),),
 )
 def test_duplicate_variables_size(variables, size, err_msg):
     raw_config = [
@@ -631,7 +631,7 @@ def test_duplicate_variables_size(variables, size, err_msg):
 def test_invalid_type():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "unknown_type",
             "distribution": {
                 "type": "uniform",
@@ -650,7 +650,7 @@ def test_invalid_type():
 def test_invalid_distribution():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "unknown_distribution",
@@ -669,7 +669,7 @@ def test_invalid_distribution():
 def test_unknown_keyword():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -691,7 +691,7 @@ def test_unknown_keyword():
 def test_immutable_name():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -711,7 +711,7 @@ def test_immutable_name():
 def test_immutable_distribution():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -734,7 +734,7 @@ def test_immutable_distribution():
 def test_immutable_variables():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_coordinate",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -755,7 +755,7 @@ def test_immutable_variables():
 def test_immutable_size():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_list_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -776,7 +776,7 @@ def test_immutable_size():
 def test_immutable_parameters():
     raw_config = [
         {
-            "name": "my_parameter_group",
+            "name": "my_parameter",
             "type": "stochastic",
             "distribution": {
                 "type": "uniform",
@@ -795,7 +795,7 @@ def test_immutable_parameters():
         parameters_config[0] = extra_parameter_config
 
 
-def test_multi_parameter_group():
+def test_multi_parameter():
     raw_config = [
         {
             "name": "name" * (idx + 1),

--- a/tests/ert_tests/ert3/engine/integration/test_engine.py
+++ b/tests/ert_tests/ert3/engine/integration/test_engine.py
@@ -623,9 +623,9 @@ def test_run_loguniform_presampled(
             assert coeff.data[key] == export_coeff[key]
 
 
-def test_sample_unknown_parameter_group(uniform_parameters_config):
+def test_sample_unknown_parameter(uniform_parameters_config):
 
-    with pytest.raises(ValueError, match="No parameter group found named: coeffs"):
+    with pytest.raises(ValueError, match="No parameter found named: coeffs"):
         ert3.engine.sample_record(uniform_parameters_config, "coeffs", 100)
 
 


### PR DESCRIPTION
What was previously a parameter group in ert3 is now just a parameter,
but it may contain multiple values (list-like or dict-like).

The command line API is altered, in the positional argument name to `ert3 record sample`.

**Issue**
Resolves #3295 

**Approach**
`grep -r group` and similar, rewritten wherever applicable.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
