### PR TITLE
Add <except.hpp> for convenient C++ exceptions

### DIFF
--- a/src/libres/lib/analysis/update.cpp
+++ b/src/libres/lib/analysis/update.cpp
@@ -1,7 +1,5 @@
 #include <Eigen/Dense>
-#include <assert.h>
 #include <cerrno>
-#include <fmt/format.h>
 #include <optional>
 #include <string>
 #include <vector>
@@ -14,6 +12,7 @@
 #include <ert/enkf/enkf_config_node.hpp>
 #include <ert/enkf/meas_data.hpp>
 #include <ert/enkf/obs_data.hpp>
+#include <ert/except.hpp>
 #include <ert/python.hpp>
 #include <ert/res_util/memory.hpp>
 #include <ert/res_util/metric.hpp>
@@ -115,11 +114,9 @@ void deserialize_node(enkf_fs_type *fs,
 void assert_matrix_size(const Eigen::MatrixXd &m, const char *name, int rows,
                         int columns) {
     if (!((m.rows() == rows) && (m.cols() == columns)))
-        throw std::invalid_argument("matrix mismatch " + std::string(name) +
-                                    ":[" + std::to_string(m.rows()) + "," +
-                                    std::to_string(m.cols()) +
-                                    "   - expected:[" + std::to_string(rows) +
-                                    "," + std::to_string(columns) + "]");
+        throw exc::invalid_argument(
+            "matrix mismatch {}:[{},{}] - expected:[{},{}]", name, m.rows(),
+            m.cols(), rows, columns);
 }
 
 /**

--- a/src/libres/lib/enkf/analysis_config.cpp
+++ b/src/libres/lib/enkf/analysis_config.cpp
@@ -38,6 +38,7 @@
 #include <ert/enkf/enkf_defaults.hpp>
 #include <ert/enkf/model_config.hpp>
 #include <ert/enkf/site_config.hpp>
+#include <ert/except.hpp>
 
 #define UPDATE_ENKF_ALPHA_KEY "ENKF_ALPHA"
 #define UPDATE_STD_CUTOFF_KEY "STD_CUTOFF"
@@ -244,8 +245,8 @@ analysis_config_get_module(const analysis_config_type *config,
     if (analysis_config_has_module(config, module_name)) {
         return config->analysis_modules.at(module_name);
     } else {
-        throw std::invalid_argument(
-            fmt::format("Analysis module named {} not found", module_name));
+        throw exc::invalid_argument("Analysis module named {} not found",
+                                    module_name);
     }
 }
 

--- a/src/libres/lib/enkf/enkf_analysis.cpp
+++ b/src/libres/lib/enkf/enkf_analysis.cpp
@@ -17,16 +17,16 @@
 */
 
 #include <cmath>
-#include <ert/python.hpp>
 #include <vector>
 
 #include <ert/util/util.h>
 
 #include <ert/analysis/analysis_module.hpp>
-
 #include <ert/enkf/enkf_analysis.hpp>
 #include <ert/enkf/meas_data.hpp>
 #include <ert/enkf/obs_data.hpp>
+#include <ert/except.hpp>
+#include <ert/python.hpp>
 
 void UpdateSnapshot::add_member(std::string observation_name,
                                 double observation_value,
@@ -97,9 +97,9 @@ void enkf_analysis_deactivate_outliers(
         const std::vector<int> deactivate_index =
             selected_obs.at(block_nr).second;
         if (obs_block_get_key(obs_block) != selected_obs.at(block_nr).first)
-            throw std::invalid_argument(fmt::format(
-                "Expected obs_key: {}, got: {}", obs_block_get_key(obs_block),
-                selected_obs.at(block_nr).first));
+            throw exc::invalid_argument("Expected obs_key: {}, got: {}",
+                                        obs_block_get_key(obs_block),
+                                        selected_obs.at(block_nr).first);
 
         int iobs;
         for (iobs = 0; iobs < meas_block_get_total_obs_size(meas_block);

--- a/src/libres/lib/enkf/state_map.cpp
+++ b/src/libres/lib/enkf/state_map.cpp
@@ -24,16 +24,15 @@
 #include <stdexcept>
 #include <stdlib.h>
 
-#include <ert/python.hpp>
-
-#include <ert/res_util/file_utils.hpp>
 #include <ert/util/bool_vector.h>
 #include <ert/util/int_vector.h>
 #include <ert/util/util.h>
 
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/state_map.hpp>
-#include <system_error>
+#include <ert/except.hpp>
+#include <ert/python.hpp>
+#include <ert/res_util/file_utils.hpp>
 
 namespace fs = std::filesystem;
 
@@ -118,8 +117,7 @@ void StateMap::set(int index, realisation_state_enum new_state) {
     if (index < 0)
         index += m_state.size();
     if (index < 0)
-        throw std::out_of_range(
-            fmt::format("index out of range: {} < 0", index));
+        throw exc::out_of_range("index out of range: {} < 0", index);
     if (index >= m_state.size())
         m_state.resize(index + 1, STATE_UNDEFINED);
 

--- a/src/libres/lib/include/ert/except.hpp
+++ b/src/libres/lib/include/ert/except.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <stdexcept>
+
+/**
+ * Convenience exception classes that accept arguments for fmtlib formatting
+ */
+namespace exc {
+
+#define STDEXCEPT(_Name)                                                       \
+    class _Name : public ::std::_Name {                                        \
+    public:                                                                    \
+        using ::std::_Name::_Name;                                             \
+        template <typename... T>                                               \
+        _Name(::fmt::format_string<T...> fmt, T &&...args)                     \
+            : _Name(::fmt::format(fmt, ::std::forward<T>(args)...)) {}         \
+    }
+
+STDEXCEPT(invalid_argument);
+STDEXCEPT(out_of_range);
+STDEXCEPT(runtime_error);
+
+#undef STDEXCEPT
+} // namespace exc

--- a/src/libres/lib/job_queue/ext_job.cpp
+++ b/src/libres/lib/job_queue/ext_job.cpp
@@ -23,13 +23,13 @@
 #include <ert/res_util/subst_list.hpp>
 #include <ert/util/hash.hpp>
 #include <ert/util/util.hpp>
-#include <fmt/format.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 
 #include <ert/config/config_parser.hpp>
+#include <ert/except.hpp>
 
 #include <ert/job_queue/ext_job.hpp>
 #include <ert/job_queue/job_kw_definitions.hpp>
@@ -412,8 +412,8 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
         // existing job we mark it as invalid - no possibility to provide
         // context replacement afterwards. The job will be discarded by the
         // calling scope.
-        throw std::invalid_argument(fmt::format(
-            "** The executable {} was not found", executable_input));
+        throw exc::invalid_argument("** The executable {} was not found",
+                                    executable_input);
     } else {
         if (search_path) {
             /* Go through the PATH variable to try to locate the executable. */
@@ -425,8 +425,8 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
                                        search_path);
                 free(path_executable);
             } else {
-                throw std::invalid_argument(fmt::format(
-                    "** The executable {} was not found", executable_input));
+                throw exc::invalid_argument(
+                    "** The executable {} was not found", executable_input);
             }
         } else {
             ext_job->executable =
@@ -439,13 +439,13 @@ void ext_job_set_executable(ext_job_type *ext_job, const char *executable_abs,
     if (ext_job->executable != NULL) {
         if (fs::exists(executable_abs)) {
             if (!util_is_executable(ext_job->executable)) {
-                throw std::invalid_argument(
-                    fmt::format("** You do not have execute rights to: {}",
-                                ext_job->executable));
+                throw exc::invalid_argument(
+                    "** You do not have execute rights to: {}",
+                    ext_job->executable);
             }
         } else {
-            throw std::invalid_argument(fmt::format(
-                "** The executable {} was not found", ext_job->executable));
+            throw exc::invalid_argument("** The executable {} was not found",
+                                        ext_job->executable);
         }
     }
 }

--- a/src/libres/lib/res_util/block_fs.cpp
+++ b/src/libres/lib/res_util/block_fs.cpp
@@ -31,8 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <fmt/ostream.h>
-
+#include <ert/except.hpp>
 #include <ert/python.hpp>
 
 #include <ert/res_util/block_fs.hpp>
@@ -260,8 +259,8 @@ static block_fs_type *block_fs_alloc_empty(const fs::path &mount_file,
     int id = util_fread_int(stream);
     int version = util_fread_int(stream);
     if (version != 0)
-        throw std::runtime_error(fmt::format(
-            "block_fs data version unexpected. Expected 0, got {}", version));
+        throw exc::runtime_error(
+            "block_fs data version unexpected. Expected 0, got {}", version);
 
     fclose(stream);
 

--- a/src/libres/tests/tmpdir.cpp
+++ b/src/libres/tests/tmpdir.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 
 #include <catch2/catch.hpp>
-#include <fmt/format.h>
+#include <ert/except.hpp>
 
 #include "tmpdir.hpp"
 
@@ -86,9 +86,8 @@ std::filesystem::path make_numbered_dir(const fs::path &basepath,
         }
     }
 
-    throw std::runtime_error(
-        fmt::format("Could not make numbered dir in {} with prefix {}",
-                    basepath.string(), norm_prefix));
+    throw exc::runtime_error("Could not make numbered dir in {} with prefix {}",
+                             basepath.string(), norm_prefix);
 }
 
 /**


### PR DESCRIPTION
The only difference is that these exceptions have an additional
constructor allowing fmtlib format strings. It makes throwing code
slightly shorter and nicer.
