### PR TITLE
Less annotation noise

### DIFF
--- a/.github/workflows/annotate_python.yml
+++ b/.github/workflows/annotate_python.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install flake8
-        run: pip install flake8 dlint flake8-bugbear flake8-simplify flake8-debugger flake8-print flake8-pep3101
+        run: pip install flake8 flake8-bugbear flake8-simplify flake8-debugger flake8-pep3101
       - name: install mypy
         run: pip install -r types-requirements.txt
       - name: install project

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ per-file-ignores =
      src/ert/experiment_server/_server.py: E501
      # Ignore all protobuf v2 files
     *_pb2.py: E
-ignore = F401,E711,W503,E203
+ignore = F401,E711,W503,E203,SIM201,SIM115
 max-line-length = 88

--- a/src/ert/_c_wrappers/analysis/configuration.py
+++ b/src/ert/_c_wrappers/analysis/configuration.py
@@ -8,12 +8,12 @@ from ert._clib.update import RowScalingParameter, Parameter
 from ert._c_wrappers.enkf.row_scaling import RowScaling
 
 
-@classmethod
+@classmethod  # type: ignore
 def __get_validators__(cls):
     yield cls.validate
 
 
-@classmethod
+@classmethod  # type: ignore
 def validate_parameter(cls, v):
     if isinstance(v, str):
         return cls(v)
@@ -21,7 +21,7 @@ def validate_parameter(cls, v):
         return cls(*v)
 
 
-@classmethod
+@classmethod  # type: ignore
 def validate_row_scaling_parameter(cls, v):
     if not isinstance(v[1], RowScaling):
         raise TypeError(f"Expected RowScaling type, got: {type(v[1])}")
@@ -45,7 +45,7 @@ class Observation(BaseModel):
 
 class UpdateStep(BaseModel):
     name: str
-    observations: conlist(Observation, min_items=1)
+    observations: conlist(Observation, min_items=1)  # type: ignore
     parameters: List[Parameter] = []
     row_scaling_parameters: List[RowScalingParameter] = []
 
@@ -83,7 +83,7 @@ class UpdateStep(BaseModel):
 
 
 class UpdateConfiguration(BaseModel):
-    update_steps: conlist(UpdateStep, min_items=1)
+    update_steps: conlist(UpdateStep, min_items=1)  # type: ignore
 
     def __iter__(self):
         yield from self.update_steps

