### PR TITLE
Use Experiment server in all run models when feature is enabled

### DIFF
--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -156,7 +156,8 @@ class ExperimentServer:
 
         This is a helper method for use by the CLI, where only one experiment
         at a time makes sense. This method therefore runs the experiment, and
-        attempts to gracefully shut down the server when complete."""
+        attempts to gracefully shut down the server when complete.
+        """
         logger.debug("running experiment %s", experiment_id)
         experiment = self._registry.get_experiment(experiment_id)
 
@@ -184,8 +185,8 @@ class ExperimentServer:
 
         # experiment is pending, but the server died, so try cancelling the experiment
         # then raise the server's exception
-        for p in pending:
-            logger.debug("task %s was pending, cancelling...", p)
-            p.cancel()
-        for d in done:
-            d.result()
+        for pending_task in pending:
+            logger.debug("task %s was pending, cancelling...", pending_task)
+            pending_task.cancel()
+        for done_task in done:
+            done_task.result()

--- a/src/ert/shared/main.py
+++ b/src/ert/shared/main.py
@@ -488,11 +488,10 @@ def log_config(config_path: str, logger: logging.Logger) -> None:
                 line = line.strip()
                 if not line or line.startswith("--"):
                     continue
-                if "--" in line:
+                if "--" in line and not any(x in line for x in ['"', "'"]):
                     # There might be a comment in this line, but it could
                     # also be an argument to a job, so we do a quick check
-                    if not any(x in line for x in ['"', "'"]):
-                        line = line.split("--")[0].rstrip()
+                    line = line.split("--")[0].rstrip()
                 config_context += line + "\n"
         logger.info(
             f"Content of the configuration file ({config_path}):\n" + config_context
@@ -567,13 +566,6 @@ def main():
             context.plugin_manager.add_logging_handle_to_root(logging.getLogger())
             logger.info(f"Running ert with {args}")
             log_config(args.config, logger)
-
-            if FeatureToggling.is_enabled("experiment-server"):
-                if args.mode != ENSEMBLE_EXPERIMENT_MODE:
-                    raise NotImplementedError(
-                        f"experiment-server can only run '{ENSEMBLE_EXPERIMENT_MODE}'"
-                    )
-
             args.func(args)
     except ErtCliError as err:
         logger.exception(str(err))

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -1,3 +1,6 @@
+import asyncio
+import concurrent
+import logging
 from typing import Any, Dict, Optional
 
 from iterative_ensemble_smoother import IterativeEnsembleSmoother
@@ -8,8 +11,11 @@ from ert._c_wrappers.enkf.enkf_fs import EnkfFs
 from ert._c_wrappers.enkf.enkf_main import EnKFMain, QueueConfig
 from ert._c_wrappers.enkf.enums import HookRuntime, RealizationStateEnum
 from ert.analysis import ErtAnalysisError
+from ert.ensemble_evaluator import identifiers
 from ert.shared.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.shared.models import BaseRunModel, ErtRunError
+
+experiment_logger = logging.getLogger("ert.experiment_server.ensemble_experiment")
 
 
 class IteratedEnsembleSmoother(BaseRunModel):
@@ -195,3 +201,172 @@ class IteratedEnsembleSmoother(BaseRunModel):
     @classmethod
     def name(cls) -> str:
         return "Iterated ensemble smoother"
+
+    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+        loop = asyncio.get_running_loop()
+        executor = concurrent.futures.ThreadPoolExecutor()
+
+        phase_count = self.facade.get_number_of_iterations() + 1
+        self.setPhaseCount(phase_count)
+
+        target_case_format = self._simulation_arguments["target_case"]
+        run_context = await loop.run_in_executor(executor, self.create_context, 0)
+
+        self.ert().analysisConfig().getAnalysisIterConfig().setCaseFormat(
+            target_case_format
+        )
+
+        ensemble_id = await self._run_and_post_process(
+            loop, executor, run_context, evaluator_server_config
+        )
+
+        analysis_config = self.ert().analysisConfig()
+        analysis_iter_config = analysis_config.getAnalysisIterConfig()
+        num_retries_per_iteration = analysis_iter_config.getNumRetries()
+        num_retries = 0
+        current_iter = 0
+
+        while (
+            current_iter < self.facade.get_number_of_iterations()
+            and num_retries < num_retries_per_iteration
+        ):
+            pre_analysis_iter_num = self._w_container.iteration_nr - 1
+            # We run the PRE_FIRST_UPDATE hook here because the current_iter is
+            # explicitly available, versus in the run_context inside analyzeStep
+            if current_iter == 0:
+                await self._run_hook(
+                    HookRuntime.PRE_FIRST_UPDATE,
+                    current_iter,
+                    loop,
+                    executor,
+                )
+            update_id = await self.analyze_step(
+                loop, executor, run_context, ensemble_id
+            )
+            current_iter = self._w_container.iteration_nr - 1
+
+            analysis_success = current_iter > pre_analysis_iter_num
+            if analysis_success:
+                run_context = await loop.run_in_executor(
+                    executor, self.create_context, current_iter, run_context
+                )
+
+                ensemble_id = await self._run_and_post_process(
+                    loop, executor, run_context, evaluator_server_config, update_id
+                )
+                num_retries = 0
+            else:
+                run_context = await loop.run_in_executor(
+                    executor, self.create_context, current_iter, run_context, True
+                )
+
+                ensemble_id = await self._run_and_post_process(
+                    loop, executor, run_context, evaluator_server_config, update_id
+                )
+
+                num_retries += 1
+
+        if current_iter == (phase_count - 1):
+            self.setPhase(phase_count, "Simulations completed.")
+        else:
+            raise ErtRunError(
+                (
+                    "Iterated ensemble smoother stopped: "
+                    "maximum number of iteration retries "
+                    f"({num_retries_per_iteration} retries) reached "
+                    f"for iteration {current_iter}"
+                )
+            )
+
+    async def _run_and_post_process(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        executor: concurrent.futures.Executor,
+        run_context: RunContext,
+        evaluator_server_config: EvaluatorServerConfig,
+        update_id: Optional[str] = None,
+    ) -> str:
+        await loop.run_in_executor(
+            executor,
+            self.ert().getEnkfSimulationRunner().createRunPath,
+            run_context,
+        )
+
+        await self._run_hook(
+            HookRuntime.PRE_SIMULATION,
+            run_context.iteration,
+            loop,
+            executor,
+        )
+
+        ensemble_id = await loop.run_in_executor(
+            executor, self._post_ensemble_data, update_id
+        )
+
+        experiment_logger.debug("evaluating")
+        await self._evaluate(run_context, evaluator_server_config)
+
+        num_successful_realizations = self._state_machine.successful_realizations(
+            run_context.iteration,
+        )
+
+        self.checkHaveSufficientRealizations(num_successful_realizations)
+
+        await self._run_hook(
+            HookRuntime.POST_SIMULATION,
+            run_context.iteration,
+            loop,
+            executor,
+        )
+
+        self._post_ensemble_results(ensemble_id)
+
+        await loop.run_in_executor(executor, self._post_ensemble_data, ensemble_id)
+
+        return ensemble_id
+
+    async def analyze_step(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        executor: concurrent.futures.Executor,
+        run_context: RunContext,
+        ensemble_id: str,
+    ) -> str:
+        await self._run_hook(
+            HookRuntime.PRE_UPDATE,
+            run_context.iteration,
+            loop,
+            executor,
+        )
+
+        try:
+            await loop.run_in_executor(
+                executor,
+                self.facade.iterative_smoother_update,
+                run_context,
+                self._w_container,
+            )
+            self._w_container.iteration_nr += 1
+        except ErtAnalysisError as e:
+            experiment_logger.exception("analysis failed")
+            await self._dispatch_ee(
+                identifiers.EVTYPE_EXPERIMENT_FAILED,
+                data={
+                    "error": str(e),
+                },
+                iteration=run_context.iteration,
+            )
+            raise ErtRunError(
+                f"Analysis of simulation failed with the following error: {e}"
+            ) from e
+
+        # Push update data to new storage
+        analysis_module_name = self.ert().analysisConfig().activeModuleName()
+        update_id = await loop.run_in_executor(
+            executor, self._post_update_data, ensemble_id, analysis_module_name
+        )
+
+        await self._run_hook(
+            HookRuntime.POST_UPDATE, run_context.iteration, loop, executor
+        )
+        return update_id

--- a/src/ert/shared/models/single_test_run.py
+++ b/src/ert/shared/models/single_test_run.py
@@ -25,6 +25,9 @@ class SingleTestRun(EnsembleExperiment):
             "Running single realisation test ...", evaluator_server_config
         )
 
