### PR TITLE
Fix inconsistent codecov reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build libres
       run: |
         mkdir cmake-build
-        cmake -S libres -B cmake-build -DBUILD_TESTS=ON -DCOVERAGE=ON
+        cmake -S libres -B cmake-build -DBUILD_TESTS=ON
         cmake --build cmake-build
 
     - name: Run tests
@@ -56,19 +56,6 @@ jobs:
         export PATH=$PWD/bin:$PATH
         ctest --output-on-failure
 
-    - name: Install gcovr
-      run: |
-        python3 -m pip install gcovr
-
-    - name: generate coverage report
-      run: |
-        gcovr -r libres/ --exclude-directories ".*tests" cmake-build/ --xml -o cov.xml
-
-    - name: Upload c coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: cov.xml
 
   build-wheels:
     timeout-minutes: 30

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,12 +1,10 @@
-name: Python coverage
+name: coverage
 
-on:
- push:
-   branches:
-     - main
-     - 'version-**'
-   tags: "*"
- pull_request:
+on: [push]
+
+env:
+  ERT_SHOW_BACKTRACE: 1
+  ECL_SKIP_SIGNAL: 1
 
 jobs:
   python-test-coverage:
@@ -15,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        system-under-test: ['res', 'ert']
+        system-under-test: ['res', 'ert', 'libres']
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,7 +28,9 @@ jobs:
       with:
         python-version: '3.9'
 
-    - name: Install with dependencies
+
+    - name: Install pip package with dependencies
+      if: matrix.system-under-test == 'ert' || matrix.system-under-test == 'res'
       run: |
         pip install .
         pip install -r dev-requirements.txt
@@ -54,7 +54,27 @@ jobs:
         cd tests
         pytest libres_tests --cov=res --cov-report=xml:cov.xml
 
-    - name: Upload python coverage to Codecov
+    - name: Run libres tests
+      if: matrix.system-under-test == 'libres'
+      run: |
+        sudo apt-get install -y valgrind
+        python3 -m pip install conan
+        git clone https://github.com/equinor/libecl
+        mkdir libecl/build
+        cmake -S libecl -B libecl/build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        sudo cmake --build libecl/build --target install
+        sudo rm -rf libecl
+        mkdir cmake-build
+        cmake -S libres -B cmake-build -DBUILD_TESTS=ON -DCOVERAGE=ON
+        cmake --build cmake-build
+        pushd cmake-build
+        export PATH=$PWD/bin:$PATH
+        ctest --output-on-failure
+        popd
+        python3 -m pip install gcovr
+        gcovr -r libres/ --exclude-directories ".*tests" cmake-build/ --xml -o tests/cov.xml
+
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ fixes:
     - "*/site-packages/::"
     - "/home/runner/work/ert/ert/::"
 comment:
-    # The code coverage is made up of 4 separate
+    # The code coverage is made up of 3 separate
     # test runs so only after all coverage reports have
     # been uploaded will the comparison be sane
-    after_n_builds: 4
+    after_n_builds: 3

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,2 @@
+exclude-unreachable-branches = yes
+exclude-throw-branches = yes

--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -54,7 +54,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 if(COVERAGE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -Wall")
+  add_compile_options("--coverage")
+  add_compile_options("-fPIC")
+  add_compile_options("-O0")
+  add_link_options("--coverage")
 endif()
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
The codecov report is currently not easy to understand and sometimes misleading. This seems to be due to a combination of factors:

* As per https://github.com/codecov/codecov-bash/issues/83 codecov has issues with github actions triggered by pull request.
* The libres tests were run both with macos and ubuntu.
* gcov reports a lot of partial hits for code that potentially could take another branch (ie. exceptions) which is often unreachable. See https://stackoverflow.com/questions/42003783/lcov-gcov-branch-coverage-with-c-producing-branches-all-over-the-place

To remedy the situation, the coverage reports are now run in a separate workflow, which is triggered by push and not pull request and only run on ubuntu. Also, gcovr is set to count more partial coverage as full coverage if the kind of branch is not of interest.

 # Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
