### PR TITLE
Adjust the still flaky qstat_concurrent_invocations

### DIFF
--- a/tests/libres_tests/res/job_queue/test_ert_qstat_proxy.py
+++ b/tests/libres_tests/res/job_queue/test_ert_qstat_proxy.py
@@ -272,8 +272,8 @@ def test_many_concurrent_qstat_invocations(tmpdir):
 
     # We require more than one backend run because there is race condition we need
     # to test for. Number of backend runs should then be relative to the time taken
-    # to run the test (plus 1 for slack)
-    assert 1 < backend_runs < int(time_taken / cache_timeout) + 1
+    # to run the test (plus 3 for slack)
+    assert 1 < backend_runs < int(time_taken / cache_timeout) + 3
 
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")


### PR DESCRIPTION
Not enough slack on fast iron

**Issue**
Resolves flaky test_ert_qstat_proxy.