### PR TITLE
Revert "Pin sphinx to <5.1.0"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ requests
 scikit-build
 semeio>=1.4.1
 setuptools_scm
-sphinx<5.1.0
+sphinx
 sphinx_rtd_theme
 sphinx-argparse
 sphinx-autoapi


### PR DESCRIPTION
Issue with sphinx that caused the pin was resolved in 5.1.1

This reverts commit 6e48689ffce99b16a8f1da155193be242ef354d3.

Upstream issue: https://github.com/sphinx-doc/sphinx/issues/10701

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
