### PR TITLE
Include thread-name also in the ert-log

### DIFF
--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -8,7 +8,7 @@ handlers:
   file:
     class: ert_logging.TimestampedFileHandler
     level: DEBUG
-    formatter: simple
+    formatter: simple_with_threading
     filename: ert-log.txt
   apifile:
     class: ert_logging.TimestampedFileHandler


### PR DESCRIPTION
Useful when analyzing logs, and also aligning log-entries with those in ee-log 

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines]