### PR TITLE
Remove unused model_config internalization

### DIFF
--- a/libres/lib/enkf/enkf_config_node.cpp
+++ b/libres/lib/enkf/enkf_config_node.cpp
@@ -584,7 +584,7 @@ bool enkf_config_node_internalize(const enkf_config_node_type *node,
     else
         return bool_vector_safe_iget(
             node->internalize,
-            report_step); /* Will return default value if report_step is beyond size. */
+            report_step); // Will return default value if report_step is beyond size.
 }
 
 /**

--- a/libres/lib/enkf/enkf_config_node.cpp
+++ b/libres/lib/enkf/enkf_config_node.cpp
@@ -547,6 +547,15 @@ enkf_config_node_get_init_file_fmt(const enkf_config_node_type *config_node) {
     return path_fmt_get_fmt(config_node->init_file_fmt);
 }
 
+/**
+ * @brief Sets the given node to be internalized at the given report step
+ *
+ * Internalize means loaded from the forward simulation and stored in the
+ * enkf_fs 'database'.
+ *
+ * @param node The config node to be internalized
+ * @param report_step The report step for which the node should be internalized.
+ */
 void enkf_config_node_set_internalize(enkf_config_node_type *node,
                                       int report_step) {
     ert_impl_type impl_type = enkf_config_node_get_impl_type(node);
@@ -565,7 +574,9 @@ void enkf_config_node_set_internalize(enkf_config_node_type *node,
     }
 }
 
