### PR TITLE
Do not generate certificates for cli tests

### DIFF
--- a/tests/ert_tests/cli/conftest.py
+++ b/tests/ert_tests/cli/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ert_shared.ensemble_evaluator.config import EvaluatorServerConfig
+
+
+@pytest.fixture(autouse=True)
+def no_cert_in_test(monkeypatch):
+    # Do not generate certificates during test, parts of it can be time
+    # consuming (e.g. 30 seconds)
+    # Specifically generating the RSA key <_openssl.RSA_generate_key_ex>
+    class MockESConfig(EvaluatorServerConfig):
+        def __init__(self, *args, **kwargs):
+            if "generate_cert" not in kwargs:
+                kwargs["generate_cert"] = False
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("ert_shared.cli.main.EvaluatorServerConfig", MockESConfig)


### PR DESCRIPTION
**Issue**
Resolves #3639


**Approach**
The time taken to generate the RSA key has been observed to vary
significantly, measuring up to 30 seconds each call. For testing
purposes we can avoid creating certificates.

Mock the init of EvaluatorServerConfig and set `generate_cert` to `False`


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
