### PR TITLE
Convert to int explicitly, avoid deprecation

### DIFF
--- a/ert_gui/tools/plot/color_chooser.py
+++ b/ert_gui/tools/plot/color_chooser.py
@@ -22,7 +22,7 @@ class ColorBox(QFrame):
         painter = QPainter(self)
         rect = self.contentsRect()
         tile_count = 3
-        tile_size = rect.width() / tile_count
+        tile_size = int(rect.width() / tile_count)
         painter.save()
         painter.translate(rect.x(), rect.y())
 

--- a/ert_gui/tools/plot/widgets/clearable_line_edit.py
+++ b/ert_gui/tools/plot/widgets/clearable_line_edit.py
@@ -47,7 +47,7 @@ class ClearableLineEdit(QLineEdit):
         frame_width = self.style().pixelMetric(QStyle.PM_DefaultFrameWidth)
         self._clear_button.move(
             right - frame_width - self._clear_button.width(),
-            (self.height() - self._clear_button.height()) / 2,
+            int((self.height() - self._clear_button.height()) / 2),
         )
         QLineEdit.resizeEvent(self, event)
 


### PR DESCRIPTION
**Issue**
Resolves deprecation warning from QT (only occuring when opening a plot style window)


**Approach**
Explicit conversion from float to int


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
