### PR TITLE
Use id for ensemble instead of ensemble evaluator

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/builder/_ensemble.py
@@ -27,25 +27,30 @@ logger = logging.getLogger(__name__)
 
 class _Ensemble:
     def __init__(
-        self, reals: Sequence[_Realization], metadata: Mapping[str, Any]
+        self, reals: Sequence[_Realization], metadata: Mapping[str, Any], id_: str
     ) -> None:
         self.reals = reals
         self.metadata = metadata
         self._snapshot = self._create_snapshot()
         self.status = self._snapshot.status
         self._status_tracker = EnsembleStateTracker(self._snapshot.status)
+        self._id: str = id_
 
     def __repr__(self) -> str:
         return f"Ensemble with {len(self.reals)} members"
 
-    def evaluate(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
+    def evaluate(self, config: "EvaluatorServerConfig") -> None:
         pass
 
-    async def evaluate_async(self, config: "EvaluatorServerConfig", ee_id: str) -> None:
+    async def evaluate_async(self, config: "EvaluatorServerConfig") -> None:
         pass
 
     def cancel(self) -> None:
         pass
+
+    @property
+    def id_(self) -> str:
+        return self._id
 
     @property
     def cancellable(self) -> bool:

--- a/src/ert/ensemble_evaluator/builder/_function_task.py
+++ b/src/ert/ensemble_evaluator/builder/_function_task.py
@@ -28,14 +28,14 @@ class FunctionTask(prefect.Task):  # type: ignore
         self,
         step: "_Step",
         output_transmitters: _stage_transmitter_mapping,
-        ee_id: str,
+        ens_id: str,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.step = step
         self._output_transmitters = output_transmitters
-        self._ee_id = ee_id
+        self._ens_id = ens_id
 
     def _attempt_execute(
         self,
@@ -95,7 +95,7 @@ class FunctionTask(prefect.Task):  # type: ignore
         self.logger.info(f"Running function {job.name}")
         client.send_event(
             ev_type=ids.EVTYPE_FM_JOB_START,
-            ev_source=job.source(self._ee_id),
+            ev_source=job.source(self._ens_id),
         )
         try:
             function: Callable[..., Any] = pickle.loads(job.command)
@@ -104,14 +104,14 @@ class FunctionTask(prefect.Task):  # type: ignore
             self.logger.error(str(e))
             client.send_event(
                 ev_type=ids.EVTYPE_FM_JOB_FAILURE,
-                ev_source=job.source(self._ee_id),
+                ev_source=job.source(self._ens_id),
                 ev_data={ids.ERROR_MSG: str(e)},
             )
             raise e
         else:
             client.send_event(
                 ev_type=ids.EVTYPE_FM_JOB_SUCCESS,
-                ev_source=job.source(self._ee_id),
+                ev_source=job.source(self._ens_id),
             )
         return output
 
@@ -123,7 +123,7 @@ class FunctionTask(prefect.Task):  # type: ignore
         ) as ee_client:
             ee_client.send_event(
                 ev_type=ids.EVTYPE_FM_STEP_RUNNING,
-                ev_source=self.step.source(self._ee_id),
+                ev_source=self.step.source(self._ens_id),
             )
 
             job = self.step.jobs[0]
@@ -134,7 +134,7 @@ class FunctionTask(prefect.Task):  # type: ignore
 
             ee_client.send_event(
                 ev_type=ids.EVTYPE_FM_STEP_SUCCESS,
-                ev_source=self.step.source(self._ee_id),
+                ev_source=self.step.source(self._ens_id),
             )
 
         return output

--- a/src/ert/ensemble_evaluator/builder/_job.py
+++ b/src/ert/ensemble_evaluator/builder/_job.py
@@ -28,8 +28,8 @@ class _BaseJob:
         self.index = index
         self._source = source
 
-    def source(self, ee_id: str) -> str:
-        return self._source.format(ee_id=ee_id)
+    def source(self, ens_id: str) -> str:
+        return self._source.format(ens_id=ens_id)
 
 
 class _UnixJob(_BaseJob):

--- a/src/ert/ensemble_evaluator/builder/_realization.py
+++ b/src/ert/ensemble_evaluator/builder/_realization.py
@@ -88,8 +88,8 @@ class _Realization:
     def set_active(self, active: bool) -> None:
         self.active = active
 
-    def source(self, ee_id: str) -> str:
-        return self._source.format(ee_id=ee_id)
+    def source(self, ens_id: str) -> str:
+        return self._source.format(ens_id=ens_id)
 
     def get_steps_sorted_topologically(self) -> Generator[_Step, None, None]:
         steps = self.steps

--- a/src/ert/ensemble_evaluator/builder/_step.py
+++ b/src/ert/ensemble_evaluator/builder/_step.py
@@ -58,8 +58,8 @@ class _Step(_Stage):
         self.jobs = jobs
         self._source = source
 
-    def source(self, ee_id: str) -> str:
-        return self._source.format(ee_id=ee_id)
+    def source(self, ens_id: str) -> str:
+        return self._source.format(ens_id=ens_id)
 
 
 class _UnixStep(_Step):
@@ -79,12 +79,12 @@ class _UnixStep(_Step):
     def get_task(
         self,
         output_transmitters: _stage_transmitter_mapping,
-        ee_id: str,
+        ens_id: str,
         *args: Any,
         **kwargs: Any,
     ) -> UnixTask:
         return UnixTask(
-            self, output_transmitters, ee_id, *args, run_path=self._run_path, **kwargs
+            self, output_transmitters, ens_id, *args, run_path=self._run_path, **kwargs
         )
 
 
@@ -92,11 +92,11 @@ class _FunctionStep(_Step):
     def get_task(
         self,
         output_transmitters: _stage_transmitter_mapping,
-        ee_id: str,
+        ens_id: str,
         *args: Any,
         **kwargs: Any,
     ) -> FunctionTask:
-        return FunctionTask(self, output_transmitters, ee_id, *args, **kwargs)
+        return FunctionTask(self, output_transmitters, ens_id, *args, **kwargs)
 
 
 class _LegacyStep(_Step):  # pylint: disable=too-many-instance-attributes

--- a/src/ert/ensemble_evaluator/builder/_template.py
+++ b/src/ert/ensemble_evaluator/builder/_template.py
@@ -1,4 +1,4 @@
-_SOURCE_TEMPLATE_BASE = "/ert/ee/{ee_id}/"
+_SOURCE_TEMPLATE_BASE = "/ert/ensemble/{ens_id}/"
 _SOURCE_TEMPLATE_REAL = "/real/{iens}"
 _SOURCE_TEMPLATE_STEP = "/step/{step_id}"
 _SOURCE_TEMPLATE_JOB = "/job/{job_id}/index/{job_index}"

--- a/src/ert/ert3/engine/_run.py
+++ b/src/ert/ert3/engine/_run.py
@@ -254,6 +254,7 @@ def run(
         ensemble_size,
         step_builder,
         active_mask,
+        ens_id="0",
     )
     ert3.evaluator.evaluate(ensemble, use_gui=use_gui)
 
@@ -343,6 +344,7 @@ def run_sensitivity_analysis(
         experiment_run_config.ensemble_config.forward_model.driver,
         ensemble_size,
         step_builder,
+        ens_id="0",
     )
 
     output_transmitters = ert3.evaluator.evaluate(ensemble, use_gui=use_gui)

--- a/src/ert/ert3/evaluator/_builder.py
+++ b/src/ert/ert3/evaluator/_builder.py
@@ -118,15 +118,18 @@ def add_step_outputs(
         step.add_output(output)
 
 
-def build_ensemble(
+def build_ensemble(  # pylint: disable=too-many-arguments
     stage: ert3.config.Step,
     driver: str,
     ensemble_size: int,
     step_builder: ert.ensemble_evaluator.StepBuilder,
     active_mask: Optional[List[bool]] = None,
+    ens_id: Optional[str] = None,
 ) -> ert.ensemble_evaluator.Ensemble:
     if active_mask is None:
         active_mask = [True] * ensemble_size
+    if ens_id is None:
+        ens_id = "0"
     if isinstance(stage, ert3.config.Function):
         step_builder.add_job(
             ert.ensemble_evaluator.JobBuilder()
@@ -151,6 +154,7 @@ def build_ensemble(
         .set_max_running(10000)
         .set_max_retries(0)
         .set_executor(driver)
+        .set_id(ens_id)
     )
     for iens, active_flag in enumerate(active_mask):
         builder = builder.add_realization(

--- a/src/ert/job_runner/cli.py
+++ b/src/ert/job_runner/cli.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def _setup_reporters(
     is_interactive_run,
-    ee_id,
+    ens_id,
     dispatch_url,
     ee_token=None,
     ee_cert_path=None,
@@ -25,7 +25,7 @@ def _setup_reporters(
     reporters: typing.List[reporting.Report] = []
     if is_interactive_run:
         reporters.append(reporting.Interactive())
-    elif ee_id and experiment_id is None:
+    elif ens_id and experiment_id is None:
         reporters.append(reporting.File(sync_disc_timeout=0))
         reporters.append(
             reporting.Event(
@@ -71,12 +71,12 @@ def main(args):
             sys.exit(f"No such directory: {parsed_args.run_path}")
         os.chdir(parsed_args.run_path)
 
-    ee_id = None
+    ens_id = None
     try:
         with open(JOBS_FILE, "r") as json_file:
             jobs_data = json.load(json_file)
             experiment_id = jobs_data.get("experiment_id")
-            ee_id = jobs_data.get("ee_id")
+            ens_id = jobs_data.get("ens_id")
             ee_token = jobs_data.get("ee_token")
             ee_cert_path = jobs_data.get("ee_cert_path")
             dispatch_url = jobs_data.get("dispatch_url")
@@ -86,7 +86,7 @@ def main(args):
     is_interactive_run = len(parsed_args.job) > 0
     reporters = _setup_reporters(
         is_interactive_run,
-        ee_id,
+        ens_id,
         dispatch_url,
         ee_token,
         ee_cert_path,

--- a/src/ert/job_runner/reporting/event.py
+++ b/src/ert/job_runner/reporting/event.py
@@ -47,7 +47,7 @@ class Event(Reporter):
         self._statemachine.add_handler((Start, Running, Exited), self._job_handler)
         self._statemachine.add_handler((Finish,), self._finished_handler)
 
-        self._ee_id = None
+        self._ens_id = None
         self._real_id = None
         self._step_id = None
         self._event_queue = queue.Queue()
@@ -74,10 +74,10 @@ class Event(Reporter):
         self._event_queue.put(event)
 
     def _step_path(self):
-        return f"/ert/ee/{self._ee_id}/real/{self._real_id}/step/{self._step_id}"
+        return f"/ert/ensemble/{self._ens_id}/real/{self._real_id}/step/{self._step_id}"
 
     def _init_handler(self, msg):
-        self._ee_id = msg.ee_id
+        self._ens_id = msg.ens_id
         self._real_id = msg.real_id
         self._step_id = msg.step_id
         self._event_publisher_thread.start()

--- a/src/ert/job_runner/reporting/message.py
+++ b/src/ert/job_runner/reporting/message.py
@@ -48,7 +48,7 @@ class Init(Message):
         jobs,
         run_id,
         ert_pid,
-        ee_id=None,
+        ens_id=None,
         real_id=None,
         step_id=None,
         experiment_id=None,
@@ -58,7 +58,7 @@ class Init(Message):
         self.run_id = run_id
         self.ert_pid = ert_pid
         self.experiment_id = experiment_id
-        self.ee_id = ee_id
+        self.ens_id = ens_id
         self.real_id = real_id
         self.step_id = step_id
 

--- a/src/ert/job_runner/reporting/protobuf.py
+++ b/src/ert/job_runner/reporting/protobuf.py
@@ -48,7 +48,7 @@ class Protobuf(Reporter):
         self._statemachine.add_handler((Finish,), self._finished_handler)
 
         self._experiment_id = None
-        self._ee_id = None
+        self._ens_id = None
         self._real_id = None
         self._step_id = None
         self._event_queue = queue.Queue()
@@ -75,7 +75,7 @@ class Protobuf(Reporter):
 
     def _init_handler(self, msg: Init):
         self._experiment_id = msg.experiment_id
-        self._ee_id = msg.ee_id
+        self._ens_id = msg.ens_id
         self._real_id = int(msg.real_id)
         self._step_id = int(msg.step_id)
         self._event_publisher_thread.start()
@@ -90,7 +90,7 @@ class Protobuf(Reporter):
                     realization=RealizationId(
                         realization=self._real_id,
                         ensemble=EnsembleId(
-                            id=self._ee_id,
+                            id=self._ens_id,
                             experiment=ExperimentId(id=self._experiment_id),
                         ),
                     ),

--- a/src/ert/job_runner/runner.py
+++ b/src/ert/job_runner/runner.py
@@ -14,7 +14,7 @@ class JobRunner:
 
         self.simulation_id = jobs_data.get("run_id")
         self.experiment_id = jobs_data.get("experiment_id")
-        self.ee_id = jobs_data.get("ee_id")
+        self.ens_id = jobs_data.get("ens_id")
         self.real_id = jobs_data.get("real_id")
         self.step_id = jobs_data.get("step_id")
         self.ert_pid = jobs_data.get("ert_pid")
@@ -44,7 +44,7 @@ class JobRunner:
             job_queue,
             self.simulation_id,
             self.ert_pid,
-            self.ee_id,
+            self.ens_id,
             self.real_id,
             self.step_id,
             self.experiment_id,

--- a/src/ert/shared/ensemble_evaluator/narratives/monitor_failing_evaluation.py
+++ b/src/ert/shared/ensemble_evaluator/narratives/monitor_failing_evaluation.py
@@ -23,16 +23,22 @@ def monitor_failing_evaluation():
             [
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_SNAPSHOT,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                 ),
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                     data={identifiers.STATUS: state.ENSEMBLE_STATE_STARTED},
                 ),
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                     data={identifiers.STATUS: state.ENSEMBLE_STATE_FAILED},
                 ),
             ]
@@ -51,7 +57,9 @@ def monitor_failing_evaluation():
             [
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_TERMINATED,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                 ),
             ]
         )

--- a/src/ert/shared/ensemble_evaluator/narratives/monitor_successful_ensemble.py
+++ b/src/ert/shared/ensemble_evaluator/narratives/monitor_successful_ensemble.py
@@ -26,7 +26,9 @@ def monitor_successful_ensemble():
             [
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_SNAPSHOT,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                 ),
             ]
         )
@@ -35,12 +37,14 @@ def monitor_successful_ensemble():
             [
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                 ),
             ],
             terminator=EventDescription(
                 type_=identifiers.EVTYPE_EE_SNAPSHOT_UPDATE,
-                source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                source=ReMatch(re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"),
                 data={identifiers.STATUS: state.ENSEMBLE_STATE_STOPPED},
             ),
         )
@@ -58,7 +62,9 @@ def monitor_successful_ensemble():
             [
                 EventDescription(
                     type_=identifiers.EVTYPE_EE_TERMINATED,
-                    source=ReMatch(re.compile(r"/ert/ee/ee."), "/ert/ee/ee-0"),
+                    source=ReMatch(
+                        re.compile(r"/ert/ensemble/ee."), "/ert/ensemble/ee-0"
+                    ),
                     datacontenttype="application/octet-stream",
                     data=cloudpickle.dumps("hello world"),
                 ),

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -294,13 +294,17 @@ class BaseRunModel:
     def run_ensemble_evaluator(
         self, run_context: RunContext, ee_config: EvaluatorServerConfig
     ) -> int:
-        ensemble = EnsembleBuilder.from_legacy(
-            run_context,
-            self.get_forward_model(),
-            self._queue_config,
-            self.ert().analysisConfig(),
-            self.ert().resConfig(),
-        ).build()
+        ensemble = (
+            EnsembleBuilder.from_legacy(
+                run_context,
+                self.get_forward_model(),
+                self._queue_config,
+                self.ert().analysisConfig(),
+                self.ert().resConfig(),
+            )
+            .set_id(str(uuid.uuid1()).split("-", maxsplit=1)[0])
+            .build()
+        )
 
         self.ert().initRun(run_context)
 
@@ -308,7 +312,6 @@ class BaseRunModel:
             ensemble,
             ee_config,
             run_context.iteration,
-            ee_id=str(uuid.uuid1()).split("-", maxsplit=1)[0],
         ).run_and_get_successful_realizations()
 
         self.deactivate_failed_jobs(run_context)
@@ -333,13 +336,18 @@ class BaseRunModel:
         experiment_logger.debug("_evaluate")
         loop = asyncio.get_running_loop()
         experiment_logger.debug("building...")
-        ensemble = EnsembleBuilder.from_legacy(
-            run_context,
-            self.get_forward_model(),
-            self._queue_config,
-            self.ert().analysisConfig(),
-            self.ert().resConfig(),
-        ).build()
+        ensemble = (
+            EnsembleBuilder.from_legacy(
+                run_context,
+                self.get_forward_model(),
+                self._queue_config,
+                self.ert().analysisConfig(),
+                self.ert().resConfig(),
+            )
+            .set_id(str(uuid.uuid1()).split("-", maxsplit=1)[0])
+            .build()
+        )
+
         experiment_logger.debug("built")
 
         ensemble_listener = asyncio.create_task(
@@ -353,7 +361,7 @@ class BaseRunModel:
                 run_context,
             )
 
-            await ensemble.evaluate_async(ee_config, self.id_)
+            await ensemble.evaluate_async(ee_config)
 
             await ensemble_listener
 

--- a/tests/ert_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert_tests/ensemble_evaluator/conftest.py
@@ -170,6 +170,7 @@ def make_ensemble_builder(queue_config):
             queue_config,
             analysis_config,
         )
+        builder.set_id("0")
         return builder
 
     return _make_ensemble_builder
@@ -207,12 +208,11 @@ def make_ee_config():
 
 @pytest.fixture
 def evaluator(make_ee_config):
-    ensemble = TestEnsemble(0, 2, 1, 2)
+    ensemble = TestEnsemble(0, 2, 1, 2, id_="0")
     ee = EnsembleEvaluator(
         ensemble,
         make_ee_config(),
         0,
-        ee_id="ee-0",
     )
     yield ee
     ee.stop()

--- a/tests/ert_tests/ensemble_evaluator/prefect/conftest.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/conftest.py
@@ -294,13 +294,15 @@ def poly_ensemble_builder(real_builder, ensemble_size):
         .set_max_retries(2)
         .set_executor("local")
         .set_forward_model(real_builder)
+        .set_id("0")
     )
     return builder
 
 
 @pytest.fixture()
 def poly_ensemble(poly_ensemble_builder):