--- a/src/ert/_c_wrappers/enkf/config/gen_kw_config.py
+++ b/src/ert/_c_wrappers/enkf/config/gen_kw_config.py
@@ -166,19 +166,20 @@ class GenKwConfig(BaseCClass):
             }
         ]
         """
-        priors = []
+        priors: List["PriorDict"] = []
         keys = self.getKeyWords()
         for i, key in enumerate(keys):
             function_type = self._get_function_type(i)
             parameter_names = self._get_function_parameter_names(i)
             parameter_values = self._get_function_parameter_values(i)
-            el = {
-                "key": key,
-                "function": function_type,
-                "parameters": {
-                    name: value
-                    for (name, value) in zip(parameter_names, parameter_values)
-                },
-            }
-            priors.append(el)
+            priors.append(
+                {
+                    "key": key,
+                    "function": function_type,
+                    "parameters": {
+                        name: value
+                        for (name, value) in zip(parameter_names, parameter_values)
+                    },
+                }
+            )
         return priors

--- a/src/ert/_c_wrappers/enkf/key_manager.py
+++ b/src/ert/_c_wrappers/enkf/key_manager.py
@@ -5,8 +5,8 @@ from ert._c_wrappers.enkf.config import GenKwConfig
 from ert._c_wrappers.enkf.enums import EnkfObservationImplementationType, ErtImplType
 
 if TYPE_CHECKING:
-    from ert._c_wrappers.enkf.config import PriorDict
     from ert._c_wrappers.enkf import EnKFMain, EnsembleConfig
+    from ert._c_wrappers.enkf.config.gen_kw_config import PriorDict
 
 
 class KeyManager:

--- a/src/ert/_c_wrappers/job_queue/external_ert_script.py
+++ b/src/ert/_c_wrappers/job_queue/external_ert_script.py
@@ -18,10 +18,10 @@ class ExternalErtScript(ErtScript):
         self.__job = Popen(command, stdout=PIPE, stderr=PIPE)
 
         # The job will complete before stdout and stderr is returned
-        self._stdoutdata, self._stderrdata = self.__job.communicate()
+        stdoutdata, stderrdata = self.__job.communicate()
 
-        self._stdoutdata = codecs.decode(self._stdoutdata, "utf8", "replace")
-        self._stderrdata = codecs.decode(self._stderrdata, "utf8", "replace")
+        self._stdoutdata = codecs.decode(stdoutdata, "utf8", "replace")
+        self._stderrdata = codecs.decode(stderrdata, "utf8", "replace")
 
         sys.stdout.write(self._stdoutdata)
 

--- a/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
+++ b/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
@@ -14,6 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from functools import partial
+from typing import TYPE_CHECKING
 
 from qtpy.QtWidgets import (
     QDoubleSpinBox,
@@ -30,6 +31,9 @@ from ert.gui.ertwidgets.models.analysismodulevariablesmodel import (
     AnalysisModuleVariablesModel,
 )
 from ert.libres_facade import LibresFacade
+
+if TYPE_CHECKING:
+    from ert._c_wrappers.analysis.analysis_module import VariableName
 
 
 class AnalysisModuleVariablesPanel(QWidget):

--- a/src/ert/gui/ertwidgets/models/analysismodulevariablesmodel.py
+++ b/src/ert/gui/ertwidgets/models/analysismodulevariablesmodel.py
@@ -13,10 +13,13 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from typing import List
+from typing import TYPE_CHECKING, List, Union
 
-from ert.libres_facade import LibresFacade
 from ert._c_wrappers.analysis.analysis_module import AnalysisModule
+from ert.libres_facade import LibresFacade
+
+if TYPE_CHECKING:
+    from ert._c_wrappers.analysis.analysis_module import VariableName
 
 
 class AnalysisModuleVariablesModel:
@@ -26,7 +29,7 @@ class AnalysisModuleVariablesModel:
     @classmethod
     def getVariableNames(
         cls, facade: LibresFacade, analysis_module_name: str
-    ) -> List[str]:
+    ) -> List["VariableName"]:
         analysis_module = facade.get_analysis_module(analysis_module_name)
         return analysis_module.getVariableNames()
 
@@ -59,8 +62,7 @@ class AnalysisModuleVariablesModel:
 
     @classmethod
     def getVariableValue(
-        cls, facade: LibresFacade, analysis_module_name: str, name: str
-    ):
-        """@rtype: int or float or bool or str"""
+        cls, facade: LibresFacade, analysis_module_name: str, name: "VariableName"
+    ) -> Union[int, float, bool]:
         analysis_module = facade.get_analysis_module(analysis_module_name)
         return analysis_module.getVariableValue(name)

--- a/src/ert/gui/tools/file/file_dialog.py
+++ b/src/ert/gui/tools/file/file_dialog.py
@@ -77,16 +77,16 @@ class FileDialog(QDialog):
         return floor(screen_height * max_ratio_of_screen)
 
     def _init_layout(self):
-        dialog_buttons = QDialogButtonBox(QDialogButtonBox.Ok)
+        dialog_buttons = QDialogButtonBox(QDialogButtonBox.Ok)  # type: ignore
         dialog_buttons.accepted.connect(self.accept)
 
         self._copy_all_button = dialog_buttons.addButton(
-            "Copy all", QDialogButtonBox.ActionRole
+            "Copy all", QDialogButtonBox.ActionRole  # type: ignore
         )
         self._copy_all_button.clicked.connect(self._copy_all)
 
         self._follow_button = dialog_buttons.addButton(
-            "Follow", QDialogButtonBox.ActionRole
+            "Follow", QDialogButtonBox.ActionRole  # type: ignore
         )
         self._follow_button.setCheckable(True)
         self._follow_button.toggled.connect(self._enable_follow_mode)
@@ -112,7 +112,7 @@ class FileDialog(QDialog):
 
     def _copy_all(self) -> None:
         text = self._view.toPlainText()
-        QApplication.clipboard().setText(text, QClipboard.Clipboard)
+        QApplication.clipboard().setText(text, QClipboard.Clipboard)  # type: ignore
         pass
 
     def _update_cursor(self, value: int) -> None:
@@ -123,16 +123,16 @@ class FileDialog(QDialog):
 
     def _enable_follow_mode(self, enable: bool) -> None:
         if enable:
-            self._view.moveCursor(QTextCursor.End)
-            self._view.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+            self._view.moveCursor(QTextCursor.End)  # type: ignore
+            self._view.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)  # type: ignore
             self._view.verticalScrollBar().setDisabled(True)
-            self._view.setTextInteractionFlags(Qt.NoTextInteraction)
+            self._view.setTextInteractionFlags(Qt.NoTextInteraction)  # type: ignore
             self._follow_mode = True
         else:
             self._view.verticalScrollBar().setDisabled(False)
-            self._view.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+            self._view.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)  # type: ignore
             self._view.setTextInteractionFlags(
-                Qt.TextSelectableByMouse | Qt.TextSelectableByKeyboard
+                Qt.TextSelectableByMouse | Qt.TextSelectableByKeyboard  # type: ignore
             )
             self._follow_mode = False
 
@@ -141,7 +141,7 @@ class FileDialog(QDialog):
         if text[-1:] == "\n":
             text = text[:-1]
         if self._follow_mode:
-            self._view.moveCursor(QTextCursor.End)
+            self._view.moveCursor(QTextCursor.End)  # type: ignore
         self._view.appendPlainText(text)
         self.adjustSize()
 

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -7,3 +7,4 @@ types-python-dateutil
 types-six
 types-decorator
 types-docutils
+types-protobuf


### PR DESCRIPTION
Reduces the amount of noise generated by annotation. This is done by 1) fix some errors that mypy insists on reporting on for regardless of which file we point it at and 2) removing dlint, flake8-print and SIM201 and SIM115 errors which has proven to only provide false-positives.

The Mypy errors in the GUI is because Mypy is unable to find some members that are non-the-less there. The bare classmethods turns out work as intended although mypy complains. The other Mypy errors are fixed by being more precise in what types are used.

There are still more than 213 typing errors left, but they should hopefully not show up too often.

There were some actually broken functions discovered that are detailed in https://github.com/equinor/ert/issues/3809. They were supposedly used by everest, but that seems impossible as they simply raise errors without any useful behavior.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
