### PR TITLE
Fix has_data check in initRun

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -382,10 +382,11 @@ class EnKFMain:
                     enkf_node = EnkfNode(node)
                     if node.getUseForwardInit():
                         continue
-                    if not enkf_node.has_data(
-                        run_context.sim_fs,
-                        NodeId(0, realization_nr)
-                        or current_status == STATE_LOAD_FAILURE,
+                    if (
+                        not enkf_node.has_data(
+                            run_context.sim_fs, NodeId(0, realization_nr)
+                        )
+                        or current_status == STATE_LOAD_FAILURE
                     ):
                         enkf_state.state_initialize(
                             rng,


### PR DESCRIPTION
This looks like a typo that might lead to some strange behaviour.
Should probably add a test that catches this.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