-    return poly_ensemble_builder.build()
+    ens = poly_ensemble_builder.build()
+    return ens
 
 
 @pytest.fixture()
@@ -349,6 +351,7 @@ def function_ensemble_builder_factory(
         .set_max_retries(2)
         .set_executor("local")
         .set_forward_model(real_builder)
+        .set_id("0")
     )
 
     def build(pickled_function):

--- a/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_prefect_step.py
@@ -92,7 +92,7 @@ def prefect_flow_run(ws_monitor, step, input_map, output_map, **kwargs):
     with prefect.context(url=ws_monitor.url, token=None, cert=None):
         with Flow("testing") as flow:
             task = step.get_task(
-                output_transmitters=output_map, ee_id="test_ee_id", **kwargs
+                output_transmitters=output_map, ens_id="test_ens_id", **kwargs
             )
             result = task(inputs=input_map)
         with tmp():
@@ -289,7 +289,7 @@ def test_on_task_failure(
             output_map=output_map,
             max_retries=retries,
             retry_delay=timedelta(seconds=1),
-            on_failure=functools.partial(_on_task_failure, ee_id="test_ee_id"),
+            on_failure=functools.partial(_on_task_failure, ens_id="test_ens_id"),
         )
     task_result = flow_run.result[result]
     assert task_result.is_successful() == expect

