### PR TITLE
Introduce basic experiment server

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -130,3 +130,6 @@ ignore_missing_imports = True
 
 [mypy-prefect.*]
 ignore_missing_imports = True
+
+[mypy-ruamel]
+ignore_missing_imports = True

--- a/docs/rst/manual/api_reference/experiment_server.rst
+++ b/docs/rst/manual/api_reference/experiment_server.rst
@@ -1,0 +1,28 @@
+Experiment Server reference
+===========================
+
+.. automodule:: ert.experiment_server
+    :members:
+    :undoc-members:
+
+.. automodule:: ert.experiment_server._experiment_protocol
+    :members:
+    :undoc-members:
+
+.. automodule:: ert.experiment_server._registry
+    :members:
+    :undoc-members:
+    :private-members:
+
+.. automodule:: ert.experiment_server._state_machine
+    :members:
+    :undoc-members:
+    :private-members:
+
+.. autoclass:: ert.ensemble_evaluator.evaluator_connection_info.EvaluatorConnectionInfo
+    :members:
+    :undoc-members:
+
+.. autoclass:: ert_shared.ensemble_evaluator.config.EvaluatorServerConfig
+    :members:
+    :undoc-members:

--- a/docs/rst/manual/api_reference/index.rst
+++ b/docs/rst/manual/api_reference/index.rst
@@ -7,3 +7,4 @@
   config_plugins
   workspace
   data
+  experiment_server

--- a/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/ert/ensemble_evaluator/builder/_ensemble.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
 
@@ -18,6 +19,7 @@ from ert_shared.ensemble_evaluator.client import Client
 from ._realization import _Realization
 
 if TYPE_CHECKING:
+    import asyncio
     from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 
 logger = logging.getLogger(__name__)
