### PR TITLE
Set cap on ert-storage because of api change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ args = dict(
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.13.0",
-        "ert-storage >= 0.3.11",
+        "ert-storage < 0.3.16",
         "fastapi",
         "graphlib_backport; python_version < '3.9'",
         "jinja2",


### PR DESCRIPTION
**Issue**
API change causes tests to fail


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
