### PR TITLE
Make all run models run async from gui

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -103,7 +103,7 @@ def run_cli(args):
 
     thread = threading.Thread(
         name="ert_cli_simulation_thread",
-        target=model.start_simulations_thread,
+        target=model.startSimulations,
         args=(evaluator_server_config,),
     )
     thread.start()

--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -1,8 +1,8 @@
 import logging
 from typing import List
 
-from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert._c_wrappers.config.active_range import ActiveRange
+from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert.shared.models.ensemble_experiment import EnsembleExperiment
 from ert.shared.models.ensemble_smoother import EnsembleSmoother
 from ert.shared.models.iterated_ensemble_smoother import IteratedEnsembleSmoother

--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List
 
+from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert._c_wrappers.config.active_range import ActiveRange
 from ert.shared.models.ensemble_experiment import EnsembleExperiment
 from ert.shared.models.ensemble_smoother import EnsembleSmoother
@@ -43,7 +44,7 @@ def create_model(ert, ensemble_size, current_case_name, args, id_):
     return model
 
 
-def _setup_single_test_run(ert, id_):
+def _setup_single_test_run(ert: EnKFMain, id_: str) -> SingleTestRun:
     simulations_argument = {"active_realizations": [True]}
     model = SingleTestRun(simulations_argument, ert, id_)
     return model

--- a/src/ert/ensemble_evaluator/_builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_builder/_ensemble.py
@@ -114,7 +114,7 @@ class Ensemble:
         pass
 
     async def evaluate_async(
-        self, config: "EvaluatorServerConfig", experiment_id: str
+        self, config: "EvaluatorServerConfig", experiment_id: Union[None, str]
     ) -> None:
         pass
 

--- a/src/ert/ensemble_evaluator/_builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_builder/_ensemble.py
@@ -114,7 +114,7 @@ class Ensemble:
         pass
 
     async def evaluate_async(
-        self, config: "EvaluatorServerConfig", experiment_id: Union[None, str]
+        self, config: "EvaluatorServerConfig", experiment_id: Optional[str]
     ) -> None:
         pass
 

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -301,7 +301,9 @@ class LegacyEnsemble(Ensemble):
         return True
 
     async def cancel(self) -> None:
-        asyncio.get_running_loop().run_until_complete(self._job_queue.kill_all_jobs())
+        await asyncio.get_running_loop().run_until_complete(
+            self._job_queue.kill_all_jobs()
+        )
         logger.debug("evaluator cancelled")
 
     @property

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -146,7 +146,7 @@ class LegacyEnsemble(Ensemble):
     async def evaluate_async(
         self,
         config: "EvaluatorServerConfig",
-        experiment_id: Union[None, str],
+        experiment_id: Optional[str],
     ) -> None:
         self._config = config
         if FeatureToggling.is_enabled("experiment-server"):

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -340,7 +340,7 @@ class EnsembleEvaluator:
     async def stop(self):
         if not self._done.done():
             self._done.set_result(None)
-        await self._shutdown_completed
+            await self._shutdown_completed
 
     async def _signal_cancel(self):
         """

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -59,6 +59,7 @@ class EnsembleEvaluator:
 
         self._loop = asyncio.get_running_loop()
         self._done = self._loop.create_future()
+        self._shutdown_completed = self._loop.create_future()
 
         self._clients: Set[WebSocketServerProtocol] = set()
         self._dispatchers_connected: asyncio.Queue = None
@@ -334,10 +335,12 @@ class EnsembleEvaluator:
                 )
 
         logger.debug("Async server exiting.")
+        self._shutdown_completed.set_result(None)
 
     async def stop(self):
         if not self._done.done():
             self._done.set_result(None)
+        await self._shutdown_completed
 
     async def _signal_cancel(self):
         """

--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -138,7 +138,9 @@ class ExperimentServer:
         logger.debug("running experiment %s", experiment_id)
         experiment = self._registry.get_experiment(experiment_id)
 
-        experiment_task = asyncio.create_task(experiment.run(self._config))
+        experiment_task = asyncio.create_task(
+            experiment.run(self._config, model_name="ies")
+        )
 
         done, pending = await asyncio.wait(
             [self._server_task, experiment_task], return_when=asyncio.FIRST_COMPLETED

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -92,7 +92,7 @@ def feature_enabled_async(feature_name):
             if FeatureToggling.is_enabled(feature_name):
                 return await func(*args, **kwargs)
             else:
-                return await asyncio.sleep(0.1)
+                return await asyncio.sleep(0)
 
         return wrapper
 

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from copy import deepcopy
 
@@ -79,6 +80,19 @@ def feature_enabled(feature_name):
                 return func(*args, **kwargs)
             else:
                 return None
+
+        return wrapper
+
+    return decorator
+
+
+def feature_enabled_async(feature_name):
+    def decorator(func):
+        async def wrapper(*args, **kwargs):
+            if FeatureToggling.is_enabled(feature_name):
+                return await func(*args, **kwargs)
+            else:
+                return await asyncio.sleep(0.1)
 
         return wrapper
 

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -451,11 +451,8 @@ class BaseRunModel:
             )
 
         if FeatureToggling.is_enabled("experiment-server"):
-            return await self.successful_realizations(
-                run_context.iteration
-                )
+            return await self.successful_realizations(run_context.iteration)
         return ensemble.get_successful_realizations()