--- a/tests/ert_tests/ensemble_evaluator/prefect/test_run_dialog_ert3.py
+++ b/tests/ert_tests/ensemble_evaluator/prefect/test_run_dialog_ert3.py
@@ -12,7 +12,7 @@ def test_success_ert3(qtbot, poly_ensemble):
         generate_cert=False,
     )
 
-    evaluator = EnsembleEvaluator(poly_ensemble, ee_config, 0, ee_id="1")
+    evaluator = EnsembleEvaluator(poly_ensemble, ee_config, 0)
     run_model = ERT3RunModel()
     widget = RunDialog("poly_example", run_model)
     widget.show()

--- a/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/ert_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -61,7 +61,7 @@ async def test_happy_path(
     assert mock_ws_task.done()
 
     event_0 = from_json(mock_ws_task.result()[0])
-    assert event_0["source"] == "/ert/ee/ee_0/real/0/step/0"
+    assert event_0["source"] == "/ert/ensemble/ee_0/real/0/step/0"
     assert event_0["type"] == "com.equinor.ert.forward_model_step.waiting"
     assert event_0.data == {"queue_event_type": "JOB_QUEUE_WAITING"}
 

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
@@ -14,24 +14,28 @@ from ert.data import (
 
 @pytest.mark.parametrize("active_real", [True, False])
 def test_build_ensemble(active_real):
-    ensemble = ee.EnsembleBuilder().add_realization(
-        ee.RealizationBuilder()
-        .set_iens(0)
-        .add_step(
-            ee.StepBuilder()
-            .add_job(
-                ee.LegacyJobBuilder()
+    ensemble = (
+        ee.EnsembleBuilder()
+        .add_realization(
+            ee.RealizationBuilder()
+            .set_iens(0)
+            .add_step(
+                ee.StepBuilder()
+                .add_job(
+                    ee.LegacyJobBuilder()
+                    .set_id("0")
+                    .set_index("0")
+                    .set_name("echo_command")
+                    .set_ext_job(Mock())
+                )
                 .set_id("0")
-                .set_index("0")
-                .set_name("echo_command")
-                .set_ext_job(Mock())
+                .set_name("some_step")
+                .set_dummy_io()
+                .set_type("unix")
             )
-            .set_id("0")
-            .set_name("some_step")
-            .set_dummy_io()
-            .set_type("unix")
+            .active(active_real)
         )
-        .active(active_real)
+        .set_id("0")
     )
     ensemble = ensemble.build()
 
@@ -69,7 +73,7 @@ def test_build_ensemble_legacy():
         res_config=res_config,
     )
 
-    ensemble = ensemble_builder.build()
+    ensemble = ensemble_builder.set_id("0").build()
 
     real = ensemble.reals[0]
     assert real.active
@@ -203,7 +207,7 @@ def test_topological_sort(steps, expected, ambiguous):
             )
         real.add_step(step)
 
-    ensemble = ee.EnsembleBuilder().add_realization(real).build()
+    ensemble = ee.EnsembleBuilder().add_realization(real).set_id("0").build()
     real = ensemble.reals[0]
 
     if ambiguous:

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -61,7 +61,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             send_dispatch_event(
                 dispatch1,
                 identifiers.EVTYPE_FM_JOB_RUNNING,
-                f"/ert/ee/{evaluator._ee_id}/real/0/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/0/step/0/job/0",
                 "event1",
                 {"current_memory_usage": 1000},
             )
@@ -70,7 +70,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             send_dispatch_event(
                 dispatch2,
                 identifiers.EVTYPE_FM_JOB_RUNNING,
-                f"/ert/ee/{evaluator._ee_id}/real/1/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/1/step/0/job/0",
                 "event1",
                 {"current_memory_usage": 1000},
             )
@@ -79,7 +79,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             send_dispatch_event(
                 dispatch2,
                 identifiers.EVTYPE_FM_JOB_SUCCESS,
-                f"/ert/ee/{evaluator._ee_id}/real/1/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/1/step/0/job/0",
                 "event1",
                 {"current_memory_usage": 1000},
             )
@@ -88,7 +88,7 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             send_dispatch_event(
                 dispatch2,
                 identifiers.EVTYPE_FM_JOB_FAILURE,
-                f"/ert/ee/{evaluator._ee_id}/real/1/step/0/job/1",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/1/step/0/job/1",
                 "event_job_1_fail",
                 {identifiers.ERROR_MSG: "error"},
             )
@@ -139,28 +139,28 @@ def test_ensure_multi_level_events_in_order(evaluator):
             send_dispatch_event(
                 dispatch1,
                 identifiers.EVTYPE_ENSEMBLE_STARTED,
-                f"/ert/ee/{evaluator._ee_id}/ensemble",
+                f"/ert/ensemble/{evaluator.ensemble.id_}",
                 "event0",
                 {},
             )
             send_dispatch_event(
                 dispatch1,
                 identifiers.EVTYPE_FM_STEP_SUCCESS,
-                f"/ert/ee/{evaluator._ee_id}/real/0/step/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/0/step/0",
                 "event1",
                 {},
             )
             send_dispatch_event(
                 dispatch1,
                 identifiers.EVTYPE_FM_STEP_SUCCESS,
-                f"/ert/ee/{evaluator._ee_id}/real/1/step/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/1/step/0",
                 "event2",
                 {},
             )
             send_dispatch_event(
                 dispatch1,
                 identifiers.EVTYPE_ENSEMBLE_STOPPED,
-                f"/ert/ee/{evaluator._ee_id}/ensemble",
+                f"/ert/ensemble/{evaluator.ensemble.id_}",
                 "event3",
                 {},
             )
@@ -194,35 +194,35 @@ def test_dying_batcher(evaluator):
             send_dispatch_event(
                 dispatch,
                 identifiers.EVTYPE_ENSEMBLE_STARTED,
-                f"/ert/ee/{evaluator._ee_id}/ensemble",
+                f"/ert/ensemble/{evaluator.ensemble.id_}",
                 "event0",
                 {},
             )
             send_dispatch_event(
                 dispatch,
                 identifiers.EVTYPE_FM_JOB_RUNNING,
-                f"/ert/ee/{evaluator._ee_id}/real/0/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/0/step/0/job/0",
                 "event1",
                 {"current_memory_usage": 1000},
             )
             send_dispatch_event(
                 dispatch,
                 identifiers.EVTYPE_FM_JOB_RUNNING,
-                f"/ert/ee/{evaluator._ee_id}/real/0/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/0/step/0/job/0",
                 "event2",
                 {},
             )
             send_dispatch_event(
                 dispatch,
                 "EXPLODING",
-                f"/ert/ee/{evaluator._ee_id}/real/1/step/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/1/step/0",
                 "event3",
                 {},
             )
             send_dispatch_event(
                 dispatch,
                 identifiers.EVTYPE_FM_STEP_SUCCESS,
-                f"/ert/ee/{evaluator._ee_id}/real/0/step/0/job/0",
+                f"/ert/ensemble/{evaluator.ensemble.id_}/real/0/step/0/job/0",
                 "event4",
                 {},
             )
@@ -236,13 +236,12 @@ def test_dying_batcher(evaluator):
 @pytest.mark.consumer_driven_contract_verification
 def test_verify_monitor_failing_ensemble(make_ee_config, event_loop):
     ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = TestEnsemble(iter=1, reals=2, steps=1, jobs=2)
+    ensemble = TestEnsemble(iter=1, reals=2, steps=1, jobs=2, id_="ee-0")
     ensemble.addFailJob(real=1, step=0, job=1)
     ee = EnsembleEvaluator(
         ensemble,
         ee_config,
         0,
-        ee_id="0",
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
@@ -253,13 +252,12 @@ def test_verify_monitor_failing_ensemble(make_ee_config, event_loop):
 @pytest.mark.consumer_driven_contract_verification
 def test_verify_monitor_failing_evaluation(make_ee_config, event_loop):
     ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = TestEnsemble(iter=1, reals=2, steps=1, jobs=2)
+    ensemble = TestEnsemble(iter=1, reals=2, steps=1, jobs=2, id_="ee-0")
     ensemble.with_failure()
     ee = EnsembleEvaluator(
         ensemble,
         ee_config,
         0,
-        ee_id="ee-0",
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
@@ -269,7 +267,7 @@ def test_verify_monitor_failing_evaluation(make_ee_config, event_loop):
 
 @pytest.mark.consumer_driven_contract_verification
 def test_verify_monitor_successful_ensemble(make_ee_config, event_loop):
-    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2).with_result(
+    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2, id_="ee-0").with_result(
         b"\x80\x04\x95\x0f\x00\x00\x00\x00\x00\x00\x00\x8c\x0bhello world\x94.",
         "application/octet-stream",
     )
@@ -278,7 +276,6 @@ def test_verify_monitor_successful_ensemble(make_ee_config, event_loop):
         ensemble,
         ee_config,
         0,
-        ee_id="ee-0",
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
@@ -297,7 +294,6 @@ def test_verify_dispatch_failing_job(make_ee_config, event_loop):
         mock_ensemble,
         ee_config,
         0,
-        ee_id="0",
     )
     ee.run()
     event_loop.run_until_complete(wait_for_evaluator(ee_config.url))
@@ -311,10 +307,12 @@ def test_ens_eval_run_and_get_successful_realizations_connection_refused_no_reco
 ):
 
     ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = AutorunTestEnsemble(iter=1, reals=num_realizations, steps=1, jobs=2)
+    ensemble = AutorunTestEnsemble(
+        iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
+    )
     for i in range(num_failing):
         ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0, ee_id="0")
+    ee = EnsembleEvaluator(ensemble, ee_config, 0)
 
     with patch.object(
         _Monitor, "track", side_effect=ConnectionRefusedError("Connection error")
@@ -326,8 +324,8 @@ def test_ens_eval_run_and_get_successful_realizations_connection_refused_no_reco
 
 def test_ens_eval_run_and_get_successful_realizations_timeout(make_ee_config):
     ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = AutorunTestEnsemble(iter=1, reals=1, steps=1, jobs=2)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0, ee_id="0")
+    ensemble = AutorunTestEnsemble(iter=1, reals=1, steps=1, jobs=2, id_="0")
+    ee = EnsembleEvaluator(ensemble, ee_config, 0)
 
     with patch.object(
         _Monitor, "track", side_effect=ServerTimeoutError("timed out")
@@ -361,10 +359,13 @@ def test_recover_from_failure_in_run_and_get_successful_realizations(
     ee_config = make_ee_config(
         use_token=False, generate_cert=False, custom_host="localhost"
     )
-    ensemble = AutorunTestEnsemble(iter=1, reals=num_realizations, steps=1, jobs=2)
+    ensemble = AutorunTestEnsemble(
+        iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
+    )
+
     for i in range(num_failing):
         ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0, ee_id="0")
+    ee = EnsembleEvaluator(ensemble, ee_config, 0)
     with patch.object(
         _Monitor,
         "track",
@@ -387,10 +388,13 @@ def test_exhaust_retries_in_run_and_get_successful_realizations(
     ee_config = make_ee_config(
         use_token=False, generate_cert=False, custom_host="localhost"
     )
-    ensemble = AutorunTestEnsemble(iter=1, reals=num_realizations, steps=1, jobs=2)
+    ensemble = AutorunTestEnsemble(
+        iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
+    )
+
     for i in range(num_failing):
         ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0, ee_id="0")
+    ee = EnsembleEvaluator(ensemble, ee_config, 0)
     with patch.object(
         _Monitor,
         "track",

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -22,7 +22,7 @@ def test_run_legacy_ensemble(tmpdir, make_ensemble_builder):
             use_token=False,
             generate_cert=False,
         )
-        evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
+        evaluator = EnsembleEvaluator(ensemble, config, 0)
         with evaluator.run() as monitor:
             for e in monitor.track():
                 if e["type"] in (
@@ -54,7 +54,7 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
             generate_cert=False,
         )
 
-        evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
+        evaluator = EnsembleEvaluator(ensemble, config, 0)
 
         with evaluator.run() as mon:
             cancel = True
@@ -85,7 +85,7 @@ def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
             use_token=False,
             generate_cert=False,
         )
-        evaluator = EnsembleEvaluator(ensemble, config, 0, ee_id="1")
+        evaluator = EnsembleEvaluator(ensemble, config, 0)
 
         with patch.object(ensemble._job_queue, "submit_complete") as faulty_queue:
             faulty_queue.side_effect = RuntimeError()

--- a/tests/ert_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert_tests/ensemble_evaluator/test_monitor.py
@@ -14,14 +14,13 @@ from .ensemble_evaluator_utils import TestEnsemble
 
 @pytest.mark.consumer_driven_contract_test
 def test_monitor_successful_ensemble(make_ee_config):
-    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2)
+    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2, id_="0")
     ensemble.addFailJob(real=1, step=0, job=1)
     ee_config = make_ee_config(use_token=False, generate_cert=False)
     ee = EnsembleEvaluator(
         ensemble,
         ee_config,
         0,
-        ee_id="ee-0",
     )
 
     ee.run()
