### PR TITLE
Overwrite Storage config file if it exits on disk

### DIFF
--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -63,7 +63,7 @@ def run_gui(args):
     args.config = os.path.basename(args.config)
     ert = EnKFMain(res_config)
     facade = LibresFacade(ert)
-    with Storage.connect_or_start_server(
+    with Storage.init_service(
         res_config=os.path.basename(args.config),
         project=os.path.abspath(facade.enspath),
     ), add_gui_log_handler() as log_handler:

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from httpx import RequestError
 from pandas import DataFrame
@@ -55,11 +54,6 @@ class PlotWindow(QMainWindow):
         except (RequestError, TimeoutError) as e:
             logger.exception(e)
             msg = f"{e}"
-            if "None of the URLs provided" in str(e):
-                msg = (
-                    f"{e} \n Remove storage_server.json from {os.getcwd()},"
-                    f" and restart the application."
-                )
 
             QMessageBox.critical(self, "Request Failed", msg)
 
@@ -97,11 +91,6 @@ class PlotWindow(QMainWindow):
         except (RequestError, TimeoutError) as e:
             logger.exception(e)
             msg = f"{e}"
-            if "None of the URLs provided" in str(e):
-                msg = (
-                    f"{e} \n Remove storage_server.json from {os.getcwd()},"
-                    f" and restart the application."
-                )
 
             QMessageBox.critical(self, "Request Failed", msg)
             cases = []
@@ -140,11 +129,6 @@ class PlotWindow(QMainWindow):
                     except (RequestError, TimeoutError) as e:
                         logger.exception(e)
                         msg = f"{e}"
-                        if "None of the URLs provided" in str(e):
-                            msg = (
-                                f"{e} \n Remove storage_server.json from {os.getcwd()},"
-                                f" and restart the application."
-                            )
 
                         QMessageBox.critical(self, "Request Failed", msg)
 
@@ -155,11 +139,6 @@ class PlotWindow(QMainWindow):
                     except (RequestError, TimeoutError) as e:
                         logger.exception(e)
                         msg = f"{e}"
-                        if "None of the URLs provided" in str(e):
-                            msg = (
-                                f"{e} \n Remove storage_server.json from {os.getcwd()},"
-                                f" and restart the application."
-                            )
 
                         QMessageBox.critical(self, "Request Failed", msg)
 
@@ -181,11 +160,6 @@ class PlotWindow(QMainWindow):
                     except (RequestError, TimeoutError) as e:
                         logger.exception(e)
                         msg = f"{e}"
-                        if "None of the URLs provided" in str(e):
-                            msg = (
-                                f"{e} \n Remove storage_server.json from {os.getcwd()},"
-                                f" and restart the application."
-                            )
 
                         QMessageBox.critical(self, "Request Failed", msg)
                         plot_context.history_data = None

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -5,7 +5,6 @@ import logging.config
 import os
 import socket
 import sys
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
@@ -24,11 +23,9 @@ class Server(uvicorn.Server):
         self,
         config: uvicorn.Config,
         connection_info: Union[str, Dict[str, Any]],
-        info_file: Path,
     ):
         super().__init__(config)
         self.connection_info = connection_info
-        self.info_file = info_file
 
     async def startup(self, sockets: list = None) -> None:
         """Overridden startup that also sends connection information"""
@@ -113,10 +110,6 @@ def run_server(args: Optional[argparse.Namespace] = None, debug: bool = False) -
         authtoken = generate_authtoken()
         os.environ["ERT_STORAGE_TOKEN"] = authtoken
 
-    lockfile = Path.cwd() / "storage_server.json"
-    if lockfile.exists():
-        sys.exit("'storage_server.json' already exists")
-
     config_args: Dict[str, Any] = {}
     if args.debug or debug:
         config_args.update(reload=True, reload_dirs=[os.path.dirname(ert_shared_path)])
@@ -142,7 +135,7 @@ def run_server(args: Optional[argparse.Namespace] = None, debug: bool = False) -
             os.path.abspath(args.config) or find_ert_config()
         )
         config = uvicorn.Config("ert.dark_storage.app:app", **config_args)
-    server = Server(config, json.dumps(connection_info), lockfile)
+    server = Server(config, json.dumps(connection_info))
 
     logger = logging.getLogger("ert.shared.storage.info")
     log_level = logging.INFO if args.verbose else logging.WARNING

--- a/src/ert/shared/main.py
+++ b/src/ert/shared/main.py
@@ -59,15 +59,18 @@ def run_webviz_ert(args):
     kwargs = {"verbose": args.verbose}
     if args.config:
         res_config = ResConfig(args.config)
-        config_path = res_config.config_path
+        os.chdir(res_config.config_path)
         ens_path = res_config.model_config.getEnspath()
-        kwargs["res_config"] = args.config
-        kwargs["project"] = f"{config_path}/{ens_path}"
+
+        # Changing current working directory means we need to
+        # only use the base name of the config file path
+        kwargs["res_config"] = os.path.basename(args.config)
+        kwargs["project"] = os.path.abspath(ens_path)
 
     if args.database_url is not None:
         kwargs["database_url"] = args.database_url
 
-    with Storage.connect_or_start_server(**kwargs) as storage:
+    with Storage.init_service(**kwargs) as storage:
         storage.wait_until_ready()
         print(
             """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,9 +122,16 @@ def use_tmpdir(tmp_path):
 
 @pytest.fixture()
 def mock_start_server(monkeypatch):
-    connect_or_start_server = MagicMock()
-    monkeypatch.setattr(Storage, "connect_or_start_server", connect_or_start_server)
-    yield connect_or_start_server
+    start_server = MagicMock()
+    monkeypatch.setattr(Storage, "start_server", start_server)
+    yield start_server
+
+
+@pytest.fixture()
+def mock_connect(monkeypatch):
+    connect = MagicMock()
+    monkeypatch.setattr(Storage, "connect", connect)
+    yield connect
 
 
 def pytest_addoption(parser):

--- a/tests/ert_tests/services/test_base_service.py
+++ b/tests/ert_tests/services/test_base_service.py
@@ -177,14 +177,6 @@ def test_json_deleted(server):
     assert not os.path.exists("dummy_server.json")
 
 
-def test_json_exists(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-
-    (tmp_path / "dummy_server.json").write_text("this is a json file")
-    with pytest.raises(SystemExit):
-        _DummyService(exec_args=["/usr/bin/true"])
-
-
 @pytest.mark.script(
     """\
 os.write(fd, b'{"authtoken": "test123", "urls": ["url"]}')


### PR DESCRIPTION
**Issue**
Resolves #3865 


**Approach**
* Do not exit ERT if `Storage` config file exits on disk.
* Try to use connection info to connect to the running instance of ERT Storage server.
*  If no instance of Ert storage is running with the connection information from the storage config file then just start a new instance of the Storage server
*  Overwrite the existing config file 


## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
