### PR TITLE
Give empty representation in case of non initialized objects

### DIFF
--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -250,6 +250,8 @@ class AnalysisConfig(BaseCClass):
         return not self == other
 
     def __repr__(self):
+        if not self._address():
+            return "<AnalysisConfig()>"
         return (
             "AnalysisConfig(config_dict={"
             f"'UPDATE_LOG_PATH': {realpath(self.get_log_path())}, "

--- a/src/ert/_c_wrappers/enkf/ecl_config.py
+++ b/src/ert/_c_wrappers/enkf/ecl_config.py
@@ -194,6 +194,8 @@ class EclConfig(BaseCClass):
         return self._get_num_cpu()
 
     def __repr__(self):
+        if not self._address():
+            return "<EclConfig()>"
         return (
             "EclConfig(config_dict={"
             f"'{ConfigKeys.DATA_FILE}': {self.getDataFile()}, "

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -206,6 +206,8 @@ class EnsembleConfig(BaseCClass):
         return self._size()
 
     def __repr__(self):
+        if not self._address():
+            return "<EnsembleConfig()>"
         return (
             "EnsembleConfig(config_dict={"
             + f"{ConfigKeys.GEN_KW}: ["

--- a/src/ert/_c_wrappers/enkf/hook_manager.py
+++ b/src/ert/_c_wrappers/enkf/hook_manager.py
@@ -75,6 +75,8 @@ class HookManager(BaseCClass):
         return self._size()
 
     def __repr__(self):
+        if not self._address():
+            return "<HookManager()>"
         return f'HookManager({", ".join([str(x) for x in self])})'
 
     def __getitem__(self, index) -> HookWorkflow:

--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -155,6 +155,8 @@ class QueueConfig(BaseCClass):
         return self._get_num_cpu()
 
     def __repr__(self):
+        if not self._address:
+            return "<QueueConfig()>"
         return (
             "QueueConfig(config_dict={"
             f"'{ConfigKeys.JOB_SCRIPT}': {self.job_script}, "

--- a/src/ert/_c_wrappers/enkf/site_config.py
+++ b/src/ert/_c_wrappers/enkf/site_config.py
@@ -130,6 +130,8 @@ class SiteConfig(BaseCClass):
         super().__init__(c_ptr)
 
     def __repr__(self):
+        if not self._address():
+            return "<SiteConfig()>"
         return (
             "SiteConfig(config_dict={"
             + f"{ConfigKeys.INSTALL_JOB}: ["

--- a/src/ert/_c_wrappers/enkf/subst_config.py
+++ b/src/ert/_c_wrappers/enkf/subst_config.py
@@ -160,6 +160,8 @@ class SubstConfig(BaseCClass):
         return f"SubstConfig({str(self)})"
 
     def __str__(self):
+        if not self._address():
+            return ""
         return (
             "["
             + ",\n".join(


### PR DESCRIPTION
Our test framework attempts to print objects involved in the test in case of failure. Many of our config objects have an underlying C object. If said object did not get initialized properly, as is often the case for failing tests, rather then getting an exception with a possibly meaningful error message, the test framework segfaults when trying to print the object without initialized C side.

We attempt to fix this for our config objects by checking whether we have an address for the C object, and if not, return a highly simplified representation of the object in question.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
