### PR TITLE
Remove File menu from main window

### DIFF
--- a/ert_gui/main_window.py
+++ b/ert_gui/main_window.py
@@ -76,8 +76,6 @@ class GertMainWindow(QMainWindow):
             tool_button.setPopupMode(QToolButton.InstantPopup)
 
     def __createMenu(self):
-        file_menu = self.menuBar().addMenu("&File")
-        file_menu.addAction("Close", self.close)
         self.__view_menu = self.menuBar().addMenu("&View")
         self.__help_menu = self.menuBar().addMenu("&Help")
         """:type: QMenu"""


### PR DESCRIPTION
It only contains a 'Close' entry, and only closes implicitly through a segfault.

Shut-down of ERT in the user experience should be sufficiently handled by
the window close button

**Issue**
Resolves #3393

**Approach**
Deleting lines.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
