### PR TITLE
Change dates written by ERT to ISO-8601

### DIFF
--- a/docs/reference/configuration/magic_strings.rst
+++ b/docs/reference/configuration/magic_strings.rst
@@ -41,6 +41,7 @@ List of keywords
    * :ref:`CONFIG_FILE <ms_config_file>`
    * :ref:`CONFIG_FILE_BASE <ms_config_file_base>`
    * :ref:`CWD <ms_cwd>`
+   * :ref:`DATE <ms_date>`
 
 * Experiment variables
 
@@ -149,6 +150,11 @@ Experiment constants
    ::
 
       YOUR_WORKFLOW_JOB /data/repos/ert/test-data/local/poly_example
+
+.. _ms_date:
+.. topic:: DATE
+
+    Will be replaced with the current date in ISO-8601 format (YYYY-MM-DD).
 
 .. _ms_exp_variables:
 

--- a/src/libres/lib/enkf/enkf_main.cpp
+++ b/src/libres/lib/enkf/enkf_main.cpp
@@ -639,8 +639,8 @@ static void update_case_log(enkf_main_type *enkf_main, const char *case_path) {
             util_set_datetime_values_utc(now, &second, &minute, &hour, &day,
                                          &month, &year);
 
-            fprintf(stream, "TIME:%02d/%02d/%4d-%02d.%02d.%02d\n", day, month,
-                    year, hour, minute, second);
+            fprintf(stream, "TIME:%04d-%02d-%02dT%02d:%02d:%02d\n", year, month,
+                    day, hour, minute, second);
         }
         fclose(stream);
         free(current_host);

--- a/src/libres/lib/enkf/obs_vector.cpp
+++ b/src/libres/lib/enkf/obs_vector.cpp
@@ -367,8 +367,8 @@ void obs_vector_load_from_SUMMARY_OBSERVATION(
                             "summary observations from the\n");
             fprintf(stderr,
                     "          start of the simulation. Problem with "
-                    "observation:%s at %02d/%02d/%4d\n",
-                    obs_key, day, month, year);
+                    "observation:%s at %4d-%02d-%02d\n",
+                    obs_key, year, month, day);
             exit(1);
         }
         {

--- a/src/libres/lib/enkf/subst_config.cpp
+++ b/src/libres/lib/enkf/subst_config.cpp
@@ -166,7 +166,10 @@ static void subst_config_init_default(subst_config_type *subst_config) {
     // Installing the based (key,value) pairs which are common to all ensemble
     // members, and independent of time.
 
-    char *date_string = util_alloc_date_stamp_utc();
+    int mday, year, month;
+    util_set_datetime_values_utc(time(NULL), NULL, NULL, NULL, &mday, &month,
+                                 &year);
+    char *date_string = util_alloc_sprintf("%4d-%02d-%02d", year, month, mday);
     subst_config_add_internal_subst_kw(subst_config, "DATE", date_string,
                                        "The current date.");
     free(date_string);

--- a/src/libres/lib/enkf/time_map.cpp
+++ b/src/libres/lib/enkf/time_map.cpp
@@ -521,10 +521,10 @@ static void time_map_update_abort(time_map_type *map, int step, time_t time) {
                              &current[2]);
     util_set_date_values_utc(time, &new_time[0], &new_time[1], &new_time[2]);
 
-    util_abort("%s: time mismatch for step:%d   New_Time: %02d/%02d/%04d   "
-               "existing: %02d/%02d/%04d \n",
-               __func__, step, new_time[0], new_time[1], new_time[2],
-               current[0], current[1], current[2]);
+    util_abort("%s: time mismatch for step:%d   New_Time: %04d-%02d-%02d   "
+               "existing: %04d-%02d-%02d \n",
+               __func__, step, new_time[2], new_time[1], new_time[0],
+               current[2], current[1], current[0]);
 }
 
 /**
@@ -537,15 +537,15 @@ static void time_map_update_abort(time_map_type *map, int step, time_t time) {
 
      time map                      Summary
      -------------------------------------------------
-     0: 01/01/2000   <-------      0: 01/01/2000
+     0: 2000-01-01   <-------      0: 2000-01-01
 
-     1: 01/02/2000   <-------      1: 01/02/2000
+     1: 2000-02-01   <-------      1: 2000-02-01
 
-     2: 01/03/2000   <-\           2: 02/02/2000 (Ignored)
+     2: 2000-03-01   <-\           2: 2000-02-02 (Ignored)
                         \
-                         \--       3: 01/03/2000
+                         \--       3: 2000-03-01
 
-     3: 01/04/2000   <-------      4: 01/04/2000
+     3: 2000-04-01   <-------      4: 2000-04-01
 
 
      index_map = { 0 , 1 , 3 , 4 }
@@ -557,13 +557,13 @@ static void time_map_update_abort(time_map_type *map, int step, time_t time) {
 
      time map                      Summary
      -------------------------------------------------
-     0: 01/01/2000   <-------      0: 01/01/2000
+     0: 2000-01-01   <-------      0: 2000-01-01
 
-     1: 01/02/2000   <-------      1: 01/02/2000
+     1: 2000-02-01   <-------      1: 2000-02-01
 
-     2: 01/03/2000                 ## ERROR -> util_abort()
+     2: 2000-03-01                 ## ERROR -> util_abort()
 
-     3: 01/04/2000   <-------      2: 01/04/2000
+     3: 2000-04-01   <-------      2: 2000-04-01
 
 */
 int_vector_type *time_map_alloc_index_map(time_map_type *map,
@@ -588,8 +588,8 @@ int_vector_type *time_map_alloc_index_map(time_map_type *map,
                 int day, month, year;
                 util_set_date_values_utc(map_time, &day, &month, &year);
                 util_abort("%s: The eclipse summary cases is missing data for "
-                           "date:%02d/%02d/%4d - aborting\n",
-                           __func__, day, month, year);
+                           "date:%4d-%02d-%02d - aborting\n",
+                           __func__, year, month, day);
             }
         }
 

