### PR TITLE
Add C tests with EXCLUDE_FROM_ALL

### DIFF
--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -4,6 +4,10 @@ project(res C CXX)
 option(BUILD_TESTS "Should the tests be built" OFF)
 option(COVERAGE "Should binaries record coverage information" OFF)
 
+if(NOT BUILD_TESTS)
+  set(TESTS_EXCLUDE_FROM_ALL "EXCLUDE_FROM_ALL")
+endif()
+
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
@@ -154,6 +158,7 @@ add_subdirectory(lib)
 
 if(BUILD_TESTS)
   enable_testing()
-  add_subdirectory(old_tests)
-  add_subdirectory(tests)
 endif()
+
+add_subdirectory(old_tests)
+add_subdirectory(tests)

--- a/libres/old_tests/analysis/CMakeLists.txt
+++ b/libres/old_tests/analysis/CMakeLists.txt
@@ -1,25 +1,28 @@
 foreach(name ies_enkf_config ies_enkf_data)
-  add_executable(${name} ies/test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} ies/test_${name}.cpp)
   target_link_libraries(${name} res)
   add_test(NAME ${name} COMMAND ${name})
 endforeach()
 
-add_executable(ies_module ies/test_ies_enkf_module.cpp)
+add_executable(ies_module ${TESTS_EXCLUDE_FROM_ALL}
+                          ies/test_ies_enkf_module.cpp)
 target_link_libraries(ies_module res)
 add_test(NAME ies_module COMMAND ies_module
                                  "${TEST_DATA_DIR}/analysis/ies/poly")
 
-add_executable(ies_linalg ies/test_ies_linalg.cpp)
+add_executable(ies_linalg ${TESTS_EXCLUDE_FROM_ALL} ies/test_ies_linalg.cpp)
 target_link_libraries(ies_linalg res)
 add_test(NAME ies_linalg COMMAND ies_linalg
                                  "${TEST_DATA_DIR}/analysis/ies/poly")
 
-add_executable(ies_std_compare ies/test_ies_std_compare.cpp)
+add_executable(ies_std_compare ${TESTS_EXCLUDE_FROM_ALL}
+                               ies/test_ies_std_compare.cpp)
 target_link_libraries(ies_std_compare res)
 add_test(NAME ies_std_compare COMMAND ies_std_compare
                                       "${TEST_DATA_DIR}/analysis/ies/poly")
 
-add_executable(ies_iteration ies/test_ies_iteration.cpp)
+add_executable(ies_iteration ${TESTS_EXCLUDE_FROM_ALL}
+                             ies/test_ies_iteration.cpp)
 target_link_libraries(ies_iteration res)
 add_test(NAME ies_iteration COMMAND ies_iteration
                                     "${TEST_DATA_DIR}/analysis/ies/poly_normal")

--- a/libres/old_tests/config/CMakeLists.txt
+++ b/libres/old_tests/config/CMakeLists.txt
@@ -5,7 +5,7 @@ endmacro()
 foreach(name config_content_node config_path_elm config_error config_content
              config_config config_schema_item)
 
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
   add_test(NAME ${name} COMMAND ${name})
 endforeach()
@@ -22,7 +22,7 @@ foreach(
   config_define
   config_argc)
 
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
 endforeach()
 

--- a/libres/old_tests/enkf/CMakeLists.txt
+++ b/libres/old_tests/enkf/CMakeLists.txt
@@ -51,13 +51,14 @@ foreach(
   rng_manager
   trans_func
   value_export)
-  add_executable(${test} test_${test}.cpp)
+  add_executable(${test} ${TESTS_EXCLUDE_FROM_ALL} test_${test}.cpp)
   target_link_libraries(${test} res)
   add_test(NAME ${test} COMMAND ${test})
 endforeach()
 
 # rng_config test is unique in that it requires mocking of logs
-add_executable(rng_config test_rng_config.cpp ../../tests/logging.cpp)
+add_executable(rng_config ${TESTS_EXCLUDE_FROM_ALL} test_rng_config.cpp
+                          ../../tests/logging.cpp)
 target_link_libraries(rng_config res)
 add_test(NAME rng_config COMMAND rng_config)
 
@@ -78,7 +79,7 @@ foreach(
   enkf_ensemble_GEN_PARAM
   gen_kw)
 
-  add_executable(${test} test_${test}.cpp)
+  add_executable(${test} ${TESTS_EXCLUDE_FROM_ALL} test_${test}.cpp)
   target_link_libraries(${test} res)
 endforeach()
 
@@ -144,7 +145,7 @@ foreach(
   enkf_time_map
   enkf_main_fs)
 
-  add_executable(${test} test_${test}.cpp)
+  add_executable(${test} ${TESTS_EXCLUDE_FROM_ALL} test_${test}.cpp)
   target_link_libraries(${test} res)
 endforeach()
 

--- a/libres/old_tests/job_queue/CMakeLists.txt
+++ b/libres/old_tests/job_queue/CMakeLists.txt
@@ -23,13 +23,13 @@ foreach(
   job_mock_slurm
   job_torque)
 
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
   add_test(NAME ${name} COMMAND ${name})
 endforeach()
 
 foreach(name job_slurm_submit job_slurm_runtest)
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
   if(SBATCH)
     add_test(NAME ${name} COMMAND ${name})
@@ -48,12 +48,12 @@ foreach(
   create_file
   job_loadFail)
 
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
 endforeach()
 
 if(NOT APPLE)
-  add_executable(job_list test_job_list.cpp)
+  add_executable(job_list ${TESTS_EXCLUDE_FROM_ALL} test_job_list.cpp)
   target_link_libraries(job_list res)
 
   add_test(NAME job_list COMMAND $<TARGET_FILE:job_list>)

--- a/libres/old_tests/res_util/CMakeLists.txt
+++ b/libres/old_tests/res_util/CMakeLists.txt
@@ -3,7 +3,7 @@ find_library(VALGRIND NAMES valgr)
 foreach(name es_testdata ert_util_subst_list
              ert_util_subst_list_add_from_string res_util_PATH)
 
-  add_executable(${name} test_${name}.cpp)
+  add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} res)
   add_test(NAME ${name} COMMAND ${name})
 endforeach()

--- a/libres/old_tests/rms/CMakeLists.txt
+++ b/libres/old_tests/rms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(rms_file_test test_rms_file.cpp)
+add_executable(rms_file_test ${TESTS_EXCLUDE_FROM_ALL} test_rms_file.cpp)
 target_link_libraries(rms_file_test res)
 
 if(NOT EXISTS "${EQUINOR_TEST_DATA_DIR}")

--- a/libres/old_tests/sched/CMakeLists.txt
+++ b/libres/old_tests/sched/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_executable(sched_history_summary test_sched_history_summary.cpp)
+add_executable(sched_history_summary ${TESTS_EXCLUDE_FROM_ALL}
+                                     test_sched_history_summary.cpp)
 target_link_libraries(sched_history_summary res)
 
 if(NOT EXISTS "${EQUINOR_TEST_DATA_DIR}")

--- a/libres/tests/CMakeLists.txt
+++ b/libres/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(Catch)
 
 add_executable(
   ert_test_suite
+  ${TESTS_EXCLUDE_FROM_ALL}
   tmpdir.cpp
   analysis/ies/test_ies_enkf_main.cpp
   analysis/test_enkf_linalg.cpp


### PR DESCRIPTION
When configuring CMake with `BUILD_TESTS=OFF`, just exclude the tests.
This allows `compile_commands.json` to have the correct lines while
avoiding the compilation times that tests bring.