### PR TITLE
Mute matplotlib debug messages

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -73,6 +73,8 @@ loggers:
     level: DEBUG
     handlers: [experiment_server_file]
     propagate: yes
+  matplotlib:
+    level: INFO
   res:
     level: DEBUG
     propagate: yes


### PR DESCRIPTION
**Issue**
Resolves 60 kb of not-so-interesting debug logs emitted from `matplotlib` on every invocation of ert.

**Approach**
Set log handler for `matlotlib` from `DEBUG` (default) to `INFO`


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