-        
 
     @abstractmethod
     async def run(

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -456,7 +456,7 @@ class BaseRunModel:
 
     @abstractmethod
     async def run(
-        self, evaluator_server_config: EvaluatorServerConfig, model_name: str
+        self, evaluator_server_config: EvaluatorServerConfig, model_name: str = "None"
     ) -> RunContext:
         raise NotImplementedError
 

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -27,7 +27,11 @@ from ert.ensemble_evaluator import (
     forward_model_ok,
 )
 from ert.libres_facade import LibresFacade
-from ert.shared.feature_toggling import feature_enabled
+from ert.shared.feature_toggling import (
+    FeatureToggling,
+    feature_enabled,
+    feature_enabled_async,
+)
 from ert.shared.storage.extraction import (
     post_ensemble_data,
     post_ensemble_results,
@@ -168,14 +172,6 @@ class BaseRunModel:
         completed = self._completed_realizations_mask
         return completed.count(True)
 
-    def start_simulations_thread(
-        self, evaluator_server_config: EvaluatorServerConfig
-    ) -> None:
-        asyncio.set_event_loop(asyncio.new_event_loop())
-        self.startSimulations(
-            evaluator_server_config=evaluator_server_config,
-        )
-
     def startSimulations(self, evaluator_server_config: EvaluatorServerConfig) -> None:
         logs: _LogAggregration = _LogAggregration()
         try:
@@ -186,7 +182,7 @@ class BaseRunModel:
                 run_context = self.runSimulations(
                     evaluator_server_config=evaluator_server_config,
                 )
-                self._completed_realizations_mask = run_context.mask
+                self._completed_realizations_mask = run_context.mask  # type: ignore # should we implement an if statement with toggling?
         except ErtRunError as e:
             self._completed_realizations_mask = []
             self._failed = True
@@ -203,7 +199,7 @@ class BaseRunModel:
 
     def runSimulations(
         self, evaluator_server_config: EvaluatorServerConfig
-    ) -> RunContext:
+    ) -> Union[RunContext, None]:
         raise NotImplementedError("Method must be implemented by inheritors!")
 
     def teardown_context(self) -> None:
@@ -304,22 +300,6 @@ class BaseRunModel:
                 + "MIN_REALIZATIONS in the config file"
             )
 
-    def run_ensemble_evaluator(
-        self, run_context: RunContext, ee_config: EvaluatorServerConfig
-    ) -> int:
-        ensemble = self._build_ensemble(run_context)
-
-        totalOk = EnsembleEvaluator(
-            ensemble,
-            ee_config,
-            run_context.iteration,
-        ).run_and_get_successful_realizations()
-
-        self.deactivate_failed_jobs(run_context)
-
-        run_context.sim_fs.fsync()
-        return totalOk
-
     @staticmethod
     def deactivate_failed_jobs(run_context: RunContext) -> None:
         for iens, run_arg in enumerate(run_context):
@@ -380,7 +360,7 @@ class BaseRunModel:
 
     async def _evaluate(
         self, run_context: RunContext, ee_config: EvaluatorServerConfig
-    ) -> None:
+    ) -> Union[None, int]:
         """Start asynchronous evaluation of an ensemble."""
         experiment_logger.debug("_evaluate")
         loop = asyncio.get_running_loop()
@@ -388,10 +368,21 @@ class BaseRunModel:
         ensemble = self._build_ensemble(run_context)
         self._iter_map[run_context.iteration] = ensemble.id_
         experiment_logger.debug("built")
-
-        ensemble_listener = asyncio.create_task(
-            self._ensemble_listener(ensemble, iter_=run_context.iteration)
-        )
+        if FeatureToggling.is_enabled("experiment-server"):
+            # If experiment-server is enabled, the server has been created already.
+            # We are only setting up a task that consumes events coming from the ensemble
+            server = None
+            ensemble_listener_task = asyncio.create_task(
+                self._ensemble_listener(ensemble, iter_=run_context.iteration)
+            )
+        else:
+            # Set up the EnsembleEvaluator server
+            server = EnsembleEvaluator(
+                ensemble,
+                ee_config,
+                run_context.iteration,
+            )
+            ensemble_listener_task = asyncio.create_task(server.evaluator_server())
 
         with concurrent.futures.ThreadPoolExecutor() as pool:
             await loop.run_in_executor(
@@ -401,24 +392,71 @@ class BaseRunModel:
                 [i for i, _ in enumerate(run_context) if run_context.is_active(i)],
             )
 
