### PR TITLE
Remove unused model config functions

### DIFF
--- a/src/clib/lib/enkf/ensemble_config.cpp
+++ b/src/clib/lib/enkf/ensemble_config.cpp
@@ -177,24 +177,6 @@ ensemble_config_alloc_full(const char *gen_kw_format_string) {
     return ensemble_config;
 }
 
-ensemble_config_type *ensemble_config_alloc_load(const char *user_config_file,
-                                                 ecl_grid_type *grid,
-                                                 const ecl_sum_type *refcase) {
-    config_parser_type *config_parser = config_alloc();
-    config_content_type *config_content = NULL;
-    if (user_config_file)
-        config_content =
-            model_config_alloc_content(user_config_file, config_parser);
-
-    ensemble_config_type *ensemble_config =
-        ensemble_config_alloc(config_content, grid, refcase);
-
-    config_content_free(config_content);
-    config_free(config_parser);
-
-    return ensemble_config;
-}
-
 // forward declaration -> implementation further down
 static void ensemble_config_init(ensemble_config_type *ensemble_config,
                                  const config_content_type *config,

--- a/src/clib/lib/include/ert/enkf/ensemble_config.hpp
+++ b/src/clib/lib/include/ert/enkf/ensemble_config.hpp
@@ -99,8 +99,6 @@ ensemble_config_keylist_from_var_type(const ensemble_config_type *,
 extern "C" stringlist_type *
 ensemble_config_alloc_keylist_from_impl_type(const ensemble_config_type *,
                                              ert_impl_type);
-ensemble_config_type *ensemble_config_alloc_load(const char *, ecl_grid_type *,
-                                                 const ecl_sum_type *);
 extern "C" ensemble_config_type *
 ensemble_config_alloc(const config_content_type *, ecl_grid_type *,
                       const ecl_sum_type *);

--- a/src/clib/lib/include/ert/enkf/model_config.hpp
+++ b/src/clib/lib/include/ert/enkf/model_config.hpp
@@ -46,10 +46,6 @@ extern "C" const char *
 model_config_get_data_root(const model_config_type *model_config);
 void model_config_set_data_root(model_config_type *model_config,
                                 const char *data_root);
-bool model_config_data_root_is_set(const model_config_type *model_config);
-
-char *model_config_alloc_jobname(const model_config_type *model_config,
-                                 int iens);
 extern "C" const char *
 model_config_get_jobname_fmt(const model_config_type *model_config);
 void model_config_set_jobname_fmt(model_config_type *model_config,
@@ -118,8 +114,6 @@ model_config_set_gen_kw_export_name(model_config_type *model_config,
 extern "C" const char *
 model_config_get_gen_kw_export_name(const model_config_type *model_config);
 
-config_content_type *model_config_alloc_content(const char *,
-                                                config_parser_type *);
 void model_config_init_config_parser(config_parser_type *config_parser);
 
 UTIL_IS_INSTANCE_HEADER(model_config);

--- a/src/clib/old_tests/enkf/test_enkf_model_config.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_model_config.cpp
@@ -53,14 +53,6 @@ void test_runpath() {
     model_config_free(model_config);
 }
 
-void test_data_root() {
-    model_config_type *model_config = model_config_alloc_empty();
-    test_assert_false(model_config_data_root_is_set(model_config));
-    model_config_set_data_root(model_config, "root");
-    test_assert_true(model_config_data_root_is_set(model_config));
-    model_config_free(model_config);
-}
-
 void test_export_file() {
     model_config_type *model_config = model_config_alloc_empty();
 
@@ -70,7 +62,6 @@ void test_export_file() {
 int main(int argc, char **argv) {
     test_create();
     test_runpath();
-    test_data_root();
     test_export_file();
     exit(0);
 }


### PR DESCRIPTION
ssue
In order to solve https://github.com/equinor/ert/issues/3847 , we need to simplify how config keys are set. There is an alternate way of getting the config keys: `model_config_alloc_content` which makes it difficult do figure out which keys are used at any given point.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
