### PR TITLE
Remove refcounting from enkf_fs

### DIFF
--- a/src/clib/lib/enkf/enkf_fs.cpp
+++ b/src/clib/lib/enkf/enkf_fs.cpp
@@ -181,8 +181,8 @@ enkf_fs_type *enkf_fs_alloc_empty(const char *mount_point, bool read_only) {
     fs->mount_point = strdup(mount_point);
     fs->lock_fd = 0;
     auto mount_path = fs::path(mount_point);
-    fs->case_name = mount_path.filename();
-    fs->lock_file = strdup((mount_path / (fs->case_name + ".lock")).c_str());
+    std::string case_name = mount_path.filename();
+    fs->lock_file = strdup((mount_path / (case_name + ".lock")).c_str());
 
     if (util_try_lockf(fs->lock_file, S_IWUSR + S_IWGRP, &fs->lock_fd)) {
         fs->read_only = false;
@@ -539,10 +539,6 @@ void enkf_fs_fwrite_vector(enkf_fs_type *enkf_fs, buffer_type *buffer,
 
 const char *enkf_fs_get_mount_point(const enkf_fs_type *fs) {
     return fs->mount_point;
-}
-
-const char *enkf_fs_get_case_name(const enkf_fs_type *fs) {
-    return fs->case_name.data();
 }
 
 bool enkf_fs_is_read_only(const enkf_fs_type *fs) { return fs->read_only; }

--- a/src/clib/lib/enkf/enkf_fs.cpp
+++ b/src/clib/lib/enkf/enkf_fs.cpp
@@ -165,9 +165,6 @@ struct enkf_fs_struct {
     path_fmt_type *case_tstep_member_fmt;
 
     int refcount;
-    /** Counts the number of simulations currently writing to this enkf_fs; the
-     * purpose is to be able to answer the question: Is this case currently 'running'? */
-    int runcount;
 };
 
 UTIL_SAFE_CAST_FUNCTION(enkf_fs, ENKF_FS_TYPE_ID)
@@ -218,7 +215,6 @@ enkf_fs_type *enkf_fs_alloc_empty(const char *mount_point, bool read_only) {
     fs->read_only = true;
     fs->mount_point = strdup(mount_point);
     fs->refcount = 0;
-    fs->runcount = 0;
     fs->lock_fd = 0;
     auto mount_path = fs::path(mount_point);
     fs->case_name = mount_path.filename();
@@ -664,16 +660,6 @@ summary_key_set_type *enkf_fs_get_summary_key_set(const enkf_fs_type *fs) {
 misfit_ensemble_type *enkf_fs_get_misfit_ensemble(const enkf_fs_type *fs) {
     return fs->misfit_ensemble;
 }
-
-void enkf_fs_increase_run_count(enkf_fs_type *fs) {
-    fs->runcount = fs->runcount + 1;
-}
-
-void enkf_fs_decrease_run_count(enkf_fs_type *fs) {
-    fs->runcount = fs->runcount - 1;
-}
-
-bool enkf_fs_is_running(const enkf_fs_type *fs) { return (fs->runcount > 0); }
 
 ERT_CLIB_SUBMODULE("enkf_fs", m) {
     using namespace py::literals;

--- a/src/clib/lib/include/ert/enkf/enkf_fs.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_fs.hpp
@@ -34,7 +34,6 @@
 #include <ert/enkf/time_map.hpp>
 
 const char *enkf_fs_get_mount_point(const enkf_fs_type *fs);
-extern "C" const char *enkf_fs_get_case_name(const enkf_fs_type *fs);
 extern "C" bool enkf_fs_is_read_only(const enkf_fs_type *fs);
 extern "C" void enkf_fs_fsync(enkf_fs_type *fs);
 

--- a/src/clib/lib/include/ert/enkf/enkf_fs.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_fs.hpp
@@ -96,10 +96,6 @@ misfit_ensemble_type *enkf_fs_get_misfit_ensemble(const enkf_fs_type *fs);
 extern "C" summary_key_set_type *
 enkf_fs_get_summary_key_set(const enkf_fs_type *fs);
 
-void enkf_fs_increase_run_count(enkf_fs_type *fs);
-void enkf_fs_decrease_run_count(enkf_fs_type *fs);
-extern "C" PY_USED bool enkf_fs_is_running(const enkf_fs_type *fs);
-
 UTIL_SAFE_CAST_HEADER(enkf_fs);
 UTIL_IS_INSTANCE_HEADER(enkf_fs);
 

--- a/src/clib/lib/include/ert/enkf/enkf_fs.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_fs.hpp
@@ -39,9 +39,6 @@ extern "C" bool enkf_fs_is_read_only(const enkf_fs_type *fs);
 extern "C" void enkf_fs_fsync(enkf_fs_type *fs);
 
 enkf_fs_type *enkf_fs_get_ref(enkf_fs_type *fs);
-extern "C" int enkf_fs_decref(enkf_fs_type *fs);
-extern "C" int enkf_fs_incref(enkf_fs_type *fs);
-extern "C" int enkf_fs_get_refcount(const enkf_fs_type *fs);
 extern "C" enkf_fs_type *enkf_fs_mount(const char *path,
                                        bool read_only = false);
 void enkf_fs_fwrite_node(enkf_fs_type *enkf_fs, buffer_type *buffer,
@@ -72,6 +69,8 @@ bool enkf_fs_has_node(enkf_fs_type *enkf_fs, const char *node_key,
 extern "C" enkf_fs_type *enkf_fs_create_fs(const char *mount_point,
                                            fs_driver_impl driver_id,
                                            bool mount);
+
+extern "C" void enkf_fs_umount(enkf_fs_type *fs);
 
 char *enkf_fs_alloc_case_filename(const enkf_fs_type *fs,
                                   const char *input_name);

--- a/src/clib/old_tests/enkf/test_enkf_fs.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_fs.cpp
@@ -77,30 +77,17 @@ void test_mount() {
         enkf_fs_type *fs = enkf_fs_mount("mnt");
         test_assert_true(fs::exists("mnt/mnt.lock"));
         test_assert_true(enkf_fs_is_instance(fs));
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
         test_assert_false(fs::exists("mnt/mnt.lock"));
     }
     {
         enkf_fs_type *fs = enkf_fs_create_fs("mnt2", BLOCK_FS_DRIVER_ID, true);
         test_assert_true(enkf_fs_is_instance(fs));
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
     }
 }
 
-void test_refcount() {
-    ecl::util::TestArea ta("ref_count");
-    enkf_fs_create_fs("mnt", BLOCK_FS_DRIVER_ID, false);
-    {
-        enkf_fs_type *fs = enkf_fs_mount("mnt");
-        test_assert_int_equal(1, enkf_fs_get_refcount(fs));
-        enkf_fs_decref(fs);
-    }
-}
-
-void mount(void *args) {
-    enkf_fs_type *fs2 = enkf_fs_mount("mnt");
-    enkf_fs_decref(fs2);
-}
+void mount(void *args) { enkf_fs_type *fs2 = enkf_fs_mount("mnt"); }
 
 void test_mount_filesystem_readwrite_twice() {
     ecl::util::TestArea ta("test_mount_filesystem_readwrite_twice");
@@ -119,11 +106,11 @@ void test_mount_filesystem_readwrite_twice() {
         waitpid(pid, &child_status, 0);
         test_assert_true(child_status == 0);
     }
+    enkf_fs_umount(fs);
 }
 
 int main(int argc, char **argv) {
     test_mount();
-    test_refcount();
     test_mount_filesystem_readwrite_twice();
     test_block_fs_driver_create_fs();
     exit(0);

--- a/src/clib/old_tests/enkf/test_enkf_gen_data_config.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_gen_data_config.cpp
@@ -85,10 +85,10 @@ void test_gendata_fload(const char *filename) {
     gen_data_fload_with_report_step(gen_data, filename, 0, write_fs);
     int data_size = gen_data_config_get_data_size(config, 0);
     test_assert_true(data_size > 0);
-    enkf_fs_decref(write_fs);
 
     gen_data_free(gen_data);
     gen_data_config_free(config);
+    enkf_fs_umount(write_fs);
 }
 
 void test_gendata_fload_empty_file(const char *filename) {
@@ -101,10 +101,10 @@ void test_gendata_fload_empty_file(const char *filename) {
     gen_data_fload_with_report_step(gen_data, filename, 0, write_fs);
     int data_size = gen_data_config_get_data_size(config, 0);
     test_assert_true(data_size == 0);
-    enkf_fs_decref(write_fs);
 
     gen_data_free(gen_data);
     gen_data_config_free(config);
+    enkf_fs_umount(write_fs);
 }
 
 void test_result_format() {

--- a/src/clib/old_tests/enkf/test_enkf_run_arg.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_run_arg.cpp
@@ -53,7 +53,7 @@ void test_queue_index() {
         test_assert_util_abort("run_arg_set_queue_index", call_set_queue_index,
                                run_arg);
         run_arg_free(run_arg);
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
     }
 }
 
@@ -78,9 +78,8 @@ void test_SMOOTHER_RUN() {
         test_assert_true(run_arg_is_instance(run_arg));
         test_assert_ptr_equal(run_arg_get_sim_fs(run_arg), sim_fs);
         run_arg_free(run_arg);
-
-        enkf_fs_decref(sim_fs);
-        enkf_fs_decref(target_fs);
+        enkf_fs_umount(sim_fs);
+        enkf_fs_umount(target_fs);
     }
 }
 
@@ -96,8 +95,7 @@ void test_INIT_ONLY() {
         test_assert_ptr_equal(run_arg_get_sim_fs(run_arg), init_fs);
 
         run_arg_free(run_arg);
-
-        enkf_fs_decref(init_fs);
+        enkf_fs_umount(init_fs);
     }
 }
 
@@ -114,7 +112,7 @@ void test_ENSEMBLE_EXPERIMENT() {
 
         test_assert_string_equal(run_arg_get_run_id(run_arg), "run_id");
         run_arg_free(run_arg);
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
     }
 }
 

--- a/src/clib/old_tests/enkf/test_gen_kw.cpp
+++ b/src/clib/old_tests/enkf/test_gen_kw.cpp
@@ -54,6 +54,7 @@ void test_write_gen_kw_export_file(enkf_main_type *enkf_main) {
         "simulations/run0", 0, init_fs);
     test_assert_true(fs::exists("simulations/run0/parameters.txt"));
     test_assert_true(fs::exists("simulations/run0/parameters.json"));
+    enkf_fs_umount(init_fs);
 }
 
 static void read_erroneous_gen_kw_file(void *arg) {

--- a/src/clib/old_tests/enkf/test_gen_kw_logarithmic.cpp
+++ b/src/clib/old_tests/enkf/test_gen_kw_logarithmic.cpp
@@ -99,7 +99,7 @@ void test_write_gen_kw_export_file(enkf_main_type *enkf_main) {
     }
     enkf_node_free(enkf_node);
     enkf_node_free(enkf_node2);
-    enkf_fs_decref(init_fs);
+    enkf_fs_umount(init_fs);
     verify_parameters_txt();
 }
 

--- a/src/clib/tests/analysis/test_copy_parameters.cpp
+++ b/src/clib/tests/analysis/test_copy_parameters.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Copy parameters from one source-fs to target-fs",
 
         //cleanup
         ensemble_config_free(ensemble_config);
-        enkf_fs_decref(fs_source);
-        enkf_fs_decref(fs_target);
+        enkf_fs_umount(fs_source);
+        enkf_fs_umount(fs_target);
     }
 }

--- a/src/clib/tests/analysis/test_save_parameters.cpp
+++ b/src/clib/tests/analysis/test_save_parameters.cpp
@@ -108,7 +108,7 @@ TEST_CASE("Write and read a matrix to enkf_fs instance",
 
         //cleanup
         ensemble_config_free(ensemble_config);
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
     }
 }
 
@@ -186,6 +186,6 @@ TEST_CASE("Reading and writing matrices with rowscaling attached",
 
         //cleanup
         ensemble_config_free(ensemble_config);
-        enkf_fs_decref(fs);
+        enkf_fs_umount(fs);
     }
 }

--- a/src/clib/tests/enkf/test_enkf_fs.cpp
+++ b/src/clib/tests/enkf/test_enkf_fs.cpp
@@ -153,10 +153,7 @@ TEST_CASE("block_fs", "[enkf_fs]") {
     }
 }
 