@@ -42,13 +41,12 @@ def test_monitor_successful_ensemble(make_ee_config):
 @pytest.mark.consumer_driven_contract_test
 def test_monitor_failing_evaluation(make_ee_config):
     ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = TestEnsemble(iter=1, reals=1, steps=1, jobs=1)
+    ensemble = TestEnsemble(iter=1, reals=1, steps=1, jobs=1, id_="0")
     ensemble.with_failure()
     ee = EnsembleEvaluator(
         ensemble,
         ee_config,
         0,
-        ee_id="ee-0",
     )
     ee.run()
     with NarrativeProxy(
@@ -69,14 +67,13 @@ def test_monitor_failing_evaluation(make_ee_config):
 
 @pytest.mark.consumer_driven_contract_test
 def test_monitor_failing_ensemble(make_ee_config):
-    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2)
+    ensemble = TestEnsemble(iter=1, reals=2, steps=2, jobs=2, id_="0")
     ensemble.addFailJob(real=1, step=0, job=1)
     ee_config = make_ee_config(use_token=False, generate_cert=False)
     ee = EnsembleEvaluator(
         ensemble,
         ee_config,
         0,
-        ee_id="ee-0",
     )
     with ee.run():
         pass

--- a/tests/ert_tests/ert3/evaluator/test_evaluator.py
+++ b/tests/ert_tests/ert3/evaluator/test_evaluator.py
@@ -97,7 +97,11 @@ def test_evaluator(
         )
 
     ensemble = ert3.evaluator.build_ensemble(
-        stage, ensemble_config.forward_model.driver, ensemble_config.size, step_builder
+        stage,
+        ensemble_config.forward_model.driver,
+        ensemble_config.size,
+        step_builder,
+        ens_id="0",
     )
 
     evaluation_records = ert3.evaluator.evaluate(ensemble, range(1024, 65535))
