### PR TITLE
Stop special casing PRED as a GEN_KW

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -891,8 +891,6 @@ and/or history matching project.
                 GEN_KW PAR_MULTPV multpv_template.txt multpv.txt multpv_priors.txt
 
         
-        Note that naming a :code:`GEN_KW` parameter :code:`PRED` will prevent the parameter from being
-        being updated.
 
         In the GRID or EDIT section of the ECLIPSE data file, we would insert the
         following include statement:

--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -280,17 +280,8 @@ std::vector<std::string> get_observation_keys(py::object self) {
 
 std::vector<std::string> get_parameter_keys(py::object self) {
     auto enkf_main = ert::from_cwrap<enkf_main_type>(self);
-
-    std::vector<std::string> parameters;
-    std::vector<std::string> keylist = ensemble_config_keylist_from_var_type(
+    return ensemble_config_keylist_from_var_type(
         res_config_get_ensemble_config(enkf_main->res_config), PARAMETER);
-
-    // Add all GEN_KW keywords to parameters that is not
-    // the SCHEDULE_PREDICTION_FILE
-    std::copy_if(keylist.begin(), keylist.end(), std::back_inserter(parameters),
-                 [](auto key) { return key != "PRED"; });
-
-    return parameters;
 }
 
 namespace enkf_main {


### PR DESCRIPTION
This was a documented feature, however it was broken a few
versions ago. That was discovered by a user reporting an issue with
a GEN_KW named PRED. They were not aware that this was being special
cased, so deleting this feature seems much safer.

Closes: #3813 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
