### PR TITLE
Log maximum memory usage in main ERT thread

### DIFF
--- a/tests/ert_tests/shared/test_log_process_usage.py
+++ b/tests/ert_tests/shared/test_log_process_usage.py
@@ -1,0 +1,26 @@
+import logging
+from ert_shared.main import log_process_usage
+
+
+def test_valid(caplog):
+    caplog.set_level(logging.INFO)
+    log_process_usage()
+
+    assert len(caplog.records) == 1
+
+
+def test_unsupported_platform(caplog, monkeypatch):
+    """
+    This test supposes that some exception occurs due to the current system not
+    supporting the 'resource' package. The correct behaviour is to silently
+    ignore errors because this is only meant for logging.
+    """
+    import resource
+
+    monkeypatch.delattr(resource, "getrusage")
+    with caplog.at_level(logging.INFO):
+        log_process_usage()
+
+        # A warning has been logged but no exception has been raised
+        assert len(caplog.records) == 1
+        assert "Exception while trying to log" in caplog.records[0].message


### PR DESCRIPTION
Resolves: #2986 

The terminology is a bit obtuse. [RSS is "Resident Set Size", which is the amount of RAM that the program is using.](https://en.wikipedia.org/wiki/Resident_set_size) This number does not include swap (when paging out) or on disk (because parts of the program haven't been loaded). I have chosen to use "Peak memory use" instead so that it's understandable without having to duckduckgo what RSS means.

Virtual memory usage is another metric that is possible to record, but is not useful for this purpose. Basically, the 64-bit address space doesn't actually need to be RAM, and the OS can map other stuff to that area. A simple example is `mmap`, which opens a file and lets the user access it as if it were in memory, but really it's still on disk. So instead of `.read()`/`.write()`, you can just read from a byte array directly. We don't care about this number though.

Compare results with `/usr/bin/time -v ert test_run snake_oil.ert`. The `-v` will record "Maximum RSS" which is the peak memory usage.