### PR TITLE
Update default branch name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ ert --help
 or, for the latest development version:
 
 ``` sh
-$ pip install git+https://github.com/equinor/ert.git@master
+$ pip install git+https://github.com/equinor/ert.git@main
 $ ert --help
 ```
 


### PR DESCRIPTION
**Issue**
Wrong name of default development branch in README


**Approach**
Change from master to main


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
