### PR TITLE
Protobuf job_runner.reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ src/ert/shared/version.py
 /_skbuild
 .libs
 /compile_commands.json
+*_pb2.py

--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -17,6 +17,9 @@ ignore_errors = True
 [mypy-ert.data.*]
 ignore_errors = True
 
+[mypy-ert.experiment_server._schema_pb2]
+ignore_errors = True
+
 [mypy-cloudpickle.*]
 ignore_missing_imports = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -90,6 +90,9 @@ ignore_errors = True
 ignore_missing_imports = False
 ignore_errors = False
 
+[mypy-ert.experiment_server._schema_pb2]
+ignore_errors = True
+
 [mypy-cwrap.*]
 ignore_missing_imports = True
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -14,7 +14,7 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=.+_pb2\.py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ directory must be removed in order for compilation to succeed.
 The C library files get installed into `res/.libs`, which is where the
 `res` module will look for them.
 
+### Compiling protocol buffers
+
+Use the following command to (re)compile protocol buffers manually:
+```shell
+python setup.py compile_protocol_buffers
+```
 
 ## Example usage
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ cmake-format
 decorator
 ecl_data_io
 flake8>=4.0.0
+grpcio-tools
 jsonpath_ng
 jupytext
 oil_reservoir_synthesizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ requires = [
     "ninja",
     "ecl",
     "conan",
-    "pybind11>=2.8.1"  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
+    "pybind11>=2.8.1",  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
+    "grpcio-tools",
 ]
+
 
 [tool.pytest.ini_options]
 addopts = "-ra --strict-markers"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,7 @@ test = pytest
 per-file-ignores =
      # long redefinition of signatures prevents per-line ignores, so ignore E501 (line-too-long) for the entire file
      src/ert/experiment_server/_server.py: E501
+     # Ignore all protobuf v2 files
+    *_pb2.py: E
 ignore = F401,E711,W503,E203
 max-line-length = 88

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -617,12 +617,13 @@ class JobQueue(BaseCClass):
         old_state, new_state = self._differ.transition(self.job_list)
         return self._differ.diff_states(old_state, new_state)
 
