### PR TITLE
Simplify rng_config

### DIFF
--- a/src/clib/lib/enkf/res_config.cpp
+++ b/src/clib/lib/enkf/res_config.cpp
@@ -23,6 +23,8 @@
 
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/res_config.hpp>
+#include <ert/logging.hpp>
+static auto logger = ert::get_logger("enkf");
 
 struct res_config_struct {
 

--- a/src/clib/lib/enkf/rng_config.cpp
+++ b/src/clib/lib/enkf/rng_config.cpp
@@ -24,6 +24,7 @@
 #include <ert/util/util.h>
 
 #include <ert/logging.hpp>
+#include <string>
 
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/model_config.hpp>
@@ -32,51 +33,16 @@
 static auto logger = ert::get_logger("enkf");
 
 struct rng_config_struct {
-    rng_alg_type type;
     char *random_seed;
 };
-
-static void rng_config_set_random_seed(rng_config_type *rng_config,
-                                       const char *random_seed) {
-    rng_config->random_seed =
-        util_realloc_string_copy(rng_config->random_seed, random_seed);
-}
 
 const char *rng_config_get_random_seed(const rng_config_type *rng_config) {
     return rng_config->random_seed;
 }
 
-void rng_config_set_type(rng_config_type *rng_config, rng_alg_type type) {
-    rng_config->type = type;
-}
-
-rng_alg_type rng_config_get_type(const rng_config_type *rng_config) {
-    return rng_config->type;
-}
-
-static rng_config_type *rng_config_alloc_default(void) {
-    rng_config_type *rng_config =
-        (rng_config_type *)util_malloc(sizeof *rng_config);
-
-    rng_config_set_type(rng_config, MZRAN); /* Only type ... */
-    rng_config->random_seed = NULL;
-
-    return rng_config;
-}
-
-rng_config_type *rng_config_alloc(const config_content_type *config_content) {
-    rng_config_type *rng_config = rng_config_alloc_default();
-
-    if (config_content)
-        rng_config_init(rng_config, config_content);
-
-    return rng_config;
-}
-rng_config_type *rng_config_alloc_full(const char *random_seed) {
-    rng_config_type *rng_config = rng_config_alloc_default();
-    rng_config->random_seed =
-        util_realloc_string_copy(rng_config->random_seed, random_seed);
-
+rng_config_type *rng_config_alloc(const char *random_seed) {
+    auto rng_config = (rng_config_type *)malloc(sizeof(rng_config_type *));
+    rng_config->random_seed = util_alloc_string_copy(random_seed);
     return rng_config;
 }
 
@@ -87,16 +53,6 @@ void rng_config_free(rng_config_type *rng) {
 
 void rng_config_add_config_items(config_parser_type *parser) {
     config_add_key_value(parser, RANDOM_SEED_KEY, false, CONFIG_STRING);
-}
-
-void rng_config_init(rng_config_type *rng_config,
-                     const config_content_type *config_content) {
-    if (config_content_has_item(config_content, RANDOM_SEED_KEY)) {
-        const char *random_seed =
-            config_content_get_value(config_content, RANDOM_SEED_KEY);
-        rng_config_set_random_seed(rng_config, random_seed);
-        logger->critical("Using RANDOM_SEED: {}", random_seed);
-    }
 }
 
 ERT_CLIB_SUBMODULE("rng_config", m) {

--- a/src/clib/lib/include/ert/enkf/rng_config.hpp
+++ b/src/clib/lib/include/ert/enkf/rng_config.hpp
@@ -27,16 +27,9 @@ typedef struct rng_config_struct rng_config_type;
 
 void rng_config_init(rng_config_type *rng_config,
                      const config_content_type *config);
-void rng_config_set_type(rng_config_type *rng_config, rng_alg_type type);
-extern "C" rng_alg_type rng_config_get_type(const rng_config_type *rng_config);
 extern "C" const char *
 rng_config_get_random_seed(const rng_config_type *rng_config);
-rng_config_type *
-rng_config_alloc_load_user_config(const char *user_config_file);
-extern "C" rng_config_type *
-rng_config_alloc(const config_content_type *config_content);
-extern "C" PY_USED rng_config_type *
-rng_config_alloc_full(const char *random_seed);
+extern "C" rng_config_type *rng_config_alloc(const char *random_seed);
 extern "C" void rng_config_free(rng_config_type *rng);
 void rng_config_add_config_items(config_parser_type *config);
 

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -248,11 +248,9 @@ class ResConfig(BaseCClass):
 
     # build configs from config dict
     def _alloc_from_dict(self, config_dict):
-        # treat the default config dir
-        config_dir = os.getcwd()
-        if ConfigKeys.CONFIG_DIRECTORY in config_dict:
-            config_dir = config_dict[ConfigKeys.CONFIG_DIRECTORY]
-        config_dict[ConfigKeys.CONFIG_DIRECTORY] = config_dir
+        # default config dir is os.getcwd()
+        if ConfigKeys.CONFIG_DIRECTORY not in config_dict:
+            config_dict[ConfigKeys.CONFIG_DIRECTORY] = os.getcwd()
 
         subst_config = SubstConfig(config_dict=config_dict)
         site_config = SiteConfig(config_dict=config_dict)
@@ -301,6 +299,7 @@ class ResConfig(BaseCClass):
             config_dict=config_dict,
         )
 
+        config_dir = config_dict[ConfigKeys.CONFIG_DIRECTORY]
         model_config = ModelConfig(
             data_root=config_dir,
             joblist=site_config.get_installed_jobs(),

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -177,7 +177,10 @@ class ResConfig(BaseCClass):
 
         subst_config = SubstConfig(config_content=config_content)
         site_config = SiteConfig(config_content=config_content)
-        rng_config = RNGConfig(config_content=config_content)
+        if config_content.hasKey(ConfigKeys.RANDOM_SEED):
+            rng_config = RNGConfig(config_content.getValue(ConfigKeys.RANDOM_SEED))
+        else:
+            rng_config = RNGConfig()
         analysis_config = AnalysisConfig(config_content=config_content)
         ecl_config = EclConfig(config_content=config_content)
         queue_config = QueueConfig(config_content=config_content)
@@ -253,7 +256,10 @@ class ResConfig(BaseCClass):
 
         subst_config = SubstConfig(config_dict=config_dict)
         site_config = SiteConfig(config_dict=config_dict)
-        rng_config = RNGConfig(config_dict=config_dict)
+        if ConfigKeys.RANDOM_SEED in config_dict:
+            rng_config = RNGConfig(config_dict[ConfigKeys.RANDOM_SEED])
+        else:
+            rng_config = RNGConfig()
         analysis_config = AnalysisConfig(config_dict=config_dict)
         ecl_config = EclConfig(config_dict=config_dict)
         queue_config = QueueConfig(config_dict=config_dict)

--- a/tests/libres_tests/res/enkf/test_rng_config.py
+++ b/tests/libres_tests/res/enkf/test_rng_config.py
@@ -45,3 +45,23 @@ def test_random_seed():
         RNGConfig(config_dict={ConfigKeys.RANDOM_SEED: "abcdefghijklmnop"}).random_seed
         == "abcdefghijklmnop"
     )
+
+
+@pytest.mark.usefixtures("copy_minimum_case")
+def test_default_random_seed():
+    assert ResConfig(
+        config={
+            "INTERNALS": {
+                "CONFIG_DIRECTORY": ".",
+            },
+            "SIMULATION": {
+                "QUEUE_SYSTEM": {
+                    "JOBNAME": "Job%d",
+                },
+                "RUNPATH": "/tmp/simulations/run%d",
+                "NUM_REALIZATIONS": 1,
+                "JOB_SCRIPT": "script.sh",
+                "ENSPATH": "Ensemble",
+            },
+        }
+    ).rng_config == RNGConfig(config_dict={ConfigKeys.RANDOM_SEED: None})

--- a/tests/libres_tests/res/enkf/test_rng_config.py
+++ b/tests/libres_tests/res/enkf/test_rng_config.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from ert._c_wrappers.enkf import ConfigKeys, ResConfig, RNGConfig
+from ert._c_wrappers.enkf import ResConfig, RNGConfig
 
 
 @pytest.mark.usefixtures("copy_minimum_case")
@@ -37,14 +37,7 @@ def test_compare_config_content_and_dict_constructor():
                 "ENSPATH": "Ensemble",
             },
         }
-    ).rng_config == RNGConfig(config_dict={ConfigKeys.RANDOM_SEED: "abcdefghijklmnop"})
-
-
-def test_random_seed():
-    assert (
-        RNGConfig(config_dict={ConfigKeys.RANDOM_SEED: "abcdefghijklmnop"}).random_seed
-        == "abcdefghijklmnop"
-    )
+    ).rng_config == RNGConfig("abcdefghijklmnop")
 
 
 @pytest.mark.usefixtures("copy_minimum_case")
