### PR TITLE
Select pytest asyncio_mode=auto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,4 @@ markers = [
     "consumer_driven_contract_verification",
     "integration_test"
 ]
+asyncio_mode = "auto"


### PR DESCRIPTION
Not specifying this option yields the legacy mode which triggers a DeprecationWarning

We have the option of selecting between `strict` and `auto`. The documentation says that we should use 
`strict` "if multiple async frameworks should be combined in the same test suite", which we probably are not doing (?)

https://github.com/pytest-dev/pytest-asyncio#auto-mode

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