@@ -161,6 +165,7 @@ def test_inactive_realizations(
         ensemble_config.size,
         step_builder,
         active_mask,
+        ens_id="0",
     )
 
     evaluation_records = ert3.evaluator.evaluate(ensemble, range(1024, 65535))
@@ -216,7 +221,11 @@ def test_inline_script(commandline, parsed_name, parsed_args, plugin_registry):
     )
 
     ensemble = ert3.evaluator.build_ensemble(
-        stage=step, driver="local", ensemble_size=1, step_builder=step_builder
+        stage=step,
+        driver="local",
+        ensemble_size=1,
+        step_builder=step_builder,
+        ens_id="0",
     )
 
     job = ensemble.reals[0].steps[0].jobs[0]

--- a/tests/libres_tests/job_runner/test_event_reporter.py
+++ b/tests/libres_tests/job_runner/test_event_reporter.py
@@ -24,14 +24,14 @@ def test_report_with_successful_start_message_argument(unused_tcp_port):
     job1 = Job({"name": "job1", "stdout": "stdout", "stderr": "stderr"}, 0)
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Start(job1))
         reporter.report(Finish())
 
     assert len(lines) == 1
     event = json.loads(lines[0])
     assert event["type"] == _FM_JOB_START
-    assert event["source"] == "/ert/ee/ee_id/real/0/step/0/job/0/index/0"
+    assert event["source"] == "/ert/ensemble/ens_id/real/0/step/0/job/0/index/0"
     assert os.path.basename(event["data"]["stdout"]) == "stdout"
     assert os.path.basename(event["data"]["stderr"]) == "stderr"
 
