### PR TITLE
Add missing logger-method to _Proc

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -61,10 +61,6 @@ ignore_errors = True
 ignore_missing_imports = True
 ignore_errors = True
 
-[mypy-ert_shared.services.*]
-ignore_missing_imports = True
-ignore_errors = True
-
 [mypy-ert_shared.share.*]
 ignore_missing_imports = True
 ignore_errors = True

--- a/src/ert_shared/services/_webviz_ert_main.py
+++ b/src/ert_shared/services/_webviz_ert_main.py
@@ -8,6 +8,7 @@ import yaml
 import pathlib
 import argparse
 from typing import Any, Optional, Dict
+
 from webviz_ert.assets import WEBVIZ_CONFIG
 
 
@@ -63,7 +64,7 @@ def create_config(
     temp_config.seek(0)
 
 
-def send_ready():
+def send_ready() -> None:
     """
     Tell ERT's BaseService that we're ready, even though we're not actually
     ready to accept requests. At the moment, ERT doesn't interface with
@@ -74,7 +75,7 @@ def send_ready():
         f.write("{}")  # Empty, but valid JSON
 
 
-def run_webviz_ert(experimental_mode: bool = False, verbose: bool = False):
+def run_webviz_ert(experimental_mode: bool = False, verbose: bool = False) -> None:
     signal.signal(signal.SIGINT, handle_exit)
     # The entry point of webviz is to call it from command line, and so do we.
 

--- a/src/ert_shared/services/storage_service.py
+++ b/src/ert_shared/services/storage_service.py
@@ -1,8 +1,10 @@
 import logging
 from os import PathLike
-import httpx
 import requests
 from typing import Any, Optional, Tuple
+
+import httpx
+
 from ert_shared.services._base_service import BaseService, local_exec_args
 from ert_storage.client import Client, ConnInfo
 
@@ -15,8 +17,8 @@ class Storage(BaseService):
         res_config: Optional[PathLike] = None,
         database_url: str = "sqlite:///ert.db",
         verbose: bool = False,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ):
         self._url: Optional[str] = None
 
@@ -63,7 +65,7 @@ class Storage(BaseService):
         )
 
     @classmethod
-    def session(cls, timeout=None) -> Client:
+    def session(cls, timeout: Optional[int] = None) -> Client:
         """
         Start a HTTP transaction with the server
         """
@@ -75,7 +77,7 @@ class Storage(BaseService):
         )
 
     @classmethod
-    async def async_session(cls, timeout=None) -> httpx.AsyncClient:
+    async def async_session(cls, timeout: Optional[int] = None) -> httpx.AsyncClient:
         """
         Start a HTTP transaction with the server
         """


### PR DESCRIPTION
Noticed that _Proc is missing a logger-method when adding Type-hints.

## Pre review checklist

- [x ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
