### PR TITLE
Pin setuptools to <64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 
 requires = [
-    "setuptools",
+    "setuptools<64",
     "setuptools_scm",
     "wheel",
     "scikit-build",


### PR DESCRIPTION

**Issue**
setuptools version 64 seems to have broken editable installs
using scikit build.


**Approach**
Pin setuptools

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
