### PR TITLE
Use Ubuntu 20.04 for running spe1 workflow

### DIFF
--- a/.github/workflows/run_examples_spe1.yml
+++ b/.github/workflows/run_examples_spe1.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         python-version: ['3.8']
         data-base: [local, postgres]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
**Issue**
opm seems to require Ubuntu 20.04 now. Reference: https://github.com/OPM/opm-simulators/issues/3982


**Approach**
Bump up Ubuntu version.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
