### PR TITLE
Remove getters only used in tests from enkf_main.cpp

### DIFF
--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -81,11 +81,6 @@ bool enkf_main_have_obs(const enkf_main_type *enkf_main) {
     return enkf_obs_have_obs(enkf_main->obs);
 }
 
-const hook_manager_type *
-enkf_main_get_hook_manager(const enkf_main_type *enkf_main) {
-    return res_config_get_hook_manager(enkf_main->res_config);
-}
-
 void enkf_main_free(enkf_main_type *enkf_main) {
 
     if (enkf_main->obs)
@@ -95,10 +90,6 @@ void enkf_main_free(enkf_main_type *enkf_main) {
 }
 
 void enkf_main_install_SIGNALS(void) { util_install_signals(); }
-
-ert_workflow_list_type *enkf_main_get_workflow_list(enkf_main_type *enkf_main) {
-    return res_config_get_workflow_list(enkf_main->res_config);
-}
 
 int enkf_main_load_from_run_context(const int ens_size,
                                     ensemble_config_type *ensemble_config,

--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -73,11 +73,6 @@ struct enkf_main_struct {
 UTIL_SAFE_CAST_FUNCTION(enkf_main, ENKF_MAIN_ID)
 UTIL_IS_INSTANCE_FUNCTION(enkf_main, ENKF_MAIN_ID)
 
-const res_config_type *
-enkf_main_get_res_config(const enkf_main_type *enkf_main) {
-    return enkf_main->res_config;
-}
-
 enkf_obs_type *enkf_main_get_obs(const enkf_main_type *enkf_main) {
     return enkf_main->obs;
 }

--- a/src/clib/lib/enkf/ert_test_context.cpp
+++ b/src/clib/lib/enkf/ert_test_context.cpp
@@ -111,9 +111,9 @@ bool ert_test_context_install_workflow_job(ert_test_context_type *test_context,
                                            const char *job_name,
                                            const char *job_file) {
     if (fs::exists(job_file)) {
-        enkf_main_type *enkf_main = ert_test_context_get_main(test_context);
+        res_config_type *res_config = ert_test_context_get_res(test_context);
         ert_workflow_list_type *workflow_list =
-            enkf_main_get_workflow_list(enkf_main);
+            res_config_get_workflow_list(res_config);
         ert_workflow_list_add_job(workflow_list, job_name, job_file);
         return ert_workflow_list_has_job(workflow_list, job_name);
     } else
@@ -124,9 +124,9 @@ bool ert_test_context_install_workflow(ert_test_context_type *test_context,
                                        const char *workflow_name,
                                        const char *workflow_file) {
     if (fs::exists(workflow_file)) {
-        enkf_main_type *enkf_main = ert_test_context_get_main(test_context);
+        res_config_type *res_config = ert_test_context_get_res(test_context);
         ert_workflow_list_type *workflow_list =
-            enkf_main_get_workflow_list(enkf_main);
+            res_config_get_workflow_list(res_config);
         ert_workflow_list_add_workflow(workflow_list, workflow_file,
                                        workflow_name);
         return ert_workflow_list_has_workflow(workflow_list, workflow_name);
@@ -144,8 +144,9 @@ void ert_test_context_fwrite_workflow_job(FILE *stream, const char *job_name,
 bool ert_test_context_run_worklow(ert_test_context_type *test_context,
                                   const char *workflow_name) {
     enkf_main_type *enkf_main = ert_test_context_get_main(test_context);
+    res_config_type *res_config = ert_test_context_get_res(test_context);
     ert_workflow_list_type *workflow_list =
-        enkf_main_get_workflow_list(enkf_main);
+        res_config_get_workflow_list(res_config);
 
     if (ert_workflow_list_has_workflow(workflow_list, workflow_name)) {
         bool result = ert_workflow_list_run_workflow_blocking(
@@ -159,9 +160,9 @@ bool ert_test_context_run_worklow(ert_test_context_type *test_context,
 bool ert_test_context_run_worklow_job(ert_test_context_type *test_context,
                                       const char *job_name,
                                       const stringlist_type *args) {
-    enkf_main_type *enkf_main = ert_test_context_get_main(test_context);
+    res_config_type *res_config = ert_test_context_get_res(test_context);
     ert_workflow_list_type *workflow_list =
-        enkf_main_get_workflow_list(enkf_main);
+        res_config_get_workflow_list(res_config);
 
     if (ert_workflow_list_has_job(workflow_list, job_name)) {
         bool status;

--- a/src/clib/lib/enkf/ert_test_context.cpp
+++ b/src/clib/lib/enkf/ert_test_context.cpp
@@ -81,6 +81,10 @@ enkf_main_type *ert_test_context_get_main(ert_test_context_type *test_context) {
     return test_context->enkf_main;
 }
 
+res_config_type *ert_test_context_get_res(ert_test_context_type *test_context) {
+    return test_context->res_config;
+}
+
 const char *
 ert_test_context_get_cwd(const ert_test_context_type *test_context) {
     return test_work_area_get_cwd(test_context->work_area);

--- a/src/clib/lib/include/ert/enkf/enkf_main.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_main.hpp
@@ -63,12 +63,6 @@ extern "C" bool enkf_main_have_obs(const enkf_main_type *enkf_main);
 
 void enkf_main_install_SIGNALS(void);
 
-extern "C" const hook_manager_type *
-enkf_main_get_hook_manager(const enkf_main_type *enkf_main);
-
-extern "C" ert_workflow_list_type *
-enkf_main_get_workflow_list(enkf_main_type *enkf_main);
-
 int enkf_main_load_from_run_context(const int ens_size,
                                     ensemble_config_type *ensemble_config,
                                     model_config_type *model_config,

--- a/src/clib/lib/include/ert/enkf/enkf_main.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_main.hpp
@@ -77,9 +77,6 @@ int enkf_main_load_from_run_context(const int ens_size,
                                     enkf_fs_type *sim_fs,
                                     std::vector<run_arg_type *> run_args);
 
-extern "C" const res_config_type *
-enkf_main_get_res_config(const enkf_main_type *enkf_main);
-
 UTIL_SAFE_CAST_HEADER(enkf_main);
 UTIL_IS_INSTANCE_HEADER(enkf_main);
 

--- a/src/clib/lib/include/ert/enkf/ert_test_context.hpp
+++ b/src/clib/lib/include/ert/enkf/ert_test_context.hpp
@@ -34,6 +34,7 @@ ert_test_context_type *ert_test_context_alloc(const char *test_name,
                                               const char *model_config);
 void ert_test_context_free(ert_test_context_type *test_context);
 enkf_main_type *ert_test_context_get_main(ert_test_context_type *test_context);
+res_config_type *ert_test_context_get_res(ert_test_context_type *test_context);
 bool ert_test_context_install_workflow_job(ert_test_context_type *test_context,
                                            const char *job_name,
                                            const char *job_file);

--- a/src/clib/old_tests/enkf/test_gen_kw_logarithmic.cpp
+++ b/src/clib/old_tests/enkf/test_gen_kw_logarithmic.cpp
@@ -50,11 +50,11 @@ void verify_parameters_txt() {
     free(file_content);
 }
 
-void test_write_gen_kw_export_file(enkf_main_type *enkf_main) {
+void test_write_gen_kw_export_file(res_config_type *res_config) {
     enkf_fs_type *init_fs =
         enkf_fs_create_fs("new_fs", BLOCK_FS_DRIVER_ID, true);
     ensemble_config_type *ens_config =
-        res_config_get_ensemble_config(enkf_main_get_res_config(enkf_main));
+        res_config_get_ensemble_config(res_config);
     enkf_node_type *enkf_node =
         enkf_node_alloc(ensemble_config_get_node(ens_config, "MULTFLT"));
     enkf_node_type *enkf_node2 =
@@ -90,11 +90,10 @@ void test_write_gen_kw_export_file(enkf_main_type *enkf_main) {
     }
 
     {
-        enkf_main::ecl_write(
-            res_config_get_ensemble_config(enkf_main_get_res_config(enkf_main)),
-            model_config_get_gen_kw_export_name(res_config_get_model_config(
-                enkf_main_get_res_config(enkf_main))),
-            "simulations/run0", 0, init_fs);
+        enkf_main::ecl_write(res_config_get_ensemble_config(res_config),
+                             model_config_get_gen_kw_export_name(
+                                 res_config_get_model_config(res_config)),
+                             "simulations/run0", 0, init_fs);
         test_assert_true(fs::exists("simulations/run0/parameters.txt"));
     }
     enkf_node_free(enkf_node);
@@ -110,10 +109,10 @@ int main(int argc, char **argv) {
         ert_test_context_type *test_context =
             ert_test_context_alloc("gen_kw_logarithmic_test", config_file);
         enkf_main_type *enkf_main = ert_test_context_get_main(test_context);
-
+        res_config_type *res_config = ert_test_context_get_res(test_context);
         test_assert_not_NULL(enkf_main);
 
-        test_write_gen_kw_export_file(enkf_main);
+        test_write_gen_kw_export_file(res_config);
 
         ert_test_context_free(test_context);
     }

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -86,7 +86,6 @@ class EnKFMain(BaseCClass):
     _get_hook_manager = ResPrototype(
         "hook_manager_ref enkf_main_get_hook_manager(enkf_main)"
     )
-    _get_res_config = ResPrototype("res_config_ref enkf_main_get_res_config(enkf_main)")
 
     def __init__(self, config: "ResConfig", read_only: bool = False):
         self.config_file = config

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -80,12 +80,6 @@ class EnKFMain(BaseCClass):
     _free = ResPrototype("void enkf_main_free(enkf_main)")
     _get_obs = ResPrototype("enkf_obs_ref enkf_main_get_obs(enkf_main)")
     _have_observations = ResPrototype("bool enkf_main_have_obs(enkf_main)")
-    _get_workflow_list = ResPrototype(
-        "ert_workflow_list_ref enkf_main_get_workflow_list(enkf_main)"
-    )
-    _get_hook_manager = ResPrototype(
-        "hook_manager_ref enkf_main_get_hook_manager(enkf_main)"
-    )
 
     def __init__(self, config: "ResConfig", read_only: bool = False):
         self.config_file = config
@@ -354,10 +348,10 @@ class EnKFMain(BaseCClass):
         return self.__key_manager
 
     def getWorkflowList(self) -> ErtWorkflowList:
-        return self._get_workflow_list().setParent(self)
+        return self.resConfig().ert_workflow_list
 
     def getHookManager(self) -> HookManager:
-        return self._get_hook_manager()
+        return self.resConfig().hook_manager
 
     def loadFromRunContext(self, run_context: RunContext, fs) -> int:
         """Returns the number of loaded realizations"""


### PR DESCRIPTION
These getters were already available in python, and only called from there outside tests, so no need to fetch them through C.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
