### PR TITLE
Raise exception if size of gen_kw in storage differs with gen_kw_config

### DIFF
--- a/src/clib/lib/enkf/gen_kw.cpp
+++ b/src/clib/lib/enkf/gen_kw.cpp
@@ -18,6 +18,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <fmt/format.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -154,8 +155,18 @@ void gen_kw_read_from_buffer(gen_kw_type *gen_kw, buffer_type *buffer,
     const int data_size = gen_kw_config_get_data_size(gen_kw->config);
     ert_impl_type file_type;
     file_type = (ert_impl_type)buffer_fread_int(buffer);
-    if ((file_type == GEN_KW) || (file_type == MULTFLT))
+    if ((file_type == GEN_KW) || (file_type == MULTFLT)) {
+        size_t expected_size =
+            buffer_get_remaining_size(buffer) / sizeof *gen_kw->data;
+        if (expected_size != data_size) {
+            const char *key = gen_kw_config_get_key(gen_kw->config);
+            throw std::range_error(
+                fmt::format("The configuration of GEN_KW parameter {} is of "
+                            "size {}, expected {}",
+                            key, data_size, expected_size));
+        }
         buffer_fread(buffer, gen_kw->data, sizeof *gen_kw->data, data_size);
+    }
 }
 #undef MULTFLT
 

--- a/tests/libres_tests/res/enkf/test_priors.py
+++ b/tests/libres_tests/res/enkf/test_priors.py
@@ -1,0 +1,40 @@
+import gc
+import os
+import shutil
+
+import pytest
+
+from ert._c_wrappers.enkf import EnKFMain, ResConfig, RunContext
+
+
+def test_adding_priors(tmpdir, source_root):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "local", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+    with tmpdir.as_cwd():
+        rc = ResConfig("poly_example/poly.ert")
+        m = EnKFMain(rc)
+        run_context = m.create_ensemble_experiment_run_context(
+            active_mask=[True] * 10,
+            iteration=0,
+        )
+        m.createRunPath(run_context)
+        del m
+        gc.collect()
+
+        with open("poly_example/coeff_priors", "a") as f:
+            f.write("COEFF_D UNIFORM 0 5\n")
+        rc = ResConfig("poly_example/poly.ert")
+        m = EnKFMain(rc)
+
+        run_context = m.create_ensemble_experiment_run_context(
+            active_mask=[True] * 10,
+            iteration=0,
+        )
+        with pytest.raises(
+            ValueError,
+            match="The configuration of GEN_KW "
+            "parameter COEFFS is of size 4, expected 3",
+        ):
+            m.createRunPath(run_context)


### PR DESCRIPTION
**Issue**
Resolves #3975 

**Approach**
Give meaningful error message when the config of GEN_KW differs to what is in storage


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
