### PR TITLE
Use standard Qt APIs in GUI proxy models

### DIFF
--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Any, List, Optional
 
 from qtpy.QtCore import (
     QAbstractItemModel,
@@ -25,7 +25,7 @@ from ert.gui.model.snapshot import (
 class JobListProxyModel(QAbstractProxyModel):
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        parent: typing.Optional[QObject],
+        parent: Optional[QObject],
         iter_: int,
         real: int,
         stage: int,
@@ -40,7 +40,7 @@ class JobListProxyModel(QAbstractProxyModel):
     step_changed = Signal(int, int, int, int)
 
     @Slot(int, int, int, int)
-    def set_step(self, iter_, real, stage, step):
+    def set_step(self, iter_: int, real: int, stage: int, step: int):
         self._disconnect()
         self.modelAboutToBeReset.emit()
         self._iter = iter_
@@ -52,20 +52,20 @@ class JobListProxyModel(QAbstractProxyModel):
         self.step_changed.emit(iter_, real, stage, step)
 
     def _disconnect(self):
-        sm = self.sourceModel()
-        if sm is None:
+        source_model = self.sourceModel()
+        if source_model is None:
             return
-        sm.dataChanged.disconnect(self._source_data_changed)
-        sm.modelAboutToBeReset.disconnect(self.modelAboutToBeReset)
-        sm.modelReset.disconnect(self.modelReset)
+        source_model.dataChanged.disconnect(self._source_data_changed)
+        source_model.modelAboutToBeReset.disconnect(self.modelAboutToBeReset)
+        source_model.modelReset.disconnect(self.modelReset)
 
     def _connect(self):
-        sm = self.sourceModel()
-        if sm is None:
+        source_model = self.sourceModel()
+        if source_model is None:
             return
-        sm.dataChanged.connect(self._source_data_changed)
-        sm.modelAboutToBeReset.connect(self.modelAboutToBeReset)
-        sm.modelReset.connect(self.modelReset)
+        source_model.dataChanged.connect(self._source_data_changed)
+        source_model.modelAboutToBeReset.connect(self.modelAboutToBeReset)
+        source_model.modelReset.connect(self.modelReset)
 
     def _get_source_parent_index(self) -> QModelIndex:
         start = self.index(0, 0, QModelIndex())
@@ -76,6 +76,7 @@ class JobListProxyModel(QAbstractProxyModel):
         source_parent = self.mapToSource(start).parent()
         return source_parent
 
+    # pylint: disable=invalid-name
     def setSourceModel(self, sourceModel: QAbstractItemModel) -> None:
         if not sourceModel:
             raise ValueError("need source model")
@@ -85,9 +86,10 @@ class JobListProxyModel(QAbstractProxyModel):
         self._connect()
         self.endResetModel()
 
+    # pylint: disable=invalid-name, no-self-use
     def headerData(
-        self, section: int, orientation: Qt.Orientation, role: int
-    ) -> typing.Any:
+        self, section: int, orientation: Qt.Orientation, role: Qt.UserRole
+    ) -> Any:
         if role != Qt.DisplayRole:
             return QVariant()
         if orientation == Qt.Horizontal:
@@ -96,7 +98,10 @@ class JobListProxyModel(QAbstractProxyModel):
             return section
         return QVariant()
 
-    def columnCount(self, parent=QModelIndex()) -> int:
+    # pylint: disable=invalid-name
+    def columnCount(self, parent=None) -> int:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return 0
         source_index = self._get_source_parent_index()
@@ -104,7 +109,9 @@ class JobListProxyModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().columnCount(source_index)
 
-    def rowCount(self, parent=QModelIndex()) -> int:
+    def rowCount(self, parent=None) -> int:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return 0
         source_index = self._get_source_parent_index()
@@ -112,32 +119,39 @@ class JobListProxyModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().rowCount(source_index)
 
-    def parent(self, index: QModelIndex):
+    # pylint: disable=no-self-use
+    def parent(self, _index: QModelIndex):
         return QModelIndex()
 
-    def index(self, row: int, column: int, parent=QModelIndex()) -> QModelIndex:
+    def index(self, row: int, column: int, parent=None) -> QModelIndex:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return QModelIndex()
         job_index = self.mapToSource(self.createIndex(row, column, parent))
         ret_index = self.createIndex(row, column, job_index.data(NodeRole))
         return ret_index
 
+    # pylint: disable=invalid-name
     def mapToSource(self, proxyIndex: QModelIndex) -> QModelIndex:
         if not proxyIndex.isValid():
             return QModelIndex()
-        sm = self.sourceModel()
-        iter_index = sm.index(self._iter, 0, QModelIndex())
-        if not iter_index.isValid() or not sm.hasChildren(iter_index):
+        source_model = self.sourceModel()
+        iter_index = source_model.index(self._iter, 0, QModelIndex())
+        if not iter_index.isValid() or not source_model.hasChildren(iter_index):
             return QModelIndex()
-        real_index = sm.index(self._real, 0, iter_index)
-        if not real_index.isValid() or not sm.hasChildren(real_index):
+        real_index = source_model.index(self._real, 0, iter_index)
+        if not real_index.isValid() or not source_model.hasChildren(real_index):
             return QModelIndex()
-        step_index = sm.index(self._step, 0, real_index)
-        if not step_index.isValid() or not sm.hasChildren(step_index):
+        step_index = source_model.index(self._step, 0, real_index)
+        if not step_index.isValid() or not source_model.hasChildren(step_index):
             return QModelIndex()
-        job_index = sm.index(proxyIndex.row(), proxyIndex.column(), step_index)
+        job_index = source_model.index(
+            proxyIndex.row(), proxyIndex.column(), step_index
+        )
         return job_index
 
+    # pylint: disable=invalid-name
     def mapFromSource(self, sourceIndex: QModelIndex) -> QModelIndex:
         if not sourceIndex.isValid():
             return QModelIndex()
@@ -146,7 +160,7 @@ class JobListProxyModel(QAbstractProxyModel):
         return self.index(sourceIndex.row(), sourceIndex.column(), QModelIndex())
 
     def _source_data_changed(
-        self, top_left: QModelIndex, bottom_right: QModelIndex, roles: typing.List[int]
+        self, top_left: QModelIndex, bottom_right: QModelIndex, roles: List[int]
     ):
         if not self._accept_index(top_left):
             return
@@ -156,6 +170,7 @@ class JobListProxyModel(QAbstractProxyModel):
             return
         self.dataChanged.emit(proxy_top_left, proxy_bottom_right, roles)
 
+    # pylint: disable=too-many-boolean-expressions
     def _accept_index(self, index: QModelIndex) -> bool:
         if index.internalPointer() is None:
             return False
@@ -167,11 +182,11 @@ class JobListProxyModel(QAbstractProxyModel):
         # traverse upwards and check step, real and iter against parents of
         # this index.
         while index.isValid() and index.internalPointer() is not None:
-            if index.data(IsStepRole) and index.row() != self._step:
-                return False
-            elif index.data(IsRealizationRole) and index.row() != self._real:
-                return False
-            elif index.data(IsEnsembleRole) and index.row() != self._iter:
+            if (
+                (index.data(IsStepRole) and (index.row() != self._step))
+                or (index.data(IsRealizationRole) and (index.row() != self._real))
+                or (index.data(IsEnsembleRole) and (index.row() != self._iter))
+            ):
                 return False
             index = index.parent()
         return True

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -27,34 +27,40 @@ class RealListModel(QAbstractProxyModel):
     iter_changed = Signal(int)
 
     @Slot(int)
-    def setIter(self, iter_):
+    # pylint: disable=invalid-name
+    def setIter(self, iter_: int):
         self._disconnect()
         self.modelAboutToBeReset.emit()
-        self._iter = iter_
+        self._iter: int = iter_
         self.modelReset.emit()
         self._connect()
         self.iter_changed.emit(iter_)
 
     def _disconnect(self):
-        sm = self.sourceModel()
-        if sm is None:
+        source_model = self.sourceModel()
+        if source_model is None:
             return
-        sm.dataChanged.disconnect(self._source_data_changed)
-        sm.rowsAboutToBeInserted.disconnect(self._source_rows_about_to_be_inserted)
-        sm.rowsInserted.disconnect(self._source_rows_inserted)
-        sm.modelAboutToBeReset.disconnect(self.modelAboutToBeReset)
-        sm.modelReset.disconnect(self.modelReset)
+        source_model.dataChanged.disconnect(self._source_data_changed)
+        source_model.rowsAboutToBeInserted.disconnect(
+            self._source_rows_about_to_be_inserted
+        )
+        source_model.rowsInserted.disconnect(self._source_rows_inserted)
+        source_model.modelAboutToBeReset.disconnect(self.modelAboutToBeReset)
+        source_model.modelReset.disconnect(self.modelReset)
 
     def _connect(self):
-        sm = self.sourceModel()
-        if sm is None:
+        source_model = self.sourceModel()
+        if source_model is None:
             return
-        sm.dataChanged.connect(self._source_data_changed)
-        sm.rowsAboutToBeInserted.connect(self._source_rows_about_to_be_inserted)
-        sm.rowsInserted.connect(self._source_rows_inserted)
-        sm.modelAboutToBeReset.connect(self.modelAboutToBeReset)
-        sm.modelReset.connect(self.modelReset)
+        source_model.dataChanged.connect(self._source_data_changed)
+        source_model.rowsAboutToBeInserted.connect(
+            self._source_rows_about_to_be_inserted
+        )
+        source_model.rowsInserted.connect(self._source_rows_inserted)
+        source_model.modelAboutToBeReset.connect(self.modelAboutToBeReset)
+        source_model.modelReset.connect(self.modelReset)
 
+    # pylint: disable=invalid-name
     def setSourceModel(self, sourceModel: QAbstractItemModel) -> None:
         if not sourceModel:
             raise ValueError("need source model")
@@ -64,7 +70,10 @@ class RealListModel(QAbstractProxyModel):
         self._connect()
         self.endResetModel()
 
-    def columnCount(self, parent=QModelIndex()) -> int:
+    # pylint: disable=invalid-name
+    def columnCount(self, parent: QModelIndex = None) -> int:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return 0
         iter_index = self.sourceModel().index(self._iter, 0, QModelIndex())
@@ -72,7 +81,10 @@ class RealListModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().columnCount(iter_index)
 
-    def rowCount(self, parent=QModelIndex()) -> int:
+    # pylint: disable=invalid-name
+    def rowCount(self, parent: QModelIndex = None) -> int:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return 0
         iter_index = self.sourceModel().index(self._iter, 0, QModelIndex())
@@ -80,16 +92,20 @@ class RealListModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().rowCount(iter_index)
 
-    def parent(self, index: QModelIndex):
+    # pylint: disable=no-self-use
+    def parent(self, _index: QModelIndex):
         return QModelIndex()
 
-    def index(self, row: int, column: int, parent=QModelIndex()) -> QModelIndex:
+    def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return QModelIndex()
         real_index = self.mapToSource(self.createIndex(row, 0, parent))
         ret_index = self.createIndex(row, column, real_index.data(NodeRole))
         return ret_index
 
+    # pylint: disable=invalid-name
     def hasChildren(self, parent: QModelIndex) -> bool:
         # Reimplemented, since in the source model, the realizations have
         # children (i.e. valid indices.). Realizations do not have children in
@@ -98,6 +114,7 @@ class RealListModel(QAbstractProxyModel):
             return False
         return self.sourceModel().hasChildren(self.mapToSource(parent))
 
+    # pylint: disable=invalid-name
     def mapToSource(self, proxyIndex: QModelIndex) -> QModelIndex:
         if not proxyIndex.isValid():
             return QModelIndex()
@@ -108,6 +125,7 @@ class RealListModel(QAbstractProxyModel):
         real_index = sm.index(proxyIndex.row(), proxyIndex.column(), iter_index)
         return real_index
 
+    # pylint: disable=invalid-name
     def mapFromSource(self, sourceIndex: QModelIndex) -> QModelIndex:
         if not sourceIndex.isValid():
             return QModelIndex()
@@ -140,7 +158,7 @@ class RealListModel(QAbstractProxyModel):
             return
         self.beginInsertRows(self.mapFromSource(parent), start, end)
 
-    def _source_rows_inserted(self, parent: QModelIndex, start: int, end: int):
+    def _source_rows_inserted(self, parent: QModelIndex, _start: int, _end: int):
         if not parent.isValid():
             return
         if not self._accept_index(parent):

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -24,6 +24,13 @@ ProgressRole = Qt.UserRole + 5
 FileRole = Qt.UserRole + 6
 RealIens = Qt.UserRole + 7
 
+# Indicates what type the underlying data is
+IsEnsembleRole = Qt.UserRole + 8
+IsRealizationRole = Qt.UserRole + 9
+IsStepRole = Qt.UserRole + 10
+IsJobRole = Qt.UserRole + 11
+StatusRole = Qt.UserRole + 12
+
 STEP_COLUMN_NAME = "Name"
 STEP_COLUMN_ERROR = "Error"
 STEP_COLUMN_STATUS = "Status"
@@ -357,6 +364,15 @@ class SnapshotModel(QAbstractItemModel):
         if role == NodeRole:
             return node
 
+        if role == IsEnsembleRole:
+            return node.type == NodeType.ITER
+        if role == IsRealizationRole:
+            return node.type == NodeType.REAL
+        if role == IsStepRole:
+            return node.type == NodeType.STEP
+        if role == IsJobRole:
+            return node.type == NodeType.JOB
+
         if node.type == NodeType.JOB:
             return self._job_data(index, node, role)
         elif node.type == NodeType.REAL:
@@ -396,6 +412,8 @@ class SnapshotModel(QAbstractItemModel):
             return node.id
         elif role == RealStatusColorHint:
             return node.data[REAL_STATUS_COLOR]
+        elif role == StatusRole:
+            return node.data[ids.STATUS]
         else:
             return QVariant()
 

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -317,13 +317,19 @@ class SnapshotModel(QAbstractItemModel):
         self.root.add_child(snapshot_tree, node_id=iter_)
         self.rowsInserted.emit(parent, snapshot_tree.row(), snapshot_tree.row())
 
-    def columnCount(self, parent=QModelIndex()):
+    # pylint: disable=invalid-name, no-self-use
+    def columnCount(self, parent: QModelIndex = None):
+        if parent is None:
+            parent = QModelIndex()
         parent_node = parent.internalPointer()
         if parent_node is None:
             return len(COLUMNS[NodeType.ROOT])
         return len(COLUMNS[parent_node.type])
 
-    def rowCount(self, parent=QModelIndex()):
+    # pylint: disable=invalid-name
+    def rowCount(self, parent: QModelIndex = None):
+        if parent is None:
+            parent = QModelIndex()
         if not parent.isValid():
             parentItem = self.root
         else:
@@ -375,7 +381,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if node.type == NodeType.JOB:
             return self._job_data(index, node, role)
-        elif node.type == NodeType.REAL:
+        if node.type == NodeType.REAL:
             return self._real_data(index, node, role)
 
         if role == Qt.DisplayRole:
@@ -398,7 +404,7 @@ class SnapshotModel(QAbstractItemModel):
 
         return QVariant()
 
-    def _real_data(self, index: QModelIndex, node: Node, role: int):
+    def _real_data(self, _index: QModelIndex, node: Node, role: int):
         if role == RealJobColorHint:
             colors: List[QColor] = []
             assert node.parent  # mypy
@@ -406,18 +412,17 @@ class SnapshotModel(QAbstractItemModel):
                 for job_id in node.parent.data[SORTED_JOB_IDS][node.id][step_id]:
                     colors.append(node.data[REAL_JOB_STATUS_AGGREGATED][job_id])
             return colors
-        elif role == RealLabelHint:
+        if role == RealLabelHint:
             return node.id
-        elif role == RealIens:
+        if role == RealIens:
             return node.id
-        elif role == RealStatusColorHint:
+        if role == RealStatusColorHint:
             return node.data[REAL_STATUS_COLOR]
-        elif role == StatusRole:
+        if role == StatusRole:
             return node.data[ids.STATUS]
-        else:
-            return QVariant()
+        return QVariant()
 
-    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-return-statements, no-self-use
     def _job_data(self, index: QModelIndex, node: Node, role: int):
         if role == Qt.BackgroundRole:
             assert node.parent  # mypy
@@ -467,22 +472,24 @@ class SnapshotModel(QAbstractItemModel):
 
         return QVariant()
 
-    def index(self, row: int, column: int, parent=QModelIndex()) -> QModelIndex:
+    def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:
+        if parent is None:
+            parent = QModelIndex()
         if not self.hasIndex(row, column, parent):
             return QModelIndex()
 
         if not parent.isValid():
-            parentItem = self.root
+            parent_item = self.root
         else:
-            parentItem = parent.internalPointer()
+            parent_item = parent.internalPointer()
 
-        childItem = None
+        child_item = None
         try:
-            childItem = list(parentItem.children.values())[row]
+            child_item = list(parent_item.children.values())[row]
         except KeyError:
             return QModelIndex()
         else:
-            return self.createIndex(row, column, childItem)
+            return self.createIndex(row, column, child_item)
 
     def reset(self):
         self.modelAboutToBeReset.emit()


### PR DESCRIPTION
**Approach**
This refactors out any direct access from a GUI proxy model to the
underlying data in the GUI snapshot model, by the introduction of new
data roles in the snapshot model, and then using those roles in the
proxy models fixing #3613.

**Issue**
Resolves #3613

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
