### PR TITLE
Emit deprecation warning for non-ISO dates in observation config files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ args = dict(
         "decorator",
         "deprecation",
         "dnspython >= 2",
-        "ecl >= 2.14.0",
+        "ecl >= 2.14.1",
         "ert-storage >= 0.3.16",
         "fastapi",
         "graphlib_backport; python_version < '3.9'",

--- a/src/clib/lib/config/conf_data.cpp
+++ b/src/clib/lib/config/conf_data.cpp
@@ -12,7 +12,7 @@ namespace fs = std::filesystem;
 #define DT_INT_STRING "integer"
 #define DT_POSINT_STRING "positive integer"
 #define DT_FLOAT_STRING "floating point number"
-#define DT_POSFLOAT_STRING "positive floating foint number"
+#define DT_POSFLOAT_STRING "positive floating point number"
 #define DT_FILE_STRING "file"
 #define DT_DATE_STRING "date"
 
@@ -72,7 +72,15 @@ bool conf_data_validate_string_as_dt_value(dt_enum dt, const char *str) {
         time_t date;
         if (util_sscanf_isodate(str, &date))
             return true;
-        return util_sscanf_date_utc(str, &date);
+        if (util_sscanf_date_utc(str, &date)) {
+            fprintf(stderr,
+                    "** Deprecation warning: The date format as in \'%s\' is "
+                    "deprecated, and its support will be removed in a future "
+                    "release. Please use ISO date format YYYY-MM-DD.\n",
+                    str);
+            return true;
+        }
+        return false;
     }
     default:
         util_abort("%s: Error parsing \"%s\".\n", __func__, str);


### PR DESCRIPTION
**Issue**
Resolves #3954 

**Approach**
Emit warning if the parser of non-iso dates is successful. Follow up to #3238 .

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
