### PR TITLE
Fix: convert job.index to int before sorting

### DIFF
--- a/ert_gui/model/node.py
+++ b/ert_gui/model/node.py
@@ -30,6 +30,8 @@ class Node:
         self.children[node_id] = node
 
     def row(self) -> int:
+        if "index" in self.data:
+            return int(self.data["index"])
         if self.parent:
             return list(self.parent.children.keys()).index(self.id)
         raise ValueError(f"{self} had no parent")

--- a/ert_gui/model/snapshot.py
+++ b/ert_gui/model/snapshot.py
@@ -114,7 +114,8 @@ class SnapshotModel(QAbstractItemModel):
                         (job.index, job_id) for job_id, job in step[ids.JOBS].items()
                     ]
                     metadata[SORTED_JOB_IDS][real_id][step_id] = [
-                        index[1] for index in sorted(indices, key=lambda indx: indx[0])
+                        index[1]
+                        for index in sorted(indices, key=lambda indx: int(indx[0]))
                     ]
 
         for real_id, real in snapshot.data()[ids.REALS].items():


### PR DESCRIPTION
**Issue**
Resolves #3399 


**Approach**
The index needs to be converted to int before sorting. If present in node, we can use to it directly to retrieve the row index.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
