### PR TITLE
Remove enkf_main alloc enkf_fs from symlink

### DIFF
--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -860,28 +860,13 @@ enkf_main_type *enkf_main_alloc(const res_config_type *res_config,
     enkf_main->dbase = NULL;
     const char *ens_path = model_config_get_enspath(
         res_config_get_model_config(enkf_main->res_config));
-    char *current_mount_point =
-        util_alloc_filename(ens_path, CURRENT_CASE, NULL);
-
     if (enkf_main_current_case_file_exists(enkf_main)) {
         char *current_case = enkf_main_read_alloc_current_case_name(enkf_main);
         enkf_main_select_fs(enkf_main, current_case, read_only);
         free(current_case);
-    } else if (enkf_fs_exists(current_mount_point) &&
-               util_is_link(current_mount_point)) {
-        /*If the current_case file does not exists, but the 'current' symlink does we use readlink to
-    get hold of the actual target before calling the  enkf_main_select_fs() function. We then
-    write the current_case file and delete the symlink.*/
-        char *target_case = util_alloc_atlink_target(ens_path, CURRENT_CASE);
-        enkf_main_select_fs(enkf_main, target_case, read_only);
-        unlink(current_mount_point);
-        enkf_main_write_current_case_file(enkf_main, target_case);
-        free(target_case);
     } else
         // Selecting (a new) default case
         enkf_main_select_fs(enkf_main, DEFAULT_CASE, read_only);
-
-    free(current_mount_point);
 
     // Init observations
     auto obs = enkf_obs_alloc(model_config_get_history(model_config),

--- a/src/clib/lib/include/ert/enkf/enkf_defaults.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_defaults.hpp
@@ -125,7 +125,6 @@
 */
 
 #define CASE_LOG "case-log"
-#define CURRENT_CASE "current"
 #define DEFAULT_CASE "default"
 #define CURRENT_CASE_FILE "current_case"
 

--- a/src/clib/old_tests/enkf/CMakeLists.txt
+++ b/src/clib/old_tests/enkf/CMakeLists.txt
@@ -102,7 +102,6 @@ add_config_test(enkf_ecl_config_config enkf_ecl_config_config
 
 foreach(
   test
-  enkf_main_fs_current_file
   enkf_plot_gendata_fs
   enkf_state_manual_load
   enkf_gen_data_config
@@ -152,9 +151,6 @@ add_equinor_test(
   "${EQUINOR_TEST_DATA_DIR}/ECLIPSE/ModifiedSummary/MISSING_TSTEP")
 
 add_equinor_test(enkf_main_fs enkf_main_fs
-                 "${EQUINOR_TEST_DATA_DIR}/config/plotData/config")
-
-add_equinor_test(enkf_main_fs_current_file enkf_main_fs_current_file
                  "${EQUINOR_TEST_DATA_DIR}/config/plotData/config")
 
 add_equinor_test(enkf_plot_gendata_fs enkf_plot_gendata_fs

--- a/src/clib/old_tests/enkf/test_enkf_main_fs_current_file.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_main_fs_current_file.cpp
@@ -27,21 +27,6 @@
 
 namespace fs = std::filesystem;
 
-void test_current_file_not_present_symlink_present(const char *model_config) {
-    test_assert_true(fs::exists("Storage/enkf"));
-    util_make_slink("enkf", "Storage/current");
-    res_config_type *res_config = res_config_alloc_load(model_config);
-    enkf_main_type *enkf_main = enkf_main_alloc(res_config);
-    test_assert_true(enkf_main_case_is_current(enkf_main, "enkf"));
-    test_assert_false(fs::exists("Storage/current"));
-    test_assert_true(fs::exists("Storage/current_case"));
-    char *current_case = enkf_main_read_alloc_current_case_name(enkf_main);
-    test_assert_string_equal(current_case, "enkf");
-    free(current_case);
-    enkf_main_free(enkf_main);
-    res_config_free(res_config);
-}
-
 void test_current_file_present(const char *model_config) {
     test_assert_true(fs::exists("Storage/current_case"));
     res_config_type *res_config = res_config_alloc_load(model_config);
@@ -91,7 +76,6 @@ int main(int argc, char **argv) {
     util_alloc_file_components(config_file, NULL, &model_config, NULL);
     ta.copy_parent_content(config_file);
 
-    test_current_file_not_present_symlink_present(model_config);
     test_current_file_present(model_config);
     test_change_case(model_config);
 


### PR DESCRIPTION
This was probably old funtionality to migrate from symlink
to current_case file. Storage is usually short-lived, so
this is unlikely to affect any users.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
