### PR TITLE
Remove unused function state_map::count_matching

### DIFF
--- a/src/clib/lib/enkf/state_map.cpp
+++ b/src/clib/lib/enkf/state_map.cpp
@@ -191,12 +191,6 @@ void StateMap::set_from_mask(const std::vector<bool> &mask,
             set(i, state);
 }
 
-size_t StateMap::count_matching(int mask) const {
-    std::lock_guard lock{m_mutex};
-    return std::count_if(m_state.begin(), m_state.end(),
-                         [mask](int value) { return value & mask; });
-}
-
 ERT_CLIB_SUBMODULE("state_map", m) {
     using namespace py::literals;
 

--- a/src/clib/lib/include/ert/enkf/state_map.hpp
+++ b/src/clib/lib/include/ert/enkf/state_map.hpp
@@ -91,14 +91,6 @@ public:
                        realisation_state_enum state);
 
     /**
-     * Count the states that have all of flags set in state_mask
-     *
-     * @param state_mask Set of state flags
-     * @return Count
-     */
-    size_t count_matching(int state_mask) const;
-
-    /**
      * Determine whether it is possible to change from state1 to state2.
      *
      * For example, it isn't permitted to go from STATE_PARENT_FAILURE to

--- a/src/clib/old_tests/enkf/test_enkf_state_map.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_state_map.cpp
@@ -162,25 +162,6 @@ void test_select_matching() {
     test_assert_int_equal(mask.size(), 51);
 }
 
-void test_count_matching() {
-    StateMap state_map;
-    state_map.set(10, STATE_INITIALIZED);
-
-    state_map.set(15, STATE_INITIALIZED);
-    state_map.set(15, STATE_HAS_DATA);
-
-    state_map.set(16, STATE_INITIALIZED);
-    state_map.set(16, STATE_HAS_DATA);
-    state_map.set(16, STATE_LOAD_FAILURE);
-
-    test_assert_int_equal(1, state_map.count_matching(STATE_HAS_DATA));
-    test_assert_int_equal(
-        2, state_map.count_matching(STATE_HAS_DATA | STATE_LOAD_FAILURE));
-    test_assert_int_equal(3, state_map.count_matching(STATE_HAS_DATA |
-                                                      STATE_LOAD_FAILURE |
-                                                      STATE_INITIALIZED));
-}
-
 // Probably means that the target should be explicitly set to
 // undefined before workflows which automatically change case.
 void test_transitions() {
@@ -252,7 +233,6 @@ int main(int argc, char **argv) {
     test_copy();
     test_io();
     test_select_matching();
-    test_count_matching();
     test_transitions();
     exit(0);
 }


### PR DESCRIPTION
Came across an unused function


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
