### PR TITLE
Remove doc referring to tagged keywords

### DIFF
--- a/libres/lib/enkf/enkf_main.cpp
+++ b/libres/lib/enkf/enkf_main.cpp
@@ -256,10 +256,6 @@ ert_run_context_type *enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(
         enkf_main_get_data_kw(enkf_main), iter);
 }
 
-/**
-   There is NO tagging anymore - if the user wants tags - the user
-   supplies the key __WITH__ tags.
-*/
 void enkf_main_add_data_kw(enkf_main_type *enkf_main, const char *key,
                            const char *value) {
     subst_config_add_subst_kw(enkf_main_get_subst_config(enkf_main), key,


### PR DESCRIPTION
In aefcc1d47a55cd9c3ac681df6e2738b9aa8c6c60 (12 years ago as of this commit), enkf_main_add_tagged_data_kw was removed and a comment on enkf_main_add_data_kw saying tagging is removed was added. This is no longer relevant information.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
