### PR TITLE
Fix broken shell scripts

### DIFF
--- a/src/ert/shared/share/ert/shell_scripts/careful_copy_file
+++ b/src/ert/shared/share/ert/shell_scripts/careful_copy_file
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import careful_copy_file
+from ert._c_wrappers.fm.shell import careful_copy_file
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/copy_directory
+++ b/src/ert/shared/share/ert/shell_scripts/copy_directory
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import copy_directory
+from ert._c_wrappers.fm.shell import copy_directory
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/copy_file
+++ b/src/ert/shared/share/ert/shell_scripts/copy_file
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import copy_file
+from ert._c_wrappers.fm.shell import copy_file
 
 if __name__ == "__main__":
     src = sys.argv[1]

--- a/src/ert/shared/share/ert/shell_scripts/delete_directory
+++ b/src/ert/shared/share/ert/shell_scripts/delete_directory
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import delete_directory
+from ert._c_wrappers.fm.shell import delete_directory
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/delete_file
+++ b/src/ert/shared/share/ert/shell_scripts/delete_file
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import delete_file
+from ert._c_wrappers.fm.shell import delete_file
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/make_directory
+++ b/src/ert/shared/share/ert/shell_scripts/make_directory
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import mkdir
+from ert._c_wrappers.fm.shell import mkdir
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/move_file
+++ b/src/ert/shared/share/ert/shell_scripts/move_file
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import move_file
+from ert._c_wrappers.fm.shell import move_file
 
 
 if __name__ == "__main__":

--- a/src/ert/shared/share/ert/shell_scripts/symlink
+++ b/src/ert/shared/share/ert/shell_scripts/symlink
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from res.fm.shell import symlink
+from ert._c_wrappers.fm.shell import symlink
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 
 import pkg_resources
 import pytest
-from ert.shared.services import Storage
 from ert._c_wrappers.enkf import ResConfig
+from ert.shared.services import Storage
 
 from .utils import SOURCE_DIR
 

--- a/tests/libres_tests/res/fm/test_shell.py
+++ b/tests/libres_tests/res/fm/test_shell.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 import os.path
-import unittest
+import subprocess
 
 from ecl.util.test import TestAreaContext
 from pytest import MonkeyPatch
@@ -308,5 +308,42 @@ class ShellTest(ResTest):
             self.assertTrue(os.path.isfile("file3"))
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_shell_scripts_integration(tmpdir):
+    """
+    The following test is a regression test that
+    checks that the scripts under src/ert/shared/share/ert/shell_scripts
+    are not broken, and correctly installed through site-config.
+    """
+    with tmpdir.as_cwd():
+
+        ert_config_fname = "test.ert"
+        with open(ert_config_fname, "w", encoding="utf-8") as file_h:
+            file_h.write(
+                """
+RUNPATH realization-%d/iter-%d
+JOBNAME TEST
+QUEUE_SYSTEM LOCAL
+NUM_REALIZATIONS 1
+FORWARD_MODEL COPY_FILE(<FROM>=<CONFIG_PATH>/file.txt, <TO>=copied.txt)
+FORWARD_MODEL COPY_FILE(<FROM>=<CONFIG_PATH>/file.txt, <TO>=copied2.txt)
+FORWARD_MODEL CAREFUL_COPY_FILE(<FROM>=<CONFIG_PATH>/file.txt, <TO>=copied3.txt)
+FORWARD_MODEL MOVE_FILE(<FROM>=copied.txt, <TO>=moved.txt)
+FORWARD_MODEL DELETE_FILE(<FILES>=copied2.txt)
+FORWARD_MODEL MAKE_DIRECTORY(<DIRECTORY>=mydir)
+FORWARD_MODEL COPY_DIRECTORY(<FROM>=mydir, <TO>=mydir2)
+FORWARD_MODEL DELETE_DIRECTORY(<DIRECTORY>=mydir)
+"""
+            )
+
+        with open("file.txt", "w", encoding="utf-8") as file_h:
+            file_h.write("something")
+
+        subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+
+        with open("realization-0/iter-0/moved.txt") as output_file:
+            assert output_file.read() == "something"
+        assert not os.path.exists("realization-0/iter-0/copied.txt")
+        assert not os.path.exists("realization-0/iter-0/copied2.txt")
+        assert os.path.exists("realization-0/iter-0/copied3.txt")
+        assert not os.path.exists("realization-0/iter-0/mydir")
+        assert os.path.exists("realization-0/iter-0/mydir2")


### PR DESCRIPTION
Some internal jobs were broken after c6bdf055be131f93843cadc9a77c62587f4b57de , this PR fixes them and adds a regression test.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
