### PR TITLE
Remove deprecation limit on ert.data.loader.load_general_data and load.summary.data

### DIFF
--- a/src/ert/data/loader.py
+++ b/src/ert/data/loader.py
@@ -86,7 +86,6 @@ def _extract_data(
 
 @deprecation.deprecated(
     deprecated_in="2.19",
-    removed_in="3.0",
     current_version=__version__,
     details="Use the data_loader_factory",
 )
@@ -104,7 +103,6 @@ def load_general_data(facade, obs_keys, case_name, include_data=True):
 
 @deprecation.deprecated(
     deprecated_in="2.19",
-    removed_in="3.0",
     current_version=__version__,
     details="Use the data_loader_factory",
 )


### PR DESCRIPTION
Removed the deprecated_on argument. We failed to remove the deprecated functions (the test is a bit hard on failure) before 3.0 was released. Instead of removing the functions now and releasing 3.1, risking that our users will have to update fast, we remove the hard check on version.

The warning of when the function will be removed has still been produced for 19 months.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
