### PR TITLE
Refactor analysis config min_required_realizations

### DIFF
--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -267,9 +267,7 @@ class BaseRunModel:
         if (
             not self.ert()
             .analysisConfig()
-            .haveEnoughRealisations(
-                num_successful_realizations, len(self._active_realizations)
-            )
+            .haveEnoughRealisations(num_successful_realizations)
         ):
             raise ErtRunError(
                 "Too many simulations have failed! You can add/adjust MIN_REALIZATIONS "
@@ -278,11 +276,7 @@ class BaseRunModel:
 
     def _checkMinimumActiveRealizations(self, run_context: ErtRunContext) -> None:
         active_realizations = self._count_active_realizations(run_context)
-        if (
-            not self.ert()
-            .analysisConfig()
-            .haveEnoughRealisations(active_realizations, len(self._active_realizations))
-        ):
+        if not self.ert().analysisConfig().haveEnoughRealisations(active_realizations):
             raise ErtRunError(
                 "Number of active realizations is less than the specified "
                 + "MIN_REALIZATIONS in the config file"

--- a/libres/lib/include/ert/enkf/analysis_config.hpp
+++ b/libres/lib/include/ert/enkf/analysis_config.hpp
@@ -92,8 +92,6 @@ void analysis_config_set_single_node_update(analysis_config_type *config,
                                             bool single_node_update);
 bool analysis_config_get_single_node_update(const analysis_config_type *config);
 
-bool analysis_config_have_enough_realisations(
-    const analysis_config_type *config, int realisations, int ensemble_size);
 extern "C" void
 analysis_config_set_stop_long_running(analysis_config_type *config,
                                       bool stop_long_running);

--- a/libres/old_tests/enkf/test_enkf_analysis_config.cpp
+++ b/libres/old_tests/enkf/test_enkf_analysis_config.cpp
@@ -45,7 +45,7 @@ void test_create() {
 
 void test_min_realizations(const char *num_realizations_str,
                            const char *min_realizations_str,
-                           int min_realizations_expected_needed) {
+                           int min_realizations_expected) {
     ecl::util::TestArea ta("min_realizations");
     {
         FILE *config_file_stream = fopen("config_file", "w");
@@ -72,41 +72,14 @@ void test_min_realizations(const char *num_realizations_str,
             analysis_config_type *ac = create_analysis_config();
             analysis_config_init(ac, content);
 
-            int num_realizations =
-                config_content_get_value_as_int(content, NUM_REALIZATIONS_KEY);
-
-            test_assert_false(analysis_config_have_enough_realisations(
-                ac, min_realizations_expected_needed - 1, num_realizations));
-            test_assert_true(analysis_config_have_enough_realisations(
-                ac, min_realizations_expected_needed, num_realizations));
-            test_assert_true(analysis_config_have_enough_realisations(
-                ac, min_realizations_expected_needed + 1, num_realizations));
-
             int min_realizations = analysis_config_get_min_realisations(ac);
-            if (min_realizations > 0) {
-                test_assert_true(analysis_config_have_enough_realisations(
-                    ac, min_realizations - 1, min_realizations - 2));
-            }
+            test_assert_true(min_realizations == min_realizations_expected);
+
             analysis_config_free(ac);
             config_content_free(content);
             config_free(c);
         }
     }
-}
-
-void test_have_enough_realisations_defaulted() {
-    analysis_config_type *ac = create_analysis_config();
-    int ensemble_size = 20;
-
-    // min_realizations not set, should then require 20 (ensemble_size)
-    test_assert_false(
-        analysis_config_have_enough_realisations(ac, 0, ensemble_size));
-    test_assert_false(
-        analysis_config_have_enough_realisations(ac, 10, ensemble_size));
-    test_assert_true(
-        analysis_config_have_enough_realisations(ac, 20, ensemble_size));
-
-    analysis_config_free(ac);
 }
 
 void test_stop_long_running() {
@@ -203,7 +176,6 @@ void test_min_realizations_number() {
 
 int main(int argc, char **argv) {
     test_create();
-    test_have_enough_realisations_defaulted();
     test_min_realizations_percent();
     test_min_realizations_number();
     test_stop_long_running();

--- a/res/enkf/analysis_config.py
+++ b/res/enkf/analysis_config.py
@@ -274,8 +274,8 @@ class AnalysisConfig(BaseCClass):
     def minimum_required_realizations(self) -> int:
         return self._get_min_realizations()
 
-    def haveEnoughRealisations(self, realizations, ensemble_size):
-        return realizations >= min(self.minimum_required_realizations, ensemble_size)
+    def haveEnoughRealisations(self, realizations):
+        return realizations >= self.minimum_required_realizations
 
     def __ne__(self, other):
         return not self == other

--- a/res/enkf/es_update.py
+++ b/res/enkf/es_update.py
@@ -206,24 +206,8 @@ class ESUpdate:
     def __init__(self, enkf_main):
         self.ert = enkf_main
 
-    @property
-    def _analysis_config(self):
-        return self.ert.analysisConfig()
-
-    def hasModule(self, name):
-        """
-        Will check if we have analysis module @name.
-        """
-        return self._analysis_config.hasModule(name)
-
-    def getModule(self, name):
-        if self.hasModule(name):
-            self._analysis_config.getModule(name)
-        else:
-            raise KeyError(f"No such module:{name}")
-
     def setGlobalStdScaling(self, weight):
-        self._analysis_config.setGlobalStdScaling(weight)
+        self.ert.analysisConfig().setGlobalStdScaling(weight)
 
     def smootherUpdate(self, run_context):
         source_fs = run_context.get_sim_fs()

--- a/res/enkf/es_update.py
+++ b/res/enkf/es_update.py
@@ -28,7 +28,6 @@ class SmootherSnapshot:
 
 def analysis_smoother_update(
     updatestep,
-    total_ens_size,
     obs,
     shared_rng,
     analysis_config,
@@ -54,11 +53,9 @@ def analysis_smoother_update(
         analysis_config.getStdCutoff(),
     )
 
-    if len(iens_active_index) < min(
-        analysis_config.minimum_required_realizations, total_ens_size
-    ):
+    if not analysis_config.haveEnoughRealisations(len(iens_active_index)):
         raise ErtAnalysisError(
-            f"There are {iens_active_index} active realisations left, which is "
+            f"There are {len(iens_active_index)} active realisations left, which is "
             "less than the minimum specified - stopping assimilation.",
         )
     if len(updatestep) > 1 and module.name() == "IES_ENKF":
@@ -217,14 +214,12 @@ class ESUpdate:
 
         analysis_config = self.ert.analysisConfig()
 
-        total_ens_size = self.ert.getEnsembleSize()
         obs = self.ert.getObservations()
         shared_rng = self.ert.rng()
         ensemble_config = self.ert.ensembleConfig()
 
         update_snapshot = analysis_smoother_update(
             updatestep,
-            total_ens_size,
             obs,
             shared_rng,
             analysis_config,

--- a/tests/libres_tests/res/enkf/test_analysis_config.py
+++ b/tests/libres_tests/res/enkf/test_analysis_config.py
@@ -38,8 +38,8 @@ class AnalysisConfigTest(ResTest):
 
             # Unless the MIN_REALIZATIONS is set in config, one is required to
             # have "all" realizations.
-            self.assertFalse(ac.haveEnoughRealisations(5, 10))
-            self.assertTrue(ac.haveEnoughRealisations(10, 10))
+            self.assertFalse(ac.haveEnoughRealisations(5))
+            self.assertTrue(ac.haveEnoughRealisations(10))
 
             ac.set_max_runtime(50)
             self.assertEqual(50, ac.get_max_runtime())

--- a/tests/libres_tests/res/enkf/test_es_update.py
+++ b/tests/libres_tests/res/enkf/test_es_update.py
@@ -23,37 +23,6 @@ def minimal_config(use_tmpdir):
     yield res_config
 
 
-@pytest.mark.parametrize(
-    "module",
-    [
-        "IES_ENKF",
-        "STD_ENKF",
-    ],
-)
-def test_get_module(module, minimal_config):
-    ert = EnKFMain(minimal_config)
-    es_update = ESUpdate(ert)
-    es_update.getModule(module)
-
-
-@pytest.mark.parametrize(
-    "module, expected", [("NO_NOT_THIS_MODULE", False), ("STD_ENKF", True)]
-)
-def test_has_module(module, expected, minimal_config):
-    ert = EnKFMain(minimal_config)
-    es_update = ESUpdate(ert)
-
-    assert es_update.hasModule(module) is expected
-
-
-def test_get_invalid_module(minimal_config):
-    ert = EnKFMain(minimal_config)
-    es_update = ESUpdate(ert)
-
-    with pytest.raises(KeyError, match="No such module:STD_ENKF_XXX"):
-        es_update.getModule("STD_ENKF_XXX")
-
-
 def test_update_report(setup_case, snapshot):
     """
     Note that this is now a snapshot test, so there is no guarantee that the


### PR DESCRIPTION
**Issue**
Analysis config is provided enough information during initialization, but was previously also requiring one to add the
pass in ensemble size as a parameter. This is no longer needed, as min_required now defaults to ensemble size
if nothing is specified. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
