### PR TITLE
Unpin fastapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ args = dict(
         "dnspython >= 2",
         "ecl >= 2.13.0",
         "ert-storage >= 0.3.11",
-        "fastapi==0.70.1",
+        "fastapi",
         "graphlib_backport; python_version < '3.9'",
         "jinja2",
         "matplotlib",


### PR DESCRIPTION
Graphql is not used anymore and was the reason for pinning fastapi. I think it should be safe to unpin at this moment.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
