### PR TITLE
Dont retry forward model if inconsistent time map

### DIFF
--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -538,10 +538,16 @@ int enkf_main_load_from_run_context(enkf_main_type *enkf_main,
 
                         state_map_update_undefined(state_map, realisation,
                                                    STATE_INITIALIZED);
-
-                        return enkf_state_load_from_forward_model(
-                            enkf_main_iget_state(enkf_main, realisation),
-                            ert_run_context_iget_arg(run_context, realisation));
+                        try {
+                            return enkf_state_load_from_forward_model(
+                                enkf_main_iget_state(enkf_main, realisation),
+                                ert_run_context_iget_arg(run_context,
+                                                         realisation));
+                        } catch (const std::invalid_argument) {
+                            state_map_iset(state_map, realisation,
+                                           STATE_LOAD_FAILURE);
+                            return (int) LOAD_FAILURE;
+                        }
                     },
                     iens, std::ref(concurrently_executing_threads))));
         }

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -517,7 +517,7 @@ int enkf_main_load_from_run_context(enkf_main_type *enkf_main,
     // executing* threads. The number of instantiated and stored futures
     // will be equal to the number of active realizations.
     Semafoor concurrently_executing_threads(100);
-    std::vector<std::tuple<int, std::future<enkf_fw_load_result_enum>>> futures;
+    std::vector<std::tuple<int, std::future<fw_load_status>>> futures;
 
     for (int iens = 0; iens < ens_size; ++iens) {
         if (bool_vector_iget(iactive, iens)) {

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -561,14 +561,6 @@ int enkf_main_load_from_run_context(enkf_main_type *enkf_main,
         } else if (result == LOAD_FAILURE) {
             logger->warning("Function {}: Realization {} load failure",
                             __func__, iens);
-        } else if (result == REPORT_STEP_INCOMPATIBLE) {
-            logger->warning("The timesteps in refcase and "
-                            "current simulation are "
-                            "not in accordance - something wrong with "
-                            "schedule file?");
-            logger->warning("Function {}: Realization {} report step "
-                            "incompatible",
-                            __func__, iens);
         } else
             logger->error("Unknown load enum");
     }

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -277,17 +277,6 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
                                                        LOAD_FAILURE);
                     throw std::invalid_argument("Inconsistent time map");
                 }
-                /*
-                 * Now there are two related / conflicting(?) systems for
-                 * checking summary time consistency, both internally in the
-                 * time_map and also through the
-                 * model_config_report_step_compatible() function.
-                 */
-
-                /*Check the loaded summary against the reference ecl_sum_type */
-                if (!model_config_report_step_compatible(model_config, summary))
-                    forward_load_context_update_result(
-                        load_context, REPORT_STEP_INCOMPATIBLE);
 
                 /* The actual loading internalizing - from ecl_sum -> enkf_node. */
                 const int iens = run_arg_get_iens(run_arg);
