### PR TITLE
Fetch storage server name, i.e. the config name, and use as title in webviz-ert

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ args = dict(
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.13.0",
-        "ert-storage >= 0.3.11",
+        "ert-storage >= 0.3.16",
         "fastapi",
         "graphlib_backport; python_version < '3.9'",
         "jinja2",

--- a/src/ert/shared/dark_storage/endpoints/__init__.py
+++ b/src/ert/shared/dark_storage/endpoints/__init__.py
@@ -6,6 +6,7 @@ from .observations import router as observations_router
 from .updates import router as updates_router
 from .compute.misfits import router as misfits_router
 from .responses import router as response_router
+from .server import router as server_router
 
 router = APIRouter()
 router.include_router(experiments_router)
@@ -15,3 +16,4 @@ router.include_router(observations_router)
 router.include_router(updates_router)
 router.include_router(misfits_router)
 router.include_router(response_router)
+router.include_router(server_router)

--- a/src/ert/shared/dark_storage/endpoints/server.py
+++ b/src/ert/shared/dark_storage/endpoints/server.py
@@ -1,0 +1,15 @@
+from typing import Mapping, Any
+from fastapi import APIRouter, Depends
+from ert.shared.dark_storage.enkf import LibresFacade, get_res
+from pathlib import Path
+
+router = APIRouter(tags=["info"])
+
+
+@router.get("/server/info", response_model=Mapping[str, Any])
+def info(
+    *,
+    res: LibresFacade = Depends(get_res),
+) -> Mapping[str, Any]:
+    config = Path(res.user_config_file)
+    return {"name": config.name}

--- a/src/ert/shared/services/webviz_ert_service.py
+++ b/src/ert/shared/services/webviz_ert_service.py
@@ -6,10 +6,15 @@ from ert.shared.services._base_service import BaseService
 class WebvizErt(BaseService):
     service_name = "webviz-ert"
 
-    def __init__(self, experimental_mode: bool = False, verbose: bool = False):
+    def __init__(
+        self, title: str = None, experimental_mode: bool = False, verbose: bool = False
+    ):
         exec_args = [sys.executable, "-m", "webviz_ert"]
         if experimental_mode:
             exec_args.append("--experimental-mode")
         if verbose:
             exec_args.append("--verbose")
+        if title:
+            exec_args.append("--title")
+            exec_args.append(title)
         super().__init__(exec_args)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/webviz-ert/issues/351


**Approach**
Make request to storage server before starting webviz-ert, and set it as the title in the webviz config.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
