### PR TITLE
Remove unused analysis_config directly from file

### DIFF
--- a/src/clib/lib/enkf/analysis_config.cpp
+++ b/src/clib/lib/enkf/analysis_config.cpp
@@ -521,22 +521,6 @@ analysis_config_type *analysis_config_alloc_default(void) {
     return config;
 }
 
-analysis_config_type *analysis_config_alloc_load(const char *user_config_file) {
-    config_parser_type *config_parser = config_alloc();
-    config_content_type *config_content = NULL;
-    if (user_config_file)
-        config_content =
-            model_config_alloc_content(user_config_file, config_parser);
-
-    analysis_config_type *analysis_config =
-        analysis_config_alloc(config_content);
-
-    config_content_free(config_content);
-    config_free(config_parser);
-
-    return analysis_config;
-}
-
 analysis_config_type *
 analysis_config_alloc(const config_content_type *config_content) {
     analysis_config_type *analysis_config = analysis_config_alloc_default();

--- a/src/clib/lib/include/ert/enkf/analysis_config.hpp
+++ b/src/clib/lib/include/ert/enkf/analysis_config.hpp
@@ -43,9 +43,6 @@ analysis_config_get_module(const analysis_config_type *config,
                            const char *module_name);
 extern "C" bool analysis_config_has_module(const analysis_config_type *config,
                                            const char *module_name);
-void analysis_config_load_module(int ens_size, analysis_config_type *config,
-                                 analysis_mode_enum mode);
-
 std::vector<std::string>
 analysis_config_module_names(const analysis_config_type *config);
 
@@ -58,8 +55,6 @@ extern "C" PY_USED analysis_config_type *analysis_config_alloc_full(
     double std_cutoff, bool stop_long_running, bool single_node_update,
     double global_std_scaling, int max_runtime, int min_realisations);
 analysis_config_type *analysis_config_alloc_default(void);
-extern "C" analysis_config_type *
-analysis_config_alloc_load(const char *user_config_file);
 extern "C" analysis_config_type *
 analysis_config_alloc(const config_content_type *config_content);
 extern "C" void analysis_config_free(analysis_config_type *);

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -14,7 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from os.path import isfile, realpath
+from os.path import realpath
 from typing import List, Optional
 
 from cwrap import BaseCClass
@@ -31,7 +31,6 @@ class AnalysisConfig(BaseCClass):
     TYPE_NAME = "analysis_config"
 
     _alloc = ResPrototype("void* analysis_config_alloc(config_content)", bind=False)
-    _alloc_load = ResPrototype("void* analysis_config_alloc_load(char*)", bind=False)
     _alloc_full = ResPrototype(
         "void* analysis_config_alloc_full(double, bool, "
         "int, char*, double, bool, bool, "
@@ -103,13 +102,10 @@ class AnalysisConfig(BaseCClass):
 
     def __init__(
         self,
-        user_config_file=None,
         config_content: Optional[ConfigContent] = None,
         config_dict=None,
     ):
-        configs = sum(
-            1 for x in [user_config_file, config_content, config_dict] if x is not None
-        )
+        configs = sum(1 for x in [config_content, config_dict] if x is not None)
 
         if configs > 1:
             raise ValueError(
@@ -123,20 +119,6 @@ class AnalysisConfig(BaseCClass):
             )
 
         c_ptr = None
-
-        if user_config_file is not None:
-            if not isfile(user_config_file):
-                raise IOError(f'No such configuration file "{user_config_file}".')
-
-            c_ptr = self._alloc_load(user_config_file)
-            if c_ptr:
-                super().__init__(c_ptr)
-            else:
-                raise ValueError(
-                    "Failed to construct AnalysisConfig instance "
-                    f"from config file {user_config_file}."
-                )
-
         if config_content is not None:
             c_ptr = self._alloc(config_content)
             if c_ptr:

--- a/tests/libres_tests/res/enkf/test_analysis_config.py
+++ b/tests/libres_tests/res/enkf/test_analysis_config.py
@@ -19,12 +19,6 @@ import pytest
 from ert._c_wrappers.enkf import AnalysisConfig, ConfigKeys
 
 
-@pytest.mark.usefixtures("use_tmpdir")
-def test_invalid_user_config():
-    with pytest.raises(IOError):
-        AnalysisConfig("this/is/not/a/file")
-
-
 @pytest.fixture
 def analysis_config(minimum_case):
     return minimum_case.resConfig().analysis_config
@@ -56,8 +50,8 @@ def test_analysis_config_global_std_scaling(analysis_config):
 
 
 def test_analysis_config_constructor(setup_case):
-    _ = setup_case("local/simple_config", "analysis_config")
-    assert AnalysisConfig(user_config_file="analysis_config") == AnalysisConfig(
+    res_config = setup_case("local/simple_config", "analysis_config")
+    assert res_config.analysis_config == AnalysisConfig(
         config_dict={
             ConfigKeys.NUM_REALIZATIONS: 10,
             ConfigKeys.ALPHA_KEY: 3,


### PR DESCRIPTION
Issue
In order to solve https://github.com/equinor/ert/issues/3847 , we need to simplify how config keys are set. AnalysisConfig can be instantiated directly from file, something which is only done in tests. This calls an alternate way of getting the config keys: model_config_alloc_content which makes it difficult do figure out which keys are used at any given point.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).