-    def add_ensemble_evaluator_information_to_jobs_file(
+    def add_dispatch_information_to_jobs_file(
         self,
         ee_id: str,
         dispatch_url: str,
         cert: Optional[Union[str, bytes]],
         token: Optional[str],
+        experiment_id: Optional[str] = None,
     ) -> None:
         for q_index, q_node in enumerate(self.job_list):
             if cert is not None:
@@ -638,6 +639,7 @@ class JobQueue(BaseCClass):
                 data["dispatch_url"] = dispatch_url
                 data["ee_token"] = token
                 data["ee_cert_path"] = cert_path if cert is not None else None
+                data["experiment_id"] = experiment_id
 
                 jobs_file.seek(0)
                 jobs_file.truncate()

--- a/src/ert/ensemble_evaluator/builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/builder/_legacy.py
@@ -213,16 +213,16 @@ class _LegacyEnsemble(_Ensemble):
 
             # Tell queue to pass info to the jobs-file
             # NOTE: This touches files on disk...
-            self._job_queue.add_ensemble_evaluator_information_to_jobs_file(
-                self._ee_id,
-                self._config.dispatch_uri,
-                self._config.cert,
-                self._config.token,
-            )
-
-            # Finally, run the queue-loop until it finishes or raises
             sema = threading.BoundedSemaphore(value=CONCURRENT_INTERNALIZATION)
-            if output_bus:
+            if output_bus:  # when running experiment server
+                self._job_queue.add_dispatch_information_to_jobs_file(
+                    ee_id=self._ee_id,
+                    dispatch_url=self._config.dispatch_uri,
+                    cert=self._config.cert,
+                    token=self._config.token,
+                    experiment_id=self._ee_id,
+                )
+                # Finally, run the queue-loop until it finishes or raises
                 await self._job_queue.execute_queue_comms_via_bus(
                     ee_id=self._ee_id,
                     pool_sema=sema,
@@ -230,6 +230,13 @@ class _LegacyEnsemble(_Ensemble):
                     output_bus=output_bus,
                 )
             else:
+                self._job_queue.add_dispatch_information_to_jobs_file(
+                    ee_id=self._ee_id,
+                    dispatch_url=self._config.dispatch_uri,
+                    cert=self._config.cert,
+                    token=self._config.token,
+                )
+                # Finally, run the queue-loop until it finishes or raises
                 await self._job_queue.execute_queue_via_websockets(
                     self._config.dispatch_uri,
                     self._ee_id,

--- a/src/ert/experiment_server/_schema.proto
+++ b/src/ert/experiment_server/_schema.proto
@@ -1,0 +1,98 @@
+syntax = "proto2";  // using proto2 to specify default-values
+       // could do proto3 but then our code gets more responsibility
+       // consider stronger support for json in proto3
+
+package experimentserver;
+import "google/protobuf/timestamp.proto";
+
+enum Status {
+    UNKNOWN   = 0;
+    STARTING  = 1;
+    RUNNING   = 2;
+    DONE      = 3;
+    FAILED    = 4;
+    CANCELLED = 5;
+}
+
+enum JobStatus {
+    JOB_START = 0;
+    JOB_RUNNING = 1;
+    JOB_SUCCESS = 2;
+    JOB_FAILURE = 3;
+}
+
+
+message DispatcherMessage {
+	oneof object {
+		Experiment experiment   = 1;
+		Ensemble ensemble       = 2;
+		Realization realization = 3;
+		Step step               = 4;
+		Job job                 = 5;
+	}
+}
+
+message ExperimentId {
+  required string id = 1 [default = "experiment"];
+}
+message EnsembleId {
+  required ExperimentId experiment = 1;
+  required string id         = 2 [default = "ensemble"];  // an ensemble is identified by a string, not index
+}
+message RealizationId {
+  required EnsembleId ensemble = 1;
+  required uint64 realization  = 2 [default = 0];
+}
+message StepId {
+  required RealizationId realization = 1;
+  required uint64 step               = 2 [default = 0]; // replace with string?
+}
+message JobId {
+  required StepId step  = 1;
+  required uint64 index = 2 [default = 0];
+}
+
+message Experiment {
+  required ExperimentId id   = 1; // NOTE: in the message the id is optional since it often will be streamed
+  optional Status status   = 2 [default = UNKNOWN];
+
+  map<string, Ensemble> ensembles= 101;
+}
+message Ensemble {
+  required EnsembleId id   = 1;
+  optional Status status   = 2 [default = UNKNOWN];
+
+  map<uint64, Realization> realizations= 101;
+}
+message Realization {
+  required RealizationId id= 1;
+  optional Status status   = 2 [default = UNKNOWN];
+  optional bool active     = 3 [default = true];  // not derived - active/inactive by user or algorithm
+  optional double start_time      = 4;  // can be derived from step-list
+  optional double end_time        = 5;  // can be derived from step-list
+
+  map<uint64, Step> steps= 101;
+}
+message Step {
+  required StepId id         = 1;
+  optional Status status   = 2 [default = UNKNOWN];
+  optional double start_time = 3;  // can be derived from job-list
+  optional double end_time   = 4;  // can be derived from job-list
+
+  map<uint64, Job> jobs = 101;
+}
+message Job {
+  required JobId id                             = 1;
+  optional JobStatus status                     = 2 [default = JOB_START];
+  optional google.protobuf.Timestamp start_time = 3;
+  optional google.protobuf.Timestamp end_time   = 4;
+  optional string name                          = 6;
+  optional string error                         = 7;
+  optional string stdout                        = 8;
+  optional string stderr                        = 9;
+
+  optional uint64 current_memory = 10;
+  optional uint64 max_memory     = 11;
+  optional int32 exit_code       = 12;
+}
+

--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -66,6 +66,10 @@ class ExperimentServer:
         websocket is a https://websockets.readthedocs.io/en/stable/reference/server.html#websockets.server.WebSocketServerProtocol  # pylint: disable=line-too-long
         """
         async for msg in websocket:
+            if isinstance(msg, bytes):
+                # TODO handle protobuf messages; update statemachine
+                event_logger.debug("handle_dispatch pbuf: %s", msg)
+                continue
             try:
                 event = from_json(msg, data_unmarshaller=evaluator_unmarshaller)
             except DataUnmarshallerError:

--- a/src/ert/job_runner/reporting/__init__.py
+++ b/src/ert/job_runner/reporting/__init__.py
@@ -2,6 +2,7 @@
 The reporting package provides classes for reporting the results of forward
 model jobs.
 """
+from .protobuf import Protobuf
 from .event import Event
 from .file import File
 from .interactive import Interactive
@@ -12,4 +13,5 @@ __all__ = [
     "Interactive",
     "Reporter",
     "Event",
+    "Protobuf",
 ]

--- a/src/ert/job_runner/reporting/event.py
+++ b/src/ert/job_runner/reporting/event.py
@@ -17,6 +17,7 @@ from ert.job_runner.reporting.message import (
 )
 from ert.job_runner.reporting.base import Reporter
 from ert.shared.ensemble_evaluator.client import Client
+from ert.job_runner.reporting.statemachine import StateMachine
 
 _FM_JOB_START = "com.equinor.ert.forward_model_job.start"
 _FM_JOB_RUNNING = "com.equinor.ert.forward_model_job.running"
@@ -30,10 +31,6 @@ _JOB_SOURCE = "source"
 logger = logging.getLogger(__name__)
 
 
-class TransitionError(ValueError):
-    pass
-
-
 class Event(Reporter):
     # pylint: disable=too-many-instance-attributes
     def __init__(self, evaluator_url, token=None, cert_path=None):
@@ -45,13 +42,16 @@ class Event(Reporter):
         else:
             self._cert = None
 
-        self._state = None
+        self._statemachine = StateMachine()
+        self._statemachine.add_handler((Init,), self._init_handler)
+        self._statemachine.add_handler((Start, Running, Exited), self._job_handler)
+        self._statemachine.add_handler((Finish,), self._finished_handler)
+
         self._ee_id = None
         self._real_id = None
         self._step_id = None
         self._event_queue = queue.Queue()
         self._event_publisher_thread = threading.Thread(target=self._publish_event)
-        self._initialize_state_machine()
 
     def _publish_event(self):
         logger.debug("Publishing event.")
@@ -62,42 +62,8 @@ class Event(Reporter):
                     return
                 client.send(to_json(event).decode())
 
-    def _initialize_state_machine(self):
-        logger.debug("Initializing state machines")
-        initialized = (Init,)
-        jobs = (Start, Running, Exited)
-        finished = (Finish,)
-        self._states: dict = {
-            initialized: self._init_handler,
-            jobs: self._job_handler,
-            finished: self._finished_handler,
-        }
-        self._transitions = {
-            None: initialized,
-            initialized: jobs + finished,
-            jobs: jobs + finished,
-        }
-        self._state = None
-
     def report(self, msg):
-        new_state = None
-        for state in self._states:
-            if isinstance(msg, state):
-                new_state = state
-
-        if self._state not in self._transitions or not isinstance(
-            msg, self._transitions[self._state]
-        ):
-            logger.error(
-                f"{msg} illegal state transition: {self._state} -> {new_state}"
-            )
-            raise TransitionError(
-                f"Illegal transition {self._state} -> {new_state} for {msg}, "
-                f"expected to transition into {self._transitions[self._state]}"
-            )
-
-        self._states[new_state](msg)
-        self._state = new_state
+        self._statemachine.transition(msg)
 
     def _dump_event(self, attributes: Dict[str, str], data: Any = None):
         if data is None and _CONTENT_TYPE in attributes:

--- a/src/ert/job_runner/reporting/message.py
+++ b/src/ert/job_runner/reporting/message.py
@@ -43,11 +43,21 @@ class Message(metaclass=_MetaMessage):
 
 
 class Init(Message):
-    def __init__(self, jobs, run_id, ert_pid, ee_id=None, real_id=None, step_id=None):
+    def __init__(
+        self,
+        jobs,
+        run_id,
+        ert_pid,
+        ee_id=None,
+        real_id=None,
+        step_id=None,
+        experiment_id=None,
+    ):
         super().__init__()
         self.jobs = jobs
         self.run_id = run_id
         self.ert_pid = ert_pid
+        self.experiment_id = experiment_id
         self.ee_id = ee_id
         self.real_id = real_id
         self.step_id = step_id

--- a/src/ert/job_runner/reporting/protobuf.py
+++ b/src/ert/job_runner/reporting/protobuf.py
@@ -1,0 +1,138 @@
+import logging
+import queue
+import threading
+from pathlib import Path
+from typing import Union
+
+from ert.experiment_server._schema_pb2 import (
+    DispatcherMessage,
+    EnsembleId,
+    ExperimentId,
+    Job,
+    JobId,
+    RealizationId,
+    StepId,
+    JOB_START,
+    JOB_RUNNING,
+    JOB_FAILURE,
+    JOB_SUCCESS,
+)
+from ert.shared.ensemble_evaluator.client import Client
+from ert.job_runner.reporting.base import Reporter
+from ert.job_runner.reporting.message import (
+    _JOB_EXIT_FAILED_STRING,
+    Exited,
+    Finish,
+    Init,
+    Running,
+    Start,
+)
+from ert.job_runner.reporting.statemachine import StateMachine
+
+logger = logging.getLogger(__name__)
+
+
+class Protobuf(Reporter):
+    def __init__(self, experiment_url, token=None, cert_path=None):
+        self._url = experiment_url
+        self._token = token
+        if cert_path is not None:
+            with open(cert_path, encoding="utf-8") as f:
+                self._cert = f.read()
+        else:
+            self._cert = None
+
+        self._statemachine = StateMachine()
+        self._statemachine.add_handler((Init,), self._init_handler)
+        self._statemachine.add_handler((Start, Running, Exited), self._job_handler)
+        self._statemachine.add_handler((Finish,), self._finished_handler)
+
+        self._experiment_id = None
+        self._ee_id = None
+        self._real_id = None
+        self._step_id = None
+        self._event_queue = queue.Queue()
+        self._event_publisher_thread = threading.Thread(target=self._publish_event)
+
+    def _dump_event(self, msg):
+        if msg is None:
+            self._event_queue.put(None)
+        else:
+            message = DispatcherMessage(job=msg)
+            self._event_queue.put(message.SerializeToString())
+
+    def _publish_event(self):
+        logger.debug("Publishing event.")
+        with Client(self._url, self._token, self._cert) as client:
+            while True:
+                event = self._event_queue.get()
+                if event is None:
+                    return
+                client.send(event)
+
+    def report(self, msg):
+        self._statemachine.transition(msg)
+
+    def _init_handler(self, msg: Init):
+        self._experiment_id = msg.experiment_id
+        self._ee_id = msg.ee_id
+        self._real_id = int(msg.real_id)
+        self._step_id = int(msg.step_id)
+        self._event_publisher_thread.start()
+
+    def _job_handler(self, msg: Union[Start, Running, Exited]):
+        job_name = msg.job.name()
+        pjob = Job(
+            id=JobId(
+                index=msg.job.index,
+                step=StepId(
+                    step=self._step_id,
+                    realization=RealizationId(
+                        realization=self._real_id,
+                        ensemble=EnsembleId(
+                            id=self._ee_id,
+                            experiment=ExperimentId(id=self._experiment_id),
+                        ),
+                    ),
+                ),
+            )
+        )
+        if isinstance(msg, Start):
+            logger.debug(f"Job {job_name} was successfully started")
+            pjob.status = JOB_START
+            pjob.stdout = str(Path(msg.job.std_out).resolve())
+            pjob.stderr = str(Path(msg.job.std_err).resolve())
+            self._dump_event(pjob)
+            if not msg.success():
+                logger.error(f"Job {job_name} FAILED to start")
+                pjob.status = JOB_FAILURE
+                pjob.error = msg.error_message
+                self._dump_event(pjob)
+
+        elif isinstance(msg, Exited):
+            if msg.success():
+                logger.debug(f"Job {job_name} exited successfully")
+                pjob.status = JOB_SUCCESS
+            else:
+                logger.error(
+                    _JOB_EXIT_FAILED_STRING.format(
+                        job_name=msg.job.name(),
+                        exit_code=msg.exit_code,
+                        error_message=msg.error_message,
+                    )
+                )
+                pjob.status = JOB_FAILURE
+                pjob.exit_code = msg.exit_code
+                pjob.error = msg.error_message
+            self._dump_event(pjob)
+
+        elif isinstance(msg, Running):
+            logger.debug(f"{job_name} job is running")
+            pjob.status = JOB_RUNNING
+            pjob.current_memory = msg.current_memory_usage
+            pjob.max_memory = msg.max_memory_usage
+            self._dump_event(pjob)
+
+    def _finished_handler(self, msg):
+        self._dump_event(None)
+        self._event_publisher_thread.join()

--- a/src/ert/job_runner/reporting/statemachine.py
+++ b/src/ert/job_runner/reporting/statemachine.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Callable, Dict, Tuple, Type
+
+from ert.job_runner.reporting.message import (
+    Message,
+    Exited,
+    Finish,
+    Init,
+    Running,
+    Start,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TransitionError(ValueError):
+    pass
+
+
+class StateMachine:
+    def __init__(self) -> None:
+
+        logger.debug("Initializing state machines")
+        initialized = (Init,)
+        jobs = (Start, Running, Exited)
+        finished = (Finish,)
+        self._handler: Dict[Message, Callable[[Message], None]] = {}
+        self._transitions = {
+            None: initialized,
+            initialized: jobs + finished,
+            jobs: jobs + finished,
+        }
+        self._state = None
+
+    def add_handler(
+        self, states: Tuple[Type[Message], ...], handler: Callable[[Message], None]
+    ) -> None:
+        if states in self._handler:
+            raise ValueError(f"{states} already handled by {self._handler[states]}")
+        self._handler[states] = handler
+
+    def transition(self, message: Message):
+        new_state = None
+        for state in self._handler:
+            if isinstance(message, state):
+                new_state = state
+
+        if self._state not in self._transitions or not isinstance(
+            message, self._transitions[self._state]
+        ):
+            logger.error(
+                f"{message} illegal state transition: {self._state} -> {new_state}"
+            )
+            raise TransitionError(
+                f"Illegal transition {self._state} -> {new_state} for {message}, "
+                f"expected to transition into {self._transitions[self._state]}"
+            )
+
+        self._handler[new_state](message)
+        self._state = new_state

--- a/src/ert/job_runner/runner.py
+++ b/src/ert/job_runner/runner.py
@@ -13,6 +13,7 @@ class JobRunner:
             os.environ["DATA_ROOT"] = self._data_root
 
         self.simulation_id = jobs_data.get("run_id")
+        self.experiment_id = jobs_data.get("experiment_id")
         self.ee_id = jobs_data.get("ee_id")
         self.real_id = jobs_data.get("real_id")
         self.step_id = jobs_data.get("step_id")
@@ -46,6 +47,7 @@ class JobRunner:
             self.ee_id,
             self.real_id,
             self.step_id,
+            self.experiment_id,
         )
 
         unused = set(names_of_jobs_to_run) - {j.name() for j in job_queue}

--- a/tests/ert_tests/experiment_server/test_server.py
+++ b/tests/ert_tests/experiment_server/test_server.py
@@ -36,7 +36,7 @@ async def test_receiving_event_from_cluster(
                     "source": "test_receiving_event_from_cluster",
                 }
             )
-            await dispatcher.send(to_json(event))
+            await dispatcher.send(to_json(event).decode())
 
     experiment.dispatch.assert_awaited_once_with(event, 0)
 

--- a/tests/libres_tests/job_runner/test_protobuf_reporter.py
+++ b/tests/libres_tests/job_runner/test_protobuf_reporter.py
@@ -1,0 +1,238 @@
+import os
+import pytest
+
+from ..libres_utils import _mock_ws_thread
+from ert.experiment_server._schema_pb2 import (
+    JOB_FAILURE,
+    JOB_RUNNING,
+    JOB_START,
+    JOB_SUCCESS,
+    DispatcherMessage,
+)
+from ert.job_runner.job import Job
+from ert.job_runner.reporting import Protobuf
+from ert.job_runner.reporting.message import Exited, Finish, Init, Running, Start
+from ert.job_runner.reporting.statemachine import TransitionError
+
+
+def test_report_with_successful_start_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                experiment_id="experiment_id",
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+            )
+        )
+        reporter.report(Start(job1))
+        reporter.report(Finish())
+
+    assert len(lines) == 1
+    event = DispatcherMessage()
+    event.ParseFromString(lines[0])
+    assert event.WhichOneof("object") == "job"
+    assert event.job.status == JOB_START
+    assert event.job.id.index == 0
+    assert event.job.id.step.step == 0
+    assert event.job.id.step.realization.realization == 0
+    assert event.job.id.step.realization.ensemble.id == "ee_id"
+    assert event.job.id.step.realization.ensemble.experiment.id == "experiment_id"
+    assert os.path.basename(event.job.stdout) == "stdout"
+    assert os.path.basename(event.job.stderr) == "stderr"
+
+
+def test_report_with_failed_start_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+
+        msg = Start(job1).with_error("massive_failure")
+
+        reporter.report(msg)
+        reporter.report(Finish())
+
+    assert len(lines) == 2
+    event = DispatcherMessage()
+    event.ParseFromString(lines[1])
+    assert event.job.status == JOB_FAILURE
+    assert event.job.error == "massive_failure"
+
+
+def test_report_with_successful_exit_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+        reporter.report(Exited(job1, 0))
+        reporter.report(Finish().with_error("failed"))
+
+    assert len(lines) == 1
+    event = DispatcherMessage()
+    event.ParseFromString(lines[0])
+    assert event.WhichOneof("object") == "job"
+    assert event.job.status == JOB_SUCCESS
+
+
+def test_report_with_failed_exit_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+        reporter.report(Exited(job1, 1).with_error("massive_failure"))
+        reporter.report(Finish())
+
+    assert len(lines) == 1
+    event = DispatcherMessage()
+    event.ParseFromString(lines[0])
+    assert event.WhichOneof("object") == "job"
+    assert event.job.status == JOB_FAILURE
+    assert event.job.error == "massive_failure"
+    assert event.job.exit_code == 1
+
+
+def test_report_with_running_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+        reporter.report(Running(job1, 100, 10))
+        reporter.report(Finish())
+
+    assert len(lines) == 1
+    event = DispatcherMessage()
+    event.ParseFromString(lines[0])
+    assert event.WhichOneof("object") == "job"
+    assert event.job.status == JOB_RUNNING
+    assert event.job.max_memory == 100
+    assert event.job.current_memory == 10
+
+
+def test_report_only_job_running_for_successful_run(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+        reporter.report(Running(job1, 100, 10))
+        reporter.report(Finish())
+
+    assert len(lines) == 1
+
+
+def test_report_with_failed_finish_message_argument(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+    job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        reporter.report(
+            Init(
+                [job1],
+                1,
+                19,
+                ee_id="ee_id",
+                real_id=0,
+                step_id=0,
+                experiment_id="experiment_id",
+            )
+        )
+        reporter.report(Running(job1, 100, 10))
+        reporter.report(Finish().with_error("massive_failure"))
+
+    assert len(lines) == 1
+
+
+def test_report_inconsistent_events(unused_tcp_port):
+    host = "localhost"
+    url = f"ws://{host}:{unused_tcp_port}"
+    reporter = Protobuf(experiment_url=url)
+
+    lines = []
+    with _mock_ws_thread(host, unused_tcp_port, lines):
+        with pytest.raises(
+            TransitionError,
+            match=r"Illegal transition None -> \(MessageType<Finish>,\)",
+        ):
+            reporter.report(Finish())

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -224,22 +224,23 @@ def test_timeout_jobs(tmpdir):
         job.wait_for()
 
 
-def test_add_ensemble_evaluator_info(tmpdir):
+def test_add_dispatch_info(tmpdir):
     os.chdir(tmpdir)
     job_queue = create_local_queue(SIMPLE_SCRIPT)
     ee_id = "some_id"
-    dispatch_url = "wss://some_url.com"
     cert = "My very nice cert"
     token = "my_super_secret_token"
+    dispatch_url = "wss://example.org"
     cert_file = ".ee.pem"
     runpaths = [Path(DUMMY_CONFIG["run_path"].format(iens)) for iens in range(10)]
     for runpath in runpaths:
         (runpath / "jobs.json").write_text(json.dumps({}), encoding="utf-8")
-    job_queue.add_ensemble_evaluator_information_to_jobs_file(
+    job_queue.add_dispatch_information_to_jobs_file(
         ee_id=ee_id,
         dispatch_url=dispatch_url,
         cert=cert,
         token=token,
+        experiment_id="experiment_id",
     )
 
     for runpath in runpaths:
@@ -248,23 +249,24 @@ def test_add_ensemble_evaluator_info(tmpdir):
         assert content["step_id"] == 0
         assert content["dispatch_url"] == dispatch_url
         assert content["ee_token"] == token
+        assert content["experiment_id"] == "experiment_id"
 
         assert content["ee_cert_path"] == str(runpath / cert_file)
         assert (runpath / cert_file).read_text(encoding="utf-8") == cert
 
 
-def test_add_ensemble_evaluator_info_cert_none(tmpdir):
+def test_add_dispatch_info_cert_none(tmpdir):
     os.chdir(tmpdir)
     job_queue = create_local_queue(SIMPLE_SCRIPT)
     ee_id = "some_id"
-    dispatch_url = "wss://some_url.com"
+    dispatch_url = "wss://example.org"
     cert = None
     token = None
     cert_file = ".ee.pem"
     runpaths = [Path(DUMMY_CONFIG["run_path"].format(iens)) for iens in range(10)]
     for runpath in runpaths:
         (runpath / "jobs.json").write_text(json.dumps({}), encoding="utf-8")
-    job_queue.add_ensemble_evaluator_information_to_jobs_file(
+    job_queue.add_dispatch_information_to_jobs_file(
         ee_id=ee_id,
         dispatch_url=dispatch_url,
         cert=cert,
@@ -277,6 +279,7 @@ def test_add_ensemble_evaluator_info_cert_none(tmpdir):
         assert content["step_id"] == 0
         assert content["dispatch_url"] == dispatch_url
         assert content["ee_token"] == token
+        assert content["experiment_id"] is None
 
         assert content["ee_cert_path"] is None
         assert not (runpath / cert_file).exists()


### PR DESCRIPTION
**Approach**
- Compile protobuf schemas on build/install
- Add `python setup.py compile_protocol_buffers` command and document it
- Add `Protobuf` reporter implementing the `Reporter` interface for producing protobuf messages over a websocket.
- Ignore schemas with regards to SCM, typing and style

**Issue**
Resolves #3616


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
