### PR TITLE
Move storage_service.json to enspath  and propagate the ensepath when starting the webviz_ert service

### DIFF
--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -62,8 +62,10 @@ def run_gui(args):
     # be the base name of the original config
     args.config = os.path.basename(args.config)
     ert = EnKFMain(res_config)
+    facade = LibresFacade(ert)
     with Storage.connect_or_start_server(
-        res_config=os.path.basename(args.config)
+        res_config=os.path.basename(args.config),
+        project=facade.enspath,
     ), add_gui_log_handler() as log_handler:
         notifier = ErtNotifier(args.config)
         # window reference must be kept until app.exec returns:

--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -65,7 +65,7 @@ def run_gui(args):
     facade = LibresFacade(ert)
     with Storage.connect_or_start_server(
         res_config=os.path.basename(args.config),
-        project=facade.enspath,
+        project=os.path.abspath(facade.enspath),
     ), add_gui_log_handler() as log_handler:
         notifier = ErtNotifier(args.config)
         # window reference must be kept until app.exec returns:

--- a/src/ert/shared/services/_base_service.py
+++ b/src/ert/shared/services/_base_service.py
@@ -104,7 +104,7 @@ class _Proc(threading.Thread):
         self._exec_args = exec_args
         self._timeout = timeout
         self._set_conn_info = set_conn_info
-        self._service_config_path = Path(project) / f"{self._service_name}_server.json"
+        self._service_config_path = project / f"{self._service_name}_server.json"
 
         self._assert_server_not_running()
 
@@ -174,7 +174,7 @@ class _Proc(threading.Thread):
         if self._service_config_path.exists():
             print(
                 f"A file called {self._service_name}_server.json is present from this "
-                f"location. This indicates there is already a ert instance running. "
+                "location. This indicates there is already a ert instance running. "
                 "If you are certain that is not the case, try to delete the file "
                 "and try again."
             )
@@ -265,7 +265,7 @@ class BaseService:
         exec_args: Sequence[str],
         timeout: int = 120,
         conn_info: ConnInfo = None,
-        project: Optional[Path] = None,
+        project: Optional[str] = None,
     ):
         self._exec_args = exec_args
         self._timeout = timeout
@@ -273,7 +273,7 @@ class BaseService:
         self._proc: Optional[_Proc] = None
         self._conn_info: ConnInfo = conn_info
         self._conn_info_event = threading.Event()
-        self._project = project or Path.cwd()
+        self._project = Path(project) if project is not None else Path.cwd()
 
         # Flag that we have connection information
         if self._conn_info:
@@ -314,7 +314,7 @@ class BaseService:
         while t < timeout:
             if (path / name).exists():
                 with (path / name).open() as f:
-                    return cls([], conn_info=json.load(f), project=path)
+                    return cls([], conn_info=json.load(f), project=str(path))
 
             sleep(1)
             t += 1

--- a/src/ert/shared/services/_storage_main.py
+++ b/src/ert/shared/services/_storage_main.py
@@ -138,7 +138,9 @@ def run_server(args: Optional[argparse.Namespace] = None, debug: bool = False) -
         # at startup. We set the database URL to an SQLite in-memory database so
         # that the import succeeds.
         os.environ["ERT_STORAGE_DATABASE_URL"] = "sqlite://"
-        os.environ["ERT_STORAGE_RES_CONFIG"] = args.config or find_ert_config()
+        os.environ["ERT_STORAGE_RES_CONFIG"] = (
+            os.path.abspath(args.config) or find_ert_config()
+        )
         config = uvicorn.Config("ert.shared.dark_storage.app:app", **config_args)
     server = Server(config, json.dumps(connection_info), lockfile)
 

--- a/src/ert/shared/services/storage_service.py
+++ b/src/ert/shared/services/storage_service.py
@@ -29,6 +29,8 @@ class Storage(BaseService):
             exec_args.extend(("--database-url", database_url))
         if verbose:
             exec_args.append("--verbose")
+        if "project" in kwargs:
+            exec_args.extend(["--project", str(kwargs["project"])])
 
         super().__init__(exec_args, *args, **kwargs)
 
@@ -40,6 +42,16 @@ class Storage(BaseService):
         Blocks while the server is starting.
         """
         return ("__token__", self.fetch_conn_info()["authtoken"])
+
+    # @classmethod
+    # def start_service(cls, *args: Any, **kwargs: Any):
+    #     try:
+    #         service = cls.connect(timeout=0, project=kwargs.get("project"))
+    #         # Attempt to fetch the service url
+    #         _ = service.fetch_url()
+    #     except TimeoutError:
+    #         return cls.start_server(*args, **kwargs)
+    #     return _Context(service)
 
     def fetch_url(self) -> str:
         """Returns the url. Blocks while the server is starting"""

--- a/src/ert/shared/services/storage_service.py
+++ b/src/ert/shared/services/storage_service.py
@@ -43,16 +43,6 @@ class Storage(BaseService):
         """
         return ("__token__", self.fetch_conn_info()["authtoken"])
 
