### PR TITLE
Add signal to close the eventviewer

### DIFF
--- a/ert_gui/gert_main.py
+++ b/ert_gui/gert_main.py
@@ -139,6 +139,8 @@ def _setup_main_window(ert: EnKFMain, notifier: ErtNotifier, args: argparse.Name
     window.addTool(PluginsTool(plugin_handler, notifier))
     window.addTool(RunAnalysisTool(ert, notifier))
     window.addTool(LoadResultsTool(facade))
-    window.addTool(EventViewerTool(gui_log_handler))
+    event_viewer = EventViewerTool(gui_log_handler)
+    window.addTool(event_viewer)
+    window.close_signal.connect(event_viewer.close_wnd)
     window.adjustSize()
     return window

--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -2,7 +2,7 @@ import functools
 
 import webbrowser
 
-from qtpy.QtCore import QSettings, Qt
+from qtpy.QtCore import QSettings, Qt, Signal
 from qtpy.QtWidgets import (
     QMainWindow,
     QWidget,
@@ -17,6 +17,8 @@ from ert_shared.plugins import ErtPluginManager
 
 
 class GertMainWindow(QMainWindow):
+    close_signal = Signal()
+
     def __init__(self, config_file):
         QMainWindow.__init__(self)
         self.tools = {}
@@ -102,6 +104,7 @@ class GertMainWindow(QMainWindow):
         # Use QT settings saving mechanism
         # settings stored in ~/.config/Equinor/ErtGui.conf
         self.__saveSettings()
+        self.close_signal.emit()
         QMainWindow.closeEvent(self, event)
 
     def __fetchSettings(self):

--- a/ert_gui/tools/event_viewer/tool.py
+++ b/ert_gui/tools/event_viewer/tool.py
@@ -1,9 +1,10 @@
 from ert_gui.ertwidgets import resourceIcon
 from ert_gui.tools import Tool
 from ert_gui.tools.event_viewer import EventViewerPanel
+from qtpy.QtCore import QObject, Slot
 
 
-class EventViewerTool(Tool):
+class EventViewerTool(Tool, QObject):
     def __init__(self, gui_handler):
         super().__init__(
             "Event viewer",
@@ -16,3 +17,7 @@ class EventViewerTool(Tool):
 
     def trigger(self):
         self.logging_window.show()
+
+    @Slot()
+    def close_wnd(self):
+        self.logging_window.close()


### PR DESCRIPTION
**Issue**
Resolves #3273 


**Approach**
Emit `close_wnd` signal when closing the main ert window. If there is another window left open we can add the signal there too.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
