### PR TITLE
Replace util_binary_split_string with standard C++

### DIFF
--- a/src/libres/lib/enkf/ensemble_config.cpp
+++ b/src/libres/lib/enkf/ensemble_config.cpp
@@ -60,15 +60,11 @@ create_opt_map(const config_content_node_type *node, int offset) {
     std::unordered_map<std::string, std::string> options;
     for (int i = offset; i < config_content_node_get_size(node); i++) {
         const char *key_value = config_content_node_iget(node, i);
-        char *value = NULL;
-        char *key = NULL;
 
-        util_binary_split_string(key_value, ":", true, &key, &value);
-        if (value)
+        auto [key, value] = ert::split_in_two(key_value, ":");
+
+        if (!value.empty())
             options[key] = value;
-
-        free(key);
-        free(value);
     }
 
     return options;

--- a/src/libres/lib/enkf/ert_template.cpp
+++ b/src/libres/lib/enkf/ert_template.cpp
@@ -23,6 +23,8 @@
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/ert_template.hpp>
 
+#include <ert/res_util/string.hpp>
+
 #define ERT_TEMPLATE_TYPE_ID 7731963
 #define ERT_TEMPLATES_TYPE_ID 6677330
 
@@ -228,22 +230,19 @@ void ert_templates_init(ert_templates_type *templates,
 
             for (int iarg = 2;
                  iarg < config_content_node_get_size(template_node); iarg++) {
-                char *key, *value;
                 const char *key_value =
                     config_content_node_iget(template_node, iarg);
-                util_binary_split_string(key_value, "=:", true, &key, &value);
 
-                if (value != NULL)
-                    ert_template_add_arg(tmpl, key, value);
+                auto [key, value] = ert::split_in_two(key_value, ":");
+
+                if (!value.empty())
+                    ert_template_add_arg(tmpl, key.c_str(), value.c_str());
                 else
                     fprintf(
                         stderr,
                         "** Warning - failed to parse argument:%s as key:value "
                         "- ignored \n",
                         config_content_iget(config, "RUN_TEMPLATE", i, iarg));
-
-                free(key);
-                free(value);
             }
         }
     }

--- a/src/libres/lib/include/ert/res_util/string.hpp
+++ b/src/libres/lib/include/ert/res_util/string.hpp
@@ -45,6 +45,24 @@ inline std::vector<std::string> split(std::string_view str, char delimiter) {
 }
 
 /**
+ * Split string into two parts
+ * First part contains all characters up to `delimiter`
+ *
+ * @param[in] str String to be split
+ * @param[in] delimiter Delimiter to split the string by
+ * @return Pair with the parts 
+ */
+inline std::pair<std::string, std::string>
+split_in_two(const std::string &str, std::string_view delimiter) {
+    auto pos = str.find(delimiter);
+    if (pos == str.npos)
+        return std::pair{str, ""};
+
+    return std::pair{str.substr(0, pos),
+                     str.substr(pos + delimiter.size(), str.npos)};
+}
+
+/**
  * Split string and get the back element
  *
  * Equivalent to Python's: `s.split(delim)[-1]`

--- a/tests/libres_tests/res/enkf/test_ert_templates.py
+++ b/tests/libres_tests/res/enkf/test_ert_templates.py
@@ -84,7 +84,7 @@ class ErtTemplatesTest(ResTest):
         templates = ErtTemplates(
             self.res_config.subst_config.subst_list, config_dict=self.config_data
         )
-        self.assertEqual(templates, self.res_config.ert_templates)
+        assert templates == self.res_config.ert_templates
 
     def test_unequal_objects_are_unequal(self):
         templates = ErtTemplates(


### PR DESCRIPTION
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
