### PR TITLE
Generate experiment_id and propagate to communication channels

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/builder/_ensemble.py
@@ -45,7 +45,9 @@ class _Ensemble:
     def evaluate(self, config: "EvaluatorServerConfig") -> None:
         pass
 
-    async def evaluate_async(self, config: "EvaluatorServerConfig") -> None:
+    async def evaluate_async(
+        self, config: "EvaluatorServerConfig", experiment_id: str
+    ) -> None:
         pass
 
     def cancel(self) -> None:

--- a/src/ert/experiment_server/_registry.py
+++ b/src/ert/experiment_server/_registry.py
@@ -15,7 +15,7 @@ class _Registry:
     def __init__(self) -> None:
         self._experiments: Dict[str, Experiment] = {}
 
-    def add_experiment(self, experiment: Experiment) -> str:
+    def add_experiment(self, experiment: Experiment) -> None:
         """Add an experiment to the registry.
 
         An id is generated here, but it should share (or receive) this ID from
@@ -23,9 +23,7 @@ class _Registry:
 
         [1] https://github.com/equinor/ert/issues/3437#issue-1247962008
         """
-        experiment_id = str(len(self._experiments.keys()))
-        self._experiments[experiment_id] = experiment
-        return experiment_id
+        self._experiments[experiment.id_] = experiment
 
     @property
     def all_experiments(self) -> List[Experiment]:

--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -127,9 +127,10 @@ class ExperimentServer:
         ensemble_size: int,
         current_case_name: str,
         args: Any,
-        factory: Callable[[EnKFMain, int, str, Any], Experiment],
+        factory: Callable[[EnKFMain, int, str, Any, str], Experiment],
+        experiment_id: str,
     ) -> str:
-        """add_legacy_experiment(self, ert, ensemble_size: int,current_case_name: str, factory: Callable[[Any, int, str, Any], Experiment])
+        """add_legacy_experiment(self, ert, ensemble_size: int,current_case_name: str, factory: Callable[[Any, int, str, Any, str], Experiment], experiment_id: str)
 
         The ert parameter, as well as the first input parameter in the factory
         :class:`Callable`, refers to the EnkfMain type.
@@ -141,12 +142,13 @@ class ExperimentServer:
             ensemble_size,
             current_case_name,
             args,
+            experiment_id,
         )
-        experiment.id_ = self._registry.add_experiment(experiment)
+        self._registry.add_experiment(experiment)
         return experiment.id_
 
     def add_experiment(self, experiment: Experiment) -> str:
-        experiment.id_ = self._registry.add_experiment(experiment)
+        self._registry.add_experiment(experiment)
         return experiment.id_
 
     async def run_experiment(self, experiment_id: str) -> None:

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -1,3 +1,4 @@
+import uuid
 from collections import OrderedDict
 
 from qtpy.QtCore import QSize, Qt
@@ -136,6 +137,7 @@ class SimulationPanel(QWidget):
                     self.facade.get_ensemble_size(),
                     self.facade.get_current_case_name(),
                     arguments,
+                    str(uuid.uuid4()),
                 ),
             )
             dialog.startSimulation()

--- a/src/ert/shared/cli/main.py
+++ b/src/ert/shared/cli/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import threading
+import uuid
 from typing import Any
 
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
@@ -48,6 +49,7 @@ def run_cli(args):
         return
 
     evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)
+    experiment_id = str(uuid.uuid4())
 
     if FeatureToggling.is_enabled("experiment-server"):
         # TODO: need to perform same case checks as for non-experiment-server.
@@ -60,6 +62,7 @@ def run_cli(args):
                 facade.get_current_case_name(),
                 args,
                 evaluator_server_config,
+                experiment_id,
             ),
             debug=False,
         )
@@ -70,6 +73,7 @@ def run_cli(args):
         facade.get_ensemble_size(),
         facade.get_current_case_name(),
         args,
+        experiment_id,
     )
     # Test run does not have a current_case
     if "current_case" in args and args.current_case:
@@ -121,11 +125,12 @@ async def _run_cli_async(
     current_case_name: str,
     args: Any,
     ee_config: EvaluatorServerConfig,
+    experiment_id: str,
 ):
     from ert.experiment_server import ExperimentServer  # noqa
 
     experiment_server = ExperimentServer(ee_config)
