### PR TITLE
Propagate ensemble id for source when building

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_ensemble_builder.py
+++ b/src/ert/ensemble_evaluator/builder/_ensemble_builder.py
@@ -18,6 +18,7 @@ from ._legacy import _LegacyEnsemble
 from ._prefect import PrefectEnsemble
 from ._realization import _RealizationBuilder
 from ._step import _StepBuilder
+from ._template import _SOURCE_TEMPLATE_ENS
 
 if TYPE_CHECKING:
     import ert
@@ -210,7 +211,9 @@ class _EnsembleBuilder:  # pylint: disable=too-many-instance-attributes
         if not self._legacy_dependencies:
             self._build_io_maps(real_builders)
 
-        reals = [builder.build() for builder in real_builders]
+        source = _SOURCE_TEMPLATE_ENS.format(ens_id=self._id)
+
+        reals = [builder.set_parent_source(source).build() for builder in real_builders]
 
         if self._legacy_dependencies:
             return _LegacyEnsemble(

--- a/src/ert/ensemble_evaluator/builder/_function_task.py
+++ b/src/ert/ensemble_evaluator/builder/_function_task.py
@@ -91,7 +91,7 @@ class FunctionTask(prefect.Task):  # type: ignore
         self.logger.info(f"Running function {job.name}")
         client.send_event(
             ev_type=ids.EVTYPE_FM_JOB_START,
-            ev_source=job.source(self._ens_id),
+            ev_source=job.source(),
         )
         try:
             function: Callable[..., Any] = pickle.loads(job.command)
@@ -100,14 +100,14 @@ class FunctionTask(prefect.Task):  # type: ignore
             self.logger.error(str(e))
             client.send_event(
                 ev_type=ids.EVTYPE_FM_JOB_FAILURE,
-                ev_source=job.source(self._ens_id),
+                ev_source=job.source(),
                 ev_data={ids.ERROR_MSG: str(e)},
             )
             raise e
         else:
             client.send_event(
                 ev_type=ids.EVTYPE_FM_JOB_SUCCESS,
-                ev_source=job.source(self._ens_id),
+                ev_source=job.source(),
             )
         return output
 
@@ -119,7 +119,7 @@ class FunctionTask(prefect.Task):  # type: ignore
         ) as ee_client:
             ee_client.send_event(
                 ev_type=ids.EVTYPE_FM_STEP_RUNNING,
-                ev_source=self.step.source(self._ens_id),
+                ev_source=self.step.source(),
             )
 
             job = self.step.jobs[0]
@@ -130,7 +130,7 @@ class FunctionTask(prefect.Task):  # type: ignore
 
             ee_client.send_event(
                 ev_type=ids.EVTYPE_FM_STEP_SUCCESS,
-                ev_source=self.step.source(self._ens_id),
+                ev_source=self.step.source(),
             )
 
         return output

--- a/src/ert/ensemble_evaluator/builder/_job.py
+++ b/src/ert/ensemble_evaluator/builder/_job.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 from ert._c_wrappers.job_queue.ext_job import ExtJob
 
-from ._template import _SOURCE_TEMPLATE_BASE, _SOURCE_TEMPLATE_JOB
+from ._template import _SOURCE_TEMPLATE_JOB
 
 _BaseJobBuilder_TV = TypeVar("_BaseJobBuilder_TV", bound="_BaseJobBuilder")
 
@@ -19,8 +19,8 @@ class _BaseJob:
         self.index = index
         self._source = source
 
-    def source(self, ens_id: str) -> str:
-        return self._source.format(ens_id=ens_id)
+    def source(self) -> str:
+        return self._source
 
 
 class _UnixJob(_BaseJob):
@@ -115,10 +115,8 @@ class _JobBuilder(_BaseJobBuilder):
             raise ValueError("job needs a name")
         if self._parent_source is None:
             raise ValueError("job need source of parent")
