### PR TITLE
Remove logging from umount

### DIFF
--- a/src/clib/lib/enkf/enkf_fs.cpp
+++ b/src/clib/lib/enkf/enkf_fs.cpp
@@ -417,9 +417,6 @@ void enkf_fs_sync(enkf_fs_type *fs) {
 }
 
 void enkf_fs_umount(enkf_fs_type *fs) {
-
-    logger->info("{} umount filesystem {}", __func__, fs->mount_point);
-
     if (fs->lock_fd > 0) {
         close(
             fs->lock_fd); // Closing the lock_file file descriptor - and releasing the lock.


### PR DESCRIPTION
If the logger was already deleted this causes problems.

**Issue**
everest crashes when cleaning up after tests.


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