-    experiment_id = experiment_server.add_legacy_experiment(
-        ert, ensemble_size, current_case_name, args, create_model
+    experiment_server.add_legacy_experiment(
+        ert, ensemble_size, current_case_name, args, create_model, experiment_id
     )
     await experiment_server.run_experiment(experiment_id=experiment_id)

--- a/src/ert/shared/cli/model_factory.py
+++ b/src/ert/shared/cli/model_factory.py
@@ -8,21 +8,23 @@ from ert.shared.models.multiple_data_assimilation import MultipleDataAssimilatio
 from ert.shared.models.single_test_run import SingleTestRun
 
 
-def create_model(ert, ensemble_size, current_case_name, args):
+def create_model(ert, ensemble_size, current_case_name, args, id_):
     # Setup model
     if args.mode == "test_run":
-        model = _setup_single_test_run(ert)
+        model = _setup_single_test_run(ert, id_)
     elif args.mode == "ensemble_experiment":
-        model = _setup_ensemble_experiment(ert, args, ensemble_size)
+        model = _setup_ensemble_experiment(ert, args, ensemble_size, id_)
     elif args.mode == "ensemble_smoother":
-        model = _setup_ensemble_smoother(ert, args, ensemble_size, current_case_name)
+        model = _setup_ensemble_smoother(
+            ert, args, ensemble_size, current_case_name, id_
+        )
     elif args.mode == "es_mda":
         model = _setup_multiple_data_assimilation(
-            ert, args, ensemble_size, current_case_name
+            ert, args, ensemble_size, current_case_name, id_
         )
     elif args.mode == "iterative_ensemble_smoother":
         model = _setup_iterative_ensemble_smoother(
-            ert, args, ensemble_size, current_case_name
+            ert, args, ensemble_size, current_case_name, id_
         )
 
     else:
@@ -31,22 +33,22 @@ def create_model(ert, ensemble_size, current_case_name, args):
     return model
 
 
-def _setup_single_test_run(ert):
+def _setup_single_test_run(ert, id_):
     simulations_argument = {"active_realizations": [True]}
-    model = SingleTestRun(simulations_argument, ert)
+    model = SingleTestRun(simulations_argument, ert, id_)
     return model
 
 
-def _setup_ensemble_experiment(ert, args, ensemble_size):
+def _setup_ensemble_experiment(ert, args, ensemble_size, id_):
     simulations_argument = {
         "active_realizations": _realizations(args, ensemble_size),
         "iter_num": int(args.iter_num),
     }
-    model = EnsembleExperiment(simulations_argument, ert, ert.get_queue_config())
+    model = EnsembleExperiment(simulations_argument, ert, ert.get_queue_config(), id_)
     return model
 
 
-def _setup_ensemble_smoother(ert, args, ensemble_size, current_case_name):
+def _setup_ensemble_smoother(ert, args, ensemble_size, current_case_name, id_):
     simulations_argument = {
         "active_realizations": _realizations(args, ensemble_size),
         "target_case": _target_case_name(
@@ -54,11 +56,11 @@ def _setup_ensemble_smoother(ert, args, ensemble_size, current_case_name):
         ),
         "analysis_module": "STD_ENKF",
     }
-    model = EnsembleSmoother(simulations_argument, ert, ert.get_queue_config())
+    model = EnsembleSmoother(simulations_argument, ert, ert.get_queue_config(), id_)
     return model
 
 
-def _setup_multiple_data_assimilation(ert, args, ensemble_size, current_case_name):
+def _setup_multiple_data_assimilation(ert, args, ensemble_size, current_case_name, id_):
     simulations_argument = {
         "active_realizations": _realizations(args, ensemble_size),
         "target_case": _target_case_name(
@@ -68,11 +70,15 @@ def _setup_multiple_data_assimilation(ert, args, ensemble_size, current_case_nam
         "weights": args.weights,
         "start_iteration": int(args.start_iteration),
     }
-    model = MultipleDataAssimilation(simulations_argument, ert, ert.get_queue_config())
+    model = MultipleDataAssimilation(
+        simulations_argument, ert, ert.get_queue_config(), id_
+    )
     return model
 
 
-def _setup_iterative_ensemble_smoother(ert, args, ensemble_size, current_case_name):
+def _setup_iterative_ensemble_smoother(
+    ert, args, ensemble_size, current_case_name, id_
+):
     simulations_argument = {
         "active_realizations": _realizations(args, ensemble_size),
         "target_case": _target_case_name(
@@ -81,7 +87,9 @@ def _setup_iterative_ensemble_smoother(ert, args, ensemble_size, current_case_na
         "analysis_module": "IES_ENKF",
         "num_iterations": _num_iterations(ert, args),
     }
-    model = IteratedEnsembleSmoother(simulations_argument, ert, ert.get_queue_config())
+    model = IteratedEnsembleSmoother(
+        simulations_argument, ert, ert.get_queue_config(), id_
+    )
     return model
 
 

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -63,6 +63,7 @@ class BaseRunModel:
         simulation_arguments: Dict[str, Any],
         ert: EnKFMain,
         queue_config: QueueConfig,
+        id_: str,
         phase_count: int = 1,
     ):
         """
@@ -94,10 +95,10 @@ class BaseRunModel:
         self._ert = ert
         self.facade = LibresFacade(ert)
         self._simulation_arguments = simulation_arguments
+        self._id: str = id_
         self.reset()
 
         # experiment-server
-        self._id: Optional[str] = None
         self._state_machine = ExperimentStateMachine()
 
     def ert(self) -> EnKFMain:
@@ -362,7 +363,7 @@ class BaseRunModel:
                 run_context,
             )
 
-            await ensemble.evaluate_async(ee_config)
+            await ensemble.evaluate_async(ee_config, self.id_)
 
             await ensemble_listener
 

--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -23,8 +23,9 @@ class EnsembleExperiment(BaseRunModel):
         simulation_arguments: Dict[str, Any],
         ert: EnKFMain,
         queue_config: QueueConfig,
+        id_: str,
     ):
-        super().__init__(simulation_arguments, ert, queue_config)
+        super().__init__(simulation_arguments, ert, queue_config, id_)
 
     async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
 

--- a/src/ert/shared/models/ensemble_smoother.py
+++ b/src/ert/shared/models/ensemble_smoother.py
@@ -14,8 +14,9 @@ class EnsembleSmoother(BaseRunModel):
         simulation_arguments: Dict[str, Any],
         ert: EnKFMain,
         queue_config: QueueConfig,
+        id_: str,
     ):
-        super().__init__(simulation_arguments, ert, queue_config, phase_count=2)
+        super().__init__(simulation_arguments, ert, queue_config, id_, phase_count=2)
         self.support_restart = False
 
     def setAnalysisModule(self, module_name: str) -> None:

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -18,8 +18,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
         simulation_arguments: Dict[str, Any],
         ert: EnKFMain,
         queue_config: QueueConfig,
+        id_: str,
     ):
-        super().__init__(simulation_arguments, ert, queue_config, phase_count=2)
+        super().__init__(simulation_arguments, ert, queue_config, id_, phase_count=2)
         self.support_restart = False
         self._w_container = IterativeEnsembleSmoother(
             len(simulation_arguments["active_realizations"])

--- a/src/ert/shared/models/multiple_data_assimilation.py
+++ b/src/ert/shared/models/multiple_data_assimilation.py
@@ -38,8 +38,9 @@ class MultipleDataAssimilation(BaseRunModel):
         simulation_arguments: Dict[str, Any],
         ert: EnKFMain,
         queue_config: QueueConfig,
+        id_: str,
     ):
-        super().__init__(simulation_arguments, ert, queue_config, phase_count=2)
+        super().__init__(simulation_arguments, ert, queue_config, id_, phase_count=2)
         self.weights = MultipleDataAssimilation.default_weights
 
     def setAnalysisModule(self, module_name: str) -> None:

--- a/src/ert/shared/models/single_test_run.py
+++ b/src/ert/shared/models/single_test_run.py
@@ -7,13 +7,11 @@ from ert.shared.models import EnsembleExperiment, ErtRunError
 
 
 class SingleTestRun(EnsembleExperiment):
-    def __init__(self, simulation_arguments: Dict[str, Any], ert: EnKFMain, *_: Any):
+    def __init__(
+        self, simulation_arguments: Dict[str, Any], ert: EnKFMain, id_: str, *_: Any
+    ):
         local_queue_config = ert.get_queue_config().create_local_copy()
-        super().__init__(
-            simulation_arguments,
-            ert,
-            local_queue_config,
-        )
+        super().__init__(simulation_arguments, ert, local_queue_config, id_)
 
     def checkHaveSufficientRealizations(self, num_successful_realizations: int) -> None:
         # Should only have one successful realization

--- a/tests/ert_tests/cli/test_model_factory.py
+++ b/tests/ert_tests/cli/test_model_factory.py
@@ -66,7 +66,7 @@ class ModelFactoryTest(ErtTest):
             ert = work_area.getErt()
             args = Namespace(iter_num=10, realizations=None)
             model = model_factory._setup_ensemble_experiment(
-                ert, args, ert.getEnsembleSize()
+                ert, args, ert.getEnsembleSize(), "experiment_id"
             )
             run_context = model.create_context()
             self.assertEqual(model._simulation_arguments["iter_num"], 10)
@@ -89,7 +89,7 @@ class ModelFactoryTest(ErtTest):
         with ErtTestContext(config_file) as work_area:
             ert = work_area.getErt()
 
-            model = model_factory._setup_single_test_run(ert)
+            model = model_factory._setup_single_test_run(ert, "experiment_id")
             self.assertTrue(isinstance(model, SingleTestRun))
             self.assertEqual(1, len(model._simulation_arguments.keys()))
             self.assertTrue("active_realizations" in model._simulation_arguments)
@@ -100,7 +100,7 @@ class ModelFactoryTest(ErtTest):
         with ErtTestContext(config_file) as work_area:
             ert = work_area.getErt()
 
-            model = model_factory._setup_single_test_run(ert)
+            model = model_factory._setup_single_test_run(ert, "experiment_id")
             self.assertTrue(isinstance(model, EnsembleExperiment))
             self.assertEqual(1, len(model._simulation_arguments.keys()))
             self.assertTrue("active_realizations" in model._simulation_arguments)
@@ -118,6 +118,7 @@ class ModelFactoryTest(ErtTest):
                 args,
                 facade.get_ensemble_size(),
                 facade.get_current_case_name(),
+                "experiment_id",
             )
             self.assertTrue(isinstance(model, EnsembleSmoother))
             self.assertEqual(3, len(model._simulation_arguments.keys()))
@@ -143,6 +144,7 @@ class ModelFactoryTest(ErtTest):
                 args,
                 facade.get_ensemble_size(),
                 facade.get_current_case_name(),
+                "experiment_id",
             )
             self.assertTrue(isinstance(model, MultipleDataAssimilation))
             self.assertEqual(5, len(model._simulation_arguments.keys()))
@@ -169,6 +171,7 @@ class ModelFactoryTest(ErtTest):
                 args,
                 facade.get_ensemble_size(),
                 facade.get_current_case_name(),
+                "experiment_id",
             )
             self.assertTrue(isinstance(model, IteratedEnsembleSmoother))
             self.assertEqual(4, len(model._simulation_arguments.keys()))

--- a/tests/ert_tests/cli/test_model_hook_order.py
+++ b/tests/ert_tests/cli/test_model_hook_order.py
@@ -26,7 +26,7 @@ def test_hook_call_order_ensemble_smoother(monkeypatch):
     """
     ert_mock = MagicMock()
     minimum_args = MagicMock()
-    test_class = EnsembleSmoother(minimum_args, ert_mock, MagicMock())
+    test_class = EnsembleSmoother(minimum_args, ert_mock, MagicMock(), "experiment_id")
     test_class.create_context = MagicMock()
     test_class.run_ensemble_evaluator = MagicMock(return_value=1)
     ert_mock.runWorkflows = MagicMock()
@@ -54,7 +54,9 @@ def test_hook_call_order_es_mda(monkeypatch):
         custom_port_range=range(1024, 65535), use_token=False, generate_cert=False
     )
     ert_mock = MagicMock()
-    test_class = MultipleDataAssimilation(minimum_args, ert_mock, MagicMock())
+    test_class = MultipleDataAssimilation(
+        minimum_args, ert_mock, MagicMock(), "experiment_id"
+    )
     ert_mock.runWorkflows = MagicMock()
 
     test_class.create_context = MagicMock()
@@ -95,7 +97,9 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
     )
     ert_mock.runWorkflows = MagicMock()
 
-    test_class = IteratedEnsembleSmoother(MagicMock(), ert_mock, MagicMock())
+    test_class = IteratedEnsembleSmoother(
+        MagicMock(), ert_mock, MagicMock(), "experiment_id"
+    )
     test_class.create_context = MagicMock()
     test_class._checkMinimumActiveRealizations = MagicMock()
     test_class._ert = ert_mock

--- a/tests/ert_tests/models/test_base_run_model.py
+++ b/tests/ert_tests/models/test_base_run_model.py
@@ -15,7 +15,7 @@ class BaseRunModelTest(ErtTest):
         config_file = self.createTestPath("local/simple_config/minimum_config")
         with ErtTestContext(config_file) as work_area:
             ert = work_area.getErt()
-            brm = BaseRunModel(None, ert, ert.get_queue_config())
+            brm = BaseRunModel(None, ert, ert.get_queue_config(), "experiment_id")
             assert brm.support_restart
 
 
@@ -60,7 +60,7 @@ def test_is_forward_model_finished(test_input, expected):
     ],
 )
 def test_active_realizations(initials, expected):
