### PR TITLE
Make default ensemble path consistent

### DIFF
--- a/src/clib/lib/enkf/model_config.cpp
+++ b/src/clib/lib/enkf/model_config.cpp
@@ -39,6 +39,8 @@
 #include <ert/enkf/model_config.hpp>
 #include <ert/enkf/site_config.hpp>
 
+namespace fs = std::filesystem;
+
 static auto logger = ert::get_logger("enkf");
 
 #define MODEL_CONFIG_TYPE_ID 661053
@@ -257,7 +259,8 @@ model_config_type *model_config_alloc_empty() {
     model_config->num_realizations = 0;
     model_config->obs_config_file = NULL;
 
-    model_config_set_enspath(model_config, DEFAULT_ENSPATH);
+    model_config_set_enspath(model_config,
+                             fs::absolute(DEFAULT_ENSPATH).c_str());
     model_config_set_max_internal_submit(model_config,
                                          DEFAULT_MAX_INTERNAL_SUBMIT);
     model_config_add_runpath(model_config, DEFAULT_RUNPATH_KEY,

--- a/tests/test_config_parsing/test_model_config.py
+++ b/tests/test_config_parsing/test_model_config.py
@@ -1,0 +1,40 @@
+from ert._c_wrappers.enkf import ResConfig
+from ert._c_wrappers.enkf.config_keys import ConfigKeys
+
+
+def test_default_model_config_ens_path(tmpdir):
+    with tmpdir.as_cwd():
+        config_file = "test.ert"
+        with open(config_file, "w") as f:
+            f.write(
+                """
+NUM_REALIZATIONS  1
+            """
+            )
+        res_config = ResConfig(config_file)
+        # By default, the ensemble path is set to 'storage'
+        default_ens_path = res_config.model_config.getEnspath()
+
+        with open(config_file, "a") as f:
+            f.write(
+                """
+ENSPATH storage
+            """
+            )
+
+        # Set the ENSPATH in the config file
+        res_config = ResConfig(config_file)
+        set_in_file_ens_path = res_config.model_config.getEnspath()
+
+        assert default_ens_path == set_in_file_ens_path
+
+        config_dict = {ConfigKeys.NUM_REALIZATIONS: 1}
+        dict_default_ens_path = ResConfig(
+            config_dict=config_dict
+        ).model_config.getEnspath()
+
+        config_dict["ENSPATH"] = "storage"
+        dict_set_ens_path = ResConfig(config_dict=config_dict).model_config.getEnspath()
+
+        assert dict_default_ens_path == dict_set_ens_path
+        assert dict_default_ens_path == default_ens_path


### PR DESCRIPTION
**Issue**
Resolves #3925


**Approach**
Get the same ensemble path if the user adds `storage` as the ENSPATH in the config file or not.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
