### PR TITLE
Release GIL before waiting for (async) futures in C++

### DIFF
--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -519,6 +519,13 @@ int enkf_main_load_from_run_context(enkf_main_type *enkf_main,
     Semafoor concurrently_executing_threads(100);
     std::vector<std::tuple<int, std::future<int>>> futures;
 
+    // If this function is called via pybind11 we need to release
+    // the GIL here because this function may spin up several
+    // threads which also may need the GIL (e.g. for logging)
+    PyThreadState *state = nullptr;
+    if (PyGILState_Check() == 1)
+        state = PyEval_SaveThread();
+
     for (int iens = 0; iens < ens_size; ++iens) {
         if (bool_vector_iget(iactive, iens)) {
 
@@ -564,6 +571,9 @@ int enkf_main_load_from_run_context(enkf_main_type *enkf_main,
         } else
             loaded++;
     }
+    if (state)
+        PyEval_RestoreThread(state);
+
     return loaded;
 }
 
@@ -676,6 +686,15 @@ std::vector<std::string> get_parameter_keys(py::object self) {
     return parameters;
 }
 
+int load_from_forward_model_with_fs_pybind(py::object self, int iter,
+                                           py::object iactive, py::object fs) {
+    auto enkf_main = ert::from_cwrap<enkf_main_type>(self);
+    auto iactive_ = ert::from_cwrap<bool_vector_type>(iactive);
+    auto fs_ = ert::from_cwrap<enkf_fs_type>(fs);
+    return enkf_main_load_from_forward_model_with_fs(enkf_main, iter, iactive_,
+                                                     fs_);
+}
+
 RES_LIB_SUBMODULE("enkf_main", m) {
     using namespace py::literals;
     m.def("get_observation_keys", get_observation_keys);
@@ -689,6 +708,8 @@ RES_LIB_SUBMODULE("enkf_main", m) {
             return enkf_main_create_run_path(enkf_main, run_context);
         },
         py::arg("self"), py::arg("run_context"));
+    m.def("load_from_forward_model", load_from_forward_model_with_fs_pybind,
+          py::arg("self"), py::arg("iter"), py::arg("iactive"), py::arg("fs"));
 }
 
 #include "enkf_main_ensemble.cpp"

--- a/libres/lib/include/ert/enkf/enkf_main.hpp
+++ b/libres/lib/include/ert/enkf/enkf_main.hpp
@@ -121,10 +121,10 @@ bool enkf_main_export_field_with_fs(const enkf_main_type *enkf_main,
                                     field_file_format_type file_type,
                                     int report_step, enkf_fs_type *fs);
 
-extern "C" int
-enkf_main_load_from_forward_model_with_fs(enkf_main_type *enkf_main, int iter,
-                                          bool_vector_type *iactive,
-                                          enkf_fs_type *fs);
+int enkf_main_load_from_forward_model_with_fs(enkf_main_type *enkf_main,
+                                              int iter,
+                                              bool_vector_type *iactive,
+                                              enkf_fs_type *fs);
 
 extern "C" int
 enkf_main_load_from_run_context(enkf_main_type *enkf_main,

--- a/res/enkf/enkf_main.py
+++ b/res/enkf/enkf_main.py
@@ -250,10 +250,6 @@ class _RealEnKFMain(BaseCClass):
         "hook_manager_ref enkf_main_get_hook_manager(enkf_main)"
     )
     _get_mount_point = ResPrototype("char* enkf_main_get_mount_root( enkf_main )")
-    _load_from_forward_model = ResPrototype(
-        "int enkf_main_load_from_forward_model_with_fs"
-        "(enkf_main, int, bool_vector, enkf_fs)"
-    )
     _load_from_run_context = ResPrototype(
         "int enkf_main_load_from_run_context(enkf_main, ert_run_context, enkf_fs)"
     )
@@ -391,7 +387,7 @@ class _RealEnKFMain(BaseCClass):
         bool_vector = BoolVector.createFromList(
             size=len(realization), source_list=true_indices
         )
-        nr_loaded = self._load_from_forward_model(iteration, bool_vector, fs)
+        nr_loaded = enkf_main.load_from_forward_model(self, iteration, bool_vector, fs)
         fs.sync()
         return nr_loaded
 


### PR DESCRIPTION
C++ futures may be executed in separate threads. If the code which waits for such futures holds the GIL, e.g. it was invoked from Python via Pybind11, this prevents code running in the futures from aquiring the GIL, causing deadlocks if code in future tries to use our logging-mechanism.