@@ -64,4 +57,4 @@ def test_default_random_seed():
                 "ENSPATH": "Ensemble",
             },
         }
-    ).rng_config == RNGConfig(config_dict={ConfigKeys.RANDOM_SEED: None})
+    ).rng_config == RNGConfig(None)

--- a/tests/test_config_parsing/test_rng_config.py
+++ b/tests/test_config_parsing/test_rng_config.py
@@ -15,4 +15,6 @@ def test_site_config_config_same_as_from_file(config_dict):
     filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
     to_config_file(filename, config_dict)
     config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
-    assert ResConfig(filename).rng_config == RNGConfig(config_dict=config_dict)
+    assert ResConfig(filename).rng_config == RNGConfig(
+        config_dict[ConfigKeys.RANDOM_SEED]
+    )


### PR DESCRIPTION
In order to #3847 we need a way of initializing `ResConfig` from the values created by the parser. This PR is an attempt to show how this can be achieved by simplifying the objects referenced by res_config. The general idea is that `ResConfig` will have three ways of being initialized (which is no more ways than status quo):
```python
class ResConfig:
  def __init__(self, ecl_config: EclConfig, rng_config: RNGConfig...):
     ...
     
  @classmethod
  def from_dict(cls, config_dict) -> "ResConfig":
     ...
     return ResConfig(...)
     
  @classmethod
  def from_file(cls, filename) -> "ResConfig":
     ...
```

At first, from_file will use the old parse, e.g.:
```python
  @classmethod
  def from_file(cls, filename) -> "ResConfig":
        parser = ConfigParser()
        config_content = ConfigContent(user_config_file, parser)

        subst_config = SubstConfig(config_content.get_value(...)
        site_config = SiteConfig(config_content.get_value(...)
        rng_config = RNGConfig(config_content.get_value(...)
        ...
        return cls(ecl_config, rng_config...)
```

Once we have created our own parser, we can replace it with:
```python
  @classmethod
  def from_file(cls, filename) -> "ResConfig":
        return ResConfig.from_dict(parse(filename))
```

while all referenced objects, such as `EnsembleConfig`, `RNGConfig` etc. will be simplified to just take their fields as parameters. This PR performs that simplification for `RNGConfig` as a proof-of-concept.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
