### PR TITLE
Pin sphinx to <5.1.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ requests
 scikit-build
 semeio>=1.4.1
 setuptools_scm
-sphinx
+sphinx<5.1.0
 sphinx_rtd_theme
 sphinx-argparse
 sphinx-autoapi


### PR DESCRIPTION
sphinx-5.1.0 broke our build. Issue raised here:
https://github.com/sphinx-doc/sphinx/issues/10701. Pinning for now.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