-            await ensemble.evaluate_async(ee_config, self.id_)
+        if FeatureToggling.is_enabled("experiment-server"):
+            await ensemble.evaluate_async(ee_config, experiment_id=self._id)
+        else:
+            evaluation_task = asyncio.create_task(
+                ensemble.evaluate_async(ee_config, experiment_id=None)
+            )
+            done, pending = await asyncio.wait(
+                [ensemble_listener_task, evaluation_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
-            await ensemble_listener
+            if evaluation_task in done:
+                experiment_logger.debug("Experiment evaluation completed")
+                # raise experiment exception if any
+                try:
+                    evaluation_task.result()
+                except Exception:  # pylint: disable=broad-except
+                    experiment_logger.exception(
+                        "Experiment failed:",
+                        exc_info=True,
+                    )
+                finally:
+                    experiment_logger.debug("Initializing shutdown of EnsembleServer")
+                    try:
+                        # If a client connects to the server, it can signal through
+                        # events that server should stop (e.g. when all information
+                        # has passed through). We allow possible clients connected
+                        #  to signal that they are finished before we stop the server
+                        await asyncio.wait_for(ensemble_listener_task, 10)
+                        experiment_logger.debug("Server stopped from client")
+                    except asyncio.TimeoutError:
+                        experiment_logger.debug("Stopping the server from experiment..")
+                        await server.stop()  # type: ignore # server is None only if FeatureToggling.is_enabled("experiment-server")
+            else:
+                # experiment is pending, but the server died, so try cancelling the experiment
+                # then raise the server's exception
+                for pending_task in pending:
+                    experiment_logger.debug(
+                        "task %s was pending, cancelling...", pending_task
+                    )
+                    pending_task.cancel()
+                for done_task in done:
+                    done_task.result()
 
-            for iens, run_arg in enumerate(run_context):
-                if run_context.is_active(iens) and run_arg.run_status in (
-                    RunStatusType.JOB_LOAD_FAILURE,
-                    RunStatusType.JOB_RUN_FAILURE,
-                ):
-                    run_context.deactivate_realization(iens)
+        for iens, run_arg in enumerate(run_context):
+            if run_context.is_active(iens) and run_arg.run_status in (
+                RunStatusType.JOB_LOAD_FAILURE,
+                RunStatusType.JOB_RUN_FAILURE,
+            ):
+                run_context.deactivate_realization(iens)
 
+        with concurrent.futures.ThreadPoolExecutor() as pool:
             await loop.run_in_executor(
                 pool,
                 run_context.sim_fs.fsync,
             )
 
+        if not FeatureToggling.is_enabled("experiment-server"):
+            return ensemble.get_successful_realizations()
+        return None
+
     @abstractmethod
-    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+    async def run(
+        self, evaluator_server_config: EvaluatorServerConfig, model_name: str
+    ) -> Union[None, RunContext]:
         raise NotImplementedError
 
     async def successful_realizations(self, iter_: int) -> int:
@@ -475,6 +513,7 @@ class BaseRunModel:
                 break
 
     @singledispatchmethod
+    @feature_enabled_async("experiment-server")
     async def dispatch(
         self,
         event: Union[CloudEvent, _ert_com_protocol.DispatcherMessage],

--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -103,7 +103,7 @@ class EnsembleExperiment(BaseRunModel):
 
         if not FeatureToggling.is_enabled("experiment-server"):
             self.setPhase(1, "Simulations completed.")  # done...
-        
+
         return run_context
 
     def runSimulations(

--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -82,7 +82,7 @@ class EnsembleExperiment(BaseRunModel):
                 )
                 event.experiment.message = str(e)
                 await self.dispatch(event)
-                return run_context
+                raise
 
             self.setPhaseName("Post processing...", indeterminate=True)
             await self._run_hook(

--- a/src/ert/shared/models/ensemble_smoother.py
+++ b/src/ert/shared/models/ensemble_smoother.py
@@ -89,7 +89,7 @@ class EnsembleSmoother(BaseRunModel):
             )
             event.experiment.message = str(e)
             await self.dispatch(event)
-            return prior_context
+            raise
 
         self.setPhaseName("Post processing...", indeterminate=True)
 
@@ -188,7 +188,7 @@ class EnsembleSmoother(BaseRunModel):
             )
             event.experiment.message = str(e)
             await self.dispatch(event)
-            return prior_context
+            raise
 
         self.setPhaseName("Post processing...", indeterminate=True)
         await self._run_hook(

--- a/src/ert/shared/models/ensemble_smoother.py
+++ b/src/ert/shared/models/ensemble_smoother.py
@@ -206,7 +206,7 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhase(2, "Simulations completed.")
 
         return prior_context
-        
+
     def runSimulations(
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:

--- a/src/ert/shared/models/ensemble_smoother.py
+++ b/src/ert/shared/models/ensemble_smoother.py
@@ -2,7 +2,7 @@ import asyncio
 import concurrent
 import logging
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import _ert_com_protocol
 from ert._c_wrappers.enkf import RunContext
@@ -10,6 +10,7 @@ from ert._c_wrappers.enkf.enkf_main import EnKFMain, QueueConfig
 from ert._c_wrappers.enkf.enums import HookRuntime, RealizationStateEnum
 from ert.analysis import ErtAnalysisError
 from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.shared.feature_toggling import FeatureToggling
 from ert.shared.models import BaseRunModel, ErtRunError
 
 experiment_logger = logging.getLogger("ert.experiment_server.ensemble_experiment")
@@ -32,7 +33,11 @@ class EnsembleSmoother(BaseRunModel):
         if not module_load_success:
             raise ErtRunError(f"Unable to load analysis module '{module_name}'!")
 
-    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+    async def run(
+        self,
+        evaluator_server_config: EvaluatorServerConfig,
+        model_name: str = "ensemble smoother",
+    ) -> Union[RunContext, None]:
         loop = asyncio.get_running_loop()
         threadpool = concurrent.futures.ThreadPoolExecutor()
 
@@ -43,8 +48,11 @@ class EnsembleSmoother(BaseRunModel):
             status="EXPERIMENT_STARTED", experiment_id=self.id_
         )
         await self.dispatch(event)
-
         self._checkMinimumActiveRealizations(len(prior_context.active_realizations))
+
+        self.setPhase(0, "Running simulations...", indeterminate=False)
+        self.setPhaseName("Pre processing...", indeterminate=True)
+
         self.ert().sample_prior(prior_context.sim_fs, prior_context.active_realizations)
         await loop.run_in_executor(
             threadpool,
@@ -61,21 +69,26 @@ class EnsembleSmoother(BaseRunModel):
         ensemble_id = await loop.run_in_executor(threadpool, self._post_ensemble_data)
 
         experiment_logger.debug("evaluating")
-        await self._evaluate(prior_context, evaluator_server_config)
+        num_successful_realizations = await self._evaluate(
+            prior_context, evaluator_server_config
+        )
 
         # Push simulation results to storage
         await loop.run_in_executor(threadpool, self._post_ensemble_results, ensemble_id)
 
-        num_successful_realizations = await self.successful_realizations(
-            prior_context.iteration
-        )
+        if FeatureToggling.is_enabled("experiment-server"):
+            num_successful_realizations = await self.successful_realizations(
+                prior_context.iteration
+            )
 
-        self.checkHaveSufficientRealizations(num_successful_realizations)
+        self.checkHaveSufficientRealizations(num_successful_realizations)  # type: ignore
+        self.setPhaseName("Post processing...", indeterminate=True)
 
         await self._run_hook(
             HookRuntime.POST_SIMULATION, prior_context.iteration, loop, threadpool
         )
 
+        self.setPhaseName("Analyzing...")
         await self._run_hook(
             HookRuntime.PRE_FIRST_UPDATE, prior_context.iteration, loop, threadpool
         )
@@ -123,7 +136,10 @@ class EnsembleSmoother(BaseRunModel):
             self.ert().analysisConfig().active_module_name(),
         )
 
+        self.setPhase(1, "Running simulations...")
         self.ert().getEnkfFsManager().switchFileSystem(prior_context.target_fs)
+
+        self.setPhaseName("Pre processing...")
 
         experiment_logger.debug("creating context for iter 1")
         rerun_context = await loop.run_in_executor(
@@ -144,17 +160,20 @@ class EnsembleSmoother(BaseRunModel):
         ensemble_id = await loop.run_in_executor(
             threadpool, self._post_ensemble_data, update_id
         )
-
-        # Evaluate
+        self.setPhaseName("Running forecast...", indeterminate=False)
         experiment_logger.debug("evaluating for iter 1")
-        await self._evaluate(rerun_context, evaluator_server_config)
-
-        num_successful_realizations = await self.successful_realizations(
-            rerun_context.iteration,
+        num_successful_realizations = await self._evaluate(
+            rerun_context, evaluator_server_config
         )
 
-        self.checkHaveSufficientRealizations(num_successful_realizations)
+        if FeatureToggling.is_enabled("experiment-server"):
+            num_successful_realizations = await self.successful_realizations(
+                rerun_context.iteration,
+            )
 
+        self.checkHaveSufficientRealizations(num_successful_realizations)  # type: ignore
+
+        self.setPhaseName("Post processing...", indeterminate=True)
         await self._run_hook(
             HookRuntime.POST_SIMULATION, rerun_context.iteration, loop, threadpool
         )
@@ -167,88 +186,16 @@ class EnsembleSmoother(BaseRunModel):
         )
         await self.dispatch(event)
         experiment_logger.debug("experiment done")
+        self.setPhase(2, "Simulations completed.")
+
+        if not FeatureToggling.is_enabled("experiment-server"):
+            return prior_context
+        return None
 
     def runSimulations(
         self, evaluator_server_config: EvaluatorServerConfig
-    ) -> RunContext:
-        prior_context = self.create_context()
-
-        self._checkMinimumActiveRealizations(len(prior_context.active_realizations))
-        self.setPhase(0, "Running simulations...", indeterminate=False)
-
-        # self.setAnalysisModule(arguments["analysis_module"])
-
-        self.setPhaseName("Pre processing...", indeterminate=True)
-        self.ert().sample_prior(prior_context.sim_fs, prior_context.active_realizations)
-        self.ert().createRunPath(prior_context)
-
-        self.ert().runWorkflows(HookRuntime.PRE_SIMULATION)
-
-        # Push ensemble, parameters, observations to new storage
-        ensemble_id = self._post_ensemble_data()
-
-        self.setPhaseName("Running forecast...", indeterminate=False)
-
-        num_successful_realizations = self.run_ensemble_evaluator(
-            prior_context, evaluator_server_config
-        )
-
-        # Push simulation results to storage
-        self._post_ensemble_results(ensemble_id)
-
-        self.checkHaveSufficientRealizations(num_successful_realizations)
-
-        self.setPhaseName("Post processing...", indeterminate=True)
-        self.ert().runWorkflows(HookRuntime.POST_SIMULATION)
-
-        self.setPhaseName("Analyzing...")
-        self.ert().runWorkflows(HookRuntime.PRE_FIRST_UPDATE)
-        self.ert().runWorkflows(HookRuntime.PRE_UPDATE)
-        try:
-            self.facade.smoother_update(prior_context)
-        except ErtAnalysisError as e:
-            raise ErtRunError(
-                f"Analysis of simulation failed with the following error: {e}"
-            ) from e
-
-        self.ert().runWorkflows(HookRuntime.POST_UPDATE)
-
-        # Create an update object in storage
-        analysis_module_name = self.ert().analysisConfig().active_module_name()
-        update_id = self._post_update_data(ensemble_id, analysis_module_name)
-
-        self.setPhase(1, "Running simulations...")
-        self.ert().getEnkfFsManager().switchFileSystem(
-            prior_context.target_fs.case_name
-        )
-
-        self.setPhaseName("Pre processing...")
-
-        rerun_context = self.create_context(prior_context=prior_context)
-
-        self.ert().createRunPath(rerun_context)
-
-        self.ert().runWorkflows(HookRuntime.PRE_SIMULATION)
-        # Push ensemble, parameters, observations to new storage
-        ensemble_id = self._post_ensemble_data(update_id=update_id)
-
-        self.setPhaseName("Running forecast...", indeterminate=False)
-
-        num_successful_realizations = self.run_ensemble_evaluator(
-            rerun_context, evaluator_server_config
-        )
-
-        self.checkHaveSufficientRealizations(num_successful_realizations)
-
-        self.setPhaseName("Post processing...", indeterminate=True)
-        self.ert().runWorkflows(HookRuntime.POST_SIMULATION)
-
-        # Push simulation results to storage
-        self._post_ensemble_results(ensemble_id)
-
-        self.setPhase(2, "Simulations completed.")
-
-        return prior_context
+    ) -> Union[RunContext, None]:
+        return asyncio.run(self.run(evaluator_server_config), debug=True)
 
     def create_context(self, prior_context: Optional[RunContext] = None) -> RunContext:
         fs_manager = self.ert().getEnkfFsManager()

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -218,7 +218,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
             )
             event.experiment.message = str(e)
             await self.dispatch(event)
-            return "Experiment failed"
+            raise
 
         await self._run_hook(
             HookRuntime.POST_SIMULATION,

--- a/src/ert/shared/models/multiple_data_assimilation.py
+++ b/src/ert/shared/models/multiple_data_assimilation.py
@@ -1,8 +1,8 @@
 import asyncio
 import concurrent
+import functools
 import logging
 from typing import Any, Dict, List, Optional, Tuple
-import functools
 
 import _ert_com_protocol
 from ert._c_wrappers.enkf import RunContext
@@ -245,7 +245,7 @@ class MultipleDataAssimilation(BaseRunModel):
             )
             event.experiment.message = str(e)
             await self.dispatch(event)
-            return run_context
+            raise
 
         phase_string = f"Post processing for iteration: {iteration}"
         self.setPhaseName(phase_string, indeterminate=True)

--- a/src/ert/shared/models/multiple_data_assimilation.py
+++ b/src/ert/shared/models/multiple_data_assimilation.py
@@ -150,7 +150,7 @@ class MultipleDataAssimilation(BaseRunModel):
 
         if not FeatureToggling.is_enabled("experiment-server"):
             self.setPhase(iteration_count + 1, "Simulations completed.")
-        
+
         return run_context
 
     def runSimulations(

--- a/src/ert/shared/models/multiple_data_assimilation.py
+++ b/src/ert/shared/models/multiple_data_assimilation.py
@@ -9,6 +9,7 @@ from ert._c_wrappers.enkf.enkf_main import EnKFMain, QueueConfig
 from ert._c_wrappers.enkf.enums import HookRuntime, RealizationStateEnum
 from ert.analysis import ErtAnalysisError
 from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.shared.feature_toggling import FeatureToggling
 from ert.shared.models import BaseRunModel, ErtRunError
 
 logger = logging.getLogger(__file__)
@@ -38,7 +39,9 @@ class MultipleDataAssimilation(BaseRunModel):
         if not module_load_success:
             raise ErtRunError(f"Unable to load analysis module '{module_name}'!")
 
-    async def run(self, evaluator_server_config: EvaluatorServerConfig) -> None:
+    async def run(
+        self, evaluator_server_config: EvaluatorServerConfig, model_name: str
+    ) -> Union[RunContext, None]:
         loop = asyncio.get_running_loop()
         threadpool = concurrent.futures.ThreadPoolExecutor()
 
@@ -67,103 +70,6 @@ class MultipleDataAssimilation(BaseRunModel):
         weights_to_run = enumerated_weights[
             min(self._simulation_arguments["start_iteration"], len(weights)) :
         ]
-        starting_iteration = self._simulation_arguments["start_iteration"]
-        case_format = self._simulation_arguments["target_case"]
-        storage_manager = self.ert().storage_manager
-        if starting_iteration > 0:
-            if case_format % starting_iteration not in storage_manager:
-                raise ErtRunError(
-                    f"Source case {case_format % starting_iteration} for iteration "
-                    f"{starting_iteration} does not exists in {storage_manager.cases}."
-                    " If you are attempting to restart ESMDA from a iteration other "
-                    "than 0, make sure the target case format is the same as for the "
-                    f"original run.(Current target case format: {case_format})"
-                )
-        else:
-            prior_fs = storage_manager.add_case(case_format % starting_iteration)
-            active_realizations = [
-                i
-                for i, val in enumerate(
-                    self._simulation_arguments["active_realizations"]
-                )
-                if val
-            ]
-            self.ert().sample_prior(prior_fs, active_realizations)
-        for iteration, weight in weights_to_run:
-            is_first_iteration = iteration == 0
-
-            run_context = await loop.run_in_executor(
-                threadpool,
-                self.create_context,
-                iteration,
-                self._simulation_arguments["active_realizations"],
-            )
-
-            await loop.run_in_executor(
-                threadpool,
-                self.ert().createRunPath,
-                run_context,
-            )
-            await self._run_hook(
-                HookRuntime.PRE_SIMULATION, iteration, loop, threadpool
-            )
-            ensemble_id = await loop.run_in_executor(
-                threadpool, self._post_ensemble_data, update_id
-            )
-            await self._evaluate(run_context, evaluator_server_config)
-
-            num_successful_realizations = await self.successful_realizations(iteration)
-
-            # Push simulation results to storage
-            await loop.run_in_executor(
-                threadpool, self._post_ensemble_results, ensemble_id
-            )
-
-            num_successful_realizations += self._simulation_arguments.get(
-                "prev_successful_realizations", 0
-            )
-            self.checkHaveSufficientRealizations(num_successful_realizations)
-
-            await self._run_hook(
-                HookRuntime.POST_SIMULATION, iteration, loop, threadpool
-            )
-
-            if is_first_iteration:
-                await self._run_hook(
-                    HookRuntime.PRE_FIRST_UPDATE, iteration, loop, threadpool
-                )
-            await self._run_hook(HookRuntime.PRE_UPDATE, iteration, loop, threadpool)
-            update_id = self.update(
-                run_context=run_context, weight=weight, ensemble_id=ensemble_id
-            )
-            await self._run_hook(HookRuntime.POST_UPDATE, iteration, loop, threadpool)
-
-        assert run_context is not None  # mypy
-        event = _ert_com_protocol.node_status_builder(
-            status="EXPERIMENT_ANALYSIS_ENDED", experiment_id=self.id_
-        )
-        await self.dispatch(event)
-
-    def runSimulations(
-        self, evaluator_server_config: EvaluatorServerConfig
-    ) -> RunContext:
-        self._checkMinimumActiveRealizations(
-            self._simulation_arguments["active_realizations"].count(True)
-        )
-        weights = self.parseWeights(self._simulation_arguments["weights"])
-        iteration_count = len(weights)
-
-        self.setAnalysisModule(self._simulation_arguments["analysis_module"])
-
-        logger.info(
-            f"Running MDA ES for {iteration_count}  "
-            f'iterations\t{", ".join(str(weight) for weight in weights)}'
-        )
-        weights = self.normalizeWeights(weights)
-
-        weight_string = ", ".join(str(round(weight, 3)) for weight in weights)
-        logger.info(f"Running MDA ES on (weights normalized)\t{weight_string}")
-
         self.setPhaseCount(iteration_count + 1)  # weights + post
         phase_string = (
             f"Running MDA ES {iteration_count} "
@@ -171,8 +77,6 @@ class MultipleDataAssimilation(BaseRunModel):
         )
         self.setPhaseName(phase_string, indeterminate=True)
 
-        update_id = None
-        enumerated_weights = list(enumerate(weights))
         starting_iteration = self._simulation_arguments["start_iteration"]
         case_format = self._simulation_arguments["target_case"]
         storage_manager = self.ert().storage_manager
@@ -195,36 +99,121 @@ class MultipleDataAssimilation(BaseRunModel):
                 if val
             ]
             self.ert().sample_prior(prior_fs, active_realizations)
-
-        weights_to_run = enumerated_weights[min(starting_iteration, len(weights)) :]
-
+        
         for iteration, weight in weights_to_run:
             is_first_iteration = iteration == 0
-            if is_first_iteration:
-                mask = self._simulation_arguments["active_realizations"]
-            else:
-                mask = None
-            run_context = self.create_context(iteration, mask=mask)
-            _, ensemble_id = self._simulateAndPostProcess(
-                run_context, evaluator_server_config, update_id=update_id
+            run_context = await loop.run_in_executor(
+                threadpool,
+                self.create_context,
+                iteration,
+                self._simulation_arguments["active_realizations"],
+            )
+            _, ensemble_id = await self._simulateAndPostProcess(
+                run_context,
+                evaluator_server_config,
+                update_id=update_id,
+                loop=loop,
+                threadpool=threadpool,
             )
             if is_first_iteration:
-                self.ert().runWorkflows(HookRuntime.PRE_FIRST_UPDATE)
-            self.ert().runWorkflows(HookRuntime.PRE_UPDATE)
-            update_id = self.update(
-                run_context=run_context, weight=weight, ensemble_id=ensemble_id
+                await self._run_hook(
+                    HookRuntime.PRE_FIRST_UPDATE, iteration, loop, threadpool
+                )
+            await self._run_hook(HookRuntime.PRE_UPDATE, iteration, loop, threadpool)
+            update_id = await loop.run_in_executor(
+                threadpool,
+                self.update,
+                run_context=run_context,
+                weight=weight,
+                ensemble_id=ensemble_id,
             )
-            self.ert().runWorkflows(HookRuntime.POST_UPDATE)
+            await self._run_hook(HookRuntime.POST_UPDATE, iteration, loop, threadpool)
 
         self.setPhaseName("Post processing...", indeterminate=True)
-        run_context = self.create_context(len(weights), update=False)
-        self._simulateAndPostProcess(
-            run_context, evaluator_server_config, update_id=update_id
+
+        run_context = await loop.run_in_executor(
+            threadpool, self.create_context, iteration, is_first_iteration
         )
 
-        self.setPhase(iteration_count + 1, "Simulations completed.")
+        event = _ert_com_protocol.node_status_builder(
+            status="EXPERIMENT_ANALYSIS_ENDED", experiment_id=self.id_
+        )
+        await self.dispatch(event)
 
-        return run_context
+        await self._simulateAndPostProcess(
+            run_context,
+            evaluator_server_config,
+            update_id=update_id,
+            loop=loop,
+            threadpool=threadpool,
+        )
+
+        if not FeatureToggling.is_enabled("experiment-server"):
+            self.setPhase(iteration_count + 1, "Simulations completed.")
+            return run_context
+        return None
+
+    async def _simulateAndPostProcess(
+        self,
+        run_context: RunContext,
+        evaluator_server_config: EvaluatorServerConfig,
+        update_id: Union[None, str],
+        loop: asyncio.AbstractEventLoop,
+        threadpool: Any,
+    ) -> Any:
+        iteration = run_context.iteration
+        phase_string = f"Running simulation for iteration: {iteration}"
+        self.setPhaseName(phase_string, indeterminate=True)
+        is_first_iteration = iteration == 0
+
+        run_context = await loop.run_in_executor(
+            threadpool, self.create_context, iteration, is_first_iteration
+        )
+
+        await loop.run_in_executor(
+            threadpool,
+            self.ert().createRunPath,
+            run_context,
+        )
+        phase_string = f"Pre processing for iteration: {iteration}"
+        self.setPhaseName(phase_string)
+        await self._run_hook(HookRuntime.PRE_SIMULATION, iteration, loop, threadpool)
+        ensemble_id = await loop.run_in_executor(
+            threadpool, self._post_ensemble_data, update_id
+        )
+        phase_string = f"Running forecast for iteration: {iteration}"
+        self.setPhaseName(phase_string, indeterminate=False)
+
+        num_successful_realizations = await self._evaluate(
+            run_context, evaluator_server_config
+        )
+
+        if FeatureToggling.is_enabled("experiment-server"):
+            num_successful_realizations = await self.successful_realizations(
+                run_context.iteration
+            )
+
+        # Push simulation results to storage
+        await loop.run_in_executor(threadpool, self._post_ensemble_results, ensemble_id)
+
+        num_successful_realizations += self._simulation_arguments.get(
+            "prev_successful_realizations", 0
+        )
+        self.checkHaveSufficientRealizations(num_successful_realizations)  # type: ignore
+
+        phase_string = f"Post processing for iteration: {iteration}"
+        self.setPhaseName(phase_string, indeterminate=True)
+
+        await self._run_hook(HookRuntime.POST_SIMULATION, iteration, loop, threadpool)
+
+        return num_successful_realizations, ensemble_id
+
+    def runSimulations(
+        self, evaluator_server_config: EvaluatorServerConfig
+    ) -> Union[RunContext, None]:
+        return asyncio.run(
+            self.run(evaluator_server_config, model_name="ES-MDA"), debug=True
+        )
 
     def _count_active_realizations(self, run_context: RunContext) -> int:
         return sum(run_context.mask)
@@ -250,46 +239,6 @@ class MultipleDataAssimilation(BaseRunModel):
         )
 
         return update_id
-
-    def _simulateAndPostProcess(
-        self,
-        run_context: RunContext,
-        evaluator_server_config: EvaluatorServerConfig,
-        update_id: Optional[str] = None,
-    ) -> Tuple[int, str]:
-        iteration = run_context.iteration
-
-        phase_string = f"Running simulation for iteration: {iteration}"
-        self.setPhaseName(phase_string, indeterminate=True)
-        self.ert().createRunPath(run_context)
-
-        phase_string = f"Pre processing for iteration: {iteration}"
-        self.setPhaseName(phase_string)
-        self.ert().runWorkflows(HookRuntime.PRE_SIMULATION)
-
-        # Push ensemble, parameters, observations to new storage
-        new_ensemble_id = self._post_ensemble_data(update_id=update_id)
-
-        phase_string = f"Running forecast for iteration: {iteration}"
-        self.setPhaseName(phase_string, indeterminate=False)
-
-        num_successful_realizations = self.run_ensemble_evaluator(
-            run_context, evaluator_server_config
-        )
-
-        # Push simulation results to storage
-        self._post_ensemble_results(new_ensemble_id)
-
-        num_successful_realizations += self._simulation_arguments.get(
-            "prev_successful_realizations", 0
-        )
-        self.checkHaveSufficientRealizations(num_successful_realizations)
-
-        phase_string = f"Post processing for iteration: {iteration}"
-        self.setPhaseName(phase_string, indeterminate=True)
-        self.ert().runWorkflows(HookRuntime.POST_SIMULATION)
-
-        return num_successful_realizations, new_ensemble_id
 
     @staticmethod
     def normalizeWeights(weights: List[float]) -> List[float]:

--- a/src/ert/shared/models/single_test_run.py
+++ b/src/ert/shared/models/single_test_run.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional
 
 from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert._c_wrappers.enkf.ert_run_context import RunContext
@@ -12,21 +12,23 @@ class SingleTestRun(EnsembleExperiment):
         self, simulation_arguments: Dict[str, Any], ert: EnKFMain, id_: str, *_: Any
     ):
         local_queue_config = ert.get_queue_config().create_local_copy()
-        super().__init__(id_, simulation_arguments, ert, local_queue_config)
+        super().__init__(simulation_arguments, ert, local_queue_config, id_)
 
     def checkHaveSufficientRealizations(self, num_successful_realizations: int) -> None:
         # Should only have one successful realization
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed!")
 
-    def runSimulations(self, evaluator_server_config: EvaluatorServerConfig) -> Union[None, RunContext]:  # type: ignore
+    def runSimulations(
+        self, evaluator_server_config: EvaluatorServerConfig
+    ) -> RunContext:
         return asyncio.run(
             self.run(evaluator_server_config, "single realisation test"), debug=True
         )
 
     async def run(
         self, evaluator_server_config: "EvaluatorServerConfig", model_name: str
-    ) -> Union[None, RunContext]:
+    ) -> RunContext:
         return await super().run(evaluator_server_config, model_name)
 
     @classmethod

--- a/src/ert/shared/models/single_test_run.py
+++ b/src/ert/shared/models/single_test_run.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+import asyncio
+from typing import Any, Dict, Union
 
 from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert._c_wrappers.enkf.ert_run_context import RunContext
@@ -11,22 +12,22 @@ class SingleTestRun(EnsembleExperiment):
         self, simulation_arguments: Dict[str, Any], ert: EnKFMain, id_: str, *_: Any
     ):
         local_queue_config = ert.get_queue_config().create_local_copy()
-        super().__init__(simulation_arguments, ert, local_queue_config, id_)
+        super().__init__(id_, simulation_arguments, ert, local_queue_config)
 
     def checkHaveSufficientRealizations(self, num_successful_realizations: int) -> None:
         # Should only have one successful realization
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed!")
 
-    def runSimulations(
-        self, evaluator_server_config: EvaluatorServerConfig
-    ) -> RunContext:
-        return self.runSimulations__(
-            "Running single realisation test ...", evaluator_server_config
+    def runSimulations(self, evaluator_server_config: EvaluatorServerConfig) -> Union[None, RunContext]:  # type: ignore
+        return asyncio.run(
+            self.run(evaluator_server_config, "single realisation test"), debug=True
         )
 
-    async def run(self, evaluator_server_config: "EvaluatorServerConfig") -> None:
-        await super().run(evaluator_server_config)
+    async def run(
+        self, evaluator_server_config: "EvaluatorServerConfig", model_name: str
+    ) -> Union[None, RunContext]:
+        return await super().run(evaluator_server_config, model_name)
 
     @classmethod
     def name(cls) -> str:

--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 from ert._c_wrappers.enkf.enums import HookRuntime
 from ert.ensemble_evaluator.config import EvaluatorServerConfig

--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, AsyncMock
 
 from ert._c_wrappers.enkf.enums import HookRuntime
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
@@ -28,7 +28,7 @@ def test_hook_call_order_ensemble_smoother(monkeypatch):
     minimum_args = MagicMock()
     test_class = EnsembleSmoother(minimum_args, ert_mock, MagicMock(), "experiment_id")
     test_class.create_context = MagicMock()
-    test_class.run_ensemble_evaluator = MagicMock(return_value=1)
+    test_class._evaluate = AsyncMock(return_value=1)
     ert_mock.runWorkflows = MagicMock()
     test_class.facade._es_update = MagicMock()
     evaluator_server_config_mock = MagicMock()
@@ -65,7 +65,7 @@ def test_hook_call_order_es_mda(monkeypatch):
     test_class.facade.get_number_of_iterations = MagicMock(return_value=-1)
     test_class.facade._es_update = MagicMock()
 
-    test_class.run_ensemble_evaluator = MagicMock(return_value=1)
+    test_class._evaluate = AsyncMock(return_value=1)
 
     test_class.runSimulations(evaluator_server_config)
 
@@ -100,7 +100,7 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
     test_class._ert = ert_mock
     test_class.parseWeights = MagicMock(return_value=[1])
     test_class.setAnalysisModule = MagicMock()
-    test_class.run_ensemble_evaluator = MagicMock(return_value=1)
+    test_class._evaluate = AsyncMock(return_value=1)
 
     test_class.setPhase = MagicMock()
     test_class.facade.get_number_of_iterations = MagicMock(return_value=1)

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -201,7 +201,7 @@ def make_ee_config():
 
 
 @pytest.fixture
-def evaluator(make_ee_config):
+async def evaluator(make_ee_config):
     ensemble = TestEnsemble(0, 2, 1, 2, id_="0")
     ee = EnsembleEvaluator(
         ensemble,
@@ -209,4 +209,3 @@ def evaluator(make_ee_config):
         0,
     )
     yield ee
-    ee.stop()

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -10,6 +10,7 @@ from cloudevents.http import CloudEvent
 from websockets.exceptions import ConnectionClosed
 
 from ert.ensemble_evaluator import identifiers, state
+from ert.ensemble_evaluator._wait_for_evaluator import wait_for_evaluator
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 
@@ -42,7 +43,8 @@ async def test_run_legacy_ensemble(tmpdir, make_ensemble_builder):
 
 
 @pytest.mark.timeout(60)
-def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
+@pytest.mark.asyncio
+async def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
     num_reals = 2
     custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():
@@ -54,19 +56,32 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
             generate_cert=False,
         )
 
-        evaluator = EnsembleEvaluator(ensemble, config, 0)
+        server = EnsembleEvaluator(ensemble, config, 0)
 
-        with evaluator.run() as mon:
-            cancel = True
-            try:
-                for _ in mon.track():
-                    if cancel:
-                        mon.signal_cancel()
-                        cancel = False
-            except ConnectionClosed:
-                pass  # monitor throws some variant of CC if dispatcher dies
+        server_task = asyncio.create_task(server.evaluator_server())
+        con_info = config.get_connection_info()
+        await wait_for_evaluator(
+            base_url=con_info.url, token=con_info.token, cert=con_info.cert
+        )
+        evaluation_task = asyncio.create_task(
+            ensemble.evaluate_async(config, experiment_id=None)
+        )
+        cancel_event = CloudEvent(
+            {
+                "type": identifiers.EVTYPE_EE_USER_CANCEL,
+                "source": f"/ert/monitor/0",
+                "id": str(uuid.uuid1()),
+            }
+        )
 
-        assert evaluator._ensemble.status == state.ENSEMBLE_STATE_CANCELLED
+        async with websockets.connect(f"{config.client_uri}") as websocket:
+            await websocket.send(to_json(cancel_event))
+
+        await evaluation_task
+        await server.stop()
+        await server_task
+
+        assert ensemble.status == state.ENSEMBLE_STATE_CANCELLED
 
         # realisations should not finish, thus not creating a status-file
         for i in range(num_reals):
@@ -74,7 +89,8 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder):
 
 
 @pytest.mark.timeout(60)
