### PR TITLE
Remove unused function gen_kw_ecl_write_template

### DIFF
--- a/libres/lib/enkf/gen_kw.cpp
+++ b/libres/lib/enkf/gen_kw.cpp
@@ -264,11 +264,6 @@ void gen_kw_write_export_file(const gen_kw_type *gen_kw, const char *filename) {
     value_export_free(export_value);
 }
 
-void gen_kw_ecl_write_template(const gen_kw_type *gen_kw,
-                               const char *file_name) {
-    gen_kw_filter_file(gen_kw, file_name);
-}
-
 void gen_kw_ecl_write(const gen_kw_type *gen_kw, const char *run_path,
                       const char *base_file, value_export_type *export_value) {
     char *target_file;

--- a/libres/lib/include/ert/enkf/gen_kw.hpp
+++ b/libres/lib/include/ert/enkf/gen_kw.hpp
@@ -46,8 +46,6 @@ extern "C" void gen_kw_data_set(gen_kw_type *, const char *, double);
 extern "C" PY_USED bool gen_kw_data_has_key(gen_kw_type *, const char *);
 extern "C" const char *gen_kw_get_name(const gen_kw_type *, int);
 void gen_kw_filter_file(const gen_kw_type *, const char *);
-extern "C" void gen_kw_ecl_write_template(const gen_kw_type *gen_kw,
-                                          const char *file_name);
 
 UTIL_SAFE_CAST_HEADER(gen_kw);
 UTIL_SAFE_CAST_HEADER_CONST(gen_kw);

--- a/res/enkf/data/gen_kw.py
+++ b/res/enkf/data/gen_kw.py
@@ -18,7 +18,6 @@ import os.path
 
 from cwrap import BaseCClass
 from ecl.util.util import DoubleVector
-
 from res import ResPrototype
 from res.enkf.config import GenKwConfig
 
@@ -28,7 +27,6 @@ class GenKw(BaseCClass):
     _alloc = ResPrototype("void*  gen_kw_alloc(gen_kw_config)", bind=False)
     _free = ResPrototype("void   gen_kw_free(gen_kw_config)")
     _export_parameters = ResPrototype("void   gen_kw_write_export_file(gen_kw , char*)")
-    _export_template = ResPrototype("void   gen_kw_ecl_write_template(gen_kw , char* )")
     _data_iget = ResPrototype("double gen_kw_data_iget(gen_kw, int, bool)")
     _data_iset = ResPrototype("void   gen_kw_data_iset(gen_kw, int, double)")
     _set_values = ResPrototype("void   gen_kw_data_set_vector(gen_kw, double_vector)")
@@ -60,10 +58,6 @@ class GenKw(BaseCClass):
     def exportParameters(self, file_name):
         """@type: str"""
         self._export_parameters(file_name)
-
-    def exportTemplate(self, file_name):
-        """@type: str"""
-        self._export_template(file_name)
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
Removes unused function `GenKw.exportTemplate`

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
