### PR TITLE
Fix bug from BoolVector replacement

### DIFF
--- a/ert_gui/ertwidgets/models/ertmodel.py
+++ b/ert_gui/ertwidgets/models/ertmodel.py
@@ -69,12 +69,9 @@ def initializeCurrentCaseFromExisting(
         and ert.getEnkfFsManager().isCaseInitialized(source_case)
         and caseExists(target_case, LibresFacade(ert))
     ):
-        if set(members) != set("0", "1"):
-            raise ValueError(
-                "Wrong member set, only 0 and 1 as strings are allowed, "
-                f"got {set(members)}"
-            )
-        member_mask = [bool(int(string)) for string in members]
+        member_mask = [False] * ert.getEnsembleSize()
+        for member in members:
+            member_mask[int(member)] = True
 
         ert.getEnkfFsManager().customInitializeCurrentFromExistingCase(
             source_case, source_report_step, member_mask, parameters


### PR DESCRIPTION
Resolves crash when clicking on 'Manage cases' -> 'Initialize from existing' -> 'Initialize'.

```
Traceback (most recent call last):
  File "/work/projects/ert/ert_gui/tools/manage_cases/case_init_configuration.py", line 160, in initializeFromExisting
    initializeCurrentCaseFromExisting(
  File "/work/projects/ert/ert_gui/ertwidgets/__init__.py", line 23, in wrapper
    res = func(*arg)
  File "/work/projects/ert/ert_gui/ertwidgets/models/ertmodel.py", line 72, in initializeCurrentCaseFromExisting
    if set(members) != set("0", "1"):
TypeError: set expected at most 1 argument, got 2
Aborted (core dumped)

```