### PR TITLE
Do not add summary keys from storage to config

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -171,8 +171,6 @@ class EnKFMain(BaseCClass):
     def storage(self, file_system):
         self.addDataKW("<ERT-CASE>", file_system.getCaseName())
         self.addDataKW("<ERTCASE>", file_system.getCaseName())
-        for key in file_system.getSummaryKeySet().keys():
-            self.ensembleConfig().add_summary(key)
         if self.config_file.ecl_config.getRefcase():
             time_map = file_system.getTimeMap()
             time_map.attach_refcase(self.config_file.ecl_config.getRefcase())

--- a/tests/ert_tests/shared/test_libres_facade.py
+++ b/tests/ert_tests/shared/test_libres_facade.py
@@ -117,7 +117,6 @@ def test_all_data_type_keys(facade):
         "FWPRH",
         "FWPT",
         "FWPTH",
-        "TIME",
         "WGOR:OP1",
         "WGOR:OP2",
         "WGORH:OP1",

--- a/tests/libres_tests/res/enkf/test_key_manager.py
+++ b/tests/libres_tests/res/enkf/test_key_manager.py
@@ -13,7 +13,7 @@ class KeyManagerTest(ResTest):
             ert = testContext.getErt()
             key_man = KeyManager(ert)
 
-            self.assertEqual(len(key_man.summaryKeys()), 47)
+            self.assertEqual(len(key_man.summaryKeys()), 46)
             self.assertTrue("FOPT" in key_man.summaryKeys())
 
             self.assertEqual(len(key_man.summaryKeysWithObservations()), 2)

--- a/tests/libres_tests/res/enkf/test_summary_key_set.py
+++ b/tests/libres_tests/res/enkf/test_summary_key_set.py
@@ -85,6 +85,4 @@ def test_with_enkf_fs(copy_case):
     ensemble_config = ert.ensembleConfig()
 
     assert "FOPT" in ensemble_config
-    assert "WWCT" in ensemble_config
-    assert "WOPR" in ensemble_config
     assert "TCPU" not in ensemble_config


### PR DESCRIPTION
Which keys are stored in storage should be defined in config-files.
Config should not be updated based on what is stored in storage.

**Issue**
Resolves #3806 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
