### PR TITLE
Remove unecessary fs version checks

### DIFF
--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -255,41 +255,6 @@ enkf_fs_type *enkf_fs_alloc_empty(const char *mount_point) {
     return fs;
 }
 
-static int enkf_fs_fread_fs_version__(FILE *stream) {
-    int version;
-    long fs_tag = util_fread_long(stream);
-    if (fs_tag == FS_MAGIC_ID)
-        version = util_fread_int(stream);
-    else
-        version = 0;
-    return version;
-}
-
-/**
-   -1 : No mount map found.
-   0  : Old mount map without version info.
-   x  : Actual version info.
-*/
-static int enkf_fs_get_fs_version__(const char *config_file) {
-    int version = -1;
-    if (fs::exists(config_file)) {
-        FILE *stream = util_fopen(config_file, "r");
-        version = enkf_fs_fread_fs_version__(stream);
-        fclose(stream);
-    }
-    return version;
-}
-
-/**
-   Function written to look for old (version <= 104) mount info maps.
-*/
-int enkf_fs_get_version104(const char *path) {
-    char *config_file = util_alloc_filename(path, ENKF_MOUNT_MAP, NULL);
-    int version = enkf_fs_get_fs_version__(config_file);
-    free(config_file);
-    return version;
-}
-
 void enkf_fs_init_path_fmt(enkf_fs_type *fs) {
     /*
     Installing the path_fmt instances for the storage of arbitrary files.

--- a/libres/lib/enkf/enkf_main_manage_fs.cpp
+++ b/libres/lib/enkf/enkf_main_manage_fs.cpp
@@ -497,39 +497,28 @@ void enkf_main_select_fs(enkf_main_type *enkf_main, const char *case_path) {
 static void enkf_main_user_select_initial_fs(enkf_main_type *enkf_main) {
     const char *ens_path =
         model_config_get_enspath(enkf_main_get_model_config(enkf_main));
-    int root_version = enkf_fs_get_version104(ens_path);
-    if (root_version == -1 || root_version == 105) {
-        char *current_mount_point =
-            util_alloc_filename(ens_path, CURRENT_CASE, NULL);
+    char *current_mount_point =
+        util_alloc_filename(ens_path, CURRENT_CASE, NULL);
 
-        if (enkf_main_current_case_file_exists(enkf_main)) {
-            char *current_case =
-                enkf_main_read_alloc_current_case_name(enkf_main);
-            enkf_main_select_fs(enkf_main, current_case);
-            free(current_case);
-        } else if (enkf_fs_exists(current_mount_point) &&
-                   util_is_link(current_mount_point)) {
-            /*If the current_case file does not exists, but the 'current' symlink does we use readlink to
-        get hold of the actual target before calling the  enkf_main_select_fs() function. We then
-        write the current_case file and delete the symlink.*/
-            char *target_case =
-                util_alloc_atlink_target(ens_path, CURRENT_CASE);
-            enkf_main_select_fs(enkf_main, target_case);
-            unlink(current_mount_point);
-            enkf_main_write_current_case_file(enkf_main, target_case);
-            free(target_case);
-        } else
-            enkf_main_select_fs(enkf_main,
-                                DEFAULT_CASE); // Selecting (a new) default case
+    if (enkf_main_current_case_file_exists(enkf_main)) {
+        char *current_case = enkf_main_read_alloc_current_case_name(enkf_main);
+        enkf_main_select_fs(enkf_main, current_case);
+        free(current_case);
+    } else if (enkf_fs_exists(current_mount_point) &&
+               util_is_link(current_mount_point)) {
+        /*If the current_case file does not exists, but the 'current' symlink does we use readlink to
+    get hold of the actual target before calling the  enkf_main_select_fs() function. We then
+    write the current_case file and delete the symlink.*/
+        char *target_case = util_alloc_atlink_target(ens_path, CURRENT_CASE);
+        enkf_main_select_fs(enkf_main, target_case);
+        unlink(current_mount_point);
+        enkf_main_write_current_case_file(enkf_main, target_case);
+        free(target_case);
+    } else
+        enkf_main_select_fs(enkf_main,
+                            DEFAULT_CASE); // Selecting (a new) default case
 
-        free(current_mount_point);
-    } else {
-        fprintf(stderr,
-                "Sorry: the filesystem located in %s must be upgraded before "
-                "the current ERT version can read it.\n",
-                ens_path);
-        exit(1);
-    }
+    free(current_mount_point);
 }
 
 bool enkf_main_fs_exists(const enkf_main_type *enkf_main,

--- a/libres/lib/include/ert/enkf/enkf_fs.hpp
+++ b/libres/lib/include/ert/enkf/enkf_fs.hpp
@@ -48,7 +48,6 @@ extern "C" PY_USED bool enkf_fs_update_disk_version(const char *mount_point,
                                                     int src_version,
                                                     int target_version);
 extern "C" int enkf_fs_disk_version(const char *mount_point);
-int enkf_fs_get_version104(const char *path);
 void enkf_fs_fwrite_node(enkf_fs_type *enkf_fs, buffer_type *buffer,
                          const char *node_key, enkf_var_type var_type,
                          int report_step, int iens);


### PR DESCRIPTION
**Issue**
Resolves #3508


**Approach**
`model_config_get_enspath(enkf_main_get_model_config(enkf_main))` returns root of `storage` which does not have an `fstab` file meaning that `root_version` is always -1.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
