### PR TITLE
Relax protobuf pin to "<4"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ args = dict(
         "pandas",
         "pluggy",
         "prefect<2",
-        "protobuf==3.19.1",
+        "protobuf<4",
         "psutil",
         "pydantic >= 1.9",
         "PyQt5",


### PR DESCRIPTION
**Issue**
The current pinning of protobuf to 3.19.1 is too tight, it breaks Everest.


**Approach**
Relax pin to "<4"

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
