### PR TITLE
Remove deprecated load_general_data and load_summary_data from ert.data.loader

### DIFF
--- a/src/ert/data/loader.py
+++ b/src/ert/data/loader.py
@@ -84,42 +84,6 @@ def _extract_data(
     return pd.concat(data_map, axis=1).astype(float)
 
 
-@deprecation.deprecated(
-    deprecated_in="2.19",
-    removed_in="3.0",
-    current_version=__version__,
-    details="Use the data_loader_factory",
-)
-def load_general_data(facade, obs_keys, case_name, include_data=True):
-    return _extract_data(
-        facade,
-        obs_keys,
-        case_name,
-        _load_general_response,
-        _load_general_obs,
-        "GEN_OBS",
-        include_data=include_data,
-    )
-
-
-@deprecation.deprecated(
-    deprecated_in="2.19",
-    removed_in="3.0",
-    current_version=__version__,
-    details="Use the data_loader_factory",
-)
-def load_summary_data(facade, obs_keys, case_name, include_data=True):
-    return _extract_data(
-        facade,
-        obs_keys,
-        case_name,
-        _load_summary_response,
-        _load_summary_obs,
-        "SUMMARY_OBS",
-        include_data=include_data,
-    )
-
-
 def _create_multi_index(key_index, data_index):
     arrays = [key_index, data_index]
     tuples = list(zip(*arrays))


### PR DESCRIPTION
**Issue**
Release 3 fails on `test_deprecated_entry_points`, remove functions set to be deprecated in version 3.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
