### PR TITLE
Remove geos installation in GA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,6 @@ jobs:
     - name: Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'unit-tests'
       run: |
-        brew install geos # this line should be removed once Shapely is distributed to mac x86_64 for Python 3.10, see https://github.com/shapely/shapely/issues/1348
         pushd tests
         pytest ert_tests -sv --durations=0 -m "not integration_test"
 
@@ -181,7 +180,6 @@ jobs:
     - name: Integration Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'integration-tests'
       run: |
-        brew install geos # this line should be removed once Shapely is distributed to mac x86_64 for Python 3.10, see https://github.com/shapely/shapely/issues/1348
         pushd tests
         pytest ert_tests performance_tests -sv --durations=0 -m "integration_test"
 


### PR DESCRIPTION
**Issue**
Resolves #3143


**Approach**
Shapely now provides wheels for macosx_10_9_x86_64, and hence building
from source is not necessary anymore. This means we can remove
the explicit geos installation in our workflows.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
