### PR TITLE
Add timestamp to log file name

### DIFF
--- a/ert_logging/__init__.py
+++ b/ert_logging/__init__.py
@@ -1,3 +1,17 @@
 import pathlib
+import os
+from logging import FileHandler
+from datetime import datetime
 
 LOGGING_CONFIG = pathlib.Path(__file__).parent.resolve() / "logger.conf"
+
+
+class TimestampedFileHandler(FileHandler):
+    def __init__(self, filename: str, *args, **kwargs) -> None:
+        filename, extension = os.path.splitext(filename)
+        filename = (
+            f"{filename}-"
+            f"{datetime.now().strftime(datetime.now().strftime('%Y-%m-%dT%H%M'))}"
+            f"{extension}"
+        )
+        super().__init__(filename, *args, **kwargs)

--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -6,17 +6,17 @@ formatters:
     format: '%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s'
 handlers:
   file:
-    class: logging.FileHandler
+    class: ert_logging.TimestampedFileHandler
     level: DEBUG
     formatter: simple
     filename: ert-log.txt
   apifile:
-    class: logging.FileHandler
+    class: ert_logging.TimestampedFileHandler
     level: DEBUG
     formatter: simple
     filename: api-log.txt
   eefile:
-    class: logging.FileHandler
+    class: ert_logging.TimestampedFileHandler
     level: DEBUG
     formatter: simple_with_threading
     filename: ee-log.txt


### PR DESCRIPTION
**Issue**
When we are writing logs to file we are always appending to the same file, making it (1) hard to read, an (2) potentially huge.


**Approach**
Add the timestamp to the log file name so we create a new file for every run.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
