### PR TITLE
Refactor FileSystemRotator

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -52,9 +52,9 @@ class EnkfFs(BaseCClass):
     _umount = ResPrototype("void enkf_fs_umount(enkf_fs)")
 
     def __init__(self, mount_point: Union[str, Path], read_only: bool = False):
-        mount_point = Path(mount_point).absolute()
-        self.case_name = mount_point.stem
-        c_ptr = self._mount(mount_point.as_posix(), read_only)
+        self.mount_point = Path(mount_point).absolute()
+        self.case_name = self.mount_point.stem
+        c_ptr = self._mount(self.mount_point.as_posix(), read_only)
         super().__init__(c_ptr)
 
     # This method will return a new Python object which shares the underlying

--- a/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
@@ -1,50 +1,35 @@
-from typing import List, Dict, Union
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Union
 
 from ert._c_wrappers.enkf.enkf_fs import EnkfFs
 
 
+@dataclass
 class FileSystemRotator:
-    def __init__(self, capacity: int):
-        super().__init__()
-        self._capacity: int = capacity
-        self._fs_list: List[str] = []
-        self._fs_map: Dict[str, EnkfFs] = {}
+    capacity: int
+    fs_map: Dict[Path, EnkfFs] = field(default_factory=dict)
 
     def __len__(self) -> int:
-        return len(self._fs_list)
+        return len(self.fs_map)
 
-    def addFileSystem(self, file_system: EnkfFs, full_name: str) -> None:
-        if self.atCapacity():
-            self.dropOldestFileSystem()
+    def append(self, file_system: "EnkfFs") -> None:
+        if len(self) == self.capacity:
+            self.drop_oldest_file_system()
+        self.fs_map[file_system.mount_point] = file_system
 
-        self._fs_list.append(full_name)
-        self._fs_map[full_name] = file_system
+    def drop_oldest_file_system(self) -> None:
+        if len(self.fs_map) > 0:
+            case_name = list(self.fs_map)[0]
+            self.fs_map[case_name].sync()
+            del self.fs_map[case_name]
 
-    def dropOldestFileSystem(self) -> None:
-        if len(self._fs_list) > 0:
-            case_name = self._fs_list[0]
-            del self._fs_list[0]
-            self._fs_map[case_name].sync()
-            del self._fs_map[case_name]
+    def __contains__(self, full_case_name: Union[str, Path]) -> bool:
+        return Path(full_case_name).absolute() in self.fs_map
 
-    def atCapacity(self) -> bool:
-        return len(self._fs_list) == self._capacity
+    def __getitem__(self, case: Union[str, Path]) -> EnkfFs:
+        return self.fs_map[Path(case).absolute()]
 
-    def __contains__(self, full_case_name: str) -> bool:
-        return full_case_name in self._fs_list
-
-    def __get_fs(self, name: str) -> EnkfFs:
-        return self._fs_map[name]
-
-    def __getitem__(self, case: Union[int, str]) -> EnkfFs:
-        if isinstance(case, str):
-            return self.__get_fs(case)
-        elif isinstance(case, int) and 0 <= case < len(self):
-            case_name = self._fs_list[case]
-            return self.__get_fs(case_name)
-        else:
-            raise IndexError(f"Value '{case}' is not a proper index or case name.")
-
-    def umountAll(self) -> None:
-        while len(self._fs_list) > 0:
-            self.dropOldestFileSystem()
+    def umount(self) -> None:
+        while len(self.fs_map) > 0:
+            self.drop_oldest_file_system()

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -185,7 +185,7 @@ class EnKFMain(BaseCClass):
         case_name = file_system.getCaseName()
         full_name = self._createFullCaseName(self.getMountPoint(), case_name)
         if full_name not in self._fs_rotator:
-            self._fs_rotator.addFileSystem(file_system, full_name)
+            self._fs_rotator.append(file_system)
         # On setting a new file system we write the current_case file
         (Path(self.getModelConfig().getEnspath()) / "current_case").write_text(
             file_system.getCaseName()
@@ -389,7 +389,7 @@ class EnKFMain(BaseCClass):
                 new_fs = EnkfFs.createFileSystem(full_case_name, read_only)
             else:
                 new_fs = EnkfFs(full_case_name, read_only)
-            self._fs_rotator.addFileSystem(new_fs, full_case_name)
+            self._fs_rotator.append(new_fs)
 
         fs = self._fs_rotator[full_case_name]
 


### PR DESCRIPTION
**Issue**
Simplify the file system rotator, since python dicts are now ordered there is no need for a list to keep track of order.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
