### PR TITLE
Increase timeout on experiment_server integration test

### DIFF
--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import shutil
 import threading
@@ -236,9 +235,8 @@ def test_ies(tmpdir, source_root):
         FeatureToggling.reset()
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="flaky on MacOS")
 @pytest.mark.integration_test
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(40)
 def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):
     shutil.copytree(
         os.path.join(source_root, "test-data", "local", "poly_example"),


### PR DESCRIPTION
**Issue**
Resolves #3639 


**Approach**
Based on the experiments, see #3639 it's concluded that the test just needed more time to finish.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