@@ -37,6 +39,9 @@ class _Ensemble:
         return f"Ensemble with {len(self.reals)} members"
 
     def evaluate(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
+        pass
+
+    async def evaluate_async(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
         pass
 
     def cancel(self) -> None:
@@ -73,6 +78,23 @@ class _Ensemble:
     ) -> None:
         async with Client(url, token, cert, max_retries=retries) as client:
             await client._send(to_json(event, data_marshaller=evaluator_marshaller))
+
+    # TODO: make legacy-only?
+    # See https://github.com/equinor/ert/issues/3456
+    @property
+    @abstractmethod
+    def output_bus(
+        self,
+    ) -> "asyncio.Queue[CloudEvent]":
+        raise NotImplementedError
+
+    # TODO: make legacy-only?
+    # See https://github.com/equinor/ert/issues/3456
+    async def queue_cloudevent(
+        self,
+        event: CloudEvent,
+    ) -> None:
+        self.output_bus.put_nowait(event)
 
     def get_successful_realizations(self) -> int:
         return self._snapshot.get_successful_realizations()

--- a/ert/ensemble_evaluator/builder/_legacy.py
+++ b/ert/ensemble_evaluator/builder/_legacy.py
@@ -2,8 +2,18 @@ import asyncio
 import logging
 import threading
 import uuid
-from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING
+from functools import partial, partialmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from cloudevents.http.event import CloudEvent
 from ert.ensemble_evaluator import identifiers
@@ -22,6 +32,8 @@ if TYPE_CHECKING:
 CONCURRENT_INTERNALIZATION = 10
 
 logger = logging.getLogger(__name__)
+event_logger = logging.getLogger("ert.event_log")
+experiment_logger = logging.getLogger("ert.experiment_server")
 
 
 class _LegacyEnsemble(_Ensemble):
@@ -41,9 +53,12 @@ class _LegacyEnsemble(_Ensemble):
         self._analysis_config = analysis_config
         self._config: Optional["EvaluatorServerConfig"] = None
         self._ee_id: Optional[str] = None
+        self._output_bus: "asyncio.Queue[CloudEvent]" = asyncio.Queue()
 
     def setup_timeout_callback(
-        self, timeout_queue: "asyncio.Queue[CloudEvent]"
+        self,
+        timeout_queue: "asyncio.Queue[CloudEvent]",
+        cloudevent_unary_send: Callable[[CloudEvent], Awaitable[None]],
     ) -> Tuple[Callable[[List[Any]], Any], "asyncio.Task[None]"]:
         def on_timeout(callback_args: Sequence[Any]) -> None:
             run_args: RunArg = callback_args[0]
@@ -62,12 +77,7 @@ class _LegacyEnsemble(_Ensemble):
                 if timeout_cloudevent is None:
                     break
                 assert self._config  # mypy
-                await self.send_cloudevent(
-                    self._config.dispatch_uri,
-                    timeout_cloudevent,
-                    token=self._config.token,
-                    cert=self._config.cert,
-                )
+                await cloudevent_unary_send(timeout_cloudevent)
 
         send_timeout_future = get_event_loop().create_task(send_timeout_message())
 
@@ -100,132 +110,167 @@ class _LegacyEnsemble(_Ensemble):
         if self._config is None:
             raise ValueError("no config")
 
-        async def _evaluate_inner() -> None:
-            """
-            This (inner) coroutine does the actual work. It prepares and
-            executes the necessary bookkeeping, prepares and executes
-            the JobQueue, and dispatches pertinent events.
+        # The cloudevent_unary_send only accepts a cloud event, but in order to
+        # send cloud events over the network, we need token, URI and cert. These are
+        # not known until evaluate() is called and _config is set. So in a hacky
+        # fashion, we create the partialmethod (bound partial) here, after evaluate().
+        # Note that this is the "sync" version of evaluate(), and that the "async"
+        # version uses a different cloudevent_unary_send.
+        self.__class__._ce_unary_send = partialmethod(  # type: ignore
+            self.__class__.send_cloudevent,
+            self._config.dispatch_uri,
+            token=self._config.token,
+            cert=self._config.cert,
+        )
 
-            Before returning, it always dispatches a CloudEvent describing
-            the final result of executing all its jobs through a JobQueue.
-            """
-            # Set up the timeout-mechanism
-            timeout_queue: "asyncio.Queue[CloudEvent]" = asyncio.Queue()
-            on_timeout, send_timeout_future = self.setup_timeout_callback(timeout_queue)
+        get_event_loop().run_until_complete(
+            self._evaluate_inner(
+                cloudevent_unary_send=self._ce_unary_send  # type: ignore
+            )
+        )
+        get_event_loop().close()
 
-            if not self._ee_id:
-                raise ValueError(f"invalid ensemble evaluator id: {self._ee_id}")
-            if not self._config:
-                raise ValueError("no config")  # mypy
+    async def evaluate_async(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
+        self._config = config
+        self._ee_id = ee_id
+        await self._evaluate_inner(
+            cloudevent_unary_send=self.queue_cloudevent,
+            output_bus=self.output_bus,
+        )
 
-            # event for normal evaluation
-            result = CloudEvent(
+    async def _evaluate_inner(
+        self,
+        cloudevent_unary_send: Callable[[CloudEvent], Awaitable[None]],
+        output_bus: Optional["asyncio.Queue[CloudEvent]"] = None,
+    ) -> None:
+        """
+        This (inner) coroutine does the actual work of evaluating the ensemble. It
+        prepares and executes the necessary bookkeeping, prepares and executes
+        the JobQueue, and dispatches pertinent events.
+
+        Before returning, it always dispatches a CloudEvent describing
+        the final result of executing all its jobs through a JobQueue.
+
+        cloudevent_unary_send determines how CloudEvents are dispatched. This
+        is a function (or bound method) that only takes a CloudEvent as a positional
+        argument.
+        """
+        # Set up the timeout-mechanism
+        timeout_queue: "asyncio.Queue[CloudEvent]" = asyncio.Queue()
+        on_timeout, send_timeout_future = self.setup_timeout_callback(
+            timeout_queue, cloudevent_unary_send
+        )
+
+        if not self._ee_id:
+            raise ValueError(f"invalid ensemble evaluator id: {self._ee_id}")
+        if not self._config:
+            raise ValueError("no config")  # mypy
+
+        # event for normal evaluation, will be overwritten later in case of failure
+        # or cancellation
+        result = CloudEvent(
+            {
+                "type": identifiers.EVTYPE_ENSEMBLE_STOPPED,
+                "source": f"/ert/ee/{self._ee_id}/ensemble",
+                "id": str(uuid.uuid1()),
+            }
+        )
+        try:
+            # Dispatch STARTED-event
+            out_cloudevent = CloudEvent(
                 {
-                    "type": identifiers.EVTYPE_ENSEMBLE_STOPPED,
+                    "type": identifiers.EVTYPE_ENSEMBLE_STARTED,
                     "source": f"/ert/ee/{self._ee_id}/ensemble",
                     "id": str(uuid.uuid1()),
                 }
             )
-            try:
-                # Dispatch STARTED-event
-                out_cloudevent = CloudEvent(
-                    {
-                        "type": identifiers.EVTYPE_ENSEMBLE_STARTED,
-                        "source": f"/ert/ee/{self._ee_id}/ensemble",
-                        "id": str(uuid.uuid1()),
-                    }
-                )
-                await self.send_cloudevent(
-                    self._config.dispatch_uri,
-                    out_cloudevent,
-                    token=self._config.token,
-                    cert=self._config.cert,
-                )
+            await cloudevent_unary_send(out_cloudevent)
 
-                # Submit all jobs to queue and inform queue when done
-                for real in self.active_reals:
-                    self._job_queue.add_ee_stage(  # type: ignore
-                        real.steps[0], callback_timeout=on_timeout
+            # Submit all jobs to queue and inform queue when done
+            for real in self.active_reals:
+                self._job_queue.add_ee_stage(  # type: ignore
+                    real.steps[0], callback_timeout=on_timeout
+                )
+            self._job_queue.submit_complete()  # type: ignore
+
+            # TODO: this is sort of a callback being preemptively called.
+            # It should be lifted out of the queue/evaluate, into the evaluator. If
+            # something is long running, the evaluator will know and should send
+            # commands to the task in order to have it killed/retried.
+            # See https://github.com/equinor/ert/issues/1229
+            queue_evaluators = None
+            if (
+                self._analysis_config.get_stop_long_running()
+                and self._analysis_config.minimum_required_realizations > 0
+            ):
+                queue_evaluators = [
+                    partial(
+                        self._job_queue.stop_long_running_jobs,
+                        self._analysis_config.minimum_required_realizations,
                     )
-                self._job_queue.submit_complete()  # type: ignore
+                ]
 
-                # TODO: this is sort of a callback being preemptively called.
-                # It should be lifted out of the queue/evaluate, into the evaluator. If
-                # something is long running, the evaluator will know and should send
-                # commands to the task in order to have it killed/retried.
-                # See https://github.com/equinor/ert/issues/1229
-                queue_evaluators = None
-                if (
-                    self._analysis_config.get_stop_long_running()
-                    and self._analysis_config.minimum_required_realizations > 0
-                ):
-                    queue_evaluators = [
-                        partial(
-                            self._job_queue.stop_long_running_jobs,
-                            self._analysis_config.minimum_required_realizations,
-                        )
-                    ]
+            # Tell queue to pass info to the jobs-file
+            # NOTE: This touches files on disk...
+            self._job_queue.add_ensemble_evaluator_information_to_jobs_file(
+                self._ee_id,
+                self._config.dispatch_uri,
+                self._config.cert,
+                self._config.token,
+            )
 
-                # Tell queue to pass info to the jobs-file
-                # NOTE: This touches files on disk...
-                self._job_queue.add_ensemble_evaluator_information_to_jobs_file(
-                    self._ee_id,
-                    self._config.dispatch_uri,
-                    self._config.cert,
-                    self._config.token,
+            # Finally, run the queue-loop until it finishes or raises
+            sema = threading.BoundedSemaphore(value=CONCURRENT_INTERNALIZATION)
+            if output_bus:
+                await self._job_queue.execute_queue_comms_via_bus(
+                    ee_id=self._ee_id,
+                    pool_sema=sema,
+                    evaluators=queue_evaluators,  # type: ignore
+                    output_bus=output_bus,
                 )
-
-                # Finally, run the queue-loop until it finishes or raises
-                await self._job_queue.execute_queue_async(
+            else:
+                await self._job_queue.execute_queue_via_websockets(
                     self._config.dispatch_uri,
                     self._ee_id,
-                    threading.BoundedSemaphore(value=CONCURRENT_INTERNALIZATION),
+                    sema,
                     queue_evaluators,  # type: ignore
                     cert=self._config.cert,
                     token=self._config.token,
                 )
 
-            except asyncio.CancelledError:
-                logger.debug("ensemble was cancelled")
-                result = CloudEvent(
-                    {
-                        "type": identifiers.EVTYPE_ENSEMBLE_CANCELLED,
-                        "source": f"/ert/ee/{self._ee_id}/ensemble",
-                        "id": str(uuid.uuid1()),
-                    }
-                )
+        except asyncio.CancelledError:
+            logger.debug("ensemble was cancelled")
+            result = CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_ENSEMBLE_CANCELLED,
+                    "source": f"/ert/ee/{self._ee_id}/ensemble",
+                    "id": str(uuid.uuid1()),
+                }
+            )
 
-            except Exception:  # pylint: disable=broad-except
-                logger.exception(
-                    "unexpected exception in ensemble",
-                    exc_info=True,
-                )
-                result = CloudEvent(
-                    {
-                        "type": identifiers.EVTYPE_ENSEMBLE_FAILED,
-                        "source": f"/ert/ee/{self._ee_id}/ensemble",
-                        "id": str(uuid.uuid1()),
-                    }
-                )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "unexpected exception in ensemble",
+                exc_info=True,
+            )
+            result = CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_ENSEMBLE_FAILED,
+                    "source": f"/ert/ee/{self._ee_id}/ensemble",
+                    "id": str(uuid.uuid1()),
+                }
+            )
 
-            else:
-                logger.debug("ensemble finished normally")
+        else:
+            logger.debug("ensemble finished normally")
 
-            finally:
-                await timeout_queue.put(None)  # signal to exit timer
-                await send_timeout_future
+        finally:
+            await timeout_queue.put(None)  # signal to exit timer
+            await send_timeout_future
 
-                # Dispatch final result from evaluator - FAILED, CANCEL or STOPPED
-                assert self._config  # mypy
-                await self.send_cloudevent(
-                    self._config.dispatch_uri,
-                    result,
-                    token=self._config.token,
-                    cert=self._config.cert,
-                )
-
-        get_event_loop().run_until_complete(_evaluate_inner())
-        get_event_loop().close()
+            # Dispatch final result from evaluator - FAILED, CANCEL or STOPPED
+            assert self._config  # mypy
+            await cloudevent_unary_send(result)
 
     @property
     def cancellable(self) -> bool:
@@ -234,3 +279,9 @@ class _LegacyEnsemble(_Ensemble):
     def cancel(self) -> None:
         self._job_queue.kill_all_jobs()
         logger.debug("evaluator cancelled")
+
+    @property
+    def output_bus(
+        self,
+    ) -> "asyncio.Queue[CloudEvent]":
+        return self._output_bus

--- a/ert/ensemble_evaluator/builder/_prefect.py
+++ b/ert/ensemble_evaluator/builder/_prefect.py
@@ -183,6 +183,15 @@ class PrefectEnsemble(_Ensemble):  # pylint: disable=too-many-instance-attribute
         self._iens_to_task = {}  # type: ignore
         self._allow_cancel = multiprocessing.Event()
 
+    @property
+    def output_bus(
+        self,
+    ) -> "asyncio.Queue[CloudEvent]":
+        # TODO: the prefect ensemble needs to return the multiprocessing.Queue or keep
+        # using websockets. See https://github.com/equinor/ert/issues/3456
+        # It cannot use asyncio.Queue as it is unpicklable.
+        raise NotImplementedError
+
     def get_flow(self, ee_id: str, iens_range: List[int]) -> Any:
         with Flow(f"Realization range {iens_range}") as flow:
             # one map pr flow (real-batch)

--- a/ert/ensemble_evaluator/identifiers.py
+++ b/ert/ensemble_evaluator/identifiers.py
@@ -113,3 +113,12 @@ EVGROUP_ENSEMBLE = {
     EVTYPE_ENSEMBLE_CANCELLED,
     EVTYPE_ENSEMBLE_FAILED,
 }
+
+EVTYPE_EXPERIMENT_STARTED = "com.equinor.ert.experiment.started"
+EVTYPE_EXPERIMENT_SUCCEEDED = "com.equinor.ert.experiment.succeeded"
+EVTYPE_EXPERIMENT_FAILED = "com.equinor.ert.experiment.failed"
+EVTYPE_EXPERIMENT_CANCELLED = "com.equinor.ert.experiment.cancelled"
+EVTYPE_EXPERIMENT_HOOK_STARTED = "com.equinor.ert.experiment.hook_started"
+EVTYPE_EXPERIMENT_HOOK_ENDED = "com.equinor.ert.experiment.hook_ended"
+EVTYPE_EXPERIMENT_ANALYSIS_STARTED = "com.equinor.ert.experiment.analysis_started"
+EVTYPE_EXPERIMENT_ANALYSIS_ENDED = "com.equinor.ert.experiment.analysis_ended"

--- a/ert/experiment_server/__init__.py
+++ b/ert/experiment_server/__init__.py
@@ -1,0 +1,27 @@
+"""
+The experiment_server package provides facilities for creating, managing and
+running experiments, as well as defining protocols for orderly and meaningful
+communication between distributed parts of ERT.
+
+This package defines the following:
+
+ - An Experiment protocol [1] which all experiments are expected to implement
+ - The communication protocols for communication between: 1) the client (GUI,
+   CLI, and other stakeholders) and the server, 2) the server and remote
+   workers.
+ - an API for creating, managing and running experiments.
+
+.. note::
+   The experiment server is currently under active design and development,
+   and is considered experimental.
+
+
+[1] see https://peps.python.org/pep-0544/ for information about protocols
+"""
+from ._server import ExperimentServer
+from ._state_machine import ExperimentStateMachine
+
+__all__ = (
+    "ExperimentServer",
+    "ExperimentStateMachine",
+)

--- a/ert/experiment_server/_experiment_protocol.py
+++ b/ert/experiment_server/_experiment_protocol.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING
+from typing_extensions import Protocol
+from cloudevents.http import CloudEvent
+
+if TYPE_CHECKING:
+    from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+
+
+class Experiment(Protocol):
+    """The experiment protocol which all experiments must implement."""
+
+    async def run(self, evaluator_server_config: "EvaluatorServerConfig") -> None:
+        """Run the experiment to completion."""
+        pass
+
+    @property
+    def id_(self) -> str:
+        """The id of the experiment."""
+        pass
+
+    @id_.setter
+    def id_(self, value: str) -> None:
+        """Set the of the experiment to ``value``. It should not be possible
+        to set this more than once."""
+        pass
+
+    async def dispatch(self, event: CloudEvent, iter_: int) -> None:
+        """dispatch(self, event, iter_: int) -> None
+
+        event is a ``CloudEvent`` https://github.com/cloudevents/sdk-python
+
+        Pass an event for ``iter_`` to the experiment. The experiment will internalize
+        the event and update its state."""
+        pass
+
+    # TODO: this is preliminary, see https://github.com/equinor/ert/issues/3407
+    async def successful_realizations(self, iter_: int) -> int:
+        """Return the amount of successful realizations."""
+        pass

--- a/ert/experiment_server/_registry.py
+++ b/ert/experiment_server/_registry.py
@@ -1,0 +1,34 @@
+from typing import Dict, List
+from ._experiment_protocol import Experiment
+
+
+class _Registry:
+    """:class:`_Registry` is a registry for registering experiments to be run
+    or managed by the :class:`ert.experiment_server._server.ExperimentServer`.
+    The registry should be manageable, but also be queryable by the
+    :class:`ert.experiment_server._server.ExperimentServer`. The class's
+    purpose is to decouple grunt tasks like managing the registry from the more
+    complex task of implementing an API on top of it.
+    """
+
+    def __init__(self) -> None:
+        self._experiments: Dict[str, Experiment] = {}
+
+    def add_experiment(self, experiment: Experiment) -> str:
+        """Add an experiment to the registry.
+
+        An id is generated here, but it should share (or receive) this ID from
+        ert-storage. See [1].
+
+        [1] https://github.com/equinor/ert/issues/3437#issue-1247962008
+        """
+        experiment_id = str(len(self._experiments.keys()))
+        self._experiments[experiment_id] = experiment
+        return experiment_id
+
+    @property
+    def all_experiments(self) -> List[Experiment]:
+        return list(self._experiments.values())
+
+    def get_experiment(self, experiment_id: str) -> Experiment:
+        return self._experiments[experiment_id]

--- a/ert/experiment_server/_server.py
+++ b/ert/experiment_server/_server.py
@@ -1,0 +1,185 @@
+import asyncio
+import logging
+import pickle
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, Set
+
+from cloudevents.exceptions import DataUnmarshallerError
+from cloudevents.http import from_json
+from websockets.legacy.server import WebSocketServerProtocol
+from websockets.server import serve
+from ert.serialization import evaluator_unmarshaller
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+from res.enkf.enkf_main import EnKFMain
+
+from ._experiment_protocol import Experiment
+from ._registry import _Registry
+
+
+logger = logging.getLogger(__name__)
+event_logger = logging.getLogger("ert.event_log")
+
+
+class ExperimentServer:
+    """:class:`ExperimentServer` implements the experiment server API, allowing
+    creation, management and running of experiments as defined by the
+    :class:`ert.experiment_server._experiment_protocol.Experiment` protocol.
+
+    :class:`ExperimentServer` also runs a server to which clients and remote
+    workers can connect.
+    """
+
+    def __init__(self, ee_config: EvaluatorServerConfig) -> None:
+        self._config = ee_config
+        self._registry = _Registry()
+        self._clients: Set[WebSocketServerProtocol] = set()
+        self._server_done = asyncio.get_running_loop().create_future()
+        self._server_task = asyncio.create_task(self._server())
+
+    async def _handler(self, websocket: WebSocketServerProtocol, path: str) -> None:
+        elements = path.split("/")
+        if elements[1] == "client":
+            await self.handle_client(websocket, path)
+        elif elements[1] == "dispatch":
+            logger.debug("dispatcher connected")
+            await self.handle_dispatch(websocket, path)
+        else:
+            logger.info(f"Connection attempt to unknown path: {path}.")
+
+    async def stop(self) -> None:
+        """Stop the server."""
+        logger.debug("stopping experiment server gracefully...")
+        try:
+            self._server_done.set_result(None)
+        except asyncio.InvalidStateError:
+            logger.debug("was already gracefully asked to stop.")
+            pass
+        await self._server_task
+
+    async def handle_dispatch(
+        self, websocket: WebSocketServerProtocol, path: str
+    ) -> None:
+        """handle_dispatch(self, websocket, path: str)
+
+        Handle incoming "dispatch" connections, which refers to remote workers.
+
+        websocket is a https://websockets.readthedocs.io/en/stable/reference/server.html#websockets.server.WebSocketServerProtocol  # pylint: disable=line-too-long
+        """
+        async for msg in websocket:
+            try:
+                event = from_json(msg, data_unmarshaller=evaluator_unmarshaller)
+            except DataUnmarshallerError:
+                event = from_json(msg, data_unmarshaller=pickle.loads)
+
+            event_logger.debug("handle_dispatch: %s", event)
+
+            await self._registry.all_experiments[0].dispatch(event, 0)
+
+    @contextmanager
+    def store_client(
+        self, websocket: WebSocketServerProtocol
+    ) -> Generator[None, None, None]:
+        """store_client(self, websocket)
+
+        Context manager for a client connection handler, allowing to know how
+        many clients are connected."""
+        logger.debug("client %s connected", websocket)
+        self._clients.add(websocket)
+        yield
+        self._clients.remove(websocket)
+
+    # pylint: disable=line-too-long
+    async def handle_client(
+        self, websocket: WebSocketServerProtocol, path: str
+    ) -> None:
+        """handle_client(self, websocket, path: str)
+
+        Handle incoming client connections. websocket is a https://websockets.readthedocs.io/en/stable/reference/server.html#websockets.server.WebSocketServerProtocol  # pylint: disable=line-too-long
+        """
+        with self.store_client(websocket):
+            async for message in websocket:
+                client_event = from_json(
+                    message, data_unmarshaller=evaluator_unmarshaller
+                )
+                logger.debug(f"got message from client: {client_event}")
+
+    async def _server(self) -> None:
+        try:
+            async with serve(
+                self._handler,
+                sock=self._config.get_socket(),
+                ssl=self._config.get_server_ssl_context(),
+            ):
+                logger.debug("Running experiment server")
+                await self._server_done
+            logger.debug("Async server exiting.")
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("crash/burn")
+
+    # pylint: disable=line-too-long
+    def add_legacy_experiment(  # pylint: disable=too-many-arguments
+        self,
+        ert: EnKFMain,
+        ensemble_size: int,
+        current_case_name: str,
+        args: Any,
+        factory: Callable[[EnKFMain, int, str, Any], Experiment],
+    ) -> str:
+        """add_legacy_experiment(self, ert, ensemble_size: int,current_case_name: str, factory: Callable[[Any, int, str, Any], Experiment])
+
+        The ert parameter, as well as the first input parameter in the factory
+        :class:`Callable`, refers to the EnkfMain type.
+
+        Create a legacy experiment using a model factory. See ``ert_shared.cli.model_factory.create_model``.
+        """
+        experiment = factory(
+            ert,
+            ensemble_size,
+            current_case_name,
+            args,
+        )
+        experiment.id_ = self._registry.add_experiment(experiment)
+        return experiment.id_
+
+    def add_experiment(self, experiment: Experiment) -> str:
+        experiment.id_ = self._registry.add_experiment(experiment)
+        return experiment.id_
+
+    async def run_experiment(self, experiment_id: str) -> None:
+        """Run the experiment with the given experiment_id.
+
+        This is a helper method for use by the CLI, where only one experiment
+        at a time makes sense. This method therefore runs the experiment, and
+        attempts to gracefully shut down the server when complete."""
+        logger.debug("running experiment %s", experiment_id)
+        experiment = self._registry.get_experiment(experiment_id)
+
+        experiment_task = asyncio.create_task(experiment.run(self._config))
+
+        done, pending = await asyncio.wait(
+            [self._server_task, experiment_task], return_when=asyncio.FIRST_COMPLETED
+        )
+
+        if experiment_task in done:
+            logger.debug("experiment %s was done", experiment_id)
+            # raise experiment exception if any
+            try:
+                experiment_task.result()
+                successful_reals = await experiment.successful_realizations(0)
+                # This is currently API
+                print(f"Successful realizations: {successful_reals}")
+            except Exception as e:  # pylint: disable=broad-except
+                print(f"Experiment failed: {str(e)}")
+                raise
+            finally:
+                # wait for shutdown of server
+                await self.stop()
+            return
+
+        # experiment is pending, but the server died, so try cancelling the experiment
+        # then raise the server's exception
+        for p in pending:
+            logger.debug("task %s was pending, cancelling...", p)
+            p.cancel()
+        for d in done:
+            d.result()

--- a/ert/experiment_server/_state_machine.py
+++ b/ert/experiment_server/_state_machine.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+from typing import Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ExperimentStateMachine:
+    """The :class:`ExperimentStateMachine` implements a state machine for the
+    entire experiment. It allows an experiment to track its own state and
+    communicate it to others."""
+
+    def __init__(self) -> None:
+        self._ensemble_to_successful_realizations: Dict[int, List[int]] = defaultdict(
+            list
+        )
+
+    def successful_realizations(self, iter_: int) -> int:
+        """Return an integer indicating the number of successful realizations
+        in an ensemble given ``iter_``. Raise :class:`IndexError` if the
+        ensemble has no successful realizations."""
+        return len(self._ensemble_to_successful_realizations[iter_])
+
+    def add_successful_realization(self, iter_: int, real: int) -> None:
+        """Add a successful realization for realization ``real`` for iteration
+        ``iter_``."""
+        logger.debug("adding successful real for iter %d, real: %d", iter_, real)
+        if real not in self._ensemble_to_successful_realizations[iter_]:
+            self._ensemble_to_successful_realizations[iter_].append(real)

--- a/ert_logging/logger.conf
+++ b/ert_logging/logger.conf
@@ -10,12 +10,48 @@ handlers:
     level: DEBUG
     formatter: simple_with_threading
     filename: ert-log.txt
+  experiment_server_file:
+    class: ert_logging.TimestampedFileHandler
+    level: DEBUG
+    formatter: simple_with_threading
+    filename: experiment-log.txt
+  asyncio_file:
+    class: ert_logging.TimestampedFileHandler
+    level: DEBUG
+    formatter: simple_with_threading
+    filename: asyncio-log.txt
+  event_log_file:
+    class: ert_logging.TimestampedFileHandler
+    level: DEBUG
+    formatter: simple_with_threading
+    filename: event-log.txt
+  apifile:
+    class: ert_logging.TimestampedFileHandler
+    level: DEBUG
+    formatter: simple
+    filename: api-log.txt
   eefile:
     class: ert_logging.TimestampedFileHandler
     level: DEBUG
     formatter: simple_with_threading
     filename: ee-log.txt
+  stream:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple_with_threading
 loggers:
+  asyncio:
+    level: DEBUG
+    handlers: [asyncio_file]
+    propagate: no
+  ert_shared.storage:
+    level: DEBUG
+    handlers: [apifile]
+    propagate: yes
+  ert.event_log:
+    level: DEBUG
+    handlers: [event_log_file]
+    propagate: no
   ert_shared.status:
     level: DEBUG
     handlers: [file]
@@ -27,6 +63,10 @@ loggers:
   websockets.server:
     level: ERROR
     handlers: [eefile]
+    propagate: yes
+  ert.experiment_server:
+    level: DEBUG
+    handlers: [experiment_server_file]
     propagate: yes
   res:
     level: DEBUG

--- a/ert_shared/cli/main.py
+++ b/ert_shared/cli/main.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+import asyncio
 import logging
 import os
 import sys
 import threading
+from typing import Any
 from ert.ensemble_evaluator import EvaluatorTracker
+from ert_shared.feature_toggling import FeatureToggling
 
 from ert_shared.cli import (
     ENSEMBLE_SMOOTHER_MODE,
@@ -43,6 +46,25 @@ def run_cli(args):
     if args.mode == WORKFLOW_MODE:
         execute_workflow(ert, args.name)
         return
+
+    evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)
+
+    if FeatureToggling.is_enabled("experiment-server"):
+        # TODO: need to perform same case checks as for non-experiment-server.
+        # TODO: asyncio.run should be called once in ert_shared/main.py
+        # see https://github.com/equinor/ert/issues/3443 for both of these TODOs
+        asyncio.run(
+            _run_cli_async(
+                ert,
+                facade.get_ensemble_size(),
+                facade.get_current_case_name(),
+                args,
+                evaluator_server_config,
+            ),
+            debug=True,
+        )
+        return
+
     model = create_model(
         ert,
         facade.get_ensemble_size(),
@@ -63,8 +85,6 @@ def run_cli(args):
             f"They were both: {args.target_case}."
         )
         raise ErtCliError(msg)
-
-    evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)
 
     thread = threading.Thread(
         name="ert_cli_simulation_thread",
@@ -93,3 +113,19 @@ def run_cli(args):
 
     if model.hasRunFailed():
         raise ErtCliError(model.getFailMessage())
+
+
+async def _run_cli_async(
+    ert: EnKFMain,
+    ensemble_size: int,
+    current_case_name: str,
+    args: Any,
+    ee_config: EvaluatorServerConfig,
+):
+    from ert.experiment_server import ExperimentServer  # noqa
+
+    experiment_server = ExperimentServer(ee_config)
+    experiment_id = experiment_server.add_legacy_experiment(
+        ert, ensemble_size, current_case_name, args, create_model
+    )
+    await experiment_server.run_experiment(experiment_id=experiment_id)

--- a/ert_shared/feature_toggling.py
+++ b/ert_shared/feature_toggling.py
@@ -17,6 +17,13 @@ class FeatureToggling:
                 "Thank you for testing our new features."
             ),
         ),