-/* Query function: */
+/** @return whether the given config node should be internalized at the given
+ * report step.
+ */
 bool enkf_config_node_internalize(const enkf_config_node_type *node,
                                   int report_step) {
     if (node->internalize == NULL)

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -352,13 +352,13 @@ int enkf_main_get_ensemble_size(const enkf_main_type *enkf_main) {
     return enkf_main->ens_size;
 }
 
-/**
-   In this function we initialize the variables which control
-   which nodes are internalized (i.e. loaded from the forward
-   simulation and stored in the enkf_fs 'database').
+/** @brief initializes internalization.
 
    The function iterates over all the observations, and ensure that the
    observed nodes (i.e. the pressure for an RFT) are internalized
+
+   Internalize means loaded from the forward simulation and stored in the
+   enkf_fs 'database'.
 */
 void enkf_main_init_internalization(enkf_main_type *enkf_main) {
     hash_type *map = enkf_obs_alloc_data_map(enkf_main->obs);

--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -355,85 +355,32 @@ int enkf_main_get_ensemble_size(const enkf_main_type *enkf_main) {
 /**
    In this function we initialize the variables which control
    which nodes are internalized (i.e. loaded from the forward
-   simulation and stored in the enkf_fs 'database'). The system is
-   based on two-levels:
+   simulation and stored in the enkf_fs 'database').
 
-   * Should we store the state? This is goverened by the variable
-     model_config->internalize_state. If this is true we will
-     internalize all nodes which have enkf_var_type = {dynamic_state ,
-     static_state}. In the same way the variable
-     model_config->internalize_results governs whether the dynamic
-     results (i.e. summary variables in ECLIPSE speak) should be
-     internalized.
-
-   * In addition we have fine-grained control in the enkf_config_node
-     objects where we can explicitly say that, altough we do not want
-     to internalize the full state, we want to internalize e.g. the
-     pressure field.
-
-   * All decisions on internalization are based on a per report step
-     basis.
-
-   The user-space API for manipulating this is (extremely)
-   limited. What is implemented here is the following:
-
-     1. We internalize the initial dynamic state.
-
-     2. For all the end-points in the current enkf_sched instance we
-        internalize the state.
-
-     3. store_results is set to true for all report steps irrespective
-        of run_mode.
-
-     4. We iterate over all the observations, and ensure that the
-        observed nodes (i.e. the pressure for an RFT) are internalized
-        (irrespective of whether they are of type dynamic_state or
-        dynamic_result).
-
-   Observe that this cascade can result in some nodes, i.e. a rate we
-   are observing, to be marked for internalization several times -
-   that is no problem.
-
-   -----
-
-   For performance reason model_config contains the bool vector
-   __load_eclipse_restart; if it is true the ECLIPSE restart state is
-   loaded from disk, otherwise no loading is performed. This implies
-   that if we do not want to internalize the full state but for
-   instance the pressure (i.e. for an RFT) we must set the
-   __load_state variable for the actual report step to true.
+   The function iterates over all the observations, and ensure that the
+   observed nodes (i.e. the pressure for an RFT) are internalized
 */
 void enkf_main_init_internalization(enkf_main_type *enkf_main) {
-    /* Clearing old internalize flags. */
-    model_config_init_internalization(enkf_main_get_model_config(enkf_main));
+    hash_type *map = enkf_obs_alloc_data_map(enkf_main->obs);
+    hash_iter_type *iter = hash_iter_alloc(map);
+    const char *obs_key = hash_iter_get_next_key(iter);
 
-    /* Internalizing the initial state. */
-    model_config_set_internalize_state(enkf_main_get_model_config(enkf_main),
-                                       0);
-
-    /* Make sure we internalize at all observation times.*/
-    {
-        hash_type *map = enkf_obs_alloc_data_map(enkf_main->obs);
-        hash_iter_type *iter = hash_iter_alloc(map);
-        const char *obs_key = hash_iter_get_next_key(iter);
-
-        while (obs_key != NULL) {
-            obs_vector_type *obs_vector =
-                enkf_obs_get_vector(enkf_main->obs, obs_key);
-            enkf_config_node_type *data_node =
-                obs_vector_get_config_node(obs_vector);
-            int active_step = -1;
-            do {
-                active_step =
-                    obs_vector_get_next_active_step(obs_vector, active_step);
-                if (active_step >= 0)
-                    enkf_config_node_set_internalize(data_node, active_step);
-            } while (active_step >= 0);
-            obs_key = hash_iter_get_next_key(iter);
-        }
-        hash_iter_free(iter);
-        hash_free(map);
+    while (obs_key != NULL) {
+        obs_vector_type *obs_vector =
+            enkf_obs_get_vector(enkf_main->obs, obs_key);
+        enkf_config_node_type *data_node =
+            obs_vector_get_config_node(obs_vector);
+        int active_step = -1;
+        do {
+            active_step =
+                obs_vector_get_next_active_step(obs_vector, active_step);
+            if (active_step >= 0)
+                enkf_config_node_set_internalize(data_node, active_step);
+        } while (active_step >= 0);
+        obs_key = hash_iter_get_next_key(iter);
     }
+    hash_iter_free(iter);
+    hash_free(map);
 }
 
 void enkf_main_get_observations(const enkf_main_type *enkf_main,

--- a/libres/lib/enkf/enkf_node.cpp
+++ b/libres/lib/enkf/enkf_node.cpp
@@ -878,7 +878,3 @@ enkf_node_type *enkf_node_deep_alloc(const enkf_config_node_type *config) {
     } else
         return enkf_node_alloc(config);
 }
-
-bool enkf_node_internalize(const enkf_node_type *node, int report_step) {
-    return enkf_config_node_internalize(node->config, report_step);
-}

--- a/libres/lib/enkf/enkf_obs.cpp
+++ b/libres/lib/enkf/enkf_obs.cpp
@@ -277,6 +277,12 @@ bool enkf_obs_has_key(const enkf_obs_type *obs, const char *key) {
     return hash_has_key(obs->obs_hash, key);
 }
 
+/** @brief get the observation vector for the given observation key.
+ *
+ * @param obs The enkf_obs_type object.
+ * @param key The observation key to get observation vector for.
+ * @return The observation vector.
+ */
 obs_vector_type *enkf_obs_get_vector(const enkf_obs_type *obs,
                                      const char *key) {
     return (obs_vector_type *)hash_get(obs->obs_hash, key);
@@ -1155,6 +1161,8 @@ stringlist_type *enkf_obs_alloc_matching_keylist(const enkf_obs_type *enkf_obs,
 }
 
 /**
+   @brief returns a map from the observation keys to the observed state keys.
+
    This function allocates a hash table which looks like this:
 
      {"OBS_KEY1": "STATE_KEY1", "OBS_KEY2": "STATE_KEY2", "OBS_KEY3": "STATE_KEY3", ....}

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -461,10 +461,6 @@ static fw_load_status enkf_state_internalize_results(
     if (last_report < 0)
         last_report = model_config_get_last_history_restart(model_config);
 
-    /* Ensure that the last step is internalized? */
-    if (last_report > 0)
-        model_config_set_internalize_state(model_config, last_report);
-
     enkf_state_internalize_GEN_DATA(ens_config, load_context, model_config,
                                     last_report);
 

--- a/libres/lib/enkf/enkf_state.cpp
+++ b/libres/lib/enkf/enkf_state.cpp
@@ -90,10 +90,7 @@ static shared_info_type *shared_info_alloc(const site_config_type *site_config,
 }
 
 static void shared_info_free(shared_info_type *shared_info) {
-    /*
-      Adding something here is a BUG - this object does
-      not own anything.
-  */
+    // Adding something here is a BUG - this object does not own anything.
     free(shared_info);
 }
 
@@ -157,7 +154,6 @@ static void enkf_state_add_nodes(enkf_state_type *enkf_state,
     // 2: Add container nodes - must ensure that all other nodes have
     //    been added already (this implies that containers of containers
     //    will be victim of hash retrieval order problems ....
-
     for (int ik = 0; ik < stringlist_get_size(container_keys); ik++) {
         const char *key = stringlist_iget(container_keys, ik);
         const enkf_config_node_type *config_node =
@@ -201,8 +197,9 @@ __enkf_state_get_time_index(enkf_fs_type *sim_fs, const ecl_sum_type *summary) {
 }
 
 /**
- * Check if there are summary keys in the ensemble config that is not found in Eclipse. If this is the case, AND we
- * have observations for this key, we have a problem. Otherwise, just print a message to the log.
+ * Check if there are summary keys in the ensemble config that is not found in
+ * Eclipse. If this is the case, AND we have observations for this key, we have
+ * a problem. Otherwise, just print a message to the log.
  */
 static void enkf_state_check_for_missing_eclipse_summary_data(
     const ensemble_config_type *ens_config,
@@ -257,14 +254,15 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
     if (load_summary || matcher_size > 0 || summary) {
         int load_start = run_arg_get_load_start(run_arg);
 
-        if (load_start ==
-            0) { /* Do not attempt to load the "S0000" summary results. */
+        if (load_start == 0) {
+            // Do not attempt to load the "S0000" summary results.
             load_start++;
         }
 
         {
             enkf_fs_type *sim_fs = run_arg_get_sim_fs(run_arg);
-            /* OK - now we have actually loaded the ecl_sum instance, or ecl_sum == NULL. */
+            // OK - now we have actually loaded the ecl_sum instance, or
+            // ecl_sum == NULL.
             if (summary) {
                 int_vector_type *time_index =
                     __enkf_state_get_time_index(sim_fs, summary);
@@ -279,10 +277,11 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
                     throw std::invalid_argument("Inconsistent time map");
                 }
 
-                /* The actual loading internalizing - from ecl_sum -> enkf_node. */
+                // The actual loading internalizing - from ecl_sum -> enkf_node.
                 const int iens = run_arg_get_iens(run_arg);
-                const int step2 = ecl_sum_get_last_report_step(
-                    summary); /* Step2 is just taken from the number of steps found in the summary file. */
+                // step2 is just taken from the number of steps found in the
+                // summary file.
+                const int step2 = ecl_sum_get_last_report_step(summary);
 
                 int_vector_iset_block(time_index, 0, load_start, -1);
                 int_vector_resize(time_index, step2 + 1, -1);
@@ -304,9 +303,9 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
                                 ens_config, key);
                         enkf_node_type *node = enkf_node_alloc(config_node);
 
-                        enkf_node_try_load_vector(
-                            node, sim_fs,
-                            iens); // Ensure that what is currently on file is loaded before we update.
+                        // Ensure that what is currently on file is loaded
+                        // before we update.
+                        enkf_node_try_load_vector(node, sim_fs, iens);
 
                         enkf_node_forward_load_vector(node, load_context,
                                                       time_index);
@@ -317,9 +316,8 @@ static bool enkf_state_internalize_dynamic_eclipse_results(
 
                 int_vector_free(time_index);
 
-                /*
-                 * Check if some of the specified keys are missing from the Eclipse data, and if there are observations for them. That is a problem.
-                 */
+                // Check if some of the specified keys are missing from the Eclipse
+                // data, and if there are observations for them. That is a problem.
                 enkf_state_check_for_missing_eclipse_summary_data(
                     ens_config, matcher, smspec, load_context, iens);
 
@@ -395,11 +393,9 @@ enkf_state_internalize_GEN_DATA(const ensemble_config_type *ens_config,
         const enkf_config_node_type *config_node = ensemble_config_get_node(
             ens_config, stringlist_iget(keylist_GEN_DATA, ikey));
 
-        /*
-         * This for loop should probably be changed to use the report
-         * steps configured in the gen_data_config object, instead of
-         * spinning through them all.
-         */
+        // This for loop should probably be changed to use the report
+        // steps configured in the gen_data_config object, instead of
+        // spinning through them all.
         int start = run_arg_get_load_start(run_arg);
         int stop = util_int_max(0, last_report); // inclusive
         enkf_state_load_gen_data_node(load_context, sim_fs, iens, config_node,
@@ -442,12 +438,10 @@ static fw_load_status enkf_state_internalize_results(
 
     forward_load_context_type *load_context =
         enkf_state_alloc_load_context(ens_config, ecl_config, run_arg);
-    /*
-     * The timing information - i.e. mainly what is the last report step
-     * in these results are inferred from the loading of summary results,
-     * hence we must load the summary results first.
-     */
 
+    // The timing information - i.e. mainly what is the last report step
+    // in these results are inferred from the loading of summary results,
+    // hence we must load the summary results first.
     try {
         enkf_state_internalize_dynamic_eclipse_results(ens_config, load_context,
                                                        model_config);
@@ -580,12 +574,10 @@ bool enkf_state_complete_forward_modelOK(const res_config_type *res_config,
     model_config_type *model_config = res_config_get_model_config(res_config);
     const int iens = run_arg_get_iens(run_arg);
 
-    /*
-     The queue system has reported that the run is OK, i.e. it has
-     completed and produced the targetfile it should. We then check
-     in this scope whether the results can be loaded back; if that
-     is OK the final status is updated, otherwise: restart.
-  */
+    // The queue system has reported that the run is OK, i.e. it has
+    // completed and produced the targetfile it should. We then check
+    // in this scope whether the results can be loaded back; if that
+    // is OK the final status is updated, otherwise: restart.
     logger->info("[{:03d}:{:04d}-{:04d}] Forward model complete - starting to "
                  "load results.",
                  iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
@@ -594,12 +586,10 @@ bool enkf_state_complete_forward_modelOK(const res_config_type *res_config,
                                                        ecl_config, run_arg);
 
     if (result == LOAD_SUCCESSFUL) {
-        /*
-      The loading succeded - so this is a howling success! We set
-      the main status to JOB_QUEUE_ALL_OK and inform the queue layer
-      about the success. In addition we set the simple status
-      (should be avoided) to JOB_RUN_OK.
-    */
+        // The loading succeded - so this is a howling success! We set
+        // the main status to JOB_QUEUE_ALL_OK and inform the queue layer
+        // about the success. In addition we set the simple status
+        // (should be avoided) to JOB_RUN_OK.
         run_arg_set_run_status(run_arg, JOB_RUN_OK);
         logger->info("[{:03d}:{:04d}-{:04d}] Results loaded successfully.",
                      iens, run_arg_get_step1(run_arg),
@@ -635,13 +625,11 @@ bool enkf_state_complete_forward_model_EXIT_handler__(run_arg_type *run_arg) {
 void enkf_state_ecl_write(const ensemble_config_type *ens_config,
                           const model_config_type *model_config,
                           const run_arg_type *run_arg, enkf_fs_type *fs) {
-    /*
-     This iteration manipulates the hash (thorugh the enkf_state_del_node() call)
+    // This iteration manipulates the hash (thorugh the enkf_state_del_node() call)
 
-     -----------------------------------------------------------------------------------------
-     T H I S  W I L L  D E A D L O C K  I F  T H E   H A S H _ I T E R  A P I   I S   U S E D.
-     -----------------------------------------------------------------------------------------
-  */
+    // -----------------------------------------------------------------------------------------
+    // T H I S  W I L L  D E A D L O C K  I F  T H E   H A S H _ I T E R  A P I   I S   U S E D.
+    // -----------------------------------------------------------------------------------------
     int iens = run_arg_get_iens(run_arg);
     const char *base_name = model_config_get_gen_kw_export_name(model_config);
     value_export_type *export_value =

--- a/libres/lib/include/ert/enkf/enkf_node.hpp
+++ b/libres/lib/include/ert/enkf/enkf_node.hpp
@@ -163,7 +163,6 @@ enkf_node_alloc_private_container(const enkf_config_node_type *config);
 const enkf_config_node_type *enkf_node_get_config(const enkf_node_type *);
 extern "C" const char *enkf_node_get_key(const enkf_node_type *);
 bool enkf_node_has_func(const enkf_node_type *, node_function_type);
-bool enkf_node_internalize(const enkf_node_type *, int);
 
 UTIL_IS_INSTANCE_HEADER(enkf_node);
 

--- a/libres/lib/include/ert/enkf/model_config.hpp
+++ b/libres/lib/include/ert/enkf/model_config.hpp
@@ -61,8 +61,6 @@ extern "C" const char *
 model_config_get_enspath(const model_config_type *model_config);
 const ecl_sum_type *
 model_config_get_refcase(const model_config_type *model_config);
-void model_config_init_internalization(model_config_type *);
-void model_config_set_internalize_state(model_config_type *, int);
 bool model_config_has_prediction(const model_config_type *);
 extern "C" PY_USED bool
 model_config_has_history(const model_config_type *config);


### PR DESCRIPTION
* Removes internalization fields that are set, but not read 
* removes outdated documentation relating to deprecated and removed behavior
* Adds documentation of current behavior

The remaining internalization code has an effect on `enkf_state_load_gen_data_node` through `enkf_config_node_internalize`.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
