### PR TITLE
Support Torque job id without a dot character

### DIFF
--- a/src/clib/lib/job_queue/qstat_proxy.sh
+++ b/src/clib/lib/job_queue/qstat_proxy.sh
@@ -91,14 +91,14 @@ fi
 
 # Replicate qstat's error behaviour:
 if [ -n "$1" ]; then
-    grep -e "^${1}\." $proxyfile >/dev/null 2>&1 || {
+    grep -e "^${1}[\.[:space:]]" $proxyfile >/dev/null 2>&1 || {
         echo "Unknown Job Id $1" && cat $proxyfile >&2 && exit 1;
         }
 fi
 
 # Extract the job id from the proxyfile:
 if [ -n "$1" ]; then
-    grep -e "-----" -e "User" -e "^$1\." $proxyfile
+    grep -e "-----" -e "User" -e "^$1[\.[:space:]]" $proxyfile
     exit 0
 fi
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -121,6 +121,11 @@ exit 1
     "qsub_script, qstat_script",
     [
         pytest.param(MOCK_QSUB, MOCK_QSTAT, id="none_flaky"),
+        pytest.param(
+            MOCK_QSUB.replace(".s034-lcam", ""),
+            MOCK_QSTAT.replace(".s034-lcam", ""),
+            id="none_flaky_no_namespace",
+        ),
         pytest.param(FLAKY_QSUB, MOCK_QSTAT, id="flaky_qsub"),
         pytest.param(MOCK_QSUB, FLAKY_QSTAT, id="flaky_qstat"),
         pytest.param(FLAKY_QSUB, FLAKY_QSTAT, id="all_flaky"),


### PR DESCRIPTION
**Issue**
Resolves #3910


**Approach**
Simple modification to existing error handling, checking if parsing of job id goes well if no dot is assumed to be present.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