-    brm = BaseRunModel(None, None, None)
+    brm = BaseRunModel(None, None, None, None)
     brm._initial_realizations_mask = initials
     assert brm._active_realizations == expected
     assert brm._ensemble_size == len(initials)
@@ -79,7 +79,7 @@ def test_active_realizations(initials, expected):
     ],
 )
 def test_failed_realizations(initials, completed, any_failed, failures):
-    brm = BaseRunModel(None, None, None)
+    brm = BaseRunModel(None, None, None, None)
     brm._initial_realizations_mask = initials
     brm._completed_realizations_mask = completed
 

--- a/tests/ert_tests/status/test_evaluator_tracker.py
+++ b/tests/ert_tests/status/test_evaluator_tracker.py
@@ -301,7 +301,7 @@ def test_tracking_progress(
 
     The final update event and end event is also tested."""
 
-    brm = run_model(None, None, None)
+    brm = run_model(None, None, None, None)
     ee_config = EvaluatorServerConfig(
         custom_port_range=range(1024, 65535),
         custom_host="127.0.0.1",

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -186,6 +186,7 @@ def test_tracking(
             facade.get_ensemble_size(),
             facade.get_current_case_name(),
             parsed,
+            "experiment_id",
         )
 
         evaluator_server_config = EvaluatorServerConfig(
@@ -310,6 +311,7 @@ def test_tracking_time_map(
             facade.get_ensemble_size(),
             facade.get_current_case_name(),
             parsed,
+            "experiment_id",
         )
 
         evaluator_server_config = EvaluatorServerConfig(
@@ -396,6 +398,7 @@ def test_tracking_missing_ecl(
             facade.get_ensemble_size(),
             facade.get_current_case_name(),
             parsed,
+            "experiment_id",
         )
 
         evaluator_server_config = EvaluatorServerConfig(


### PR DESCRIPTION
**Issue**
Resolves #3720


**Approach**
Generate experiment id, attach to experiment type objects and propagate id as required.

Continued work from: https://github.com/equinor/ert/pull/3729
Depends on: https://github.com/equinor/ert/pull/3793

Edit:
I initially approached this by changing the `source` content in each of `ensemble`, `realization` etc, but found that adding this information which would not be used in any way (as the `snapshot` model does not take into account the experiment aspect), I decided to revert. Now the experiment id is included in the ensemble and only added to the `jobs.json` file, as the dispatcher side uses protobuf if `experiment_server` is used.

As we include protobuf messaging into more locations (e.g. jobqueue dispatch), the experiment_id will need to be included there as well, given the construct of our protobuf message.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
