### PR TITLE
Allow resize of simulations failed message box

### DIFF
--- a/ert_gui/ertwidgets/message_box.py
+++ b/ert_gui/ertwidgets/message_box.py
@@ -1,0 +1,36 @@
+from qtpy.QtWidgets import (
+    QDialog,
+    QStyle,
+    QDialogButtonBox,
+    QTextEdit,
+    QLabel,
+    QGridLayout,
+)
+
+
+# This might seem like NIH, however the QtMessageBox is notoriously
+# hard to work with if you need anything like for example resizing.
+class ErtMessageBox(QDialog):
+    def __init__(self, text, detailed_text, parent=None):
+        super().__init__(parent)
+        box = QDialogButtonBox(
+            QDialogButtonBox.Ok,
+            centerButtons=True,
+        )
+        box.accepted.connect(self.accept)
+
+        self.details_text = QTextEdit(detailed_text)
+        self.details_text.setReadOnly(True)
+
+        self.label_text = QLabel(text)
+        self.label_icon = QLabel()
+        icon = self.style().standardIcon(QStyle.SP_MessageBoxCritical)
+        self.label_icon.setPixmap(icon.pixmap(32))
+
+        lay = QGridLayout(self)
+        lay.addWidget(self.label_icon, 1, 1, 1, 1)
+        lay.addWidget(self.label_text, 1, 2, 1, 2)
+        lay.addWidget(self.details_text, 2, 1, 1, 3)
+        lay.addWidget(box, 3, 1, 1, 3)
+
+        self.setMinimumSize(640, 100)

--- a/ert_gui/simulation/run_dialog.py
+++ b/ert_gui/simulation/run_dialog.py
@@ -6,6 +6,7 @@ from concurrent import futures
 from PyQt5.QtWidgets import QAbstractItemView
 
 from ert_gui.ertwidgets import resourceMovie
+from ert_gui.ertwidgets.message_box import ErtMessageBox
 from ert_gui.model.job_list import JobListProxyModel
 from ert_gui.model.snapshot import RealIens, SnapshotModel, FileRole
 from ert_gui.simulation.tracker_worker import TrackerWorker
@@ -397,10 +398,7 @@ class RunDialog(QDialog):
         )
 
         if failed:
-            msg = QMessageBox()
-            msg.setIcon(QMessageBox.Critical)
-            msg.setText("Simulations failed!".center(100))
-            msg.setDetailedText(failed_msg)
+            msg = ErtMessageBox("Ert simulations failed!", failed_msg)
             msg.exec_()
 
     @Slot()

--- a/tests/ert_tests/gui/test_gui_load.py
+++ b/tests/ert_tests/gui/test_gui_load.py
@@ -8,6 +8,7 @@ from qtpy.QtCore import Qt
 
 import ert_gui
 from ert_gui.ertnotifier import ErtNotifier
+from ert_gui.ertwidgets.message_box import ErtMessageBox
 from ert_gui.gert_main import _start_window, run_gui
 
 
@@ -166,3 +167,10 @@ def test_gui_iter_num(monkeypatch, tmpdir, qtbot, patch_enkf_main):
     start_simulation = gui.findChild(qtpy.QtWidgets.QWidget, name="start_simulation")
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
     assert sim_panel.getSimulationArguments().iter_num == 10
+
+
+def test_dialog(qtbot):
+    msg = ErtMessageBox("Simulations failed!", "failed_msg")
+    qtbot.addWidget(msg)
+    assert msg.label_text.text() == "Simulations failed!"
+    assert msg.details_text.toPlainText() == "failed_msg"


### PR DESCRIPTION
**Issue**
Resolves #3368 


**Approach**
The issue makes it sound like it should be super easy, barely an inconvenience, but turns out `QMessageBox` is not very flexible. I had to reimplement something similar. ~I chose to keep the API fairly similar to `QMessageBox`, but could do everything in the constructor instead potentially.~ Edit: simplified it to setting everything at creation. Also, if there are good alternatives I am all ears.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
