### PR TITLE
Upgrade to cloudevents 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ args = dict(
         "ansicolors==1.1.8",
         "async-generator",
         "beartype >= 0.9.1",
-        "cloudevents",
+        "cloudevents>=1.6.0",
         "cloudpickle",
         "tqdm>=4.62.0",
         "cryptography",

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -27,7 +27,8 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
 
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 from cwrap import BaseCClass
 from websockets.client import connect
 from websockets.datastructures import Headers

--- a/src/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/builder/_ensemble.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
 
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 from ert.ensemble_evaluator import state
 from ert.ensemble_evaluator.snapshot import (
     Job,

--- a/src/ert/ensemble_evaluator/builder/_prefect.py
+++ b/src/ert/ensemble_evaluator/builder/_prefect.py
@@ -15,7 +15,8 @@ from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 import cloudpickle
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 
 with warnings.catch_warnings():
     # This is needed until dask_jobqueue is tagged by something newer

--- a/src/ert/job_runner/reporting/event.py
+++ b/src/ert/job_runner/reporting/event.py
@@ -4,7 +4,8 @@ import logging
 from pathlib import Path
 from typing import Dict, Any
 
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 
 from ert.job_runner.reporting.message import (
     Exited,

--- a/src/ert/shared/ensemble_evaluator/client.py
+++ b/src/ert/shared/ensemble_evaluator/client.py
@@ -100,4 +100,4 @@ class Client:  # pylint: disable=too-many-instance-attributes
             },
             ev_data,
         )
-        self.send(cloudevents.http.to_json(event).decode())
+        self.send(cloudevents.conversion.to_json(event).decode())

--- a/src/ert/shared/ensemble_evaluator/evaluator.py
+++ b/src/ert/shared/ensemble_evaluator/evaluator.py
@@ -10,8 +10,8 @@ from typing import Optional, Set
 import cloudevents.exceptions
 import cloudpickle
 import websockets
-from cloudevents.http import from_json, to_json
-from cloudevents.http.event import CloudEvent
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent, from_json
 from contextlib import asynccontextmanager
 from websockets.exceptions import ConnectionClosedError
 from aiohttp import ClientError

--- a/src/ert/shared/ensemble_evaluator/monitor.py
+++ b/src/ert/shared/ensemble_evaluator/monitor.py
@@ -6,8 +6,8 @@ from typing import Optional, TYPE_CHECKING
 
 from ert.ensemble_evaluator import identifiers
 from cloudevents.exceptions import DataUnmarshallerError
-from cloudevents.http import from_json, to_json
-from cloudevents.http.event import CloudEvent
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent, from_json
 from ert.serialization import evaluator_marshaller, evaluator_unmarshaller
 from ert.shared.ensemble_evaluator.sync_ws_duplexer import SyncWebsocketDuplexer
 

--- a/src/ert/shared/ensemble_evaluator/narratives/narrative.py
+++ b/src/ert/shared/ensemble_evaluator/narratives/narrative.py
@@ -17,7 +17,8 @@ from ert.ensemble_evaluator import wait_for_evaluator
 
 from websockets.client import connect
 from websockets.server import serve
-from cloudevents.http import CloudEvent, from_json, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent, from_json
 
 _DATACONTENTTYPE = "datacontenttype"
 

--- a/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -2,7 +2,8 @@ import asyncio
 import threading
 
 import websockets
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 
 from ert.shared.ensemble_evaluator.client import Client
 from ert.ensemble_evaluator import identifiers

--- a/tests/ert_tests/ensemble_evaluator/test_contracts.py
+++ b/tests/ert_tests/ensemble_evaluator/test_contracts.py
@@ -1,6 +1,7 @@
 import pytest
 import websockets
-from cloudevents.http import CloudEvent, from_json, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent, from_json
 
 from ert.shared.ensemble_evaluator.narratives.narrative import (
     Consumer,

--- a/tests/ert_tests/ensemble_evaluator/test_data_marshaller_and_unmarshaller.py
+++ b/tests/ert_tests/ensemble_evaluator/test_data_marshaller_and_unmarshaller.py
@@ -1,7 +1,7 @@
 import datetime
 
-from cloudevents.http import from_json, to_json
-from cloudevents.http.event import CloudEvent
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent, from_json
 
 from ert import serialization
 

--- a/tests/ert_tests/experiment_server/test_server.py
+++ b/tests/ert_tests/experiment_server/test_server.py
@@ -8,7 +8,8 @@ except ImportError:
 from ert.experiment_server._experiment_protocol import Experiment
 from typing import AsyncContextManager, Awaitable, Callable
 
-from cloudevents.http import CloudEvent, to_json
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
 from websockets.client import WebSocketClientProtocol
 
 # All test coroutines will be treated as marked.


### PR DESCRIPTION
**Issue**
Cloudevents have been upgraded and moved conversion function
Resolves https://github.com/equinor/ert/issues/3782

**Approach**
Migrate import structure


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
