### PR TITLE
Pin protobuf and grpcio-tools

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ cmake-format
 decorator
 ecl_data_io
 flake8>=4.0.0
-grpcio-tools
+grpcio-tools==1.41.0
 isort
 jsonpath_ng
 jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
     "ecl",
     "conan",
     "pybind11>=2.8.1",  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
-    "grpcio-tools",
+    "grpcio-tools==1.41.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,12 @@
 import os
-from pathlib import Path
-import sys
-
-from setuptools import find_packages, Command
-from setuptools_scm import get_version
-
-from skbuild import setup
-from setuptools.command.egg_info import egg_info
-
 import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Command, find_packages
+from setuptools.command.egg_info import egg_info
+from setuptools_scm import get_version
+from skbuild import setup
 
 # list of pair of .proto file and out directory
 PROTOBUF_FILES = [
@@ -142,7 +140,7 @@ args = dict(
         "pandas",
         "pluggy",
         "prefect<2",
-        "protobuf",
+        "protobuf==3.19.1",
         "psutil",
         "pydantic >= 1.9",
         "PyQt5",


### PR DESCRIPTION
**Issue**
Test for ert_documentation fails due to we need to have the older version of protobuf package.
```sh
 _EMPTY = _descriptor.Descriptor(
/prog/res/komodo/bleeding-py38-rhel7/root/lib64/python3.8/site-packages/google/protobuf/descriptor.py:313: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
