### PR TITLE
Small fix for running experiment_server

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/builder/_legacy.py
@@ -122,13 +122,14 @@ class _LegacyEnsemble(_Ensemble):
             token=self._config.token,
             cert=self._config.cert,
         )
-
-        get_event_loop().run_until_complete(
-            self._evaluate_inner(
-                cloudevent_unary_send=self._ce_unary_send  # type: ignore
+        try:
+            get_event_loop().run_until_complete(
+                self._evaluate_inner(
+                    cloudevent_unary_send=self._ce_unary_send  # type: ignore
+                )
             )
-        )
-        get_event_loop().close()
+        finally:
+            get_event_loop().close()
 
     async def evaluate_async(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
         self._config = config

--- a/src/ert_shared/cli/main.py
+++ b/src/ert_shared/cli/main.py
@@ -61,7 +61,7 @@ def run_cli(args):
                 args,
                 evaluator_server_config,
             ),
-            debug=True,
+            debug=False,
         )
         return
 

--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import threading
+import asyncio
 from argparse import ArgumentParser
 from unittest.mock import Mock, call
 
@@ -238,9 +239,6 @@ def test_ies(tmpdir, source_root):
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @pytest.mark.integration_test
 @pytest.mark.timeout(20)
-@pytest.mark.skip(
-    "Experiment server seemingly causes failures with other tests, possiby bad cleanup"
-)
 def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),
@@ -263,9 +261,10 @@ def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):
         )
 
         FeatureToggling.update_from_args(parsed)
-
         run_cli(parsed)
         captured = capsys.readouterr()
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
         assert captured.out == "Successful realizations: 5\n"
 
     FeatureToggling.reset()

--- a/tests/ert_tests/ert3/conftest.py
+++ b/tests/ert_tests/ert3/conftest.py
@@ -130,7 +130,7 @@ def workspace_integration(tmpdir):
     with chdir(workspace_dir):
 
         # timeout=None means non-blocking: on ci, timing is unreliable
-        with Storage.start_server(timeout=None):
+        with Storage.start_server(timeout=30):
             workspace_obj = ert3.workspace.initialize(workspace_dir)
             ert.storage.init(workspace_name=workspace_obj.name)
             yield workspace_obj


### PR DESCRIPTION
**Issue**
Resolves #3639 


**Approach**
Add extra test that `event_loop` was deleted. Fix `run_until_complete` with try block. Put back `timeout=30` in `workspace_integration` fixture.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
