### PR TITLE
Add webviz-ert as dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         "websockets >= 9.0.1",
         "httpx",
         "tables",
+        "webviz-ert",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
**Issue**
Installing `ert` and then run the command `ert vis .... ` will fail due to `webviz-ert` not being installed. 


**Approach**
Add `webviz-ert` as dependency in setup.py

Resolves #3560 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
