### PR TITLE
Remove unused modules from coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
         # of 3.0.0) will create an incorrect report when a directory matches
         # the package name
         cd tests
-        pytest ert_tests --cov=ert --cov=ert3 --cov=ert_shared --cov=ert_logging --cov=res --cov-report=xml:cov.xml
+        pytest ert_tests --cov=ert --cov=res --cov-report=xml:cov.xml
 
     - name: Run res tests
       if: matrix.system-under-test == 'res'


### PR DESCRIPTION
**Approach**
Due to `ert_shared` transfer to `ert.shared` we remove unused modules


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
