### PR TITLE
Create an experiment id via uuid

### DIFF
--- a/src/ert/experiment_server/_registry.py
+++ b/src/ert/experiment_server/_registry.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+import uuid
 from ._experiment_protocol import Experiment
 
 
@@ -14,7 +15,7 @@ class _Registry:
     def __init__(self) -> None:
         self._experiments: Dict[str, Experiment] = {}
 
-    def add_experiment(self, experiment: Experiment) -> str:
+    def add_experiment(self, experiment: Experiment) -> None:
         """Add an experiment to the registry.
 
         An id is generated here, but it should share (or receive) this ID from
@@ -22,9 +23,8 @@ class _Registry:
 
         [1] https://github.com/equinor/ert/issues/3437#issue-1247962008
         """
-        experiment_id = str(len(self._experiments.keys()))
-        self._experiments[experiment_id] = experiment
-        return experiment_id
+        experiment.id_ = str(uuid.uuid4())
+        self._experiments[experiment.id_] = experiment
 
     @property
     def all_experiments(self) -> List[Experiment]:

--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -138,11 +138,11 @@ class ExperimentServer:
             current_case_name,
             args,
         )
-        experiment.id_ = self._registry.add_experiment(experiment)
+        self._registry.add_experiment(experiment)
         return experiment.id_
 
     def add_experiment(self, experiment: Experiment) -> str:
-        experiment.id_ = self._registry.add_experiment(experiment)
+        self._registry.add_experiment(experiment)
         return experiment.id_
 
     async def run_experiment(self, experiment_id: str) -> None:


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/3720


**Approach**
- [x] Adds an experiment id, via uuid, when adding a new experiment to the registry.
- [ ] Propagated correctly to the job_runner


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
