### PR TITLE
Make CMakeLists dependent on ecl from PyPI

### DIFF
--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -26,15 +26,7 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11
-
-    - name: Build libecl
-      run: |
-        git clone https://github.com/equinor/libecl
-        mkdir libecl/build
-        cmake -S libecl -B libecl/build -DCMAKE_BUILD_TYPE=DEBUG
-        sudo cmake --build libecl/build --target install
-        sudo rm -rf libecl
+        python3 -m pip install conan pybind11 ecl
 
     - name: Create compile commands for clib
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,24 +43,15 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11
+        python3 -m pip install conan pybind11 ecl
         echo "PIP_PKGS_PATH=$(python3 -m pip show conan | grep Location | cut -d ' ' -f 2 | sed -e 's@/lib/.*site-packages$@/bin@')" >> "$GITHUB_ENV"
-
-    - name: Build libecl
-      run: |
-        export PATH=$PATH:${{ env.PIP_PKGS_PATH }}
-        git clone https://github.com/equinor/libecl
-        mkdir libecl/build
-        cmake -S libecl -B libecl/build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-        sudo cmake --build libecl/build --target install
-        sudo rm -rf libecl
 
     - name: Build ert clib
       run: |
         export PATH=$PATH:${{ env.PIP_PKGS_PATH }}
         mkdir cmake-build
         cmake -S src/clib -B cmake-build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON -DCOVERAGE=ON
-        cmake --build cmake-build -j2
+        cmake --build cmake-build "-j$(nproc)"
 
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ likely that some core performance-critical functionality will be implemented in
 C++ and the rest of the business logic will be implemented in Python.
 
 While running `--editable` will create the necessary Python extension module
-(`res/_lib.cpython-*.so`), changing C++ code will not take effect even when
+(`src/ert/_clib.cpython-*.so`), changing C++ code will not take effect even when
 reloading ERT. This requires recompilation, which means reinstalling ERT from
 scratch.
 
@@ -153,9 +153,9 @@ do a full rebuild, delete the `_skbuild` directory.
 Note: This will create a debug build, which is faster to compile and comes with
 debugging functionality enabled. This means that, for example, Eigen
 computations will be checked and will abort if preconditions aren't met (eg.
-when inverting a matrix, it will first check that the matrix is square). The
-downside is that this makes the code unoptimised and slow. Debugging flags are
-therefore not present in builds of ERT that we release on Komodo or PyPI. To
+when inverting a matrix, it will explicitly check that the matrix is square).
+The downside is that this makes the code unoptimised and slow. Debugging flags
+are therefore not present in builds of ERT that we release on Komodo or PyPI. To
 build a release build for development, use `script/build --release`.
 
 ### Notes
@@ -170,38 +170,27 @@ command `ulimit -a`. In order to increase maximum number of open files, run
 `ulimit -n 16384` (or some other large number) and put the command in your
 `.profile` to make it persist.
 
-### Testing C code
+### Running C++ tests
 
