### PR TITLE
Remove RSH_DRIVER from test config dict generation

### DIFF
--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -57,7 +57,6 @@ queue_systems = st.sampled_from(
     [
         QueueDriverEnum.LSF_DRIVER,
         QueueDriverEnum.LOCAL_DRIVER,
-        QueueDriverEnum.RSH_DRIVER,
         QueueDriverEnum.TORQUE_DRIVER,
         QueueDriverEnum.SLURM_DRIVER,
     ]
@@ -82,12 +81,6 @@ def valid_queue_options(queue_system):
             "EXCLUDE_HOST",
             "PROJECT_CODE",
             "SUBMIT_SLEEP",
-        ]
-    elif queue_system == QueueDriverEnum.RSH_DRIVER:
-        valids += [
-            "RSH_HOSTLIST",
-            "RSH_CLEAR_HOSTLIST",
-            "RSH_CMD",
         ]
     elif queue_system == QueueDriverEnum.SLURM_DRIVER:
         valids += [


### PR DESCRIPTION
**Issue**

* Needed to fix multiple tests 
* Partial work from #930 

## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
