### PR TITLE
Faster state transitions

### DIFF
--- a/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/ert/ensemble_evaluator/builder/_ensemble.py
@@ -54,15 +54,12 @@ class _Ensemble:
     def snapshot(self) -> Snapshot:
         return self._snapshot
 
-    def update_snapshot(self, events: List[CloudEvent]) -> PartialSnapshot:
-        snapshot_mutate_event = PartialSnapshot(self._snapshot)
-        for event in events:
-            snapshot_mutate_event.from_cloudevent(event)
-        self._snapshot.merge_event(snapshot_mutate_event)
+    @snapshot.setter
+    def snapshot(self, new_snapshot: Snapshot):
+        self._snapshot = new_snapshot
         if self.status != self._snapshot.status:
             self.status = self._status_tracker.update_state(self._snapshot.status)
-        return snapshot_mutate_event
-
+        
     async def send_cloudevent(  # pylint: disable=too-many-arguments
         self,
         url: str,

--- a/ert_shared/ensemble_evaluator/_update_snapshot.py
+++ b/ert_shared/ensemble_evaluator/_update_snapshot.py
@@ -1,0 +1,13 @@
+from typing import List
+from cloudevents.http import CloudEvent
+from ert.ensemble_evaluator.snapshot import Snapshot, PartialSnapshot
+
+def _calculate_updated_snapshot(snapshot: Snapshot, events: List[CloudEvent]) -> (Snapshot, PartialSnapshot):
+#    return ensemble.update_snapshot(events)
+    snapshot_mutate_event = PartialSnapshot(snapshot)
+    for event in events:
+        snapshot_mutate_event.from_cloudevent(event)
+    snapshot.merge_event(snapshot_mutate_event)
+#    if self.status != self._snapshot.status:
+#        self.status = self._status_tracker.update_state(self._snapshot.status)
+    return (snapshot, snapshot_mutate_event)


### PR DESCRIPTION
**Issue**
Resolves #3401

**Approach**
- divide work into smaller batches, meaning blocking the asyncio loop for a shorter amount of time
- use processpool to do the heavy snapshot update

## Pre review checklist

- [x] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