-        source = (
-            _SOURCE_TEMPLATE_BASE
-            + self._parent_source
-            + _SOURCE_TEMPLATE_JOB.format(job_id=self._id, job_index=self._index)
+        source = self._parent_source + _SOURCE_TEMPLATE_JOB.format(
+            job_id=self._id, job_index=self._index
         )
         try:
             cmd_is_callable = isinstance(self._executable, bytes) and callable(

--- a/src/ert/ensemble_evaluator/builder/_prefect.py
+++ b/src/ert/ensemble_evaluator/builder/_prefect.py
@@ -141,7 +141,7 @@ def _on_task_failure(
             event = CloudEvent(
                 {
                     "type": EVTYPE_FM_STEP_FAILURE,
-                    "source": task.step.source(ens_id),
+                    "source": task.step.source(),
                     "datacontenttype": "application/json",
                 },
                 {"error_msg": state.message},

--- a/src/ert/ensemble_evaluator/builder/_template.py
+++ b/src/ert/ensemble_evaluator/builder/_template.py
@@ -1,4 +1,4 @@
-_SOURCE_TEMPLATE_BASE = "/ert/ensemble/{ens_id}/"
+_SOURCE_TEMPLATE_ENS = "/ert/ensemble/{ens_id}"
 _SOURCE_TEMPLATE_REAL = "/real/{iens}"
 _SOURCE_TEMPLATE_STEP = "/step/{step_id}"
 _SOURCE_TEMPLATE_JOB = "/job/{job_id}/index/{job_index}"

--- a/src/ert/ensemble_evaluator/builder/_unix_task.py
+++ b/src/ert/ensemble_evaluator/builder/_unix_task.py
@@ -93,7 +93,7 @@ class UnixTask(prefect.Task):  # type: ignore
             self.logger.error(cmd_exec.stderr)
             _send_event(
                 EVTYPE_FM_JOB_FAILURE,
-                job.source(self._ens_id),
+                job.source(),
                 {ERROR_MSG: cmd_exec.stderr},
             )
             raise OSError(
@@ -106,14 +106,14 @@ class UnixTask(prefect.Task):  # type: ignore
             self.logger.info(f"Running command {job.name}")
             _send_event(
                 EVTYPE_FM_JOB_START,
-                job.source(self._ens_id),
+                job.source(),
             )
             if not isinstance(job, _UnixJob):
                 raise TypeError(f"unexpected job {type(job)} in unix task")
             self.run_job(job, run_path)
             _send_event(
                 EVTYPE_FM_JOB_SUCCESS,
-                job.source(self._ens_id),
+                job.source(),
             )
 
     def _load_and_dump_input(
@@ -158,7 +158,7 @@ class UnixTask(prefect.Task):  # type: ignore
                 self._load_and_dump_input(transmitters=inputs, runpath=run_path)
             _send_event(
                 EVTYPE_FM_STEP_RUNNING,
-                self.step.source(self._ens_id),
+                self.step.source(),
             )
 
             outputs: _stage_transmitter_mapping = {}
@@ -187,6 +187,6 @@ class UnixTask(prefect.Task):  # type: ignore
             get_event_loop().run_until_complete(asyncio.gather(*futures))
             _send_event(
                 EVTYPE_FM_STEP_SUCCESS,
-                self.step.source(self._ens_id),
+                self.step.source(),
             )
         return outputs

--- a/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
+++ b/tests/ert_tests/ensemble_evaluator/test_ensemble_builder.py
@@ -1,7 +1,7 @@
 import pathlib
 import re
 from graphlib import CycleError
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,29 +19,34 @@ def test_build_ensemble(active_real):
         ee.EnsembleBuilder()
         .add_realization(
             ee.RealizationBuilder()
-            .set_iens(0)
+            .set_iens(2)
             .add_step(
                 ee.StepBuilder()
                 .add_job(
-                    ee.LegacyJobBuilder()
-                    .set_id("0")
-                    .set_index("0")
+                    ee.JobBuilder()
+                    .set_id("4")
+                    .set_index("5")
                     .set_name("echo_command")
-                    .set_ext_job(Mock())
+                    .set_executable(pathlib.Path("some_path_object"))
                 )
-                .set_id("0")
+                .set_id("3")
                 .set_name("some_step")
                 .set_dummy_io()
                 .set_type("unix")
             )
             .active(active_real)
         )
-        .set_id("0")
+        .set_id("1")
     )
     ensemble = ensemble.build()
 
     real = ensemble.reals[0]
     assert real.active == active_real
+    assert real.source() == "/ert/ensemble/1/real/2"
+    step = real.steps[0]
+    assert step.source() == "/ert/ensemble/1/real/2/step/3"
+    job = step.jobs[0]
+    assert job.source() == "/ert/ensemble/1/real/2/step/3/job/4/index/5"
 
 
 def test_build_ensemble_legacy():


### PR DESCRIPTION
Ensemble id has been included as a property and should be included as
part of source and propagated through realizations, steps and jobs.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