-Install [*ecl*](https://github.com/Equinor/ecl) using CMake as a C library. Then:
+The C++ code and tests require [libecl](https://github.com/Equinor/ecl). As long
+as you have `pip install ecl`'d into your Python virtualenv all should work.
 
 ``` sh
-$ cd src
-$ mkdir build
-$ cd build
-$ cmake ../clib -DBUILD_TESTS=ON
-$ cmake --build .
-$ ctest --output-on-failure
+# Create and enable a virtualenv
+python3 -m venv my_virtualenv
+source my_virtualenv/bin/activate
+
+# Install build dependencies
+pip install pybind11 conan cmake ecl
+
+# Build ERT and tests
+mkdir build && cd build
+cmake ../src/clib -DCMAKE_BUILD_TYPE=Debug
+make -j$(nproc)
+
+# Run tests
+ctest --output-on-failure
 ```
-
-### Building
-
-Use the following commands to start developing from a clean virtualenv
-```
-$ pip install -r requirements.txt
-$ python setup.py develop
-```
-
-Alternatively, `pip install -e .` will also setup ERT for development, but
-it will be more difficult to recompile the C library.
-
-[scikit-build](https://scikit-build.readthedocs.io/en/latest/index.html) is used
-for compiling the C library. It creates a directory named `_skbuild` which is
-reused upon future invocations of either `python setup.py develop`, or `python
-setup.py build_ext`. The latter only rebuilds the C library. In some cases this
-directory must be removed in order for compilation to succeed.
-
-The C library files get installed into `res/.libs`, which is where the
-`res` module will look for them.
 
 ### Compiling protocol buffers
 

--- a/ci/jenkins/Jenkinsfile-libres
+++ b/ci/jenkins/Jenkinsfile-libres
@@ -12,7 +12,6 @@ pipeline {
         }
         stage('build libres') {
             steps {
-                sh 'sh ci/jenkins/test_libres_jenkins.sh build_libecl'
                 sh 'sh ci/jenkins/test_libres_jenkins.sh build_ert_clib'
             }
         }

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,6 @@ if "CONAN_CACERT_PATH" not in os.environ:
         break
 
 
-def get_ecl_include():
-    from ecl import get_include
-
-    return get_include()
-
-
 def package_files(directory):
     paths = []
     for (path, _, filenames) in os.walk(directory):
@@ -162,12 +156,11 @@ args = dict(
         ]
     },
     cmake_args=[
-        "-DECL_INCLUDE_DIRS=" + get_ecl_include(),
+        "-DBUILD_TESTS=OFF",
         # we can safely pass OSX_DEPLOYMENT_TARGET as it's ignored on
         # everything not OS X. We depend on C++17, which makes our minimum
         # supported OS X release 10.15
         "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
-        f"-DPYTHON_EXECUTABLE={sys.executable}",
     ],
     cmake_source_dir="src/clib/",
     classifiers=[

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 project(ert C CXX)
 
-option(BUILD_TESTS "Should the tests be built" OFF)
+option(BUILD_TESTS "Should the tests be built" ON)
 option(COVERAGE "Should binaries record coverage information" OFF)
 
 if(NOT BUILD_TESTS)
@@ -22,15 +22,31 @@ if(NOT SKBUILD)
       "Refer to the README for more information.")
 endif()
 
+# Force old pre-C++11 ABI on Linux
+#
+# libecl that is distributed on PyPI is build using manylinux2014 at time of
+# writing. Manylinux2014 is based on CentOS 7, which is in turn based on RHEL 7.
+# The latter hard-code the ABI to be pre-C++11 with no option to enable the new
+# ABI. ERT links directly to libecl and therefore has to use the same ABI.
+# Otherwise we get linker errors because `std::basic_string` and
+# `std::__cxx11::basic_string` are distinct types.
+#
+# This line should be removed either when we stop linking to libecl directly, we
+# use a newer manylinux (RHEL 8 and up supports the new ABI), or the heat death
+# of the universe occurs.
+#
+# https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+add_compile_definitions("_GLIBCXX_USE_CXX11_ABI=0")
+
 # -----------------------------------------------------------------
 # Detect pybind11
 # -----------------------------------------------------------------
 
 # Default to "python3" in user's local environment if PYTHON_EXECUTABLE is not
-# set. This is preferable to CMake's `set(PYTHON_EXECUTABLE ... CACHE ...)`
+# set. This is preferable to CMake's `set(Python_EXECUTABLE ... CACHE ...)`
 # because we avoid messing with future `FindPython.cmake` invocations.
-if(DEFINED PYTHON_EXECUTABLE)
-  set(_python_executable "${PYTHON_EXECUTABLE}")
+if(DEFINED Python_EXECUTABLE)
+  set(_python_executable "${Python_EXECUTABLE}")
 else()
   set(_python_executable "python3")
 endif()
@@ -42,6 +58,50 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT COMMAND_ERROR_IS_FATAL
   LAST)
 list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+# -----------------------------------------------------------------
+# Detect libecl
+# -----------------------------------------------------------------
+
+execute_process(
+  COMMAND "${_python_executable}" -c "import ecl; print(ecl.get_include())"
+  OUTPUT_VARIABLE ECL_INCLUDE_DIRS
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT COMMAND_ERROR_IS_FATAL
+  LAST)
+
+execute_process(
+  COMMAND "${_python_executable}" -c
+          "import ecl; print(ecl.EclPrototype.lib._name)"
+  OUTPUT_VARIABLE ECL_LIBRARY
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT COMMAND_ERROR_IS_FATAL
+  LAST)
+
+add_library(ecl SHARED IMPORTED GLOBAL)
+set_target_properties(ecl PROPERTIES IMPORTED_LOCATION "${ECL_LIBRARY}"
+                                     IMPORTED_NO_SONAME TRUE)
+
+function(fix_install_names target)
+  # CMake doesn't let us link to absolute paths on macOS. This means that
+  # regardless of where libecl is, the OS will expect to find it in either
+  # "/usr/lib" or "/usr/local/lib". This function will force a full path.
+
+  if(APPLE)
+    add_custom_command(
+      TARGET "${target}"
+      POST_BUILD
+      COMMAND "${CMAKE_INSTALL_NAME_TOOL}" -change libecl.dylib
+              "${ECL_LIBRARY}" $<TARGET_FILE:${target}>)
+
+    # PyPI 'ecl' ships with versioned shared libraries, and thus Clang will
+    # prefer libecl.2.dylib over libecl.dylib. This is a bug that should be
+    # resolved, and the following is a workaround.
+    add_custom_command(
+      TARGET "${target}"
+      POST_BUILD
+      COMMAND "${CMAKE_INSTALL_NAME_TOOL}" -change libecl.2.dylib
+              "${ECL_LIBRARY}" $<TARGET_FILE:${target}>)
+  endif()
+endfunction()
 
 # -----------------------------------------------------------------
 # Set default CMAKE_BUILD_TYPE
@@ -124,14 +184,10 @@ conan_cmake_run(
 
 find_package(Eigen3 REQUIRED)
 find_package(Filesystem REQUIRED)
+find_package(Threads REQUIRED)
 find_package(cJSON REQUIRED)
 find_package(fmt REQUIRED)
 find_package(pybind11 REQUIRED)
-
-find_package(Threads)
-if(CMAKE_USE_PTHREADS_INIT)
-  set(HAVE_PTHREAD TRUE)
-endif()
 
 # feature tests
 include(CheckFunctionExists)

--- a/src/clib/lib/CMakeLists.txt
+++ b/src/clib/lib/CMakeLists.txt
@@ -1,10 +1,3 @@
-if(NOT SKBUILD)
-  # Link directly to libecl if not using `pip install`
-  find_package(ecl REQUIRED)
-  set(ECL ecl)
-  set(RES res)
-endif()
-
 pybind11_add_module(
   _clib
   SHARED
@@ -103,16 +96,10 @@ pybind11_add_module(
 # Target: Python C Extension 'ert._clib'
 # -----------------------------------------------------------------
 
-target_link_libraries(_clib PUBLIC ${ECL} std::filesystem cJSON::cJSON fmt::fmt
-                                   Eigen3::Eigen)
-target_include_directories(
-  _clib
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include>
-  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private-include>
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private-include/ext/json>
-  PRIVATE "${ECL_INCLUDE_DIRS}")
+target_link_libraries(_clib PUBLIC std::filesystem cJSON::cJSON fmt::fmt
+                                   Eigen3::Eigen Threads::Threads)
+target_include_directories(_clib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                                        "${ECL_INCLUDE_DIRS}")
 
 set_target_properties(_clib PROPERTIES CXX_VISIBILITY_PRESET "default")
 install(TARGETS _clib LIBRARY DESTINATION src/ert)
@@ -129,6 +116,7 @@ file(
 # -----------------------------------------------------------------
 
 if(BUILD_TESTS)
-  add_library(ert $<TARGET_OBJECTS:_clib>)
-  target_link_libraries(ert _clib pybind11::embed)
+  add_library(ert SHARED $<TARGET_OBJECTS:_clib>)
+  target_link_libraries(ert _clib pybind11::embed ecl)
+  fix_install_names(ert)
 endif()

--- a/src/clib/old_tests/config/CMakeLists.txt
+++ b/src/clib/old_tests/config/CMakeLists.txt
@@ -7,6 +7,7 @@ foreach(name config_content_node config_path_elm config_error config_content
 
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
   add_test(NAME ${name} COMMAND ${name})
 endforeach()
 
@@ -23,6 +24,7 @@ foreach(
 
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
 endforeach()
 
 config_test(config_append append_test)

--- a/src/clib/old_tests/enkf/CMakeLists.txt
+++ b/src/clib/old_tests/enkf/CMakeLists.txt
@@ -34,6 +34,7 @@ foreach(
   trans_func)
   add_executable(${test} ${TESTS_EXCLUDE_FROM_ALL} test_${test}.cpp)
   target_link_libraries(${test} ert)
+  fix_install_names(${test})
   add_test(NAME ${test} COMMAND ${test})
 endforeach()
 

--- a/src/clib/old_tests/job_queue/CMakeLists.txt
+++ b/src/clib/old_tests/job_queue/CMakeLists.txt
@@ -24,12 +24,14 @@ foreach(
 
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
   add_test(NAME ${name} COMMAND ${name})
 endforeach()
 
 foreach(name job_slurm_submit job_slurm_runtest)
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
   if(SBATCH)
     add_test(NAME ${name} COMMAND ${name})
   endif()
@@ -47,11 +49,13 @@ foreach(
 
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
 endforeach()
 
 if(NOT APPLE)
   add_executable(job_list ${TESTS_EXCLUDE_FROM_ALL} test_job_list.cpp)
   target_link_libraries(job_list ert)
+  fix_install_names(job_list)
 
   add_test(NAME job_list COMMAND $<TARGET_FILE:job_list>)
 endif()

--- a/src/clib/old_tests/res_util/CMakeLists.txt
+++ b/src/clib/old_tests/res_util/CMakeLists.txt
@@ -5,5 +5,6 @@ foreach(name ert_util_subst_list ert_util_subst_list_add_from_string
 
   add_executable(${name} ${TESTS_EXCLUDE_FROM_ALL} test_${name}.cpp)
   target_link_libraries(${name} ert)
+  fix_install_names(${name})
   add_test(NAME ${name} COMMAND ${name})
 endforeach()

--- a/src/clib/tests/CMakeLists.txt
+++ b/src/clib/tests/CMakeLists.txt
@@ -19,5 +19,6 @@ add_executable(
   job_queue/test_lsf_driver.cpp)
 
 target_link_libraries(ert_test_suite ert Catch2::Catch2WithMain fmt::fmt)
+fix_install_names(ert_test_suite)
 
 catch_discover_tests(ert_test_suite)


### PR DESCRIPTION
It is a hassle to install libecl manually just to build ERT's C tests.
This commit changes it so that we the user only needs to be in a
virtualenv with the `ecl` package installed.