### PR TITLE
Catch unexpected exceptions and clean up to avoid hanging GUI

### DIFF
--- a/ert/ensemble_evaluator/tracker/evaluator_tracker.py
+++ b/ert/ensemble_evaluator/tracker/evaluator_tracker.py
@@ -102,6 +102,14 @@ class EvaluatorTracker:
             except (ConnectionClosedError) as e:
                 # The monitor connection closed unexpectedly
                 drainer_logger.debug(f"connection closed error: {e}")
+            except BaseException:  # pylint: disable=broad-except
+                drainer_logger.exception("unexpected error: ")
+                # We really don't know what happened...  shut down
+                # the thread and get out of here. The monitor has
+                # been stopped by the ctx-mgr
+                self._work_queue.put(EvaluatorTracker.DONE)
+                self._work_queue.join()
+                return
         drainer_logger.debug(
             "observed that model was finished, waiting tasks completion..."
         )


### PR DESCRIPTION
Resolves #3244

**Approach**
Prevent exceptions to pass the `EvaluatorTracker` as this seems to be able to freeze Qt.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