+        "experiment-server": _Feature(
+            default_enabled=False,
+            msg=(
+                "The experiment server is a step towards becoming Cloud Native. "
+                "Thanks for testing."
+            ),
+        ),
     }
 
     _conf = deepcopy(_conf_original)

--- a/ert_shared/main.py
+++ b/ert_shared/main.py
@@ -496,6 +496,13 @@ def main():
             context.plugin_manager.add_logging_handle_to_root(logging.getLogger())
             logger.info(f"Running ert with {args}")
             log_config(args.config, logger)
+
+            if FeatureToggling.is_enabled("experiment-server"):
+                if args.mode != ENSEMBLE_EXPERIMENT_MODE:
+                    raise NotImplementedError(
+                        f"experiment-server can only run '{ENSEMBLE_EXPERIMENT_MODE}'"
+                    )
+
             args.func(args)
     except ErtCliError as err:
         logger.exception(str(err))

--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -1,29 +1,32 @@
+import asyncio
+import concurrent
 import logging
-from contextlib import contextmanager
-
 import time
 import uuid
-from typing import Optional, List, Union, Dict, Any, Iterator
-import asyncio
+from abc import abstractmethod
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Union
 
-from res.enkf import EnKFMain, QueueConfig
-from res.enkf.ert_run_context import ErtRunContext
-from res.job_queue import (
-    RunStatusType,
-    ForwardModel,
-)
-from ert_shared.libres_facade import LibresFacade
-from ert_shared.feature_toggling import feature_enabled
-from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
+from cloudevents.http import CloudEvent
+from ert.ensemble_evaluator import Ensemble, EnsembleBuilder, identifiers
+from ert.ensemble_evaluator.util._tool import get_real_id
+from ert.experiment_server import ExperimentStateMachine
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+from ert_shared.ensemble_evaluator.evaluator import EnsembleEvaluator
+from ert_shared.feature_toggling import feature_enabled
+from ert_shared.libres_facade import LibresFacade
 from ert_shared.storage.extraction import (
     post_ensemble_data,
     post_ensemble_results,
     post_update_data,
 )
