### PR TITLE
Fix the logging path when running the GUI

### DIFF
--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -9,10 +9,16 @@ STORAGE_LOG_CONFIG = pathlib.Path(__file__).parent.resolve() / "storage_log.conf
 
 class TimestampedFileHandler(FileHandler):
     def __init__(self, filename: str, *args, **kwargs) -> None:
+
         filename, extension = os.path.splitext(filename)
         filename = (
             f"{filename}-"
             f"{datetime.now().strftime(datetime.now().strftime('%Y-%m-%dT%H%M'))}"
             f"{extension}"
         )
+
+        if kwargs.pop("use_log_dir_from_env", False) and "ERT_LOG_DIR" in os.environ:
+            log_dir = os.environ["ERT_LOG_DIR"]
+            filename = log_dir + "/" + filename
+
         super().__init__(filename, *args, **kwargs)

--- a/src/ert/logging/storage_log.conf
+++ b/src/ert/logging/storage_log.conf
@@ -18,9 +18,10 @@ handlers:
     stream: ext://sys.stdout
   file:
     formatter: standard
-    class: ert.logging.TimestampedFileHandler
     level: DEBUG
-    filename: api-log.txt
+    filename: api-log-storage.txt
+    (): ert.logging.TimestampedFileHandler
+    use_log_dir_from_env: true
 loggers:
     uvicorn.error:
       level: INFO

--- a/src/ert/shared/main.py
+++ b/src/ert/shared/main.py
@@ -191,7 +191,9 @@ def range_limited_int(user_input):
 def run_gui_wrapper(args):
     from ert.gui.gert_main import run_gui
 
+    os.environ["ERT_LOG_DIR"] = os.getcwd()
     run_gui(args)
+    os.environ.pop("ERT_LOG_DIR")
 
 
 def get_ert_parser(parser=None):


### PR DESCRIPTION
**Issue**
Resolves #3588 


**Approach**
Add the logging path to the environment that is sent to the subprocess then use this in the custom file handler.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
