### PR TITLE
FIx usage of manylinux2014 in the github actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Build Linux Wheel
-      uses: docker://quay.io/pypa/manylinux2014_x86_64:2022-04-03-da6ecb3
+      uses: docker://quay.io/pypa/manylinux2014_x86_64
       with:
         entrypoint: /github/workspace/ci/github/build_linux_wheel.sh
         args: ${{ matrix.python-version }}

--- a/ci/github/build_linux_wheel.sh
+++ b/ci/github/build_linux_wheel.sh
@@ -13,6 +13,8 @@ case "$1" in
         ;;
 esac
 
+git config --global --add safe.directory /github/workspace
+
 # Build wheel
 cd /github/workspace
 /opt/python/$pyver/bin/pip wheel . --no-deps -w wheelhouse


### PR DESCRIPTION
**Issue**
Resolves #3282


**Approach**
Solution can be found in: https://github.com/pypa/manylinux/issues/1309

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
