### PR TITLE
Fix flaky bug in test_ert_qstat_proxy

### DIFF
--- a/src/libres/lib/job_queue/qstat_proxy.sh
+++ b/src/libres/lib/job_queue/qstat_proxy.sh
@@ -34,8 +34,8 @@ if [ -z $QSTAT ]; then
     QSTAT=`which qstat 2>/dev/null`
 fi
 
-if [[ $OSTYPE == "darwin"* ]]; then
-    # No sufficient file locking mechanism available on Mac OS X. Fallback:
+if [ `uname` != "Linux" ]; then
+    # Fallback if we are not on Linux
     $QSTAT $@
     exit $?
 fi


### PR DESCRIPTION
The subprocesses were not allowed to finished before the backend script was removed
from path (provided by the testpath context manager)

**Issue**
Resolves unreported flakyness in test script for qstat proxy.

**Approach**
Extend lifetime of context manager


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
