### PR TITLE
Run ert3 tests in separation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,13 +157,13 @@ jobs:
         ci/github/start_herbstluftwm.sh &
         sleep 5
         pushd tests
-        pytest ert_tests -sv --durations=0 -m "not integration_test"
+        pytest ert_tests -sv --durations=0 -m "not integration_test and not ert3"
 
     - name: Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'unit-tests'
       run: |
         pushd tests
-        pytest ert_tests -sv --durations=0 -m "not integration_test"
+        pytest ert_tests -sv --durations=0 -m "not integration_test and not ert3"
 
     - name: Integration Test Ubuntu
       if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'integration-tests'
@@ -173,13 +173,13 @@ jobs:
         ci/github/start_herbstluftwm.sh &
         sleep 5
         pushd tests
-        pytest ert_tests performance_tests -sv --durations=0 -m "integration_test"
+        pytest ert_tests performance_tests -sv --durations=0 -m "integration_test and not ert3"
 
     - name: Integration Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'integration-tests'
       run: |
         pushd tests
-        pytest ert_tests performance_tests -sv --durations=0 -m "integration_test"
+        pytest ert_tests performance_tests -sv --durations=0 -m "integration_test and not ert3"
 
     - name: Test for a clean repository
       run: |
@@ -191,6 +191,48 @@ jobs:
       run: |
         ert --help
 
+  tests-ert3:
+    name: Run ert3 tests
+    needs: [build-wheels]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: './.github/actions/install_dependencies'
+      with:
+        os: ${{ matrix.os }}
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get wheels
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.os }} Python ${{ matrix.python-version }} wheel
+
+    - name: Install wheel and test dependencies
+      run: |
+        find . -name "*.whl" -exec pip install {} \;
+        pip install -r dev-requirements.txt
+
+    - name: Run tests
+      env:
+        DISPLAY: ':99.0'
+      run: |
+        ci/github/start_herbstluftwm.sh &
+        sleep 5
+        pushd tests
+        pytest ert_tests -sv --durations=0 -m "ert3"
 
   docs-ert:
     name: Test ert docs

--- a/.github/workflows/run_examples_polynomial.yml
+++ b/.github/workflows/run_examples_polynomial.yml
@@ -13,12 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10']
         os: [ubuntu-latest, macos-latest]
-        # Excluded to keep build times down on Github actions
-        exclude:
-          - os: macos-latest
-            python-version: '3.9'
 
     runs-on: ${{ matrix.os }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ markers =
     consumer_driven_contract_test
     consumer_driven_contract_verification
     integration_test
+    ert3
 log_cli = false
 
 [flake8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,8 +116,13 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "quick_only" in item.keywords:
                 item.add_marker(skip_quick)
+            if "ert3" in str(item.fspath):
+                item.add_marker(pytest.mark.ert3)
+
     else:
         skip_slow = pytest.mark.skip(reason="need --runslow option to run")
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+            if "ert3" in str(item.fspath):
+                item.add_marker(pytest.mark.ert3)


### PR DESCRIPTION
**Issue**
CI times are really slow, and ert3 is not in active development, this runs a minimum of ert3 tests

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
