### PR TITLE
Fix config reprs

### DIFF
--- a/src/clib/lib/include/ert/enkf/site_config.hpp
+++ b/src/clib/lib/include/ert/enkf/site_config.hpp
@@ -45,7 +45,7 @@ site_config_set_license_root_path(site_config_type *site_config,
 extern "C" void site_config_free(site_config_type *);
 extern "C" ext_joblist_type *
 site_config_get_installed_jobs(const site_config_type *);
-const env_varlist_type *
+extern "C" const env_varlist_type *
 site_config_get_env_varlist(const site_config_type *site_config);
 int site_config_install_job(site_config_type *site_config, const char *job_name,
                             const char *install_file);

--- a/src/clib/lib/include/ert/job_queue/environment_varlist.hpp
+++ b/src/clib/lib/include/ert/job_queue/environment_varlist.hpp
@@ -19,18 +19,18 @@
 #ifndef ENVIRONMENT_VARLIST_H
 #define ENVIRONMENT_VARLIST_H
 
-#include <stdio.h>
+#include <cstdio>
 
 typedef struct env_varlist_struct env_varlist_type;
 
 extern "C" env_varlist_type *env_varlist_alloc();
 
-void env_varlist_update_path(env_varlist_type *list, const char *path_var,
-                             const char *new_path);
+extern "C" void env_varlist_update_path(env_varlist_type *list,
+                                        const char *path_var,
+                                        const char *new_path);
 extern "C" void env_varlist_setenv(env_varlist_type *list, const char *var,
                                    const char *value);
 void env_varlist_json_fprintf(const env_varlist_type *list, FILE *stream);
-extern "C" int env_varlist_get_size(env_varlist_type *list);
 
 extern "C" void env_varlist_free(env_varlist_type *list);
 

--- a/src/clib/lib/job_queue/environment_varlist.cpp
+++ b/src/clib/lib/job_queue/environment_varlist.cpp
@@ -20,63 +20,49 @@
 
 #include <ert/res_util/res_env.hpp>
 
-#include <ert/util/hash.hpp>
+#include <map>
 
 #define ENV_VAR_KEY_STRING "global_environment"
 #define UPDATE_PATH_KEY_STRING "global_update_path"
 
 struct env_varlist_struct {
-    hash_type *varlist;
-    hash_type *updatelist;
+    std::map<std::string, std::string> varlist;
+    std::map<std::string, std::string> updatelist;
 };
 
-env_varlist_type *env_varlist_alloc() {
-    env_varlist_type *list = (env_varlist_type *)util_malloc(sizeof *list);
-    list->varlist = hash_alloc();
-    list->updatelist = hash_alloc();
-    return list;
-}
+env_varlist_type *env_varlist_alloc() { return new env_varlist_struct; }
 
 void env_varlist_update_path(env_varlist_type *list, const char *path_var,
                              const char *new_path) {
-    hash_insert_string(list->updatelist, path_var,
-                       res_env_update_path_var(path_var, new_path, false));
+    list->updatelist[path_var] =
+        res_env_update_path_var(path_var, new_path, false);
 }
 
 void env_varlist_setenv(env_varlist_type *list, const char *key,
                         const char *value) {
-    const char *interp_value = res_env_interp_setenv(key, value);
-    hash_insert_string(list->varlist, key, interp_value);
+    list->varlist[key] = res_env_interp_setenv(key, value);
 }
 
-static void env_varlist_fprintf_hash(const hash_type *list,
-                                     const char *keystring, FILE *stream) {
-    int size = hash_get_size(list);
-    fprintf(stream, "\"%s\" : {", keystring);
-    stringlist_type *stringlist = hash_alloc_stringlist(list);
-    int i_max = size - 1;
-    for (int i = 0; i < size; i++) {
-        const char *key = stringlist_iget(stringlist, i);
-        fprintf(stream, "\"%s\" : \"%s\"", key, (char *)hash_get(list, key));
-        if (i < i_max)
+static void print_map_as_json(const std::map<std::string, std::string> &map,
+                              FILE *stream) {
+    bool first = true;
+    fprintf(stream, "{");
+    for (const auto &[key, value] : map) {
+        if (!first) {
             fprintf(stream, ", ");
+        }
+        first = false;
+        fprintf(stream, R"("%s" : "%s")", key.c_str(), value.c_str());
     }
     fprintf(stream, "}");
-    stringlist_free(stringlist);
 }
 
 void env_varlist_json_fprintf(const env_varlist_type *list, FILE *stream) {
-    env_varlist_fprintf_hash(list->varlist, ENV_VAR_KEY_STRING, stream);
+    fprintf(stream, "\"%s\" : ", ENV_VAR_KEY_STRING);
+    print_map_as_json(list->varlist, stream);
     fprintf(stream, ",\n");
-    env_varlist_fprintf_hash(list->updatelist, UPDATE_PATH_KEY_STRING, stream);
+    fprintf(stream, "\"%s\" : ", UPDATE_PATH_KEY_STRING);
+    print_map_as_json(list->updatelist, stream);
 }
 
-int env_varlist_get_size(env_varlist_type *list) {
-    return hash_get_size(list->varlist);
-}
-
-void env_varlist_free(env_varlist_type *list) {
-    hash_free(list->varlist);
-    hash_free(list->updatelist);
-    free(list);
-}
+void env_varlist_free(env_varlist_type *list) { delete list; }

--- a/src/clib/lib/job_queue/environment_varlist.cpp
+++ b/src/clib/lib/job_queue/environment_varlist.cpp
@@ -22,6 +22,8 @@
 
 #include <map>
 
+#include <ert/python.hpp>
+
 #define ENV_VAR_KEY_STRING "global_environment"
 #define UPDATE_PATH_KEY_STRING "global_update_path"
 
@@ -66,3 +68,21 @@ void env_varlist_json_fprintf(const env_varlist_type *list, FILE *stream) {
 }
 
 void env_varlist_free(env_varlist_type *list) { delete list; }
+
+ERT_CLIB_SUBMODULE("env_varlist", m) {
+    using namespace py::literals;
+    m.def(
+        "_get_varlist",
+        [](py::object self_py) {
+            auto self = ert::from_cwrap<env_varlist_type>(self_py);
+            return self->varlist;
+        },
+        py::arg("self"));
+    m.def(
+        "_get_updatelist",
+        [](py::object self_py) {
+            auto self = ert::from_cwrap<env_varlist_type>(self_py);
+            return self->updatelist;
+        },
+        py::arg("self"));
+}

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -205,6 +205,56 @@ class EnsembleConfig(BaseCClass):
     def __len__(self):
         return self._size()
 
+    def __repr__(self):
+        return (
+            "EnsembleConfig(config_dict={"
+            + f"{ConfigKeys.GEN_KW}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.GEN_KW
+            )
+            + "], "
+            + f"{ConfigKeys.GEN_PARAM}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.GEN_DATA
+                and self.getNode(key).getVariableType() == EnkfVarType.PARAMETER
+            )
+            + "], "
+            + f"{ConfigKeys.GEN_DATA}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.GEN_DATA
+                and self.getNode(key).getVariableType() == EnkfVarType.DYNAMIC_RESULT
+            )
+            + "], "
+            + f"{ConfigKeys.SURFACE_KEY}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.SURFACE
+            )
+            + "], "
+            + f"{ConfigKeys.SUMMARY}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.SUMMARY
+            )
+            + "], "
+            + f"{ConfigKeys.FIELD_KEY}: ["
+            + ", ".join(
+                f"{self.getNode(key)}"
+                for key in self.alloc_keylist()
+                if self.getNode(key).getImplementationType() == ErtImplType.FIELD
+            )
+            + "]"
+            + "}"
+        )
+
     def __getitem__(self, key: str) -> EnkfConfigNode:
         if key in self:
             return self._get_node(key).setParent(self)

