### PR TITLE
Remove some remaining references to libres

### DIFF
--- a/ci/jenkins/testkomodo-libres-ctest.sh
+++ b/ci/jenkins/testkomodo-libres-ctest.sh
@@ -54,6 +54,6 @@ install_package () {
 }
 
 start_tests () {
-    # build and run libres ctests
+    # build and run c tests
     run_ert_clib_tests
 }

--- a/ci/jenkins/testkomodo-repeat-flaky.sh
+++ b/ci/jenkins/testkomodo-repeat-flaky.sh
@@ -7,7 +7,7 @@ copy_test_files () {
     # Trick ERT to find a fake source root
     mkdir ${CI_TEST_ROOT}/.git
 
-    # libres
+    # clib
     mkdir -p ${CI_TEST_ROOT}/src/clib/res/fm/rms
     ln -s ${CI_SOURCE_ROOT}/src/ert/_c_wrappers/fm/rms/rms_config.yml ${CI_TEST_ROOT}/src/clib/res/fm/rms/rms_config.yml
 

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -7,7 +7,7 @@ copy_test_files () {
     # Trick ERT to find a fake source root
     mkdir ${CI_TEST_ROOT}/.git
 
-    # libres
+    # clib
     mkdir -p ${CI_TEST_ROOT}/src/clib/res/fm/rms
     ln -s ${CI_SOURCE_ROOT}/src/ert/_c_wrappers/fm/rms/rms_config.yml ${CI_TEST_ROOT}/src/clib/res/fm/rms/rms_config.yml
     ln -s {$CI_SOURCE_ROOT,$CI_TEST_ROOT}/src/clib/lib

--- a/docs/reference/configuration/forward_model.rst
+++ b/docs/reference/configuration/forward_model.rst
@@ -41,8 +41,7 @@ Default jobs
 ~~~~~~~~~~~~
 
 It is quite simple to *install* your own executables to be used as forward model
-job in ert, but some common jobs are distributed with the ert/libres
-distribution.
+job in ert, but some common jobs are distributed with the ert.
 
 see :doc:`../forward_models`
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/equinor/ert",
-    packages=find_packages(where="src", exclude=["libres"]),
+    packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={
         "ert": package_files("src/ert/gui/resources/")

--- a/src/clib/lib/enkf/ecl_config.cpp
+++ b/src/clib/lib/enkf/ecl_config.cpp
@@ -379,11 +379,10 @@ void ecl_config_init(ecl_config_type *ecl_config,
     if (ecl_config->can_restart)
         fprintf(
             stderr,
-            "** Warning: The ECLIPSE data file contains a <INIT> section, the "
-            "support\n"
-            "            for this functionality has been removed. libres will "
-            "not\n"
-            "            be able to properly initialize the ECLIPSE MODEL.\n");
+            "** Warning: The ECLIPSE data file contains a <INIT> section, the\n"
+            "            support for this functionality has been removed. Ert\n"
+            "            will not be able to properly initialize the ECLIPSE "
+            "MODEL.\n");
 
     if (config_content_has_item(config, SCHEDULE_PREDICTION_FILE_KEY))
         handle_has_schedule_prediction_file_key(ecl_config, config);

--- a/src/clib/lib/job_queue/qstat_proxy.sh
+++ b/src/clib/lib/job_queue/qstat_proxy.sh
@@ -29,7 +29,7 @@ CACHE_INVALID=10
 QSTAT=`which qstat 2>/dev/null`
 
 if [ -z $QSTAT ]; then
-    # libres/old_tests/job_queue tests require the backend in current working directory
+    # clib/old_tests/job_queue tests require the backend in current working directory
     export PATH=.:$PATH
     QSTAT=`which qstat 2>/dev/null`
 fi

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -25,8 +25,7 @@ class BatchSimulator:
     ):
         """Will create simulator which can be used to run multiple simulations.
 
-        The @res_config argument should be a ResConfig object, representing the
-        fully configured state of libres.
+        The @res_config argument should be a ResConfig object.
 
 
         The @controls argument configures which parameters the simulator should
@@ -62,7 +61,7 @@ class BatchSimulator:
         When later invoking the start() method the simulator expects to get
         values for all parameters configured with the @controls argument,
         otherwise an exception will be raised.
-        Internally in libres code the controls will be implemented as
+        Internally in ert the controls will be implemented as
         'ext_param' instances.
 
 


### PR DESCRIPTION
libres is now ert/clib. This removes some easy to remove references to libres.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
