### PR TITLE
Remove py36 specifics in tests

### DIFF
--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 import threading
 import asyncio
 from argparse import ArgumentParser
@@ -236,7 +235,6 @@ def test_ies(tmpdir, source_root):
         FeatureToggling.reset()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @pytest.mark.integration_test
 @pytest.mark.timeout(20)
 def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):

--- a/tests/ert_tests/experiment_server/conftest.py
+++ b/tests/ert_tests/experiment_server/conftest.py
@@ -1,15 +1,10 @@
 import asyncio
-import sys
 from typing import AsyncGenerator, Awaitable, Callable, Optional
 import pytest
 from websockets.client import WebSocketClientProtocol, connect
 import ert.experiment_server
 from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
-
-if sys.version_info < (3, 7):
-    from async_generator import asynccontextmanager
-else:
-    from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager
 
 
 @pytest.fixture

--- a/tests/ert_tests/experiment_server/test_server.py
+++ b/tests/ert_tests/experiment_server/test_server.py
@@ -1,4 +1,3 @@
-import sys
 import ert.experiment_server
 import pytest
 
@@ -14,12 +13,8 @@ from websockets.client import WebSocketClientProtocol
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
-minversion = pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="requires python3.7 or higher"
-)
 
 
-@minversion
 async def test_receiving_event_from_cluster(
     experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
     dispatcher_factory: AsyncContextManager[
@@ -46,7 +41,6 @@ async def test_receiving_event_from_cluster(
     experiment.dispatch.assert_awaited_once_with(event, 0)
 
 
-@minversion
 async def test_successful_run(
     experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
     capsys,
@@ -61,7 +55,6 @@ async def test_successful_run(
     assert captured.out == "Successful realizations: 5\n"
 
 
-@minversion
 async def test_failed_run(
     experiment_server_ctx: AsyncContextManager[ert.experiment_server.ExperimentServer],
     capsys,


### PR DESCRIPTION
**Issue**
Resolves leftover Py36 specific code

**Approach**
rm

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
