### PR TITLE
Add string representation of ResConfig

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -685,3 +685,21 @@ class ResConfig(BaseCClass):
 
     def __ne__(self, other):
         return not self == other
+
+    def __repr__(self):
+        return f"<ResConfig(\n{str(self)}\n)>"
+
+    def __str__(self):
+        return (
+            f"SubstConfig: {self.subst_config},\n"
+            f"SiteConfig: {self.site_config},\n"
+            f"RandomSeed: {self.random_seed},\n"
+            f"AnalysisConfig: {self.analysis_config},\n"
+            f"ErtWorkflowList: {self.ert_workflow_list},\n"
+            f"HookManager: {self.hook_manager},\n"
+            f"ErtTemplates: {self.ert_templates},\n"
+            f"EclConfig: {self.ecl_config},\n"
+            f"EnsembleConfig: {self.ensemble_config},\n"
+            f"ModelConfig: {self.model_config},\n"
+            f"QueueConfig: {self.queue_config}"
+        )


### PR DESCRIPTION
**Issue**
Resolves getting a nice diff when testing the resconfig with asserts and whatnot while working on the config milestone.


**Approach**
We make a string representing the data.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
