### PR TITLE
Do not use colors on jenkins

### DIFF
--- a/ci/jenkins/test_libres_jenkins.sh
+++ b/ci/jenkins/test_libres_jenkins.sh
@@ -139,7 +139,7 @@ run_pytest_normal () {
 
 	# Avoid implicitly loaded cwd modules
 	pushd ${ERT_CLIB_BUILD}
-	python -m pytest --durations=10 ${ERT_SOURCE_ROOT}/tests/libres_tests
+	python -m pytest --color=no --durations=10 ${ERT_SOURCE_ROOT}/tests/libres_tests
 	popd
 }
 

--- a/ci/jenkins/testkomodo-ERT.sh
+++ b/ci/jenkins/testkomodo-ERT.sh
@@ -30,7 +30,7 @@ start_tests () {
     # a lock filgit ree for the default server and kill the run
     # Allow xvfb to find a new server
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \
-    pytest -k "not test_gui_load and not test_formatting" \
+    pytest --color=no -k "not test_gui_load and not test_formatting" \
     -m "not requires_window_manager" tests/ert_tests
     popd
 }

--- a/ci/jenkins/testkomodo-libres-pytest.sh
+++ b/ci/jenkins/testkomodo-libres-pytest.sh
@@ -28,7 +28,7 @@ start_tests () {
     pushd ${CI_TEST_ROOT}/tests/libres_tests
     ln -s /project/res-testdata/ErtTestData ${CI_TEST_ROOT}/test-data/Equinor
     export ECL_SKIP_SIGNAL=ON
-    pytest                                                   \
+    pytest --color=no                                                     \
         --ignore="tests/libres_tests/res/enkf/test_analysis_config.py"    \
         --ignore="tests/libres_tests/res/enkf/test_res_config.py"         \
         --ignore="tests/libres_tests/res/enkf/test_site_config.py"        \

--- a/ci/jenkins/testkomodo-repeat-flaky.sh
+++ b/ci/jenkins/testkomodo-repeat-flaky.sh
@@ -29,10 +29,10 @@ run_ert_clib_tests(){
     # A test on the internal CI is activated by writing a comment with "test flaky please"
     # Requires that the user is allowed to run the tests.
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \
-    pytest tests/ert_tests -k "not test_gui_load and not test_formatting" \
+    pytest --color=no tests/ert_tests -k "not test_gui_load and not test_formatting" \
     -m "not requires_window_manager"
 
-    pytest tests/libres_tests                                         \
+    pytest --color=no tests/libres_tests                              \
     --ignore="tests/libres_tests/res/enkf/test_analysis_config.py"    \
     --ignore="tests/libres_tests/res/enkf/test_res_config.py"         \
     --ignore="tests/libres_tests/res/enkf/test_site_config.py"        \

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -36,14 +36,14 @@ start_tests () {
     # Allow xvfb to find a new server
     pushd ${CI_TEST_ROOT}/tests/ert_tests
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \
-    pytest -k "not test_gui_load and not test_formatting" \
+    pytest --color=no -k "not test_gui_load and not test_formatting" \
     -m "not requires_window_manager"
     popd
 
     pushd ${CI_TEST_ROOT}/tests/libres_tests
     ln -s /project/res-testdata/ErtTestData ${CI_TEST_ROOT}/test-data/Equinor
     export ECL_SKIP_SIGNAL=ON
-    pytest                                                   \
+    pytest --color=no                                                     \
         --ignore="tests/libres_tests/res/enkf/test_analysis_config.py"    \
         --ignore="tests/libres_tests/res/enkf/test_res_config.py"         \
         --ignore="tests/libres_tests/res/enkf/test_site_config.py"        \


### PR DESCRIPTION
Jenkins does not handle color in terminal at all so terminal codes makes garabage output.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
