### PR TITLE
Use standard library for string split and file handling

### DIFF
--- a/libres/lib/enkf/enkf_fs.cpp
+++ b/libres/lib/enkf/enkf_fs.cpp
@@ -141,8 +141,6 @@ static auto logger = ert::get_logger("enkf");
 struct enkf_fs_struct {
     UTIL_TYPE_ID_DECLARATION;
     std::string case_name;
-    std::string root_path;
-    /** mount_point = root_path / case_name; the mount_point is the fundamental INPUT. */
     char *mount_point;
 
     char *lock_file;
@@ -219,36 +217,21 @@ enkf_fs_type *enkf_fs_alloc_empty(const char *mount_point) {
     fs->summary_key_set = summary_key_set_alloc();
     fs->misfit_ensemble = misfit_ensemble_alloc();
     fs->read_only = true;
-    fs->mount_point = util_alloc_string_copy(mount_point);
+    fs->mount_point = strdup(mount_point);
     fs->refcount = 0;
     fs->runcount = 0;
     fs->lock_fd = 0;
+    auto mount_path = fs::path(mount_point);
+    fs->case_name = mount_path.filename();
+    fs->lock_file = strdup((mount_path / (fs->case_name + ".lock")).c_str());
 
-    if (mount_point == NULL)
-        util_abort("%s: fatal internal error: mount_point == NULL \n",
-                   __func__);
-    {
-        std::vector<std::string> path_tmp;
-
-        ert::split(fs->mount_point, UTIL_PATH_SEP_STRING[0],
-                   [&path_tmp](auto t) { path_tmp.emplace_back(t); });
-
-        fs->case_name = path_tmp.back();
-
-        fs->root_path =
-            fmt::format("{}", fmt::join(path_tmp, UTIL_PATH_SEP_STRING));
-
-        fs->lock_file =
-            util_alloc_filename(fs->mount_point, fs->case_name.c_str(), "lock");
-
-        if (util_try_lockf(fs->lock_file, S_IWUSR + S_IWGRP, &fs->lock_fd)) {
-            fs->read_only = false;
-        } else {
-            fprintf(stderr, " Another program has already opened filesystem "
-                            "read-write - this instance will be UNSYNCRONIZED "
-                            "read-only. Cross your fingers ....\n");
-            fs->read_only = true;
-        }
+    if (util_try_lockf(fs->lock_file, S_IWUSR + S_IWGRP, &fs->lock_fd)) {
+        fs->read_only = false;
+    } else {
+        fprintf(stderr, " Another program has already opened filesystem "
+                        "read-write - this instance will be UNSYNCRONIZED "
+                        "read-only. Cross your fingers ....\n");
+        fs->read_only = true;
     }
     return fs;
 }

--- a/libres/lib/enkf/ensemble_config.cpp
+++ b/libres/lib/enkf/ensemble_config.cpp
@@ -731,34 +731,24 @@ static void ensemble_config_init(ensemble_config_type *ensemble_config,
 const enkf_config_node_type *
 ensemble_config_user_get_node(const ensemble_config_type *config,
                               const char *full_key, char **index_key) {
-    const enkf_config_node_type *node = NULL;
-    std::vector<std::string> key_list;
-    int keys;
-    int key_length = 1;
-    int offset;
-
     *index_key = NULL;
+    auto key_list = ert::split(full_key, USER_KEY_JOIN_STRING[0]);
 
-    ert::split(full_key, USER_KEY_JOIN_STRING[0],
-               [&key_list](auto t) { key_list.emplace_back(t); });
+    std::string current_key;
+    auto it =
+        std::find_if(key_list.begin(), key_list.end(), [&](auto key) -> bool {
+            if (!current_key.empty()) {
+                current_key.push_back(USER_KEY_JOIN_STRING[0]);
+            }
+            current_key += key;
+            return ensemble_config_has_key(config, current_key.c_str());
+        });
+    if (it == key_list.end())
+        return nullptr;
 
-    while (node == NULL && key_length <= key_list.size()) {
-        auto key_list_slice = std::vector<std::string>(
-            key_list.begin(), key_list.begin() + key_length);
-        auto current_key =
-            fmt::format("{}", fmt::join(key_list_slice, USER_KEY_JOIN_STRING));
-        if (ensemble_config_has_key(config, current_key.c_str()))
-            node = ensemble_config_get_node(config, current_key.c_str());
-        else
-            key_length++;
-        offset = strlen(current_key.c_str());
-    }
-    if (node != NULL) {
-        if (offset < strlen(full_key))
-            *index_key = util_alloc_string_copy(&full_key[offset + 1]);
-    }
-
-    return node;
+    if (current_key.size() < strlen(full_key))
+        *index_key = strdup(&full_key[current_key.size() + 1]);
+    return ensemble_config_get_node(config, current_key.c_str());
 }
 
 stringlist_type *

--- a/libres/lib/include/ert/res_util/string.hpp
+++ b/libres/lib/include/ert/res_util/string.hpp
@@ -2,14 +2,19 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace ert {
 
 /**
  * Non memory allocating string splitting function
  *
- * \note The input string is a view. It is therefore Undefined Behaviour to
+ * @note The input string is a view. It is therefore Undefined Behaviour to
  * modify the original string from inside the `func` parameter.
+ *
+ * @param[in] str String to be split
+ * @param[in] delimiter Delimiter to split the string by
+ * @param func Callback which is called with the string parts
  */
 template <typename Func>
 void split(std::string_view str, char delimiter, Func &&func) {
@@ -23,6 +28,20 @@ void split(std::string_view str, char delimiter, Func &&func) {
         pos = next_pos + 1;
     }
     func(str.substr(pos));
+}
+
+/**
+ * Split string into a container of strings
+ *
+ * @param[in] str String to be split
+ * @param[in] delimiter Delimiter to split the string by
+ * @return List of the parts
+ */
+inline std::vector<std::string> split(std::string_view str, char delimiter) {
+    std::vector<std::string> vec;
+    split(str, delimiter,
+          [&vec](std::string_view substr) { vec.emplace_back(substr); });
+    return vec;
 }
 
 /**

--- a/libres/lib/job_queue/rsh_driver.cpp
+++ b/libres/lib/job_queue/rsh_driver.cpp
@@ -16,6 +16,7 @@
    for more details.
 */
 
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -310,26 +311,24 @@ void rsh_driver_add_host(rsh_driver_type *rsh_driver, const char *hostname,
 }
 
 /**
-   Hostname should be a string as host:max_running, the ":max_running"
-   part is optional, and will default to 1.
-*/
-void rsh_driver_add_host_from_string(rsh_driver_type *rsh_driver,
-                                     const char *hostname) {
-    int host_max_running;
-    std::vector<std::string> tmp;
-    std::string host;
+ * Split RSH hostnames into host and (optionally) max_running
+ *
+ * Eg. If the hostname is "foo:42", return {"foo", 42}
+ * If the hostname is just "foo", return {"foo", 1}
+ *
+ * @param[in] hostname String to split. Eg. "foo:42" or just "foo"
+ * @return Pair of host, max_running.
+ */
+std::pair<std::string, int> rsh_split_host(std::string hostname) {
+    int host_max_running = 1;
 
-    ert::split(hostname, ':', [&tmp](auto t) { tmp.emplace_back(t); });
-
-    int tokens = tmp.size();
-    if (tokens > 1) {
-        if (!util_sscanf_int(tmp[tokens - 1].c_str(), &host_max_running))
-            util_abort("%s: failed to parse out integer from: %s \n", __func__,
-                       hostname);
-        host = fmt::format("{}", fmt::join(tmp, ":"));
-    } else
-        host = tmp[0];
-    rsh_driver_add_host(rsh_driver, host.c_str(), host_max_running);
+    auto pos = hostname.rfind(':');
+    if (pos != hostname.npos) {
+        // found ':'
+        host_max_running = std::stoi(hostname.substr(pos + 1));
+        hostname = hostname.substr(0, pos);
+    }
+    return {hostname, host_max_running};
 }
 
 bool rsh_driver_set_option(void *__driver, const char *option_key,
@@ -338,10 +337,11 @@ bool rsh_driver_set_option(void *__driver, const char *option_key,
     rsh_driver_type *driver = rsh_driver_safe_cast(__driver);
     bool has_option = true;
     {
-        if (strcmp(RSH_HOST, option_key) ==
-            0) /* Add one host - value should be hostname:max */
-            rsh_driver_add_host_from_string(driver, value);
-        else if (
+        if (strcmp(RSH_HOST, option_key) == 0) {
+            // Add one host - value should be hostname:max
+            auto [host, host_max_running] = rsh_split_host(value);
+            rsh_driver_add_host(driver, host.c_str(), host_max_running);
+        } else if (
             strcmp(RSH_HOSTLIST, option_key) ==
             0) { /* Set full host list - value should be hash of integers. */
             if (value != NULL) {

--- a/libres/lib/res_util/res_env.cpp
+++ b/libres/lib/res_util/res_env.cpp
@@ -40,15 +40,11 @@ void res_env_setenv(const char *variable, const char *value) {
    variable.
 */
 std::vector<std::string> res_env_alloc_PATH_list() {
-    std::vector<std::string> path_list;
     char *path_env = getenv("PATH");
     if (path_env != NULL) {
-        int path_size;
-
-        ert::split(path_env, ':',
-                   [&path_list](auto t) { path_list.emplace_back(t); });
+        return ert::split(path_env, ':');
     }
-    return path_list;
+    return std::vector<std::string>();
 }
 
 /**
@@ -127,10 +123,7 @@ const char *res_env_update_path_var(const char *variable, const char *value,
     else {
         bool update = true;
 
-        std::vector<std::string> path_list;
-
-        ert::split(current_value, ':',
-                   [&path_list](auto t) { path_list.emplace_back(t); });
+        std::vector<std::string> path_list = ert::split(current_value, ':');
 
         if (append) {
             int i;

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   res_util/test_metric.cpp
   analysis/test_update.cpp
   job_queue/test_lsf_driver.cpp
+  job_queue/test_rsh_driver.cpp
   job_queue/test_ext_job_executable.cpp)
 
 target_link_libraries(ert_test_suite res Catch2::Catch2WithMain fmt::fmt)

--- a/libres/tests/job_queue/test_rsh_driver.cpp
+++ b/libres/tests/job_queue/test_rsh_driver.cpp
@@ -1,0 +1,27 @@
+#include <string>
+
+#include "catch2/catch.hpp"
+
+#include "../tmpdir.hpp"
+
+std::pair<std::string, int> rsh_split_host(std::string hostname);
+
+TEST_CASE("parse hostnames", "[rsh]") {
+    SECTION("Only hostname") {
+        auto [host, max_running] = rsh_split_host("foo");
+        REQUIRE(host == "foo");
+        REQUIRE(max_running == 1);
+    }
+
+    SECTION("Hostname with max_running") {
+        auto [host, max_running] = rsh_split_host("bar:42");
+        REQUIRE(host == "bar");
+        REQUIRE(max_running == 42);
+    }
+
+    SECTION("Hostname with multiple colons") {
+        auto [host, max_running] = rsh_split_host("foo:bar:quz:100");
+        REQUIRE(host == "foo:bar:quz");
+        REQUIRE(max_running == 100);
+    }
+}


### PR DESCRIPTION
During review #3500 several possibilities for using c++17 standard library instead of internal utilities were found. They were split into this commit.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