-from ert.ensemble_evaluator import (
-    EnsembleBuilder,
-)
+from res.enkf import EnKFMain, QueueConfig
+from res.enkf.enkf_simulation_runner import EnkfSimulationRunner
+from res.enkf.ert_run_context import ErtRunContext
+from res.job_queue import ForwardModel, RunStatusType
+
+event_logger = logging.getLogger("ert.event_log")
+experiment_logger = logging.getLogger("ert.experiment_server.base_run_model")
 
 
 class ErtRunError(Exception):
@@ -92,6 +95,10 @@ class BaseRunModel:
         self.facade = LibresFacade(ert)
         self._simulation_arguments = simulation_arguments
         self.reset()
+
+        # experiment-server
+        self._id: Optional[str] = None
+        self._state_machine = ExperimentStateMachine()
 
     def ert(self) -> EnKFMain:
         return self._ert
@@ -318,6 +325,136 @@ class BaseRunModel:
 
         run_context.get_sim_fs().fsync()
         return totalOk
+
+    async def _evaluate(
+        self, run_context: ErtRunContext, ee_config: EvaluatorServerConfig
+    ) -> None:
+        """Start asynchronous evaluation of an ensemble."""
+        experiment_logger.debug("_evaluate")
+        loop = asyncio.get_running_loop()
+        if run_context.get_step():
+            self.ert().eclConfig().assert_restart()
+        experiment_logger.debug("building...")
+        ensemble = EnsembleBuilder.from_legacy(
+            run_context,
+            self.get_forward_model(),
+            self._queue_config,
+            self.ert().analysisConfig(),
+            self.ert().resConfig(),
+        ).build()
+        experiment_logger.debug("built")
+
+        ensemble_listener = asyncio.create_task(
+            self._ensemble_listener(ensemble, iter_=run_context.get_iter())
+        )
+
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            await loop.run_in_executor(
+                pool,
+                self.ert().initRun,
+                run_context,
+            )
+
+            await ensemble.evaluate_async(ee_config, self.id_)
+
+            await ensemble_listener
+
+            for iens, run_arg in enumerate(run_context):
+                if run_context.is_active(iens):
+                    if run_arg.run_status in (
+                        RunStatusType.JOB_LOAD_FAILURE,
+                        RunStatusType.JOB_RUN_FAILURE,
+                    ):
+                        run_context.deactivate_realization(iens)
+
+            await loop.run_in_executor(
+                pool,
+                run_context.get_sim_fs().fsync,
+            )
+
+    @abstractmethod
+    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+        raise NotImplementedError
+
+    async def successful_realizations(self, iter_: int) -> int:
+        return self._state_machine.successful_realizations(iter_)
+
+    async def _run_hook(
+        self,
+        hook: int,  # HookRuntime
+        iter_: int,
+        loop: asyncio.AbstractEventLoop,
+        executor: concurrent.futures.Executor,
+    ) -> None:
+        # Send HOOK_STARTED
+        await self.dispatch(
+            CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_EXPERIMENT_HOOK_STARTED,
+                    "source": f"/ert/experiment/{self.id_}",
+                    "id": str(uuid.uuid1()),
+                },
+                {
+                    "name": str(hook),
+                },
+            ),
+            iter_,
+        )
+
+        # Run hook
+        await loop.run_in_executor(
+            executor,
+            EnkfSimulationRunner.runWorkflows,
+            hook,
+            self.ert(),
+        )
+
+        # Send HOOK_ENDED
+        await self.dispatch(
+            CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_EXPERIMENT_HOOK_ENDED,
+                    "source": f"/ert/experiment/{self.id_}",
+                    "id": str(uuid.uuid1()),
+                },
+                {
+                    "name": str(hook),
+                },
+            ),
+            iter_,
+        )
+
+    @property
+    def id_(self) -> str:
+        if not self._id:
+            raise RuntimeError(f"{self} does not have an ID")
+        return self._id
+
+    @id_.setter
+    def id_(self, value: str) -> None:
+        if self._id is not None:
+            raise ValueError("experiment id can only be set once")
+        self._id = value
+
+    async def _ensemble_listener(self, ensemble: Ensemble, iter_: int) -> None:
+        """Redirect events emitted by the ensemble to this experiment."""
+        while True:
+            event: CloudEvent = await ensemble.output_bus.get()
+            await self.dispatch(event, iter_)
+            if event["type"] in (
+                identifiers.EVTYPE_ENSEMBLE_FAILED,
+                identifiers.EVTYPE_ENSEMBLE_CANCELLED,
+                identifiers.EVTYPE_ENSEMBLE_STOPPED,
+            ):
+                break
+
+    async def dispatch(self, event: CloudEvent, iter_: int) -> None:
+        event_logger.debug(
+            "dispatch: %s (experiment: %s, iter: %d)", event, self.id_, iter_
+        )
+        if event["type"] == identifiers.EVTYPE_FM_STEP_SUCCESS:
+            real = int(get_real_id(event["source"]))
+            self._state_machine.add_successful_realization(iter_, real)
 
     def get_forward_model(self) -> ForwardModel:
         return self.ert().resConfig().model_config.getForwardModel()

