### PR TITLE
Use async context manager for ens_evaluator client

### DIFF
--- a/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/ert/ensemble_evaluator/builder/_ensemble.py
@@ -69,12 +69,10 @@ class _Ensemble:
         event: CloudEvent,
         token: Optional[str] = None,
         cert: Optional[Union[str, bytes]] = None,
-        retries: int = 1,
+        retries: int = 10,
     ) -> None:
-        client = Client(url, token, cert)
-        await client._send(to_json(event, data_marshaller=evaluator_marshaller))
-        assert client.websocket  # mypy
-        await client.websocket.close()
+        async with Client(url, token, cert, max_retries=retries) as client:
+            await client._send(to_json(event, data_marshaller=evaluator_marshaller))
 
     def get_successful_realizations(self) -> int:
         return self._snapshot.get_successful_realizations()

--- a/ert_shared/ensemble_evaluator/client.py
+++ b/ert_shared/ensemble_evaluator/client.py
@@ -16,6 +16,15 @@ class Client:  # pylint: disable=too-many-instance-attributes
             self.loop.run_until_complete(self.websocket.close())
         self.loop.close()
 
+    async def __aenter__(self) -> "Client":
+        return self
+
+    async def __aexit__(
+        self, exc_type: Any, exc_value: Any, exc_traceback: Any
+    ) -> None:
+        if self.websocket is not None:
+            await self.websocket.close()
+
     def __init__(  # pylint: disable=too-many-arguments
         self,
         url: str,


### PR DESCRIPTION
Flyby proposal while reading up on the experimental server and asyncio in general.

+ Bonus non-exposed bugfix in that the `retries` argument for `send_cloudevent` was ignored. Changed the argument default from 1 to 10 to ensure current behaviour is not modified.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
