### PR TITLE
Add `Cwrap<T>`

### DIFF
--- a/src/clib/lib/analysis/analysis_module.cpp
+++ b/src/clib/lib/analysis/analysis_module.cpp
@@ -302,9 +302,9 @@ analysis_module_get_module_config(const analysis_module_type *module) {
     return module->module_config.get();
 }
 
-ies::Config *analysis_module_get_module_config_pybind(py::object module) {
-    auto module_ = ert::from_cwrap<analysis_module_type>(module);
-    return analysis_module_get_module_config(module_);
+ies::Config *
+analysis_module_get_module_config_pybind(Cwrap<analysis_module_type> module) {
+    return analysis_module_get_module_config(module);
 }
 
 ERT_CLIB_SUBMODULE("analysis_module", m) {

--- a/src/clib/lib/analysis/update.cpp
+++ b/src/clib/lib/analysis/update.cpp
@@ -1,3 +1,4 @@
+#include "ert/enkf/ensemble_config.hpp"
 #include <Eigen/Dense>
 #include <cerrno>
 #include <optional>
@@ -323,92 +324,67 @@ std::pair<Eigen::MatrixXd, ObservationHandler> load_observations_and_responses(
 
 namespace {
 static Eigen::MatrixXd generate_noise(int active_obs_size, int active_ens_size,
-                                      py::object shared_rng) {
-    auto shared_rng_ = ert::from_cwrap<rng_type>(shared_rng);
+                                      Cwrap<rng_type> shared_rng) {
     Eigen::MatrixXd noise =
         Eigen::MatrixXd::Zero(active_obs_size, active_ens_size);
     for (int j = 0; j < active_ens_size; j++)
         for (int i = 0; i < active_obs_size; i++)
-            noise(i, j) = enkf_util_rand_normal(0, 1, shared_rng_);
+            noise(i, j) = enkf_util_rand_normal(0, 1, shared_rng);
     return noise;
 }
 
-static void copy_parameters_pybind(py::object source_fs, py::object target_fs,
-                                   py::object ensemble_config,
+static void copy_parameters_pybind(Cwrap<enkf_fs_type> source_fs,
+                                   Cwrap<enkf_fs_type> target_fs,
+                                   Cwrap<ensemble_config_type> ensemble_config,
                                    std::vector<bool> ens_mask) {
-    auto ensemble_config_ =
-        ert::from_cwrap<ensemble_config_type>(ensemble_config);
-    auto source_fs_ = ert::from_cwrap<enkf_fs_type>(source_fs);
-    auto target_fs_ = ert::from_cwrap<enkf_fs_type>(target_fs);
-    return analysis::copy_parameters(source_fs_, target_fs_, ensemble_config_,
+    return analysis::copy_parameters(source_fs, target_fs, ensemble_config,
                                      ens_mask);
 }
 
 static std::pair<Eigen::MatrixXd, analysis::ObservationHandler>
 load_observations_and_responses_pybind(
-    py::object source_fs, py::object obs, double alpha, double std_cutoff,
-    double global_std_scaling, std::vector<bool> ens_mask,
+    Cwrap<enkf_fs_type> source_fs, Cwrap<enkf_obs_type> obs, double alpha,
+    double std_cutoff, double global_std_scaling, std::vector<bool> ens_mask,
     const std::vector<std::pair<std::string, std::vector<int>>>
         &selected_observations) {
-
-    auto source_fs_ = ert::from_cwrap<enkf_fs_type>(source_fs);
-    auto obs_ = ert::from_cwrap<enkf_obs_type>(obs);
-
     return analysis::load_observations_and_responses(
-        source_fs_, obs_, alpha, std_cutoff, global_std_scaling, ens_mask,
+        source_fs, obs, alpha, std_cutoff, global_std_scaling, ens_mask,
         selected_observations);
 }
 
 static std::vector<std::pair<Eigen::MatrixXd, std::shared_ptr<RowScaling>>>
 load_row_scaling_parameters_pybind(
-    py::object target_fs, py::object ensemble_config,
+    Cwrap<enkf_fs_type> target_fs, Cwrap<ensemble_config_type> ensemble_config,
     const std::vector<int> &iens_active_index,
     const std::vector<analysis::RowScalingParameter> &config_parameters) {
-
-    auto target_fs_ = ert::from_cwrap<enkf_fs_type>(target_fs);
-    auto ensemble_config_ =
-        ert::from_cwrap<ensemble_config_type>(ensemble_config);
-
     return analysis::load_row_scaling_parameters(
-        target_fs_, ensemble_config_, iens_active_index, config_parameters);
+        target_fs, ensemble_config, iens_active_index, config_parameters);
 }
 
 static std::optional<Eigen::MatrixXd>
-load_parameters_pybind(py::object target_fs, py::object ensemble_config,
+load_parameters_pybind(Cwrap<enkf_fs_type> target_fs,
+                       Cwrap<ensemble_config_type> ensemble_config,
                        const std::vector<int> &iens_active_index,
                        const std::vector<analysis::Parameter> &parameters) {
-
-    auto target_fs_ = ert::from_cwrap<enkf_fs_type>(target_fs);
-    auto ensemble_config_ =
-        ert::from_cwrap<ensemble_config_type>(ensemble_config);
-
-    return analysis::load_parameters(target_fs_, ensemble_config_,
+    return analysis::load_parameters(target_fs, ensemble_config,
                                      iens_active_index, parameters);
 }
 
-static void save_parameters_pybind(py::object target_fs,
-                                   py::object ensemble_config,
+static void save_parameters_pybind(Cwrap<enkf_fs_type> target_fs,
+                                   Cwrap<ensemble_config_type> ensemble_config,
                                    std::vector<int> iens_active_index,
                                    std::vector<analysis::Parameter> &parameters,
                                    const Eigen::MatrixXd &A) {
-    auto target_fs_ = ert::from_cwrap<enkf_fs_type>(target_fs);
-    auto ensemble_config_ =
-        ert::from_cwrap<ensemble_config_type>(ensemble_config);
-
-    analysis::save_parameters(target_fs_, ensemble_config_, iens_active_index,
+    analysis::save_parameters(target_fs, ensemble_config, iens_active_index,
                               parameters, A);
 }
 static void save_row_scaling_parameters_pybind(
-    py::object target_fs, py::object ensemble_config,
+    Cwrap<enkf_fs_type> target_fs, Cwrap<ensemble_config_type> ensemble_config,
     std::vector<int> iens_active_index,
     const std::vector<analysis::RowScalingParameter> &config_parameters,
     const std::vector<std::pair<Eigen::MatrixXd, std::shared_ptr<RowScaling>>>
         scaled_A) {
-    auto target_fs_ = ert::from_cwrap<enkf_fs_type>(target_fs);
-    auto ensemble_config_ =
-        ert::from_cwrap<ensemble_config_type>(ensemble_config);
-
-    analysis::save_row_scaling_parameters(target_fs_, ensemble_config_,
+    analysis::save_row_scaling_parameters(target_fs, ensemble_config,
                                           iens_active_index, config_parameters,
                                           scaled_A);
 }

--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -269,9 +269,7 @@ ERT_CLIB_SUBMODULE("config_keywords", m) {
     using namespace py::literals;
     m.def(
         "init_res_config_parser",
-        [](py::object py_config_parser) {
-            auto config_parser =
-                ert::from_cwrap<config_parser_type>(py_config_parser);
+        [](Cwrap<config_parser_type> config_parser) {
             add_path_keyword(config_parser, WORKFLOW_JOB_DIRECTORY_KEY);
             add_load_workflow_keyword(config_parser);
             add_load_workflow_job_keyword(config_parser);

--- a/src/clib/lib/enkf/enkf_fs.cpp
+++ b/src/clib/lib/enkf/enkf_fs.cpp
@@ -698,11 +698,7 @@ ERT_CLIB_SUBMODULE("enkf_fs", m) {
 
     m.def(
         "get_state_map",
-        [](py::handle self) {
-            auto enkf_fs = ert::from_cwrap<enkf_fs_type>(self);
-            return enkf_fs->state_map;
-        },
-        "self"_a);
+        [](Cwrap<enkf_fs_type> self) { return self->state_map; }, "self"_a);
     m.def(
         "read_state_map",
         [](std::string case_path) {
@@ -711,11 +707,8 @@ ERT_CLIB_SUBMODULE("enkf_fs", m) {
         "case_path"_a);
     m.def(
         "is_initialized",
-        [](py::handle self, py::handle ensemble_config_py,
+        [](Cwrap<enkf_fs_type> fs, Cwrap<ensemble_config_type> ensemble_config,
            std::vector<std::string> parameter_keys, int ens_size) {
-            auto fs = ert::from_cwrap<enkf_fs_type>(self);
-            const auto ensemble_config =
-                ert::from_cwrap<ensemble_config_type>(ensemble_config_py);
             bool initialized = true;
             for (int ikey = 0; (ikey < parameter_keys.size()) && initialized;
                  ikey++) {
@@ -733,19 +726,17 @@ ERT_CLIB_SUBMODULE("enkf_fs", m) {
         },
         py::arg("self"), py::arg("ensemble_config"), py::arg("parameter_names"),
         py::arg("ensemble_size"));
-    m.def("load_from_run_path",
-          [](py::object self, int ens_size, py::object ensemble_config,
-             py::object model_config, py::object ecl_config,
-             std::vector<py::object> run_args_, std::vector<bool> active_mask) {
-              std::vector<run_arg_type *> run_args;
-              for (auto &run_arg : run_args_) {
-                  run_args.push_back(ert::from_cwrap<run_arg_type>(run_arg));
-              }
-              return load_from_run_path(
-                  ens_size,
-                  ert::from_cwrap<ensemble_config_type>(ensemble_config),
-                  ert::from_cwrap<model_config_type>(model_config),
-                  ert::from_cwrap<ecl_config_type>(ecl_config), active_mask,
-                  ert::from_cwrap<enkf_fs_type>(self), run_args);
-          });
+    m.def("load_from_run_path", [](Cwrap<enkf_fs_type> enkf_fs, int ens_size,
+                                   Cwrap<ensemble_config_type> ensemble_config,
+                                   Cwrap<model_config_type> model_config,
+                                   Cwrap<ecl_config_type> ecl_config,
+                                   py::sequence run_args_,
+                                   std::vector<bool> active_mask) {
+        std::vector<run_arg_type *> run_args;
+        for (auto run_arg : run_args_) {
+            run_args.push_back(ert::from_cwrap<run_arg_type>(run_arg));
+        }
+        return load_from_run_path(ens_size, ensemble_config, model_config,
+                                  ecl_config, active_mask, enkf_fs, run_args);
+    });
 }

--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -132,39 +132,34 @@ ERT_CLIB_SUBMODULE("enkf_main", m) {
     using namespace py::literals;
     m.def(
         "init_current_case_from_existing_custom",
-        [](py::object ensemble_config_py, py::object source_case_py,
-           py::object current_case_py, int source_report_step,
-           std::vector<std::string> &node_list, std::vector<bool> &iactive) {
-            auto source_case_fs = ert::from_cwrap<enkf_fs_type>(source_case_py);
-            auto current_fs = ert::from_cwrap<enkf_fs_type>(current_case_py);
-            auto ensemble_config =
-                ert::from_cwrap<ensemble_config_type>(ensemble_config_py);
-            enkf_main_copy_ensemble(ensemble_config, source_case_fs,
-                                    source_report_step, current_fs, iactive,
+        [](Cwrap<ensemble_config_type> ensemble_config,
+           Cwrap<enkf_fs_type> source_case, Cwrap<enkf_fs_type> current_case,
+           int source_report_step, std::vector<std::string> &node_list,
+           std::vector<bool> &iactive) {
+            enkf_main_copy_ensemble(ensemble_config, source_case,
+                                    source_report_step, current_case, iactive,
                                     node_list);
-            enkf_fs_fsync(current_fs);
+            enkf_fs_fsync(current_case);
         },
         py::arg("self"), py::arg("source_case"), py::arg("current_case"),
         py::arg("source_report_step"), py::arg("node_list"),
         py::arg("iactive"));
     m.def(
         "init_active_run",
-        [](py::object model_config, py::object ensemble_config,
-           py::object site_config, char *run_path, int iens, py::object sim_fs,
-           char *run_id, char *job_name, py::object subst_list) {
-            enkf_main::init_active_run(
-                ert::from_cwrap<model_config_type>(model_config),
-                ert::from_cwrap<ensemble_config_type>(ensemble_config),
-                ert::from_cwrap<site_config_type>(site_config), run_path, iens,
-                ert::from_cwrap<enkf_fs_type>(sim_fs), run_id, job_name,
-                ert::from_cwrap<subst_list_type>(subst_list));
+        [](Cwrap<model_config_type> model_config,
+           Cwrap<ensemble_config_type> ensemble_config,
+           Cwrap<site_config_type> site_config, char *run_path, int iens,
+           Cwrap<enkf_fs_type> sim_fs, char *run_id, char *job_name,
+           Cwrap<subst_list_type> subst_list) {
+            enkf_main::init_active_run(model_config, ensemble_config,
+                                       site_config, run_path, iens, sim_fs,
+                                       run_id, job_name, subst_list);
         },
         py::arg("model_config"), py::arg("ensemble_config"),
         py::arg("site_config"), py::arg("run_path"), py::arg("iens"),
         py::arg("sim_fs"), py::arg("run_id"), py::arg("job_name"),
         py::arg("subst_list"));
-    m.def("log_seed", [](py::object rng_) {
-        auto rng = ert::from_cwrap<rng_type>(rng_);
+    m.def("log_seed", [](Cwrap<rng_type> rng) {
         uint32_t random_seeds[4];
         rng_get_state(rng, reinterpret_cast<char *>(random_seeds));
 

--- a/src/clib/lib/enkf/enkf_state.cpp
+++ b/src/clib/lib/enkf/enkf_state.cpp
@@ -359,10 +359,9 @@ bool enkf_state_complete_forward_model_EXIT_handler__(run_arg_type *run_arg) {
 }
 
 ERT_CLIB_SUBMODULE("enkf_state", m) {
-    m.def("state_initialize", [](py::object rng, py::object param_node,
-                                 py::object fs, int iens) {
-        return enkf_state_initialize(
-            ert::from_cwrap<rng_type>(rng), ert::from_cwrap<enkf_fs_type>(fs),
-            ert::from_cwrap<enkf_node_type>(param_node), iens);
-    });
+    m.def("state_initialize",
+          [](Cwrap<rng_type> rng, Cwrap<enkf_node_type> param_node,
+             Cwrap<enkf_fs_type> fs, int iens) {
+              return enkf_state_initialize(rng, fs, param_node, iens);
+          });
 }

--- a/src/clib/lib/enkf/gen_obs.cpp
+++ b/src/clib/lib/enkf/gen_obs.cpp
@@ -472,9 +472,8 @@ VOID_UPDATE_STD_SCALE(gen_obs)
 
 class ActiveList;
 namespace {
-void update_std_scaling(py::handle obj, double scaling,
+void update_std_scaling(Cwrap<gen_obs_type> self, double scaling,
                         const ActiveList &active_list) {
-    auto *self = ert::from_cwrap<gen_obs_type>(obj);
     gen_obs_update_std_scale(self, scaling, &active_list);
 }
 } // namespace

--- a/src/clib/lib/job_queue/environment_varlist.cpp
+++ b/src/clib/lib/job_queue/environment_varlist.cpp
@@ -73,16 +73,10 @@ ERT_CLIB_SUBMODULE("env_varlist", m) {
     using namespace py::literals;
     m.def(
         "_get_varlist",
-        [](py::object self_py) {
-            auto self = ert::from_cwrap<env_varlist_type>(self_py);
-            return self->varlist;
-        },
+        [](Cwrap<env_varlist_type> self) { return self->varlist; },
         py::arg("self"));
     m.def(
         "_get_updatelist",
-        [](py::object self_py) {
-            auto self = ert::from_cwrap<env_varlist_type>(self_py);
-            return self->updatelist;
-        },
+        [](Cwrap<env_varlist_type> self) { return self->updatelist; },
         py::arg("self"));
 }

--- a/src/clib/lib/python/enkf_fs_general_data.cpp
+++ b/src/clib/lib/python/enkf_fs_general_data.cpp
@@ -7,9 +7,8 @@
 ERT_CLIB_SUBMODULE("enkf_fs_general_data", m) {
     m.def(
         "gendata_get_realizations",
-        [](py::object self, const std::vector<int> &realizations) {
-            auto enkf_plot_gendata =
-                ert::from_cwrap<enkf_plot_gendata_type>(self);
+        [](Cwrap<enkf_plot_gendata_type> enkf_plot_gendata,
+           const std::vector<int> &realizations) {
             const int data_size =
                 enkf_plot_gendata_get_data_size(enkf_plot_gendata);
             if (data_size < 0) {

--- a/src/clib/lib/python/enkf_fs_keyword_data.cpp
+++ b/src/clib/lib/python/enkf_fs_keyword_data.cpp
@@ -11,13 +11,9 @@ static auto logger = ert::get_logger("enkf_fs");
 ERT_CLIB_SUBMODULE("enkf_fs_keyword_data", m) {
     m.def(
         "keyword_data_get_realizations",
-        [](py::object config, py::object fs,
-           const std::vector<std::string> &keys,
+        [](Cwrap<ensemble_config_type> ensemble_config,
+           Cwrap<enkf_fs_type> enkf_fs, const std::vector<std::string> &keys,
            const std::vector<int> &realizations) {
-            auto ensemble_config =
-                ert::from_cwrap<ensemble_config_type>(config);
-            auto enkf_fs = ert::from_cwrap<enkf_fs_type>(fs);
-
             const int key_count = std::size(keys);
             const int realization_size = std::size(realizations);
             const size_t size = realization_size * key_count;

--- a/src/clib/lib/python/enkf_fs_summary_data.cpp
+++ b/src/clib/lib/python/enkf_fs_summary_data.cpp
@@ -8,13 +8,10 @@
 ERT_CLIB_SUBMODULE("enkf_fs_summary_data", m) {
     m.def(
         "get_summary_data",
-        [](py::object ens_cfg, py::object fs,
+        [](Cwrap<ensemble_config_type> ensemble_config,
+           Cwrap<enkf_fs_type> enkfs_fs,
            const std::vector<std::string> &summary_keys,
            const std::vector<int> &realizations, const int time_map_size) {
-            auto ensemble_config =
-                ert::from_cwrap<ensemble_config_type>(ens_cfg);
-            auto enkfs_fs = ert::from_cwrap<enkf_fs_type>(fs);
-
             const int realization_size = std::size(realizations);
             const int summary_key_size = std::size(summary_keys);
             const size_t size =

--- a/src/clib/lib/python/ensemble_config.cpp
+++ b/src/clib/lib/python/ensemble_config.cpp
@@ -8,8 +8,7 @@ namespace py = pybind11;
 ERT_CLIB_SUBMODULE("ensemble_config", m) {
     m.def(
         "ensemble_config_keylist_from_var_type",
-        [](py::object self, int var_mask) {
-            auto ensemble_config = ert::from_cwrap<ensemble_config_type>(self);
+        [](Cwrap<ensemble_config_type> ensemble_config, int var_mask) {
             return ensemble_config_keylist_from_var_type(ensemble_config,
                                                          var_mask);
         },

--- a/src/clib/lib/python/init.cpp
+++ b/src/clib/lib/python/init.cpp
@@ -52,16 +52,14 @@ PYBIND11_MODULE(_clib, m) {
 
     m.def(
         "obs_vector_get_step_list",
-        [](py::object self) {
-            auto obs_vector = ert::from_cwrap<obs_vector_type>(self);
-            return obs_vector_get_step_list(obs_vector);
+        [](Cwrap<obs_vector_type> self) {
+            return obs_vector_get_step_list(self);
         },
         py::arg("self"));
     m.def(
         "analysis_config_module_names",
-        [](py::object self) {
-            auto analysis_config = ert::from_cwrap<analysis_config_type>(self);
-            return analysis_config_module_names(analysis_config);
+        [](Cwrap<analysis_config_type> self) {
+            return analysis_config_module_names(self);
         },
         py::arg("self"));
 }

--- a/src/clib/lib/python/model_callbacks.cpp
+++ b/src/clib/lib/python/model_callbacks.cpp
@@ -11,18 +11,17 @@ ERT_CLIB_SUBMODULE("model_callbacks", m) {
         .value("TIME_MAP_FAILURE", TIME_MAP_FAILURE)
         .export_values();
 
-    m.def("forward_model_exit", [](std::vector<py::object> arr) {
+    m.def("forward_model_exit", [](py::sequence arr) {
         auto run_arg = ert::from_cwrap<run_arg_type>(arr[0]);
         return enkf_state_complete_forward_model_EXIT_handler__(run_arg);
     });
 
-    m.def("forward_model_ok", [](py::object run_arg, py::object ens_conf,
-                                 py::object model_conf, py::object ecl_conf) {
-        auto result = enkf_state_load_from_forward_model(
-            ert::from_cwrap<ensemble_config_type>(ens_conf),
-            ert::from_cwrap<model_config_type>(model_conf),
-            ert::from_cwrap<ecl_config_type>(ecl_conf),
-            ert::from_cwrap<run_arg_type>(run_arg));
+    m.def("forward_model_ok", [](Cwrap<run_arg_type> run_arg,
+                                 Cwrap<ensemble_config_type> ens_conf,
+                                 Cwrap<model_config_type> model_conf,
+                                 Cwrap<ecl_config_type> ecl_conf) {
+        auto result = enkf_state_load_from_forward_model(ens_conf, model_conf,
+                                                         ecl_conf, run_arg);
 
         if (result.first == LOAD_SUCCESSFUL) {
             result.second = "Results loaded successfully.";


### PR DESCRIPTION
Add `ert::Cwrap<T>` type with a pybind11 caster which calls `ert::from_cwrap<T>` implicitly.

Before:
```cpp
m.def("foo", [](py::handle self_) {
  auto self = ert::from_cwrap<enkf_fs_type>(self_);
  enkf_fs_do_something(self);
});
```

After:
```cpp
m.def("foo", [](Cwrap<enkf_fs_type> self) {
  enkf_fs_do_something(self);
});
```