--- a/ert_shared/models/ensemble_experiment.py
+++ b/ert_shared/models/ensemble_experiment.py
@@ -1,10 +1,19 @@
+import logging
+import concurrent
+import asyncio
+from ert_shared.models.base_run_model import ErtRunError
 from res.enkf.enkf_main import EnKFMain, QueueConfig
 from res.enkf.enums import HookRuntime
 from res.enkf import ErtRunContext, EnkfSimulationRunner
-
+import uuid
 from ert_shared.models import BaseRunModel
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
 from typing import Dict, Any
+from ert.ensemble_evaluator import identifiers
+
+from cloudevents.http import CloudEvent
+
+experiment_logger = logging.getLogger("ert.experiment_server.ensemble_experiment")
 
 
 class EnsembleExperiment(BaseRunModel):
@@ -15,6 +24,93 @@ class EnsembleExperiment(BaseRunModel):
         queue_config: QueueConfig,
     ):
         super().__init__(simulation_arguments, ert, queue_config)
+
+    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+
+        # Send EXPERIMENT_STARTED
+        experiment_logger.debug("starting ensemble experiment")
+        await self.dispatch(
+            CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_EXPERIMENT_STARTED,
+                    "source": f"/ert/experiment/{self.id_}",
+                    "id": str(uuid.uuid1()),
+                }
+            ),
+            0,
+        )
+
+        loop = asyncio.get_running_loop()
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            run_context = await loop.run_in_executor(executor, self.create_context)
+
+            # Create runpaths
+            experiment_logger.debug("creating runpaths")
+            await loop.run_in_executor(
+                executor,
+                self.ert().getEnkfSimulationRunner().createRunPath,
+                run_context,
+            )
+
+            ensemble_id = await loop.run_in_executor(executor, self._post_ensemble_data)
+
+            await self._run_hook(
+                HookRuntime.PRE_SIMULATION, run_context.get_iter(), loop, executor
+            )
+
+            # Evaluate
+            experiment_logger.debug("evaluating")
+            await self._evaluate(run_context, evaluator_server_config)
+
+            num_successful_realizations = self._state_machine.successful_realizations(
+                run_context.get_iter()
+            )
+
+            num_successful_realizations += self._simulation_arguments.get(
+                "prev_successful_realizations", 0
+            )
+            try:
+                self.checkHaveSufficientRealizations(num_successful_realizations)
+            except ErtRunError as e:
+
+                # Send EXPERIMENT_FAILED
+                await self.dispatch(
+                    CloudEvent(
+                        {
+                            "type": identifiers.EVTYPE_EXPERIMENT_FAILED,
+                            "source": f"/ert/experiment/{self.id_}",
+                            "id": str(uuid.uuid1()),
+                        },
+                        {
+                            "error": str(e),
+                        },
+                    ),
+                    run_context.get_iter(),
+                )
+                return
+
+            await self._run_hook(
+                HookRuntime.POST_SIMULATION, run_context.get_iter(), loop, executor
+            )
+
+            # Push simulation results to storage
+            await loop.run_in_executor(
+                executor,
+                self._post_ensemble_results,
+                ensemble_id,
+            )
+
+        # Send EXPERIMENT_COMPLETED
+        await self.dispatch(
+            CloudEvent(
+                {
+                    "type": identifiers.EVTYPE_EXPERIMENT_SUCCEEDED,
+                    "source": f"/ert/experiment/{self.id_}",
+                    "id": str(uuid.uuid1()),
+                },
+            ),
+            run_context.get_iter(),
+        )
 
     def runSimulations__(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,8 @@ markers =
     consumer_driven_contract_verification
     integration_test
 log_cli = false
+
+[flake8]
+per-file-ignores =
+     # long redefinition of signatures prevents per-line ignores, so ignore E501 (line-too-long) for the entire file
+     ert/experiment_server/_server.py: E501

--- a/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -49,7 +49,7 @@ async def test_happy_path(
         queue.add_ee_stage(real.steps[0], None)
     queue.submit_complete()
 
-    await queue.execute_queue_async(
+    await queue.execute_queue_via_websockets(
         url, "ee_0", threading.BoundedSemaphore(value=10), None
     )
     done.set_result(None)

--- a/tests/ert_tests/experiment_server/conftest.py
+++ b/tests/ert_tests/experiment_server/conftest.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+from typing import AsyncGenerator, Awaitable, Callable, Optional
+import pytest
+from websockets.client import WebSocketClientProtocol, connect
+import ert.experiment_server
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+
+if sys.version_info < (3, 7):
+    from async_generator import asynccontextmanager
+else:
+    from contextlib import asynccontextmanager
+
+
+@pytest.fixture
+@asynccontextmanager
+async def experiment_server_ctx() -> AsyncGenerator[
+    ert.experiment_server.ExperimentServer, None
+]:
+    config = EvaluatorServerConfig(
+        custom_port_range=range(1024, 65535),
+        custom_host="127.0.0.1",
+        use_token=False,
+        generate_cert=False,
+    )
+    server = ert.experiment_server.ExperimentServer(config)
+    yield server
+    await server.stop()
+
+
+@pytest.fixture
+@asynccontextmanager
+async def dispatcher_factory() -> AsyncGenerator[
+    Callable[
+        [ert.experiment_server.ExperimentServer], Awaitable[WebSocketClientProtocol]
+    ],
+    None,
+]:
+    connection: Optional[WebSocketClientProtocol] = None
+
+    async def _make_dispatcher(
+        server: ert.experiment_server.ExperimentServer,
+    ) -> WebSocketClientProtocol:
+        nonlocal connection
+
+        async def _wait_for_connection() -> WebSocketClientProtocol:
+            async for websocket in connect(server._config.dispatch_uri):
+                return websocket
+            raise RuntimeError
+
+        connection = await asyncio.wait_for(_wait_for_connection(), timeout=60)
+        return connection
+
+    yield _make_dispatcher
+
+    if connection:
+        await connection.close()

--- a/tests/ert_tests/experiment_server/test_server.py
+++ b/tests/ert_tests/experiment_server/test_server.py
@@ -1,0 +1,78 @@
+import sys
+import ert.experiment_server
+import pytest
+
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
+from ert.experiment_server._experiment_protocol import Experiment
+from typing import AsyncContextManager, Awaitable, Callable
+
+from cloudevents.http import CloudEvent, to_json
+from websockets.client import WebSocketClientProtocol
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+minversion = pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="requires python3.7 or higher"
+)
+
+
+@minversion
+async def test_receiving_event_from_cluster(
+    experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
+    dispatcher_factory: AsyncContextManager[
+        Callable[
+            [ert.experiment_server.ExperimentServer], Awaitable[WebSocketClientProtocol]
+        ]
+    ],
+):
+    async with experiment_server_ctx as experiment_server:
+        experiment = AsyncMock(Experiment)
+        experiment_server.add_experiment(experiment)
+
+        async with dispatcher_factory as make_dispatcher:
+            dispatcher = await make_dispatcher(experiment_server)
+
+            event = CloudEvent(
+                {
+                    "type": "test.event",
+                    "source": "test_receiving_event_from_cluster",
+                }
+            )
+            await dispatcher.send(to_json(event))
+
+    experiment.dispatch.assert_awaited_once_with(event, 0)
+
+
+@minversion
+async def test_successful_run(
+    experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
+    capsys,
+):
+    async with experiment_server_ctx as experiment_server:
+        experiment = AsyncMock(Experiment)
+        experiment.successful_realizations.return_value = 5
+        id_ = experiment_server.add_experiment(experiment)
+        await experiment_server.run_experiment(id_)
+
+    captured = capsys.readouterr()
+    assert captured.out == "Successful realizations: 5\n"
+
+
+@minversion
+async def test_failed_run(
+    experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
+    capsys,
+):
+    async with experiment_server_ctx as experiment_server:
+        experiment = AsyncMock(Experiment)
+        experiment.run.side_effect = RuntimeError("boom")
+        id_ = experiment_server.add_experiment(experiment)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await experiment_server.run_experiment(id_)
+
+    captured = capsys.readouterr()
+    assert captured.out == "Experiment failed: boom\n"

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -303,7 +303,7 @@ async def test_retry_on_closed_connection(tmpdir):
         # the queue ate both the exception, and the websocket_mock, trying to
         # consume a third item from the mock causes an (expected) exception
         with pytest.raises(RuntimeError, match="coroutine raised StopIteration"):
-            await job_queue.execute_queue_async(
+            await job_queue.execute_queue_via_websockets(
                 ws_uri="ws://example.org",
                 ee_id="",
                 pool_sema=pool_sema,


### PR DESCRIPTION
**Issue**
Resolves #3414 


**Approach**
- Add feature flag: `--enable-experiment-server`
- Allow execution of an _Ensemble Experiment_ via the experiment server
- Add basic functionality, like printing whether or not the experiment
  was successful.

The experiment server is created by instantiating `ExperimentServer`. This starts a websockets server that listens for communication from `job_dispatch.py` (the remote, distributed workers). An experiment is created per usual, using `create_model`, but it is owned by the `ExperimentServer`. This experiment implements the `Experiment` protocol (see [pep-0544](https://peps.python.org/pep-0544/). We immediately run the experiment, which will initiate three event "flows":

1. the `EnsembleExperiment.run()` implementation will at different stages "dispatch" CloudEvents that describes what happened to the experiment, e.g. the event `com.equinor.ert.experiment.started` and `com.equinor.ert.experiment.hook_ended`.
2. During the evaluation of an ensemble, the ensemble puts CloudEvents on a "public facing" `asyncio.Queue` that the experiment then dispatches. These are events like `com.equinor.ert.ensemble.started` and `com.equinor.ert.ensemble.failed`, but also events emitted by the job queue, like `com.equinor.ert.forward_model_step.waiting` and `com.equinor.ert.forward_model_step.timeout`.
3. The queue runs the `job_dispatch.py` program on the cluster (or locally), which will send its events to the experiment server. These events are, based on the source, dispatched to the correct experiment. The events include `com.equinor.ert.forward_model_job.start` and `com.equinor.ert.forward_model_job.running`.

At the moment, the dispatch method of the experiment simply counts the successful realizations and stores them in the _state machine_.

When the experiment is done, the server shuts down.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
