### PR TITLE
Add DisableParametersUpdate workflow

### DIFF
--- a/src/ert/shared/hook_implementations/workflows/__init__.py
+++ b/src/ert/shared/hook_implementations/workflows/__init__.py
@@ -1,6 +1,7 @@
 from ert.shared.plugins.plugin_manager import hook_implementation
 from ert.shared.plugins.plugin_response import plugin_response
 
+from .disable_parameters import DisableParametersUpdate
 from .export_misfit_data import ExportMisfitDataJob
 from .export_runpath import ExportRunpathJob
 
@@ -14,3 +15,9 @@ def legacy_ertscript_workflow(config):
 
     workflow = config.add_workflow(ExportRunpathJob, "EXPORT_RUNPATH")
     workflow.description = ExportRunpathJob.__doc__
+
+    # Intentionally did not add description to this workflow as we would
+    # like to replace it with a better solution, see:
+    # https://github.com/equinor/ert/issues/3859, if this is not done
+    # use the doc string of the class as documentation
+    config.add_workflow(DisableParametersUpdate, "DISABLE_PARAMETERS")

--- a/src/ert/shared/hook_implementations/workflows/disable_parameters.py
+++ b/src/ert/shared/hook_implementations/workflows/disable_parameters.py
@@ -1,0 +1,33 @@
+from ert._c_wrappers.job_queue import ErtScript
+
+
+class DisableParametersUpdate(ErtScript):
+    """The DISABLE_PARAMETERS workflow disables parameters,
+    so they are excluded from the update step. The job takes a list
+    of parameters as input:
+
+    DISABLE_PARAMETERS "PARAMETER_1, PARAMETER_2"
+
+    The parameters that are given as arguments will be removed from the
+    update. Note that if giving more than one parameter as input the list
+    must be enclosed in quotes.
+
+    Note that unknown parameter names will be silently ignored.
+
+    This workflow is recommended to be run as a PRE_FIRST_UPDATE hook
+    """
+
+    def run(self, disable_parameters):
+        ert = self.ert()
+        disable_parameters = disable_parameters.split(",")
+        disable_parameters = [val.strip() for val in disable_parameters]
+        altered_update_step = [
+            {
+                "name": "DISABLED_PARAMETERS",
+                "observations": ert._observation_keys,
+                "parameters": [
+                    key for key in ert._parameter_keys if key not in disable_parameters
+                ],
+            }
+        ]
+        ert.update_configuration = altered_update_step


### PR DESCRIPTION
This is added because users were previously depending on naming the
excluded parameter PRED. This option has been removed as it could easily
happen without intention.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
