### PR TITLE
Use DATE and not RESTART in snake oil observations

### DIFF
--- a/test-data/local/snake_oil/observations/observations.txt
+++ b/test-data/local/snake_oil/observations/observations.txt
@@ -12,7 +12,7 @@ SUMMARY_OBSERVATION WOPR_OP1_36
 {
     VALUE   = 0.7;
     ERROR   = 0.07;
-    DATE    = 26/12/2010;  -- (RESTART = 36)
+    DATE    = 2010-12-26;  -- (RESTART = 36)
     KEY     = WOPR:OP1;
 };
 
@@ -20,7 +20,7 @@ SUMMARY_OBSERVATION WOPR_OP1_72
 {
     VALUE   = 0.5;
     ERROR   = 0.05;
-    RESTART = 72;  -- (DATE = 2011-12-21)
+    DATE    = 2011-12-21;  -- (RESTART = 72)
     KEY     = WOPR:OP1;
 };
 
@@ -28,7 +28,7 @@ SUMMARY_OBSERVATION WOPR_OP1_108
 {
     VALUE   = 0.3;
     ERROR   = 0.075;
-    RESTART = 108;
+    DATE    = 2012-12-15; -- (RESTART = 108)
     KEY     = WOPR:OP1;
 };
 
@@ -36,7 +36,7 @@ SUMMARY_OBSERVATION WOPR_OP1_144
 {
     VALUE   = 0.2;
     ERROR   = 0.035;
-    RESTART = 144;
+    DATE    = 2013-12-10;  -- (RESTART = 144)
     KEY     = WOPR:OP1;
 };
 
@@ -44,13 +44,13 @@ SUMMARY_OBSERVATION WOPR_OP1_190
 {
     VALUE   = 0.015;
     ERROR   = 0.01;
-    RESTART = 190;
+    DATE    = 2015-03-15;  -- (RESTART = 190)
     KEY     = WOPR:OP1;
 };
 
 GENERAL_OBSERVATION WPR_DIFF_1 {
    DATA       = SNAKE_OIL_WPR_DIFF;
    INDEX_LIST = 400,800,1200,1800;
-   RESTART    = 199;
+   DATE       = 2015-06-13;  -- (RESTART = 199)
    OBS_FILE   = wpr_diff_obs.txt;
 };

--- a/test-data/local/snake_oil_field/observations/observations.txt
+++ b/test-data/local/snake_oil_field/observations/observations.txt
@@ -4,7 +4,7 @@ SUMMARY_OBSERVATION WOPR_OP1_9
 {
     VALUE   = 0.1;
     ERROR   = 0.05;
-    RESTART = 9;
+    DATE    = 2010-03-31;  -- (RESTART = 9)
     KEY     = WOPR:OP1;
 };
 
@@ -12,7 +12,7 @@ SUMMARY_OBSERVATION WOPR_OP1_36
 {
     VALUE   = 0.7;
     ERROR   = 0.07;
-    RESTART = 36;
+    DATE    = 2010-12-26;  -- (RESTART = 36)
     KEY     = WOPR:OP1;
 };
 
@@ -20,7 +20,7 @@ SUMMARY_OBSERVATION WOPR_OP1_72
 {
     VALUE   = 0.5;
     ERROR   = 0.05;
-    RESTART = 72;
+    DATE    = 2011-12-21;  -- (RESTART = 72)
     KEY     = WOPR:OP1;
 };
 
@@ -28,7 +28,7 @@ SUMMARY_OBSERVATION WOPR_OP1_108
 {
     VALUE   = 0.3;
     ERROR   = 0.075;
-    RESTART = 108;
+    DATE    = 2012-12-15; -- (RESTART = 108)
     KEY     = WOPR:OP1;
 };
 
@@ -36,7 +36,7 @@ SUMMARY_OBSERVATION WOPR_OP1_144
 {
     VALUE   = 0.2;
     ERROR   = 0.035;
-    RESTART = 144;
+    DATE    = 2013-12-10;  -- (RESTART = 144)
     KEY     = WOPR:OP1;
 };
 
@@ -44,13 +44,13 @@ SUMMARY_OBSERVATION WOPR_OP1_190
 {
     VALUE   = 0.015;
     ERROR   = 0.01;
-    RESTART = 190;
+    DATE    = 2015-03-15;  -- (RESTART = 190)
     KEY     = WOPR:OP1;
 };
 
 GENERAL_OBSERVATION WPR_DIFF_1 {
    DATA       = SNAKE_OIL_WPR_DIFF;
    INDEX_LIST = 400,800,1200,1800;
-   RESTART    = 199;
+   DATE       = 2015-06-13;  -- (RESTART = 199)
    OBS_FILE   = wpr_diff_obs.txt;
 };

--- a/test-data/local/snake_oil_structure/ert/input/observations/obsfiles/observations.txt
+++ b/test-data/local/snake_oil_structure/ert/input/observations/obsfiles/observations.txt
@@ -4,7 +4,7 @@ SUMMARY_OBSERVATION WOPR_OP1_9
 {
     VALUE   = 0.1;
     ERROR   = 0.05;
-    RESTART = 9;
+    DATE    = 2010-03-31;  -- (RESTART = 9)
     KEY     = WOPR:OP1;
 };
 
@@ -12,7 +12,7 @@ SUMMARY_OBSERVATION WOPR_OP1_36
 {
     VALUE   = 0.7;
     ERROR   = 0.07;
-    RESTART = 36;
+    DATE    = 2010-12-26;  -- (RESTART = 36)
     KEY     = WOPR:OP1;
 };
 
@@ -20,7 +20,7 @@ SUMMARY_OBSERVATION WOPR_OP1_72
 {
     VALUE   = 0.5;
     ERROR   = 0.05;
-    RESTART = 72;
+    DATE    = 2011-12-21;  -- (RESTART = 72)
     KEY     = WOPR:OP1;
 };
 
@@ -28,7 +28,7 @@ SUMMARY_OBSERVATION WOPR_OP1_108
 {
     VALUE   = 0.3;
     ERROR   = 0.075;
-    RESTART = 108;
+    DATE    = 2012-12-15; -- (RESTART = 108)
     KEY     = WOPR:OP1;
 };
 
@@ -36,7 +36,7 @@ SUMMARY_OBSERVATION WOPR_OP1_144
 {
     VALUE   = 0.2;
     ERROR   = 0.035;
-    RESTART = 144;
+    DATE    = 2013-12-10;  -- (RESTART = 144)
     KEY     = WOPR:OP1;
 };
 
@@ -44,13 +44,7 @@ SUMMARY_OBSERVATION WOPR_OP1_190
 {
     VALUE   = 0.015;
     ERROR   = 0.01;
-    RESTART = 190;
+    DATE    = 2015-03-15;  -- (RESTART = 190)
     KEY     = WOPR:OP1;
 };
 
-GENERAL_OBSERVATION WPR_DIFF_1 {
-   DATA       = SNAKE_OIL_WPR_DIFF;
-   INDEX_LIST = 400,800,1200,1800;
-   RESTART    = 199;
-   OBS_FILE   = observations/wpr_diff_obs.txt;
-};


### PR DESCRIPTION
**Issue**
RESTART in observation files is a subject of future deprecation, and
also makes it harder for tools unaware of the REFCASE to process
the observations


**Approach**
Use DATE instead of RESTART


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
