### PR TITLE
Add libres apidocs to fmudocs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,9 @@ jobs:
 
     - name: Test docs
       run: |
+        sudo apt-get install -y doxygen
+        doxygen docs/rst/manual/doxyfile
+        breathe-apidoc -g file docs/rst/manual/doxygen/xml -o docs/rst/manual/libres_apidoc/
         sphinx-build -n -v -E -W ./docs/rst/manual ./tmp/ert_docs
 
   tests-libres:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,3 +25,4 @@ sphinx_rtd_theme
 sphinx-argparse
 sphinx-autoapi
 sphinxcontrib.datatemplates
+breathe

--- a/docs/rst/manual/conf.py
+++ b/docs/rst/manual/conf.py
@@ -13,6 +13,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
 
 sys.path.append(os.path.abspath("./_ext"))
@@ -22,6 +23,7 @@ from pkg_resources import get_distribution  # noqa
 # -- Project information -----------------------------------------------------
 
 project = "ERT"
+breathe_default_project = "ERT"
 copyright = "Equinor"
 author = "Joakim Hove"
 
@@ -32,6 +34,12 @@ version = ".".join(dist_version.split(".")[:2])
 # The full version, including alpha/beta/rc tags
 release = dist_version
 
+# -- build doxygen for breathe first if on READTHEDOCS servers-------------
+read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
+
+if read_the_docs_build:
+
+    subprocess.call("cd ../doxygen; doxygen", shell=True)
 
 # -- General configuration ---------------------------------------------------
 
@@ -49,14 +57,18 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.imgmath",
     "sphinxarg.ext",
     "sphinx.ext.todo",
     "sphinxcontrib.datatemplates",
+    "breathe",
     "ert_jobs",
     "ert_narratives",
     "ert3_plugin_configs",
     "ert3_plugin_references",
 ]
+
+breathe_projects = {"ERT": "doxygen/xml"}
 
 # Autodoc settings:
 autodoc_class_signature = "separated"

--- a/docs/rst/manual/doxyfile
+++ b/docs/rst/manual/doxyfile
@@ -1,0 +1,352 @@
+# Doxyfile 1.9.1
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "ERT"
+PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = docs/rst/manual/doxygen
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+OUTPUT_TEXT_DIRECTION  = None
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+JAVADOC_BANNER         = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = YES
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = libres/lib/
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.c \
+                         *.cc \
+                         *.cxx \
+                         *.cpp \
+                         *.c++ \
+                         *.h \
+                         *.hh \
+                         *.hxx \
+                         *.hpp
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = NO
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+HTML_FORMULA_FORMAT    = png
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         =
+MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+LATEX_EMOJI_DIRECTORY  =
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/docs/rst/manual/index.rst
+++ b/docs/rst/manual/index.rst
@@ -77,6 +77,13 @@ with model updates and uncertainty estimation. You can read more about the theor
 
 .. toctree::
    :hidden:
+   :maxdepth: 1
+   :caption: libres apidoc
+
+   libres_apidoc/index
+
+.. toctree::
+   :hidden:
    :caption: About
 
    about/index

--- a/docs/rst/manual/libres_apidoc/index.rst
+++ b/docs/rst/manual/libres_apidoc/index.rst
@@ -1,0 +1,8 @@
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   introduction
+   pages
+   modules
+   filelist

--- a/docs/rst/manual/libres_apidoc/introduction.rst
+++ b/docs/rst/manual/libres_apidoc/introduction.rst
@@ -1,0 +1,7 @@
+Introduction
+============
+
+The API provided for libres form the c++ backend of the python res
+module in the ert package. It is ment to only be used internally by
+ert.
+

--- a/docs/rst/manual/libres_apidoc/modules.rst
+++ b/docs/rst/manual/libres_apidoc/modules.rst
@@ -1,0 +1,7 @@
+Modules
+=======
+
+.. toctree::
+
+   modules/ecl_config
+   modules/config_parser

--- a/docs/rst/manual/libres_apidoc/modules/config_parser.rst
+++ b/docs/rst/manual/libres_apidoc/modules/config_parser.rst
@@ -1,0 +1,5 @@
+config_parser
+=============
+
+.. doxygenstruct:: config_parser_struct
+   :members:

--- a/docs/rst/manual/libres_apidoc/modules/ecl_config.rst
+++ b/docs/rst/manual/libres_apidoc/modules/ecl_config.rst
@@ -1,0 +1,6 @@
+ecl_config
+==========
+
+.. doxygenstruct:: ecl_config_struct
+    :members:
+

--- a/docs/rst/manual/libres_apidoc/pages.rst
+++ b/docs/rst/manual/libres_apidoc/pages.rst
@@ -1,0 +1,6 @@
+Pages
+=====
+
+.. toctree::
+
+   pages/enkf_node_diagram