@@ -607,15 +596,6 @@ bool enkf_state_complete_forward_modelOK(const res_config_type *res_config,
 
     auto result = enkf_state_load_from_forward_model__(ens_config, model_config,
                                                        ecl_config, run_arg);
-
-    if (result == REPORT_STEP_INCOMPATIBLE) {
-        // If refcase has been used for observations: crash and burn.
-        fprintf(
-            stderr,
-            "** Warning the timesteps in refcase and current simulation are "
-            "not in accordance - something wrong with schedule file?\n");
-        result = LOAD_SUCCESSFUL;
-    }
 
     if (result == LOAD_SUCCESSFUL) {
         /*

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -446,7 +446,7 @@ enkf_state_alloc_load_context(const ensemble_config_type *ens_config,
    Will mainly be called at the end of the forward model, but can also
    be called manually from external scope.
 */
-static enkf_fw_load_result_enum enkf_state_internalize_results(
+static fw_load_status enkf_state_internalize_results(
     ensemble_config_type *ens_config, model_config_type *model_config,
     const ecl_config_type *ecl_config, const run_arg_type *run_arg) {
 
@@ -483,7 +483,7 @@ static enkf_fw_load_result_enum enkf_state_internalize_results(
     return result;
 }
 
-static enkf_fw_load_result_enum enkf_state_load_from_forward_model__(
+static fw_load_status enkf_state_load_from_forward_model__(
     ensemble_config_type *ens_config, model_config_type *model_config,
     const ecl_config_type *ecl_config, const run_arg_type *run_arg) {
     auto result = LOAD_SUCCESSFUL;
@@ -504,9 +504,8 @@ static enkf_fw_load_result_enum enkf_state_load_from_forward_model__(
     return result;
 }
 
-enkf_fw_load_result_enum
-enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
-                                   run_arg_type *run_arg) {
+fw_load_status enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
+                                                  run_arg_type *run_arg) {
 
     ensemble_config_type *ens_config = enkf_state->ensemble_config;
     model_config_type *model_config = enkf_state->shared_info->model_config;

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -969,10 +969,11 @@ int ensemble_config_get_size(const ensemble_config_type *ensemble_config) {
     return ensemble_config->config_nodes.size();
 }
 
-int ensemble_config_forward_init(const ensemble_config_type *ens_config,
-                                 const run_arg_type *run_arg) {
+enkf_fw_load_result_enum
+ensemble_config_forward_init(const ensemble_config_type *ens_config,
+                             const run_arg_type *run_arg) {
 
-    int result = 0;
+    auto result = LOAD_SUCCESSFUL;
     if (run_arg_get_step1(run_arg) == 0) {
         int iens = run_arg_get_iens(run_arg);
         for (auto &config_pair : ens_config->config_nodes) {
@@ -1007,7 +1008,7 @@ int ensemble_config_forward_init(const ensemble_config_type *ens_config,
                                     enkf_node_get_key(node));
 
                         free(init_file);
-                        result |= LOAD_FAILURE;
+                        result = LOAD_FAILURE;
                     }
                 }
                 enkf_node_free(node);

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -969,7 +969,7 @@ int ensemble_config_get_size(const ensemble_config_type *ensemble_config) {
     return ensemble_config->config_nodes.size();
 }
 
-enkf_fw_load_result_enum
+fw_load_status
 ensemble_config_forward_init(const ensemble_config_type *ens_config,
                              const run_arg_type *run_arg) {
 

--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -45,7 +45,7 @@ struct forward_load_context_struct {
 
     /* The variables below are updated during the load process. */
     int load_step;
-    int load_result;
+    enkf_fw_load_result_enum load_result;
     bool ecl_active;
 };
 
@@ -144,7 +144,7 @@ forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,
     load_context->run_arg = run_arg;
     load_context->load_step =
         -1; // Invalid - must call forward_load_context_select_step()
-    load_context->load_result = 0;
+    load_context->load_result = LOAD_SUCCESSFUL;
     load_context->ecl_config = ecl_config;
     if (ecl_config)
         load_context->ecl_active = ecl_config_active(ecl_config);
@@ -155,14 +155,14 @@ forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,
     return load_context;
 }
 
-int forward_load_context_get_result(
-    const forward_load_context_type *load_context) {
+enkf_fw_load_result_enum
+forward_load_context_get_result(const forward_load_context_type *load_context) {
     return load_context->load_result;
 }
 
 void forward_load_context_update_result(forward_load_context_type *load_context,
-                                        int flags) {
-    load_context->load_result |= flags;
+                                        enkf_fw_load_result_enum flags) {
+    load_context->load_result = flags;
 }
 
 void forward_load_context_free(forward_load_context_type *load_context) {

--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -45,7 +45,7 @@ struct forward_load_context_struct {
 
     /* The variables below are updated during the load process. */
     int load_step;
-    enkf_fw_load_result_enum load_result;
+    fw_load_status load_result;
     bool ecl_active;
 };
 
@@ -155,13 +155,13 @@ forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,
     return load_context;
 }
 
-enkf_fw_load_result_enum
+fw_load_status
 forward_load_context_get_result(const forward_load_context_type *load_context) {
     return load_context->load_result;
 }
 
 void forward_load_context_update_result(forward_load_context_type *load_context,
-                                        enkf_fw_load_result_enum flags) {
+                                        fw_load_status flags) {
     load_context->load_result = flags;
 }
 

--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -789,17 +789,3 @@ config_content_type *model_config_alloc_content(const char *user_config_file,
 
     return content;
 }
-
-bool model_config_report_step_compatible(
-    const model_config_type *model_config,
-    const ecl_sum_type *ecl_sum_simulated) {
-    bool ret = true;
-    const ecl_sum_type *ecl_sum_reference =
-        model_config_get_refcase(model_config);
-
-    if (ecl_sum_reference) //Can be NULL
-        ret = ecl_sum_report_step_compatible(ecl_sum_reference,
-                                             ecl_sum_simulated);
-
-    return ret;
-}

--- a/libres/lib/include/ert/enkf/enkf_state.hpp
+++ b/libres/lib/include/ert/enkf/enkf_state.hpp
@@ -52,9 +52,8 @@ extern "C" void enkf_state_initialize(
     enkf_state_type *enkf_state, rng_type *rng, enkf_fs_type *fs,
     const std::vector<std::string> &param_list, init_mode_type init_mode);
 
-enkf_fw_load_result_enum
-enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
-                                   run_arg_type *run_arg);
+fw_load_status enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
+                                                  run_arg_type *run_arg);
 
 void enkf_state_init_eclipse(const res_config_type *res_config,
                              const run_arg_type *run_arg);

--- a/libres/lib/include/ert/enkf/enkf_state.hpp
+++ b/libres/lib/include/ert/enkf/enkf_state.hpp
@@ -52,8 +52,9 @@ extern "C" void enkf_state_initialize(
     enkf_state_type *enkf_state, rng_type *rng, enkf_fs_type *fs,
     const std::vector<std::string> &param_list, init_mode_type init_mode);
 
-int enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
-                                       run_arg_type *run_arg);
+enkf_fw_load_result_enum
+enkf_state_load_from_forward_model(enkf_state_type *enkf_state,
+                                   run_arg_type *run_arg);
 
 void enkf_state_init_eclipse(const res_config_type *res_config,
                              const run_arg_type *run_arg);

--- a/libres/lib/include/ert/enkf/enkf_types.hpp
+++ b/libres/lib/include/ert/enkf/enkf_types.hpp
@@ -97,6 +97,7 @@ typedef enum {
 */
 
 typedef enum {
+    LOAD_SUCCESSFUL = 0,
     REPORT_STEP_INCOMPATIBLE = 1,
     LOAD_FAILURE = 2
 } enkf_fw_load_result_enum;

--- a/libres/lib/include/ert/enkf/enkf_types.hpp
+++ b/libres/lib/include/ert/enkf/enkf_types.hpp
@@ -96,11 +96,7 @@ typedef enum {
    In addition to enkf_config_add_type().
 */
 
-typedef enum {
-    LOAD_SUCCESSFUL = 0,
-    REPORT_STEP_INCOMPATIBLE = 1,
-    LOAD_FAILURE = 2
-} fw_load_status;
+typedef enum { LOAD_SUCCESSFUL = 0, LOAD_FAILURE = 2 } fw_load_status;
 
 /**
       These are 2^n bitmasks.

--- a/libres/lib/include/ert/enkf/enkf_types.hpp
+++ b/libres/lib/include/ert/enkf/enkf_types.hpp
@@ -100,7 +100,7 @@ typedef enum {
     LOAD_SUCCESSFUL = 0,
     REPORT_STEP_INCOMPATIBLE = 1,
     LOAD_FAILURE = 2
-} enkf_fw_load_result_enum;
+} fw_load_status;
 
 /**
       These are 2^n bitmasks.

--- a/libres/lib/include/ert/enkf/ensemble_config.hpp
+++ b/libres/lib/include/ert/enkf/ensemble_config.hpp
@@ -121,7 +121,7 @@ ensemble_config_get_summary_key_matcher(
     const ensemble_config_type *ensemble_config);
 extern "C" int
 ensemble_config_get_size(const ensemble_config_type *ensemble_config);
-enkf_fw_load_result_enum
+fw_load_status
 ensemble_config_forward_init(const ensemble_config_type *ens_config,
                              const run_arg_type *run_arg);
 

--- a/libres/lib/include/ert/enkf/ensemble_config.hpp
+++ b/libres/lib/include/ert/enkf/ensemble_config.hpp
@@ -121,8 +121,9 @@ ensemble_config_get_summary_key_matcher(
     const ensemble_config_type *ensemble_config);
 extern "C" int
 ensemble_config_get_size(const ensemble_config_type *ensemble_config);
-int ensemble_config_forward_init(const ensemble_config_type *ens_config,
-                                 const run_arg_type *run_arg);
+enkf_fw_load_result_enum
+ensemble_config_forward_init(const ensemble_config_type *ens_config,
+                             const run_arg_type *run_arg);
 
 UTIL_IS_INSTANCE_HEADER(ensemble_config);
 UTIL_SAFE_CAST_HEADER(ensemble_config);

--- a/libres/lib/include/ert/enkf/forward_load_context.hpp
+++ b/libres/lib/include/ert/enkf/forward_load_context.hpp
@@ -33,8 +33,8 @@
 typedef struct forward_load_context_struct forward_load_context_type;
 
 void forward_load_context_update_result(forward_load_context_type *load_context,
-                                        enkf_fw_load_result_enum flags);
-enkf_fw_load_result_enum
+                                        fw_load_status flags);
+fw_load_status
 forward_load_context_get_result(const forward_load_context_type *load_context);
 extern "C" forward_load_context_type *
 forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,

--- a/libres/lib/include/ert/enkf/forward_load_context.hpp
+++ b/libres/lib/include/ert/enkf/forward_load_context.hpp
@@ -27,14 +27,15 @@
 
 #include <ert/enkf/ecl_config.hpp>
 #include <ert/enkf/enkf_fs_type.hpp>
+#include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/run_arg_type.hpp>
 
 typedef struct forward_load_context_struct forward_load_context_type;
 
 void forward_load_context_update_result(forward_load_context_type *load_context,
-                                        int flags);
-int forward_load_context_get_result(
-    const forward_load_context_type *load_context);
+                                        enkf_fw_load_result_enum flags);
+enkf_fw_load_result_enum
+forward_load_context_get_result(const forward_load_context_type *load_context);
 extern "C" forward_load_context_type *
 forward_load_context_alloc(const run_arg_type *run_arg, bool load_summary,
                            const ecl_config_type *ecl_config);

--- a/libres/lib/include/ert/enkf/model_config.hpp
+++ b/libres/lib/include/ert/enkf/model_config.hpp
@@ -124,8 +124,6 @@ model_config_get_gen_kw_export_name(const model_config_type *model_config);
 config_content_type *model_config_alloc_content(const char *,
                                                 config_parser_type *);
 void model_config_init_config_parser(config_parser_type *config_parser);
-bool model_config_report_step_compatible(const model_config_type *model_config,
-                                         const ecl_sum_type *ecl_sum_simulated);
 
 UTIL_IS_INSTANCE_HEADER(model_config);
 

--- a/libres/old_tests/enkf/test_enkf_forward_init_FIELD.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_init_FIELD.cpp
@@ -139,7 +139,6 @@ int main(int argc, char **argv) {
             test_assert_true(util_is_directory("simulations/run0"));
 
             {
-                int result;
 
                 test_assert_false(enkf_node_has_data(field_node, fs, node_id));
 
@@ -148,28 +147,26 @@ int main(int argc, char **argv) {
                 test_assert_false(
                     enkf_node_forward_init(field_node, "simulations/run0", 0));
                 enkf_state_type *state = enkf_main_iget_state(enkf_main, 0);
-                result = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_true(LOAD_FAILURE & result);
+                auto result = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(LOAD_FAILURE == result);
 
-                result = 0;
                 {
                     enkf_fs_type *fs = enkf_main_get_fs(enkf_main);
                     state_map_type *state_map = enkf_fs_get_state_map(fs);
                     state_map_iset(state_map, 0, STATE_INITIALIZED);
                 }
                 result = enkf_state_load_from_forward_model(state, run_arg);
-                test_assert_true(LOAD_FAILURE & result);
+                test_assert_true(LOAD_FAILURE == result);
             }
 
             util_copy_file(init_file, "simulations/run0/petro.grdecl");
             {
-                int result;
                 enkf_state_type *state = enkf_main_iget_state(enkf_main, 0);
 
                 test_assert_true(
                     enkf_node_forward_init(field_node, "simulations/run0", 0));
-                result = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_int_equal(result, 0);
+                auto result = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(result == LOAD_SUCCESSFUL);
                 result = enkf_state_load_from_forward_model(state, run_arg);
 
                 test_assert_int_equal(result, 0);

--- a/libres/old_tests/enkf/test_enkf_forward_init_GEN_KW.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_init_GEN_KW.cpp
@@ -112,7 +112,6 @@ int main(int argc, char **argv) {
             test_assert_true(util_is_directory("simulations/run0"));
 
             {
-                int error;
                 bool_vector_type *iactive = bool_vector_alloc(
                     enkf_main_get_ensemble_size(enkf_main), true);
 
@@ -121,8 +120,8 @@ int main(int argc, char **argv) {
 
                 test_assert_false(
                     enkf_node_forward_init(gen_kw_node, "simulations/run0", 0));
-                error = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_true(LOAD_FAILURE & error);
+                auto error = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(LOAD_FAILURE == error);
 
                 {
                     enkf_fs_type *fs = enkf_main_get_fs(enkf_main);
@@ -131,7 +130,7 @@ int main(int argc, char **argv) {
                 }
                 error = enkf_state_load_from_forward_model(state, run_arg);
                 bool_vector_free(iactive);
-                test_assert_true(LOAD_FAILURE & error);
+                test_assert_true(LOAD_FAILURE == error);
             }
 
             {
@@ -141,15 +140,13 @@ int main(int argc, char **argv) {
             }
 
             {
-                int error;
-
                 test_assert_true(
                     enkf_node_forward_init(gen_kw_node, "simulations/run0", 0));
-                error = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_int_equal(0, error);
+                auto error = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(error == LOAD_SUCCESSFUL);
                 error = enkf_state_load_from_forward_model(state, run_arg);
 
-                test_assert_int_equal(0, error);
+                test_assert_true(error == LOAD_SUCCESSFUL);
 
                 {
                     double value;

--- a/libres/old_tests/enkf/test_enkf_forward_init_GEN_PARAM.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_init_GEN_PARAM.cpp
@@ -120,13 +120,12 @@ int main(int argc, char **argv) {
             }
 
             {
-                int error;
 
                 test_assert_true(enkf_node_forward_init(gen_param_node,
                                                         "simulations/run0", 0));
 
-                error = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_int_equal(0, error);
+                auto error = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(error == LOAD_SUCCESSFUL);
                 {
                     enkf_fs_type *fs = enkf_main_get_fs(enkf_main);
                     state_map_type *state_map = enkf_fs_get_state_map(fs);
@@ -134,7 +133,7 @@ int main(int argc, char **argv) {
                 }
                 error = enkf_state_load_from_forward_model(state, run_arg);
 
-                test_assert_int_equal(0, error);
+                test_assert_true(error == LOAD_SUCCESSFUL);
 
                 {
                     double value;

--- a/libres/old_tests/enkf/test_enkf_forward_init_SURFACE.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_init_SURFACE.cpp
@@ -138,8 +138,6 @@ int main(int argc, char **argv) {
             test_assert_true(util_is_directory("simulations/run0"));
 
             {
-                int error;
-
                 test_assert_false(
                     enkf_node_has_data(surface_node, fs, node_id));
 
@@ -147,8 +145,8 @@ int main(int argc, char **argv) {
 
                 test_assert_false(enkf_node_forward_init(
                     surface_node, "simulations/run0", 0));
-                error = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_true(LOAD_FAILURE & error);
+                auto error = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(LOAD_FAILURE == error);
 
                 {
                     enkf_fs_type *fs = enkf_main_get_fs(enkf_main);
@@ -156,19 +154,18 @@ int main(int argc, char **argv) {
                     state_map_iset(state_map, 0, STATE_INITIALIZED);
                 }
                 error = enkf_state_load_from_forward_model(state, run_arg);
-                test_assert_true(LOAD_FAILURE & error);
+                test_assert_true(LOAD_FAILURE == error);
             }
 
             util_copy_file(init_file, "simulations/run0/Surface.irap");
             {
-                int error;
 
                 test_assert_true(enkf_node_forward_init(surface_node,
                                                         "simulations/run0", 0));
-                error = ensemble_config_forward_init(ens_config, run_arg);
-                test_assert_int_equal(0, error);
+                auto error = ensemble_config_forward_init(ens_config, run_arg);
+                test_assert_true(error == LOAD_SUCCESSFUL);
                 error = enkf_state_load_from_forward_model(state, run_arg);
-                test_assert_int_equal(0, error);
+                test_assert_true(error == LOAD_SUCCESSFUL);
 
                 {
                     double value;

--- a/libres/old_tests/enkf/test_enkf_forward_init_transform.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_init_transform.cpp
@@ -129,10 +129,9 @@ int main(int argc, char **argv) {
         enkf_state_type *state = enkf_main_iget_state(enkf_main, 0);
         bool_vector_type *iactive =
             bool_vector_alloc(enkf_main_get_ensemble_size(enkf_main), true);
-        int error;
-        error = enkf_state_load_from_forward_model(state, run_arg);
+        auto error = enkf_state_load_from_forward_model(state, run_arg);
         bool_vector_free(iactive);
-        test_assert_int_equal(error, 0);
+        test_assert_true(error == LOAD_SUCCESSFUL);
     }
 
     test_assert_true(check_original_exported_data_equal(field_node));

--- a/libres/old_tests/enkf/test_enkf_forward_load_context.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_load_context.cpp
@@ -26,17 +26,21 @@ void test_update_result() {
     forward_load_context_type *load_context =
         forward_load_context_alloc(NULL, false, NULL);
     test_assert_int_equal(forward_load_context_get_result(load_context), 0);
-    forward_load_context_update_result(load_context, 1);
-    test_assert_int_equal(forward_load_context_get_result(load_context), 1);
+    forward_load_context_update_result(load_context, REPORT_STEP_INCOMPATIBLE);
+    test_assert_true(forward_load_context_get_result(load_context) ==
+                     REPORT_STEP_INCOMPATIBLE);
 
-    forward_load_context_update_result(load_context, 1);
-    test_assert_int_equal(forward_load_context_get_result(load_context), 1);
+    forward_load_context_update_result(load_context, REPORT_STEP_INCOMPATIBLE);
+    test_assert_true(forward_load_context_get_result(load_context) ==
+                     REPORT_STEP_INCOMPATIBLE);
 
-    forward_load_context_update_result(load_context, 2);
-    test_assert_int_equal(forward_load_context_get_result(load_context), 3);
+    forward_load_context_update_result(load_context, LOAD_FAILURE);
+    test_assert_true(forward_load_context_get_result(load_context) ==
+                     LOAD_FAILURE);
 
-    forward_load_context_update_result(load_context, 5);
-    test_assert_int_equal(forward_load_context_get_result(load_context), 7);
+    forward_load_context_update_result(load_context, LOAD_SUCCESSFUL);
+    test_assert_true(forward_load_context_get_result(load_context) ==
+                     LOAD_SUCCESSFUL);
 
     forward_load_context_free(load_context);
 }

--- a/libres/old_tests/enkf/test_enkf_forward_load_context.cpp
+++ b/libres/old_tests/enkf/test_enkf_forward_load_context.cpp
@@ -26,13 +26,6 @@ void test_update_result() {
     forward_load_context_type *load_context =
         forward_load_context_alloc(NULL, false, NULL);
     test_assert_int_equal(forward_load_context_get_result(load_context), 0);
-    forward_load_context_update_result(load_context, REPORT_STEP_INCOMPATIBLE);
-    test_assert_true(forward_load_context_get_result(load_context) ==
-                     REPORT_STEP_INCOMPATIBLE);
-
-    forward_load_context_update_result(load_context, REPORT_STEP_INCOMPATIBLE);
-    test_assert_true(forward_load_context_get_result(load_context) ==
-                     REPORT_STEP_INCOMPATIBLE);
 
     forward_load_context_update_result(load_context, LOAD_FAILURE);
     test_assert_true(forward_load_context_get_result(load_context) ==

--- a/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
+++ b/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
@@ -40,7 +40,7 @@ bool check_ecl_sum_compatible(const enkf_main_type *enkf_main) {
     auto error = enkf_state_load_from_forward_model(state, run_arg);
 
     free(job_name);
-    return (REPORT_STEP_INCOMPATIBLE == error) ? false : true;
+    return (LOAD_FAILURE == error) ? false : true;
 }
 
 int main(int argc, char **argv) {

--- a/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
+++ b/libres/old_tests/enkf/test_enkf_state_report_step_compatible.cpp
@@ -37,10 +37,10 @@ bool check_ecl_sum_compatible(const enkf_main_type *enkf_main) {
     state_map_type *state_map = enkf_fs_get_state_map(fs);
     state_map_iset(state_map, 0, STATE_INITIALIZED);
 
-    int error = enkf_state_load_from_forward_model(state, run_arg);
+    auto error = enkf_state_load_from_forward_model(state, run_arg);
 
     free(job_name);
-    return (REPORT_STEP_INCOMPATIBLE & error) ? false : true;
+    return (REPORT_STEP_INCOMPATIBLE == error) ? false : true;
 }
 
 int main(int argc, char **argv) {

--- a/libres/old_tests/enkf/test_enkf_state_skip_summary_load.cpp
+++ b/libres/old_tests/enkf/test_enkf_state_skip_summary_load.cpp
@@ -38,13 +38,13 @@ bool check_ecl_sum_loaded(const enkf_main_type *enkf_main) {
     state_map_type *state_map = enkf_fs_get_state_map(fs);
     state_map_iset(state_map, 0, STATE_INITIALIZED);
 
-    int error = enkf_state_load_from_forward_model(state1, run_arg1);
+    auto error = enkf_state_load_from_forward_model(state1, run_arg1);
 
     state_map_iset(state_map, 1, STATE_INITIALIZED);
     error = enkf_state_load_from_forward_model(state2, run_arg2);
 
     free(job_name);
-    return (0 == error);
+    return (error == LOAD_SUCCESSFUL);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Before the forward model would retry if there was an inconsistent
time map. However a retry is very unlikely to help as the user most
likely has an out of sync ref.case that will not change. This means
that they dont have to rerun things that can not pass.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
