### PR TITLE
Utilize `fmt` arg when invoke plot_date to avoid UserWarning

### DIFF
--- a/ert_gui/plottery/plots/ensemble.py
+++ b/ert_gui/plottery/plots/ensemble.py
@@ -63,10 +63,9 @@ class EnsemblePlot:
                 y=data.to_numpy(),
                 color=style.color,
                 alpha=style.alpha,
-                marker=style.marker,
-                linestyle=style.line_style,
                 linewidth=style.width,
                 markersize=style.size,
+                fmt=f"{style.marker}{style.line_style}",
             )
         else:
             lines = axes.plot(

--- a/ert_gui/plottery/plots/history.py
+++ b/ert_gui/plottery/plots/history.py
@@ -21,10 +21,9 @@ def plotHistory(plot_context, axes):
         y=data,
         color=style.color,
         alpha=style.alpha,
-        marker=style.marker,
-        linestyle=style.line_style,
         linewidth=style.width,
         markersize=style.size,
+        fmt=f"{style.marker}{style.line_style}",
     )
 
     if len(lines) > 0 and style.isVisible():


### PR DESCRIPTION
Plot date provides a default `fmt` argument with a value `o`. This
is in conflict with our keyword-args specifying marker and line-style.
There is printed warnings in the terminal the keyword args is taking
precedense over the provided `fmt` because they are conflicting.
By utilizing the `fmt` keyword to provide marker and line-style,
this will solve the issue.