--- a/docs/rst/manual/libres_apidoc/pages/enkf_node_diagram.rst
+++ b/docs/rst/manual/libres_apidoc/pages/enkf_node_diagram.rst
@@ -1,0 +1,4 @@
+Relationship between enkf_node, enkf_config, field and file_config
+==================================================================
+
+.. doxygenpage:: enkf_node_diagram

--- a/libres/lib/config/config_parser.cpp
+++ b/libres/lib/config/config_parser.cpp
@@ -41,14 +41,13 @@ namespace fs = std::filesystem;
 /**
 Structure to parse configuration files of this type:
 
-KEYWORD1  ARG2   ARG2  ARG3
-KEYWORD2  ARG1-2
-....
-KEYWORDN  ARG1  ARG2
+    KEYWORD1  ARG2   ARG2  ARG3
+    KEYWORD2  ARG1-2
+    ....
+    KEYWORDN  ARG1  ARG2
 
 A keyword can occure many times.
-
-
+@verbatim
                            =============================
                            | config_type object        |
                            |                           |
@@ -84,23 +83,25 @@ A keyword can occure many times.
 |--------------------------|  |--------------------------|   |--------------------------|
 | ARG1 ARG2 ARG3           |  | VERBOSE                  |   | DEBUG                    |
 ============================  ============================   ============================
+@endverbatim
+
 
 
 The example illustrated above would correspond to the following config
 file (invariant under line-permutations):
 
-KEY1   ARG1 ARG2 ARG3
-KEY1   VERBOSE
-KEY2   DEBUG
+    KEY1   ARG1 ARG2 ARG3
+    KEY1   VERBOSE
+    KEY2   DEBUG
 
 
 Example config file(2):
 
-OUTFILE   filename
-INPUT     filename
-OPTIONS   store
-OPTIONS   verbose
-OPTIONS   optimize cache=1
+    OUTFILE   filename
+    INPUT     filename
+    OPTIONS   store
+    OPTIONS   verbose
+    OPTIONS   optimize cache=1
 
 In this case the whole config object will contain three items,
 corresponding to the keywords OUTFILE, INPUT and OPTIONS. The two
@@ -113,6 +114,8 @@ struct config_parser_struct {
     /** Can print a (warning) message when a keyword is encountered. */
     hash_type *messages;
 };