--- a/src/ert/_c_wrappers/enkf/rng_config.py
+++ b/src/ert/_c_wrappers/enkf/rng_config.py
@@ -56,6 +56,13 @@ class RNGConfig(BaseCClass):
     def alg_type(self):
         return self._rng_alg_type()
 
+    def __repr__(self):
+        return (
+            "RNGConfig(config_dict={"
+            f"{ConfigKeys.RANDOM_SEED}: {self.random_seed}"
+            "})"
+        )
+
     @property
     def random_seed(self):
         return self._random_seed()

--- a/src/ert/_c_wrappers/enkf/site_config.py
+++ b/src/ert/_c_wrappers/enkf/site_config.py
@@ -120,9 +120,13 @@ class SiteConfig(BaseCClass):
             ext_job_list.convertToCReference(None)
 
             # Create varlist
-            env_var_list = EnvironmentVarlist()
-            for (var, value) in config_dict.get(ConfigKeys.SETENV, []):
-                env_var_list[var] = value
+            environment_vars = config_dict.get(ConfigKeys.SETENV, [])
+            env_var_list = EnvironmentVarlist(
+                vars={
+                    elem[ConfigKeys.NAME]: elem[ConfigKeys.VALUE]
+                    for elem in environment_vars
+                }
+            )
 
             env_var_list.convertToCReference(None)
             umask = config_dict.get(ConfigKeys.UMASK)

