### PR TITLE
Expose priors in dark-storage endpoint

### DIFF
--- a/ert_shared/dark_storage/endpoints/experiments.py
+++ b/ert_shared/dark_storage/endpoints/experiments.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, List
 from fastapi import APIRouter, Body, Depends
 from ert_storage import json_schema as js
 
+from ert_shared.storage.extraction import create_priors
 from ert_shared.dark_storage.enkf import LibresFacade, get_res, get_id, get_size
 
 router = APIRouter(tags=["experiment"])
@@ -11,12 +12,13 @@ router = APIRouter(tags=["experiment"])
 
 @router.get("/experiments", response_model=List[js.ExperimentOut])
 def get_experiments(*, res: LibresFacade = Depends(get_res)) -> List[js.ExperimentOut]:
+    priors = create_priors(res)
     return [
         js.ExperimentOut(
             name="default",
             id=get_id("experiment", "default"),
             ensemble_ids=[get_id("ensemble", case) for case in res.cases()],
-            priors={},
+            priors=priors,
             userdata={},
         )
     ]
@@ -30,7 +32,7 @@ def get_experiment_by_id(
         name="default",
         id=get_id("experiment", "default"),
         ensemble_ids=[get_id("ensemble", case) for case in res.cases()],
-        priors={},
+        priors=create_priors(res),
         userdata={},
     )
 

--- a/ert_shared/storage/extraction.py
+++ b/ert_shared/storage/extraction.py
@@ -20,7 +20,7 @@ logger = logging.getLogger()
 
 
 def create_experiment(ert) -> dict:
-    return dict(name=str(datetime.datetime.now()), priors=_create_priors(ert))
+    return dict(name=str(datetime.datetime.now()), priors=create_priors(ert))
 
 
 def create_ensemble(
@@ -265,7 +265,7 @@ _PRIOR_NAME_MAP = {
 }
 
 
-def _create_priors(ert) -> Mapping[str, dict]:
+def create_priors(ert) -> Mapping[str, dict]:
     priors = {}
     for group, gen_kw_priors in ert.gen_kw_priors().items():
         for gen_kw_prior in gen_kw_priors:


### PR DESCRIPTION
**Issue**
Priors have only been made available through graphql endpoints which is about to be removed. Because of this - they need to be exposed through the REST endpoints as well


**Approach**
Utilizing a `create_prior` function which makes the same format of the prior-dict as exposed from new storage. No changes required in `webviz-ert` when switching endpoint

Resolves #3505 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