+/** @memberof config_parser_struct
+ * \{*/
 
 int config_get_schema_size(const config_parser_type *config) {
     return hash_get_size(config->schema_items);
@@ -500,26 +503,23 @@ bool config_parser_add_key_values(
 
 
    Example:
-   --------
 
-   char * add_angular_brackets(const char * key) {
-       char * new_key = (char*)util_alloc_sprintf("<%s>" , key);
-   }
+       char * add_angular_brackets(const char * key) {
+           char * new_key = (char*)util_alloc_sprintf("<%s>" , key);
+       }
 
-
-
-   config_parse(... , "myDEF" , add_angular_brackets , ...)
+       config_parse(... , "myDEF" , add_angular_brackets , ...)
 
 
-   Config file:
-   -------------
-   myDEF   Name         BJARNE
-   myDEF   pet        Dog
-   ...
-   ...
-   PERSON  <Name> 28 <pet>
-   ...
-   ------------
+       Config file:
+       -------------
+       myDEF   Name         BJARNE
+       myDEF   pet        Dog
+       ...
+       ...
+       PERSON  <Name> 28 <pet>
+       ...
+       ------------
 
    After parsing we will have an entry: "NAME" , "Bjarne" , "28" , "Dog".
 
@@ -692,3 +692,4 @@ void config_parser_deprecate(config_parser_type *config, const char *kw,
     } else
         util_abort("%s: item:%s not recognized \n", __func__, kw);
 }
+/** \}*/

--- a/libres/lib/enkf/ecl_config.cpp
+++ b/libres/lib/enkf/ecl_config.cpp
@@ -74,6 +74,8 @@ struct ecl_config_struct {
     /** Either metric, field or lab */
     ert_ecl_unit_enum unit_system;
 };
+/** \memberof ecl_config_struct
+ * \{*/
 
 /**
  With this function we try to determine whether ECLIPSE is active
@@ -93,15 +95,16 @@ bool ecl_config_active(const ecl_config_type *config) {
     return false;
 }
 
-/*
-   Could look up the sched_file instance directly - because the
-   ecl_config will never be the owner of a file with predictions.
-   */
-
+/**
+Getter for the last_history_restart field
+*/
 int ecl_config_get_last_history_restart(const ecl_config_type *ecl_config) {
     return ecl_config->last_history_restart;
 }
 
+/**
+* Returns whether an <INIT> section is supplied in the ECLIPSE data file.
+*/
 bool ecl_config_can_restart(const ecl_config_type *ecl_config) {
     return ecl_config->can_restart;
 }
@@ -259,6 +262,9 @@ static ecl_config_type *ecl_config_alloc_empty(void) {
     return ecl_config;
 }
 
+/**
+ * allocates an ecl_config and initializes it with the given config content.
+ */
 ecl_config_type *ecl_config_alloc(const config_content_type *config_content) {
     ecl_config_type *ecl_config = ecl_config_alloc_empty();
 
@@ -268,6 +274,9 @@ ecl_config_type *ecl_config_alloc(const config_content_type *config_content) {
     return ecl_config;
 }
 
+/**
+ * Allocates and initializes ecl_config from struct members.
+ */
 ecl_config_type *
 ecl_config_alloc_full(bool have_eclbase, char *data_file, ecl_grid_type *grid,
                       char *refcase_default, stringlist_type *ref_case_list,
@@ -580,3 +589,4 @@ const char *ecl_config_get_pressure_unit(const ecl_config_type *ecl_config) {
         return NULL;
     }
 }
+/** \}*/

--- a/libres/lib/enkf/enkf_node.cpp
+++ b/libres/lib/enkf/enkf_node.cpp
@@ -36,12 +36,11 @@
 
 #define ENKF_NODE_TYPE_ID 71043086
 
-/**
-   A small illustration (says more than thousand words ...) of how the
-   enkf_node, enkf_config_node, field[1] and field_config[1] objects
-   are linked.
+/** @page enkf_node_diagram Documentation of relationship between enkf_node, enkf_config_node, field[1] and field_config[1] objects
 
 
+   The following diagram summarizes the relationship between these objects:
+   @verbatim
    ================
    |              |   o-----------
    |  ================           |                =====================
@@ -50,17 +49,17 @@
    |  |  |              |        |                |  enkf_config_node |
    |  |  |              |        |                |                   |
    ===|  |  enkf_node   |  o------                |                   |
-   o |  |              |                         |                   |
-   | ===|              |                         =====================
-   |  o |              |                                   o
-   |  | ================                                   |
-   |  |        o                                           |
-   |  \        |                                           |
-   |   \       |                                           |
-   |    |      |                                           |
-   |    |      |                                           |
-   |    |      |                                           |
-   |    |      |                                           |
+    o |  |              |                         |                   |
+    | ===|              |                         =====================
+    |  o |              |                                   o
+    |  | ================                                   |
+    |  |        o                                           |
+    |  \        |                                           |
+    |   \       |                                           |
+    |    |      |                                           |
+    |    |      |                                           |
+    |    |      |                                           |
+    |    |      |                                           |
    \|/   |      |                                           |
    ======|======|==                                        \|/
    |    \|/     | |   o-----------
@@ -74,7 +73,7 @@
    ===   |              |                         =====================
          |              |
          ================
-
+   @endverbatim
 
    To summarize in words:
 
@@ -94,8 +93,7 @@
    [1]: field is just an example, and could be replaced with any of
    the enkf object types.
 
-   A note on memory
-   ================
+   A note on memory:
 
    The enkf_nodes can consume large amounts of memory, and for large
    models/ensembles we have a situation where not all the
@@ -114,7 +112,6 @@
 
 
    The following 'rules' apply to the memory treatment:
-   ----------------------------------------------------
 
    o Functions writing to memory can always be called, and it is their
    responsibility to allocate memory before actually writing on it. The
@@ -139,15 +136,13 @@
    o The only memory operation which is exported to 'user-space'
    (i.e. the enkf_state object) is enkf_node_free_data().
 
-   Keeeping track of node state.
-   =============================
+   Keeeping track of node state:
 
    To keep track of the state of the node's data (actually the data of
    the contained enkf_object, i.e. a field) we have three highly
    internal variables __state, __modified , __iens, and
    __report_step. These three variables are used/updated in the
    following manner:
-
 
 
    1. The nodes are created with (modified, report_step, state, iens) ==


### PR DESCRIPTION
Generate libres api documentation using doxygen, convert to rst with breathe and include it in fmu-docs.

The intent behind this change is to enable easier discoverability of documentation in the libres code. 
The general idea is to introduce doxygen markup to the c/cpp comments so that it is possible to cross-reference,
and use the breathe/sphinx pipeline to add that documentation to fmu-docs. 

The current approach does not include the entire apidoc by default, only those explicitly added to `docs/rst/manual/libres_apidoc`. This is to avoid poor signal to noise ratio as large parts of the code
has no documentation. It is possible to add every piece of code to the doc via either `breathe-apidoc`
or the `doxygenindex` directive in the future.

![documentation_example](https://user-images.githubusercontent.com/32731672/171610132-d5651a9a-55be-4d78-b802-637bed790fe5.png)


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
