### PR TITLE
Ensure jenkins tests see pyproject.toml

### DIFF
--- a/ci/jenkins/testkomodo-ERT.sh
+++ b/ci/jenkins/testkomodo-ERT.sh
@@ -6,6 +6,9 @@ copy_test_files () {
 
     # Trick ERT to find a fake source root
     mkdir ${CI_TEST_ROOT}/.git
+
+    # Keep pytest configuration:
+    ln -s ${CI_SOURCE_ROOT}/pyproject.toml ${CI_TEST_ROOT}/pyproject.toml
 }
 
 install_test_dependencies () {

--- a/ci/jenkins/testkomodo-libres-pytest.sh
+++ b/ci/jenkins/testkomodo-libres-pytest.sh
@@ -11,6 +11,9 @@ copy_test_files () {
     ln -s {$CI_SOURCE_ROOT,$CI_TEST_ROOT}/libres/bin
 
     ln -s ${CI_SOURCE_ROOT}/share ${CI_TEST_ROOT}/share
+
+    # Keep pytest configuration:
+    ln -s ${CI_SOURCE_ROOT}/pyproject.toml ${CI_TEST_ROOT}/pyproject.toml
 }
 
 install_test_dependencies () {

--- a/ci/jenkins/testkomodo-repeat-flaky.sh
+++ b/ci/jenkins/testkomodo-repeat-flaky.sh
@@ -10,6 +10,9 @@ copy_test_files () {
     # libres
     mkdir -p ${CI_TEST_ROOT}/src/libres/res/fm/rms
     ln -s ${CI_SOURCE_ROOT}/src/res/fm/rms/rms_config.yml ${CI_TEST_ROOT}/src/libres/res/fm/rms/rms_config.yml
+
+    # Keep pytest configuration:
+    ln -s ${CI_SOURCE_ROOT}/pyproject.toml ${CI_TEST_ROOT}/pyproject.toml
 }
 
 install_test_dependencies () {

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -14,6 +14,10 @@ copy_test_files () {
     ln -s {$CI_SOURCE_ROOT,$CI_TEST_ROOT}/libres/bin
 
     ln -s ${CI_SOURCE_ROOT}/share ${CI_TEST_ROOT}/share
+
+    # Keep pytest configuration:
+    ln -s ${CI_SOURCE_ROOT}/pyproject.toml ${CI_TEST_ROOT}/pyproject.toml
+
 }
 
 install_test_dependencies () {


### PR DESCRIPTION
**Issue**
Jenkins tests do not enjoy the configuration (e.g. for pytest) specified in pyproject.toml since these shell scripts
set up their own context by hand. This results in warnings for at least unregistered markers, example:
https://ci.equinor.com/scout/job/komodo_testing/job/ert-custom-script-pr/16267/console

**Approach**

Symlink pyproject.toml so pytest can discover it


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
