### PR TITLE
Fix issue where geo id was not set early enough

### DIFF
--- a/res/simulator/simulation_context.py
+++ b/res/simulator/simulation_context.py
@@ -18,15 +18,16 @@ class SimulationContext:
         job_queue.set_max_job_duration(max_runtime)
         self._queue_manager = JobQueueManager(job_queue)
 
+        # fill in the missing geo_id data
+        for sim_id, (geo_id, _) in enumerate(case_data):
+            if mask[sim_id]:
+                ert.set_geo_id(geo_id, sim_id, itr)
+
         self._run_context = ert.create_ensemble_experiment_run_context(
             source_filesystem=sim_fs,
             active_mask=mask,
             iteration=itr,
         )
-        # fill in the missing geo_id data
-        for sim_id, (geo_id, _) in enumerate(case_data):
-            if mask[sim_id]:
-                ert.set_geo_id(geo_id, sim_id, itr)
 
         self._ert.getEnkfSimulationRunner().createRunPath(self._run_context)
         EnkfSimulationRunner.runWorkflows(HookRuntime.PRE_SIMULATION, self._ert)

--- a/test-data/local/batch_sim/sleepy_time.ert
+++ b/test-data/local/batch_sim/sleepy_time.ert
@@ -3,7 +3,7 @@ QUEUE_OPTION LOCAL MAX_RUNNING 10
 
 NUM_REALIZATIONS 10
 
-RUNPATH runpath/realization-%d/iter-%d
+RUNPATH runpath/realization-%d-<GEO_ID>/iter-%d
 JOBNAME OLE_LUKKOYE
 
 INSTALL_JOB SLEEP jobs/SLEEP

--- a/tests/libres_tests/res/simulator/test_simulation_context.py
+++ b/tests/libres_tests/res/simulator/test_simulation_context.py
@@ -1,65 +1,68 @@
-from libres_utils import ResTest, tmpdir, wait_until
+from libres_utils import wait_until
 
+from res.enkf import EnKFMain
 from res.enkf.enums import RealizationStateEnum
 from res.simulator import SimulationContext
-from res.test import ErtTestContext
 
 
-class SimulationContextTest(ResTest):
-    @tmpdir()
-    def test_simulation_context(self):
-        config_file = self.createTestPath("local/batch_sim/sleepy_time.ert")
-        with ErtTestContext(config_file) as test_context:
-            ert = test_context.getErt()
+def test_simulation_context(setup_case):
+    res_config = setup_case("local/batch_sim", "sleepy_time.ert")
+    ert = EnKFMain(res_config)
 
-            size = 4
-            even_mask = [True, False] * (size // 2)
-            odd_mask = [False, True] * (size // 2)
+    size = 4
+    even_mask = [True, False] * (size // 2)
+    odd_mask = [False, True] * (size // 2)
 
-            fs_manager = ert.getEnkfFsManager()
-            even_half = fs_manager.getFileSystem("even_half")
-            odd_half = fs_manager.getFileSystem("odd_half")
+    fs_manager = ert.getEnkfFsManager()
+    even_half = fs_manager.getFileSystem("even_half")
+    odd_half = fs_manager.getFileSystem("odd_half")
 
-            case_data = [(geo_id, {}) for geo_id in range(size)]
-            even_ctx = SimulationContext(ert, even_half, even_mask, 0, case_data)
-            odd_ctx = SimulationContext(ert, odd_half, odd_mask, 0, case_data)
+    case_data = [(geo_id, {}) for geo_id in range(size)]
+    even_ctx = SimulationContext(ert, even_half, even_mask, 0, case_data)
+    odd_ctx = SimulationContext(ert, odd_half, odd_mask, 0, case_data)
 
-            for iens in range(size):
-                if iens % 2 == 0:
-                    self.assertFalse(even_ctx.isRealizationFinished(iens))
-                else:
-                    self.assertFalse(odd_ctx.isRealizationFinished(iens))
+    for iens in range(size):
+        if iens % 2 == 0:
+            assert not even_ctx.isRealizationFinished(iens)
+        else:
+            assert not odd_ctx.isRealizationFinished(iens)
 
-            def any_is_running():
-                return even_ctx.isRunning() or odd_ctx.isRunning()
+    def all_stopped():
+        assert not even_ctx.isRunning() and not odd_ctx.isRunning()
 
-            wait_until(func=(lambda: self.assertFalse(any_is_running())), timeout=90)
+    wait_until(all_stopped, timeout=90)
 
-            self.assertEqual(even_ctx.getNumFailed(), 0)
-            self.assertEqual(even_ctx.getNumRunning(), 0)
-            self.assertEqual(even_ctx.getNumSuccess(), size / 2)
+    for iens in range(size):
+        if iens % 2 == 0:
+            assert even_ctx.get_run_args(iens).runpath.endswith(
+                f"runpath/realization-{iens}-{iens}/iter-0"
+            )
+        else:
+            assert odd_ctx.get_run_args(iens).runpath.endswith(
+                f"runpath/realization-{iens}-{iens}/iter-0"
+            )
 
-            self.assertEqual(odd_ctx.getNumFailed(), 0)
-            self.assertEqual(odd_ctx.getNumRunning(), 0)
-            self.assertEqual(odd_ctx.getNumSuccess(), size / 2)
+    assert even_ctx.getNumFailed() == 0
+    assert even_ctx.getNumRunning() == 0
+    assert even_ctx.getNumSuccess() == size / 2
 
-            even_state_map = even_half.getStateMap()
-            odd_state_map = odd_half.getStateMap()
+    assert odd_ctx.getNumFailed() == 0
+    assert odd_ctx.getNumRunning() == 0
+    assert odd_ctx.getNumSuccess() == size / 2
 
-            for iens in range(size):
-                if iens % 2 == 0:
-                    self.assertTrue(even_ctx.didRealizationSucceed(iens))
-                    self.assertFalse(even_ctx.didRealizationFail(iens))
-                    self.assertTrue(even_ctx.isRealizationFinished(iens))
+    even_state_map = even_half.getStateMap()
+    odd_state_map = odd_half.getStateMap()
 
-                    self.assertEqual(
-                        even_state_map[iens], RealizationStateEnum.STATE_HAS_DATA
-                    )
-                else:
-                    self.assertTrue(odd_ctx.didRealizationSucceed(iens))
-                    self.assertFalse(odd_ctx.didRealizationFail(iens))
-                    self.assertTrue(odd_ctx.isRealizationFinished(iens))
+    for iens in range(size):
+        if iens % 2 == 0:
+            assert even_ctx.didRealizationSucceed(iens)
+            assert not even_ctx.didRealizationFail(iens)
+            assert even_ctx.isRealizationFinished(iens)
 
-                    self.assertEqual(
-                        odd_state_map[iens], RealizationStateEnum.STATE_HAS_DATA
-                    )
+            assert even_state_map[iens] == RealizationStateEnum.STATE_HAS_DATA
+        else:
+            assert odd_ctx.didRealizationSucceed(iens)
+            assert not odd_ctx.didRealizationFail(iens)
+            assert odd_ctx.isRealizationFinished(iens)
+
+            assert odd_state_map[iens] == RealizationStateEnum.STATE_HAS_DATA


### PR DESCRIPTION
**Issue**
Resolves a bug where runpath is not set early enough to include geo id. This defect was introduced in #3583 .


**Approach**
Moved setting of geo id before creation of runpath and add a regression test. The
regression test is added by refactoring test_simulation_context to use pytest.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
