### PR TITLE
Stopp logging to stderr in the config_parser

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -39,6 +39,11 @@ handlers:
     class: logging.StreamHandler
     level: DEBUG
     formatter: simple_with_threading
+  stderr:
+    level: WARNING
+    formatter: simple
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
 loggers:
   asyncio:
     level: DEBUG
@@ -71,6 +76,9 @@ loggers:
   res:
     level: DEBUG
     propagate: yes
+  res.config:
+    level: WARNING
+    handlers: [stderr, file]
 root:
   level: DEBUG
   handlers: [file]

--- a/src/ert/logging/storage_log.conf
+++ b/src/ert/logging/storage_log.conf
@@ -36,6 +36,10 @@ loggers:
       level: INFO
     res:
       level: INFO
+    res.config:
+      level: WARNING
+      handlers: [file]
+      propagate: False
 root:
   handlers: [default, file]
   level: INFO

--- a/src/libres/lib/config/config_parser.cpp
+++ b/src/libres/lib/config/config_parser.cpp
@@ -409,9 +409,8 @@ bool config_parser_add_key_values(
             return false;
 
         if (unrecognized == CONFIG_UNRECOGNIZED_WARN) {
-            fprintf(
-                stderr,
-                "** Warning keyword: %s not recognized when parsing: %s --- \n",
+            logger->warning(
+                "** Warning keyword: {} not recognized when parsing: {} ---",
                 kw, config_filename);
             return false;
         }

--- a/src/libres/lib/enkf/model_config.cpp
+++ b/src/libres/lib/enkf/model_config.cpp
@@ -447,9 +447,9 @@ void model_config_init(model_config_type *model_config,
             model_config->external_time_map = time_map;
         else {
             time_map_free(time_map);
-            fprintf(stderr,
-                    "** ERROR: Loading external time map from:%s failed \n",
-                    filename);
+            logger->warning(
+                "** ERROR: Loading external time map from: {} failed.",
+                filename);
         }
     }
 
@@ -704,13 +704,16 @@ config_content_type *model_config_alloc_content(const char *user_config_file,
 
     const stringlist_type *warnings = config_content_get_warnings(content);
     if (stringlist_get_size(warnings) > 0) {
-        fprintf(
-            stderr,
-            " ** There were warnings when parsing the configuration file: %s",
-            user_config_file);
-
-        for (int i = 0; i < stringlist_get_size(warnings); i++)
-            fprintf(stderr, " %02d : %s \n", i, stringlist_iget(warnings, i));
+        std::string error_string =
+            "** There were warnings when parsing the configuration file: ";
+        error_string.append(user_config_file);
+        error_string.append(". ");
+        for (int i = 0; i < stringlist_get_size(warnings); i++) {
+            error_string.append(std::to_string(i));
+            error_string.append(" : ");
+            error_string.append(stringlist_iget(warnings, i));
+        }
+        logger->warning(error_string);
     }
 
     if (!config_content_is_valid(content)) {


### PR DESCRIPTION
**Issue**
Resolves #3712 


**Approach**
Fix the logging so the subprocess does not write to stderr


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