-void mount(void *args) {
-    enkf_fs_type *fs2 = enkf_fs_mount("mnt");
-    enkf_fs_decref(fs2);
-}
+void mount(void *args) { enkf_fs_type *fs2 = enkf_fs_mount("mnt"); }
 
 TEST_CASE("Mount filesystem read/write twice", "[enkf_fs]") {
     WITH_TMPDIR;
@@ -175,4 +172,5 @@ TEST_CASE("Mount filesystem read/write twice", "[enkf_fs]") {
         waitpid(pid, &child_status, 0);
         REQUIRE(child_status == 0);
     }
+    enkf_fs_umount(fs);
 }

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -44,7 +44,6 @@ class EnkfFs(BaseCClass):
     _get_refcount = ResPrototype("int   enkf_fs_get_refcount(enkf_fs)")
     _get_case_name = ResPrototype("char* enkf_fs_get_case_name(enkf_fs)")
     _is_read_only = ResPrototype("bool  enkf_fs_is_read_only(enkf_fs)")
-    _is_running = ResPrototype("bool  enkf_fs_is_running(enkf_fs)")
     _fsync = ResPrototype("void  enkf_fs_fsync(enkf_fs)")
     _create = ResPrototype(
         "enkf_fs_obj   enkf_fs_create_fs(char* , enkf_fs_type_enum , bool)",
@@ -91,9 +90,6 @@ class EnkfFs(BaseCClass):
 
     def refCount(self) -> int:
         return self._get_refcount()
-
-    def is_running(self) -> bool:
-        return self._is_running()
 
     def is_initalized(
         self,

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -39,7 +39,6 @@ class EnkfFs(BaseCClass):
 
     _mount = ResPrototype("void* enkf_fs_mount(char*, bool)", bind=False)
     _sync = ResPrototype("void enkf_fs_sync(enkf_fs)")
-    _get_case_name = ResPrototype("char* enkf_fs_get_case_name(enkf_fs)")
     _is_read_only = ResPrototype("bool  enkf_fs_is_read_only(enkf_fs)")
     _fsync = ResPrototype("void  enkf_fs_fsync(enkf_fs)")
     _create = ResPrototype(
@@ -54,6 +53,7 @@ class EnkfFs(BaseCClass):
 
     def __init__(self, mount_point: Union[str, Path], read_only: bool = False):
         mount_point = Path(mount_point).absolute()
+        self.case_name = mount_point.stem
         c_ptr = self._mount(mount_point.as_posix(), read_only)
         super().__init__(c_ptr)
 
@@ -76,7 +76,7 @@ class EnkfFs(BaseCClass):
         return _clib.enkf_fs.read_state_map(case_path)
 
     def getCaseName(self) -> str:
-        return self._get_case_name()
+        return self.case_name
 
     def isReadOnly(self) -> bool:
         return self._is_read_only()

--- a/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
@@ -34,8 +34,7 @@ class FileSystemRotator:
         return full_case_name in self._fs_list
 
     def __get_fs(self, name: str) -> EnkfFs:
-        fs = self._fs_map[name]
-        return fs.copy()
+        return self._fs_map[name]
 
     def __getitem__(self, case: Union[int, str]) -> EnkfFs:
         if isinstance(case, str):

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -407,9 +407,6 @@ class EnKFMain(BaseCClass):
         """Returns the currently selected file system"""
         return self.storage
 
-    def umount(self) -> None:
-        self._fs_rotator.umount()
-
     def getFileSystemCount(self) -> int:
         return len(self._fs_rotator)
 

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -395,13 +395,6 @@ class EnKFMain(BaseCClass):
 
         return fs
 
-    def isCaseRunning(self, case_name: str, mount_root: str = None) -> bool:
-        """Returns true if case is mounted and write_count > 0"""
-        if self.isCaseMounted(case_name, mount_root):
-            case_fs = self.getFileSystem(case_name, mount_root)
-            return case_fs.is_running()
-        return False
-
     def caseExists(self, case_name: str) -> bool:
         return case_name in self.getCaseList()
 

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -225,9 +225,6 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def case_has_data(self, case: str) -> bool:
         return self._enkf_main.caseHasData(case)
 
-    def is_case_running(self, case: str) -> bool:
-        return self._enkf_main.isCaseRunning(case)
-
     def all_data_type_keys(self) -> List[str]:
         return self._enkf_main.getKeyManager().allDataTypeKeys()
 

--- a/tests/ert_tests/shared/test_libres_facade.py
+++ b/tests/ert_tests/shared/test_libres_facade.py
@@ -87,11 +87,6 @@ def test_case_has_data(facade):
     assert not facade.case_has_data("default")
 
 
-def test_case_is_running(facade):
-    assert not facade.is_case_running("default_0")
-    assert not facade.is_case_running("nocase")
-
-
 def test_all_data_type_keys(facade):
     keys = facade.all_data_type_keys()
 

--- a/tests/libres_tests/res/enkf/test_enkf_fs.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs.py
@@ -11,8 +11,6 @@ def test_create(copy_case):
 
     assert os.path.exists(mount_point)
     fs = EnkfFs(mount_point)
-    assert fs.refCount() == 1
-    fs.umount()
 
     assert not os.path.exists("newFS")
     fs = EnkfFs.createFileSystem("newFS")

--- a/tests/libres_tests/res/enkf/test_enkf_fs_manager1.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs_manager1.py
@@ -14,14 +14,12 @@ def test_enkf_fs_manager_create(setup_case):
     assert fsm.isCaseMounted("default_0")
     assert fsm.caseExists("default_0")
     assert fsm.caseHasData("default_0")
-    assert not fsm.isCaseRunning("default_0")
 
     assert fsm.getFileSystemCount() == 1
 
     assert not fsm.isCaseMounted("newFS")
     assert not fsm.caseExists("newFS")
     assert not fsm.caseHasData("newFS")
-    assert not fsm.isCaseRunning("newFS")
 
     fsm.getFileSystem("newFS")
     assert fsm.getFileSystemCount() == 2
@@ -29,4 +27,3 @@ def test_enkf_fs_manager_create(setup_case):
     assert fsm.isCaseMounted("newFS")
     assert fsm.caseExists("newFS")
     assert not fsm.caseHasData("newFS")
-    assert not fsm.isCaseRunning("newFS")

--- a/tests/libres_tests/res/enkf/test_enkf_fs_manager2.py
+++ b/tests/libres_tests/res/enkf/test_enkf_fs_manager2.py
@@ -25,19 +25,10 @@ class TestEnKFFSManager2(ResTest):
             for index in range(5):
                 fs_list.append(fsm.getFileSystem(f"fs_fill_{index}"))
 
-            for fs in fs_list:
-                self.assertEqual(2, fs.refCount())
-                fs_copy = fs.copy()
-                self.assertEqual(3, fs.refCount())
-                self.assertEqual(3, fs_copy.refCount())
-
-                del fs_copy
-                self.assertEqual(2, fs.refCount())
-
             self.assertEqual(5, fsm.getFileSystemCount())
 
             for index in range(3 * 5):
                 fs_name = f"fs_test_{index}"
                 sys.stderr.write(f"Mounting: {fs_name}\n")
-                fs = fsm.getFileSystem(fs_name)
+                fsm.getFileSystem(fs_name)
                 self.assertEqual(5, fsm.getFileSystemCount())

--- a/tests/performance_tests/enkf/test_enkf_fs_performance.py
+++ b/tests/performance_tests/enkf/test_enkf_fs_performance.py
@@ -7,7 +7,6 @@ def mount_and_umount(ert, case_name):
     mount_point = fs_manager.getFileSystem(case_name)
     assert fs_manager.isCaseMounted(case_name)
     del mount_point
-    fs_manager.umount()
 
 
 def test_mount_fs(benchmark, template_config):


### PR DESCRIPTION
**Issue**
All file system creation outside tests are now in python, meaning that automatic refcounting should be handled automatically. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
