### PR TITLE
Set file dialog to reasonable min width and height

### DIFF
--- a/tests/ert_tests/gui/simulation/stdout-just-right
+++ b/tests/ert_tests/gui/simulation/stdout-just-right
@@ -1,0 +1,11 @@
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'

--- a/tests/ert_tests/gui/simulation/stdout-long
+++ b/tests/ert_tests/gui/simulation/stdout-long
@@ -1,0 +1,35 @@
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'

--- a/tests/ert_tests/gui/simulation/stdout-long-and-extra-wide
+++ b/tests/ert_tests/gui/simulation/stdout-long-and-extra-wide
@@ -1,0 +1,49 @@
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits, in thy mercy.' And the Lord did grin. And the people did feast upon the lambs, and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou take out the Holy Pin. Then shalt thou count to three, no more, no less. Three shall be the number thou shalt count, and the number of the counting shall be three. Four shalt thou not count, neither count thou two, excepting that thou then proceed to three. Five is right out. Once the number three, being the third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'
+
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'

--- a/tests/ert_tests/gui/simulation/stdout-short
+++ b/tests/ert_tests/gui/simulation/stdout-short
@@ -1,0 +1,1 @@
+hello there

--- a/tests/ert_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert_tests/gui/simulation/test_run_dialog.py
@@ -1,8 +1,13 @@
+from os import path
+import math
 from unittest.mock import patch
+from typing import List
+from qtpy.QtWidgets import QApplication
+from qtpy.QtCore import Qt
+import pytest
+from pydantic import BaseModel
 
 from ert.ensemble_evaluator import identifiers as ids
-import pytest
-from ert_gui.simulation.run_dialog import RunDialog
 from ert.ensemble_evaluator.snapshot import (
     PartialSnapshot,
     SnapshotBuilder,
@@ -13,7 +18,8 @@ from ert.ensemble_evaluator.event import (
     FullSnapshotEvent,
     SnapshotUpdateEvent,
 )
-from qtpy.QtCore import Qt
+from ert_gui.simulation.run_dialog import RunDialog
+from ert_gui.model.snapshot import FileRole
 
 
 def test_success(runmodel, qtbot, mock_tracker):
@@ -298,3 +304,163 @@ def test_run_dialog(events, tab_widget_count, runmodel, qtbot, mock_tracker):
             lambda: widget._tab_widget.count() == tab_widget_count, timeout=5000
         )
         qtbot.waitUntil(lambda: widget.done_button.isVisible(), timeout=5000)
