### PR TITLE
Set file dialog to reasonable width and height - simplified approach

### DIFF
--- a/ert_gui/tools/file/file_dialog.py
+++ b/ert_gui/tools/file/file_dialog.py
@@ -1,4 +1,5 @@
-from qtpy.QtCore import QThread, Slot, Qt
+from math import floor
+from qtpy.QtCore import QThread, Slot, Qt, QSize
 from qtpy.QtWidgets import (
     QDialog,
     QMessageBox,
@@ -59,10 +60,23 @@ class FileDialog(QDialog):
         self._thread.quit()
         self._thread.wait()
 
-    def _init_layout(self):
-        self.setMinimumWidth(600)
-        self.setMinimumHeight(400)
+    def _calculate_font_based_width(self):
+        font_metrics = self._view.fontMetrics()
+        desired_width_in_characters = 120
+        extra_bit_of_margin_space = 2
+        extra_space_for_vertical_scroll_bar = 5
+        return (
+            desired_width_in_characters
+            + extra_bit_of_margin_space
+            + extra_space_for_vertical_scroll_bar
+        ) * font_metrics.averageCharWidth()
 
+    def _calculate_screen_size_based_height(self):
+        screen_height = QApplication.primaryScreen().geometry().height()
+        max_ratio_of_screen = 1.0 / 3.0
+        return floor(screen_height * max_ratio_of_screen)
+
+    def _init_layout(self):
         dialog_buttons = QDialogButtonBox(QDialogButtonBox.Ok)
         dialog_buttons.accepted.connect(self.accept)
 
@@ -129,3 +143,10 @@ class FileDialog(QDialog):
         if self._follow_mode:
             self._view.moveCursor(QTextCursor.End)
         self._view.appendPlainText(text)
+        self.adjustSize()
+
+    def sizeHint(self) -> QSize:
+        return QSize(
+            self._calculate_font_based_width(),
+            self._calculate_screen_size_based_height(),
+        )

--- a/tests/ert_tests/gui/tools/file/filedialog.py
+++ b/tests/ert_tests/gui/tools/file/filedialog.py
@@ -1,0 +1,42 @@
+from os import path
+import math
+import pytest
+from qtpy.QtWidgets import QApplication
+
+from ert_gui.tools.file.file_dialog import FileDialog
+
+testCaseTextFiles = [
+    "stdout-short",
+    "stdout-just-right",
+    "stdout-long",
+    "stdout-long-and-extra-wide",
+]
+
+
+@pytest.mark.parametrize(
+    "textFile",
+    map(lambda textFile: pytest.param(textFile, id=textFile), testCaseTextFiles),
+)
+def test_filedialog_size(textFile, qtbot):
+    filepath = path.join(
+        path.dirname(path.realpath(__file__)),
+        textFile,
+    )
+    fileDialog = FileDialog(filepath, "the-job", 42, 13, 23)
+    qtbot.addWidget(fileDialog)
+    with qtbot.waitExposed(fileDialog, timeout=2000):
+        textField = fileDialog._view
+        fontMetrics = textField.fontMetrics()
+        charWidth = fontMetrics.averageCharWidth()
+        screenHeight = QApplication.primaryScreen().geometry().height()
+        expectedWidth = math.ceil(120 * charWidth)
+        expectedHeight = math.floor(1 / 3 * screenHeight)
+
+        # sadly we have to wait for the dialog to be sized appropriately
+        qtbot.wait(10)
+
+        assert textField.height() == pytest.approx(
+            expectedHeight, abs=0.05 * screenHeight
+        )
+        assert textField.width() == pytest.approx(expectedWidth, abs=charWidth * 10)
+        fileDialog._stop_thread()

--- a/tests/ert_tests/gui/tools/file/stdout-just-right
+++ b/tests/ert_tests/gui/tools/file/stdout-just-right
@@ -1,0 +1,11 @@
+And Saint Attila raised the hand grenade up on high, saying, 'O Lord, bless
+this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits,
+in thy mercy.' And the Lord did grin. And the people did feast upon the lambs,
+and sloths, and carp, and anchovies, and orangutans, and breakfast cereals, and
+fruit bats, and large chulapas. And the Lord spake, saying, 'First shalt thou
+take out the Holy Pin. Then shalt thou count to three, no more, no less. Three
+shall be the number thou shalt count, and the number of the counting shall be
+three. Four shalt thou not count, neither count thou two, excepting that thou
+then proceed to three. Five is right out. Once the number three, being the
+third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch
+towards thy foe, who, being naughty in My sight, shall snuff it.'

--- a/tests/ert_tests/gui/tools/file/stdout-long
+++ b/tests/ert_tests/gui/tools/file/stdout-long
@@ -1,0 +1,144 @@
+ARTHUR: You fight with the strength of many men, Sir Knight.
+
+[pause]
+
+I am Arthur, King of the Britons.
+
+[pause]
+
+I seek the finest and the bravest knights in the land to join me in my court at
+Camelot.
+
+[pause]
+
+You have proved yourself worthy. Will you join me?
+
+[pause]
+
+You make me sad. So be it. Come, Patsy.
+
+BLACK KNIGHT: None shall pass.
+
+ARTHUR: What?
+
+BLACK KNIGHT: None shall pass.
+
+ARTHUR: I have no quarrel with you, good Sir Knight, but I must cross this
+bridge.
+
+BLACK KNIGHT: Then you shall die.
+
+ARTHUR: I command you, as King of the Britons, to stand aside!
+
+BLACK KNIGHT: I move for no man.
+
+ARTHUR: So be it!
+
+ARTHUR and BLACK KNIGHT: Aaah!, hiyaah!, etc.
+
+[ARTHUR chops the BLACK KNIGHT's left arm off]
+
+ARTHUR: Now stand aside, worthy adversary.
+
+BLACK KNIGHT: 'Tis but a scratch.
+
+ARTHUR: A scratch? Your arm's off!
+
+BLACK KNIGHT: No, it isn't.
+
+ARTHUR: Well, what's that, then?
+
+BLACK KNIGHT: I've had worse.
+
+ARTHUR: You liar!
+
+BLACK KNIGHT: Come on, you pansy!
+
+[clang]
+
+Huyah!
+
+[clang]
+
+Hiyaah!
+
+[clang]
+
+Aaaaaaaah!
+
+[ARTHUR chops the BLACK KNIGHT's right arm off]
+
+ARTHUR: Victory is mine!
+
+[kneeling]
+
+We thank Thee Lord, that in Thy mer--
+
+BLACK KNIGHT: Hah!
+
+[kick]
+
+Come on, then.
+
+ARTHUR: What?
+
+BLACK KNIGHT: Have at you!
+
+[kick]
+
+ARTHUR: Eh. You are indeed brave, Sir Knight, but the fight is mine.
+
+BLACK KNIGHT: Oh, had enough, eh?
+
+ARTHUR: Look, you stupid bastard. You've got no arms left.
+
+BLACK KNIGHT: Yes, I have.
+
+ARTHUR: Look!
+
+BLACK KNIGHT: Just a flesh wound.
+
+[kick]
+
+ARTHUR: Look, stop that.
+
+BLACK KNIGHT: Chicken!
+
+[kick]
+
+Chickennn!
+
+ARTHUR: Look, I'll have your leg.
+
+[kick]
+
+Right!
+
+[whop]
+
+[ARTHUR chops the BLACK KNIGHT's right leg off]
+
+BLACK KNIGHT: Right. I'll do you for that!
+
+ARTHUR: You'll what?
+
+BLACK KNIGHT: Come here!
+
+ARTHUR: What are you going to do, bleed on me?
+
+BLACK KNIGHT: I'm invincible!
+
+ARTHUR: You're a looney.
+
+BLACK KNIGHT: The Black Knight always triumphs! Have at you! Come on, then.
+
+[whop]
+
+[ARTHUR chops the BLACK KNIGHT's last leg off]
+
+BLACK KNIGHT: Oh? All right, we'll call it a draw.
+
+ARTHUR: Come, Patsy.
+
+BLACK KNIGHT: Oh. Oh, I see. Running away, eh? You yellow bastards! Come back
+here and take what's coming to you. I'll bite your legs off!

--- a/tests/ert_tests/gui/tools/file/stdout-long-and-extra-wide
+++ b/tests/ert_tests/gui/tools/file/stdout-long-and-extra-wide
@@ -1,0 +1,146 @@
+BLOOD & THUNDER PROPHET: ...And the bezan shall be huge and black, and the eyes thereof red with the blood of living creatures, and the whore of Babylon shall ride forth on a three-headed serpent, and throughout the lands, there'll be a great rubbing of parts. Yeeah...
+
+FALSE PROPHET: ...For the demon shall bear a nine-bladed sword. Nine-bladed!  Not two or five or seven, but nine, which he will wield on all wretched sinners, sinners just like you, sir, there, and the horns shall be on the head, with which he will...
+
+BORING PROPHET: ...Obadiah, his servants. There shall, in that time, be rumors of things going astray, erm, and there shall be a great confusion as to where things really are, and nobody will really know where lieth those little things wi-- with the sort of raffia work base that has an attachment. At this time, a friend shall lose his friend's hammer and the young shall not know where lieth the things possessed by their fathers that their fathers put there only just the night before, about eight o'clock. Yea, it is written in the book of Cyril that, in that time, shall the third one...
+
+BRIAN: How much? Quick.
+
+HARRY THE HAGGLER: What?
+
+BRIAN: It's for the wife.
+
+HARRY THE HAGGLER: Oh. Uhhh, twenty shekels.
+
+BRIAN: Right.
+
+HARRY THE HAGGLER: What?
+
+BRIAN: There you are.
+
+HARRY THE HAGGLER: Wait a minute.
+
+BRIAN: What?
+
+HARRY THE HAGGLER: Well, we're-- we're supposed to haggle.
+
+BRIAN: No, no. I've got to get--
+
+HARRY THE HAGGLER: What do you mean, 'no, no, no'?
+
+BRIAN: I haven't time. I've got--
+
+HARRY THE HAGGLER: Well, give it back, then.
+
+BRIAN: No, no, no. I just paid you.
+
+HARRY THE HAGGLER: Burt!
+
+BURT: Yeah?
+
+HARRY THE HAGGLER: This bloke won't haggle.
+
+BURT: Won't haggle?!
+
+BRIAN: All right. Do we have to?
+
+HARRY THE HAGGLER: Now, look. I want twenty for that.
+
+BRIAN: I-- I just gave you twenty.
+
+HARRY THE HAGGLER: Now, are you telling me that's not worth twenty shekels?
+
+BRIAN: No.
+
+HARRY THE HAGGLER: Look at it. Feel the quality. That's none of your goat.
+
+BRIAN: All right. I'll give you nineteen then.
+
+HARRY THE HAGGLER: No, no, no. Come on. Do it properly.
+
+BRIAN: What?
+
+HARRY THE HAGGLER: Haggle properly. This isn't worth nineteen.
+
+BRIAN: Well, you just said it was worth twenty.
+
+HARRY THE HAGGLER: Ohh, dear. Ohh, dear. Come on. Haggle.
+
+BRIAN: Huh. All right. I'll give you ten.
+
+HARRY THE HAGGLER: That's more like it. Ten?! Are you trying to insult me?! Me,
+with a poor dying grandmother?! Ten?!
+
+BRIAN: All right. I'll give you eleven.
+
+HARRY THE HAGGLER: Now you're gettin' it. Eleven?! Did I hear you right?!
+Eleven?! This cost me twelve. You want to ruin me?!
+
+BRIAN: Seventeen?
+
+HARRY THE HAGGLER: No, no, no, no. Seventeen.
+
+BRIAN: Eighteen?
+
+HARRY THE HAGGLER: No, no. You go to fourteen now.
+
+BRIAN: All right. I'll give you fourteen.
+
+HARRY THE HAGGLER: Fourteen?! Are you joking?!
+
+BRIAN: That's what you told me to say.
+
+HARRY THE HAGGLER: Ohh, dear.
+
+BRIAN: Ohh, tell me what to say. Please!
+
+HARRY THE HAGGLER: Offer me fourteen.
+
+BRIAN: I'll give you fourteen.
+
+HARRY THE HAGGLER: He's offering me fourteen for this!
+
+BRIAN: Fifteen!
+
+HARRY THE HAGGLER: Seventeen. My last word. I won't take a penny less, or
+strike me dead.
+
+BRIAN: Sixteen.
+
+HARRY THE HAGGLER: Done. Nice to do business with you.
+
+BRIAN: Huh.
+
+HARRY THE HAGGLER: Tell you what. I'll throw you in this as well.
+
+BRIAN: I don't want it, but thanks.
+
+HARRY THE HAGGLER: Burt!
+
+BURT: Yeah?
+
+BRIAN: All right! All right. All right.
+
+HARRY THE HAGGLER: Now, where's the sixteen you owe me?
+
+BRIAN: I just gave you twenty.
+
+HARRY THE HAGGLER: Oh, yeah. That's right. That's four I owe you, then.
+
+BRIAN: Well, that's all right. That's fine. That's fine.
+
+HARRY THE HAGGLER: No. Hang on. I've got it here somewhere.
+
+BRIAN: That's all right. That's four for the gourd.
+
+HARRY THE HAGGLER: Four? For this gourd? Four?! Look at it. It's worth ten if
+it's worth a shekel.
+
+BRIAN: But you just gave it to me for nothing.
+
+HARRY THE HAGGLER: Yes, but it's worth ten!
+
+BRIAN: All right. All right.
+
+HARRY THE HAGGLER: No, no, no, no. It's not worth ten. You're supposed to
+argue, 'Ten for that? You must be mad!' Ohh, well. sniff One born every minute.

--- a/tests/ert_tests/gui/tools/file/stdout-short
+++ b/tests/ert_tests/gui/tools/file/stdout-short
@@ -1,0 +1,2 @@
+Wenn ist das Nunstück git und Slotermeyer? Ja! Beiherhund das Oder die
+Flipperwaldt gersput!


### PR DESCRIPTION
We set the file dialog for viewing stdout and stderr of simulations to a
standard width of 80, and a height of 1/3 of the screen.

**Issue**
Closes #997


**Approach**
See commit message above


## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