--- a/src/ert/_c_wrappers/enkf/site_config.py
+++ b/src/ert/_c_wrappers/enkf/site_config.py
@@ -142,19 +142,16 @@ class SiteConfig(BaseCClass):
         return self._get_config_file()
 
     def get_installed_jobs(self):
-        """@rtype: ExtJoblist"""
         return self._get_installed_jobs().setParent(self)
 
-    def get_license_root_path(self):
-        """@rtype: str"""
+    def get_license_root_path(self) -> str:
         return self._get_license_root_path()
 
     def set_license_root_pathmax_submit(self, path):
         self._set_license_root_path(path)
 
     @classmethod
-    def getLocation(cls):
-        """@rtype: str"""
+    def getLocation(cls) -> str:
         return cls._get_location()
 
     def free(self):

--- a/src/ert/_c_wrappers/enkf/site_config.py
+++ b/src/ert/_c_wrappers/enkf/site_config.py
@@ -45,6 +45,9 @@ class SiteConfig(BaseCClass):
     _get_location = ResPrototype("char* site_config_get_location()", bind=False)
     _get_config_file = ResPrototype("char* site_config_get_config_file(site_config)")
     _get_umask = ResPrototype("int site_config_get_umask(site_config)")
+    _get_env_var_list = ResPrototype(
+        "env_varlist_ref site_config_get_env_varlist(site_config)"
+    )
 
     def __init__(self, user_config_file=None, config_content=None, config_dict=None):
 
@@ -139,7 +142,15 @@ class SiteConfig(BaseCClass):
         super().__init__(c_ptr)
 
     def __repr__(self):
-        return f"Site Config {SiteConfig.getLocation()}"
+        return (
+            "SiteConfig(config_dict={"
+            + f"{ConfigKeys.UMASK}: {self.umask},"
+            + f"{ConfigKeys.INSTALL_JOB}: ["
+            + ", ".join(str(job) for job in self.get_installed_jobs())
+            + "],"
+            + f"{ConfigKeys.SETENV}: {self._get_env_var_list()}"
+            + "})"
+        )
 
     @property
     def config_file(self):
@@ -171,6 +182,9 @@ class SiteConfig(BaseCClass):
 
         self_job_list = self.get_installed_jobs()
         other_job_list = other.get_installed_jobs()
+
+        if self._get_env_var_list() != other._get_env_var_list():
+            return False
 
         if set(other_job_list.getAvailableJobNames()) != set(
             self_job_list.getAvailableJobNames()

--- a/tests/libres_tests/res/enkf/test_site_config.py
+++ b/tests/libres_tests/res/enkf/test_site_config.py
@@ -87,7 +87,7 @@ class SiteConfigTest(ResTest):
                     ERT_SHARE_PATH + "/forward-models/old_style",
                 ],
                 ConfigKeys.SETENV: [
-                    {ConfigKeys.NAME: "SILLY_VAR", ConfigKeys.VALUE: "silly-value"},
+                    {ConfigKeys.NAME: "SILLY_VAR", ConfigKeys.VALUE: "silly-valye"},
                     {
                         ConfigKeys.NAME: "OPTIONAL_VAR",
                         ConfigKeys.VALUE: "optional-value",

--- a/tests/libres_tests/res/job_queue/test_forward_model_formatted_print.py
+++ b/tests/libres_tests/res/job_queue/test_forward_model_formatted_print.py
@@ -411,11 +411,9 @@ class ForwardModelFormattedPrintTest(ResTest):
         second_value = "TheSecondValue"
         third_value = "$FIRST:$SECOND"
         third_value_correct = f"{first_value}:{second_value}"
-        varlist = EnvironmentVarlist()
-        varlist[first] = first_value
-        varlist[second] = second_value
-        varlist[third] = third_value
-        self.assertEqual(len(varlist), 3)
+        varlist = EnvironmentVarlist(
+            {first: first_value, second: second_value, third: third_value}
+        )
         with TestAreaContext("python/job_queue/env_varlist"):
             forward_model = self.set_up_forward_model([])
             run_id = "test_no_jobs_id"


### PR DESCRIPTION
In order to continue the work with #3847 , we need to more easily inspect the objects that are created. Therefore the `__eq__` and `__repr__` are improved to align more with the convention of [`__repr__`](https://docs.python.org/3/library/functions.html?highlight=__repr__#repr), namely that either `eval(repr(a)) == a` or `repr(a) == "< AClass ... >`. where `AClass` is the type of `a`.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