-def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
+@pytest.mark.asyncio
+async def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
     num_reals = 2
     custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():
@@ -86,17 +102,22 @@ def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder):
             generate_cert=False,
         )
         evaluator = EnsembleEvaluator(ensemble, config, 0)
+        server = EnsembleEvaluator(ensemble, config, 0)
+        server_task = asyncio.create_task(server.evaluator_server())
+
+        con_info = config.get_connection_info()
+        await wait_for_evaluator(
+            base_url=con_info.url, token=con_info.token, cert=con_info.cert
+        )
 
         with patch.object(ensemble._job_queue, "submit_complete") as faulty_queue:
             faulty_queue.side_effect = RuntimeError()
-            with evaluator.run() as monitor:
-                for e in monitor.track():
-                    if e.data is not None and e.data.get(identifiers.STATUS) in [
-                        state.ENSEMBLE_STATE_FAILED,
-                        state.ENSEMBLE_STATE_STOPPED,
-                    ]:
-                        monitor.signal_done()
-            assert evaluator._ensemble.status == state.ENSEMBLE_STATE_FAILED
+            await ensemble.evaluate_async(config, experiment_id=None)
+
+        await server.stop()
+        await server_task
+
+        assert evaluator._ensemble.status == state.ENSEMBLE_STATE_FAILED
 
         # realisations should not finish, thus not creating a status-file
         for i in range(num_reals):

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -29,10 +29,11 @@ async def test_run_legacy_ensemble(tmpdir, make_ensemble_builder):
             generate_cert=False,
         )
         server = EnsembleEvaluator(ensemble, config, 0)
