### PR TITLE
Refactor loading parameter matrices out of make_update_data

### DIFF
--- a/libres/lib/include/ert/analysis/update.hpp
+++ b/libres/lib/include/ert/analysis/update.hpp
@@ -21,44 +21,23 @@ namespace analysis {
 class update_data_type : public std::enable_shared_from_this<update_data_type> {
 public:
     update_data_type() = default;
-    update_data_type(
-        Eigen::MatrixXd S_in, Eigen::MatrixXd E_in, Eigen::MatrixXd D_in,
-        Eigen::MatrixXd R_in, std::optional<Eigen::MatrixXd> A_in,
-        std::vector<std::pair<Eigen::MatrixXd, std::shared_ptr<RowScaling>>>
-            A_with_rowscaling_in,
-        const std::vector<bool> &obs_mask_in,
-        const UpdateSnapshot &update_snapshot_in)
+    update_data_type(Eigen::MatrixXd S_in, Eigen::MatrixXd E_in,
+                     Eigen::MatrixXd D_in, Eigen::MatrixXd R_in,
+                     const std::vector<bool> &obs_mask_in,
+                     const UpdateSnapshot &update_snapshot_in)
         : S(std::move(S_in)), E(std::move(E_in)), D(std::move(D_in)),
-          R(std::move(R_in)), A(std::move(A_in)),
-          obs_mask(std::move(obs_mask_in)),
-          update_snapshot(std::move(update_snapshot_in)),
-          A_with_rowscaling(std::move(A_with_rowscaling_in)) {
+          R(std::move(R_in)), obs_mask(std::move(obs_mask_in)),
+          update_snapshot(std::move(update_snapshot_in)) {
         has_observations = true;
-    }
-
-    // These functions are needed for pybind to return a writable numpy array
-    // using pybind.
-    Eigen::Ref<Eigen::MatrixXd> get_A() { return A.value(); }
-    std::vector<
-        std::pair<Eigen::Ref<Eigen::MatrixXd>, std::shared_ptr<RowScaling>>>
-    get_A_with_rowscaling() {
-        std::vector<
-            std::pair<Eigen::Ref<Eigen::MatrixXd>, std::shared_ptr<RowScaling>>>
-            tmp;
-        for (auto &[A, row_scaling] : A_with_rowscaling)
-            tmp.push_back({A, row_scaling});
-        return tmp;
     }
 
     Eigen::MatrixXd S;
     Eigen::MatrixXd E;
     Eigen::MatrixXd D;
     Eigen::MatrixXd R;
-    std::optional<Eigen::MatrixXd> A;
     std::vector<bool> obs_mask;
     UpdateSnapshot update_snapshot;
-    std::vector<std::pair<Eigen::MatrixXd, std::shared_ptr<RowScaling>>>
-        A_with_rowscaling;
+
     bool has_observations = false;
 };
 

--- a/res/enkf/es_update.py
+++ b/res/enkf/es_update.py
@@ -75,8 +75,6 @@ def analysis_smoother_update(
             analysis_config,
             ens_mask,
             update_step.observation_config(),
-            update_step.parameters,
-            update_step.row_scaling_parameters,
             shared_rng,
         )
         # pylint: disable=unsupported-assignment-operation
@@ -95,18 +93,27 @@ def analysis_smoother_update(
             2. The second chunk is loop over all the parameters which have row
                 scaling attached. These parameters are updated one at a time.
             """
+            A = update.load_parameters(
+                target_fs, ensemble_config, iens_active_index, update_step.parameters
+            )
+            A_with_rowscaling = update.load_row_scaling_parameters(
+                target_fs,
+                ensemble_config,
+                iens_active_index,
+                update_step.row_scaling_parameters,
+            )
 
             module_config = analysis_module.get_module_config(module)
             module_data = analysis_module.get_module_data(module)
 
-            if update_data.A is not None:
+            if A is not None:
                 if module_config.iterable:
                     ies.init_update(module_data, ens_mask, update_data.obs_mask)
                     iteration_nr = module_data.inc_iteration_nr()
 
                     ies.update_A(
                         module_data,
-                        update_data.get_A(),
+                        A,
                         update_data.S,
                         update_data.R,
                         update_data.E,
@@ -121,20 +128,28 @@ def analysis_smoother_update(
                         update_data.R,
                         update_data.E,
                         update_data.D,
-                        update_data.A,
+                        A,
                         ies_inversion=module_config.inversion,
                         truncation=module_config.get_truncation(),
                     )
-                    update_data.A = update_data.A @ X
+                    A = A @ X
 
-            if update_data.A_with_rowscaling:
+                update.save_parameters(
+                    target_fs,
+                    ensemble_config,
+                    iens_active_index,
+                    update_step.parameters,
+                    A,
+                )
+
+            if A_with_rowscaling:
                 if module_config.iterable:
                     raise ErtAnalysisError(
                         "Sorry - row scaling for distance based "
                         "localization can not be combined with "
                         "analysis modules which update the A matrix"
                     )
-                for (A, row_scaling) in update_data.get_A_with_rowscaling():
+                for (A, row_scaling) in A_with_rowscaling:
                     X = ies.make_X(
                         update_data.S,
                         update_data.R,
@@ -146,14 +161,13 @@ def analysis_smoother_update(
                     )
                     row_scaling.multiply(A, X)
 
-            update.save_parameters(
-                target_fs,
-                ensemble_config,
-                iens_active_index,
-                update_step.parameters,
-                update_step.row_scaling_parameters,
-                update_data,
-            )
+                update.save_row_scaling_parameters(
+                    target_fs,
+                    ensemble_config,
+                    iens_active_index,
+                    update_step.row_scaling_parameters,
+                    A_with_rowscaling,
+                )
 
         else:
             raise ErtAnalysisError(


### PR DESCRIPTION
The loading and saving of paramter matrices are binded to python
and called directly from es_update

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