+    async def run(self, evaluator_server_config: "EvaluatorServerConfig") -> None:
+        await super().run(evaluator_server_config)
+
     @classmethod
     def name(cls) -> str:
         return "Single realization test-run"

--- a/tests/ert_tests/cli/test_integration_cli.py
+++ b/tests/ert_tests/cli/test_integration_cli.py
@@ -267,3 +267,71 @@ def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):
         assert captured.out == "Successful realizations: 5\n"
 
     FeatureToggling.reset()
+
+
+@pytest.mark.integration_test
+@pytest.mark.timeout(40)
+def test_experiment_server_ensemble_smoother(tmpdir, source_root, capsys):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+
+    with tmpdir.as_cwd():
+        parser = ArgumentParser(prog="test_main")
+        parsed = ert_parser(
+            parser,
+            [
+                ENSEMBLE_SMOOTHER_MODE,
+                "poly_example/poly.ert",
+                "--port-range",
+                "1024-65535",
+                "--enable-experiment-server",
+                "--realizations",
+                "0-1",
+                "--target-case",
+                "test_case",
+            ],
+        )
+
+        FeatureToggling.update_from_args(parsed)
+
+        run_cli(parsed)
+        captured = capsys.readouterr()
+        assert captured.out == "Successful realizations: 2\n"
+
+    FeatureToggling.reset()
+
+
+@pytest.mark.integration_test
+@pytest.mark.timeout(40)
+def test_experiment_server_mda(tmpdir, source_root, capsys):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+    with tmpdir.as_cwd():
+        parser = ArgumentParser(prog="test_main")
+        parsed = ert_parser(
+            parser,
+            [
+                ES_MDA_MODE,
+                "--enable-experiment-server",
+                "--target-case",
+                "iter-%d",
+                "--realizations",
+                "1,2,4,8,16",
+                "poly_example/poly.ert",
+                "--port-range",
+                "1024-65535",
+                "--weights",
+                "1",
+            ],
+        )
+        FeatureToggling.update_from_args(parsed)
+
+        run_cli(parsed)
+        captured = capsys.readouterr()
+        assert "Successful realizations: 5\n" in captured.out
+
+    FeatureToggling.reset()


### PR DESCRIPTION
**Issue**
Resolves #3413


**Approach**
`runSimulations()` in each run model has been ported to an async function alongside that uses the experiment server.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
