### PR TITLE
Add erronously removed deactivate_realization

### DIFF
--- a/ert_shared/models/base_run_model.py
+++ b/ert_shared/models/base_run_model.py
@@ -315,6 +315,13 @@ class BaseRunModel:
             ee_id=str(uuid.uuid1()).split("-", maxsplit=1)[0],
         ).run_and_get_successful_realizations()
 
+        self.deactivate_failed_jobs(run_context)
+
+        run_context.get_sim_fs().fsync()
+        return totalOk
+
+    @staticmethod
+    def deactivate_failed_jobs(run_context: ErtRunContext) -> None:
         for iens, run_arg in enumerate(run_context):
             if run_context.is_active(iens):
                 if run_arg.run_status in (
@@ -322,9 +329,6 @@ class BaseRunModel:
                     RunStatusType.JOB_RUN_FAILURE,
                 ):
                     run_context.deactivate_realization(iens)
-
-        run_context.get_sim_fs().fsync()
-        return totalOk
 
     async def _evaluate(
         self, run_context: ErtRunContext, ee_config: EvaluatorServerConfig

--- a/res/enkf/ert_run_context.py
+++ b/res/enkf/ert_run_context.py
@@ -191,3 +191,6 @@ class ErtRunContext(BaseCClass):
 
     def get_step(self):
         return self._get_step()
+
+    def deactivate_realization(self, realization_nr):
+        self._deactivate_realization(realization_nr)


### PR DESCRIPTION
**Issue**
Fixes an error caused by #3583 

**Approach**
The `deactivate_realization` function was erronously removed in #3583. Now added back in.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
