### PR TITLE
Hoverinfo formatting

### DIFF
--- a/libres/lib/analysis/analysis_module.cpp
+++ b/libres/lib/analysis/analysis_module.cpp
@@ -39,9 +39,9 @@ auto logger = ert::get_logger("analysis");
 
 struct analysis_module_struct {
     std::unique_ptr<ies::Config> module_config;
-    char *
-        user_name; /* String used to identify this module for the user; not used in
-                                                   the linking process. */
+    /** String used to identify this module for the user; not used in the
+     * linking process. */
+    char *user_name;
     analysis_mode_enum mode;
     std::unordered_set<std::string> keys;
 };

--- a/libres/lib/analysis/enkf_linalg.cpp
+++ b/libres/lib/analysis/enkf_linalg.cpp
@@ -76,7 +76,7 @@ int enkf_linalg_svdS(const Eigen::MatrixXd &S,
     return num_significant;
 }
 
-/*
+/**
  Routine computes X1 and eig corresponding to Eqs 14.54-14.55
  Geir Evensen
 */
@@ -116,7 +116,7 @@ void enkf_linalg_lowrankE(
     W = U0 * Sigma_inv.transpose() * svd.matrixU();
 }
 
-/* B = Xo = (N-1) * Sigma0^(+) * U0'* Cee * U0 * Sigma0^(+')  (14.26)*/
+/** B = Xo = (N-1) * Sigma0^(+) * U0'* Cee * U0 * Sigma0^(+')  (14.26)*/
 Eigen::MatrixXd enkf_linalg_Cee(int nrens, const Eigen::MatrixXd &R,
                                 const Eigen::MatrixXd &U0,
                                 const Eigen::VectorXd &inv_sig0) {

--- a/libres/lib/analysis/ies/ies.cpp
+++ b/libres/lib/analysis/ies/ies.cpp
@@ -228,7 +228,7 @@ void ies::updateA(Data &data,
     A = A0 * X;
 }
 
-/*  COMPUTING THE PROJECTION Y= Y * (Ai^+ * Ai) (only used when state_size < ens_size-1)    */
+/**  COMPUTING THE PROJECTION Y= Y * (Ai^+ * Ai) (only used when state_size < ens_size-1)    */
 void ies::linalg_compute_AA_projection(const Eigen::MatrixXd &A,
                                        Eigen::MatrixXd &Y) {
 
@@ -240,7 +240,7 @@ void ies::linalg_compute_AA_projection(const Eigen::MatrixXd &A,
     Y *= AAi;
 }
 
-/*
+/**
 * COMPUTE  Omega= I + W (I-11'/sqrt(ens_size))    from Eq. (36).                                   (Line 6)
 *  When solving the system S = Y inv(Omega) we write
 *     Omega^T S^T = Y^T
@@ -263,7 +263,7 @@ Eigen::MatrixXd ies::linalg_solve_S(const Eigen::MatrixXd &W0,
     return ST.transpose();
 }
 
-/*
+/**
 *  The standard inversion works on the equation
 *          S'*(S*S'+R)^{-1} H           (a)
 */
@@ -308,7 +308,7 @@ void ies::linalg_subspace_inversion(
     W0 = ies_steplength * S.transpose() * X3 + (1.0 - ies_steplength) * W0;
 }
 
-/*
+/**
 *  The standard inversion works on the equation
 *          S'*(S*S'+R)^{-1} H           (a)
 *  which in the case when R=I can be rewritten as
@@ -335,7 +335,7 @@ void ies::linalg_exact_inversion(Eigen::MatrixXd &W0, const int ies_inversion,
     W0 = ies_steplength * Z * ZtStH + (1.0 - ies_steplength) * W0;
 }
 
-/*
+/**
 * the updated W is stored for each iteration in data->W. If we have lost realizations we copy only the active rows and cols from
 * W0 to data->W which is then used in the algorithm.  (note the definition of the pointer dataW to data->W)
 */

--- a/libres/lib/analysis/ies/ies_data.cpp
+++ b/libres/lib/analysis/ies/ies_data.cpp
@@ -41,7 +41,7 @@ int ies::Data::obs_mask_size() const { return this->m_obs_mask.size(); }
 
 int ies::Data::ens_mask_size() const { return (this->m_ens_mask.size()); }
 
-/* We store the initial observation perturbations in E, corresponding to active data->obs_mask0
+/** We store the initial observation perturbations in E, corresponding to active data->obs_mask0
    in data->E. The unused rows in data->E corresponds to false data->obs_mask0 */
 void ies::Data::store_initialE(const Eigen::MatrixXd &E0) {
     if (E.rows() != 0 || E.cols() != 0)
@@ -66,7 +66,7 @@ void ies::Data::store_initialE(const Eigen::MatrixXd &E0) {
     }
 }
 
-/* We augment the additional observation perturbations arriving in later iterations, that was not stored before,
+/** We augment the additional observation perturbations arriving in later iterations, that was not stored before,
    in data->E. */
 void ies::Data::augment_initialE(const Eigen::MatrixXd &E0) {
 

--- a/libres/lib/analysis/update.cpp
+++ b/libres/lib/analysis/update.cpp
@@ -34,7 +34,7 @@ bool_vector_to_active_list(const std::vector<bool> &bool_vector) {
 }
 } // namespace
 
-/*
+/**
  This is very awkward; the problem is that for the GEN_DATA type the config
  object does not really own the size. Instead the size is pushed (on load time)
  from gen_data instances to the gen_data_config instance. Therefore we have to
@@ -123,7 +123,7 @@ void assert_matrix_size(const Eigen::MatrixXd &m, const char *name, int rows,
                                     "," + std::to_string(columns) + "]");
 }
 
-/*
+/**
 load a set of parameters from a enkf_fs_type storage into a set of
 matrices.
 */
@@ -172,7 +172,7 @@ void save_parameters(enkf_fs_type *target_fs,
     }
 }
 
-/*
+/**
 Store a parameters into a enkf_fs_type storage
 */
 void save_row_scaling_parameters(
@@ -198,7 +198,7 @@ void save_row_scaling_parameters(
     }
 }
 
-/*
+/**
 load a set of parameters from a enkf_fs_type storage into a set of
 matrices with the corresponding row-scaling object.
 */
@@ -237,7 +237,7 @@ load_row_scaling_parameters(
     return parameters;
 }
 
-/*
+/**
 Copy all parameters from source_fs to target_fs
 */
 void copy_parameters(enkf_fs_type *source_fs, enkf_fs_type *target_fs,

--- a/libres/lib/config/conf.cpp
+++ b/libres/lib/config/conf.cpp
@@ -34,33 +34,45 @@
 namespace fs = std::filesystem;
 
 struct conf_class_struct {
-    const conf_class_type *super_class; /* Can be NULL */
+    /** Can be NULL */
+    const conf_class_type *super_class;
     char *class_name;
-    char *help; /* Can be NULL if not given */
+    /** Can be NULL if not given */
+    char *help;
     bool require_instance;
     bool singleton;
 
-    hash_type *sub_classes;    /* conf_class_types */
-    hash_type *item_specs;     /* conf_item_spec_types */
-    vector_type *item_mutexes; /* item_mutex_types */
+    /** conf_class_types */
+    hash_type *sub_classes;
+    /** conf_item_spec_types */
+    hash_type *item_specs;
+    /** item_mutex_types */
+    vector_type *item_mutexes;
 };
 
 struct conf_instance_struct {
     const conf_class_type *conf_class;
     char *name;
 
-    hash_type *sub_instances; /* conf_instance_types */
-    hash_type *items;         /* conf_item_types */
+    /** conf_instance_types */
+    hash_type *sub_instances;
+    /** conf_item_types */
+    hash_type *items;
 };
 
 struct conf_item_spec_struct {
-    const conf_class_type *super_class; /* NULL if not inserted into a class */
+    /** NULL if not inserted into a class */
+    const conf_class_type *super_class;
     char *name;
-    bool required_set;   /* Require the item to take a valid value */
-    char *default_value; /* Can be NULL if not given */
-    dt_enum dt;          /* Data type. See conf_data */
+    /** Require the item to take a valid value */
+    bool required_set;
+    /** Can be NULL if not given */
+    char *default_value;
+    /** Data type. See conf_data */
+    dt_enum dt;
     std::set<std::string> *restriction;
-    char *help; /* Can be NULL if not given */
+    /** Can be NULL if not given */
+    char *help;
 };
 
 struct conf_item_struct {
@@ -71,8 +83,8 @@ struct conf_item_struct {
 struct conf_item_mutex_struct {
     const conf_class_type *super_class;
     bool require_one;
-    bool
-        inverse; /* if inverse == true the 'mutex' implements: if A then ALSO B, C and D */
+    /** if inverse == true the 'mutex' implements: if A then ALSO B, C and D */
+    bool inverse;
     hash_type *item_spec_refs;
 };
 
@@ -649,7 +661,7 @@ conf_instance_get_item_value_ref(const conf_instance_type *conf_instance,
     return conf_item->value;
 }
 
-/* If the dt supports it, this function shall return the item value as an int.
+/** If the dt supports it, this function shall return the item value as an int.
     If the dt does not support it, the function will abort.
 */
 int conf_instance_get_item_value_int(const conf_instance_type *conf_instance,
@@ -666,7 +678,7 @@ int conf_instance_get_item_value_int(const conf_instance_type *conf_instance,
     return conf_data_get_int_from_string(conf_item_spec->dt, conf_item->value);
 }
 
-/* If the dt supports it, this function shall return the item value as a double.
+/** If the dt supports it, this function shall return the item value as a double.
     If the dt does not support it, the function will abort.
 */
 double
@@ -686,7 +698,7 @@ conf_instance_get_item_value_double(const conf_instance_type *conf_instance,
                                             conf_item->value);
 }
 
-/* If the dt supports it, this function shall return the item value as a time_t.
+/** If the dt supports it, this function shall return the item value as a time_t.
     If the dt does not support it, the function will abort.
 */
 time_t

--- a/libres/lib/config/conf_util.cpp
+++ b/libres/lib/config/conf_util.cpp
@@ -25,7 +25,7 @@
 
 #include <ert/config/conf_util.hpp>
 
-/*
+/**
   This function creates a string buffer from a file. Furthermore, if the strings in pad_keys are found in the buffer,
   they are padded with a space before and after.
 
@@ -74,7 +74,7 @@ char *conf_util_fscanf_alloc_token_buffer(const char *file_name) {
     return buffer;
 }
 
-/*
+/**
   This function takes a pointer to a position in a string and returns a copy
   of the next token in the string. Furthermore, the position in the string is
   moved to the position after the token. Strings inside quotations " and ' are

--- a/libres/lib/config/config_content.cpp
+++ b/libres/lib/config/config_content.cpp
@@ -34,9 +34,9 @@
 
 struct config_content_struct {
     UTIL_TYPE_ID_DECLARATION;
-    std::set<std::string> *
-        parsed_files; /* A set of config files whcih have been parsed - to protect against circular includes. */
-
+    /** A set of config files which have been parsed - to protect against
+     * circular includes. */
+    std::set<std::string> *parsed_files;
     vector_type *nodes;
     hash_type *items;
     config_error_type *parse_errors;
@@ -217,11 +217,10 @@ double config_content_iget_as_double(const config_content_type *content,
     return config_content_item_iget_as_double(item, occurence, index);
 }
 
-/*
+/**
    This function will return NULL is the item has not been set,
    however it must be installed with config_add_schema_item().
 */
-
 const char *config_content_safe_iget(const config_content_type *content,
                                      const char *kw, int occurence, int index) {
     const char *value = NULL;
@@ -237,13 +236,12 @@ const char *config_content_safe_iget(const config_content_type *content,
     return value;
 }
 
-/*
+/**
    Return the number of times a keyword has been set - dies on unknown
    'kw'. If the append_arg attribute has been set to false the
    function will return 0 or 1 irrespective of how many times the item
    has been set in the config file.
 */
-
 int config_content_get_occurences(const config_content_type *content,
                                   const char *kw) {
     if (config_content_has_item(content, kw))

--- a/libres/lib/config/config_content_item.cpp
+++ b/libres/lib/config/config_content_item.cpp
@@ -31,7 +31,7 @@ struct config_content_item_struct {
     const config_path_elm_type *path_elm;
 };
 
-/*
+/**
    This function counts the number of times a config item has been
    set. Referring again to the example at the top:
 
@@ -39,7 +39,6 @@ struct config_content_item_struct {
 
    will return 2.
 */
-
 int config_content_item_get_size(const config_content_item_type *item) {
     return vector_get_size(item->nodes);
 }
@@ -62,7 +61,7 @@ config_content_item_iget_stringlist_ref(const config_content_item_type *item,
     return config_content_node_get_stringlist(node);
 }
 
-/*
+/**
    If copy == false - the hash will break down when/if the
    config object is freed - your call.
 */
@@ -122,7 +121,7 @@ double config_content_item_iget_as_double(const config_content_item_type *item,
     return value;
 }
 
-/*
+/**
    Used to reset an item is the special string 'CLEAR_STRING'
    is found as the only argument:
 
@@ -136,7 +135,6 @@ double config_content_item_iget_as_double(const config_content_item_type *item,
    where several config files are parsed serially; and the user can
    not/will not update the first.
 */
-
 void config_content_item_clear(config_content_item_type *item) {
     vector_clear(item->nodes);
 }

--- a/libres/lib/config/config_content_node.cpp
+++ b/libres/lib/config/config_content_node.cpp
@@ -34,7 +34,8 @@ namespace fs = std::filesystem;
 struct config_content_node_struct {
     UTIL_TYPE_ID_DECLARATION;
     const config_schema_item_type *schema;
-    stringlist_type *stringlist; /* The values which have been set. */
+    /** The values which have been set. */
+    stringlist_type *stringlist;
     const config_path_elm_type *cwd;
     stringlist_type *string_storage;
 };
@@ -246,7 +247,7 @@ void config_content_node_assert_key_value(
                    __func__, config_schema_item_get_kw(node->schema));
 }
 
-/*
+/**
    The node should contain elements of the type:
 
       KEY1:VALUE1    KEY2:Value2   XX Key3:Val3  Ignored
@@ -255,7 +256,6 @@ void config_content_node_assert_key_value(
    "VALUE1" , ... } Elements which do not conform to this syntax are
    ignored.
 */
-
 void config_content_node_init_opt_hash(const config_content_node_type *node,
                                        hash_type *opt_hash, int elm_offset) {
     int i;

--- a/libres/lib/config/config_parser.cpp
+++ b/libres/lib/config/config_parser.cpp
@@ -38,7 +38,7 @@ namespace fs = std::filesystem;
 
 #define CLEAR_STRING "__RESET__"
 
-/*
+/**
 Structure to parse configuration files of this type:
 
 KEYWORD1  ARG2   ARG2  ARG3
@@ -47,10 +47,6 @@ KEYWORD2  ARG1-2
 KEYWORDN  ARG1  ARG2
 
 A keyword can occure many times.
-
-*/
-
-/*
 
 
                            =============================
@@ -112,18 +108,17 @@ first will again only contain one node each, whereas the OPTIONS item
 will contain three nodes, corresponding to the three times the keyword
 "OPTIONS" appear in the config file.
 */
-
 struct config_parser_struct {
     hash_type *schema_items;
-    hash_type *
-        messages; /* Can print a (warning) message when a keyword is encountered. */
+    /** Can print a (warning) message when a keyword is encountered. */
+    hash_type *messages;
 };
 
 int config_get_schema_size(const config_parser_type *config) {
     return hash_get_size(config->schema_items);
 }
 
-/*
+/**
   The last argument (config_file) is only used for printing
   informative error messages, and can be NULL. The config_cwd is
   essential if we are looking up a filename, otherwise it can be NULL.
@@ -132,7 +127,6 @@ int config_get_schema_size(const config_parser_type *config) {
   arguments were OK. The string is allocated here, but is assumed that
   calling scope will free it.
 */
-
 static config_content_node_type *config_content_item_set_arg__(
     subst_list_type *define_list, config_error_type *parse_errors,
     config_content_item_type *item, stringlist_type *token_list,
@@ -230,14 +224,13 @@ static void config_insert_schema_item(config_parser_type *config,
                                    config_schema_item_free__);
 }
 
-/*
+/**
    This function allocates a simple item with all values
    defaulted. The item is added to the config object, and a pointer is
    returned to the calling scope. If you want to change the properties
    of the item you can do that with config_schema_item_set_xxxx() functions
    from the calling scope.
 */
-
 config_schema_item_type *config_add_schema_item(config_parser_type *config,
                                                 const char *kw, bool required) {
 
@@ -246,7 +239,7 @@ config_schema_item_type *config_add_schema_item(config_parser_type *config,
     return item;
 }
 
-/*
+/**
   This is a minor wrapper for adding an item with the properties.
 
     1. It has argc_minmax = {1,1}
@@ -254,7 +247,6 @@ config_schema_item_type *config_add_schema_item(config_parser_type *config,
    The value can than be extracted with config_get_value() and
    config_get_value_as_xxxx functions.
 */
-
 config_schema_item_type *config_add_key_value(config_parser_type *config,
                                               const char *key, bool required,
                                               config_item_types item_type) {
@@ -274,11 +266,10 @@ config_get_schema_item(const config_parser_type *config, const char *kw) {
     return (config_schema_item_type *)hash_get(config->schema_items, kw);
 }
 
-/*
+/**
   Due to the possibility of aliases we must go through the canonical
   keyword which is internalized in the schema_item.
 */
-
 static void config_validate_content_item(const config_parser_type *config,
                                          config_content_type *content,
                                          const config_content_item_type *item) {
@@ -465,7 +456,7 @@ bool config_parser_add_key_values(
     return new_node != NULL;
 }
 
-/*
+/**
    This function parses the config file 'filename', and updated the
    internal state of the config object as parsing proceeds. If
    comment_string != NULL everything following 'comment_string' on a
@@ -535,7 +526,6 @@ bool config_parser_add_key_values(
    The         key-value pairs internalized during the config parsing are NOT
    returned to the calling scope in any way.
 */
-
 static void
 config_parse__(config_parser_type *config, config_content_type *content,
                path_stack_type *path_stack, const char *config_filename,
@@ -675,7 +665,7 @@ config_parse(config_parser_type *config, const char *filename,
     return content;
 }
 
-/*
+/**
    This function adds an alias to an existing item; so that the
    value+++ of an item can be referred to by two different names.
 */

--- a/libres/lib/config/config_path_elm.cpp
+++ b/libres/lib/config/config_path_elm.cpp
@@ -27,8 +27,10 @@
 
 struct config_path_elm_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *abs_path; // This will always be absolute
-    char *rel_path; // This will always be relative to the root path.
+    /** This will always be absolute */
+    char *abs_path;
+    /** This will always be relative to the root path. */
+    char *rel_path;
     const config_root_path_type *root_path;
 };
 

--- a/libres/lib/config/config_root_path.cpp
+++ b/libres/lib/config/config_root_path.cpp
@@ -28,12 +28,11 @@ struct config_root_path_struct {
     char *rel_path;
 };
 
-/*
+/**
    Input must be an existing directory, which will be used as the
    root; or NULL in which case cwd will be used as root. The input
    directory can be both realtive or absolute.
 */
-
 config_root_path_type *config_root_path_alloc(const char *input_path) {
     if (input_path == NULL || util_is_directory(input_path)) {
         config_root_path_type *root_path =

--- a/libres/lib/config/config_schema_item.cpp
+++ b/libres/lib/config/config_schema_item.cpp
@@ -227,9 +227,11 @@ config_schema_item_type *config_schema_item_alloc(const char *kw,
     item->deprecate_msg = NULL;
     item->required_children = NULL;
     item->required_children_value = NULL;
-    item->expand_envvar =
-        true; /* Default is to expand $VAR expressions; can be turned off with
-                                            config_schema_item_set_envvar_expansion( item , false ); */
+    item->expand_envvar = true; // Default is to expand $VAR expressions;
+                                // can be turned off with
+                                // config_schema_item_set_envvar_expansion(
+                                //     item,
+                                //     false);
     item->validate = validate_alloc();
     return item;
 }

--- a/libres/lib/config/config_schema_item.cpp
+++ b/libres/lib/config/config_schema_item.cpp
@@ -36,7 +36,7 @@ namespace fs = std::filesystem;
 
 typedef struct validate_struct validate_type;
 
-/*
+/**
    This is a 'support-struct' holding various pieces of information
    needed during the validation process. Observe the following about
    validation:
@@ -68,35 +68,43 @@ typedef struct validate_struct validate_type;
     2. If setting indexed_selection_set or type_map, you MUST set
        argc_max first.
 */
-
 struct validate_struct {
-    std::set<std::string>
-        common_selection_set; /* A selection set which will apply uniformly to all the arguments. */
+    std::set<std::string> common_selection_set; /** A selection set which will
+                                                  apply uniformly to all the
+                                                  arguments. */
     std::vector<std::set<std::string>> indexed_selection_set;
 
-    int argc_min; /* The minimum number of arguments: -1 means no lower limit. */
-    int argc_max; /* The maximum number of arguments: -1 means no upper limit. */
-    int_vector_type *
-        type_map; /* A list of types for the items. Set along with argc_minmax(); */
-    stringlist_type *
-        required_children; /* A list of item's which must also be set (if this item is set). (can be NULL) */
-    hash_type *
-        required_children_value; /* A list of item's which must also be set - depending on the value of this item. (can be NULL) (This one is complex). */
+    /** The minimum number of arguments: -1 means no lower limit. */
+    int argc_min;
+    /** The maximum number of arguments: -1 means no upper limit. */
+    int argc_max;
+    /** A list of types for the items. Set along with argc_minmax(); */
+    int_vector_type *type_map;
+    /** A list of item's which must also be set (if this item is set). (can be
+     * NULL) */
+    stringlist_type *required_children;
+    /** A list of item's which must also be set - depending on the value of
+     * this item. (can be NULL) (This one is complex). */
+    hash_type *required_children_value;
 };
 
 #define CONFIG_SCHEMA_ITEM_ID 6751
 struct config_schema_item_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *kw; /* The kw which identifies this item */
+    /** The kw which identifies this item */
+    char *kw;
 
     bool required_set;
-    stringlist_type *
-        required_children; /* A list of item's which must also be set (if this item is set). (can be NULL) */
-    hash_type *
-        required_children_value; /* A list of item's which must also be set - depending on the value of this item. (can be NULL) */
-    validate_type *validate;     /* Information need during validation. */
-    bool
-        expand_envvar; /* Should environment variables like $HOME be expanded?*/
+    /** A list of item's which must also be set (if this item is set). (can be
+     * NULL) */
+    stringlist_type *required_children;
+    /** A list of item's which must also be set - depending on the value of
+     * this item. (can be NULL) */
+    hash_type *required_children_value;
+    /** Information need during validation. */
+    validate_type *validate;
+    /** Should environment variables like $HOME be expanded?*/
+    bool expand_envvar;
     bool deprecated;
     char *deprecate_msg;
 };
@@ -523,14 +531,13 @@ void config_schema_item_set_required_children_on_value(
                                stringlist_free__);
 }
 
-/*
+/**
    This function is used to set the minimum and maximum number of
    arguments for an item. In addition you can pass in a pointer to an
    array of config_schema_item_types values which will be used for validation
    of the input. This vector must be argc_max elements long; it can be
    NULL.
 */
-
 void config_schema_item_set_argc_minmax(config_schema_item_type *item,
                                         int argc_min, int argc_max) {
 

--- a/libres/lib/enkf/active_list.cpp
+++ b/libres/lib/enkf/active_list.cpp
@@ -66,13 +66,12 @@ void ActiveList::add_index(int new_index) {
     }
 }
 
-/*
+/**
    When mode == PARTLY_ACTIVE the active_list instance knows the size
    of the active set; if the mode is INACTIVE 0 will be returned and
    if the mode is ALL_ACTIVE the input parameter @total_size will be
    passed back to calling scope.
 */
-
 int ActiveList::active_size(int total_size) const {
     int active_size;
     switch (this->m_mode) {
@@ -87,13 +86,12 @@ int ActiveList::active_size(int total_size) const {
 
 active_mode_type ActiveList::getMode() const { return this->m_mode; }
 
-/*
+/**
    This will return a (const int *) pointer to the active indices. IFF
    (mode == INACTIVE || mode == ALL_ACTIVE) it will instead just
    return NULL. In that case it is the responsability of the calling
    scope to not dereference the NULL pointer.
 */
-
 const int *ActiveList::active_list_get_active() const {
     if (this->m_mode == PARTLY_ACTIVE)
         return this->m_index_list.data();

--- a/libres/lib/enkf/analysis_config.cpp
+++ b/libres/lib/enkf/analysis_config.cpp
@@ -50,16 +50,18 @@ struct analysis_config_struct {
     UTIL_TYPE_ID_DECLARATION;
     std::unordered_map<std::string, analysis_module_type *> analysis_modules;
     analysis_module_type *analysis_module;
-    char *log_path; /* Points to directory with update logs. */
+    /** Points to directory with update logs. */
+    char *log_path;
 
-    bool
-        rerun; /* Should we rerun the simulator when the parameters have been updated? */
-    int rerun_start; /* When rerunning - from where should we start? */
+    /** Should we rerun the simulator when the parameters have been updated? */
+    bool rerun;
+    /** When rerunning - from where should we start? */
+    int rerun_start;
 
     config_settings_type *update_settings;
 
-    bool
-        single_node_update; /* When creating the default ALL_ACTIVE local configuration. */
+    /** When creating the default ALL_ACTIVE local configuration. */
+    bool single_node_update;
     analysis_iter_config_type *iter_config;
     int min_realisations;
     bool stop_long_running;
@@ -182,7 +184,7 @@ void analysis_config_set_log_path(analysis_config_type *config,
     config->log_path = util_realloc_string_copy(config->log_path, log_path);
 }
 
-/*
+/**
    Will in addition create the path.
 */
 const char *analysis_config_get_log_path(const analysis_config_type *config) {
@@ -305,11 +307,10 @@ void analysis_config_load_internal_modules(analysis_config_type *config) {
     analysis_config_select_module(config, DEFAULT_ANALYSIS_MODULE);
 }
 
-/*
+/**
    The analysis_config object is instantiated with the default values
    for enkf_defaults.h
 */
-
 void analysis_config_init(analysis_config_type *analysis,
                           const config_content_type *config) {
     config_settings_apply(analysis->update_settings, config);

--- a/libres/lib/enkf/block_fs_driver.cpp
+++ b/libres/lib/enkf/block_fs_driver.cpp
@@ -48,8 +48,8 @@ struct bfs_config_struct {
 struct bfs_struct {
     UTIL_TYPE_ID_DECLARATION;
     block_fs_type *block_fs;
-    char *
-        mountfile; // The full path to the file mounted by the block_fs layer - including extension.
+    /** The full path to the file mounted by the block_fs layer - including extension.*/
+    char *mountfile;
 
     const bfs_config_type *config;
 };
@@ -257,11 +257,10 @@ void block_fs_driver_create_fs(FILE *stream, const char *mount_point,
     }
 }
 
-/*
+/**
   @path should contain both elements called root_path and case_path in
   the block_fs_driver_create() function.
 */
-
 ert::block_fs_driver *ert::block_fs_driver::open(FILE *fstab_stream,
                                                  const char *mount_point,
                                                  bool read_only) {

--- a/libres/lib/enkf/block_obs.cpp
+++ b/libres/lib/enkf/block_obs.cpp
@@ -56,7 +56,8 @@ static UTIL_SAFE_CAST_FUNCTION(point_obs, POINT_OBS_TYPE_ID);
 
 struct block_obs_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *obs_key; /* A user provided label for the observation.      */
+    /** A user provided label for the observation.*/
+    char *obs_key;
     vector_type *point_list;
     const ecl_grid_type *grid;
     const void *data_config;
@@ -204,7 +205,7 @@ block_obs_type *block_obs_alloc(const char *obs_key, const void *data_config,
     }
 }
 
-/*
+/**
    The input vectors i,j,k should contain offset zero values.
 */
 block_obs_type *

--- a/libres/lib/enkf/ecl_config.cpp
+++ b/libres/lib/enkf/ecl_config.cpp
@@ -427,30 +427,7 @@ void ecl_config_init(ecl_config_type *ecl_config,
             "            for this functionality has been removed. libres will "
             "not\n"
             "            be able to properly initialize the ECLIPSE MODEL.\n");
-    /*
-     This is a hard error - the datafile contains <INIT>, however
-     the config file does NOT contain INIT_SECTION, i.e. we have
-     no information to fill in for the <INIT> section. This case
-     will not be able to initialize an ECLIPSE model, and that is
-     broken behaviour.
-     */
 
-    /*
-   The user has not supplied a INIT_SECTION keyword whatsoever,
-   this essentially means that we can not restart - because:
-
-   1. The EQUIL section must be inlined in the DATAFILE without any
-   special markup.
-
-   2. ECLIPSE will fail hard if the datafile contains both an EQUIL
-   section and a restart statement, and when we have not marked
-   the EQUIL section specially with the INIT_SECTION keyword it
-   is impossible for ERT to dynamically change between a
-   datafile with initialisation and a datafile for restart.
-
-   IFF the user has no intentitions of any form of restart, this is
-   perfectly legitemate.
-   */
     if (config_content_has_item(config, END_DATE_KEY))
         handle_has_end_date_key(ecl_config, config);
 

--- a/libres/lib/enkf/ecl_config.cpp
+++ b/libres/lib/enkf/ecl_config.cpp
@@ -38,9 +38,8 @@
 
 namespace fs = std::filesystem;
 
-/*
- This file implements a struct which holds configuration information
- needed to run ECLIPSE.
+/**
+ The ecl_config_struct holds configuration information needed to run ECLIPSE.
 
  Pointers to the fields in this structure are passed on to e.g. the
  enkf_state->shared_info object, but this struct is the *OWNER* of
@@ -50,25 +49,33 @@ namespace fs = std::filesystem;
  Observe that the distinction of what goes in model_config, and what
  goes in ecl_config is not entirely clear.
  */
-
 struct ecl_config_struct {
-    ecl_io_config_type *
-        io_config; /* This struct contains information of whether the eclipse files should be formatted|unified|endian_fliped */
-    char *data_file; /* Eclipse data file. */
-    time_t
-        end_date; /* An optional date value which can be used to check if the ECLIPSE simulation has been 'long enough'. */
+    /** This struct contains information of whether the eclipse files should be
+     * formatted|unified|endian_fliped */
+    ecl_io_config_type *io_config;
+    /** Eclipse data file. */
+    char *data_file;
+    /** An optional date value which can be used to check if the ECLIPSE
+     * simulation has been 'long enough'. */
+    time_t end_date;
     ecl_refcase_list_type *refcase_list;
-    ecl_grid_type *grid; /* The grid which is active for this model. */
-    char *
-        schedule_prediction_file; /* Name of schedule prediction file - observe that this is internally handled as a gen_kw node. */
+    /** The grid which is active for this model. */
+    ecl_grid_type *grid;
+    /** Name of schedule prediction file - observe that this is internally
+     * handled as a gen_kw node. */
+    char *schedule_prediction_file;
     int last_history_restart;
-    bool can_restart; /* Have we found the <INIT> tag in the data file? */
+    /** Have we found the <INIT> tag in the data file? */
+    bool can_restart;
     bool have_eclbase;
-    int num_cpu; /* We should parse the ECLIPSE data file and determine how many cpus this eclipse file needs. */
-    ert_ecl_unit_enum unit_system; /* Either metric, field or lab */
+    /** We should parse the ECLIPSE data file and determine how many cpus this
+     * eclipse file needs. */
+    int num_cpu;
+    /** Either metric, field or lab */
+    ert_ecl_unit_enum unit_system;
 };
 
-/*
+/**
  With this function we try to determine whether ECLIPSE is active
  for this case, i.e. if ECLIPSE is part of the forward model. This
  should ideally be inferred from the FORWARD model, but what we do
@@ -76,7 +83,6 @@ struct ecl_config_struct {
  have been set. If they are both equal to NULL we assume that
  ECLIPSE is not active and return false, otherwise we return true.
  */
-
 bool ecl_config_active(const ecl_config_type *config) {
     if (config->have_eclbase)
         return true;
@@ -165,11 +171,10 @@ ecl_config_get_schedule_prediction_file(const ecl_config_type *ecl_config) {
     return ecl_config->schedule_prediction_file;
 }
 
-/*
+/**
    Observe: The real schedule prediction functionality is implemented
    as a special GEN_KW node in ensemble_config.
  */
-
 void ecl_config_set_schedule_prediction_file(
     ecl_config_type *ecl_config, const char *schedule_prediction_file) {
     ecl_config->schedule_prediction_file = util_realloc_string_copy(
@@ -201,7 +206,7 @@ ui_return_type *ecl_config_validate_eclbase(const ecl_config_type *ecl_config,
     }
 }
 
-/*
+/**
  Can be called with @refcase == NULL - which amounts to clearing the
  current refcase.
 */
@@ -223,9 +228,9 @@ ui_return_type *ecl_config_validate_refcase(const ecl_config_type *ecl_config,
     }
 }
 
-/*
+/**
  Will return NULL if no refcase is set.
- */
+*/
 const char *ecl_config_get_refcase_name(const ecl_config_type *ecl_config) {
     const ecl_sum_type *refcase =
         ecl_refcase_list_get_default(ecl_config->refcase_list);
@@ -477,7 +482,7 @@ const char *ecl_config_get_gridfile(const ecl_config_type *ecl_config) {
         return ecl_grid_get_name(ecl_config->grid);
 }
 
-/*
+/**
    The ecl_config object isolated supports run-time changing of the
    grid, however this does not (in general) apply to the system as a
    whole. Other objects which internalize pointers (i.e. field_config
@@ -485,7 +490,6 @@ const char *ecl_config_get_gridfile(const ecl_config_type *ecl_config) {
    pointers; and things will probably die an ugly death. So - changing
    grid runtime should be done with extreme care.
 */
-
 void ecl_config_set_grid(ecl_config_type *ecl_config, const char *grid_file) {
     if (ecl_config->grid != NULL)
         ecl_grid_free(ecl_config->grid);
@@ -569,7 +573,7 @@ void ecl_config_add_config_items(config_parser_type *config) {
     config_schema_item_set_argc_minmax(item, 1, 1);
 }
 
-/* Units as specified in the ECLIPSE technical manual */
+/** Units as specified in the ECLIPSE technical manual */
 const char *ecl_config_get_depth_unit(const ecl_config_type *ecl_config) {
     switch (ecl_config->unit_system) {
     case ECL_METRIC_UNITS:

--- a/libres/lib/enkf/ecl_refcase_list.cpp
+++ b/libres/lib/enkf/ecl_refcase_list.cpp
@@ -61,15 +61,16 @@
 
 typedef struct sum_pair_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *case_name; // This  should be (path)/basename - no extension
+    /** case_name should be (path)/basename - no extension */
+    char *case_name;
     ecl_sum_type *ecl_sum;
 } sum_pair_type;
 
 struct ecl_refcase_list_struct {
     sum_pair_type *default_case;
     hash_type *case_dict;
-    vector_type *
-        case_list; /* This is created, and sorted, on demand when we do indexed lookup of cases. */
+    /** The case_lost is created, and sorted, on demand when we do indexed lookup of cases.*/
+    vector_type *case_list;
     bool sorted;
 };
 
@@ -173,10 +174,9 @@ static void ecl_refcase_list_del_default(ecl_refcase_list_type *refcase_list) {
     }
 }
 
-/*
+/**
   If a valid refcase has been set already, and this fails, nothing happens.
 */
-
 bool ecl_refcase_list_set_default(ecl_refcase_list_type *refcase_list,
                                   const char *default_case) {
 
@@ -199,10 +199,9 @@ bool ecl_refcase_list_set_default(ecl_refcase_list_type *refcase_list,
     }
 }
 
-/*
+/**
    Will sort the list and remove all elements which can not be loaded.
 */
-
 static void ecl_refcase_list_assert_clean(ecl_refcase_list_type *refcase_list) {
     if (!refcase_list->sorted) {
         vector_free(refcase_list->case_list);
@@ -333,7 +332,7 @@ int ecl_refcase_list_add_case(ecl_refcase_list_type *refcase_list,
         return 0;
 }
 
-/*
+/**
   The glob_string pattern must (for all practical purposes) end in an
   explicit extension:
 
@@ -344,7 +343,6 @@ int ecl_refcase_list_add_case(ecl_refcase_list_type *refcase_list,
   If the input glob string does not have an explicit extension we add
   .*SMSPEC for the matching purpose.
 */
-
 int ecl_refcase_list_add_matching(ecl_refcase_list_type *refcase_list,
                                   const char *__glob_string) {
     int count = 0;

--- a/libres/lib/enkf/enkf_config_node.cpp
+++ b/libres/lib/enkf/enkf_config_node.cpp
@@ -50,30 +50,35 @@ struct enkf_config_node_struct {
     ert_impl_type impl_type;
     enkf_var_type var_type;
     bool vector_storage;
-    bool
-        forward_init; /* Should the (parameter) node be initialized by loading results from the Forward model? */
+    /** Should the (parameter) node be initialized by loading results from the
+     * Forward model? */
+    bool forward_init;
 
-    bool_vector_type *
-        internalize; /* Should this node be internalized - observe that question of what to internalize is MOSTLY handled at a higher level - without consulting this variable. Can be NULL. */
-    stringlist_type
-        *obs_keys; /* Keys of observations which observe this node. */
+    /** Should this node be internalized - observe that question of what to
+     * internalize is MOSTLY handled at a higher level - without consulting
+     * this variable. Can be NULL. */
+    bool_vector_type *internalize;
+    /** Keys of observations which observe this node. */
+    stringlist_type *obs_keys;
     char *key;
     char *init_file_abs_path;
-    path_fmt_type
-        *init_file_fmt; /* Format used to create files for initialization. */
-    path_fmt_type *
-        enkf_infile_fmt; /* Format used to load in file from forward model - one %d (if present) is replaced with report_step. */
-    path_fmt_type *
-        enkf_outfile_fmt; /* Name of file which is written by EnKF, and read by the forward model. */
-    void *
-        data; /* This points to the config object of the actual implementation.        */
+    /** Format used to create files for initialization. */
+    path_fmt_type *init_file_fmt;
+    /** Format used to load in file from forward model - one %d (if present) is
+     * replaced with report_step. */
+    path_fmt_type *enkf_infile_fmt;
+    /** Name of file which is written by EnKF, and read by the forward model. */
+    path_fmt_type *enkf_outfile_fmt;
+    /** This points to the config object of the actual implementation. */
+    void *data;
     enkf_node_type *min_std;
     char *min_std_file;
 
+    /** Function pointers to methods working on the underlying config object. */
     vector_type *container_nodes;
-    /* Function pointers to methods working on the underlying config object. */
-    get_data_size_ftype *
-        get_data_size; /* Function pointer to ask the underlying config object of the size - i.e. number of elements. */
+    /** Function pointer to ask the underlying config object of the size - i.e.
+     * number of elements. */
+    get_data_size_ftype *get_data_size;
     config_free_ftype *freef;
 };
 
@@ -248,7 +253,7 @@ void enkf_config_node_update_gen_kw(
                             min_std_file);
 }
 
-/*
+/**
    This will create a new gen_kw_config instance which is NOT yet
    valid.
 */
@@ -374,7 +379,7 @@ enkf_config_node_iget_container_key(const enkf_config_node_type *config_node,
     return child_node->key;
 }
 
-/*
+/**
    This will create a new gen_kw_config instance which is NOT yet
    valid. Mainly support code for the GUI.
 */
@@ -444,10 +449,9 @@ int enkf_config_node_container_size(const enkf_config_node_type *node) {
     return vector_get_size(node->container_nodes);
 }
 
-/*
+/**
    Invokes the get_data_size() function of the underlying node object.
 */
-
 int enkf_config_node_get_data_size(const enkf_config_node_type *node,
                                    int report_step) {
     if (node->impl_type == GEN_DATA)
@@ -572,11 +576,10 @@ bool enkf_config_node_internalize(const enkf_config_node_type *node,
             report_step); /* Will return default value if report_step is beyond size. */
 }
 
-/*
+/**
    This is the filename used when loading from a completed forward
    model.
 */
-
 char *enkf_config_node_alloc_infile(const enkf_config_node_type *node,
                                     int report_step) {
     if (node->enkf_infile_fmt != NULL)
@@ -593,11 +596,10 @@ char *enkf_config_node_alloc_outfile(const enkf_config_node_type *node,
         return NULL;
 }
 
-/*
+/**
   The path argument is used when the function is during forward_model
   based initialisation.
 */
-
 char *enkf_config_node_alloc_initfile(const enkf_config_node_type *node,
                                       const char *path, int iens) {
     if (node->init_file_fmt == NULL)
@@ -657,10 +659,9 @@ int enkf_config_node_get_num_obs(const enkf_config_node_type *config_node) {
     return stringlist_get_size(config_node->obs_keys);
 }
 
-/*
+/**
    This checks the index_key - and sums up over all the time points of the observation.
 */
-
 int enkf_config_node_load_obs(const enkf_config_node_type *config_node,
                               enkf_obs_type *enkf_obs, const char *key_index,
                               int obs_count, time_t *_sim_time, double *_y,

--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -145,8 +145,8 @@ struct enkf_fs_struct {
     UTIL_TYPE_ID_DECLARATION;
     char *case_name;
     char *root_path;
-    char *
-        mount_point; // mount_point = root_path / case_name; the mount_point is the fundamental INPUT.
+    /** mount_point = root_path / case_name; the mount_point is the fundamental INPUT. */
+    char *mount_point;
 
     char *lock_file;
     int lock_fd;
@@ -155,24 +155,24 @@ struct enkf_fs_struct {
     std::unique_ptr<ert::block_fs_driver> parameter;
     std::unique_ptr<ert::block_fs_driver> index;
 
-    bool read_only; /* Whether this filesystem has been mounted read-only. */
+    /** Whether this filesystem has been mounted read-only. */
+    bool read_only;
     time_map_type *time_map;
     cases_config_type *cases_config;
     state_map_type *state_map;
     summary_key_set_type *summary_key_set;
+    /* The variables below here are for storing arbitrary files within the
+     * enkf_fs storage directory, but not as serialized enkf_nodes. */
     misfit_ensemble_type *misfit_ensemble;
-    /*
-     The variables below here are for storing arbitrary files within
-     the enkf_fs storage directory, but not as serialized enkf_nodes.
-  */
     path_fmt_type *case_fmt;
     path_fmt_type *case_member_fmt;
     path_fmt_type *case_tstep_fmt;
     path_fmt_type *case_tstep_member_fmt;
 
     int refcount;
-    int runcount; // Counts the number of simulations currently writing to this enkf_fs; the purpose is to
-        // be able to answer the question: Is this case currently 'running'?
+    /** Counts the number of simulations currently writing to this enkf_fs; the
+     * purpose is to be able to answer the question: Is this case currently 'running'? */
+    int runcount;
 };
 
 UTIL_SAFE_CAST_FUNCTION(enkf_fs, ENKF_FS_TYPE_ID)
@@ -265,12 +265,11 @@ static int enkf_fs_fread_fs_version__(FILE *stream) {
     return version;
 }
 
-/*
+/**
    -1 : No mount map found.
    0  : Old mount map without version info.
    x  : Actual version info.
 */
-
 static int enkf_fs_get_fs_version__(const char *config_file) {
     int version = -1;
     if (fs::exists(config_file)) {
@@ -281,10 +280,9 @@ static int enkf_fs_get_fs_version__(const char *config_file) {
     return version;
 }
 
-/*
+/**
    Function written to look for old (version <= 104) mount info maps.
 */
-
 int enkf_fs_get_version104(const char *path) {
     char *config_file = util_alloc_filename(path, ENKF_MOUNT_MAP, NULL);
     int version = enkf_fs_get_fs_version__(config_file);

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -58,7 +58,9 @@
 
 static auto logger = ert::get_logger("enkf");
 
-/*
+#define ENKF_MAIN_ID 8301
+
+/**
    This object should contain **everything** needed to run a enkf
    simulation. A way to wrap up all available information/state and
    pass it around. An attempt has been made to collect various pieces
@@ -85,12 +87,10 @@ static auto logger = ert::get_logger("enkf");
        and matched into other small holding objects defined in
        enkf_state.c.
 */
-
-#define ENKF_MAIN_ID 8301
-
 struct enkf_main_struct {
     UTIL_TYPE_ID_DECLARATION;
-    enkf_fs_type *dbase; /* The internalized information. */
+    /** The internalized information. */
+    enkf_fs_type *dbase;
 
     const res_config_type *res_config;
     rng_manager_type *rng_manager;
@@ -98,8 +98,10 @@ struct enkf_main_struct {
 
     enkf_obs_type *obs;
 
-    enkf_state_type **ensemble; /* The ensemble ... */
-    int ens_size;               /* The size of the ensemble */
+    /** The ensemble */
+    enkf_state_type **ensemble;
+    /** The size of the ensemble */
+    int ens_size;
 };
 
 void enkf_main_init_internalization(enkf_main_type *);
@@ -249,7 +251,7 @@ void enkf_main_create_run_path(enkf_main_type *enkf_main,
     enkf_main_write_run_path(enkf_main, run_context);
 }
 
-/*
+/**
    This function will initialize the necessary enkf_main structures
    before a run. Currently this means:
 
@@ -259,7 +261,6 @@ void enkf_main_create_run_path(enkf_main_type *enkf_main,
      2. Set up the configuration of what should be internalized.
 
 */
-
 void enkf_main_init_run(enkf_main_type *enkf_main,
                         const ert_run_context_type *run_context) {
     enkf_main_init_internalization(enkf_main);
@@ -282,7 +283,7 @@ ert_run_context_type *enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(
         enkf_main_get_data_kw(enkf_main), iter);
 }
 
-/*
+/**
    There is NO tagging anymore - if the user wants tags - the user
    supplies the key __WITH__ tags.
 */
@@ -343,7 +344,7 @@ static void enkf_main_add_ensemble_members(enkf_main_type *enkf_main) {
     enkf_main_increase_ensemble(enkf_main, num_realizations);
 }
 
-/*
+/**
    This function boots everything needed for running a EnKF
    application from the provided res_config.
 
@@ -358,14 +359,10 @@ static void enkf_main_add_ensemble_members(enkf_main_type *enkf_main) {
     SCHEDULE_FILE
     ECLBASE
 
-*/
-
-/*
    It is possible to pass NULL as the model_config argument, in that
    case only the site config file will be parsed. The purpose of this
    is mainly to be able to test that the site config file is valid.
 */
-
 enkf_main_type *enkf_main_alloc(const res_config_type *res_config) {
     enkf_main_type *enkf_main = enkf_main_alloc_empty();
     enkf_main->res_config = res_config;
@@ -382,7 +379,7 @@ int enkf_main_get_ensemble_size(const enkf_main_type *enkf_main) {
     return enkf_main->ens_size;
 }
 
-/*
+/**
    In this function we initialize the variables which control
    which nodes are internalized (i.e. loaded from the forward
    simulation and stored in the enkf_fs 'database'). The system is
@@ -433,7 +430,6 @@ int enkf_main_get_ensemble_size(const enkf_main_type *enkf_main) {
    instance the pressure (i.e. for an RFT) we must set the
    __load_state variable for the actual report step to true.
 */
-
 void enkf_main_init_internalization(enkf_main_type *enkf_main) {
     /* Clearing old internalize flags. */
     model_config_init_internalization(enkf_main_get_model_config(enkf_main));

--- a/libres/lib/enkf/enkf_main_manage_fs.cpp
+++ b/libres/lib/enkf/enkf_main_manage_fs.cpp
@@ -27,12 +27,11 @@
 
 namespace fs = std::filesystem;
 
-/*
+/**
   This small function is here only to make sure that the main
   enkf_main.c file does not contain any explicit mention of the
   dbase member.
 */
-
 static void enkf_main_init_fs(enkf_main_type *enkf_main) {
     enkf_main->dbase = NULL;
 }
@@ -200,14 +199,13 @@ void enkf_main_init_case_from_existing(const enkf_main_type *enkf_main,
     enkf_fs_fsync(target_case_fs);
 }
 
-/*
+/**
    This function will go through the filesystem and check that we have
    initial data for all parameters and all realizations. If the second
    argument mask is different from NULL, the function will only
    consider the realizations for which mask is true (if mask == NULL
    all realizations will be checked).
 */
-
 static bool
 enkf_main_case_is_initialized__(const ensemble_config_type *ensemble_config,
                                 enkf_fs_type *fs, const int ens_size) {
@@ -355,7 +353,7 @@ char *enkf_main_alloc_mount_point(const enkf_main_type *enkf_main,
     return mount_point;
 }
 
-/*
+/**
   Return a weak reference - i.e. the refcount is not increased.
 */
 enkf_fs_type *enkf_main_get_fs(const enkf_main_type *enkf_main) {
@@ -374,7 +372,7 @@ const char *enkf_main_get_current_fs(const enkf_main_type *enkf_main) {
     return enkf_fs_get_case_name(enkf_main->dbase);
 }
 
-/*
+/**
   This function will return a valid enkf_fs instance; either just a
   pointer to the current enkf_main->dbase, or alternatively it will
   create a brand new fs instance. Because we do not really know whether
@@ -387,7 +385,6 @@ const char *enkf_main_get_current_fs(const enkf_main_type *enkf_main) {
        close the filesystem and free all resources when the reference
        count has reached zero.
 */
-
 enkf_fs_type *enkf_main_mount_alt_fs(const enkf_main_type *enkf_main,
                                      const char *case_path, bool create) {
     if (enkf_main_case_is_current(enkf_main, case_path)) {
@@ -444,7 +441,7 @@ static void enkf_main_update_summary_config_from_fs__(enkf_main_type *enkf_main,
     stringlist_free(keys);
 }
 
-/*
+/**
    The enkf_fs instances employ a simple reference counting
    scheme. The main point with this system is to avoid opening the
    full timesystem more than necessary (this is quite compute
@@ -474,7 +471,6 @@ static void enkf_main_update_summary_config_from_fs__(enkf_main_type *enkf_main,
    is not checked for in any way - but the crash will be horrible if
    this is not adhered to.
 */
-
 void enkf_main_set_fs(enkf_main_type *enkf_main, enkf_fs_type *fs,
                       const char *case_path /* Can be NULL */) {
     if (enkf_main->dbase != fs) {

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -456,17 +456,6 @@ static void enkf_obs_update_keys(enkf_obs_type *enkf_obs) {
     }
 }
 
-/*
- *
- * Here comes four helper functions for enkf_obs_load:
- *
- * * handle_history_observation(enkf_obs, enkf_conf, last_report, std_cutoff);
- * * handle_summary_observation(enkf_obs, enkf_conf, last_report);
- * * handle_block_observation(enkf_obs, enkf_conf);
- * * handle_general_observation(enkf_obs, enkf_conf);
- *
- */
-
 /** Handle HISTORY_OBSERVATION instances. */
 static void handle_history_observation(enkf_obs_type *enkf_obs,
                                        conf_instance_type *enkf_conf,

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -34,7 +34,8 @@
 #include <ert/enkf/obs_vector.hpp>
 #include <ert/enkf/summary_obs.hpp>
 
-/*
+#define ENKF_OBS_TYPE_ID 637297
+/**
 
 The observation system
 ----------------------
@@ -157,20 +158,19 @@ In the following example we have two observations
  instance.
 
  */
-
-#define ENKF_OBS_TYPE_ID 637297
 struct enkf_obs_struct {
     UTIL_TYPE_ID_DECLARATION;
-    /* A hash of obs_vector_types indexed by user provided keys. */
+    /** A hash of obs_vector_types indexed by user provided keys. */
     vector_type *obs_vector;
     hash_type *obs_hash;
-    time_map_type *obs_time; /* For fast lookup of report_step -> obs_time */
+    /** For fast lookup of report_step -> obs_time */
+    time_map_type *obs_time;
 
     bool valid;
     /* Several shared resources - can generally be NULL*/
-    const history_type *
-        history; /* A shared (not owned by enkf_obs) reference to the history object - used when
-                                         adding HISTORY observations. */
+    /** A shared (not owned by enkf_obs) reference to the history object - used
+     * when adding HISTORY observations. */
+    const history_type *history;
     const ecl_sum_type *refcase;
     const ecl_grid_type *grid;
     time_map_type *external_time_map;
@@ -255,7 +255,7 @@ time_t enkf_obs_iget_obs_time(const enkf_obs_type *enkf_obs, int report_step) {
     return time_map_iget(enkf_obs->obs_time, report_step);
 }
 
-/*
+/**
    Observe that the obs_vector can be NULL - in which it is of course not added.
 */
 void enkf_obs_add_obs_vector(enkf_obs_type *enkf_obs,
@@ -410,11 +410,10 @@ static void enkf_obs_get_obs_and_measure_node(
     }
 }
 
-/*
+/**
   This will append observations and simulated responses from
   report_step to obs_data and meas_data.
 */
-
 void enkf_obs_get_obs_and_measure_data(
     const enkf_obs_type *enkf_obs, enkf_fs_type *fs,
     const std::vector<std::pair<std::string, std::vector<int>>> &observations,
@@ -433,11 +432,10 @@ void enkf_obs_clear(enkf_obs_type *enkf_obs) {
     ensemble_config_clear_obs_keys(enkf_obs->ensemble_config);
 }
 
-/*
+/**
    Adding inverse observation keys to the enkf_nodes; can be called
    several times.
 */
-
 static void enkf_obs_update_keys(enkf_obs_type *enkf_obs) {
     /* First clear all existing observation keys. */
     ensemble_config_clear_obs_keys(enkf_obs->ensemble_config);
@@ -469,7 +467,7 @@ static void enkf_obs_update_keys(enkf_obs_type *enkf_obs) {
  *
  */
 
-/* Handle HISTORY_OBSERVATION instances. */
+/** Handle HISTORY_OBSERVATION instances. */
 static void handle_history_observation(enkf_obs_type *enkf_obs,
                                        conf_instance_type *enkf_conf,
                                        int last_report, double std_cutoff) {
@@ -523,7 +521,7 @@ static void handle_history_observation(enkf_obs_type *enkf_obs,
     stringlist_free(hist_obs_keys);
 }
 
-/* Handle SUMMARY_OBSERVATION instances. */
+/** Handle SUMMARY_OBSERVATION instances. */
 static void handle_summary_observation(enkf_obs_type *enkf_obs,
                                        conf_instance_type *enkf_conf,
                                        int last_report) {
@@ -567,7 +565,7 @@ static void handle_summary_observation(enkf_obs_type *enkf_obs,
     stringlist_free(sum_obs_keys);
 }
 
-/* Handle BLOCK_OBSERVATION instances. */
+/** Handle BLOCK_OBSERVATION instances. */
 static void handle_block_observation(enkf_obs_type *enkf_obs,
                                      conf_instance_type *enkf_conf) {
     stringlist_type *block_obs_keys =
@@ -588,7 +586,7 @@ static void handle_block_observation(enkf_obs_type *enkf_obs,
     stringlist_free(block_obs_keys);
 }
 
-/* Handle GENERAL_OBSERVATION instances. */
+/** Handle GENERAL_OBSERVATION instances. */
 static void handle_general_observation(enkf_obs_type *enkf_obs,
                                        conf_instance_type *enkf_conf) {
     stringlist_type *block_obs_keys =
@@ -620,7 +618,7 @@ static void enkf_obs_reinterpret_DT_FILE(const char *errors) {
     // clang-format on
 }
 
-/*
+/**
  This function will load an observation configuration from the
    observation file @config_file.
 
@@ -1110,7 +1108,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
     return enkf_conf_class;
 }
 
-/*
+/**
    Allocates a stringlist of obs target keys which correspond to
    summary observations, these are then added to the state vector in
    enkf_main.
@@ -1167,7 +1165,7 @@ stringlist_type *enkf_obs_alloc_matching_keylist(const enkf_obs_type *enkf_obs,
     return matching_keys;
 }
 
-/*
+/**
    This function allocates a hash table which looks like this:
 
      {"OBS_KEY1": "STATE_KEY1", "OBS_KEY2": "STATE_KEY2", "OBS_KEY3": "STATE_KEY3", ....}
@@ -1192,7 +1190,6 @@ stringlist_type *enkf_obs_alloc_matching_keylist(const enkf_obs_type *enkf_obs,
    I.e. there are three different observations keys, all observing the
    same state_kw.
 */
-
 hash_type *enkf_obs_alloc_data_map(enkf_obs_type *enkf_obs) {
     hash_type *map = hash_alloc();
     hash_iter_type *iter = hash_iter_alloc(enkf_obs->obs_hash);

--- a/libres/lib/enkf/enkf_plot_gen_kw.cpp
+++ b/libres/lib/enkf/enkf_plot_gen_kw.cpp
@@ -28,8 +28,10 @@
 struct enkf_plot_gen_kw_struct {
     UTIL_TYPE_ID_DECLARATION;
     const enkf_config_node_type *config_node;
-    int size;                                /* Number of ensembles. */
-    enkf_plot_gen_kw_vector_type **ensemble; /* One vector for each ensemble. */
+    /** Number of ensembles. */
+    int size;
+    /** One vector for each ensemble. */
+    enkf_plot_gen_kw_vector_type **ensemble;
 };
 
 UTIL_IS_INSTANCE_FUNCTION(enkf_plot_gen_kw, ENKF_PLOT_GEN_KW_TYPE_ID)

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -42,7 +42,7 @@
 static auto logger = ert::get_logger("enkf");
 #define ENKF_STATE_TYPE_ID 78132
 
-/*
+/**
    This struct contains various objects which the enkf_state needs
    during operation, which the enkf_state_object *DOES NOT* own. The
    struct only contains pointers to objects owned by (typically) the
@@ -54,11 +54,11 @@ static auto logger = ert::get_logger("enkf");
    The elements in this struct should not change during the
    application lifetime?
 */
-
 typedef struct shared_info_struct {
-    model_config_type *model_config; /* .... */
-    ext_joblist_type *
-        joblist; /* The list of external jobs which are installed - and *how* they should be run (with Python code) */
+    model_config_type *model_config;
+    /** The list of external jobs which are installed - and *how* they should
+     * be run (with Python code) */
+    ext_joblist_type *joblist;
     const site_config_type *site_config;
     ert_templates_type *templates;
     const ecl_config_type *ecl_config;
@@ -67,10 +67,10 @@ typedef struct shared_info_struct {
 struct enkf_state_struct {
     UTIL_TYPE_ID_DECLARATION;
     hash_type *node_hash;
-    ensemble_config_type *
-        ensemble_config; /* The config nodes for the enkf_node objects contained in node_hash. */
-    shared_info_type *
-        shared_info; /* Pointers to shared objects which is needed by the enkf_state object (read only). */
+    /** The config nodes for the enkf_node objects contained in node_hash. */
+    ensemble_config_type *ensemble_config;
+    /** Pointers to shared objects which is needed by the enkf_state object (read only). */
+    shared_info_type *shared_info;
     int __iens;
 };
 
@@ -96,7 +96,7 @@ static void shared_info_free(shared_info_type *shared_info) {
     free(shared_info);
 }
 
-/*
+/**
   This function does not acces the nodes of the enkf_state object.
 */
 void enkf_state_initialize(enkf_state_type *enkf_state, rng_type *rng,
@@ -199,7 +199,7 @@ __enkf_state_get_time_index(enkf_fs_type *sim_fs, const ecl_sum_type *summary) {
     return time_map_alloc_index_map(time_map, summary);
 }
 
-/*
+/**
  * Check if there are summary keys in the ensemble config that is not found in Eclipse. If this is the case, AND we
  * have observations for this key, we have a problem. Otherwise, just print a message to the log.
  */
@@ -427,7 +427,7 @@ enkf_state_alloc_load_context(const ensemble_config_type *ens_config,
     return load_context;
 }
 
-/*
+/**
    This function loads the results from a forward simulations from report_step1
    to report_step2. The details of what to load are in model_config and the
    spesific nodes for special cases.
@@ -567,14 +567,13 @@ void enkf_state_init_eclipse(const res_config_type *res_config,
         run_arg_get_subst_list(run_arg), umask, varlist);
 }
 
-/*
+/**
     Observe that if run_arg == false, this routine will return with
     job_completeOK == true, that might be a bit misleading.
 
     Observe that if an internal retry is performed, this function will
     be called several times - MUST BE REENTRANT.
 */
-
 bool enkf_state_complete_forward_modelOK(const res_config_type *res_config,
                                          run_arg_type *run_arg) {
 
@@ -627,15 +626,15 @@ bool enkf_state_complete_forward_model_EXIT_handler__(run_arg_type *run_arg) {
     return false;
 }
 
-/*
+/**
   This function writes out all the files needed by an ECLIPSE simulation, this
   includes the restart file, and the various INCLUDE files corresponding to
   parameters estimated by EnKF.
 
   The writing of restart file is delegated to enkf_state_write_restart_file().
-*/
 
-// TODO: enkf_fs_type could be fetched from run_arg
+  TODO: enkf_fs_type could be fetched from run_arg
+*/
 void enkf_state_ecl_write(const ensemble_config_type *ens_config,
                           const model_config_type *model_config,
                           const run_arg_type *run_arg, enkf_fs_type *fs) {

--- a/libres/lib/enkf/enkf_state_nodes.cpp
+++ b/libres/lib/enkf/enkf_state_nodes.cpp
@@ -15,7 +15,7 @@ static void enkf_state_del_node(enkf_state_type *enkf_state,
                 __func__, node_key);
 }
 
-/*
+/**
    The enkf_state inserts a reference to the node object. The
    enkf_state object takes ownership of the node object, i.e. it will
    free it when the game is over.
@@ -24,7 +24,6 @@ static void enkf_state_del_node(enkf_state_type *enkf_state,
    removed (freed and so on ... ) from the enkf_state object before
    adding the new; this was previously considered a run-time error.
 */
-
 void enkf_state_add_node(enkf_state_type *enkf_state, const char *node_key,
                          const enkf_config_node_type *config) {
     if (enkf_state_has_node(enkf_state, node_key))

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -97,7 +97,7 @@ struct ensemble_config_struct {
 UTIL_IS_INSTANCE_FUNCTION(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID)
 UTIL_SAFE_CAST_FUNCTION(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID)
 
-/*
+/**
    setting the format string used to 'mangle' the string in the gen_kw
    template files. consider the following example:
 
@@ -126,7 +126,6 @@ UTIL_SAFE_CAST_FUNCTION(ensemble_config, ENSEMBLE_CONFIG_TYPE_ID)
       tagged_string = util_alloc_sprintf( gen_kw_format_string , parameter_name );
 
 */
-
 void ensemble_config_set_gen_kw_format(ensemble_config_type *ensemble_config,
                                        const char *gen_kw_format_string) {
     if (!util_string_equal(gen_kw_format_string,
@@ -658,12 +657,11 @@ static void ensemble_config_init_PRED(ensemble_config_type *ensemble_config,
     free(target_file);
 }
 
-/*
+/**
    observe that if the user has not given a refcase with the refcase
    key the refcase pointer will be NULL. in that case it will be
    impossible to use wildcards when expanding summary variables.
 */
-
 static void ensemble_config_init(ensemble_config_type *ensemble_config,
                                  const config_content_type *config,
                                  ecl_grid_type *grid,
@@ -703,7 +701,9 @@ static void ensemble_config_init(ensemble_config_type *ensemble_config,
     }
 }
 
-/*
+/**
+   @brief Retrieve enkf_config_node by key string in an ensemble_config.
+
    this function takes a string like this: "pressure:1,4,7" - it
    splits the string on ":" and tries to lookup a config object with
    that key. for the general string a:b:c:d it will try consecutively
@@ -715,8 +715,14 @@ static void ensemble_config_init(ensemble_config_type *ensemble_config,
    the example "pressure:1,4,7", the index_key will contain
    "1,4,7". if the full full_key is used to find an object index_key
    will be NULL, that also applies if no object is found.
-*/
 
+   @param[in] config The ensemble_config to retrieve a config_node from.
+   @param[in] full_key a string on the form "pressure:1,4,7"
+   @param[out] index_key the index part of the key, ie. "1,4,7", NULL if no
+    node is found.
+   @return The enkf_config_node if found, NULL otherwise.
+
+*/
 const enkf_config_node_type *
 ensemble_config_user_get_node(const ensemble_config_type *config,
                               const char *full_key, char **index_key) {
@@ -808,12 +814,11 @@ bool ensemble_config_require_summary(const ensemble_config_type *ens_config) {
     return ensemble_config_has_impl_type(ens_config, SUMMARY);
 }
 
-/*
+/**
    this function will look up the user_key in the ensemble_config. if
    the corresponding config_node can not be found 0 will be returned,
    otherwise enkf_config_node functions will be invoked.
 */
-
 int ensemble_config_get_observations(const ensemble_config_type *config,
                                      enkf_obs_type *enkf_obs,
                                      const char *user_key, int obs_count,
@@ -859,7 +864,7 @@ enkf_config_node_type *ensemble_config_add_gen_kw(ensemble_config_type *config,
     return config_node;
 }
 
-/*
+/**
    this function ensures that object contains a node with 'key' and
    type == summary.
 
@@ -868,7 +873,6 @@ enkf_config_node_type *ensemble_config_add_gen_kw(ensemble_config_type *config,
    a warning will be printed on stderr and the function will return
    NULL.
 */
-
 enkf_config_node_type *
 ensemble_config_add_summary(ensemble_config_type *ensemble_config,
                             const char *key, load_fail_type load_fail) {
@@ -917,7 +921,7 @@ ensemble_config_add_surface(ensemble_config_type *ensemble_config,
     return config_node;
 }
 
-/*
+/**
   If key == NULL the function will create a random key.
 */
 enkf_config_node_type *

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -342,27 +342,6 @@ void ensemble_config_add_config_items(config_parser_type *config) {
         item, GRID_KEY); /* if you are using a field - you must have a grid. */
 }
 
-/*
-  The var type parameter is determined by inspecting the
-  combination of input parameters. It is possible to specify an
-  invalid input combination; that should be identified with a call
-  to gen_data_config_is_valid() in the calling scope.
-
-
-  PARAMETER:      init_file_fmt    != NULL
-                  enkf_outfile_fmt != NULL
-                  enkf_infile_fmt  == NULL
-
-  DYNAMIC_STATE:  init_file_fmt    != NULL
-                  enkf_outfile_fmt != NULL
-                  enkf_infile_fmt  != NULL
-
-  DYNAMIC_RESULT: init_file_fmt    == NULL
-                  enkf_outfile_fmt == NULL
-                  enkf_infile_fmt  != NULL
-
-*/
-
 static void ensemble_config_init_GEN_DATA(ensemble_config_type *ensemble_config,
                                           const config_content_type *config) {
     if (config_content_has_item(config, GEN_DATA_KEY)) {

--- a/libres/lib/enkf/ert_run_context.cpp
+++ b/libres/lib/enkf/ert_run_context.cpp
@@ -48,13 +48,12 @@ struct ert_run_context_struct {
     char *run_id;
 };
 
-/*
+/**
   Observe that since this function uses one shared subst_list instance
   for all realisations it is __NOT__ possible to get per realisation
   substititions in the runpath; i.e. a <IENS> element in the RUNPATH
   will *not* be replaced.
 */
-
 char *ert_run_context_alloc_runpath(int iens, const path_fmt_type *runpath_fmt,
                                     const subst_list_type *subst_list,
                                     int iter) {

--- a/libres/lib/enkf/ert_template.cpp
+++ b/libres/lib/enkf/ert_template.cpp
@@ -70,8 +70,8 @@ ert_template_type *ert_template_alloc(const char *template_file,
     ert_template->tmpl = template_alloc(
         template_file, false,
         parent_subst); /* The templates are instantiated with internalize_template == false;
-                                                                                     this means that substitutions are performed on the filename of the
-                                                                                     template itself .*/
+                          this means that substitutions are performed on the filename of the
+                          template itself .*/
 
     ert_template->target_file = NULL;
     ert_template_set_target_file(ert_template, target_file);

--- a/libres/lib/enkf/field.cpp
+++ b/libres/lib/enkf/field.cpp
@@ -41,7 +41,7 @@ namespace fs = std::filesystem;
 
 GET_DATA_SIZE_HEADER(field);
 
-/*
+/**
   The field data type contains for "something" which is distributed
   over the full grid, i.e. permeability or pressure. All configuration
   information is stored in the config object, which is of type
@@ -53,21 +53,22 @@ GET_DATA_SIZE_HEADER(field);
   * The data is stored in a char pointer; the real underlying data can
     be (at least) of the types int, float and double.
 */
-
 struct field_struct {
     int __type_id;
-    /* The field config object - containing information of active cells++ */
+    /** The field config object - containing information of active cells++ */
     const field_config_type *config;
-    /* The actual storage for the field - suitabley casted to int/float/double on use*/
+    /** The actual storage for the field - suitabley casted to int/float/double on use*/
     char *data;
 
-    /* If the data is shared - i.e. managed (xalloc & free) from another scope. */
+    /** If the data is shared - i.e. managed (xalloc & free) from another scope. */
     bool shared_data;
-    /* The size of the shared buffer (if it is shared). */
+    /** The size of the shared buffer (if it is shared). */
     int shared_byte_size;
-    /* IFF an output transform should be applied this pointer will hold the transformed data. */
+    /** IFF an output transform should be applied this pointer will hold the
+     * transformed data. */
     char *export_data;
-    /* IFF an output transform, this pointer will hold the original data during the transform and export. */
+    /** IFF an output transform, this pointer will hold the original data
+     * during the transform and export. */
     char *__data;
 };
 
@@ -229,7 +230,7 @@ void field_export3D(const field_type *field, void *_target_data,
         }                                                                      \
     }
 
-/*
+/**
    The main function of the field_import3D and field_export3D
    functions are to skip the inactive cells (field_import3D) and
    distribute inactive cells (field_export3D).
@@ -248,7 +249,6 @@ void field_export3D(const field_type *field, void *_target_data,
    buffers, the actual reading and writing of files is done in other
    functions (calling these).
 */
-
 static void field_import3D(field_type *field, const void *_src_data,
                            bool rms_index_order, bool keep_inactive_cells,
                            ecl_data_type src_type) {
@@ -466,12 +466,11 @@ static void *__field_alloc_3D_data(const field_type *field, int data_size,
    o Export in RMS ROFF format.
 */
 
-/*
+/**
     This function exports *one* field instance to the rms_file
     instance. It is the responsibility of the field_ROFF_export()
     function to initialize and close down the rms_file instance.
 */
-
 static void field_ROFF_export__(const field_type *field,
                                 rms_file_type *rms_file,
                                 const char *init_file) {
@@ -512,7 +511,7 @@ static void field_complete_ROFF_export(const field_type *field,
     rms_file_free(rms_file);
 }
 
-/*
+/**
     This function exports the data of a field as a parameter to an RMS
     roff file. The export process is divided in three parts:
 
@@ -526,7 +525,6 @@ static void field_complete_ROFF_export(const field_type *field,
     calls to 2 (i.e. field_ROFF_export__()) - that is currently not
     implemented.
 */
-
 void field_ROFF_export(const field_type *field, const char *export_filename,
                        const char *init_file) {
     rms_file_type *rms_file = field_init_ROFF_export(field, export_filename);
@@ -675,10 +673,9 @@ static void field_apply_truncation(field_type *field) {
     }
 }
 
-/*
+/**
     Does both the explicit output transform *AND* the truncation.
 */
-
 static void field_output_transform(field_type *field) {
     field_func_type *output_transform =
         field_config_get_output_transform(field->config);
@@ -705,7 +702,7 @@ static void field_revert_output_transform(field_type *field) {
     }
 }
 
-/*
+/**
   This is the generic "export field to eclipse" function. It will
   check up the config object to determine how to export the field,
   and then call the appropriate function. The alternatives are:
@@ -718,7 +715,6 @@ static void field_revert_output_transform(field_type *field) {
   that if you call e.g. the ROFF export function directly, the output
   transform will *NOT* be applied.
 */
-
 void field_export(const field_type *__field, const char *file,
                   fortio_type *restart_fortio, field_file_format_type file_type,
                   bool output_transform, const char *init_file) {
@@ -762,7 +758,7 @@ void field_export(const field_type *__field, const char *file,
         field_revert_output_transform(field);
 }
 
-/*
+/**
    Observe that the output transform is hooked in here, that means
    that if you call e.g. the ROFF export function directly, the output
    transform will *NOT* be applied.
@@ -771,7 +767,6 @@ void field_export(const field_type *__field, const char *file,
    not in place. When the export is complete the field->data will be
    unchanged.
 */
-
 void field_ecl_write(const field_type *field, const char *run_path,
                      const char *file, void *filestream) {
     field_file_format_type export_format =
@@ -865,7 +860,7 @@ double field_ijk_get_double(const field_type *field, int i, int j, int k) {
     return field_iget_double(field, index);
 }
 
-/*
+/**
    Takes an active or global index as input, and returns a double.
 */
 double field_iget_double(const field_type *field, int index) {
@@ -890,7 +885,7 @@ double field_iget_double(const field_type *field, int index) {
     }
 }
 
-/*
+/**
    Takes an active or global index as input, and returns a double.
 */
 float field_iget_float(const field_type *field, int index) {
@@ -926,10 +921,9 @@ float field_iget_float(const field_type *field, int index) {
                 (t)[index[i]] = (s)[i];                                        \
     }
 
-/*
+/**
    Copying data from a (PACKED) ecl_kw instance down to a fields data.
 */
-
 void field_copy_ecl_kw_data(field_type *field, const ecl_kw_type *ecl_kw) {
     const field_config_type *config = field->config;
     const int data_size = field_config_get_data_size(config);
@@ -1103,7 +1097,7 @@ bool field_fload_keep_inactive(field_type *field, const char *filename) {
     return field_fload_custom__(field, filename, keep_inactive);
 }
 
-/*
+/**
   Here, index_key is i a tree digit string with the i, j and k indicies of
   the requested block separated by comma. E.g., 1,1,1.
 

--- a/libres/lib/enkf/field_config.cpp
+++ b/libres/lib/enkf/field_config.cpp
@@ -32,7 +32,9 @@
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/field_config.hpp>
 
-/*
+#define FIELD_CONFIG_ID 78269
+
+/**
    About transformations and truncations
    -------------------------------------
 
@@ -102,53 +104,52 @@ _______________/                     \___________/       |  with EnKF.          
                                                                  \____________________/         _\|/_
 
 
-
-
-
-
-*/
-
-/*Observe the following convention:
+Observe the following convention:
 
     global_index:  [0 , nx*ny*nz)
     active_index:  [0 , nactive)
 */
-
-#define FIELD_CONFIG_ID 78269
-
 struct field_config_struct {
     UTIL_TYPE_ID_DECLARATION;
 
-    char *ecl_kw_name; /* Name/key ... */
-    int data_size, nx, ny,
-        nz; /* The number of elements in the three directions. */
-    bool
-        keep_inactive_cells; /* Whether the data contains only active cells or active and inactive cells */
-    ecl_grid_type
-        *grid; /* A shared reference to the grid this field is defined on. */
+    /** Name/key ... */
+    char *ecl_kw_name;
+    /** The number of elements in the three directions. */
+    int data_size, nx, ny, nz;
+    /** Whether the data contains only active cells or active and inactive
+     * cells */
+    bool keep_inactive_cells;
+    /** A shared reference to the grid this field is defined on. */
+    ecl_grid_type *grid;
     bool private_grid;
 
-    int truncation; /* How the field should be trunacted before exporting for simulation, and for the inital import. OR'd combination of truncation_type from enkf_types.h*/
-    double min_value; /* The min value used in truncation. */
-    double max_value; /* The maximum value used in truncation. */
+    /** How the field should be trunacted before exporting for simulation, and
+     * for the inital import. OR'd combination of truncation_type from enkf_types.h*/
+    int truncation;
+    /** The min value used in truncation. */
+    double min_value;
+    /** The maximum value used in truncation. */
+    double max_value;
 
     field_file_format_type export_format;
     field_file_format_type import_format;
     ecl_data_type internal_data_type;
-    bool
-        __enkf_mode; /* See doc of functions field_config_set_key() / field_config_enkf_OFF() */
+    /** See doc of functions field_config_set_key() / field_config_enkf_OFF() */
+    bool __enkf_mode;
     bool write_compressed;
 
     field_type_enum type;
     field_type *min_std;
-    field_trans_table_type *
-        trans_table; /* Internalize a (pointer to) a table of the available transformation functions. */
-    field_func_type *
-        output_transform; /* Function to apply to the data before they are exported - NULL: no transform. */
-    field_func_type *
-        init_transform; /* Function to apply on the data when they are loaded the first time - i.e. initialized. NULL : no transform*/
-    field_func_type *
-        input_transform; /* Function to apply on the data when they are loaded from the forward model - i.e. for dynamic data. */
+    /** Internalize a (pointer to) a table of the available transformation functions. */
+    field_trans_table_type *trans_table;
+    /** Function to apply to the data before they are exported - NULL: no transform. */
+    field_func_type *output_transform;
+    /** Function to apply on the data when they are loaded the first time -
+     * i.e. initialized. NULL : no transform*/
+    field_func_type *init_transform;
+    /** Function to apply on the data when they are loaded from the forward
+     * model - i.e. for dynamic data. */
+    field_func_type *input_transform;
 
     char *output_transform_name;
     char *init_transform_name;
@@ -162,7 +163,7 @@ void field_config_set_ecl_data_type(field_config_type *config,
     memcpy(&config->internal_data_type, &data_type, sizeof data_type);
 }
 
-/*
+/**
    This function takes a field_file_format_type variable, and returns
    a string containing a default extension for files of this type. For
    ecl_kw_file it will return NULL, i.e. no default extension.
@@ -174,7 +175,6 @@ void field_config_set_ecl_data_type(field_config_type *config,
    It will return UPPERCASE or lowercase depending on the value of the
    second argument.
 */
-
 const char *field_config_default_extension(field_file_format_type file_type,
                                            bool upper_case) {
     if (file_type == RMS_ROFF_FILE) {
@@ -216,7 +216,7 @@ field_config_default_export_format(const char *filename) {
     return export_format;
 }
 
-/*
+/**
 This function takes in a filename and tries to guess the type of the
 file. It can determine the following three types of files:
 
@@ -262,11 +262,10 @@ field_config_get_export_format(const field_config_type *field_config) {
     return field_config->export_format;
 }
 
-/*
+/**
    Will return the name of the init_transform function, or NULL if no
    init_transform function has been registered.
 */
-
 const char *
 field_config_get_init_transform_name(const field_config_type *field_config) {
     return field_config->init_transform_name;
@@ -277,7 +276,7 @@ field_config_get_output_transform_name(const field_config_type *field_config) {
     return field_config->output_transform_name;
 }
 
-/*
+/**
    IFF the @private_grid parameter is true, the field_config instance
    will take ownership of grid, i.e. freeing it in
    field_config_free().
@@ -287,7 +286,6 @@ field_config_get_output_transform_name(const field_config_type *field_config) {
    during a run there are many other dependencies which must also be
    updated, which are not handled.
 */
-
 void field_config_set_grid(field_config_type *config, ecl_grid_type *grid,
                            bool private_grid) {
     if ((config->private_grid) && (config->grid != NULL))
@@ -454,7 +452,7 @@ void field_config_update_general_field(
     field_config_set_output_transform(config, output_transform);
 }
 
-/*
+/**
    Requirements:
 
    ECLIPSE_PARAMETER: export_format != UNDEFINED_FORMAT
@@ -463,7 +461,6 @@ void field_config_update_general_field(
 
    GENERAL          : export_format != UNDEFINED_FORMAT
 */
-
 bool field_config_is_valid(const field_config_type *field_config) {
     bool valid = true;
 
@@ -488,14 +485,13 @@ field_type_enum field_config_get_type(const field_config_type *config) {
     return config->type;
 }
 
-/*
+/**
   Observe that the indices are zero-based, in contrast to those used
   by eclipse which are based on one.
 
   This function will return an index in the interval: [0...nactive),
   and -1 if i,j,k correspond to an inactive cell.
 */
-
 int field_config_active_index(const field_config_type *config, int i, int j,
                               int k) {
     return ecl_grid_get_active_index3(config->grid, i, j, k);
@@ -506,25 +502,23 @@ int field_config_global_index(const field_config_type *config, int i, int j,
     return ecl_grid_get_global_index3(config->grid, i, j, k);
 }
 
-/*
+/**
     This function checks that i,j,k are in the intervals [0..nx),
     [0..ny) and [0..nz). It does *NOT* check if the corresponding
     index is active.
 */
-
 bool field_config_ijk_valid(const field_config_type *config, int i, int j,
                             int k) {
     return ecl_grid_ijk_valid(config->grid, i, j, k);
 }
 
-/*
+/**
     This function checks that i,j,k are in the intervals [0..nx),
     [0..ny) and [0..nz) AND that the corresponding cell is active. If
     the function returns false it is impossible to differentiate
     between (i,j,k) values which are out of bounds and an inactive
     cell.
 */
-
 bool field_config_ijk_active(const field_config_type *config, int i, int j,
                              int k) {
     if (ecl_grid_ijk_valid(config->grid, i, j, k)) {
@@ -589,7 +583,7 @@ int field_config_get_sizeof_ctype(const field_config_type *config) {
     return ecl_type_get_sizeof_ctype(config->internal_data_type);
 }
 
-/*
+/**
    Returns true / false whether a cell is active.
 */
 bool field_config_active_cell(const field_config_type *config, int i, int j,
@@ -614,7 +608,7 @@ int field_config_get_ny(const field_config_type *config) { return config->ny; }
 
 int field_config_get_nz(const field_config_type *config) { return config->nz; }
 
-/*
+/**
    The field_config and field objects are mainly written for use in
    the enkf application. In that setting a field instance is *NOT*
    allowed to write on it's field_config object.
@@ -634,7 +628,6 @@ int field_config_get_nz(const field_config_type *config) { return config->nz; }
    key. Also it is essential to observe that this will break **HARD**
    is the file contains several parameters
 */
-
 void field_config_set_key(field_config_type *config, const char *key) {
     if (config->__enkf_mode)
         util_abort("%s: internal error - must call field_config_enkf_OFF() "
@@ -677,7 +670,7 @@ field_config_get_init_transform(const field_config_type *config) {
     return config->init_transform;
 }
 
-/*
+/**
   This function asserts that a unary function can be applied
   to the field - i.e. that the underlying data_type is ecl_float or ecl_double.
 */
@@ -693,7 +686,7 @@ void field_config_assert_unary(const field_config_type *field_config,
                    __func__, caller);
 }
 
-/*
+/**
    Asserts that two fields can be combined in a binary operation.
 */
 void field_config_assert_binary(const field_config_type *config1,
@@ -711,20 +704,15 @@ void field_config_assert_binary(const field_config_type *config1,
 }
 
 /*
-   Parses a string of the type "1,5,6", and returns the indices i,j,k
-   by reference. The return value of the function as a whole is
-   whether the string constitutes a valid cell:
+   @brief Parses a string of the type "1,5,6", and returns the indices i,j,k
+   by reference.
 
-      0: All is OK.
-      1: The string could not pe parsed to three valid integers.
-      2: ijk are not in the grid.
-      3: ijk correspond to an inactive cell.
-
-   In cases 2 & 3 the i,j,k are valid (in the string-parsing sense).
-   The input string is assumed to have offset one, and the return
-   values (by reference) are offset zero.
+   @param[in] index_key The index key string, ie. "1,5,6"
+   @param[out] i The i index as an int, ie. 1.
+   @param[out] j The j index as an int, ie. 5.
+   @param[out] k The k index as an int, ie. 6.
+   @return True if parsing was successfull.
 */
-
 bool field_config_parse_user_key__(const char *index_key, int *i, int *j,
                                    int *k) {
     int length;
@@ -746,6 +734,27 @@ bool field_config_parse_user_key__(const char *index_key, int *i, int *j,
         return false;
 }
 
+/*
+   @brief Parses a string of the type "1,5,6", and returns the indices i,j,k
+   by reference.
+
+
+   @param[in] config The field_config which is the context for whether the
+       i,j,k values are valid.
+   @param[in] index_key The index key string, ie. "1,5,6"
+   @param[out] i The i index as an int, ie. 1.
+   @param[out] j The j index as an int, ie. 5.
+   @param[out] k The k index as an int, ie. 6.
+   @return The return value of the function is
+     whether the string constitutes a valid cell:
+      0: All is OK.
+      1: The string could not pe parsed to three valid integers.
+      2: ijk are not in the grid.
+      3: ijk correspond to an inactive cell.
+      In cases 2 & 3 the i,j,k are valid (in the string-parsing sense).
+      The input string is assumed to have offset one, and the return
+      values (by reference) are offset zero.
+*/
 int field_config_parse_user_key(const field_config_type *config,
                                 const char *index_key, int *i, int *j, int *k) {
     int return_value = 0;

--- a/libres/lib/enkf/field_trans.cpp
+++ b/libres/lib/enkf/field_trans.cpp
@@ -113,12 +113,11 @@ void field_trans_table_fprintf(const field_trans_table_type *table,
     hash_iter_free(iter);
 }
 
-/*
+/**
   This function takes a key input, and returns a pointer to the
   corresponding function. The function will fail if the key is not
   recognized.
 */
-
 field_func_type *field_trans_table_lookup(field_trans_table_type *table,
                                           const char *_key) {
     field_func_type *func;
@@ -146,7 +145,7 @@ field_func_type *field_trans_table_lookup(field_trans_table_type *table,
     return func;
 }
 
-/*
+/**
    Will return false if _key == NULL
 */
 bool field_trans_table_has_key(field_trans_table_type *table,

--- a/libres/lib/enkf/forward_load_context.cpp
+++ b/libres/lib/enkf/forward_load_context.cpp
@@ -37,11 +37,12 @@ struct forward_load_context_struct {
     ecl_sum_type *ecl_sum;
     ecl_file_type *restart_file;
     const run_arg_type *run_arg;
-    const ecl_config_type *ecl_config; // Can be NULL
+    /** Can be NULL */
+    const ecl_config_type *ecl_config;
 
     int step2;
-    stringlist_type
-        *messages; // This is managed by external scope - can be NULL
+    /** Messages is managed by external scope - can be NULL */
+    stringlist_type *messages;
 
     /* The variables below are updated during the load process. */
     int load_step;

--- a/libres/lib/enkf/fs_driver.cpp
+++ b/libres/lib/enkf/fs_driver.cpp
@@ -60,25 +60,26 @@ void fs_driver_init_fstab(FILE *stream, fs_driver_impl driver_id) {
     util_fwrite_int(driver_id, stream);
 }
 
-/*
-   Will open fstab stream and return it. The semantics with respect to
-   existing/not existnig fstab file depends on the value of the
-   @create parameter:
-
-   @create = True: If the fstab file exists the function will return
-   NULL, otherwise it will return a stream opened for writing to the
-   fstab file.
-
-   @create = False: If the fstab file exists the the function will
-   return a stream opened for reading of the fstab file, otherwise
-   it will return NULL.
-
-*/
-
 char *fs_driver_alloc_fstab_file(const char *path) {
     return util_alloc_filename(path, "ert_fstab", NULL);
 }
 
+/**
+   Will open fstab stream and return it. The semantics with respect to
+   existing/not existnig fstab file depends on the value of the
+   create parameter:
+
+   @param path The file path
+   @param create If create=true and the fstab file exists the function will
+       return NULL, otherwise it will return a stream opened for writing to the
+       fstab file.
+
+       if create = False and the fstab file exists the the function will return a
+       stream opened for reading of the fstab file, otherwise it will return
+       NULL.
+
+   @return A stream to the opened file.
+*/
 FILE *fs_driver_open_fstab(const char *path, bool create) {
     FILE *stream = NULL;
     char *fstab_file = fs_driver_alloc_fstab_file(path);

--- a/libres/lib/enkf/fs_types.cpp
+++ b/libres/lib/enkf/fs_types.cpp
@@ -18,15 +18,16 @@
 
 #include <ert/enkf/fs_types.hpp>
 
-/*
+/**
+  @brief returns whether fs type is valid.
+
   The driver type DRIVER_STATIC has been removed completely as of
-  December 2015, but there will still be many mount map files with
+  December 2015 and therefore not valid. There will still be many mount map files with
   this enum value around on disk. This function is a minor convenience
   to handle that.
 
-  The driver type DRIVER_DYNAMIC_ANALYZED was removed ~april 2016.
+  The driver type DRIVER_DYNAMIC_ANALYZED was removed ~april 2016, and is not valid.
 */
-
 bool fs_types_valid(fs_driver_enum driver_type) {
     if ((driver_type == DRIVER_STATIC) ||
         (driver_type == DRIVER_DYNAMIC_ANALYZED))

--- a/libres/lib/enkf/gen_common.cpp
+++ b/libres/lib/enkf/gen_common.cpp
@@ -117,12 +117,11 @@ void *gen_common_fread_alloc(const char *file, ecl_data_type load_data_type,
     return buffer;
 }
 
-/*
+/**
   If the load_format is binary_float or binary_double, the ASCII_type
   is *NOT* consulted. The load_type is set to float/double depending
   on what was actually used when the data was loaded.
 */
-
 void *gen_common_fload_alloc(const char *file,
                              gen_data_file_format_type load_format,
                              ecl_data_type ASCII_data_type,

--- a/libres/lib/enkf/gen_data.cpp
+++ b/libres/lib/enkf/gen_data.cpp
@@ -40,8 +40,8 @@
 namespace fs = std::filesystem;
 static auto logger = ert::get_logger("enkf");
 
-/*
-   The file implements a general data type which can be used to update
+/**
+   A general data type which can be used to update
    arbitrary data which the EnKF system has *ABSOLUTELY NO IDEA* of
    how is organised; how it should be used in the forward model and so
    on. Similarly to the field objects, the gen_data objects can be
@@ -51,15 +51,17 @@ static auto logger = ert::get_logger("enkf");
    data) is determined at the enkf_node level, and no busissiness of
    the gen_data implementation.
 */
-
 struct gen_data_struct {
     int __type_id;
-    gen_data_config_type *
-        config; /* Thin config object - mainly contains filename for remote load */
-    char *data; /* Actual storage - will be casted to double or float on use. */
-    int current_report_step; /* Need this to look up the correct size in the config object. */
-    bool_vector_type *
-        active_mask; /* Mask of active/not active - loaded from a "_active" file created by the forward model. Not used when used as parameter*/
+    /** Thin config object - mainly contains filename for remote load */
+    gen_data_config_type *config;
+    /** Actual storage - will be casted to double or float on use. */
+    char *data;
+    /** Need this to look up the correct size in the config object. */
+    int current_report_step;
+    /** Mask of active/not active - loaded from a "_active" file created by the
+     * forward model. Not used when used as parameter*/
+    bool_vector_type *active_mask;
 };
 
 void gen_data_assert_size(gen_data_type *gen_data, int size, int report_step) {
@@ -76,7 +78,7 @@ int gen_data_get_size(const gen_data_type *gen_data) {
                                          gen_data->current_report_step);
 }
 
-/*
+/**
    It is a bug to call this before some function has set the size.
 */
 void gen_data_realloc_data(gen_data_type *gen_data) {
@@ -115,7 +117,7 @@ void gen_data_free(gen_data_type *gen_data) {
     free(gen_data);
 }
 
-/*
+/**
    Observe that this function writes parameter size to disk, that is
    special. The reason is that the config object does not know the
    size (on allocation).
@@ -126,7 +128,6 @@ void gen_data_free(gen_data_type *gen_data) {
    is changed to false some semantics in the load code must be
    changed.
 */
-
 C_USED bool gen_data_write_to_buffer(const gen_data_type *gen_data,
                                      buffer_type *buffer, int report_step) {
     const bool write_zero_size =
@@ -206,11 +207,10 @@ void gen_data_deserialize(gen_data_type *gen_data, node_id_type node_id,
     }
 }
 
-/*
+/**
   This function sets the data field of the gen_data instance after the
   data has been loaded from file.
 */
-
 static void gen_data_set_data__(gen_data_type *gen_data, int size,
                                 const forward_load_context_type *load_context,
                                 ecl_data_type load_data_type,
@@ -294,7 +294,7 @@ static bool gen_data_fload_active__(gen_data_type *gen_data,
     return file_exists;
 }
 
-/*
+/**
    This functions loads data from file. Observe that there is *NO*
    header information in this file - the size is determined by seeing
    how much can be successfully loaded.
@@ -310,7 +310,6 @@ static bool gen_data_fload_active__(gen_data_type *gen_data,
    Return value is whether file was found or was empty
   - might have to check this in calling scope.
 */
-
 bool gen_data_fload_with_report_step(
     gen_data_type *gen_data, const char *filename,
     const forward_load_context_type *load_context) {
@@ -347,7 +346,7 @@ bool gen_data_forward_load(gen_data_type *gen_data, const char *ecl_file,
     return gen_data_fload_with_report_step(gen_data, ecl_file, load_context);
 }
 
-/*
+/**
    This function initializes the parameter. This is based on loading a
    file. The name of the file is derived from a path_fmt instance
    owned by the config object. Observe that there is *NO* header
@@ -361,7 +360,6 @@ bool gen_data_forward_load(gen_data_type *gen_data, const char *ecl_file,
    If gen_data_config_alloc_initfile() returns NULL that means that
    the gen_data instance does not have any init function - that is OK.
 */
-
 C_USED bool gen_data_initialize(gen_data_type *gen_data, int iens,
                                 const char *init_file, rng_type *rng) {
     bool ret = false;
@@ -451,13 +449,12 @@ void gen_data_export(const gen_data_type *gen_data, const char *full_path,
     }
 }
 
-/*
+/**
     It is the enkf_node layer which knows whether the node actually
     has any data to export. If it is not supposed to write data to the
     forward model, i.e. it is of enkf_type 'dynamic_result' that is
     signaled down here with eclfile == NULL.
 */
-
 void gen_data_ecl_write(const gen_data_type *gen_data, const char *run_path,
                         const char *eclfile, value_export_type *export_value) {
     if (eclfile != NULL) {
@@ -509,13 +506,12 @@ void gen_data_export_data(const gen_data_type *gen_data,
     }
 }
 
-/*
+/**
    The filesystem will (currently) store gen_data instances which do
    not hold any data. Therefore it will be quite common to enter this
    function with an empty instance, we therefore just set valid =>
    false, and return silently in that case.
 */
-
 C_USED bool gen_data_user_get(const gen_data_type *gen_data,
                               const char *index_key, int report_step,
                               double *value) {

--- a/libres/lib/enkf/gen_kw.cpp
+++ b/libres/lib/enkf/gen_kw.cpp
@@ -288,7 +288,7 @@ const char *gen_kw_get_name(const gen_kw_type *gen_kw, int kw_nr) {
     return gen_kw_config_iget_name(gen_kw->config, kw_nr);
 }
 
-/*
+/**
    This function will load values for gen_kw instance from file. The
    file should be formatted as either:
 
@@ -319,7 +319,6 @@ const char *gen_kw_get_name(const gen_kw_type *gen_kw, int kw_nr) {
     2. The values are in the N(0,1) domain, i.e. the untransformed variables.
 
 */
-
 static bool gen_kw_fload(gen_kw_type *gen_kw, const char *filename) {
     FILE *stream = util_fopen__(filename, "r");
     if (stream) {
@@ -389,7 +388,7 @@ static bool gen_kw_fload(gen_kw_type *gen_kw, const char *filename) {
         return false;
 }
 
-/*
+/**
    Will return 0.0 on invalid input, and set valid -> false. It is the
    responsibility of the calling scope to check valid.
 */

--- a/libres/lib/enkf/gen_kw_config.cpp
+++ b/libres/lib/enkf/gen_kw_config.cpp
@@ -49,11 +49,12 @@ typedef struct {
 struct gen_kw_config_struct {
     UTIL_TYPE_ID_DECLARATION;
     char *key;
-    vector_type *parameters; /* Vector of gen_kw_parameter_type instances. */
+    /** Vector of gen_kw_parameter_type instances. */
+    vector_type *parameters;
     char *template_file;
     char *parameter_file;
-    const char *
-        tag_fmt; /* Pointer to the tag_format owned by the ensemble config object. */
+    /** Pointer to the tag_format owned by the ensemble config object. */
+    const char *tag_fmt;
 };
 
 UTIL_SAFE_CAST_FUNCTION(gen_kw_parameter, GEN_KW_PARAMETER_TYPE_ID)
@@ -106,7 +107,7 @@ const char *gen_kw_config_get_template_file(const gen_kw_config_type *config) {
     return config->template_file;
 }
 
-/*
+/**
   The input template file must point to an existing file.
 */
 void gen_kw_config_set_template_file(gen_kw_config_type *config,
@@ -158,7 +159,7 @@ const char *gen_kw_config_get_parameter_file(const gen_kw_config_type *config) {
     return config->parameter_file;
 }
 
-/*
+/**
    Unfortunately the GUI makes it necessary(??) to be able to create
    halfways initialized gen_kw_config objects; and we then have to be
    able to query the gen_kw_config object if it is valid.
@@ -169,7 +170,6 @@ const char *gen_kw_config_get_parameter_file(const gen_kw_config_type *config) {
     * parameter_file != NULL  (this means that the special schedule_prediction_file keyword will be invalid).
 
 */
-
 bool gen_kw_config_is_valid(const gen_kw_config_type *config) {
     if (config->template_file != NULL && config->parameter_file != NULL)
         return true;
@@ -177,7 +177,7 @@ bool gen_kw_config_is_valid(const gen_kw_config_type *config) {
         return false;
 }
 
-/*
+/**
    A call to gen_kw_config_update_tag_format() must be called
    afterwards, otherwise all tagged strings will just be NULL.
 */
@@ -283,7 +283,7 @@ gen_kw_config_alloc_name_list(const gen_kw_config_type *config) {
     return name_list;
 }
 
-/*
+/**
    Will return -1 if the index is invalid.
 */
 int gen_kw_config_get_index(const gen_kw_config_type *config, const char *key) {

--- a/libres/lib/enkf/gen_obs.cpp
+++ b/libres/lib/enkf/gen_obs.cpp
@@ -33,7 +33,10 @@
 #include <ert/enkf/gen_obs.hpp>
 
 #include "ert/python.hpp"
-/*
+
+#define GEN_OBS_TYPE_ID 77619
+
+/**
    This file implemenets a structure for general observations. A
    general observation is just a vector of numbers - where EnKF has no
    understanding whatsover of the type of these data. The actual data
@@ -41,9 +44,7 @@
 
    Currently it can only observe gen_data instances - but that should
    be generalized.
-*/
 
-/*
   The std_scaling field of the xxx_obs structure can be used to scale
   the standard deviation used for the observations, either to support
   workflows with multiple data assimilation or to reduce the effect of
@@ -54,25 +55,30 @@
   be returned, whereas when the function gen_obs_measure() is used the
   std_scaling will be incorporated in the result.
 */
-
-#define GEN_OBS_TYPE_ID 77619
-
 struct gen_obs_struct {
     UTIL_TYPE_ID_DECLARATION;
-    int obs_size; /* This is the total size of the observation vector. */
-    int *
-        data_index_list; /* The indexes which are observed in the corresponding gen_data instance - of length obs_size. */
-    bool
-        observe_all_data; /* Flag which indiactes whether all data in the gen_data instance should be observed - in that case we must do a size comparizon-check at use time. */
+    /** This is the total size of the observation vector. */
+    int obs_size;
+    /** The indexes which are observed in the corresponding gen_data instance -
+     * of length obs_size. */
+    int *data_index_list;
+    /** Flag which indiactes whether all data in the gen_data instance should
+     * be observed - in that case we must do a size comparizon-check at use time.*/
+    bool observe_all_data;
 
-    double *obs_data;    /* The observed data. */
-    double *obs_std;     /* The observed standard deviation. */
-    double *std_scaling; /* Scaling factor for the standard deviation */
+    /** The observed data. */
+    double *obs_data;
+    /** The observed standard deviation. */
+    double *obs_std;
+    /** Scaling factor for the standard deviation */
+    double *std_scaling;
 
-    char *
-        obs_key; /* The key this observation is held by - in the enkf_obs structur (only for debug messages). */
-    gen_data_file_format_type
-        obs_format; /* The format, i.e. ASCII, binary_double or binary_float, of the observation file. */
+    /** The key this observation is held by - in the enkf_obs structur (only
+     * for debug messages). */
+    char *obs_key;
+    /** The format, i.e. ASCII, binary_double or binary_float, of the
+     * observation file. */
+    gen_data_file_format_type obs_format;
     gen_data_config_type *data_config;
 };
 
@@ -94,7 +100,7 @@ static double IGET_SCALED_STD(const gen_obs_type *gen_obs, int index) {
     return gen_obs->obs_std[index] * gen_obs->std_scaling[index];
 }
 
-/*
+/**
    This function loads the actual observations from disk, and
    initializes the obs_data and obs_std pointers with the
    observations. It also sets the obs_size field of the gen_obs
@@ -108,7 +114,6 @@ static double IGET_SCALED_STD(const gen_obs_type *gen_obs, int index) {
    can be in formatted ASCII or binary_float / binary_double. Observe
    that there is *NO* header information in this file.
 */
-
 static void gen_obs_set_data(gen_obs_type *gen_obs, int buffer_size,
                              const double *buffer) {
     gen_obs->obs_size = buffer_size / 2;
@@ -200,14 +205,13 @@ gen_obs_type *gen_obs_alloc__(const gen_data_config_type *data_config,
     return obs;
 }
 
-/*
+/**
    data_index_file is the name of a file with indices which should be
    observed, data_inde_string is the same, in the form of a
    "1,2,3,4-10, 17,19,22-100" string. Only one of these items can be
    != NULL. If both are NULL it is assumed that all the indices of the
    gen_data instance should be observed.
 */
-
 gen_obs_type *gen_obs_alloc(const gen_data_config_type *data_config,
                             const char *obs_key, const char *obs_file,
                             double scalar_value, double scalar_error,

--- a/libres/lib/enkf/hook_manager.cpp
+++ b/libres/lib/enkf/hook_manager.cpp
@@ -32,7 +32,7 @@
 
 struct hook_manager_struct {
     vector_type
-        *hook_workflow_list; /* vector of hook_workflow_type instances */
+        *hook_workflow_list; /** vector of hook_workflow_type instances */
     runpath_list_type *runpath_list;
     ert_workflow_list_type *workflow_list;
     hash_type *input_context;

--- a/libres/lib/enkf/misfit_ensemble.cpp
+++ b/libres/lib/enkf/misfit_ensemble.cpp
@@ -79,9 +79,8 @@ void misfit_ensemble_initialize(misfit_ensemble_type *misfit_ensemble,
                                      misfit_ensemble->history_length, 0,
                                      ens_size, chi2_work);
 
-            /*
-          Internalizing the results from the chi2_work table into the misfit structure.
-      */
+            // Internalizing the results from the chi2_work table into the
+            // misfit structure.
             for (int iens = 0; iens < ens_size; iens++) {
                 misfit_member_type *node =
                     misfit_ensemble_iget_member(misfit_ensemble, iens);

--- a/libres/lib/enkf/misfit_ensemble.cpp
+++ b/libres/lib/enkf/misfit_ensemble.cpp
@@ -26,23 +26,16 @@
 #include <ert/enkf/enkf_obs.hpp>
 #include <ert/enkf/misfit_ensemble.hpp>
 
-/*
-   This file implements a type misfit_ensemble which is used to rank the
-   different realization according to various criteria.
-
-   The top level datastructure in this file is the misfit_ensemble, and
-   that is the only exported datatype, but in addition there are the
-   misfit_member which is the misfit for one ensemble member, and
-   misfit_ts which is the misfit for one ensemble member / one
-   observation key.
+/**
+   The misfit_ensemble_struct is used to rank the different realization
+   according to various criteria.
 */
-
 struct misfit_ensemble_struct {
     UTIL_TYPE_ID_DECLARATION;
     bool initialized;
     int history_length;
-    vector_type *
-        ensemble; /* Vector of misfit_member_type instances - one for each ensemble member. */
+    /** Vector of misfit_member_type instances - one for each ensemble member. */
+    vector_type *ensemble;
 };
 
 static double **__2d_malloc(int rows, int columns) {
@@ -124,7 +117,7 @@ void misfit_ensemble_fwrite(const misfit_ensemble_type *misfit_ensemble,
     }
 }
 
-/*
+/**
    This funcion is a feeble attempt at allowing the ensemble size to
    change runtime. If the new ensemble size is larger than the current
    ensemble size ALL the currently internalized misfit information is

--- a/libres/lib/enkf/misfit_member.cpp
+++ b/libres/lib/enkf/misfit_member.cpp
@@ -25,12 +25,14 @@
 
 #define MISFIT_MEMBER_TYPE_ID 541066
 
+/** misfit_member_struct contains the misfit for one ensemble member */
 struct misfit_member_struct {
     UTIL_TYPE_ID_DECLARATION;
     int my_iens;
-    hash_type *
-        obs; /* hash table of misfit_ts_type instances - indexed by observation keys. The structure
-                                 of this hash table is duplicated for each ensemble member.*/
+    /** hash table of misfit_ts_type instances - indexed by observation keys.
+     * The structure of this hash table is duplicated for each ensemble
+     * member.*/
+    hash_type *obs;
 };
 
 static UTIL_SAFE_CAST_FUNCTION(misfit_member, MISFIT_MEMBER_TYPE_ID);

--- a/libres/lib/enkf/misfit_ranking.cpp
+++ b/libres/lib/enkf/misfit_ranking.cpp
@@ -30,21 +30,21 @@
 #include <ert/enkf/misfit_ranking.hpp>
 #include <ert/enkf/ranking_common.hpp>
 
-/*
+#define MISFIT_RANKING_TYPE_ID 671108
+
+/**
    This struct contains the misfits & sort keys for one particular
    misfit_ranking. I.e. all the RFT measurements.
 */
-
-#define MISFIT_RANKING_TYPE_ID 671108
-
 struct misfit_ranking_struct {
     UTIL_TYPE_ID_DECLARATION;
-    vector_type *
-        ensemble; /* An ensemble of hash instances. Each hash instance is populated like this: hash_insert_double(hash , "WGOR" , 1.09); */
-    double_vector_type *
-        total; /* An enemble of total misfit values (for this misfit_ranking). */
-    perm_vector_type *
-        sort_permutation; /* This is how the ens members should be permuted to be sorted under this misfit_ranking.                                     */
+    /** An ensemble of hash instances. Each hash instance is populated like
+     * this: hash_insert_double(hash , "WGOR" , 1.09); */
+    vector_type *ensemble;
+    /** An enemble of total misfit values (for this misfit_ranking). */
+    double_vector_type *total;
+    /** This is how the ens members should be permuted to be sorted under this misfit_ranking. */
+    perm_vector_type *sort_permutation;
     int ens_size;
 };
 

--- a/libres/lib/enkf/misfit_ts.cpp
+++ b/libres/lib/enkf/misfit_ts.cpp
@@ -27,10 +27,11 @@
 
 #define MISFIT_TS_TYPE_ID 641066
 
+/** misfit for one ensemble member / observation key. */
 struct misfit_ts_struct {
     UTIL_TYPE_ID_DECLARATION;
-    double_vector_type *
-        data; /* A double vector of length 'history_length' with actual misfit values. */
+    /** A double vector of length 'history_length' with actual misfit values. */
+    double_vector_type *data;
 };
 
 static UTIL_SAFE_CAST_FUNCTION(misfit_ts, MISFIT_TS_TYPE_ID);

--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -44,7 +44,8 @@
 
 static auto logger = ert::get_logger("enkf");
 
-/*
+#define MODEL_CONFIG_TYPE_ID 661053
+/**
    This struct contains configuration which is specific to this
    particular model/run. Such of the information is actually accessed
    directly through the enkf_state object; but this struct is the
@@ -55,9 +56,6 @@ static auto logger = ert::get_logger("enkf");
    goes in ecl_config is not entirely clear; ECLIPSE is unfortunately
    not (yet ??) exactly 'any' reservoir simulator in this context.
 
-*/
-
-/*
   The runpath format is governed by a hash table where new runpaths
   are added with model_config_add_runpath() and then current runpath
   is selected with model_config_select_runpath(). However this
@@ -66,16 +64,17 @@ static auto logger = ert::get_logger("enkf");
   the RUNPATH config key (key DEFAULT_RUNPATH_KEY in the hash table)
   This semantically predefined runpath is the only option visible to the user.
  */
-
-#define MODEL_CONFIG_TYPE_ID 661053
 struct model_config_struct {
     UTIL_TYPE_ID_DECLARATION;
-    forward_model_type *
-        forward_model; /* The forward_model - as loaded from the config file. Each enkf_state object internalizes its private copy of the forward_model. */
+    /** The forward_model - as loaded from the config file. Each enkf_state
+     * object internalizes its private copy of the forward_model. */
+    forward_model_type *forward_model;
     time_map_type *external_time_map;
-    history_type *history; /* The history object. */
-    path_fmt_type *
-        current_runpath; /* path_fmt instance for runpath - runtime the call gets arguments: (iens, report_step1 , report_step2) - i.e. at least one %d must be present.*/
+    /** The history object. */
+    history_type *history;
+    /** path_fmt instance for runpath - runtime the call gets arguments: (iens,
+     * report_step1 , report_step2) - i.e. at least one %d must be present.*/
+    path_fmt_type *current_runpath;
     char *current_path_key;
     hash_type *runpath_map;
     char *jobname_fmt;
@@ -84,19 +83,21 @@ struct model_config_struct {
     char *data_root;
     char *default_data_root;
 
-    int max_internal_submit; /* How many times to retry if the load fails. */
-    const ecl_sum_type *
-        refcase; /* A pointer to the refcase - can be NULL. Observe that this ONLY a pointer
-                                                        to the ecl_sum instance owned and held by the ecl_config object. */
+    /** How many times to retry if the load fails. */
+    int max_internal_submit;
+    /** A pointer to the refcase - can be NULL. Observe that this ONLY a
+     * pointer to the ecl_sum instance owned and held by the ecl_config object.
+     * */
+    const ecl_sum_type *refcase;
     char *gen_kw_export_name;
     int num_realizations;
     char *obs_config_file;
 
     /* The results are always loaded. */
-    bool_vector_type *
-        internalize_state; /* Should the (full) state be internalized (at this report_step). */
-    bool_vector_type *
-        __load_eclipse_restart; /* Internal variable: is it necessary to load the state? */
+    /** Should the (full) state be internalized (at this report_step). */
+    bool_vector_type *internalize_state;
+    /** Internal variable: is it necessary to load the state? */
+    bool_vector_type *__load_eclipse_restart;
 };
 
 char *model_config_alloc_jobname(const model_config_type *model_config,
@@ -145,11 +146,10 @@ void model_config_add_runpath(model_config_type *model_config,
                                path_fmt_free__);
 }
 
-/*
+/**
   If the path_key does not exists it will return false and stay
   silent.
 */
-
 bool model_config_select_runpath(model_config_type *model_config,
                                  const char *path_key) {
     if (hash_has_key(model_config->runpath_map, path_key)) {
@@ -593,11 +593,10 @@ int model_config_get_num_realizations(const model_config_type *model_config) {
     return model_config->num_realizations;
 }
 
-/*
+/**
    Will be NULL unless the user has explicitly loaded an external time
    map with the TIME_MAP config option.
 */
-
 time_map_type *
 model_config_get_external_time_map(const model_config_type *config) {
     return config->external_time_map;
@@ -625,12 +624,11 @@ void model_config_init_internalization(model_config_type *config) {
     bool_vector_reset(config->__load_eclipse_restart);
 }
 
-/*
+/**
    This function sets the internalize_state flag to true for
    report_step. Because of the coupling to the __load_eclipse_restart variable
    this function can __ONLY__ be used to set internalize to true.
 */
-
 void model_config_set_internalize_state(model_config_type *config,
                                         int report_step) {
     bool_vector_iset(config->internalize_state, report_step, true);

--- a/libres/lib/enkf/model_config.cpp
+++ b/libres/lib/enkf/model_config.cpp
@@ -489,12 +489,9 @@ void model_config_init(model_config_type *model_config,
         }
     }
 
-    /*
-    The full treatment of the SCHEDULE_PREDICTION_FILE keyword is in
-    the ensemble_config file, because the functionality is implemented
-    as (quite) plain GEN_KW instance. Here we just check if it is
-    present or not.
-  */
+    // The full treatment of the SCHEDULE_PREDICTION_FILE keyword is in the
+    // ensemble_config file, because the functionality is implemented as
+    // (quite) plain GEN_KW instance. Here we just check if it is present or not.
 
     if (config_content_has_item(config, ENSPATH_KEY))
         model_config_set_enspath(
@@ -506,16 +503,14 @@ void model_config_init(model_config_type *model_config,
             model_config,
             config_content_get_value_as_path(config, DATA_ROOT_KEY));
 
-    /*
-    The keywords ECLBASE and JOBNAME can be used as synonyms. But
-    observe that:
+    // The keywords ECLBASE and JOBNAME can be used as synonyms. But observe
+    // that:
 
-      1. The ecl_config object will also pick up the ECLBASE keyword,
-         and set the have_eclbase flag of that object.
+    //   1. The ecl_config object will also pick up the ECLBASE keyword, and
+    //   set the have_eclbase flag of that object.
 
-      2. If both ECLBASE and JOBNAME are in the config file the
-         JOBNAME keyword will be preferred.
-  */
+    //   2. If both ECLBASE and JOBNAME are in the config file the JOBNAME
+    //   keyword will be preferred.
     if (config_content_has_item(config, ECLBASE_KEY))
         model_config_set_jobname_fmt(
             model_config, config_content_get_value(config, ECLBASE_KEY));

--- a/libres/lib/enkf/obs_data.cpp
+++ b/libres/lib/enkf/obs_data.cpp
@@ -89,7 +89,8 @@ struct obs_block_struct {
 };
 
 struct obs_data_struct {
-    vector_type *data; /* vector with obs_block instances. */
+    /** vector with obs_block instances. */
+    vector_type *data;
     bool_vector_type *mask;
     double global_std_scaling;
 };

--- a/libres/lib/enkf/obs_vector.cpp
+++ b/libres/lib/enkf/obs_vector.cpp
@@ -742,10 +742,8 @@ obs_vector_type *obs_vector_alloc_from_BLOCK_OBSERVATION(
             obs_value[obs_pt_nr] = value;
             obs_std[obs_pt_nr] = error;
 
-            /*
-         The input values i,j,k come from the user, and are offset 1. They
-         are immediately shifted with -1 to become C-based offset zero.
-      */
+            // The input values i,j,k come from the user, and are offset 1.
+            // They are immediately shifted with -1 to become C-based offset zero.
             obs_i[obs_pt_nr] =
                 conf_instance_get_item_value_int(obs_instance, "I") - 1;
             obs_j[obs_pt_nr] =
@@ -786,9 +784,6 @@ obs_vector_type *obs_vector_alloc_from_BLOCK_OBSERVATION(
                 for (int i = 0; i < stringlist_get_size(summary_keys); i++) {
                     const char *sum_key = stringlist_iget(summary_keys, i);
                     if (!ecl_sum_has_key(refcase, sum_key)) {
-                        /*
-              If the
-            */
                         fprintf(stderr,
                                 "** Warning missing summary %s for cell: "
                                 "(%d,%d,%d) in refcase - make sure that \"BPR  "

--- a/libres/lib/enkf/rng_manager.cpp
+++ b/libres/lib/enkf/rng_manager.cpp
@@ -34,10 +34,10 @@ static auto logger = ert::get_logger("enkf");
 struct rng_manager_struct {
     UTIL_TYPE_ID_DECLARATION;
     rng_alg_type rng_alg;
-    rng_type *
-        internal_seed_rng; /* This is used to seed the RNG's which are managed. */
-    rng_type *
-        external_seed_rng; /* This is used to seed the RNG's which are managed by external scope. */
+    /** This is used to seed the RNG's which are managed. */
+    rng_type *internal_seed_rng;
+    /** This is used to seed the RNG's which are managed by external scope. */
+    rng_type *external_seed_rng;
     vector_type *rng_list;
 };
 
@@ -58,7 +58,7 @@ static rng_manager_type *rng_manager_alloc__(rng_init_mode init_mode) {
     return rng_manager;
 }
 
-/*
+/**
  * Allocates an rng_manager with the specified seed.
  *
  * NOTE: With random algorithm mzran the provided seed should contain 16

--- a/libres/lib/enkf/row_scaling.cpp
+++ b/libres/lib/enkf/row_scaling.cpp
@@ -72,7 +72,7 @@ double RowScaling::assign(size_t index, double value) {
     return m_data.at(index);
 }
 
-/*
+/**
   The final step in the Ensemble Smoother update is the matrix multiplication
 
      A' = A * X
@@ -96,7 +96,6 @@ double RowScaling::assign(size_t index, double value) {
   multiplications are grouped together where all rows with the same alpha valued
   are multiplied in one go.
  */
-
 void RowScaling::multiply(Eigen::Ref<Eigen::MatrixXd> A,
                           const Eigen::MatrixXd &X0) const {
     if (m_data.size() != A.rows())
@@ -114,7 +113,7 @@ void RowScaling::multiply(Eigen::Ref<Eigen::MatrixXd> A,
     /*
     The sort_index vector is an index permutation corresponding to sorted
     row_scaling data.
-  */
+    */
     std::vector<int> sort_index(this->size());
     std::iota(sort_index.begin(), sort_index.end(), 0);
     std::sort(sort_index.begin(), sort_index.end(),
@@ -127,8 +126,7 @@ void RowScaling::multiply(Eigen::Ref<Eigen::MatrixXd> A,
     the A matrix / row_scaling vector. In the inner loop we identify a list of
     rows which have the same row_scaling value, then we scale the X matrix
     according to this shared alpha value and calculate the update.
-  */
-
+    */
     std::size_t index_offset = 0;
     while (true) {
         if (index_offset == m_data.size())

--- a/libres/lib/enkf/row_scaling.cpp
+++ b/libres/lib/enkf/row_scaling.cpp
@@ -110,10 +110,8 @@ void RowScaling::multiply(Eigen::Ref<Eigen::MatrixXd> A,
 
     Eigen::MatrixXd X = Eigen::MatrixXd::Zero(X0.rows(), X0.cols());
 
-    /*
-    The sort_index vector is an index permutation corresponding to sorted
-    row_scaling data.
-    */
+    // The sort_index vector is an index permutation corresponding to sorted
+    // row_scaling data.
     std::vector<int> sort_index(this->size());
     std::iota(sort_index.begin(), sort_index.end(), 0);
     std::sort(sort_index.begin(), sort_index.end(),
@@ -121,12 +119,10 @@ void RowScaling::multiply(Eigen::Ref<Eigen::MatrixXd> A,
                   return this->operator[](index1) > this->operator[](index2);
               });
 
-    /*
-    This is a double while loop where we eventually go through all the rows in
-    the A matrix / row_scaling vector. In the inner loop we identify a list of
-    rows which have the same row_scaling value, then we scale the X matrix
-    according to this shared alpha value and calculate the update.
-    */
+    // This is a double while loop where we eventually go through all the rows
+    // in the A matrix / row_scaling vector. In the inner loop we identify a
+    // list of rows which have the same row_scaling value, then we scale the X
+    // matrix according to this shared alpha value and calculate the update.
     std::size_t index_offset = 0;
     while (true) {
         if (index_offset == m_data.size())

--- a/libres/lib/enkf/run_arg.cpp
+++ b/libres/lib/enkf/run_arg.cpp
@@ -213,11 +213,9 @@ void run_arg_set_run_status(run_arg_type *run_arg, run_status_type run_status) {
 }
 
 void run_arg_set_geo_id(run_arg_type *run_arg, int geo_id) {
-    /*
-   * Providing the geo_id upon initialization is the last step to achieve
-   * immutability for run_arg. Although we allow setting the geo_id for now, it
-   * should only be done once.
-   */
+    // Providing the geo_id upon initialization is the last step to achieve
+    // immutability for run_arg. Although we allow setting the geo_id for now,
+    // it should only be done once.
     if (run_arg->geo_id != -1)
         util_abort("%s: Tried to set run_arg's geo_id twice!\n", __func__);
 

--- a/libres/lib/enkf/run_arg.cpp
+++ b/libres/lib/enkf/run_arg.cpp
@@ -29,19 +29,28 @@
 struct run_arg_struct {
     UTIL_TYPE_ID_DECLARATION;
     int iens;
-    int max_internal_submit; /* How many times the enkf_state object should try to resubmit when the queueu has said everything is OK - but the load fails. */
+    /** How many times the enkf_state object should try to resubmit when the
+     * queueu has said everything is OK - but the load fails. */
+    int max_internal_submit;
     int num_internal_submit;
-    int load_start; /* When loading back results - start at this step. */
-    int step1;      /* The forward model is integrated: step1 -> step2 */
+    /** When loading back results - start at this step. */
+    int load_start;
+    /** The forward model is integrated: step1 -> step2 */
+    int step1;
     int step2;
     int iter;
-    char *
-        run_path; /* The currently used  runpath - is realloced / freed for every step. */
-    char *
-        job_name; /* Name of the job - will correspond to ECLBASE for eclipse jobs. */
-    run_mode_type run_mode; /* What type of run this is */
-    int queue_index; /* The job will in general have a different index in the queue than the iens number. */
-    int geo_id; /* This will be used by WPRO - and mapped to context key <GEO_ID>; set during submit. */
+    /** The currently used  runpath - is realloced / freed for every step. */
+    char *run_path;
+    /** Name of the job - will correspond to ECLBASE for eclipse jobs. */
+    char *job_name;
+    /* What type of run this is */
+    run_mode_type run_mode;
+    /** The job will in general have a different index in the queue than the
+     * iens number. */
+    int queue_index;
+    /** This will be used by WPRO - and mapped to context key <GEO_ID>; set
+     * during submit. */
+    int geo_id;
     enkf_fs_type *sim_fs;
     enkf_fs_type *update_target_fs;
     subst_list_type *subst_list;

--- a/libres/lib/enkf/runpath_list.cpp
+++ b/libres/lib/enkf/runpath_list.cpp
@@ -34,8 +34,8 @@ typedef struct runpath_node_struct runpath_node_type;
 struct runpath_list_struct {
     pthread_rwlock_t lock;
     vector_type *list;
-    char *
-        line_fmt; // Format string : Values are in the order: (iens , runpath , basename)
+    /** Format string : Values are in the order: (iens , runpath , basename) */
+    char *line_fmt;
     char *export_file;
 };
 
@@ -76,10 +76,9 @@ static void runpath_node_free__(void *arg) {
     runpath_node_free(node);
 }
 
-/*
+/**
   The comparison is first based on iteration number and then on iens.
 */
-
 static int runpath_node_cmp(const void *arg1, const void *arg2) {
     const runpath_node_type *node1 = runpath_node_safe_cast_const(arg1);
     const runpath_node_type *node2 = runpath_node_safe_cast_const(arg2);

--- a/libres/lib/enkf/site_config.cpp
+++ b/libres/lib/enkf/site_config.cpp
@@ -40,7 +40,7 @@
 
 namespace fs = std::filesystem;
 
-/*
+/**
    This struct contains information which is specific to the site
    where this enkf instance is running. Pointers to the fields in this
    structure are passed on to e.g. the enkf_state->shared_info object,
@@ -76,25 +76,25 @@ namespace fs = std::filesystem;
    updated. When saving only fields which are different from their
    xxx_site counterpart are stored.
  */
-
 struct site_config_struct {
 
     char *config_file;
 
-    ext_joblist_type
-        *joblist; /* The list of external jobs which have been installed.
-                                                     These jobs will be the parts of the forward model. */
+    /** The list of external jobs which have been installed. These jobs will be
+     * the parts of the forward model. */
+    ext_joblist_type *joblist;
 
-    env_varlist_type *
-        env_varlist; //Container for the environment variables set in the user config file.
+    /** Container for the environment variables set in the user config file. */
+    env_varlist_type *env_varlist;
 
     mode_t umask;
 
-    char *license_root_path; /* The license_root_path value set by the user. */
-    char *
-        license_root_path_site; /* The license_root_path value set by the site. */
-    char *
-        __license_root_path; /* The license_root_path value actually used - includes a user/pid subdirectory. */
+    /** The license_root_path value set by the user. */
+    char *license_root_path;
+    /** The license_root_path value set by the site. */
+    char *license_root_path_site;
+    /** The license_root_path value actually used - includes a user/pid subdirectory. */
+    char *__license_root_path;
 
     bool user_mode;
     bool search_path;
@@ -121,9 +121,9 @@ static void site_config_set_config_file(site_config_type *site_config,
         util_realloc_string_copy(site_config->config_file, config_file);
 }
 
-/*
+/**
    This site_config object is not really ready for prime time.
- */
+*/
 static site_config_type *site_config_alloc_empty() {
     site_config_type *site_config =
         (site_config_type *)util_malloc(sizeof *site_config);
@@ -156,7 +156,7 @@ static void site_config_load_config(site_config_type *site_config) {
     config_content_free(content);
 }
 
-/*
+/**
  * NOTE: The queue config is not loaded until the site_config_alloc_load_user.
  */
 static site_config_type *site_config_alloc_default() {
@@ -210,14 +210,13 @@ site_config_get_license_root_path(const site_config_type *site_config) {
     return site_config->license_root_path;
 }
 
-/*
+/**
    Observe that this variable can not "really" be set to different
    values during a simulation, when creating ext_job instances they
    will store a pointer to this variable on creation, if the variable
    is later changed they will be left with a dangling copy. That is
    not particularly elegant, however it should nonetheless work.
- */
-
+*/
 void site_config_set_license_root_path(site_config_type *site_config,
                                        const char *license_root_path) {
     util_make_path(license_root_path);
@@ -246,11 +245,10 @@ void site_config_set_license_root_path(site_config_type *site_config,
     }
 }
 
-/*
+/**
    Will return 0 if the job is added correctly, and a non-zero (not
    documented ...) error code if the job is not added.
- */
-
+*/
 int site_config_install_job(site_config_type *site_config, const char *job_name,
                             const char *install_file) {
     ext_job_type *new_job = ext_job_fscanf_alloc(
@@ -337,14 +335,13 @@ static void site_config_init_env(site_config_type *site_config,
     }
 }
 
-/*
+/**
    This function will be called twice, first when the config instance
    is an internalization of the site-wide configuration file, and
    secondly when config is an internalisation of the user's
    configuration file. The @user_config parameter will be true in the
    latter case.
  */
-
 static bool site_config_init(site_config_type *site_config,
                              const config_content_type *config) {
 

--- a/libres/lib/enkf/site_config.cpp
+++ b/libres/lib/enkf/site_config.cpp
@@ -223,12 +223,10 @@ void site_config_set_license_root_path(site_config_type *site_config,
     {
         char *full_license_root_path = util_alloc_realpath(license_root_path);
         {
-            /*
-         Appending /user/pid to the license root path. Everything
-         including the pid is removed when exiting (gracefully ...).
+            // Appending /user/pid to the license root path. Everything
+            // including the pid is removed when exiting (gracefully ...).
 
-         Dangling license directories after a crash can just be removed.
-       */
+            // Dangling license directories after a crash can just be removed.
             site_config->license_root_path = util_realloc_string_copy(
                 site_config->license_root_path, full_license_root_path);
             site_config->__license_root_path = util_realloc_sprintf(
@@ -406,32 +404,26 @@ void site_config_add_config_items(config_parser_type *config, bool site_mode) {
     config_schema_item_type *item;
     ert_workflow_list_add_config_items(config);
 
-    /*
-     You can set environment variables which will be applied to the
-     run-time environment. Can unfortunately not use constructions
-     like PATH=$PATH:/some/new/path, use the UPDATE_PATH function instead.
-   */
+    // You can set environment variables which will be applied to the run-time
+    // environment. Can unfortunately not use constructions like
+    // PATH=$PATH:/some/new/path, use the UPDATE_PATH function instead.
     item = config_add_schema_item(config, SETENV_KEY, false);
     config_schema_item_set_argc_minmax(item, 2, 2);
-    config_schema_item_set_envvar_expansion(
-        item,
-        false); /* Do not expand $VAR expressions (that is done in util_interp_setenv()). */
+    // Do not expand $VAR expressions (that is done in util_interp_setenv()).
+    config_schema_item_set_envvar_expansion(item, false);
 
     item = config_add_schema_item(config, UMASK_KEY, false);
     config_schema_item_set_deprecated(
         item, "UMASK is deprecated and will be removed in the future.");
     config_schema_item_set_argc_minmax(item, 1, 1);
 
-    /*
-     UPDATE_PATH   LD_LIBRARY_PATH   /path/to/some/funky/lib
+    // UPDATE_PATH   LD_LIBRARY_PATH   /path/to/some/funky/lib
 
-     Will prepend "/path/to/some/funky/lib" at the front of LD_LIBRARY_PATH.
-   */
+    // Will prepend "/path/to/some/funky/lib" at the front of LD_LIBRARY_PATH.
     item = config_add_schema_item(config, UPDATE_PATH_KEY, false);
     config_schema_item_set_argc_minmax(item, 2, 2);
-    config_schema_item_set_envvar_expansion(
-        item,
-        false); /* Do not expand $VAR expressions (that is done in util_interp_setenv()). */
+    // Do not expand $VAR expressions (that is done in util_interp_setenv()).
+    config_schema_item_set_envvar_expansion(item, false);
 
     if (!site_mode) {
         item = config_add_schema_item(config, LICENSE_PATH_KEY, false);

--- a/libres/lib/enkf/subst_config.cpp
+++ b/libres/lib/enkf/subst_config.cpp
@@ -154,7 +154,7 @@ static void subst_config_init_default(subst_config_type *subst_config) {
       o Common to all ensemble members.
 
       o Constant in time.
-  */
+    */
 
     /* Installing the functions. */
     subst_list_insert_func(subst_config->subst_list, "EXP", "__EXP__");
@@ -163,10 +163,8 @@ static void subst_config_init_default(subst_config_type *subst_config) {
     subst_list_insert_func(subst_config->subst_list, "ADD", "__ADD__");
     subst_list_insert_func(subst_config->subst_list, "MUL", "__MUL__");
 
-    /*
-     Installing the based (key,value) pairs which are common to all
-     ensemble members, and independent of time.
-  */
+    // Installing the based (key,value) pairs which are common to all ensemble
+    // members, and independent of time.
 
     char *date_string = util_alloc_date_stamp_utc();
     subst_config_add_internal_subst_kw(subst_config, "DATE", date_string,
@@ -191,10 +189,8 @@ subst_config_install_config_directory(subst_config_type *subst_config,
 
 static void subst_config_install_data_kw(subst_config_type *subst_config,
                                          hash_type *config_data_kw) {
-    /*
-    Installing the DATA_KW keywords supplied by the user - these are
-    at the very top level, so they can reuse everything defined later.
-  */
+    // Installing the DATA_KW keywords supplied by the user - these are at the
+    // very top level, so they can reuse everything defined later.
     if (config_data_kw) {
         hash_iter_type *iter = hash_iter_alloc(config_data_kw);
         const char *key = hash_iter_get_next_key(iter);

--- a/libres/lib/enkf/summary.cpp
+++ b/libres/lib/enkf/summary.cpp
@@ -32,9 +32,10 @@
 #define SUMMARY_UNDEF -9999
 
 struct summary_struct {
-    int __type_id; /* Only used for run_time checking. */
-    summary_config_type
-        *config; /* Can not be NULL - var_type is set on first load. */
+    /** Only used for run_time checking. */
+    int __type_id;
+    /** Can not be NULL - var_type is set on first load. */
+    summary_config_type *config;
     double_vector_type *data_vector;
 };
 
@@ -146,7 +147,7 @@ void summary_user_get_vector(const summary_type *summary, const char *index_key,
     double_vector_memcpy(value, summary->data_vector);
 }
 
-/*
+/**
    There are three typical reasons why the node data can not be loaded:
 
      1. The ecl_sum instance is equal to NULL.
@@ -159,7 +160,6 @@ void summary_user_get_vector(const summary_type *summary, const char *index_key,
    return true. This is done because this is a typical situation for
    e.g. a well which has not yet opened.
 */
-
 bool summary_forward_load(summary_type *summary, const char *ecl_file_name,
                           const forward_load_context_type *load_context) {
     bool loadOK = false;

--- a/libres/lib/enkf/summary.cpp
+++ b/libres/lib/enkf/summary.cpp
@@ -185,14 +185,13 @@ bool summary_forward_load(summary_type *summary, const char *ecl_file_name,
         } else {
             load_value = 0;
             /*
-         The summary object does not have this variable - probably
-         meaning that it is a well/group which has not yet
-         opened. When required == false we do not signal load
-         failure in this situation.
+            The summary object does not have this variable - probably meaning
+            that it is a well/group which has not yet opened. When required ==
+            false we do not signal load failure in this situation.
 
-         If the user has misspelled the name, we will go through
-         the whole simulation without detecting that error.
-      */
+            If the user has misspelled the name, we will go through the whole
+            simulation without detecting that error.
+            */
             if (load_fail_action == LOAD_FAIL_EXIT)
                 loadOK = false;
             else {
@@ -215,7 +214,7 @@ bool summary_forward_load(summary_type *summary, const char *ecl_file_name,
 
          Hmmm - there is a "if (report_step > 0)" check in the
          enkf_state_internalize_x() function as well.
-      */
+        */
         else {
             if (load_fail_action == LOAD_FAIL_EXIT)
                 loadOK = false;
@@ -253,10 +252,8 @@ bool summary_forward_load_vector(summary_type *summary,
     bool normal_load = false;
 
     if (load_fail_action != LOAD_FAIL_EXIT) {
-        /*
-      The load will always ~succeed - but if we do not have the data;
-      we will fill the vector with zeros.
-    */
+        // The load will always ~succeed - but if we do not have the data; we
+        // will fill the vector with zeros.
 
         if (!ecl_sum_has_general_var(ecl_sum, var_key)) {
             for (int step = 0; step < int_vector_size(time_index); step++) {

--- a/libres/lib/enkf/summary_config.cpp
+++ b/libres/lib/enkf/summary_config.cpp
@@ -32,12 +32,12 @@
 struct summary_config_struct {
     int __type_id;
     load_fail_type load_fail;
-    ecl_smspec_var_type
-        var_type; /* The type of the variable - according to ecl_summary nomenclature. */
-    char *
-        var; /* This is ONE variable of summary.x format - i.e. WOPR:OP_2, RPR:4, ... */
-    std::set<std::string>
-        obs_set; /* Set of keys (which fit in enkf_obs) which are observations of this node. */
+    /** The type of the variable - according to ecl_summary nomenclature. */
+    ecl_smspec_var_type var_type;
+    /** This is ONE variable of summary.x format - i.e. WOPR:OP_2, RPR:4, ... */
+    char *var;
+    /** Set of keys (which fit in enkf_obs) which are observations of this node. */
+    std::set<std::string> obs_set;
 };
 
 UTIL_IS_INSTANCE_FUNCTION(summary_config, SUMMARY_CONFIG_TYPE_ID)
@@ -51,14 +51,13 @@ summary_config_get_load_fail_mode(const summary_config_type *config) {
     return config->load_fail;
 }
 
-/*
+/**
    Unfortunately it is a bit problematic to set the required flag to
    TRUE for well and group variables because they do not exist in the
    summary results before the well has actually opened, i.e. for a
    partial summary case the results will not be there, and the loader
    will incorrectly(?) signal failure.
 */
-
 void summary_config_set_load_fail_mode(summary_config_type *config,
                                        load_fail_type load_fail) {
     if ((config->var_type == ECL_SMSPEC_WELL_VAR) ||
@@ -69,10 +68,9 @@ void summary_config_set_load_fail_mode(summary_config_type *config,
         config->load_fail = load_fail;
 }
 
-/*
+/**
    This can only be used to increase the load_fail strictness.
 */
-
 void summary_config_update_load_fail_mode(summary_config_type *config,
                                           load_fail_type load_fail) {
     if (load_fail > config->load_fail)

--- a/libres/lib/enkf/summary_obs.cpp
+++ b/libres/lib/enkf/summary_obs.cpp
@@ -32,16 +32,18 @@
 
 struct summary_obs_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *
-        summary_key; /* The observation, in summary.x syntax, e.g. GOPR:FIELD.    */
+    /** The observation, in summary.x syntax, e.g. GOPR:FIELD. */
+    char *summary_key;
     char *obs_key;
 
-    double value; /* Observation value. */
-    double std;   /* Standard deviation of observation. */
+    /** Observation value. */
+    double value;
+    /** Standard deviation of observation. */
+    double std;
     double std_scaling;
 };
 
-/*
+/**
   This function allocates a summary_obs instance. The summary_key
   string should be of the format used by the summary.x program.
   E.g., WOPR:P4 would condition on WOPR in well P4.

--- a/libres/lib/enkf/summary_obs.cpp
+++ b/libres/lib/enkf/summary_obs.cpp
@@ -82,11 +82,6 @@ const char *summary_obs_get_summary_key(const summary_obs_type *summary_obs) {
     return summary_obs->summary_key;
 }
 
-/*
-   Hardcodes an assumption that the size of summary data|observations
-   is always one; i.e. PARTLY_ACTIVE and ALL_ACTIVE are treated in the
-   same manner.
-*/
 void summary_obs_get_observations(const summary_obs_type *summary_obs,
                                   obs_data_type *obs_data, enkf_fs_type *fs,
                                   int report_step) {

--- a/libres/lib/enkf/surface.cpp
+++ b/libres/lib/enkf/surface.cpp
@@ -28,10 +28,12 @@
 #include <ert/enkf/surface.hpp>
 
 struct surface_struct {
-    int __type_id; /* Only used for run_time checking. */
-    surface_config_type
-        *config;  /* Can not be NULL - var_type is set on first load. */
-    double *data; /* Size should always be one */
+    /** Only used for run_time checking. */
+    int __type_id;
+    /** Can not be NULL - var_type is set on first load. */
+    surface_config_type *config;
+    /** Size should always be one */
+    double *data;
 };
 
 C_USED void surface_clear(surface_type *surface) {

--- a/libres/lib/enkf/time_map.cpp
+++ b/libres/lib/enkf/time_map.cpp
@@ -518,11 +518,8 @@ static void time_map_update_abort(time_map_type *map, int step, time_t time) {
 
 static void time_map_summary_log_mismatch(time_map_type *map,
                                           const ecl_sum_type *ecl_sum) {
-    /*
-     If the normal summary update fails we just play through all
-     time steps to pinpoint exactly the step where the update fails.
-  */
-
+    // If the normal summary update fails we just play through all time steps
+    // to pinpoint exactly the step where the update fails.
     int first_step = ecl_sum_get_first_report_step(ecl_sum);
     int last_step = ecl_sum_get_last_report_step(ecl_sum);
     int step;

--- a/libres/lib/enkf/time_map.cpp
+++ b/libres/lib/enkf/time_map.cpp
@@ -67,7 +67,7 @@ time_map_type *time_map_alloc() {
     return map;
 }
 
-/*
+/**
    The refcase will only be attached if it is consistent with the
    current time map; we will accept attaching a refcase which is
    shorter than the current case.
@@ -198,13 +198,12 @@ void time_map_free(time_map_type *map) {
 
 bool time_map_is_readonly(const time_map_type *tm) { return tm->read_only; }
 
-/*
+/**
    Must hold the write lock. When a refcase is supplied we gurantee
    that all values written into the map agree with the refcase
    values. However the time map is not preinitialized with the refcase
    values.
 */
-
 static bool time_map_update__(time_map_type *map, int step,
                               time_t update_time) {
     bool updateOK = true;
@@ -290,13 +289,12 @@ static void time_map_assert_writable(const time_map_type *map) {
         util_abort("%s: attempt to modify read-only time-map. \n", __func__);
 }
 
-/*
+/**
    Observe that the locking is opposite of the function name; i.e.
    the time_map_fwrite() function reads the time_map and takes the
    read lock, whereas the time_map_fread() function takes the write
    lock.
 */
-
 void time_map_fwrite(time_map_type *map, const char *filename) {
     pthread_rwlock_rdlock(&map->rw_lock);
     {
@@ -331,12 +329,11 @@ void time_map_fread(time_map_type *map, const char *filename) {
     map->modified = false;
 }
 
-/*
+/**
   Observe that the return value from this function is an inclusive
   value; i.e. it should be permissible to ask for results at this report
   step.
 */
-
 int time_map_get_last_step(time_map_type *map) {
     int last_step;
 
@@ -572,7 +569,7 @@ static void time_map_summary_log_mismatch(time_map_type *map,
         ecl_sum_get_path(ecl_sum), error_msg);
 }
 
-/*
+/**
   This function creates an integer index mapping from the time map
   into the summary case. In general the time <-> report step mapping
   of the summary data should coincide exactly with the one maintained
@@ -611,7 +608,6 @@ static void time_map_summary_log_mismatch(time_map_type *map,
      3: 01/04/2000   <-------      2: 01/04/2000
 
 */
-
 int_vector_type *time_map_alloc_index_map(time_map_type *map,
                                           const ecl_sum_type *ecl_sum) {
     int_vector_type *index_map = int_vector_alloc(0, -1);

--- a/libres/lib/enkf/trans_func.cpp
+++ b/libres/lib/enkf/trans_func.cpp
@@ -27,14 +27,16 @@
 #include <ert/enkf/trans_func.hpp>
 
 struct trans_func_struct {
-    char *name; /* The name this function is registered as. */
-    double_vector_type
-        *params; /* The parameter values registered for this function. */
-    transform_ftype
-        *func; /* A pointer to the actual transformation function. */
-    validate_ftype *
-        validate; /* A pointer to a a function which can be used to validate the parameters - can be NULL. */
-    stringlist_type *param_names; /* A list of the parameter names. */
+    /** The name this function is registered as. */
+    char *name;
+    /** The parameter values registered for this function. */
+    double_vector_type *params;
+    /** A pointer to the actual transformation function. */
+    transform_ftype *func;
+    /** A pointer to a a function which can be used to validate the parameters can be NULL. */
+    validate_ftype *validate;
+    /* A list of the parameter names. */
+    stringlist_type *param_names;
     bool use_log;
 };
 
@@ -129,7 +131,7 @@ static double trans_lognormal(double x, const double_vector_type *arg) {
     return exp(x * std + mu);
 }
 
-/*
+/**
    Used to sample values between min and max - BUT it is the logarithm
    of y which is uniformly distributed. Relates to the uniform
    distribution in the same manner as the lognormal distribution

--- a/libres/lib/include/ert/analysis/enkf_linalg.hpp
+++ b/libres/lib/include/ert/analysis/enkf_linalg.hpp
@@ -23,7 +23,7 @@ void enkf_linalg_lowrankE(
     Eigen::MatrixXd
         &W, /* (nrobs x nrmin) Corresponding to X1 from Eqs. 14.54-14.55 */
     Eigen::VectorXd
-        &eig, /* (nrmin)         Corresponding to 1 / (1 + Lambda1^2) (14.54) */
+        &eig, /* (nrmin) Corresponding to 1 / (1 + Lambda1^2) (14.54) */
     const std::variant<double, int> &truncation);
 
 Eigen::MatrixXd enkf_linalg_genX3(const Eigen::MatrixXd &W,

--- a/libres/lib/include/ert/analysis/ies/ies_config.hpp
+++ b/libres/lib/include/ert/analysis/ies/ies_config.hpp
@@ -58,18 +58,18 @@ public:
 
     double get_steplength(int iteration_nr) const;
 
-    // Controlled by config key: DEFAULT_IES_INVERSION
+    /** Controlled by config key: DEFAULT_IES_INVERSION */
     inversion_type inversion;
     bool iterable;
-    // Controlled by config key: DEFAULT_IES_MAX_STEPLENGTH_KEY
+    /** Controlled by config key: DEFAULT_IES_MAX_STEPLENGTH_KEY */
     double max_steplength;
-    // Controlled by config key: DEFAULT_IES_MIN_STEPLENGTH_KEY
+    /** Controlled by config key: DEFAULT_IES_MIN_STEPLENGTH_KEY */
     double min_steplength;
 
 private:
-    // Used for setting threshold of eigen values or number of eigen values
+    /** Used for setting threshold of eigen values or number of eigen values */
     std::variant<double, int> m_truncation;
-    // Controlled by config key: DEFAULT_IES_DEC_STEPLENGTH_KEY
+    /** Controlled by config key: DEFAULT_IES_DEC_STEPLENGTH_KEY */
     double m_dec_steplength;
 };
 

--- a/libres/lib/include/ert/analysis/ies/ies_data.hpp
+++ b/libres/lib/include/ert/analysis/ies/ies_data.hpp
@@ -38,14 +38,15 @@ public:
 
 private:
     bool m_converged = false;
-    Eigen::MatrixXd
-        W; // Coefficient matrix used to compute Omega = I + W (I -11'/N)/sqrt(N-1)
+    /** Coefficient matrix used to compute Omega = I + W (I -11'/N)/sqrt(N-1) */
+    Eigen::MatrixXd W;
 
     std::vector<bool> m_ens_mask{};
     std::vector<bool> m_obs_mask0{};
     std::vector<bool> m_obs_mask{};
-    Eigen::MatrixXd A0{}; // Prior ensemble used in Ei=A0 Omega_i
-    // Prior ensemble of measurement perturations (should be the same for all iterations)
+    /** Prior ensemble used in Ei=A0 Omega_i */
+    Eigen::MatrixXd A0{};
+    /** Prior ensemble of measurement perturations (should be the same for all iterations) */
     Eigen::MatrixXd E;
 };
 

--- a/libres/lib/include/ert/enkf/active_list.hpp
+++ b/libres/lib/include/ert/enkf/active_list.hpp
@@ -34,12 +34,11 @@
    The same type is used both for variables (PRESSURE/PORO/MULTZ/...)
    and for observations.
 */
-
 typedef enum {
-    ALL_ACTIVE =
-        1, /* The variable/observation is fully active, i.e. all cells/all faults/all .. */
-    PARTLY_ACTIVE =
-        3 /* Partly active - must supply additonal type spesific information on what is active.*/
+    /** The variable/observation is fully active, i.e. all cells/all faults/all .. */
+    ALL_ACTIVE = 1,
+    /** Partly active - must supply additonal type spesific information on what is active.*/
+    PARTLY_ACTIVE = 3
 } active_mode_type;
 
 class ActiveList {

--- a/libres/lib/include/ert/enkf/enkf_types.hpp
+++ b/libres/lib/include/ert/enkf/enkf_types.hpp
@@ -21,7 +21,7 @@
 
 #include <ert/tooling.hpp>
 
-/*
+/**
   This enum signals the three different states a "cell" in
   observation/data node can be in:
 
@@ -35,15 +35,16 @@
     deactivating outliers.
 
 */
-
 typedef enum {
     ACTIVE = 1,
-    LOCAL_INACTIVE = 2, /* Not active in current local update scheme. */
-    DEACTIVATED = 3,    /* Deactivaed due to to small overlap, or... */
+    /** Not active in current local update scheme. */
+    LOCAL_INACTIVE = 2,
+    /** Deactivaed due to to small overlap, or... */
+    DEACTIVATED = 3,
     MISSING = 4
 } active_type; /* Set as missing by the forward model. */
 
-/*
+/**
   The enkf_var_type enum defines logical groups of variables. All
   variables in the same group, i.e. 'parameter' are typically treated
   in the same manner. So the reason for creating this type is to be
@@ -52,15 +53,14 @@ typedef enum {
   Observe that these are used as bitmask's, i.e. the numerical values
   must be a power of 2 series.
 */
-
 typedef enum {
     INVALID_VAR = 0,
-    PARAMETER =
-        1, /* A parameter which is updated with enkf: PORO , MULTFLT , ..*/
-    DYNAMIC_RESULT =
-        4, /* Dynamic results which are NOT needed for a restart - i.e. well rates. */
-    INDEX_STATE =
-        16, /* Index data - enum value is used for storage classification */
+    /** A parameter which is updated with enkf: PORO, MULTFLT, ..*/
+    PARAMETER = 1,
+    /** Dynamic results which are NOT needed for a restart - i.e. well rates. */
+    DYNAMIC_RESULT = 4,
+    /** Index data - enum value is used for storage classification */
+    INDEX_STATE = 16,
     EXT_PARAMETER = 32
 } /* Parameter fully managed by external scope. */
 enkf_var_type;
@@ -141,8 +141,9 @@ typedef enum { //ENKF_ASSIMILATION       = 1,
 
 typedef enum {
     JOB_NOT_STARTED = 0,
-    JOB_SUBMITTED =
-        1, // This implies that it has been submitted to the internal queue system; we don't know if it is actually running or not.
+    /** This implies that it has been submitted to the internal queue system;
+     * we don't know if it is actually running or not. */
+    JOB_SUBMITTED = 1,
     JOB_RUN_FAILURE = 2,
     JOB_LOAD_FAILURE = 3,
     JOB_RUN_OK = 4

--- a/libres/lib/include/ert/enkf/field_config.hpp
+++ b/libres/lib/include/ert/enkf/field_config.hpp
@@ -42,9 +42,7 @@
    This is purely a convenience structure used during initialization,
    to denote which arguments are required and, which should be
    defualted.
-
 */
-
 typedef enum {
     ECLIPSE_RESTART = 1,
     ECLIPSE_PARAMETER = 2,
@@ -78,18 +76,19 @@ typedef enum {
      3. Treatment is not symmetric for input/output.
 
 */
-
 typedef enum {
     UNDEFINED_FORMAT = 0,
     RMS_ROFF_FILE = 1,
-    ECL_KW_FILE =
-        2, /* ecl_kw format either packed (i.e. active cells) *or* all cells - used when reading from file. */
-    ECL_KW_FILE_ACTIVE_CELLS =
-        3, /* ecl_kw format, only active cells - used writing to file. */
-    ECL_KW_FILE_ALL_CELLS =
-        4, /* ecl_kw_format, all cells - used when writing to file. */
+    /** ecl_kw format either packed (i.e. active cells) *or* all cells - used
+     * when reading from file. */
+    ECL_KW_FILE = 2,
+    /** ecl_kw format, only active cells - used writing to file. */
+    ECL_KW_FILE_ACTIVE_CELLS = 3,
+    /** ecl_kw_format, all cells - used when writing to file. */
+    ECL_KW_FILE_ALL_CELLS = 4,
     ECL_GRDECL_FILE = 5,
-    ECL_FILE = 6, /* Assumes packed on export. */
+    /** Assumes packed on export. */
+    ECL_FILE = 6,
     FILE_FORMAT_NULL = 7
 } field_file_format_type; /* Used when the guess functions are given NULL to check -should never be read. */
 

--- a/libres/lib/include/ert/enkf/fs_types.hpp
+++ b/libres/lib/include/ert/enkf/fs_types.hpp
@@ -19,45 +19,35 @@
 #ifndef ERT_FS_TYPES_H
 #define ERT_FS_TYPES_H
 
-/*
+/**
   The various driver implementations - this goes on disk all over the
   place, and the numbers should be considered SET IN STONE. When a new
   driver is added the switch statement in the enkf_fs_mount() function
   must be updated.
 */
-
-// Version from ~ svn:3720
-//typedef enum {
-//  INVALID_DRIVER_ID          = 0,
-//  PLAIN_DRIVER_INDEX_ID      = 1001,
-//  PLAIN_DRIVER_STATIC_ID     = 1002,  /* Depreceated */
-//  PLAIN_DRIVER_DYNAMIC_ID    = 1003,  /* Depreceated */
-//  PLAIN_DRIVER_PARAMETER_ID  = 1004,  /* Depreceated */
-//  PLAIN_DRIVER_ID            = 1005,
-//  BLOCK_FS_DRIVER_ID         = 3001,
-//  BLOCK_FS_DRIVER_INDEX_ID   = 3002 } fs_driver_impl;
-
 typedef enum {
     INVALID_DRIVER_ID = 0,
     BLOCK_FS_DRIVER_ID = 3001
 } fs_driver_impl;
 
-/*
+/**
   The categories of drivers. To reduce the risk of programming
   error (or at least to detect it ...), there should be no overlap
   between these ID's and the ID's of the actual implementations
   above. The same comment about permanent storage applies to these
   numbers as well.
 */
-
 typedef enum {
     DRIVER_PARAMETER = 1,
-    DRIVER_STATIC =
-        2, // Driver static is no longer in use since December 2015 - but it must be retained here for old mount files on disk.
-    DRIVER_INDEX = 4, // DRIVER_DYNAMIC = 3; removed at svn ~ 3720.
+    /** Driver static is no longer in use since December 2015 - but it must be
+     * retained here for old mount files on disk.*/
+    DRIVER_STATIC = 2,
+    // DRIVER_DYNAMIC = 3; removed at svn ~ 3720.
+    DRIVER_INDEX = 4,
     DRIVER_DYNAMIC_FORECAST = 5,
-    DRIVER_DYNAMIC_ANALYZED =
-        6 // Driver DYNAMIC_ANALYZED is no longer in use since April 2016 - but it must be retained here for old mount files on disk.
+    /** Driver DYNAMIC_ANALYZED is no longer in use since April 2016 - but it
+     * must be retained here for old mount files on disk. */
+    DRIVER_DYNAMIC_ANALYZED = 6
 } fs_driver_enum;
 
 bool fs_types_valid(fs_driver_enum driver_type);

--- a/libres/lib/include/ert/enkf/gen_data_config.hpp
+++ b/libres/lib/include/ert/enkf/gen_data_config.hpp
@@ -32,14 +32,14 @@
 
 typedef enum {
     GEN_DATA_UNDEFINED = 0,
-    ASCII =
-        1, /*   The file is ASCII file with a vector of numbers formatted with "%g".       */
-    ASCII_TEMPLATE =
-        2, /*   The data is inserted into a user defined template file.                    */
-    BINARY_DOUBLE =
-        3, /*   The data is in a binary file with doubles.                                 */
+    /** The file is ASCII file with a vector of numbers formatted with "%g".*/
+    ASCII = 1,
+    /** The data is inserted into a user defined template file. */
+    ASCII_TEMPLATE = 2,
+    /** The data is in a binary file with doubles.*/
+    BINARY_DOUBLE = 3,
     BINARY_FLOAT = 4
-} /*   The data is in a binary file with floats.                                  */
+} /*   The data is in a binary file with floats. */
 gen_data_file_format_type;
 
 bool gen_data_config_is_dynamic(const gen_data_config_type *config);

--- a/libres/lib/include/ert/enkf/queue_config.hpp
+++ b/libres/lib/include/ert/enkf/queue_config.hpp
@@ -64,13 +64,13 @@ bool queue_config_has_queue_driver(const queue_config_type *queue_config,
 void queue_config_create_queue_drivers(queue_config_type *queue_config);
 
 /**
-     * Queue system is typically one of LSF, LOCAL, TORQUE, RHS, ...  Given a
-     * queue system, you can obtain the _driver_ (e.g. lsf_driver).
-     *
-     * Should not be confused with queue_name, which is typically just a
-     * parameter we can send to the LSF cluster to get a certain queue,
-     * e.g. "mr".
-     */
+ * Queue system is typically one of LSF, LOCAL, TORQUE, RHS, ...  Given a
+ * queue system, you can obtain the _driver_ (e.g. lsf_driver).
+ *
+ * Should not be confused with queue_name, which is typically just a
+ * parameter we can send to the LSF cluster to get a certain queue,
+ * e.g. "mr".
+ */
 extern "C" const char *
 queue_config_get_queue_system(const queue_config_type *queue_config);
 

--- a/libres/lib/include/ert/enkf/summary_config.hpp
+++ b/libres/lib/include/ert/enkf/summary_config.hpp
@@ -29,18 +29,18 @@
 
 #include <ert/enkf/enkf_macros.hpp>
 
-/*
+/**
   How should the run system handle a load problem of a summary
   variable. Observe that the numerical enum values are actually used -
   they should be listed with the most strict mode having the
   numerically largest value.
 */
-
 typedef enum {
-    LOAD_FAIL_SILENT =
-        0, // We just try to load - and if it is not there we do not care at all.
-    LOAD_FAIL_WARN =
-        2, // If the key can not be found we will print a warning on stdout - but the run will still be flagged as successful.
+    /** We just try to load - and if it is not there we do not care at all. */
+    LOAD_FAIL_SILENT = 0,
+    /** If the key can not be found we will print a warning on stdout - but the
+     * run will still be flagged as successful. */
+    LOAD_FAIL_WARN = 2,
     LOAD_FAIL_EXIT = 4
 } // The data is deemed important - and we let the run fail if this data can not be found.
 load_fail_type;

--- a/libres/lib/include/ert/job_queue/ext_joblist.hpp
+++ b/libres/lib/include/ert/job_queue/ext_joblist.hpp
@@ -35,7 +35,6 @@ extern "C" void ext_joblist_add_job(ext_joblist_type *joblist, const char *name,
 extern "C" ext_job_type *ext_joblist_get_job(const ext_joblist_type *,
                                              const char *);
 ext_job_type *ext_joblist_get_job_copy(const ext_joblist_type *, const char *);
-//void               ext_joblist_python_fprintf(const ext_joblist_type * , const stringlist_type * , const char * , const subst_list_type *);
 extern "C" bool ext_joblist_has_job(const ext_joblist_type *, const char *);
 extern "C" stringlist_type *
 ext_joblist_alloc_list(const ext_joblist_type *joblist);

--- a/libres/lib/include/ert/job_queue/job_status.hpp
+++ b/libres/lib/include/ert/job_queue/job_status.hpp
@@ -79,22 +79,27 @@
 */
 
 typedef enum {
-    JOB_QUEUE_NOT_ACTIVE =
-        1, /* This value is used in external query routines - for jobs which are (currently) not active. */
-    JOB_QUEUE_WAITING = 2, /* A node which is waiting in the internal queue. */
-    JOB_QUEUE_SUBMITTED =
-        4, /* Internal status: It has has been submitted - the next status update will (should) place it as pending or running. */
-    JOB_QUEUE_PENDING =
-        8, /* A node which is pending - a status returned by the external system. I.e LSF */
-    JOB_QUEUE_RUNNING = 16, /* The job is running */
-    JOB_QUEUE_DONE =
-        32, /* The job is done - but we have not yet checked if the target file is produced */
-    JOB_QUEUE_EXIT =
-        64, /* The job has exited - check attempts to determine if we retry or go to complete_fail   */
-    JOB_QUEUE_IS_KILLED =
-        128, /* The job has been killed, following a JOB_QUEUE_DO_KILL*/
-    JOB_QUEUE_DO_KILL =
-        256, /* The job should be killed, either due to user request, or automated measures - the job can NOT be restarted. */
+    /** This value is used in external query routines - for jobs which are
+     * (currently) not active. */
+    JOB_QUEUE_NOT_ACTIVE = 1,
+    /** A node which is waiting in the internal queue. */
+    JOB_QUEUE_WAITING = 2,
+    /** Internal status: It has has been submitted - the next status update
+     * will (should) place it as pending or running. */
+    JOB_QUEUE_SUBMITTED = 4,
+    /** A node which is pending - a status returned by the external system. I.e LSF */
+    JOB_QUEUE_PENDING = 8,
+    /** The job is running */
+    JOB_QUEUE_RUNNING = 16,
+    /** The job is done - but we have not yet checked if the target file is produced */
+    JOB_QUEUE_DONE = 32,
+    /** The job has exited - check attempts to determine if we retry or go to complete_fail*/
+    JOB_QUEUE_EXIT = 64,
+    /** The job has been killed, following a JOB_QUEUE_DO_KILL*/
+    JOB_QUEUE_IS_KILLED = 128,
+    /** The job should be killed, either due to user request, or automated
+     * measures - the job can NOT be restarted. */
+    JOB_QUEUE_DO_KILL = 256,
     JOB_QUEUE_SUCCESS = 512,
     JOB_QUEUE_RUNNING_DONE_CALLBACK = 1024,
     JOB_QUEUE_RUNNING_EXIT_CALLBACK = 2048,

--- a/libres/lib/include/ert/job_queue/queue_driver.hpp
+++ b/libres/lib/include/ert/job_queue/queue_driver.hpp
@@ -98,9 +98,10 @@ queue_driver_get_max_running(const queue_driver_type *driver);
 
 typedef enum {
     SUBMIT_OK = 0,
-    SUBMIT_JOB_FAIL = 1, /* Typically no more attempts. */
-    SUBMIT_DRIVER_FAIL =
-        2, /* The driver would not take the job - for whatever reason?? */
+    /** Typically no more attempts. */
+    SUBMIT_JOB_FAIL = 1,
+    /** The driver would not take the job - for whatever reason?? */
+    SUBMIT_DRIVER_FAIL = 2,
     SUBMIT_QUEUE_CLOSED = 3
 } /* The queue is currently not accepting more jobs - either (temporarilty)
                                              because of pause or it is going down. */

--- a/libres/lib/include/ert/job_queue/queue_driver.hpp
+++ b/libres/lib/include/ert/job_queue/queue_driver.hpp
@@ -34,9 +34,7 @@ typedef enum {
 
 #define JOB_DRIVER_ENUM_SIZE 5
 
-/*
-    The options supported by the base queue_driver.
-   */
+// The options supported by the base queue_driver.
 #define MAX_RUNNING "MAX_RUNNING"
 
 typedef struct queue_driver_struct queue_driver_type;

--- a/libres/lib/include/ert/logging.hpp
+++ b/libres/lib/include/ert/logging.hpp
@@ -49,7 +49,7 @@ protected:
     virtual void log(Level level, fmt::string_view f,
                      fmt::format_args args) = 0;
 };
-/*
+/**
 * Creates a logger that logs only to Python's logger of the same
 * name, prefixed with libres' namespace. Can be created statically, although
 * it no-ops outside of the lifetime of this Python module.

--- a/libres/lib/include/ert/res_util/file_utils.hpp
+++ b/libres/lib/include/ert/res_util/file_utils.hpp
@@ -9,7 +9,6 @@ namespace fs = std::filesystem;
    Open file-stream to "/some/path/to/file.txt" without first ensuring
    that "/some/path/to" exists.
 */
-
 FILE *mkdir_fopen(fs::path, const char *);
 
 #endif

--- a/libres/lib/include/ert/res_util/template.hpp
+++ b/libres/lib/include/ert/res_util/template.hpp
@@ -44,7 +44,4 @@ char *template_get_args_as_string(template_type *_template);
 void template_set_template_file(template_type *_template,
                                 const char *template_file);
 const char *template_get_template_file(const template_type *_template);
-
-//void template_eval_loops( const template_type * template_ , buffer_type * buffer );
-
 #endif

--- a/libres/lib/include/ert/res_util/template_type.hpp
+++ b/libres/lib/include/ert/res_util/template_type.hpp
@@ -13,16 +13,18 @@
 
 struct template_struct {
     UTIL_TYPE_ID_DECLARATION;
-    char *
-        template_file; /* The template file - if internalize_template == false this filename can contain keys which will be replaced at instantiation time. */
-    char *
-        template_buffer; /* The content of the template buffer; only has valid content if internalize_template == true. */
-    bool
-        internalize_template; /* Should the template be loadad and internalized at template_alloc(). */
-    subst_list_type
-        *arg_list; /* Key-value mapping established at alloc time. */
-    char *
-        arg_string; /* A string representation of the arguments - ONLY used for a _get_ function. */
+    /** The template file - if internalize_template == false this filename can
+     * contain keys which will be replaced at instantiation time. */
+    char *template_file;
+    /** The content of the template buffer; only has valid content if
+     * internalize_template == true. */
+    char *template_buffer;
+    /** Should the template be loadad and internalized at template_alloc(). */
+    bool internalize_template;
+    /* Key-value mapping established at alloc time. */
+    subst_list_type *arg_list;
+    /* A string representation of the arguments - ONLY used for a _get_ function. */
+    char *arg_string;
 #ifdef ERT_HAVE_REGEXP
     regex_t start_regexp;
     regex_t end_regexp;

--- a/libres/lib/include/ert/sched/history.hpp
+++ b/libres/lib/include/ert/sched/history.hpp
@@ -32,8 +32,10 @@
 
 typedef enum {
     SCHEDULE = 0,
-    REFCASE_SIMULATED = 1, /* ecl_sum_get_well_var( "WWCT" );  */
-    REFCASE_HISTORY = 2,   /* ecl_sum_get_well_var( "WWCTH" ); */
+    /** ecl_sum_get_well_var( "WWCT" );  */
+    REFCASE_SIMULATED = 1,
+    /** ecl_sum_get_well_var( "WWCTH" ); */
+    REFCASE_HISTORY = 2,
     HISTORY_SOURCE_INVALID = 10
 } history_source_type;
 

--- a/libres/lib/job_queue/ext_job.cpp
+++ b/libres/lib/job_queue/ext_job.cpp
@@ -105,47 +105,56 @@ jobList = [
 
 #define EXT_JOB_STDOUT "stdout"
 #define EXT_JOB_STDERR "stderr"
-#define EXT_JOB_NO_STD_FILE                                                    \
-    "null" //Setting STDOUT null or STDERR null in forward model directs output to screen
+//Setting STDOUT null or STDERR null in forward model directs output to screen
+#define EXT_JOB_NO_STD_FILE "null"
 
 struct ext_job_struct {
     UTIL_TYPE_ID_DECLARATION;
     char *name;
     char *executable;
     char *target_file;
-    char *error_file; /* Job has failed if this is present. */
-    char *start_file; /* Will not start if not this file is present */
+    /** Job has failed if this is present. */
+    char *error_file;
+    /** Will not start if not this file is present */
+    char *start_file;
     char *stdout_file;
     char *stdin_file;
     char *stderr_file;
-    char *license_path; /* If this is NULL - it will be unrestricted ... */
+    /** If this is NULL - it will be unrestricted ... */
+    char *license_path;
     char *license_root_path;
     char *config_file;
-    int max_running; /* 0 means unlimited. */
-    int max_running_minutes; /* The maximum number of minutes this job is allowed to run - 0: unlimited. */
+    /** 0 means unlimited. */
+    int max_running;
+    /** The maximum number of minutes this job is allowed to run - 0:
+     * unlimited. */
+    int max_running_minutes;
 
     int min_arg;
     int max_arg;
     int_vector_type *arg_types;
-    stringlist_type
-        *argv; /* Currently not in use, but will replace deprected_argv */
-    subst_list_type *
-        private_args; /* A substitution list of input arguments which is performed before the external substitutions -
-                                              these are the arguments supplied as key=value pairs in the forward model call. */
+    /** Currently not in use, but will replace deprected_argv */
+    stringlist_type *argv;
+    /** A substitution list of input arguments which is performed before the
+     * external substitutions - these are the arguments supplied as key=value
+     * pairs in the forward model call. */
+    subst_list_type *private_args;
     const subst_list_type *define_args;
     char *private_args_string;
     char *argv_string;
-    stringlist_type
-        *deprecated_argv; /* This should *NOT* start with the executable */
+    /** This should *NOT* start with the executable */
+    stringlist_type *deprecated_argv;
     hash_type *environment;
     hash_type *default_mapping;
     hash_type *exec_env;
     char *help_text;
 
-    bool
-        private_job; /* Can the current user/delete this job? (private_job == true) means the user can edit it. */
-    bool
-        __valid; /* Temporary variable consulted during the bootstrap - when the ext_job is completely initialized this should NOT be consulted anymore. */
+    /** Can the current user/delete this job? (private_job == true) means the
+     * user can edit it. */
+    bool private_job;
+    /** Temporary variable consulted during the bootstrap - when the ext_job is
+     * completely initialized this should NOT be consulted anymore. */
+    bool __valid;
 };
 
 static UTIL_SAFE_CAST_FUNCTION(ext_job, EXT_JOB_TYPE_ID)
@@ -357,43 +366,39 @@ void ext_job_set_max_time(ext_job_type *ext_job, int max_time) {
     ext_job->max_running_minutes = max_time;
 }
 
-/*
-  @executable parameter:
-  The raw executable is either
-    - an absolute path read directly from config
-    - an absolute path constructed from the relative path from config
-      with the assumption that the path was a relative path from the
-      location of the job description file to the executable.
-
-  @executable_raw parameter:
-  The raw executable as read from config, unprocessed.
-
+/**
   This method have the following logic:
 
-     @executable exists:
+     executable_abs exists:
          We store the full path as the executable field of the job; and
          try to update the mode of the full_path executable to make sure it
          is executable.
 
-     @executable does not exist, but @executable_raw exists:
+     executable_abs does not exist, but executable_input exists:
         We have found an executable relative to the current working
         directory. This is deprecated behaviour, support will later be
         removed. Suggest new path to executable to user, relative to job
         description file and do a recursive call to this method, using
         the absolute path as @executable parameter
 
-     @executable does not exist, @executable_raw does not exist and
+     executable_abs does not exist, executable_input does not exist and
      is an absolute path:
         Write error message
 
-     @executable does not exist, @executable_raw does not exist and
+     executable_abs does not exist, executable_input does not exist and
      is a relative path:
         Search trough the PATH variable to try to locate the executable.
         If found, do a recursive call to this method, using the absolute path
-        as @executable parameter
+        as executable_abs parameter
 
+  @param executable_abs is either
+    - an absolute path read directly from config
+    - an absolute path constructed from the relative path from config
+      with the assumption that the path was a relative path from the
+      location of the job description file to the executable.
+
+  @param executable_input is the raw executable as read from config, unprocessed.
 */
-
 void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
                             const char *executable_input, bool search_path) {
 
@@ -452,11 +457,10 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
     }
 }
 
-/*
+/**
    Observe that this does NOT reread the ext_job instance from the new
    config_file.
 */
-
 void ext_job_set_args(ext_job_type *ext_job, const stringlist_type *argv) {
     stringlist_deep_copy(ext_job->argv, argv);
 }
@@ -731,10 +735,9 @@ static void __fprintf_python_int(FILE *stream, const char *prefix,
     fprintf(stream, "%s", suffix);
 }
 
-/*
+/**
    This is special cased to support the default mapping.
 */
-
 static void __fprintf_python_argList(FILE *stream, const char *prefix,
                                      const ext_job_type *ext_job,
                                      const char *suffix,
@@ -897,12 +900,11 @@ void ext_job_json_fprintf(const ext_job_type *ext_job, int job_index,
         fprintf(stream, "%d\n", value);                                        \
     }
 
-/*
+/**
    Observe that the job will save itself to the internalized
    config_file; if you wish to save to some other place you must call
    ext_job_set_config_file() first.
 */
-
 void ext_job_save(const ext_job_type *ext_job) {
     auto stream = mkdir_fopen(fs::path(ext_job->config_file), "w");
 
@@ -1279,7 +1281,7 @@ const stringlist_type *ext_job_get_argvalues(const ext_job_type *ext_job) {
     return result;
 }
 
-/*
+/**
    Set the internal arguments of the job based on an input string
    @arg_string which is of the form:
 
@@ -1288,7 +1290,6 @@ const stringlist_type *ext_job_get_argvalues(const ext_job_type *ext_job) {
    The internal private argument list is cleared before adding these
    arguments.
 */
-
 void ext_job_set_private_args_from_string(ext_job_type *ext_job,
                                           const char *arg_string) {
     subst_list_clear(ext_job->private_args);

--- a/libres/lib/job_queue/ext_job.cpp
+++ b/libres/lib/job_queue/ext_job.cpp
@@ -194,10 +194,8 @@ static UTIL_SAFE_CAST_FUNCTION(ext_job, EXT_JOB_TYPE_ID)
     ext_job->help_text = NULL;
     ext_job->private_args_string = NULL;
 
-    /*
-     ext_job->private_args is set explicitly in the ext_job_alloc()
-     and ext_job_alloc_copy() functions.
-  */
+    // ext_job->private_args is set explicitly in the ext_job_alloc()
+    // and ext_job_alloc_copy() functions.
     return ext_job;
 }
 
@@ -403,20 +401,17 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
                             const char *executable_input, bool search_path) {
 
     if (fs::exists(executable_abs)) {
-        /*
-       The @executable parameter points to an existing file; we store
-       the full path as the executable field of the job.
-    */
+        // The executable_abs parameter points to an existing file; we store
+        // the full path as the executable field of the job.
         char *full_path = (char *)util_alloc_realpath(executable_abs);
         ext_job->executable =
             util_realloc_string_copy(ext_job->executable, full_path);
         free(full_path);
     } else if (util_is_abs_path(executable_input)) {
-        /* If you have given an absolute path (i.e. starting with '/' to
-       a non existing job we mark it as invalid - no possibility to
-       provide context replacement afterwards. The job will be
-       discarded by the calling scope.
-    */
+        // If you have given an absolute path (i.e. starting with '/' to a non
+        // existing job we mark it as invalid - no possibility to provide
+        // context replacement afterwards. The job will be discarded by the
+        // calling scope.
         throw std::invalid_argument(fmt::format(
             "** The executable {} was not found", executable_input));
     } else {
@@ -439,10 +434,8 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
         }
     }
 
-    /*
-     If in the end we do not have execute rights to the executable :
-     discard the job.
-  */
+    // If in the end we do not have execute rights to the executable:
+    // discard the job.
     if (ext_job->executable != NULL) {
         if (fs::exists(executable_abs)) {
             if (!util_is_executable(ext_job->executable)) {
@@ -657,19 +650,16 @@ static hash_type *__alloc_filtered_hash(hash_type *input_hash,
     const char *key = hash_iter_get_next_key(iter);
     while (key != NULL) {
         const char *value = (const char *)hash_get(input_hash, key);
-        /*
-      If the value is NULL or alternatively the special string value "null" we
-      print the @null_value variable and continue.
-    */
+        // If the value is NULL or alternatively the special string value
+        // "null" we print the @null_value variable and continue.
         if (!value || strcmp(value, "null") == 0)
             hash_insert_ref(output_hash, key, NULL);
         else {
             char *fv =
                 __alloc_filtered_string(value, private_args, global_args);
-            /*
-        If the value string contains a <XXX> string which is not represented in
-        the substitutionlists we will not print out the <xxxx> literal.
-      */
+            // If the value string contains a <XXX> string which is not
+            // represented in the substitutionlists we will not print out the
+            // <xxxx> literal.
             if (include_angular_values)
                 hash_insert_hash_owned_ref(output_hash, key, fv, free);
             else {
@@ -1226,9 +1216,8 @@ ext_job_type *ext_job_fscanf_alloc(const char *name,
                 }
 
                 if (!ext_job->__valid) {
-                    /*
-            Something NOT OK (i.e. EXECUTABLE now); free the job instance and return NULL:
-          */
+                    // Something NOT OK (i.e. EXECUTABLE now); free the job
+                    // instance and return NULL
                     ext_job_free(ext_job);
                     ext_job = NULL;
                     fprintf(stderr,

--- a/libres/lib/job_queue/ext_joblist.cpp
+++ b/libres/lib/job_queue/ext_joblist.cpp
@@ -116,7 +116,7 @@ stringlist_type *ext_joblist_alloc_list(const ext_joblist_type *joblist) {
     return hash_alloc_stringlist(joblist->jobs);
 }
 
-/*
+/**
    Will attempt to remove the job @job_name from the joblist; if the
    job is marked as a shared_job (i.e. installed centrally) the user
    is not allowed to delete it. In this case the function will fail
@@ -124,7 +124,6 @@ stringlist_type *ext_joblist_alloc_list(const ext_joblist_type *joblist) {
 
    Returns true if the job is actually removed, and false otherwise.
 */
-
 bool ext_joblist_del_job(ext_joblist_type *joblist, const char *job_name) {
     ext_job_type *job = ext_joblist_get_job(joblist, job_name);
     if (!ext_job_is_shared(job)) {

--- a/libres/lib/job_queue/forward_model.cpp
+++ b/libres/lib/job_queue/forward_model.cpp
@@ -35,9 +35,11 @@
 */
 
 struct forward_model_struct {
-    vector_type *jobs; /* The actual jobs in this forward model. */
-    const ext_joblist_type *
-        ext_joblist; /* This is the list of external jobs which have been installed - which we can choose from. */
+    /** The actual jobs in this forward model. */
+    vector_type *jobs;
+    /** This is the list of external jobs which have been installed - which we
+     * can choose from. */
+    const ext_joblist_type *ext_joblist;
 };
 
 #define DEFAULT_JOB_JSON "jobs.json"
@@ -55,7 +57,7 @@ forward_model_type *forward_model_alloc(const ext_joblist_type *ext_joblist) {
     return forward_model;
 }
 
-/*
+/**
    Allocates and returns a stringlist with all the names in the
    current forward_model.
 */
@@ -72,12 +74,11 @@ forward_model_alloc_joblist(const forward_model_type *forward_model) {
     return names;
 }
 
-/*
+/**
    This function adds the job named 'job_name' to the forward model. The return
    value is the newly created ext_job instance. This can be used to set private
    arguments for this job.
 */
-
 ext_job_type *forward_model_add_job(forward_model_type *forward_model,
                                     const char *job_name) {
     ext_job_type *new_job =
@@ -95,10 +96,9 @@ void forward_model_free(forward_model_type *forward_model) {
     free(forward_model);
 }
 
-/*
+/**
   Used with SIMULATION_JOB keyword
 */
-
 void forward_model_parse_job_args(forward_model_type *forward_model,
                                   const stringlist_type *list,
                                   const subst_list_type *define_args) {
@@ -112,7 +112,7 @@ void forward_model_parse_job_args(forward_model_type *forward_model,
     ext_job_set_define_args(current_job, define_args);
 }
 
-/*
+/**
    DEPRECATED, used with the old FORWARD_MODEL keyword
 
    this function takes an input string of the type:
@@ -125,7 +125,6 @@ void forward_model_parse_job_args(forward_model_type *forward_model,
       between the end of the function name and the opening parenthesis.
 
 */
-
 void forward_model_parse_job_deprecated_args(
     forward_model_type *forward_model, const char *input_string,
     const subst_list_type *define_args) {

--- a/libres/lib/job_queue/job_list.cpp
+++ b/libres/lib/job_queue/job_list.cpp
@@ -63,7 +63,7 @@ int job_list_get_size(const job_list_type *job_list) {
     return job_list->active_size;
 }
 
-/*
+/**
   This takes ownership to the job node instance.
 */
 void job_list_add_job(job_list_type *job_list, job_queue_node_type *job_node) {

--- a/libres/lib/job_queue/job_node.cpp
+++ b/libres/lib/job_queue/job_node.cpp
@@ -213,10 +213,8 @@ void job_queue_node_free_data(job_queue_node_type *node) {
 }
 
 void job_queue_node_free(job_queue_node_type *node) {
-    /*
-    The callback_arg will not be freed; that will be the responsability of the
-    calling scope.
-  */
+    // The callback_arg will not be freed; that will be the responsability of
+    // the calling scope.
     job_queue_node_free_data(node);
     job_queue_node_free_error_info(node);
     free(node->run_path);
@@ -378,12 +376,9 @@ void job_queue_node_set_status(job_queue_node_type *node,
                   job_status_get_name(new_status));
     node->job_status = new_status;
 
-    /*
-    We record sim start when the node is in state JOB_QUEUE_WAITING
-    to be sure that we do not miss the start time completely for
-    very fast jobs which are registered in the state
-    JOB_QUEUE_RUNNING.
-  */
+    // We record sim start when the node is in state JOB_QUEUE_WAITING to be
+    // sure that we do not miss the start time completely for very fast jobs
+    // which are registered in the state JOB_QUEUE_RUNNING.
     if (new_status == JOB_QUEUE_WAITING)
         node->sim_start = time(NULL);
 
@@ -413,11 +408,9 @@ submit_status_type job_queue_node_submit(job_queue_node_type *node,
     job_status_type new_status;
 
     if (job_data == NULL) {
-        /*
-      In this case the status of the job itself will be
-      unmodified; i.e. it will still be WAITING, and a new attempt
-      to submit it will be performed in the next round.
-    */
+        // In this case the status of the job itself will be
+        // unmodified; i.e. it will still be WAITING, and a new attempt
+        // to submit it will be performed in the next round.
         submit_status = SUBMIT_DRIVER_FAIL;
         logger->warning("Failed to submit job {} (attempt {})", node->job_name,
                         node->submit_attempt);
@@ -432,14 +425,11 @@ submit_status_type job_queue_node_submit(job_queue_node_type *node,
 
     node->job_data = job_data;
     node->submit_attempt++;
-    /*
-    The status JOB_QUEUE_SUBMITTED is internal, and not
-    exported anywhere. The job_queue_update_status() will
-    update this to PENDING or RUNNING at the next call. The
-    important difference between SUBMITTED and WAITING is
-    that SUBMITTED have job_data != NULL and the
-    job_queue_node free function must be called on it.
-  */
+    // The status JOB_QUEUE_SUBMITTED is internal, and not exported anywhere.
+    // The job_queue_update_status() will update this to PENDING or RUNNING at
+    // the next call. The important difference between SUBMITTED and WAITING is
+    // that SUBMITTED have job_data != NULL and the job_queue_node free
+    // function must be called on it.
     submit_status = SUBMIT_OK;
     job_queue_node_set_status(node, new_status);
     job_queue_status_transition(status, old_status, new_status);
@@ -461,11 +451,9 @@ submit_status_type job_queue_node_submit_simple(job_queue_node_type *node,
     job_status_type new_status;
 
     if (job_data == NULL) {
-        /*
-      In this case the status of the job itself will be
-      unmodified; i.e. it will still be WAITING, and a new attempt
-      to submit it will be performed in the next round.
-    */
+        // In this case the status of the job itself will be
+        // unmodified; i.e. it will still be WAITING, and a new attempt
+        // to submit it will be performed in the next round.
         submit_status = SUBMIT_DRIVER_FAIL;
         logger->warning("Failed to submit job {} (attempt {})", node->job_name,
                         node->submit_attempt);
@@ -481,14 +469,11 @@ submit_status_type job_queue_node_submit_simple(job_queue_node_type *node,
 
     node->job_data = job_data;
     node->submit_attempt++;
-    /*
-    The status JOB_QUEUE_SUBMITTED is internal, and not
-    exported anywhere. The job_queue_update_status() will
-    update this to PENDING or RUNNING at the next call. The
-    important difference between SUBMITTED and WAITING is
-    that SUBMITTED have job_data != NULL and the
-    job_queue_node free function must be called on it.
-  */
+    // The status JOB_QUEUE_SUBMITTED is internal, and not exported anywhere.
+    // The job_queue_update_status() will update this to PENDING or RUNNING at
+    // the next call. The important difference between SUBMITTED and WAITING is
+    // that SUBMITTED have job_data != NULL and the job_queue_node free
+    // function must be called on it.
     submit_status = SUBMIT_OK;
     job_queue_node_set_status(node, new_status);
     pthread_mutex_unlock(&node->data_mutex);
@@ -635,11 +620,9 @@ bool job_queue_node_kill(job_queue_node_type *node,
 
     job_status_type current_status = job_queue_node_get_status(node);
     if (current_status & JOB_QUEUE_CAN_KILL) {
-        /*
-      If the job is killed before it is even started no driver
-      specific job data has been assigned; we therefore must check
-      the node->job_data pointer before entering.
-    */
+        // If the job is killed before it is even started no driver specific
+        // job data has been assigned; we therefore must check the
+        // node->job_data pointer before entering.
         if (node->job_data) {
             queue_driver_kill_job(driver, node->job_data);
             queue_driver_free_job(driver, node->job_data);
@@ -664,11 +647,9 @@ bool job_queue_node_kill_simple(job_queue_node_type *node,
     pthread_mutex_lock(&node->data_mutex);
     job_status_type current_status = job_queue_node_get_status(node);
     if (current_status & JOB_QUEUE_CAN_KILL) {
-        /*
-      If the job is killed before it is even started no driver
-      specific job data has been assigned; we therefore must check
-      the node->job_data pointer before entering.
-    */
+        // If the job is killed before it is even started no driver specific
+        // job data has been assigned; we therefore must check the
+        // node->job_data pointer before entering.
         if (node->job_data) {
             queue_driver_kill_job(driver, node->job_data);
             queue_driver_free_job(driver, node->job_data);

--- a/libres/lib/job_queue/job_queue.cpp
+++ b/libres/lib/job_queue/job_queue.cpp
@@ -603,8 +603,8 @@ static void job_queue_run_EXIT_callback(job_queue_type *job_queue,
         bool retry = job_queue_node_run_RETRY_callback(node);
 
         if (retry) {
-            /* OK - we have invoked the retry_callback() - and that has returned true;
-	   giving this job a brand new start. */
+            // OK - we have invoked the retry_callback() - and that has
+            // returned true; giving this job a brand new start.
             job_queue_node_reset_submit_attempt(node);
             job_queue_change_node_status(job_queue, node, JOB_QUEUE_WAITING);
         } else {
@@ -694,9 +694,9 @@ bool job_queue_accept_jobs(const job_queue_type *queue) {
  */
 static bool submit_new_jobs(job_queue_type *queue) {
 
-    int max_submit =
-        5; /* This is the maximum number of jobs submitted in one while() { ... } below.
-                             Only to ensure that the waiting time before a status update is not too long. */
+    // max_submit is the maximum number of jobs submitted in one while() { ... } below.
+    // Only to ensure that the waiting time before a status update is not too long.
+    int max_submit = 5;
     int total_active =
         job_queue_status_get_count(queue->status, JOB_QUEUE_PENDING) +
         job_queue_status_get_count(queue->status, JOB_QUEUE_RUNNING);
@@ -828,10 +828,11 @@ static void job_queue_loop(job_queue_type *queue, int num_total_run,
         {
             JobListReadLock rl(queue->job_list);
 
-            if (queue
-                    ->user_exit) { /* An external thread has called the job_queue_user_exit() function, and we should kill
-                               all jobs, do some clearing up and go home. Observe that we will go through the
-                               queue handling codeblock below ONE LAST TIME before exiting. */
+            if (queue->user_exit) {
+                // An external thread has called the job_queue_user_exit()
+                // function, and we should kill all jobs, do some clearing up
+                // and go home. Observe that we will go through the queue
+                // handling codeblock below ONE LAST TIME before exiting.
                 logger->info("Received queue->user_exit in inner loop of "
                              "job_queue_run_jobs, exiting");
                 job_queue_user_exit__(queue);
@@ -851,21 +852,19 @@ static void job_queue_loop(job_queue_type *queue, int num_total_run,
                 job_queue_status_get_count(queue->status, JOB_QUEUE_IS_KILLED);
 
             if ((num_total_run > 0) && (num_total_run == num_complete))
-                /* The number of jobs completed is equal to the number
-			 of jobs we have said we want to run; so we are finished.
-		  */
+                // The number of jobs completed is equal to the number
+                // of jobs we have said we want to run; so we are finished.
                 complete = true;
             else if (num_total_run == 0) {
-                /* We have not informed about how many jobs we will
-			 run. To check if we are complete we perform the two
-			 tests:
+                // We have not informed about how many jobs we will
+                // run. To check if we are complete we perform the two
+                // tests:
 
-			 1. All the jobs which have been added with
-			 job_queue_add_job() have completed.
+                // 1. All the jobs which have been added with
+                // job_queue_add_job() have completed.
 
-			 2. The user has used job_queue_complete_submit()
-			 to signal that no more jobs will be forthcoming.
-		  */
+                // 2. The user has used job_queue_complete_submit()
+                // to signal that no more jobs will be forthcoming.
                 if ((num_complete == job_list_get_size(queue->job_list)) &&
                     queue->submit_complete)
                     complete = true;

--- a/libres/lib/job_queue/job_queue_status.cpp
+++ b/libres/lib/job_queue/job_queue_status.cpp
@@ -168,10 +168,8 @@ bool job_queue_status_transition(job_queue_status_type *status_count,
     if (src_status == target_status)
         return false;
 
-    /*
-    The target_status indicates that the routine which queried for new
-    status failed; we just remain in the current status.
-  */
+    // The target_status indicates that the routine which queried for new
+    // status failed; we just remain in the current status.
     if (target_status == JOB_QUEUE_STATUS_FAILURE)
         return false;
 

--- a/libres/lib/job_queue/local_driver.cpp
+++ b/libres/lib/job_queue/local_driver.cpp
@@ -71,12 +71,11 @@ void local_driver_kill_job(void *__driver, void *__job) {
         kill(job->child_process, SIGTERM);
 }
 
-/*
+/**
   This function needs to dereference the job pointer after the waitpid() call is
   complete, it is therefore essential that no other threads have called free(job)
   while the external process is running.
 */
-
 void submit_job_thread(const char *executable, int argc, char **argv,
                        local_job_type *job) {
     int wait_status;

--- a/libres/lib/job_queue/lsb.cpp
+++ b/libres/lib/job_queue/lsb.cpp
@@ -156,11 +156,9 @@ stringlist_type *lsb_get_error_list(const lsb_type *lsb) {
 }
 
 int lsb_initialize(const lsb_type *lsb) {
-    /*
-    The environment variable LSF_ENVDIR must be set to point the
-    directory containing LSF configuration information, the whole
-    thing will crash and burn if this is not properly set.
-  */
+    // The environment variable LSF_ENVDIR must be set to point the directory
+    // containing LSF configuration information, the whole thing will crash and
+    // burn if this is not properly set.
     if (lsb->lsb_init(NULL) != 0) {
 
         fprintf(stderr, "LSF_ENVDIR: ");

--- a/libres/lib/job_queue/lsf_driver.cpp
+++ b/libres/lib/job_queue/lsf_driver.cpp
@@ -120,8 +120,8 @@ struct lsf_job_struct {
     long int lsf_jobnr;
     int num_exec_host;
     char **exec_host;
-    char *
-        lsf_jobnr_char; /* Used to look up the job status in the bjobs_cache hash table */
+    /** Used to look up the job status in the bjobs_cache hash table */
+    char *lsf_jobnr_char;
     char *job_name;
 };
 
@@ -154,14 +154,14 @@ struct lsf_driver_struct {
     bool debug_output;
     int bjobs_refresh_interval;
     time_t last_bjobs_update;
-    hash_type
-        *my_jobs; /* A hash table of all jobs submitted by this ERT instance -
-                                             to ensure that we do not check status of old jobs in e.g. ZOMBIE status. */
+    /** A hash table of all jobs submitted by this ERT instance - to ensure
+     * that we do not check status of old jobs in e.g. ZOMBIE status. */
+    hash_type *my_jobs;
     hash_type *status_map;
-    hash_type
-        *bjobs_cache; /* The output of calling bjobs is cached in this table. */
-    pthread_mutex_t
-        bjobs_mutex; /* Only one thread should update the bjobs_chache table. */
+    /** The output of calling bjobs is cached in this table. */
+    hash_type *bjobs_cache;
+    /** Only one thread should update the bjobs_chache table. */
+    pthread_mutex_t bjobs_mutex;
     char *remote_lsf_server;
     char *rsh_cmd;
     char *bsub_cmd;
@@ -335,7 +335,7 @@ static void lsf_driver_assert_submit_method(const lsf_driver_type *driver) {
     }
 }
 
-/*
+/**
   A resource string can be "span[host=1] select[A && B] bla[xyz]".
   The blacklisting feature is to have select[hname!=bad1 && hname!=bad2].
 
@@ -379,7 +379,7 @@ alloc_composed_resource_request(const lsf_driver_type *driver,
     return req;
 }
 
-/*
+/**
   The resource request string contains spaces, and when passed
   through the shell it must be protected with \"..\"; this applies
   when submitting to a remote lsf server with ssh. However when
@@ -469,7 +469,7 @@ stringlist_type *lsf_driver_alloc_cmd(lsf_driver_type *driver,
     return argv;
 }
 
-/*
+/**
  * Submit internal job (LSF_SUBMIT_INTERNAL) using system calls instead of
  * invoking shell commands.  This method only works when actually called from
  * an LSF node.
@@ -741,7 +741,7 @@ static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
     return bhist_ok;
 }
 
-/*
+/**
   When a job has completed you can query the status using the bjobs
   command for a while, and then the job will be evicted from the LSF
   status table. If there have been connection problems with the LSF
@@ -765,7 +765,6 @@ static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
 
     4. Status unknown - have not got a clue?!
 */
-
 static int lsf_driver_get_bhist_status_shell(lsf_driver_type *driver,
                                              lsf_job_type *job) {
     int status = JOB_STAT_UNKWN;
@@ -914,7 +913,7 @@ void lsf_driver_free_job(void *__job) {
     lsf_job_free(job);
 }
 
-/*
+/**
  * Parses the given file containing colon separated hostnames, ie.
  * "hname1:hname2:hname3". This is the same format as
  * written by lsf_job_write_bjobs_to_file().
@@ -1320,12 +1319,11 @@ void lsf_driver_init_option_list(stringlist_type *option_list) {
     stringlist_append_copy(option_list, LSF_BJOBS_TIMEOUT);
 }
 
-/*
+/**
    Observe that this driver IS not properly initialized when returning
    from this function, the option interface must be used to set the
    keys:
 */
-
 void lsf_driver_set_bjobs_refresh_interval(lsf_driver_type *driver,
                                            int refresh_interval) {
     driver->bjobs_refresh_interval = refresh_interval;
@@ -1382,12 +1380,11 @@ static void lsf_driver_shell_init(lsf_driver_type *lsf_driver) {
     pthread_mutex_init(&lsf_driver->bjobs_mutex, NULL);
 }
 
-/*
+/**
   If the lsb library is compiled in and the runtime loading of the lsb libraries
   has succeeded we default to submitting through internal library calls,
   otherwise we will submit using shell commands on the local workstation.
 */
-
 static void lsf_driver_init_submit_method(lsf_driver_type *driver) {
 #ifdef HAVE_LSF_LIBRARY
     if (lsb_ready(driver->lsb)) {

--- a/libres/lib/job_queue/lsf_driver.cpp
+++ b/libres/lib/job_queue/lsf_driver.cpp
@@ -631,10 +631,9 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
 
                 if (sscanf(line, "%d %s %s", &job_id_int, user, status) == 3) {
                     char *job_id = (char *)util_alloc_sprintf("%d", job_id_int);
-
-                    if (hash_has_key(
-                            driver->my_jobs,
-                            job_id)) /* Consider only jobs submitted by this ERT instance - not old jobs lying around from the same user. */
+                    // Consider only jobs submitted by this ERT instance - not
+                    // old jobs lying around from the same user.
+                    if (hash_has_key(driver->my_jobs, job_id))
                         hash_insert_int(
                             driver->bjobs_cache, job_id,
                             lsf_driver_get_status__(driver, status, job_id));
@@ -660,16 +659,13 @@ static int lsf_driver_get_job_status_libary(void *__driver, void *__job) {
 #ifdef HAVE_LSF_LIBRARY
         lsf_job_type *job = lsf_job_safe_cast(__job);
         if (lsb_openjob(driver->lsb, job->lsf_jobnr) != 1) {
-            /*
-         Failed to get information about the job - we boldly assume
-         the following situation has occured:
+            // Failed to get information about the job - we boldly assume the
+            // following situation has occured:
 
-         1. The job is running happily along.
-         2. The lsf deamon is not responding for a long time.
-         3. The job finishes, and is eventually expired from the LSF job database.
-         4. The lsf deamon answers again - but can not find the job...
-
-      */
+            // 1. The job is running happily along.
+            // 2. The lsf deamon is not responding for a long time.
+            // 3. The job finishes, and is eventually expired from the LSF job database.
+            // 4. The lsf deamon answers again - but can not find the job...
             fprintf(stderr,
                     "Warning: failed to get status information for job:%ld - "
                     "assuming it is finished. \n",
@@ -802,12 +798,10 @@ static int lsf_driver_get_job_status_shell(void *__driver, void *__job) {
         lsf_driver_type *driver = lsf_driver_safe_cast(__driver);
 
         {
-            /*
-         Updating the bjobs_table of the driver involves a significant change in
-         the internal state of the driver; that is semantically a bit
-         unfortunate because this is clearly a get() function; to protect
-         against concurrent updates of this table we use a mutex.
-      */
+            // Updating the bjobs_table of the driver involves a significant
+            // change in the internal state of the driver; that is semantically
+            // a bit unfortunate because this is clearly a get() function; to
+            // protect against concurrent updates of this table we use a mutex.
             pthread_mutex_lock(&driver->bjobs_mutex);
             {
                 bool update_cache =
@@ -824,11 +818,10 @@ static int lsf_driver_get_job_status_shell(void *__driver, void *__job) {
             if (hash_has_key(driver->bjobs_cache, job->lsf_jobnr_char))
                 status = hash_get_int(driver->bjobs_cache, job->lsf_jobnr_char);
             else {
-                /*
-           The job was not in the status cache, this *might* mean that
-           it has completed/exited and fallen out of the bjobs status
-           table maintained by LSF. We try calling bhist to get the status.
-        */
+                // The job was not in the status cache, this *might* mean that
+                // it has completed/exited and fallen out of the bjobs status
+                // table maintained by LSF. We try calling bhist to get the
+                // status.
                 logger->warning(
                     "In lsf_driver we found that job was not in the "
                     "status cache, this *might* mean that it has "
@@ -1041,10 +1034,8 @@ void *lsf_driver_submit_job(void *__driver, const char *submit_cmd, int num_cpu,
             fclose(stream);
             return job;
         } else {
-            /*
-        The submit failed - the queue system shall handle
-        NULL return values.
-      */
+            // The submit failed - the queue system shall handle
+            // NULL return values.
             driver->error_count++;
 
             if (driver->error_count >= driver->max_error_count)

--- a/libres/lib/job_queue/queue_driver.cpp
+++ b/libres/lib/job_queue/queue_driver.cpp
@@ -220,12 +220,10 @@ static queue_driver_type *queue_driver_alloc_empty() {
 
 static UTIL_SAFE_CAST_FUNCTION(queue_driver, QUEUE_DRIVER_ID)
 
-    /*
-   The driver created in this function has all the function pointers
-   correctly initialized; but no options have been set. I.e. unless
-   the driver in question needs no options (e.g. the LOCAL driver) the
-   returned driver will NOT be ready for use.
- */
+    // The driver created in this function has all the function pointers
+    // correctly initialized; but no options have been set. I.e. unless
+    // the driver in question needs no options (e.g. the LOCAL driver) the
+    // returned driver will NOT be ready for use.
 
     queue_driver_type *queue_driver_alloc(job_driver_type type) {
     queue_driver_type *driver = queue_driver_alloc_empty();

--- a/libres/lib/job_queue/queue_driver.cpp
+++ b/libres/lib/job_queue/queue_driver.cpp
@@ -57,10 +57,8 @@
 
 struct queue_driver_struct {
     UTIL_TYPE_ID_DECLARATION;
-    /*
-     Function pointers - pointing to low level functions in the implementations of
-     e.g. lsf_driver.
-   */
+    /** Function pointers - pointing to low level functions in the
+     * implementations of e.g. lsf_driver. */
     submit_job_ftype *submit;
     free_job_ftype *free_job;
     kill_job_ftype *kill_job;
@@ -71,18 +69,19 @@ struct queue_driver_struct {
     get_option_ftype *get_option;
     init_option_list_ftype *init_options;
 
-    void *
-        data; /* Driver specific data - passed as first argument to the driver functions above. */
+    /** Driver specific data - passed as first argument to the driver functions above. */
+    void *data;
 
-    /*
-    Generic data - common to all driver types.
-   */
-    char *name;                  /* String name of driver. */
-    job_driver_type driver_type; /* Enum value for driver. */
+    /* Generic data - common to all driver types. */
+    /** String name of driver. */
+    char *name;
+    /** Enum value for driver. */
+    job_driver_type driver_type;
     char *max_running_string;
-    int max_running; /* Possible to maintain different max_running values for different
-                                        drivers; the value 0 is interpreted as no limit - i.e. the queue layer
-                                        will (try) to send an unlimited number of jobs to the driver. */
+    /** Possible to maintain different max_running values for different
+     * drivers; the value 0 is interpreted as no limit - i.e. the queue layer
+     * will (try) to send an unlimited number of jobs to the driver. */
+    int max_running;
 };
 
 UTIL_IS_INSTANCE_FUNCTION(queue_driver, QUEUE_DRIVER_ID)
@@ -149,7 +148,7 @@ static bool queue_driver_has_generic_option__(queue_driver_type *driver,
         return false;
 }
 
-/*
+/**
    Set option - can also be used to perform actions - not only setting
    of parameters. There is no limit :-)
  */
@@ -169,7 +168,7 @@ bool queue_driver_set_option(queue_driver_type *driver, const char *option_key,
     return false;
 }
 
-/*
+/**
    Unset the given option. If the option cannot be unset, it is restored to its default value.
  */
 bool queue_driver_unset_option(queue_driver_type *driver,
@@ -188,7 +187,7 @@ bool queue_driver_unset_option(queue_driver_type *driver,
     return false;
 }
 
-/*
+/**
    Observe that after the driver instance has been allocated it does
    NOT support modification of the common fields, only the data owned
    by the specific low level driver, i.e. the LSF data, can be
@@ -197,7 +196,6 @@ bool queue_driver_unset_option(queue_driver_type *driver,
    The driver returned from the queue_driver_alloc_empty() function is
    NOT properly initialized and NOT ready for use.
  */
-
 static queue_driver_type *queue_driver_alloc_empty() {
     queue_driver_type *driver =
         (queue_driver_type *)util_malloc(sizeof *driver);

--- a/libres/lib/job_queue/rsh_driver.cpp
+++ b/libres/lib/job_queue/rsh_driver.cpp
@@ -120,10 +120,8 @@ static void rsh_host_submit_job(rsh_host_type *rsh_host, rsh_job_type *job,
                                 const char *rsh_cmd, const char *submit_cmd,
                                 int num_cpu, int job_argc,
                                 const char **job_argv) {
-    /*
-     Observe that this job has already been added to the running jobs
-     in the rsh_host_available function.
-  */
+    // Observe that this job has already been added to the running jobs
+    // in the rsh_host_available function.
     int argc = job_argc + 2;
     const char **argv = (const char **)util_malloc(argc * sizeof *argv);
 
@@ -196,9 +194,7 @@ void *rsh_driver_submit_job(void *__driver, const char *submit_cmd,
     rsh_driver_type *driver = rsh_driver_safe_cast(__driver);
     rsh_job_type *job = NULL;
     {
-        /*
-       command is freed in the start_routine() function
-    */
+        // command is freed in the start_routine() function
         std::lock_guard guard{driver->submit_lock};
         {
             rsh_host_type *host = NULL;
@@ -277,20 +273,14 @@ void rsh_driver_set_host_list(rsh_driver_type *rsh_driver,
     }
 }
 
-/*
-
-*/
-
 void *rsh_driver_alloc() {
     rsh_driver_type *rsh_driver =
         (rsh_driver_type *)util_malloc(sizeof *rsh_driver);
     UTIL_TYPE_ID_INIT(rsh_driver, RSH_DRIVER_TYPE_ID);
 
-    /*
-      To simplify the Python wrapper it is possible to pass in NULL as
-      rsh_host_list pointer, and then subsequently add hosts with
-      rsh_driver_add_host().
-  */
+    // To simplify the Python wrapper it is possible to pass in NULL as
+    // rsh_host_list pointer, and then subsequently add hosts with
+    // rsh_driver_add_host().
     rsh_driver->num_hosts = 0;
     rsh_driver->host_list = NULL;
     rsh_driver->last_host_index = 0;

--- a/libres/lib/job_queue/rsh_driver.cpp
+++ b/libres/lib/job_queue/rsh_driver.cpp
@@ -33,17 +33,22 @@
 
 struct rsh_job_struct {
     UTIL_TYPE_ID_DECLARATION;
-    bool active; /* Means that it allocated - not really in use */
+    /** Means that it allocated - not really in use */
+    bool active;
     job_status_type status;
     std::optional<std::thread> run_thread;
-    const char *host_name; /* Currently not set */
+    /** Currently not set */
+    const char *host_name;
     char *run_path;
 };
 
 typedef struct {
     char *host_name;
-    int max_running; /* How many can the host handle. */
-    int running; /* How many are currently running on the host (goverened by this driver instance that is). */
+    /** How many can the host handle. */
+    int max_running;
+    /** How many are currently running on the host (goverened by this driver
+     * instance that is). */
+    int running;
     std::mutex host_mutex;
 } rsh_host_type;
 
@@ -64,12 +69,11 @@ static UTIL_SAFE_CAST_FUNCTION_CONST(rsh_driver, RSH_DRIVER_TYPE_ID);
 static UTIL_SAFE_CAST_FUNCTION(rsh_driver, RSH_DRIVER_TYPE_ID);
 static UTIL_SAFE_CAST_FUNCTION(rsh_job, RSH_JOB_TYPE_ID);
 
-/*
+/**
    If the host is for some reason not available, NULL should be
    returned. Will also return NULL if some funny guy tries to allocate
    with max_running <= 0.
 */
-
 static rsh_host_type *rsh_host_alloc(const char *host_name, int max_running) {
     if (max_running > 0) {
         struct addrinfo *result;
@@ -309,11 +313,10 @@ void rsh_driver_add_host(rsh_driver_type *rsh_driver, const char *hostname,
     }
 }
 
-/*
+/**
    Hostname should be a string as host:max_running, the ":max_running"
    part is optional, and will default to 1.
 */
-
 void rsh_driver_add_host_from_string(rsh_driver_type *rsh_driver,
                                      const char *hostname) {
     int host_max_running;

--- a/libres/lib/job_queue/slurm_driver.cpp
+++ b/libres/lib/job_queue/slurm_driver.cpp
@@ -69,9 +69,9 @@ public:
         return false;
     }
 
-    /*
-   This function is used when the status of the jobs is updated with squeue. The
-   semantics is as follows:
+    /**
+    This function is used when the status of the jobs is updated with squeue. The
+    semantics is as follows:
 
      1. The squeue command is run and the squeue_jobs variable is filled up with
         a job_id -> status mapping.
@@ -85,8 +85,7 @@ public:
      3. The return value is a list of jobs which were previously registered as
         active, but are not fallen out. Calling scope must update their status
         with calls to scontrol.
-  */
-
+    */
     std::vector<int>
     squeue_update(const std::unordered_map<int, job_status_type> &squeue_jobs) {
         std::vector<int> active_jobs;
@@ -424,12 +423,11 @@ static std::string make_submit_script(const slurm_driver_type *driver,
     return submit_script;
 }
 
-/*
+/**
  The slurm jobs are submitted by first creating a submit script, which is a
  small shell which contains the command to run along with possible slurm
  options, and then this script is submitted with the 'sbatch' command.
 */
-
 void *slurm_driver_submit_job(void *__driver, const char *cmd, int num_cpu,
                               const char *run_path, const char *job_name,
                               int argc, const char **argv) {
@@ -583,7 +581,7 @@ static void slurm_driver_update_status_cache(const slurm_driver_type *driver) {
     }
 }
 
-/*
+/**
   Getting the status of jobs involves two different executables - 'squeue' and
   'scontrol'. While a job is pending in the queue and when it is actually
   running the squeue command will give the status, but as soon as the job has
@@ -597,7 +595,6 @@ static void slurm_driver_update_status_cache(const slurm_driver_type *driver) {
   of minutes, when this happens we have hopefully recorded the eventual status
   of the job.
 */
-
 job_status_type slurm_driver_get_job_status(void *__driver, void *__job) {
     slurm_driver_type *driver = slurm_driver_safe_cast(__driver);
     const auto *job = static_cast<const SlurmJob *>(__job);

--- a/libres/lib/job_queue/slurm_driver.cpp
+++ b/libres/lib/job_queue/slurm_driver.cpp
@@ -344,11 +344,9 @@ bool slurm_driver_set_option(void *__driver, const char *option_key,
             return false;
     }
 
-    /*
-    The --time option in slurm which is used to set the maximum runtime of a job
-    is in minutes, whereas the libres option system uses seconds. This is to
-    ensure overall consistency in libres for timeouts.
-  */
+    // The --time option in slurm which is used to set the maximum runtime of a
+    // job is in minutes, whereas the libres option system uses seconds. This
+    // is to ensure overall consistency in libres for timeouts.
     if (strcmp(option_key, SLURM_MAX_RUNTIME_OPTION) == 0) {
         const char *string_value = static_cast<const char *>(value);
         int max_runtime_seconds;
@@ -517,13 +515,11 @@ slurm_driver_get_job_status_scontrol(const slurm_driver_type *driver,
     auto values = load_scontrol(driver, string_id);
     const auto status_iter = values.find("JobState");
 
-    /*
-    When a job has finished running it quite quickly - the order of minutes -
-    falls out of the slurm database, and the scontrol command will not give any
-    output. In this situation we guess that the job has completed succesfully
-    and return status JOB_QUEUE_DONE. If the job has actually not succeded this
-    should be picked up the libres post run checking.
-  */
+    // When a job has finished running it quite quickly - the order of minutes
+    // - falls out of the slurm database, and the scontrol command will not
+    // give any output. In this situation we guess that the job has completed
+    // succesfully and return status JOB_QUEUE_DONE. If the job has actually
+    // not succeded this should be picked up the libres post run checking.
     if (status_iter == values.end()) {
         logger->warning("The command 'scontrol show jobid {}' gave no "
                         "output for job:{} - assuming it is COMPLETED",

--- a/libres/lib/job_queue/torque_driver.cpp
+++ b/libres/lib/job_queue/torque_driver.cpp
@@ -495,10 +495,8 @@ void *torque_driver_submit_job(void *__driver, const char *submit_cmd,
     if (job->torque_jobnr > 0)
         return job;
     else {
-        /*
-      The submit failed - the queue system shall handle
-      NULL return values.
-     */
+        // The submit failed - the queue system shall handle
+        // NULL return values.
         torque_job_free(job);
         return NULL;
     }

--- a/libres/lib/job_queue/torque_driver.cpp
+++ b/libres/lib/job_queue/torque_driver.cpp
@@ -504,7 +504,7 @@ void *torque_driver_submit_job(void *__driver, const char *submit_cmd,
     }
 }
 
-/*
+/**
    Will return NULL if "something" fails; that again will be
    translated to JOB_QUEUE_STATUS_FAILURE - which the queue layer will
    just interpret as "No change in status". Possible failures are:
@@ -513,7 +513,6 @@ void *torque_driver_submit_job(void *__driver, const char *submit_cmd,
     2. Can not extract the correct status string from the stdout file.
 
 */
-
 static job_status_type
 torque_driver_get_qstat_status(torque_driver_type *driver,
                                const char *jobnr_char) {

--- a/libres/lib/job_queue/workflow_job.cpp
+++ b/libres/lib/job_queue/workflow_job.cpp
@@ -171,11 +171,9 @@ void workflow_job_update_config_compiler(const workflow_job_type *workflow_job,
                                          config_parser_type *config_compiler) {
     config_schema_item_type *item =
         config_add_schema_item(config_compiler, workflow_job->name, false);
-    /*
-     Ensure that the arg_types mapping is at least as large as the
-     max_arg value. The arg_type vector will be left padded with
-     CONFIG_STRING values.
-  */
+    // Ensure that the arg_types mapping is at least as large as the
+    // max_arg value. The arg_type vector will be left padded with
+    // CONFIG_STRING values.
     {
         int iarg;
         config_schema_item_set_argc_minmax(item, workflow_job->min_arg,

--- a/libres/lib/job_queue/workflow_job.cpp
+++ b/libres/lib/job_queue/workflow_job.cpp
@@ -104,8 +104,8 @@ struct workflow_job_struct {
     bool internal;
     int min_arg;
     int max_arg;
-    int_vector_type *
-        arg_types; // Should contain values from the config_item_types enum in config.h.
+    /** Should contain values from the config_item_types enum in config.h.*/
+    int_vector_type *arg_types;
     char *executable;
     char *internal_script_path;
     char *function;
@@ -409,13 +409,12 @@ void workflow_job_free__(void *arg) {
     workflow_job_free(workflow_job);
 }
 
-/*
+/**
   The workflow job can return an arbitrary (void *) pointer. It is the
   calling scopes responsability to interpret this object correctly. If
   the the workflow job allocates storage the calling scope must
   discard it.
 */
-
 static void *workflow_job_run_internal(const workflow_job_type *job, void *self,
                                        bool verbose,
                                        const stringlist_type *arg) {
@@ -439,7 +438,7 @@ static void *workflow_job_run_external(const workflow_job_type *job,
     return NULL;
 }
 
-/* This is the old C way and will only be used from the TUI */
+/** This is the old C way and will only be used from the TUI */
 void *workflow_job_run(const workflow_job_type *job, void *self, bool verbose,
                        const stringlist_type *arg) {
     if (job->internal) {

--- a/libres/lib/res_util/block_fs.cpp
+++ b/libres/lib/res_util/block_fs.cpp
@@ -186,23 +186,18 @@ static file_node_type *file_node_fread_alloc(FILE *stream, char **key) {
             node_size = util_fread_int(stream);
             if (node_size <= 0)
                 status = NODE_INVALID;
-            /*
-        A case has occured with an invalid node with size 0. That
-        resulted in a deadlock, because the reader never got beyond
-        the broken node. We therefore explicitly check for this
-        condition.
-      */
-
+            // A case has occured with an invalid node with size 0. That
+            // resulted in a deadlock, because the reader never got beyond
+            // the broken node. We therefore explicitly check for this
+            // condition.
             file_node = file_node_alloc(status, node_offset, node_size);
             if (status == NODE_IN_USE) {
                 file_node->data_size = util_fread_int(stream);
                 file_node->data_offset = ftell(stream) - file_node->node_offset;
             }
         } else {
-            /*
-         We did not recognize the status identifier; the node will
-         eventually be marked as free.
-      */
+            // We did not recognize the status identifier; the node will
+            // eventually be marked as free.
             if (status != NODE_WRITE_ACTIVE)
                 status = NODE_INVALID;
             file_node = file_node_alloc(status, node_offset, 0);
@@ -387,26 +382,22 @@ static bool block_fs_fseek_valid_node(block_fs_type *block_fs) {
         if (fread(&byte, sizeof byte, 1, block_fs->data_stream) == 1) {
             if (byte == NODE_IN_USE_BYTE) {
                 long int pos = ftell(block_fs->data_stream);
-                /*
-           OK - we found one interesting byte; let us try to read the
-           whole integer and see if we have hit any of the valid status identifiers.
-        */
+                // OK - we found one interesting byte; let us try to read the
+                // whole integer and see if we have hit any of the valid status
+                // identifiers.
                 fseek__(block_fs->data_stream, -1, SEEK_CUR);
                 if (fread(&status, sizeof status, 1, block_fs->data_stream) ==
                     1) {
                     if (status == NODE_IN_USE) {
-                        /*
-               OK - we have found a valid identifier. We reposition to
-               the start of this valid status id and return true.
-            */
+                        // OK - we have found a valid identifier. We reposition
+                        // to the start of this valid status id and return
+                        // true.
                         fseek__(block_fs->data_stream, -sizeof status,
                                 SEEK_CUR);
                         return true;
                     } else
-                        /*
-               OK - this was not a valid id; we go back and continue
-               reading single bytes.
-            */
+                        // OK - this was not a valid id; we go back and
+                        // continue reading single bytes.
                         block_fs_fseek(block_fs, pos);
                 } else
                     break; /* EOF */
@@ -439,11 +430,9 @@ static void block_fs_open_data(block_fs_type *block_fs,
             block_fs->data_stream = util_fopen(data_file.c_str(), "r");
         else
             block_fs->data_stream = NULL;
-        /*
-       If we ever try to dereference this pointer it will break
-       hard; but it should be stopped in hash_get() calls before the
-       data_stream is dereferenced anyway?
-    */
+        // If we ever try to dereference this pointer it will break
+        // hard; but it should be stopped in hash_get() calls before the
+        // data_stream is dereferenced anyway?
     }
     if (block_fs->data_stream == NULL)
         block_fs->data_fd = -1;
@@ -541,12 +530,10 @@ static void block_fs_build_index(block_fs_type *block_fs,
                                    __func__, file_node->status);
                     }
                 } else {
-                    /*
-             Could not find a valid END_TAG - indicating that
-             the filesystem was shut down during the write of
-             this node.  This node will NOT be added to the
-             index.  The node will be updated to become a free node.
-          */
+                    // Could not find a valid END_TAG - indicating that the
+                    // filesystem was shut down during the write of this node.
+                    // This node will NOT be added to the index.  The node will
+                    // be updated to become a free node.
                     fprintf(stderr,
                             "** Warning found node:%s at offset:%ld which was "
                             "incomplete - discarded.\n",
@@ -672,7 +659,8 @@ static void block_fs_fwrite__(block_fs_type *block_fs, const char *filename,
     node->data_size = data_size;
     file_node_set_data_offset(node, filename);
 
-    /* This marks the node section in the datafile as write in progress with: NODE_WRITE_ACTIVE_START ... NODE_WRITE_ACTIVE_END */
+    // This marks the node section in the datafile as write in progress with:
+    // NODE_WRITE_ACTIVE_START ... NODE_WRITE_ACTIVE_END
     file_node_init_fwrite(node, block_fs->data_stream);
 
     /* Writes the actual data content. */

--- a/libres/lib/res_util/es_testdata.cpp
+++ b/libres/lib/res_util/es_testdata.cpp
@@ -238,13 +238,12 @@ void es_testdata::save(const std::string &path) const {
     save_matrix_data("dObs", this->dObs);
 }
 
-/*
+/**
   This function will allocate a matrix based on data found on disk. The data on
   disk is only the actual content of the matrix, in row_major order. Before the
   matrix is constructed it is verified that the number of elements is a multiple
   of this->active_ens_size.
 */
-
 Eigen::MatrixXd es_testdata::make_state(const std::string &name) const {
 
     pushd tmp_path(this->path);

--- a/libres/lib/res_util/path_fmt.cpp
+++ b/libres/lib/res_util/path_fmt.cpp
@@ -26,8 +26,10 @@
 
 #include <ert/res_util/path_fmt.hpp>
 
-/*
-The basic idea of the path_fmt_type is that it should be possible for
+#define PATH_FMT_ID 7519200
+
+/**
+The basic idea of the path_fmt_struct is that it should be possible for
 a user to specify an arbirtrary path *WITH* embedded format
 strings. It is implemented with the the help av variable length
 argument lists. This has the following disadvantages:
@@ -51,9 +53,6 @@ char * path = path_fmt_alloc(path_fmt , "BaseCase" , 67);
 => path = /tmp/ECLIPSE/Basecase/Run-67
 
 */
-
-#define PATH_FMT_ID 7519200
-
 struct path_fmt_struct {
     UTIL_TYPE_ID_DECLARATION;
     char *fmt;
@@ -80,8 +79,7 @@ static path_fmt_type *path_fmt_alloc__(const char *fmt, bool is_directory) {
     return path;
 }
 
-/*
-
+/**
   This function is used to allocate a path_fmt instance which is
   intended to hold a directory, if the second argument is true, the
   resulting directory will be automatically created when
@@ -108,16 +106,14 @@ static path_fmt_type *path_fmt_alloc__(const char *fmt, bool is_directory) {
   variable length argument lists, and **NO** checking of argument list
   versus format string is performed.
 */
-
 path_fmt_type *path_fmt_alloc_directory_fmt(const char *fmt) {
     return path_fmt_alloc__(fmt, true);
 }
 
-/*
+/**
    Most general. Can afterwards be used to allocate strings
    representing both directories and files.
 */
-
 path_fmt_type *path_fmt_alloc_path_fmt(const char *fmt) {
     return path_fmt_alloc__(fmt, false);
 }
@@ -140,7 +136,7 @@ char *path_fmt_alloc_path(const path_fmt_type *path, bool auto_mkdir, ...) {
     return new_path;
 }
 
-/*
+/**
   This function is used to allocate a filename (full path) from a
   path_fmt instance:
 
@@ -172,7 +168,6 @@ char *path_fmt_alloc_path(const path_fmt_type *path, bool auto_mkdir, ...) {
    * [Path]: The resulting string will be split on "/", and the path
      component will be created.
 */
-
 char *path_fmt_alloc_file(const path_fmt_type *path, bool auto_mkdir, ...) {
     if (path->is_directory) {
         char *filename;
@@ -228,8 +223,7 @@ void path_fmt_assert_fmt(const path_fmt_type * path , int num_input , const node
   }
 }
 */
-
-/*
+/**
   fmt == NULL
   -----------
   The function will return NULL, possibly freeing the incoming
@@ -241,7 +235,6 @@ void path_fmt_assert_fmt(const path_fmt_type * path , int num_input , const node
   The current path_fmt instance will be updated, or a new created. The
   new/updated path_fmt instance is returned.
 */
-
 path_fmt_type *path_fmt_realloc_path_fmt(path_fmt_type *path_fmt,
                                          const char *fmt) {
     if (fmt == NULL) {

--- a/libres/lib/res_util/path_fmt.cpp
+++ b/libres/lib/res_util/path_fmt.cpp
@@ -202,27 +202,6 @@ char *path_fmt_alloc_file(const path_fmt_type *path, bool auto_mkdir, ...) {
     }
 }
 
-/*
-   This function is used to assert that the format in a path_fmt
-   instance is according to specification. What is checked is that the
-   format string contains %d, %lfg and %s in as specified in the
-   input_types vector.
-
-   Observe that %s is mapped to void_pointer - as the node_ctype does not
-   have typed pointers.
-*/
-
-/*
-void path_fmt_assert_fmt(const path_fmt_type * path , int num_input , const node_ctype * input_types) {
-  int input_nr = 0;
-  int char_nr  = 0;
-  do {
-    if (path->fmt[char_nr] == '%') {
-
-    }
-  }
-}
-*/
 /**
   fmt == NULL
   -----------

--- a/libres/lib/res_util/res_env.cpp
+++ b/libres/lib/res_util/res_env.cpp
@@ -142,13 +142,14 @@ const char *res_env_update_path_var(const char *variable, const char *value,
                 int i;
                 for (i = 0; i < num_path; i++) {
                     if (util_string_equal(path_list[i], value))
-                        update =
-                            false; /* The environment variable already contains @value - no point in appending it at the end. */
+                        // The environment variable already contains @value -
+                        // no point in appending it at the end.
+                        update = false;
                 }
             } else {
                 if (util_string_equal(path_list[0], value))
-                    update =
-                        false; /* The environment variable already starts with @value. */
+                    // The environment variable already starts with @value.
+                    update = false;
             }
             util_free_stringlist(path_list, num_path);
         }
@@ -198,32 +199,29 @@ const char *res_env_interp_setenv(const char *variable, const char *value) {
 
    If the input value is NULL - the function will just return NULL;
 */
-
 char *res_env_alloc_envvar(const char *value) {
     if (value == NULL)
         return NULL;
     else {
-        buffer_type *buffer =
-            buffer_alloc(1024); /* Start by filling up a buffer instance with
-                                                                  the current content of @value. */
+        // Start by filling up a buffer instance with the current content of @value.
+        buffer_type *buffer = buffer_alloc(1024);
         buffer_fwrite_char_ptr(buffer, value);
         buffer_rewind(buffer);
 
         while (true) {
             if (buffer_strchr(buffer, '$')) {
                 const char *data = (const char *)buffer_get_data(buffer);
-                int offset =
-                    buffer_get_offset(buffer) +
-                    1; /* Points at the first character following the '$' */
+                // offset points at the first character following the '$'
+                int offset = buffer_get_offset(buffer) + 1;
                 int var_length = 0;
 
                 /* Find the length of the variable name */
                 while (true) {
                     char c;
                     c = data[offset + var_length];
-                    if (!(isalnum(c) ||
-                          c ==
-                              '_')) /* Any character which is NOT in the set [a-Z,0-9_] marks the end of the variable. */
+                    if (!(isalnum(c) || c == '_'))
+                        // Any character which is NOT in the set [a-Z,0-9_]
+                        // marks the end of the variable.
                         break;
 
                     if (c == '\0') /* The end of the string. */
@@ -239,13 +237,11 @@ char *res_env_alloc_envvar(const char *value) {
                     const char *var_value = getenv(&var_name[1]);
 
                     if (var_value != NULL)
-                        buffer_search_replace(
-                            buffer, var_name,
-                            var_value); /* The actual string replacement. */
+                        // The actual string replacement:
+                        buffer_search_replace(buffer, var_name, var_value);
                     else
-                        buffer_fseek(
-                            buffer, var_length,
-                            SEEK_CUR); /* The variable is not defined, and we leave the $name. */
+                        // The variable is not defined, and we leave the $name.
+                        buffer_fseek(buffer, var_length, SEEK_CUR);
 
                     free(var_name);
                 }
@@ -305,10 +301,8 @@ char *res_env_isscanf_alloc_envvar(const char *string, int env_index) {
     } while ((env_count <= env_index) && (env_ptr != NULL));
 
     if (env_ptr != NULL) {
-        /*
-       We found an environment variable we are interested in. Find the
-       end of this variable and return a copy.
-    */
+        // We found an environment variable we are interested in. Find the
+        // end of this variable and return a copy.
         int length = 1;
         bool cont = true;
         do {

--- a/libres/lib/res_util/res_env.cpp
+++ b/libres/lib/res_util/res_env.cpp
@@ -33,11 +33,10 @@ void res_env_setenv(const char *variable, const char *value) {
     setenv(variable, value, overwrite);
 }
 
-/*
+/**
    Will return a NULL terminated list char ** of the paths in the PATH
    variable.
 */
-
 char **res_env_alloc_PATH_list() {
     char **path_list = NULL;
     char *path_env = getenv("PATH");
@@ -55,7 +54,7 @@ char **res_env_alloc_PATH_list() {
     return path_list;
 }
 
-/*
+/**
    This function searches through the content of the (currently set)
    PATH variable, and allocates a string containing the full path
    (first match) to the executable given as input.
@@ -68,7 +67,6 @@ char **res_env_alloc_PATH_list() {
 
    * If the executable is not found in the PATH list NULL is returned.
 */
-
 char *res_env_alloc_PATH_executable(const char *executable) {
     if (util_is_abs_path(executable)) {
         if (util_is_executable(executable))
@@ -114,7 +112,7 @@ char *res_env_alloc_PATH_executable(const char *executable) {
     }
 }
 
-/*
+/**
    This function updates an environment variable representing a path,
    before actually updating the environment variable the current value
    is checked, and the following rules apply:
@@ -127,7 +125,6 @@ char *res_env_alloc_PATH_executable(const char *executable) {
 
    A pointer to the updated(?) environment variable is returned.
 */
-
 const char *res_env_update_path_var(const char *variable, const char *value,
                                     bool append) {
     const char *current_value = getenv(variable);
@@ -169,7 +166,7 @@ const char *res_env_update_path_var(const char *variable, const char *value,
     return getenv(variable);
 }
 
-/*
+/**
    This is a thin wrapper around the setenv() call, with the twist
    that all $VAR expressions in the @value parameter are replaced with
    getenv() calls, so that the function call:
@@ -182,7 +179,6 @@ const char *res_env_update_path_var(const char *variable, const char *value,
 
    If @value == NULL a call to unsetenv( @variable ) will be issued.
 */
-
 const char *res_env_interp_setenv(const char *variable, const char *value) {
     char *interp_value = res_env_alloc_envvar(value);
     if (interp_value != NULL) {
@@ -194,7 +190,7 @@ const char *res_env_interp_setenv(const char *variable, const char *value) {
     return getenv(variable);
 }
 
-/*
+/**
    This function will take a string as input, and then replace all if
    $VAR expressions with the corresponding environment variable. If
    the environament variable VAR is not set, the string literal $VAR
@@ -266,7 +262,7 @@ char *res_env_alloc_envvar(const char *value) {
     }
 }
 
-/*
+/**
    This function will allocate a string copy of the env_index'th
    occurence of an embedded environment variable from the input
    string.
@@ -298,7 +294,6 @@ char *res_env_alloc_envvar(const char *value) {
 
 
 */
-
 char *res_env_isscanf_alloc_envvar(const char *string, int env_index) {
     int env_count = 0;
     const char *offset = string;

--- a/libres/lib/res_util/subst_func.cpp
+++ b/libres/lib/res_util/subst_func.cpp
@@ -36,12 +36,13 @@ struct subst_func_struct {
     UTIL_TYPE_ID_DECLARATION;
     subst_func_ftype *func;
     char *name;
-    char *doc_string; /* doc_string for this function - can be NULL. */
+    /** doc_string for this function - can be NULL. */
+    char *doc_string;
     bool vararg;
     int argc_min;
     int argc_max;
-    void *
-        arg; /* 100% unmanaged void argument passed in from the construction. */
+    /** 100% unmanaged void argument passed in from the construction. */
+    void *arg;
 };
 
 char *subst_func_eval(const subst_func_type *subst_func,

--- a/libres/lib/res_util/subst_list.cpp
+++ b/libres/lib/res_util/subst_list.cpp
@@ -495,8 +495,9 @@ static bool subst_list_eval_funcs____(const subst_list_type *subst_list,
                 char *arg_start = (char *)buffer_get_data(buffer);
                 arg_start += buffer_get_offset(buffer) + strlen(func_name);
 
-                if (arg_start[0] ==
-                    '(') { /* We require that an opening paren follows immediately behind the function name. */
+                if (arg_start[0] == '(') {
+                    // We require that an opening paren follows immediately
+                    // behind the function name.
                     char *arg_end = strchr(arg_start, ')');
                     if (arg_end != NULL) {
                         /* OK - we found an enclosing () pair. */
@@ -622,9 +623,8 @@ bool subst_list_update_buffer(const subst_list_type *subst_list,
                               buffer_type *buffer) {
     bool match1 = subst_list_replace_strings(subst_list, buffer);
     bool match2 = subst_list_eval_funcs__(subst_list, buffer);
-    return (
-        match1 ||
-        match2); // Funny construction to ensure to avoid fault short circuit.
+    // Funny construction to ensure to avoid fault short circuit:
+    return (match1 || match2);
 }
 
 /**
@@ -638,15 +638,13 @@ bool subst_list_update_buffer(const subst_list_type *subst_list,
    Observe that @target_file can contain a path component, that
    component will be created if it does not exist.
 */
-
 bool subst_list_filter_file(const subst_list_type *subst_list,
                             const char *src_file, const char *target_file) {
     bool match;
     char *backup_file = NULL;
     buffer_type *buffer = buffer_fread_alloc(src_file);
-    buffer_fseek(
-        buffer, 0,
-        SEEK_END); /* Ensure that the buffer is a \0 terminated string. */
+    // Ensure that the buffer is a \0 terminated string:
+    buffer_fseek(buffer, 0, SEEK_END);
     buffer_fwrite_char(buffer, '\0');
 
     if (util_same_file(src_file, target_file)) {

--- a/libres/lib/res_util/subst_list.cpp
+++ b/libres/lib/res_util/subst_list.cpp
@@ -85,38 +85,40 @@ typedef enum {
 
 struct subst_list_struct {
     UTIL_TYPE_ID_DECLARATION;
-    const subst_list_type *
-        parent; /* A parent subst_list instance - can be NULL - no destructor is called for the parent. */
-    vector_type *string_data; /* The string substitutions we should do. */
-    vector_type *func_data;   /* The functions we support. */
-    const subst_func_pool_type
-        *func_pool; /* NOT owned by the subst_list instance - can be NULL */
+    /** A parent subst_list instance - can be NULL - no destructor is called
+     * for the parent. */
+    const subst_list_type *parent;
+    /** The string substitutions we should do. */
+    vector_type *string_data;
+    /** The functions we support. */
+    vector_type *func_data;
+    /** NOT owned by the subst_list instance - can be NULL */
+    const subst_func_pool_type *func_pool;
     hash_type *map;
 };
 
 typedef struct {
-    subst_func_type *
-        func; /* Pointer to the real subst_func_type - implemented in subst_func.c */
-    char *
-        name; /* The name the function is recognized as - in this substitution context. */
+    /** Pointer to the real subst_func_type - implemented in subst_func.c */
+    subst_func_type *func;
+    /** The name the function is recognized as - in this substitution context. */
+    char *name;
 } subst_list_func_type;
 
-/*
+/**
    The subst_list type is implemented as a hash of subst_list_node
    instances. This node type is not exported out of this file scope at
    all.
 */
-
 typedef struct {
-    bool
-        value_owner; /* Wether the memory pointed to by value should bee freed.*/
+    /** Wether the memory pointed to by value should bee freed.*/
+    bool value_owner;
     char *value;
     char *key;
-    char *
-        doc_string; /* A doc_string of this substitution - only for documentation - can be NULL. */
+    /** A doc_string of this substitution - only for documentation - can be NULL. */
+    char *doc_string;
 } subst_list_string_type;
 
-/* Allocates an empty instance with no values. */
+/** Allocates an empty instance with no values. */
 static subst_list_string_type *subst_list_string_alloc(const char *key) {
     subst_list_string_type *node =
         (subst_list_string_type *)util_malloc(sizeof *node);
@@ -143,7 +145,7 @@ static void subst_list_string_free__(void *node) {
     subst_list_string_free((subst_list_string_type *)node);
 }
 
-/*
+/**
    input_value can be NULL.
 */
 static void subst_list_string_set_value(subst_list_string_type *node,
@@ -171,11 +173,10 @@ static void subst_list_string_set_value(subst_list_string_type *node,
             util_realloc_string_copy(node->doc_string, doc_string);
 }
 
-/*
+/**
    When arriving at this function the main subst scope should already have verified that
    the requested function is available in the function pool.
 */
-
 static subst_list_func_type *subst_list_func_alloc(const char *func_name,
                                                    subst_func_type *func) {
     subst_list_func_type *subst_func =
@@ -199,10 +200,9 @@ static char *subst_list_func_eval(const subst_list_func_type *subst_func,
     return subst_func_eval(subst_func->func, arglist);
 }
 
-/*
+/**
    Find the node corresponding to 'key' -  returning NULL if it is not found.
 */
-
 static subst_list_string_type *
 subst_list_get_string_node(const subst_list_type *subst_list, const char *key) {
     subst_list_string_type *node = NULL;
@@ -241,14 +241,13 @@ subst_list_insert_new_node(subst_list_type *subst_list, const char *key,
 
 UTIL_IS_INSTANCE_FUNCTION(subst_list, SUBST_LIST_TYPE_ID)
 
-/*
+/**
    Observe that this function sets both the subst parent, and the pool
    of available functions. If this is call is repeated it is possible
    to create a weird config with dangling function pointers - that is
    a somewhat contrived and pathological use case, and not checked
    for.
 */
-
 void subst_list_set_parent(subst_list_type *subst_list,
                            const subst_list_type *parent) {
     subst_list->parent = parent;
@@ -260,7 +259,7 @@ bool subst_list_has_key(const subst_list_type *subst_list, const char *key) {
     return hash_has_key(subst_list->map, key);
 }
 
-/*
+/**
    The input argument is currently only (void *), runtime it will be
    checked whether it is of type subst_list_type, in which case it is
    interpreted as a parent instance, if it is of type
@@ -271,7 +270,6 @@ bool subst_list_has_key(const subst_list_type *subst_list, const char *key) {
    the parent is used also for the newly allocated subst_list
    instance.
 */
-
 subst_list_type *subst_list_alloc(const void *input_arg) {
     subst_list_type *subst_list =
         (subst_list_type *)util_malloc(sizeof *subst_list);
@@ -297,7 +295,7 @@ subst_list_type *subst_list_alloc(const void *input_arg) {
     return subst_list;
 }
 
-/*
+/**
    The semantics of the doc_string string is as follows:
 
     1. If doc_string is different from NULL the doc_string is stored in the node.
@@ -309,7 +307,6 @@ subst_list_type *subst_list_alloc(const void *input_arg) {
    time a (key,value) pair is added. On subsequent updates of the
    value, the doc_string string can be NULL.
 */
-
 static void subst_list_insert__(subst_list_type *subst_list, const char *key,
                                 const char *value, const char *doc_string,
                                 bool append, subst_insert_type insert_mode) {
@@ -372,13 +369,12 @@ void subst_list_prepend_copy(subst_list_type *subst_list, const char *key,
                         SUBST_DEEP_COPY);
 }
 
-/*
+/**
    This function will install the function @func_name from the current
    subst_func_pool, it will be made available to this subst_list
    instance with the function name @local_func_name. If @func_name is
    not available, the function will fail hard.
 */
-
 void subst_list_insert_func(subst_list_type *subst_list, const char *func_name,
                             const char *local_func_name) {
 
@@ -421,7 +417,7 @@ void subst_list_free(subst_list_type *subst_list) {
   applies to the function replacements.
 */
 
-/*
+/**
    Updates the buffer inplace with all the string substitutions in the
    subst_list. This is the lowest level function, which does *NOT*
    consider the parent pointer.
@@ -447,7 +443,7 @@ static bool subst_list_replace_strings__(const subst_list_type *subst_list,
     return global_match;
 }
 
-/*
+/**
    Updates the buffer inplace by evaluationg all the string functions
    in the subst_list. Last performing all the replacements in the
    parent.
@@ -476,7 +472,6 @@ static bool subst_list_replace_strings__(const subst_list_type *subst_list,
        and exp().
 
 */
-
 static bool subst_list_eval_funcs____(const subst_list_type *subst_list,
                                       const basic_parser_type *parser,
                                       buffer_type *buffer) {
@@ -552,7 +547,7 @@ static bool subst_list_eval_funcs__(const subst_list_type *subst_list,
     return match;
 }
 
-/*
+/**
    Should we evaluate the parent first (i.e. top down), or this
    instance first and then subsequently the parent (i.e. bottom
    up). The problem is with inherited defintions:
@@ -604,7 +599,6 @@ static bool subst_list_eval_funcs__(const subst_list_type *subst_list,
    of recursion, the low level function doing the stuff is
    subst_list_replace_strings__() which is not recursive.
 */
-
 static bool subst_list_replace_strings(const subst_list_type *subst_list,
                                        buffer_type *buffer) {
     bool match = false;
@@ -616,7 +610,7 @@ static bool subst_list_replace_strings(const subst_list_type *subst_list,
     return match;
 }
 
-/*
+/**
   This function updates a buffer instance inplace with all the
   substitutions in the subst_list.
 
@@ -624,7 +618,6 @@ static bool subst_list_replace_strings(const subst_list_type *subst_list,
   subst_update_xxx() functions. Observe that it is a hard assumption
   that the buffer has a \0 terminated string.
 */
-
 bool subst_list_update_buffer(const subst_list_type *subst_list,
                               buffer_type *buffer) {
     bool match1 = subst_list_replace_strings(subst_list, buffer);
@@ -634,7 +627,7 @@ bool subst_list_update_buffer(const subst_list_type *subst_list,
         match2); // Funny construction to ensure to avoid fault short circuit.
 }
 
-/*
+/**
    This function reads the content of a file, and writes a new file
    where all substitutions in subst_list have been performed. Observe
    that target_file and src_file *CAN* point to the same file, in
@@ -691,7 +684,7 @@ bool subst_list_filter_file(const subst_list_type *subst_list,
     return match;
 }
 
-/*
+/**
    This function does search-replace on string instance inplace.
 */
 bool subst_list_update_string(const subst_list_type *subst_list,
@@ -705,11 +698,10 @@ bool subst_list_update_string(const subst_list_type *subst_list,
     return match;
 }
 
-/*
+/**
    This function allocates a new string where the search-replace
    operation has been performed.
 */
-
 char *subst_list_alloc_filtered_string(const subst_list_type *subst_list,
                                        const char *string) {
     char *filtered_string = util_alloc_string_copy(string);
@@ -718,13 +710,12 @@ char *subst_list_alloc_filtered_string(const subst_list_type *subst_list,
     return filtered_string;
 }
 
-/*
+/**
    This allocates a new subst_list instance, the copy process is deep,
    in the sense that all srings inserted in the new subst_list
    instance have their own storage, irrespective of the ownership in
    the original subst_list instance.
 */
-
 subst_list_type *subst_list_alloc_deep_copy(const subst_list_type *src) {
     subst_list_type *copy;
     if (src->parent != NULL)
@@ -808,18 +799,20 @@ void subst_list_fprintf(const subst_list_type *subst_list, FILE *stream) {
     }
 }
 
-// This function splits a string on the given character, taking into account
-// that it may contain strings delimited by ' or ". It returns the length of the
-// first part of the splitted string. For instance, splitting on a ','
-// character, if the input is:
-//
-// foo "blah, foo" x 'y', and more "stuff"
-//
-// it will find the comma after 'y', and hence return a value of 21.
-//
-// The function returns a negative value if it contains a string, started with '
-// or ", which is not terminated. It returns the length of the string if the
-// split character is not found.
+/**
+   This function splits a string on the given character, taking into account
+   that it may contain strings delimited by ' or ". It returns the length of the
+   first part of the splitted string. For instance, splitting on a ','
+   character, if the input is:
+
+   foo "blah, foo" x 'y', and more "stuff"
+
+   it will find the comma after 'y', and hence return a value of 21.
+
+   The function returns a negative value if it contains a string, started with '
+   or ", which is not terminated. It returns the length of the string if the
+   split character is not found.
+*/
 static int find_substring(const char *arg_string, const char *split_char) {
     char pattern[4] = {'"', '\'', '\0',
                        '\0'}; // we accept both ' and " to delimite strings.
@@ -863,8 +856,10 @@ static int find_substring(const char *arg_string, const char *split_char) {
     return len;
 }
 
-// Trim spaces left and right from a string. Do not reallocate the string, just
-// move the start pointer of the string, and terminate the string appropiately.
+/**
+   Trim spaces left and right from a string. Do not reallocate the string, just
+   move the start pointer of the string, and terminate the string appropiately.
+*/
 static char *trim_string(char *str) {
     // Move the start of the string to skip space.
     while (isspace(*str))

--- a/libres/lib/res_util/template.cpp
+++ b/libres/lib/res_util/template.cpp
@@ -33,7 +33,7 @@
 
 namespace fs = std::filesystem;
 
-/*
+/**
    Iff the template is set up with internaliz_template == false the
    template content is loaded at instantiation time, and in that case
    the name of the template file can contain substitution characters -
@@ -43,7 +43,6 @@ namespace fs = std::filesystem;
    To avoid race issues this function does not set actually update the
    state of the template object.
 */
-
 static char *template_load(const template_type *_template,
                            const subst_list_type *ext_arg_list) {
     int buffer_size;
@@ -76,14 +75,13 @@ const char *template_get_template_file(const template_type *_template) {
     return _template->template_file;
 }
 
-/*
+/**
    This function allocates a template object based on the source file
    'template_file'. If @internalize_template is true the template
    content will be read and internalized at boot time, otherwise that
    is deferred to template instantiation time (in which case the
    template file can change dynamically).
 */
-
 template_type *template_alloc(const char *template_file,
                               bool internalize_template,
                               subst_list_type *parent_subst) {
@@ -116,7 +114,7 @@ void template_free(template_type *_template) {
     free(_template);
 }
 
-/*
+/**
    This function will create the file @__target_file based on the
    template instance. Before the target file is written all the
    internal substitutions and then subsequently the subsititutions in
@@ -140,7 +138,6 @@ void template_free(template_type *_template) {
          ensuring that a remote file is not updated.
 
 */
-
 void template_instantiate(const template_type *template_,
                           const char *__target_file,
                           const subst_list_type *arg_list,
@@ -196,7 +193,7 @@ void template_instantiate(const template_type *template_,
     free(target_file);
 }
 
-/*
+/**
    Add an internal key_value pair. This substitution will be performed
    before the internal substitutions.
 */

--- a/libres/lib/res_util/template.cpp
+++ b/libres/lib/res_util/template.cpp
@@ -172,10 +172,8 @@ void template_instantiate(const template_type *template_,
         }
 #endif
 
-        /*
-       Check if target file already exists as a symlink,
-       and remove it if override_symlink is true.
-    */
+        // Check if target file already exists as a symlink,
+        // and remove it if override_symlink is true.
         if (override_symlink) {
             if (util_is_link(target_file))
                 remove(target_file);

--- a/libres/lib/res_util/template_loop.cpp
+++ b/libres/lib/res_util/template_loop.cpp
@@ -147,11 +147,9 @@ static void loop_eval(const loop_type *loop, const char *body,
                 break;
             else {
 
-                /* Check that the match is either at the very start of the
-           string, or alternatively NOT preceeded by alphanumeric
-           character. If the variable starts with a '$' we ignore this
-           test.
-        */
+                // Check that the match is either at the very start of the
+                // string, or alternatively NOT preceeded by alphanumeric
+                // character. If the variable starts with a '$' we ignore this test.
                 if (!loop->replace_substring) {
                     if (match_ptr != &data[search_offset]) {
                         char pre_char = match_ptr[-1];
@@ -165,9 +163,8 @@ static void loop_eval(const loop_type *loop, const char *body,
                         }
                     }
 
-                    /*
-             Check that the match is at the very end of the string, or
-             alternatively followed by a NON alphanumeric character. */
+                    // Check that the match is at the very end of the string,
+                    // or alternatively followed by a NON alphanumeric character.
                     if (strlen(match_ptr) > loop->var_length) {
                         char end_char = match_ptr[loop->var_length];
                         if (isalnum(end_char))
@@ -224,9 +221,8 @@ int template_eval_loop(const template_type *_template, buffer_type *buffer,
             }
         }
 
-        /* We have completed the sub loops; the buffer has (possibly)
-       changed so we must search for the end again - to get the right
-       offset. */
+        // We have completed the sub loops; the buffer has (possibly) changed
+        // so we must search for the end again - to get the right offset.
         {
             char *search_data = (char *)buffer_get_data(buffer);
             search_offset = global_offset;

--- a/libres/lib/rms/rms_file.cpp
+++ b/libres/lib/rms/rms_file.cpp
@@ -94,7 +94,7 @@ rms_tag_type *rms_file_get_tag_ref(const rms_file_type *rms_file,
     return return_tag;
 }
 
-/*
+/**
     This function allocates and rms_file_type * handle, but it does
     not load the file content.
 */

--- a/libres/lib/rms/rms_tag.cpp
+++ b/libres/lib/rms/rms_tag.cpp
@@ -40,7 +40,8 @@ struct rms_tag_struct {
     UTIL_TYPE_ID_DECLARATION;
     char *name;
     vector_type *key_list;
-    hash_type *key_hash; /* Hash of tagkey instances */
+    /** Hash of tagkey instances */
+    hash_type *key_hash;
 };
 
 rms_tag_type *rms_tag_alloc(const char *name) {
@@ -91,7 +92,7 @@ void rms_tag_fread_header(rms_tag_type *tag, FILE *stream, bool *eof_tag) {
     free(buffer);
 }
 
-/*
+/**
    This function does a "two-level" comparison.
 
    1. tag->name is compared with tagname.

--- a/libres/lib/rms/rms_util.cpp
+++ b/libres/lib/rms/rms_util.cpp
@@ -24,7 +24,7 @@
 
 #include <ert/rms/rms_util.hpp>
 
-/*
+/**
   This translates from the RMS data layout to "Fortan / ECLIPSE" data
   layout.
 
@@ -34,7 +34,6 @@
   This function should be *THE ONLY* place in the code where explicit mention
   is made to the RMS ordering sequence.
 */
-
 int rms_util_global_index_from_eclipse_ijk(int nx, int ny, int nz, int i, int j,
                                            int k) {
     return i * ny * nz + j * nz + (nz - k - 1);
@@ -69,7 +68,7 @@ int rms_util_fread_strlen(FILE *stream) {
     return len;
 }
 
-/*
+/**
   max_length *includes* the trailing \0.
 */
 bool rms_util_fread_string(char *string, int max_length, FILE *stream) {

--- a/libres/lib/sched/history.cpp
+++ b/libres/lib/sched/history.cpp
@@ -30,8 +30,9 @@
 
 struct history_struct {
     UTIL_TYPE_ID_DECLARATION;
-    const ecl_sum_type *
-        refcase; /* ecl_sum instance used when the data are taken from a summary instance. Observe that this is NOT owned by history instance.*/
+    /** ecl_sum instance used when the data are taken from a summary instance.
+     * Observe that this is NOT owned by history instance.*/
+    const ecl_sum_type *refcase;
     history_source_type source;
 };
 


### PR DESCRIPTION
Updates the documentation to conform to doxygen style so that it works with doxygen and editors (should now be possible to get hover info in visual studio code).

Also, several pieces of documentation and comments had problematic formatting (indentation mostly) or was outdated. In addition to the main commit [b27a333](https://github.com/equinor/ert/pull/3475/commits/b27a3336a5bc71b2560d3d266595bd609ada3a2d), there are some other commits that fix up or remove outdated documentation.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
