### PR TITLE
Close stdin/stdout/stderr files when done

### DIFF
--- a/src/ert/job_runner/job.py
+++ b/src/ert/job_runner/job.py
@@ -22,7 +22,6 @@ class Job:
         self.std_out = job_data.get("stdout")
 
     def run(self):
-        # pylint: disable=consider-using-with
         start_message = Start(self)
 
         errors = self._check_job_files()
@@ -44,6 +43,8 @@ class Job:
         if self.job_data.get("argList"):
             arg_list += self.job_data["argList"]
 
+        # pylint: disable=consider-using-with
+        # stdin/stdout/stderr are closed at the end of this function
         if self.job_data.get("stdin"):
             stdin = open(self.job_data.get("stdin"), encoding="utf-8")
         else:


### PR DESCRIPTION
Opted for not using a context manager (ExitStack)
to avoid having to indent all lines in the function

Plus bonus pylinting

**Issue**
Resolves unclosed sdin/stdout/stdin files opened by the `Job` object.

**Approach**
Close at the end.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
