### PR TITLE
Remove reading of site_config directly from file

### DIFF
--- a/src/clib/lib/enkf/site_config.cpp
+++ b/src/clib/lib/enkf/site_config.cpp
@@ -167,23 +167,6 @@ static site_config_type *site_config_alloc_default() {
     return site_config;
 }
 
-site_config_type *
-site_config_alloc_load_user_config(const char *user_config_file) {
-    config_parser_type *config_parser = config_alloc();
-    config_content_type *config_content = NULL;
-
-    if (user_config_file)
-        config_content =
-            model_config_alloc_content(user_config_file, config_parser);
-
-    site_config_type *site_config = site_config_alloc(config_content);
-
-    config_free(config_parser);
-    config_content_free(config_content);
-
-    return site_config;
-}
-
 site_config_type *site_config_alloc(const config_content_type *config_content) {
     site_config_type *site_config = site_config_alloc_default();
 

--- a/src/clib/lib/include/ert/enkf/site_config.hpp
+++ b/src/clib/lib/include/ert/enkf/site_config.hpp
@@ -51,7 +51,6 @@ int site_config_install_job(site_config_type *site_config, const char *job_name,
                             const char *install_file);
 void site_config_set_umask(site_config_type *site_config, mode_t umask);
 extern "C" mode_t site_config_get_umask(const site_config_type *site_config);
-extern "C" site_config_type *site_config_alloc_load_user_config(const char *);
 extern "C" site_config_type *
 site_config_alloc(const config_content_type *config_content);
 extern "C" site_config_type *

--- a/src/clib/tests/enkf/test_deprecated_umask.cpp
+++ b/src/clib/tests/enkf/test_deprecated_umask.cpp
@@ -33,13 +33,6 @@ SCENARIO("Using UMASK in config") {
                     "UMASK is deprecated and will be removed in the future."));
             }
         }
-        WHEN("Loading the config") {
-            set_site_config("config.ert");
-            THEN("The constructer raises a invalid argument error") {
-                REQUIRE_NOTHROW(
-                    site_config_alloc_load_user_config("config.ert"));
-            }
-        }
     }
     GIVEN("A config file with umask set to 0") {
         WITH_TMPDIR;
@@ -63,14 +56,6 @@ SCENARIO("Using UMASK in config") {
                 REQUIRE(stringlist_contains(
                     warnings,
                     "UMASK is deprecated and will be removed in the future."));
-            }
-        }
-        WHEN("Loading the config") {
-            set_site_config("config.ert");
-            THEN("The constructer raises a invalid argument error") {
-                REQUIRE_THROWS_AS(
-                    site_config_alloc_load_user_config("config.ert"),
-                    std::invalid_argument);
             }
         }
     }

--- a/src/ert/_c_wrappers/enkf/site_config.py
+++ b/src/ert/_c_wrappers/enkf/site_config.py
@@ -29,9 +29,6 @@ class SiteConfig(BaseCClass):
     _alloc_full = ResPrototype(
         "void* site_config_alloc_full(ext_joblist, env_varlist, int)", bind=False
     )
-    _alloc_load_user_config = ResPrototype(
-        "void* site_config_alloc_load_user_config(char*)", bind=False
-    )
     _free = ResPrototype("void site_config_free( site_config )")
     _get_installed_jobs = ResPrototype(
         "ext_joblist_ref site_config_get_installed_jobs(site_config)"
@@ -49,11 +46,9 @@ class SiteConfig(BaseCClass):
         "env_varlist_ref site_config_get_env_varlist(site_config)"
     )
 
-    def __init__(self, user_config_file=None, config_content=None, config_dict=None):
+    def __init__(self, config_content=None, config_dict=None):
 
-        configs = sum(
-            1 for x in [user_config_file, config_content, config_dict] if x is not None
-        )
+        configs = sum(1 for x in [config_content, config_dict] if x is not None)
 
         if configs > 1:
             raise ValueError(
@@ -66,12 +61,7 @@ class SiteConfig(BaseCClass):
             )
 
         c_ptr = None
-        if user_config_file is not None:
-            if not os.path.isfile(user_config_file):
-                raise IOError(f'No such configuration file "{user_config_file}".')
-            c_ptr = self._alloc_load_user_config(user_config_file)
-
-        elif config_content is not None:
+        if config_content is not None:
             c_ptr = self._alloc(config_content)
 
         elif config_dict is not None:

--- a/tests/libres_tests/res/enkf/test_site_config.py
+++ b/tests/libres_tests/res/enkf/test_site_config.py
@@ -32,12 +32,6 @@ def test_umask_is_written_to_json(setup_case):
     assert json.load(Path("simulations/run0/jobs.json").open())["umask"] == "0022"
 
 
-@pytest.mark.usefixtures("use_tmpdir")
-def test_invalid_user_config():
-    with pytest.raises(IOError):
-        SiteConfig("this/is/not/a/file")
-
-
 def test_constructors(snake_oil_case):
     ert_site_config = SiteConfig.getLocation()
     ert_share_path = os.path.dirname(ert_site_config)
@@ -79,7 +73,7 @@ def test_constructors(snake_oil_case):
 
 def test_2_inits_raises():
     with pytest.raises(ValueError):
-        SiteConfig(user_config_file="a_config", config_dict={"some": "config"})
+        SiteConfig(config_content="a_config", config_dict={"some": "config"})
 
 
 def test_site_config_hook_workflow(monkeypatch, tmp_path):


### PR DESCRIPTION
**Issue**
In order to solve #3847 , we need to simplify how config keys are set. JobQueue, SiteConfig, and AnalysisConfig can be instantiated directly from file, something which is only done in tests. This calls an alternate way of getting the config keys: `model_config_alloc_content` which makes it difficult do figure out which keys are used at any given point.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
