### PR TITLE
Fix experiment server iterated ensemble smoother

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_prefect.py
+++ b/src/ert/ensemble_evaluator/builder/_prefect.py
@@ -50,7 +50,7 @@ from ._step import _FunctionStep, _UnixStep
 from ._unix_task import UnixTask
 
 if TYPE_CHECKING:
-    from multiprocessing.context import DefaultContext
+    from multiprocessing.context import ForkServerContext
 
     from ert.shared.ensemble_evaluator.config import EvaluatorServerConfig
 
@@ -227,7 +227,7 @@ class PrefectEnsemble(_Ensemble):  # pylint: disable=too-many-instance-attribute
         return flow
 
     @staticmethod
-    def _get_multiprocessing_context() -> "DefaultContext":
+    def _get_multiprocessing_context() -> "ForkServerContext":
         """See _prefect_forkserver_preload"""
         preload_module_name = (
             "ert.ensemble_evaluator.builder._prefect_forkserver_preload"

--- a/src/ert/ensemble_evaluator/builder/_prefect.py
+++ b/src/ert/ensemble_evaluator/builder/_prefect.py
@@ -10,7 +10,6 @@ import threading
 import time
 import warnings
 from datetime import timedelta
-from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
@@ -51,6 +50,8 @@ from ._step import _FunctionStep, _UnixStep
 from ._unix_task import UnixTask
 
 if TYPE_CHECKING:
+    from multiprocessing.context import DefaultContext
+
     from ert.shared.ensemble_evaluator.config import EvaluatorServerConfig
 
 DEFAULT_MAX_RETRIES = 0
@@ -226,7 +227,7 @@ class PrefectEnsemble(_Ensemble):  # pylint: disable=too-many-instance-attribute
         return flow
 
     @staticmethod
-    def _get_multiprocessing_context() -> BaseContext:
+    def _get_multiprocessing_context() -> "DefaultContext":
         """See _prefect_forkserver_preload"""
         preload_module_name = (
             "ert.ensemble_evaluator.builder._prefect_forkserver_preload"

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -288,7 +288,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
     ) -> str:
         await loop.run_in_executor(
             executor,
-            self.ert().getEnkfSimulationRunner().createRunPath,
+            self.ert().createRunPath,
             run_context,
         )
 
@@ -346,7 +346,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 run_context,
                 self._w_container,
             )
-            self._w_container.iteration_nr += 1
         except ErtAnalysisError as e:
             experiment_logger.exception("analysis failed")
             await self._dispatch_ee(


### PR DESCRIPTION
**Issue**
- Fix `createRunPath` call since `ert.getEnkfSimulationRunner()` was removed.
- Remove increate iter_num since this is done automatically in the `update_step`
- Fix mypy ForkServerContext


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