+        qtbot.wait(3000)
+
+
+def create_file_dialog_events(text_filepath: str) -> List[BaseModel]:
+    return [
+        FullSnapshotEvent(
+            snapshot=(
+                SnapshotBuilder()
+                .add_step(step_id="0", status=state.STEP_STATE_UNKNOWN)
+                .add_job(
+                    step_id="0",
+                    job_id="0",
+                    index="0",
+                    name="job_0",
+                    stdout=path.join(
+                        path.dirname(path.realpath(__file__)),
+                        text_filepath,
+                    ),
+                    data={},
+                    status=state.JOB_STATE_START,
+                )
+                .build(["0"], state.REALIZATION_STATE_UNKNOWN)
+            ),
+            phase_name="Foo",
+            current_phase=0,
+            total_phases=1,
+            progress=0.25,
+            iteration=0,
+            indeterminate=False,
+        ),
+        SnapshotUpdateEvent(
+            partial_snapshot=PartialSnapshot(
+                SnapshotBuilder()
+                .add_step(step_id="0", status=state.STEP_STATE_SUCCESS)
+                .add_job(
+                    step_id="0",
+                    job_id="0",
+                    index="0",
+                    status=state.JOB_STATE_FINISHED,
+                    name="job_0",
+                    data={},
+                )
+                .build(["1"], status=state.REALIZATION_STATE_RUNNING)
+            ),
+            phase_name="Foo",
+            current_phase=0,
+            total_phases=1,
+            progress=0.5,
+            iteration=0,
+            indeterminate=False,
+        ),
+        EndEvent(failed=False, failed_msg=""),
+    ]
+
+
+def create_file_dialog_params():
+    testCaseTextFiles = [
+        "stdout-short",
+        "stdout-just-right",
+        "stdout-long",
+        "stdout-long-and-extra-wide",
+    ]
+    return list(
+        map(
+            lambda textFile: pytest.param(
+                create_file_dialog_events(textFile),
+                1,
+                id=textFile,
+            ),
+            testCaseTextFiles,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "events,tab_widget_count",
+    create_file_dialog_params(),
+)
+def test_stdout_dialog(events, tab_widget_count, runmodel, qtbot, mock_tracker):
+    runDialogWidget = RunDialog("poly.ert", runmodel)
+    runDialogWidget.show()
+    qtbot.addWidget(runDialogWidget)
+
+    with patch("ert_gui.simulation.run_dialog.EvaluatorTracker") as tracker:
+        tracker.return_value = mock_tracker(events)
+        runDialogWidget.startSimulation()
+
+    with qtbot.waitExposed(runDialogWidget, timeout=30000):
+        qtbot.mouseClick(runDialogWidget.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(
+            lambda: runDialogWidget._tab_widget.count() == tab_widget_count,
+            timeout=5000,
+        )
+        qtbot.waitUntil(runDialogWidget.done_button.isVisible, timeout=5000)
+        qtbot.waitUntil(lambda: runDialogWidget._total_progress_bar.value() == 100)
+
+        # need to click on the realization
+        tabWidget = runDialogWidget._tab_widget
+        realizationsWidget = tabWidget.currentWidget()
+        currentJob = realizationsWidget._real_view.model().index(0, 0)
+        assert currentJob.isValid()
+        qtbot.mouseClick(
+            realizationsWidget._real_view.viewport(),
+            Qt.LeftButton,
+            pos=realizationsWidget._real_view.visualRect(currentJob).center(),
+        )
+
+        # find STDOUT field in table and click it
+        jobView = runDialogWidget._job_view
+        snapshotModel = jobView.model()
+        jobIndex = snapshotModel.index(0, 4)
+        assert jobIndex.isValid()
+        rect = jobView.visualRect(jobIndex)
+        qtbot.mouseClick(
+            runDialogWidget._job_view.viewport(), Qt.LeftButton, pos=rect.center()
+        )
+
+        # check that we have a file dialog widget
+        selectedFile = jobIndex.data(FileRole)
+        assert selectedFile is not None
+        fileDialog = runDialogWidget._open_files[selectedFile]
+        qtbot.addWidget(fileDialog)
+        qtbot.waitUntil(fileDialog.isVisible)
+
+        # check that text field is large enough to display contents, but not
+        # "too large" (expressed as ratios of screen width and height)
+        textField = fileDialog._view
+        fontMetrics = textField.fontMetrics()
+        lineHeight = math.ceil(fontMetrics.lineSpacing())
+        charWidth = fontMetrics.averageCharWidth()
+        sizeLongestLine = get_size_of_longest_line(selectedFile) * charWidth
+        textHeight = get_number_of_lines(selectedFile) * lineHeight
+        screenHeight = QApplication.primaryScreen().geometry().height()
+        screenWidth = QApplication.primaryScreen().geometry().width()
+        maxWidth = 1 / 3 * screenWidth
+        maxHeight = 1 / 3 * screenHeight
+
+        # sadly we have to wait for the dialog to be sized appropriately
+        qtbot.wait(10)
+
+        if textHeight < maxHeight:
+            assert textField.height() >= textHeight
+        else:
+            assert textField.height() == pytest.approx(
+                maxHeight, rel=0.05 * screenHeight
+            )
+        if sizeLongestLine < maxWidth:
+            assert textField.width() >= sizeLongestLine
+        else:
+            assert textField.width() == pytest.approx(maxWidth, rel=0.05 * screenWidth)
+
+
+def get_size_of_longest_line(filepath: str) -> int:
+    with open(filepath, mode="r", encoding="utf-8") as filePointer:
+        return max(map(len, filePointer.readlines()))
+
+
+def get_number_of_lines(filepath: str) -> int:
+    with open(filepath, mode="r", encoding="utf-8") as filePointer:
+        return len(filePointer.readlines())


### PR DESCRIPTION
We assume a "standard" width of 80 chars (plus a bit of extra space),
and a height that will display all lines of the text, with an upper
bound given by a third of the relevant screen height.

**Issue**
Resolves #997


**Approach**
See commit message above


## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
