### PR TITLE
Fix global-statement pylint error

### DIFF
--- a/tests/performance_tests/conftest.py
+++ b/tests/performance_tests/conftest.py
@@ -92,6 +92,7 @@ def template_config(request, source_root, tmp_path_factory):
 
 
 def pytest_configure(config):
+    # pylint: disable=global-statement
     global template_config_path
     template_config_path = config.getoption("--template-config-path")
 


### PR DESCRIPTION
**Issue**
Due to order of merging PRs a pylint error was introduced after it was
enabled in testing.


**Approach**
Disable the error for the specific line


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
