### PR TITLE
Mute connection closed error from websocket

### DIFF
--- a/src/ert/shared/ensemble_evaluator/client.py
+++ b/src/ert/shared/ensemble_evaluator/client.py
@@ -5,7 +5,7 @@ from typing import Any, AnyStr, Dict, Optional, Union
 import cloudevents
 from websockets.client import WebSocketClientProtocol, connect
 from websockets.datastructures import Headers
-from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 
 class Client:  # pylint: disable=too-many-instance-attributes
@@ -75,7 +75,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 # Connection was closed no point in trying to send more messages
                 raise
             except (
-                ConnectionClosed,
+                ConnectionClosedError,
                 ConnectionRefusedError,
                 OSError,
                 asyncio.TimeoutError,

--- a/src/ert/shared/ensemble_evaluator/dispatch.py
+++ b/src/ert/shared/ensemble_evaluator/dispatch.py
@@ -78,12 +78,12 @@ class BatchingDispatcher:
             self._LOOKUP_MAP[event_type].append((function, batching))
 
     async def handle_event(self, event):
-        for f, batching in self._LOOKUP_MAP[event["type"]]:
+        for function, batching in self._LOOKUP_MAP[event["type"]]:
             if batching:
                 if self._task.done():
                     raise asyncio.InvalidStateError(
                         "trying to handle event after batcher is done"
                     )
-                self._buffer.append((f, event))
+                self._buffer.append((function, event))
             else:
-                await f(event)
+                await function(event)


### PR DESCRIPTION
Whenever dispatchers die (killed by ERT f.ex or for other reasons)
the websocket is not properly closed and the exception is not caught. That leads to a situation that needs a timeout to resolve (20 seconds) (it is waiting for dispatchers to disconnect, even when there is none)

**Issue**
Resolves #3758 


**Approach**
Catch and log exception. Then carry on.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
