### PR TITLE
Fix broken imports

### DIFF
--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -5,7 +5,7 @@ import pandas
 import sys
 
 
-from res.enkf import ErtPlugin, CancelPluginException
+from res.job_queue import ErtPlugin, CancelPluginException
 from res.enkf.export import (
     SummaryCollector,
     GenKwCollector,

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -6,7 +6,7 @@ import pandas
 import sys
 
 from ecl.rft import WellTrajectory
-from res.enkf import ErtPlugin, CancelPluginException
+from res.job_queue import ErtPlugin, CancelPluginException
 from res.enkf import RealizationStateEnum
 from res.enkf.enums import EnkfObservationImplementationType
 from res.enkf.export import GenDataCollector, ArgLoader


### PR DESCRIPTION
In ab7224e2b1f8af5a3b0cad501b8db082cb162562 , res.enkf
no longer re-exported ErtPlugin and CancelPluginException.
Two scripts were not updated

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