@@ -45,7 +45,7 @@ def test_report_with_failed_start_message_argument(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
 
         msg = Start(job1).with_error("massive_failure")
 
@@ -66,7 +66,7 @@ def test_report_with_successful_exit_message_argument(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Exited(job1, 0))
         reporter.report(Finish().with_error("failed"))
 
@@ -83,7 +83,7 @@ def test_report_with_failed_exit_message_argument(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Exited(job1, 1).with_error("massive_failure"))
         reporter.report(Finish())
 
@@ -101,7 +101,7 @@ def test_report_with_running_message_argument(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Running(job1, 100, 10))
         reporter.report(Finish())
 
@@ -120,7 +120,7 @@ def test_report_only_job_running_for_successful_run(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Running(job1, 100, 10))
         reporter.report(Finish())
 
@@ -135,7 +135,7 @@ def test_report_with_failed_finish_message_argument(unused_tcp_port):
 
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
-        reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
+        reporter.report(Init([job1], 1, 19, ens_id="ens_id", real_id=0, step_id=0))
         reporter.report(Running(job1, 100, 10))
         reporter.report(Finish().with_error("massive_failure"))
 

--- a/tests/libres_tests/job_runner/test_job_dispatch.py
+++ b/tests/libres_tests/job_runner/test_job_dispatch.py
@@ -246,21 +246,21 @@ else:
 
 
 @pytest.mark.parametrize(
-    "is_interactive_run, ee_id",
+    "is_interactive_run, ens_id",
     [(False, None), (False, "1234"), (True, None), (True, "1234")],
 )
-def test_setup_reporters(is_interactive_run, ee_id):
-    reporters = _setup_reporters(is_interactive_run, ee_id, "")
+def test_setup_reporters(is_interactive_run, ens_id):
+    reporters = _setup_reporters(is_interactive_run, ens_id, "")
 
-    if not is_interactive_run and not ee_id:
+    if not is_interactive_run and not ens_id:
         assert len(reporters) == 1
         assert not any(isinstance(r, Event) for r in reporters)
 
-    if not is_interactive_run and ee_id:
+    if not is_interactive_run and ens_id:
         assert len(reporters) == 2
         assert any(isinstance(r, Event) for r in reporters)
 
-    if is_interactive_run and ee_id:
+    if is_interactive_run and ens_id:
         assert len(reporters) == 1
         assert any(isinstance(r, Interactive) for r in reporters)
 
@@ -269,7 +269,7 @@ def test_setup_reporters(is_interactive_run, ee_id):
 def test_job_dispatch_kills_itself_after_unsuccessful_job(unused_tcp_port):
     host = "localhost"
     port = unused_tcp_port
-    jobs_json = json.dumps({"ee_id": "_id_", "dispatch_url": f"ws://localhost:{port}"})
+    jobs_json = json.dumps({"ens_id": "_id_", "dispatch_url": f"ws://localhost:{port}"})
 
     with patch("ert.job_runner.cli.os") as mock_os, patch(
         "ert.job_runner.cli.open", new=mock_open(read_data=jobs_json)

--- a/tests/libres_tests/job_runner/test_protobuf_reporter.py
+++ b/tests/libres_tests/job_runner/test_protobuf_reporter.py
@@ -28,7 +28,7 @@ def test_report_with_successful_start_message_argument(unused_tcp_port):
                 1,
                 19,
                 experiment_id="experiment_id",
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
             )
@@ -44,7 +44,7 @@ def test_report_with_successful_start_message_argument(unused_tcp_port):
     assert event.job.id.index == 0
     assert event.job.id.step.step == 0
     assert event.job.id.step.realization.realization == 0
-    assert event.job.id.step.realization.ensemble.id == "ee_id"
+    assert event.job.id.step.realization.ensemble.id == "ens_id"
     assert event.job.id.step.realization.ensemble.experiment.id == "experiment_id"
     assert os.path.basename(event.job.stdout) == "stdout"
     assert os.path.basename(event.job.stderr) == "stderr"
@@ -64,7 +64,7 @@ def test_report_with_failed_start_message_argument(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",
@@ -96,7 +96,7 @@ def test_report_with_successful_exit_message_argument(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",
@@ -125,7 +125,7 @@ def test_report_with_failed_exit_message_argument(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",
@@ -156,7 +156,7 @@ def test_report_with_running_message_argument(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",
@@ -187,7 +187,7 @@ def test_report_only_job_running_for_successful_run(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",
@@ -212,7 +212,7 @@ def test_report_with_failed_finish_message_argument(unused_tcp_port):
                 [job1],
                 1,
                 19,
-                ee_id="ee_id",
+                ens_id="ens_id",
                 real_id=0,
                 step_id=0,
                 experiment_id="experiment_id",

--- a/tests/libres_tests/res/job_queue/test_job_queue.py
+++ b/tests/libres_tests/res/job_queue/test_job_queue.py
@@ -227,7 +227,7 @@ def test_timeout_jobs(tmpdir):
 def test_add_dispatch_info(tmpdir):
     os.chdir(tmpdir)
     job_queue = create_local_queue(SIMPLE_SCRIPT)
-    ee_id = "some_id"
+    ens_id = "some_id"
     cert = "My very nice cert"
     token = "my_super_secret_token"
     dispatch_url = "wss://example.org"
@@ -236,7 +236,7 @@ def test_add_dispatch_info(tmpdir):
     for runpath in runpaths:
         (runpath / "jobs.json").write_text(json.dumps({}), encoding="utf-8")
     job_queue.add_dispatch_information_to_jobs_file(
-        ee_id=ee_id,
+        ens_id=ens_id,
         dispatch_url=dispatch_url,
         cert=cert,
         token=token,
@@ -258,7 +258,7 @@ def test_add_dispatch_info(tmpdir):
 def test_add_dispatch_info_cert_none(tmpdir):
     os.chdir(tmpdir)
     job_queue = create_local_queue(SIMPLE_SCRIPT)
-    ee_id = "some_id"
+    ens_id = "some_id"
     dispatch_url = "wss://example.org"
     cert = None
     token = None
@@ -267,7 +267,7 @@ def test_add_dispatch_info_cert_none(tmpdir):
     for runpath in runpaths:
         (runpath / "jobs.json").write_text(json.dumps({}), encoding="utf-8")
     job_queue.add_dispatch_information_to_jobs_file(
-        ee_id=ee_id,
+        ens_id=ens_id,
         dispatch_url=dispatch_url,
         cert=cert,
         token=token,
@@ -304,7 +304,7 @@ async def test_retry_on_closed_connection(tmpdir):
         with pytest.raises(RuntimeError, match="coroutine raised StopIteration"):
             await job_queue.execute_queue_via_websockets(
                 ws_uri="ws://example.org",
-                ee_id="",
+                ens_id="",
                 pool_sema=pool_sema,
                 evaluators=[],
             )


### PR DESCRIPTION
Instead of each ensemble evaluators having an ee_id, we specify an id
for each individual ensemble. This makes more sense when referring to an
entity (such as realization, job, and now also ensemble). Will be more
consistent with an experiment having an id as well.

As with an experiment, the id is not created on initialization but
rather set after creation. This means the caller will be responsible for
creating the id instead of the object itself.

**Issue**
Resolves #3723

**Approach**
Refactor `EnsembleEvaluator` and `_Ensemble` and move the `id` to the `Ensemble`. We use the same approach as for `Experiment` and have the caller of the ensemble to create and set the `id`. 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
