### PR TITLE
Remove init_internalization from enkf_main

### DIFF
--- a/src/res/enkf/enkf_main.py
+++ b/src/res/enkf/enkf_main.py
@@ -335,8 +335,6 @@ class EnKFMain(BaseCClass):
         )
 
     def initRun(self, run_context):
-        enkf_main.init_internalization(self)
-
         for realization_nr in range(self.getEnsembleSize()):
             if run_context.is_active(realization_nr):
                 enkf_state.state_initialize(


### PR DESCRIPTION
This sets the internalization flag for all observations to ensure
they are loaded, however it is only ever read for GEN_DATA which
always sets the flag on allocation.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
