### PR TITLE
Simplify return type to reflect function behaviour

### DIFF
--- a/libres/lib/include/ert/job_queue/job_node.hpp
+++ b/libres/lib/include/ert/job_queue/job_node.hpp
@@ -87,9 +87,8 @@ void job_queue_node_free_driver_data(job_queue_node_type *node,
 PY_USED bool job_queue_node_update_status(job_queue_node_type *node,
                                           job_queue_status_type *status,
                                           queue_driver_type *driver);
-extern "C" PY_USED bool
-job_queue_node_update_status_simple(job_queue_node_type *node,
-                                    queue_driver_type *driver);
+extern "C" PY_USED job_status_type job_queue_node_refresh_status(
+    job_queue_node_type *node, queue_driver_type *driver);
 extern "C" int
 job_queue_node_get_submit_attempt(const job_queue_node_type *node);
 void job_queue_node_reset_submit_attempt(job_queue_node_type *node);

--- a/libres/lib/include/ert/job_queue/job_status.hpp
+++ b/libres/lib/include/ert/job_queue/job_status.hpp
@@ -92,9 +92,9 @@ typedef enum {
     JOB_QUEUE_EXIT =
         64, /* The job has exited - check attempts to determine if we retry or go to complete_fail   */
     JOB_QUEUE_IS_KILLED =
-        128, /* The job has been killed, following a  JOB_QUEUE_DO_KILL*/
+        128, /* The job has been killed, following a JOB_QUEUE_DO_KILL*/
     JOB_QUEUE_DO_KILL =
-        256, /* The the job should be killed, either due to user request, or automated measures - the job can NOT be restarted. */
+        256, /* The job should be killed, either due to user request, or automated measures - the job can NOT be restarted. */
     JOB_QUEUE_SUCCESS = 512,
     JOB_QUEUE_RUNNING_DONE_CALLBACK = 1024,
     JOB_QUEUE_RUNNING_EXIT_CALLBACK = 2048,

--- a/libres/lib/job_queue/job_node.cpp
+++ b/libres/lib/job_queue/job_node.cpp
@@ -557,20 +557,17 @@ cleanup:
     return status_change;
 }
 
-bool job_queue_node_update_status_simple(job_queue_node_type *node,
-                                         queue_driver_type *driver) {
-    bool status_change = false;
+job_status_type job_queue_node_refresh_status(job_queue_node_type *node,
+                                              queue_driver_type *driver) {
     pthread_mutex_lock(&node->data_mutex);
-    job_status_type current_status;
+    job_status_type current_status = job_queue_node_get_status(node);
     bool confirmed;
 
     if (!node->job_data) {
         job_queue_node_update_timestamp(node);
         pthread_mutex_unlock(&node->data_mutex);
-        return status_change;
+        return current_status;
     }
-
-    current_status = job_queue_node_get_status(node);
 
     confirmed = job_queue_node_status_update_confirmed_running__(node);
 
@@ -592,9 +589,10 @@ bool job_queue_node_update_status_simple(job_queue_node_type *node,
         job_status_type new_status =
             queue_driver_get_status(driver, node->job_data);
         job_queue_node_set_status(node, new_status);
+        current_status = job_queue_node_get_status(node);
     }
     pthread_mutex_unlock(&node->data_mutex);
-    return status_change;
+    return current_status;
 }
 
 bool job_queue_node_status_transition(job_queue_node_type *node,

--- a/res/job_queue/job_queue_node.py
+++ b/res/job_queue/job_queue_node.py
@@ -38,8 +38,9 @@ class JobQueueNode(BaseCClass):
     _get_status = ResPrototype(
         "job_status_type_enum job_queue_node_get_status(job_queue_node)"
     )
-    _update_status = ResPrototype(
-        "bool job_queue_node_update_status_simple(job_queue_node, driver)"
+
+    _refresh_status = ResPrototype(
+        "job_status_type_enum job_queue_node_refresh_status(job_queue_node, driver)"
     )
     _set_status = ResPrototype(
         "void job_queue_node_set_status(job_queue_node, job_status_type_enum)"
@@ -114,6 +115,9 @@ class JobQueueNode(BaseCClass):
     def submit_attempt(self):
         return self._get_submit_attempt()
 
+    def refresh_status(self, driver):
+        return self._refresh_status(driver)
+
     @property
     def status(self):
         return self._get_status()
@@ -168,8 +172,7 @@ class JobQueueNode(BaseCClass):
         if submit_status is not JobSubmitStatusType.SUBMIT_OK:
             self._set_status(JobStatusType.JOB_QUEUE_DONE)
 
-        self.update_status(driver)
-        current_status = self.status
+        current_status = self.refresh_status(driver)
 
         while self.is_running(current_status):
             if (
@@ -178,7 +181,6 @@ class JobQueueNode(BaseCClass):
             ):
                 self._start_time = time.time()
             time.sleep(1)
-            self.update_status(driver)
             if self._should_be_killed():
                 self._kill(driver)
                 if self._max_runtime and self.runtime >= self._max_runtime:
@@ -197,7 +199,7 @@ class JobQueueNode(BaseCClass):
                     with self._mutex:
                         self._timed_out = True
 
-            current_status = self.status
+            current_status = self.refresh_status(driver)
 
         self._end_time = time.time()
 
@@ -207,7 +209,7 @@ class JobQueueNode(BaseCClass):
                     self.run_done_callback()
 
             # refresh cached status after running the callback
-            current_status = self.status
+            current_status = self.refresh_status(driver)
             if current_status == JobStatusType.JOB_QUEUE_SUCCESS:
                 pass
             elif current_status == JobStatusType.JOB_QUEUE_EXIT:
@@ -264,10 +266,6 @@ class JobQueueNode(BaseCClass):
     def wait_for(self):
         if self._thread is not None and self._thread.is_alive():
             self._thread.join()
-
-    def update_status(self, driver):
-        if self.status != JobStatusType.JOB_QUEUE_WAITING:
-            self._update_status(driver)
 
     def _set_thread_status(self, new_status):
         self._thread_status = new_status


### PR DESCRIPTION
Closes #3323

**Issue**
Resolves #3323


**Approach**
Changed return type from `bool` to `void` as suggested, changed return statements accordingly, removed unused return variable.


## Pre review checklist

- [ ] Added appropriate release note label **not sure what to choose here**
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