-    # @classmethod
-    # def start_service(cls, *args: Any, **kwargs: Any):
-    #     try:
-    #         service = cls.connect(timeout=0, project=kwargs.get("project"))
-    #         # Attempt to fetch the service url
-    #         _ = service.fetch_url()
-    #     except TimeoutError:
-    #         return cls.start_server(*args, **kwargs)
-    #     return _Context(service)
-
     def fetch_url(self) -> str:
         """Returns the url. Blocks while the server is starting"""
         if self._url is not None:

--- a/src/ert/shared/services/webviz_ert_service.py
+++ b/src/ert/shared/services/webviz_ert_service.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 
 from ert.shared.services._base_service import BaseService
 
@@ -6,15 +7,14 @@ from ert.shared.services._base_service import BaseService
 class WebvizErt(BaseService):
     service_name = "webviz-ert"
 
-    def __init__(
-        self, title: str = None, experimental_mode: bool = False, verbose: bool = False
-    ):
+    def __init__(self, **kwargs: Any):
         exec_args = [sys.executable, "-m", "webviz_ert"]
-        if experimental_mode:
+        if kwargs.get("experimental_mode", False):
             exec_args.append("--experimental-mode")
-        if verbose:
+        if kwargs.get("verbose", False):
             exec_args.append("--verbose")
-        if title:
-            exec_args.append("--title")
-            exec_args.append(title)
-        super().__init__(exec_args)
+        exec_args.extend(["--title", str(kwargs.get("title"))])
+        project = kwargs.get("project")
+        exec_args.extend(["--project_identifier", str(project)])
+
+        super().__init__(exec_args, project=project)

--- a/tests/ert_tests/gui/test_gui_load.py
+++ b/tests/ert_tests/gui/test_gui_load.py
@@ -130,8 +130,11 @@ def test_gui_full(monkeypatch, tmpdir, qapp, mock_start_server):
             lambda: None
         )  # exec_ starts the event loop, and will stall the test.
         monkeypatch.setattr(ert.gui.gert_main, "QApplication", Mock(return_value=qapp))
+        monkeypatch.setattr(ert.gui.gert_main.LibresFacade, "enspath", str(tmpdir))
         run_gui(args_mock)
-        mock_start_server.assert_called_once_with(res_config="config.ert")
+        mock_start_server.assert_called_once_with(
+            project=str(tmpdir), res_config="config.ert"
+        )
 
 
 def test_gui_iter_num(monkeypatch, tmpdir, qtbot, patch_enkf_main):

--- a/tests/ert_tests/services/test_base_service.py
+++ b/tests/ert_tests/services/test_base_service.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from ert.shared.services._base_service import (
-    SERVICE_NAMES,
+    SERVICE_CONF_PATHS,
     BaseService,
     ServerBootFail,
     cleanup_service_files,
@@ -307,22 +307,23 @@ def test_local_exec_args_multi():
 
 
 def test_cleanup_service_files(tmpdir):
-    storage_service_name = "storage"
-    storage_service_file = f"{storage_service_name}_server.json"
-    with open(storage_service_file, "w") as f:
-        f.write("storage_service info")
-    assert Path(storage_service_file).exists()
-    SERVICE_NAMES.add(storage_service_name)
+    with tmpdir.as_cwd():
+        storage_service_name = "storage"
+        storage_service_file = f"{storage_service_name}_server.json"
+        with open(storage_service_file, "w") as f:
+            f.write("storage_service info")
+        assert Path(storage_service_file).exists()
+        SERVICE_CONF_PATHS.add(tmpdir / storage_service_file)
 
-    webviz_service_name = "webviz-ert"
-    webviz_service_file = f"{webviz_service_name}_server.json"
-    with open(webviz_service_file, "w") as f:
-        f.write("webviz-ert info")
-    assert Path(webviz_service_file).exists()
-    SERVICE_NAMES.add(webviz_service_name)
+        webviz_service_name = "webviz-ert"
+        webviz_service_file = f"{webviz_service_name}_server.json"
+        with open(webviz_service_file, "w") as f:
+            f.write("webviz-ert info")
+        assert Path(webviz_service_file).exists()
+        SERVICE_CONF_PATHS.add(tmpdir / webviz_service_file)
 
-    with pytest.raises(OSError):
-        cleanup_service_files(signum=99, frame=None)
+        with pytest.raises(OSError):
+            cleanup_service_files(signum=99, frame=None)
 
-    assert not Path(storage_service_file).exists()
-    assert not Path(webviz_service_file).exists()
+        assert not Path(storage_service_file).exists()
+        assert not Path(webviz_service_file).exists()


### PR DESCRIPTION
**Issue**
Resolves #3873 


**Approach**

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
