### PR TITLE
Simplify block_fs

### DIFF
--- a/libres/lib/enkf/block_fs_driver.cpp
+++ b/libres/lib/enkf/block_fs_driver.cpp
@@ -39,7 +39,6 @@ typedef struct bfs_config_struct bfs_config_type;
 
 struct bfs_config_struct {
     bool read_only;
-    int block_size;
 };
 
 #define BFS_TYPE_ID 5510643
@@ -58,7 +57,6 @@ bfs_config_type *bfs_config_alloc(bool read_only) {
         bfs_config_type *config =
             (bfs_config_type *)util_malloc(sizeof *config);
         config->read_only = read_only;
-        config->block_size = 64;
         return config;
     }
 }
@@ -93,8 +91,7 @@ static bfs_type *bfs_alloc_new(const bfs_config_type *config, char *mountfile) {
 
 static void bfs_mount(bfs_type *bfs) {
     const bfs_config_type *config = bfs->config;
-    bfs->block_fs =
-        block_fs_mount(bfs->mountfile, config->block_size, config->read_only);
+    bfs->block_fs = block_fs_mount(bfs->mountfile, config->read_only);
 }
 
 static void bfs_fsync(bfs_type *bfs) { block_fs_fsync(bfs->block_fs); }

--- a/libres/lib/enkf/block_fs_driver.cpp
+++ b/libres/lib/enkf/block_fs_driver.cpp
@@ -38,7 +38,6 @@ typedef struct bfs_struct bfs_type;
 typedef struct bfs_config_struct bfs_config_type;
 
 struct bfs_config_struct {
-    int fsync_interval;
     bool read_only;
     int block_size;
 };
@@ -55,13 +54,9 @@ struct bfs_struct {
 };
 
 bfs_config_type *bfs_config_alloc(bool read_only) {
-    const int fsync_interval =
-        10; /* An fsync() call is issued for every 10'th write. */
-
     {
         bfs_config_type *config =
             (bfs_config_type *)util_malloc(sizeof *config);
-        config->fsync_interval = fsync_interval;
         config->read_only = read_only;
         config->block_size = 64;
         return config;
@@ -98,8 +93,8 @@ static bfs_type *bfs_alloc_new(const bfs_config_type *config, char *mountfile) {
 
 static void bfs_mount(bfs_type *bfs) {
     const bfs_config_type *config = bfs->config;
-    bfs->block_fs = block_fs_mount(bfs->mountfile, config->block_size,
-                                   config->fsync_interval, config->read_only);
+    bfs->block_fs =
+        block_fs_mount(bfs->mountfile, config->block_size, config->read_only);
 }
 
 static void bfs_fsync(bfs_type *bfs) { block_fs_fsync(bfs->block_fs); }

--- a/libres/lib/include/ert/res_util/block_fs.hpp
+++ b/libres/lib/include/ert/res_util/block_fs.hpp
@@ -30,8 +30,7 @@ typedef struct user_file_node_struct user_file_node_type;
 void block_fs_fsync(block_fs_type *block_fs);
 static bool block_fs_is_readonly(const block_fs_type *block_fs);
 block_fs_type *block_fs_mount(const std::filesystem::path &mount_file,
-                              int block_size, int fsync_interval,
-                              bool read_only);
+                              int block_size, bool read_only);
 void block_fs_close(block_fs_type *block_fs);
 void block_fs_fwrite_file(block_fs_type *block_fs, const char *filename,
                           const void *ptr, size_t byte_size);

--- a/libres/lib/include/ert/res_util/block_fs.hpp
+++ b/libres/lib/include/ert/res_util/block_fs.hpp
@@ -30,7 +30,7 @@ typedef struct user_file_node_struct user_file_node_type;
 void block_fs_fsync(block_fs_type *block_fs);
 static bool block_fs_is_readonly(const block_fs_type *block_fs);
 block_fs_type *block_fs_mount(const std::filesystem::path &mount_file,
-                              int block_size, bool read_only);
+                              bool read_only);
 void block_fs_close(block_fs_type *block_fs);
 void block_fs_fwrite_file(block_fs_type *block_fs, const char *filename,
                           const void *ptr, size_t byte_size);

--- a/libres/lib/res_util/block_fs.cpp
+++ b/libres/lib/res_util/block_fs.cpp
@@ -103,8 +103,6 @@ struct block_fs_struct {
 
     /** The total number of bytes in the data_file. */
     long int data_file_size;
-    /** The size of blocks in bytes. */
-    int block_size;
 
     std::mutex mutex;
 
@@ -308,11 +306,9 @@ static void block_fs_reinit(block_fs_type *block_fs) {
 }
 
 static block_fs_type *block_fs_alloc_empty(const fs::path &mount_file,
-                                           int block_size, bool read_only) {
+                                           bool read_only) {
     block_fs_type *block_fs = new block_fs_type;
     UTIL_TYPE_ID_INIT(block_fs, BLOCK_FS_TYPE_ID);
-
-    block_fs->block_size = block_size;
 
     FILE *stream = util_fopen(mount_file.c_str(), "r");
     int id = util_fread_int(stream);
@@ -547,8 +543,7 @@ static bool block_fs_is_readonly(const block_fs_type *bfs) {
         return true;
 }
 
-block_fs_type *block_fs_mount(const fs::path &mount_file, int block_size,
-                              bool read_only) {
+block_fs_type *block_fs_mount(const fs::path &mount_file, bool read_only) {
     fs::path path = mount_file.parent_path();
     std::string base_name = mount_file.stem();
     auto data_file = path / (base_name + ".data_0");
@@ -557,36 +552,29 @@ block_fs_type *block_fs_mount(const fs::path &mount_file, int block_size,
     if (!fs::exists(mount_file))
         /* This is a brand new filesystem - create the mount map first. */
         block_fs_fwrite_mount_info(mount_file);
-    {
-        std::vector<long> fix_nodes;
-        block_fs = block_fs_alloc_empty(mount_file, block_size, read_only);
+    std::vector<long> fix_nodes;
+    block_fs = block_fs_alloc_empty(mount_file, read_only);
 
-        block_fs_open_data(block_fs, data_file);
-        if (block_fs->data_stream != nullptr) {
-            std::error_code ec;
-            fs::remove(index_file, ec /* error code is ignored */);
-            block_fs_build_index(block_fs, data_file, fix_nodes);
-        }
-        block_fs_fix_nodes(block_fs, fix_nodes);
+    block_fs_open_data(block_fs, data_file);
+    if (block_fs->data_stream != nullptr) {
+        std::error_code ec;
+        fs::remove(index_file, ec /* error code is ignored */);
+        block_fs_build_index(block_fs, data_file, fix_nodes);
     }
+    block_fs_fix_nodes(block_fs, fix_nodes);
     return block_fs;
 }
 
 static file_node_type *block_fs_get_new_node(block_fs_type *block_fs,
-                                             size_t min_size) {
+                                             const char *filename,
+                                             size_t size) {
 
     long int offset;
-    int node_size;
     file_node_type *new_node;
-
-    div_t d = div(min_size, block_fs->block_size);
-    node_size = d.quot * block_fs->block_size;
-    if (d.rem)
-        node_size += block_fs->block_size;
 
     /* Must lock the total size here ... */
     offset = block_fs->data_file_size;
-    new_node = file_node_alloc(NODE_IN_USE, offset, node_size);
+    new_node = file_node_alloc(NODE_IN_USE, offset, size);
     block_fs_install_node(
         block_fs, new_node); /* <- This will update the total file size. */
 

--- a/libres/lib/res_util/block_fs.cpp
+++ b/libres/lib/res_util/block_fs.cpp
@@ -101,9 +101,6 @@ struct block_fs_struct {
     int data_fd;
     FILE *data_stream;
 
-    /** The total number of bytes in the data_file. */
-    long int data_file_size;
-
     std::mutex mutex;
 
     /** THE HASH table of all the nodes/files which have been stored. */
@@ -292,17 +289,12 @@ static void block_fs_insert_index_node(block_fs_type *block_fs,
 */
 static void block_fs_install_node(block_fs_type *block_fs,
                                   file_node_type *node) {
-    block_fs->data_file_size =
-        (block_fs->data_file_size > (node->node_offset + node->node_size))
-            ? block_fs->data_file_size
-            : node->node_offset + node->node_size;
     vector_append_owned_ref(block_fs->file_nodes, node, file_node_free__);
 }
 
 static void block_fs_reinit(block_fs_type *block_fs) {
     block_fs->index = hash_alloc();
     block_fs->file_nodes = vector_alloc_new();
-    block_fs->data_file_size = 0;
 }
 
 static block_fs_type *block_fs_alloc_empty(const fs::path &mount_file,
@@ -566,17 +558,15 @@ block_fs_type *block_fs_mount(const fs::path &mount_file, bool read_only) {
 }
 
 static file_node_type *block_fs_get_new_node(block_fs_type *block_fs,
-                                             const char *filename,
                                              size_t size) {
 
     long int offset;
     file_node_type *new_node;
 
-    /* Must lock the total size here ... */
-    offset = block_fs->data_file_size;
+    fseek__(block_fs->data_stream, 0, SEEK_END);
+    offset = ftell(block_fs->data_stream);
     new_node = file_node_alloc(NODE_IN_USE, offset, size);
-    block_fs_install_node(
-        block_fs, new_node); /* <- This will update the total file size. */
+    block_fs_install_node(block_fs, new_node);
 
     return new_node;
 }
@@ -586,18 +576,10 @@ bool block_fs_has_file(block_fs_type *block_fs, const char *filename) {
     return hash_has_key(block_fs->index, filename);
 }
 
-/**
-   It seems it is not enough to call fsync(); must also issue this
-   funny fseek + ftell combination to ensure that all data is on
-   disk after an uncontrolled shutdown.
-
-   Could possibly use fdatasync() to improve speed slightly?
-*/
 void block_fs_fsync(block_fs_type *block_fs) {
     if (!block_fs_is_readonly(block_fs)) {
         fsync(block_fs->data_fd);
-        block_fs_fseek(block_fs, block_fs->data_file_size);
-        ftell(block_fs->data_stream);
+        fseek__(block_fs->data_stream, 0, SEEK_END);
     }
 }
 

--- a/libres/tests/enkf/test_enkf_fs.cpp
+++ b/libres/tests/enkf/test_enkf_fs.cpp
@@ -56,8 +56,6 @@ TEST_CASE("enkf_fs_fwrite_misfit", "[enkf_fs]") {
 }
 
 TEST_CASE("block_fs", "[enkf_fs]") {
-    const int block_size = 64;
-
     std::vector<char> random(1000);
     {
         std::ifstream s{"/dev/urandom"};
@@ -66,7 +64,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
     GIVEN("A single read-write instance of block_fs") {
         WITH_TMPDIR;
-        auto bfs = block_fs_mount("bfs", block_size, false /* read-only */);
+        auto bfs = block_fs_mount("bfs", false /* read-only */);
 
         WHEN("data is written to storage") {
             block_fs_fwrite_file(bfs, "FOO", random.data(), random.size());
@@ -88,7 +86,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
             AND_WHEN("block_fs is closed and opened") {
                 block_fs_close(bfs);
-                bfs = block_fs_mount("bfs", block_size, true /* read-only */);
+                bfs = block_fs_mount("bfs", true /* read-only */);
 
                 THEN("writing new data results in exception") {
                     REQUIRE_THROWS_WITH(
@@ -133,7 +131,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
             AND_WHEN("block_fs is closed and opened") {
                 block_fs_close(bfs);
-                bfs = block_fs_mount("bfs", block_size, true /* read-only */);
+                bfs = block_fs_mount("bfs", true /* read-only */);
 
                 THEN("reading FOO fill return the overwritten data") {
                     auto buf = buffer_alloc(100);

--- a/libres/tests/enkf/test_enkf_fs.cpp
+++ b/libres/tests/enkf/test_enkf_fs.cpp
@@ -57,7 +57,6 @@ TEST_CASE("enkf_fs_fwrite_misfit", "[enkf_fs]") {
 
 TEST_CASE("block_fs", "[enkf_fs]") {
     const int block_size = 64;
-    const int fsync_interval = 10;
 
     std::vector<char> random(1000);
     {
@@ -67,8 +66,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
     GIVEN("A single read-write instance of block_fs") {
         WITH_TMPDIR;
-        auto bfs = block_fs_mount("bfs", block_size, fsync_interval,
-                                  false /* read-only */);
+        auto bfs = block_fs_mount("bfs", block_size, false /* read-only */);
 
         WHEN("data is written to storage") {
             block_fs_fwrite_file(bfs, "FOO", random.data(), random.size());
@@ -90,8 +88,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
             AND_WHEN("block_fs is closed and opened") {
                 block_fs_close(bfs);
-                bfs = block_fs_mount("bfs", block_size, fsync_interval,
-                                     true /* read-only */);
+                bfs = block_fs_mount("bfs", block_size, true /* read-only */);
 
                 THEN("writing new data results in exception") {
                     REQUIRE_THROWS_WITH(
@@ -136,8 +133,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
 
             AND_WHEN("block_fs is closed and opened") {
                 block_fs_close(bfs);
-                bfs = block_fs_mount("bfs", block_size, fsync_interval,
-                                     true /* read-only */);
+                bfs = block_fs_mount("bfs", block_size, true /* read-only */);
 
                 THEN("reading FOO fill return the overwritten data") {
                     auto buf = buffer_alloc(100);


### PR DESCRIPTION
Simplifies `block_fs` by removing `block_size`, `fsync_interval`, `data_file_size` and using `std::unordered_map` for the `index`. This also introduces a more cpp like struct for `file_node` named `BlockMeta`.

This PR supersedes #3333 and is built upon in #3555.  There is a lot of further refactoring one can do (renaming `file_node_*` to `block_meta` comes to mind), but these are deffered to #3555.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
