### PR TITLE
Move responsibility of creating the log folder into the writing of the update report logic

### DIFF
--- a/src/clib/lib/enkf/analysis_config.cpp
+++ b/src/clib/lib/enkf/analysis_config.cpp
@@ -185,11 +185,7 @@ void analysis_config_set_log_path(analysis_config_type *config,
     config->log_path = util_realloc_string_copy(config->log_path, log_path);
 }
 
-/**
-   Will in addition create the path.
-*/
 const char *analysis_config_get_log_path(const analysis_config_type *config) {
-    util_make_path(config->log_path);
     return config->log_path;
 }
 

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -200,6 +200,8 @@ def analysis_IES(
 
 
 def _write_update_report(fname: Path, snapshot: SmootherSnapshot) -> None:
+    # Make sure log file parents exist
+    fname.parent.mkdir(parents=True, exist_ok=True)
     for update_step_name, update_step in snapshot.update_step_snapshots.items():
         with open(fname, "w") as fout:
             fout.write("=" * 127 + "\n")


### PR DESCRIPTION
**Issue**
Resolves #2558


**Approach**
Move responsibility of creating the log folder into the writing of the update report logic


## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