-        asyncio.create_task(server.evaluator_server())
+        server_task = asyncio.create_task(server.evaluator_server())
 
         await ensemble.evaluate_async(config, experiment_id=None)
         await server.stop()
+        await server_task
 
         assert ensemble.status == state.ENSEMBLE_STATE_STOPPED
         assert ensemble.get_successful_realizations() == num_reals

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -194,7 +194,7 @@ def test_tracking(
 
         thread = threading.Thread(
             name="ert_cli_simulation_thread",
-            target=model.start_simulations_thread,
+            target=model.startSimulations,
             args=(evaluator_server_config,),
         )
         thread.start()
@@ -319,7 +319,7 @@ def test_tracking_time_map(
 
         thread = threading.Thread(
             name="ert_cli_simulation_thread",
-            target=model.start_simulations_thread,
+            target=model.startSimulations,
             args=(evaluator_server_config,),
         )
         with caplog.at_level(logging.INFO):
@@ -406,7 +406,7 @@ def test_tracking_missing_ecl(
 
         thread = threading.Thread(
             name="ert_cli_simulation_thread",
-            target=model.start_simulations_thread,
+            target=model.startSimulations,
             args=(evaluator_server_config,),
         )
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
**Issue**
Resolves #3948 


**Approach**
Make the asyncio entry point up one level. Currently the paths used by `EnsembleEvaluator` and `ExperimentServer` merge at `ensemble.evaluate`, we want them to merge on `experiment.run`. We use the same kind of handling of tasks when setting up the `EnsembleServer` as we did with with `ExperimentServer`

**Remaining work**
- [x] Make it run with GUI
- [x] Finalize the `evaluate` in BaseRunModel (shared by all RunModels)
- [x] Evaluate if we can implement for just `EnsembleExperiment` in first iteration
- [ ] Make the tests pass (refactor tests) - size of task depends on if single runmodel is updated or all of them
- [ ] If we remove tests that are no longer relevant, we should at the same time make sure we add tests for the new functionality implemented.

Given that all runmodels must be implemented at the same time, fix:
- [x] TestRun
- [x] EnsembleExperiment
- [x] EnsembleSmoother
- [x] IteratedEnsembleSmoother
- [x] ES-MDA

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
