### PR TITLE
Avoid crashing if not connected to network, fallback to localhost

### DIFF
--- a/ert_shared/ensemble_evaluator/config.py
+++ b/ert_shared/ensemble_evaluator/config.py
@@ -44,7 +44,7 @@ def get_machine_name():
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name
         return socket.getfqdn()
-    except socket.gaierror:
+    except (socket.gaierror, exception.DNSException):
         return "localhost"
 
 

--- a/ert_shared/port_handler.py
+++ b/ert_shared/port_handler.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import socket
 from typing import Optional, Tuple
@@ -13,6 +14,9 @@ class NoPortsInRangeException(Exception):
 
 class InvalidHostException(Exception):
     pass
+
+
+logger = logging.getLogger(__name__)
 
 
 def find_available_port(
@@ -134,7 +138,19 @@ def get_family(host: str) -> socket.AddressFamily:
         return socket.AF_INET
 
 
+# See https://stackoverflow.com/a/28950776
 def _get_ip_address() -> str:
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    return s.getsockname()[0]
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(0)
+        # try pinging a reserved, internal address in order
+        # to determine IP representing the default route
+        s.connect(("10.255.255.255", 1))
+        retval = s.getsockname()[0]
+    except BaseException:  # pylint: disable=broad-except
+        logger.warning("Cannot determine ip-address. Fallback to localhost...")
+        retval = "127.0.0.1"
+    finally:
+        s.close()
+    logger.debug(f"ip-address: {retval}")
+    return retval


### PR DESCRIPTION
Previous approach hit 8.8.8.8, using the socket to determine public
ip-address. This approach does not hit a public ip-address but still
finds the ip-address used by default route.

(cherry picked from commit 30e4329c8b1ee7b0244669b23fa0cafc05342cea)