--- a/src/libres/lib/sched/history.cpp
+++ b/src/libres/lib/sched/history.cpp
@@ -181,9 +181,9 @@ int history_get_restart_nr_from_time_t(const history_type *history,
         else {
             int mday, year, month;
             util_set_date_values_utc(time, &mday, &month, &year);
-            util_abort("%s: Date: %02d/%02d/%04d  does not cooincide with any "
+            util_abort("%s: Date: %04d-%02d-%02d does not coincide with any "
                        "report time. Aborting.\n",
-                       __func__, mday, month, year);
+                       __func__, year, month, mday);
             return -1;
         }
     }

--- a/tests/libres_tests/res/enkf/test_subst_config.py
+++ b/tests/libres_tests/res/enkf/test_subst_config.py
@@ -16,6 +16,7 @@
 import os
 import os.path
 import unittest
+import datetime
 
 from ecl.util.test import TestAreaContext
 from res.enkf import ConfigKeys, ResConfig, SubstConfig
@@ -69,6 +70,9 @@ class SubstConfigTest(ResTest):
         subst_config = SubstConfig(config_dict=self.config_data)
         self.assertKeyValue(subst_config, "<CWD>", self.path)
         self.assertKeyValue(subst_config, "<CONFIG_PATH>", self.path)
+        self.assertKeyValue(
+            subst_config, "<DATE>", datetime.datetime.now().date().isoformat()
+        )
         self.assertKeyValue(subst_config, "keyA", "valA")
         self.assertKeyValue(subst_config, "keyB", "valB")
         self.assertKeyValue(subst_config, "keyC", "valC")


### PR DESCRIPTION
* The magic string `<DATE>` now writes 2022-01-01 instead of 01/01/2022. This is a breaking change.
* Document the magic string DATE.
* Change other occurences of old date formats in mostly error messages

**Issue**
Resolves missing ISO-8601 fixes.

**Approach**
Change to ISO-8601

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
