### PR TITLE
Mute external DEBUG messages

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -71,14 +71,12 @@ loggers:
     level: DEBUG
     handlers: [eefile]
     propagate: no
-  websockets.server:
-    level: ERROR
-    handlers: [eefile]
-    propagate: yes
   ert.experiment_server:
     level: DEBUG
     handlers: [experiment_server_file]
     propagate: yes
+  h5py:
+    level: INFO
   matplotlib:
     level: INFO
   res:
@@ -87,6 +85,14 @@ loggers:
   res.config:
     level: WARNING
     handlers: [stderr, file]
+  shapely:
+    level: INFO
+  subscript:
+    level: INFO
+  websockets.server:
+    level: ERROR
+    handlers: [eefile]
+    propagate: yes
 root:
   level: DEBUG
   handlers: [file]


### PR DESCRIPTION
This removed DEBUG logs from some packages that are not as critical to the ERT application.

In particular, for Drogon, `subscript.fmuobs.parsers` emit 200-300 lines of DEBUG messages when parsing the observations.

**Issue**
Resolves overloading users and debuggers with not-so-interesting log messages.


**Approach**
Adjust the log-level on a per package level away from the default `DEBUG`. This does not scale perfectly, as more packages introduced by users through configuration can still spur similar loads of debug messages.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
