### PR TITLE
Improve ci time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
     - name: Build libres
       run: |
         mkdir cmake-build
-        cmake -S libres -B cmake-build -DBUILD_TESTS=ON -DCOVERAGE=ON
-        cmake --build cmake-build
+        cmake -S libres -B cmake-build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON -DCOVERAGE=ON
+        cmake --build cmake-build -j2
 
     - name: Run tests
       run: |

--- a/libres/CMakeLists.txt
+++ b/libres/CMakeLists.txt
@@ -67,7 +67,9 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 if(COVERAGE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -Wall")
+  add_compile_options("--coverage")
+  add_compile_options("-fPIC")
+  add_link_options("--coverage")
 endif()
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
Attempts to reduce build times by refactoring the cmake workflow.
 
Sampled run times before PR look like this:

```
run-ert3-spe1(local): 10m 7s
run-ert3-spe1(postgres): 10m 2s
type-checking: 7m 12s
check-style: 8m 49s
run-ert3-spe1 (38, local): 8m 42s
run-ert3-spe1 (38, postgres): 9m 11s
run-ert3-snakeoil: 10m 11s
run-ert3-polynomial-local(38): 13m 17s
run-ert3-polynomial-postgres(38): 14m 52s
run-ert2-test-data(38, ubuntu): 6m
run-ert2-test-data(38, macos): 12m 6s
cmake(ubuntu): 30m 24s
cmake(macos): 21m 38s
build-wheels(ubuntu-38) -> run ert test(38, ubuntu, integration-test): 6m 31s + 13m 43s = 20m 14s
build-wheels(macos-38) -> run ert test(38, macos, integration-test): 5m 24s + 13m 17s = 18m 41s
build-wheels(ubuntu-38) -> run ert test(38, ubuntu, unit-test): 6m 31s + 13m 43s = 20m 14s
build-wheels(macos-38) -> run ert test(38, macos, unit-test): 5m 24s + 19m 29s = 24m 53s
build-wheels(ubuntu-38) -> run libres test(38, ubuntu): 6m 31s + 6m 24s = 12m 55s
build-wheels(macos-38) -> run libres test(38, macos): 5m 24s + 12m 0s = 17m 24s
```

The bottle neck is cmake on ubuntu so improving it is the priority.

By building with debug, about 3 minutes of compile time seems to be removed. Supposedly, the work nodes on github actions have 2 cores available, so j2 is used but the effect seems neglible.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
