### PR TITLE
Fix flaky timeout on ci

### DIFF
--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -134,7 +134,8 @@ def workspace_integration(tmpdir):
     workspace_dir.mkdir()
     with chdir(workspace_dir):
 
-        with Storage.start_server(timeout=120):
+        # timeout=None means non-blocking: on ci, timing is unreliable
+        with Storage.start_server(timeout=None):
             workspace_obj = ert3.workspace.initialize(workspace_dir)
             ert.storage.init(workspace_name=workspace_obj.name)
             yield workspace_obj


### PR DESCRIPTION
Fixes flaky timeout test. On github actions timing is unreliable, so timeouts will inevitably fail. Therefore we use non-blocking behavior instead. 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
