### PR TITLE
Explicitly load no-self-use pylint extension

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -60,7 +60,6 @@ jobs:
             consider-using-enumerate, \
             consider-using-f-string
             consider-using-from-import, \
-            consider-using-generator, \
             consider-using-min-builtin, \
             consider-using-set-comprehension, \
             empty-docstring, \

--- a/.pylintrc
+++ b/.pylintrc
@@ -31,7 +31,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.no_self_use
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
It was made optional in pylint version 2.14, which means it has to be
loaded explicitly in the config.

See https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html

**Issue**
Resolves pylint warning


**Approach**
Load the extension


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
