### PR TITLE
Handle unexpected exceptions in EnsembleEvaluator

### DIFF
--- a/ert_shared/ensemble_evaluator/evaluator.py
+++ b/ert_shared/ensemble_evaluator/evaluator.py
@@ -14,6 +14,7 @@ import websockets
 from cloudevents.http import from_json, to_json
 from cloudevents.http.event import CloudEvent
 from websockets.exceptions import ConnectionClosedError
+from aiohttp import ClientError
 from websockets.legacy.server import WebSocketServerProtocol
 
 import ert_shared.ensemble_evaluator.monitor as ee_monitor
@@ -130,14 +131,9 @@ class EnsembleEvaluator:
                 logger.debug(f"got message from client: {client_event}")
                 if client_event["type"] == identifiers.EVTYPE_EE_USER_CANCEL:
                     logger.debug(f"Client {websocket.remote_address} asked to cancel.")
-                    if self._ensemble.cancellable:
-                        # The evaluator will stop after the ensemble has
-                        # indicated it has been cancelled.
-                        self._ensemble.cancel()
-                    else:
-                        self._stop()
+                    self._signal_cancel()
 
-                if client_event["type"] == identifiers.EVTYPE_EE_USER_DONE:
+                elif client_event["type"] == identifiers.EVTYPE_EE_USER_DONE:
                     logger.debug(f"Client {websocket.remote_address} signalled done.")
                     self._stop()
 
@@ -247,6 +243,22 @@ class EnsembleEvaluator:
         self._loop.call_soon_threadsafe(self._stop)
         self._ws_thread.join()
 
+    def _signal_cancel(self):
+        """
+        This is just a wrapper around logic for whether to signal cancel via
+        a cancellable ensemble or to use internal stop-mechanism directly
+
+        I.e. if the ensemble can be cancelled, it is, otherwise cancel
+        is signalled internally. In both cases the evaluator waits for
+        the  cancel-message to arrive before it shuts down properly.
+        """
+        if self._ensemble.cancellable:
+            logger.debug("Cancelling current ensemble")
+            self._ensemble.cancel()
+        else:
+            logger.debug("Stopping current ensemble")
+            self._stop()
+
     def run_and_get_successful_realizations(self) -> int:
         monitor = self.run()
         unsuccessful_connection_attempts = 0
@@ -255,12 +267,12 @@ class EnsembleEvaluator:
                 for _ in monitor.track():
                     unsuccessful_connection_attempts = 0
                 break
-            except ConnectionClosedError as e:
+            except (ConnectionClosedError) as e:
                 logger.debug(
                     "Connection closed unexpectedly in "
                     f"run_and_get_successful_realizations: {e}"
                 )
-            except ConnectionRefusedError as e:
+            except (ConnectionRefusedError, ClientError) as e:
                 unsuccessful_connection_attempts += 1
                 logger.debug(
                     f"run_and_get_successful_realizations caught {e}."
@@ -271,18 +283,21 @@ class EnsembleEvaluator:
                     == _MAX_UNSUCCESSFUL_CONNECTION_ATTEMPTS
                 ):
                     logger.debug("Max connection attempts reached")
-                    if self._ensemble.cancellable:
-                        logger.debug("Cancelling current ensemble")
-                        self._ensemble.cancel()
-                    else:
-                        logger.debug("Stopping current ensemble")
-                        self._stop()
+                    self._signal_cancel()
                     break
+
                 sleep_time = 0.25 * 2**unsuccessful_connection_attempts
                 logger.debug(
                     f"Sleeping for {sleep_time} seconds before attempting to reconnect"
                 )
                 time.sleep(sleep_time)
+            except (BaseException):  # pylint: disable=broad-except
+                logger.exception("unexpected error: ")
+                # We really don't know what happened...  shut down and
+                # get out of here. Monitor is stopped by context-mgr
+                self._signal_cancel()
+                break
+
         logger.debug("Waiting for evaluator shutdown")
         self._ws_thread.join()
         logger.debug("Evaluator is done")


### PR DESCRIPTION
Like EvaluatorTracker this code also calls _Monitor.track() and is thus exposed to the same unexpected exceptions we handled in https://github.com/equinor/ert/pull/3315.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines]