### PR TITLE
Allow c++ as compiler in build script

### DIFF
--- a/script/build
+++ b/script/build
@@ -41,7 +41,7 @@ def check_cxx_version() -> None:
     """
     Check that the user's compiler is compatible with ERT.
     """
-    cxx = shutil.which(os.environ.get("CXX", "c++"))
+    cxx = Path(shutil.which(os.environ.get("CXX", "c++"))).resolve()
     print_info(f"Using C++ compiler: {cxx}")
 
     version_line = subprocess.check_output([cxx, "--version"]).splitlines()[0].decode()
@@ -51,7 +51,7 @@ def check_cxx_version() -> None:
         sys.exit(1)
     version = tuple(int(version_match[x + 1]) for x in range(3))
 
-    if "GCC" in version_line:
+    if "GCC" in version_line or "g++" in version_line:
         min_version = MIN_GCC_VERSION
     elif "clang" in version_line:
         min_version = MIN_CLANG_VERSION


### PR DESCRIPTION
**Issue**
Did not open an issue for this one. should i? i can describe the problem though - working on ubuntu 22.04, for some reason the suggested compilers in the build script are not enough - my system is using `c++`.

**Approach**
i'm adding `c++` as an accepted compiler

## Pre review checklist

HELP! I have no idea how I should label this - is it an improvement? an enhancement? only developers gain from this... does it need a release notes label? would that be misc?

- [ ] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
