### PR TITLE
Silence mypy false positive

### DIFF
--- a/src/ert/ensemble_evaluator/builder/_prefect.py
+++ b/src/ert/ensemble_evaluator/builder/_prefect.py
@@ -243,7 +243,7 @@ class PrefectEnsemble(_Ensemble):  # pylint: disable=too-many-instance-attribute
 
         # everything in self will be pickled since we bind a member function in target
         ctx = self._get_multiprocessing_context()
-        eval_proc = ctx.Process(target=self._evaluate)
+        eval_proc = ctx.Process(target=self._evaluate)  # type: ignore
         eval_proc.daemon = True
         eval_proc.start()
         self._eval_proc = eval_proc


### PR DESCRIPTION
**Issue**
Newest version of mypy has a false positive error in _prefect. this is now fixed.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
