### PR TITLE
Make sure that processing reporter.event_queue does not yield ConnectionError

### DIFF
--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -61,7 +61,9 @@ class Client:  # pylint: disable=too-many-instance-attributes
 
     async def get_websocket(self) -> WebSocketClientProtocol:
         return await connect(
-            self.url, ssl=self._ssl_context, extra_headers=self._extra_headers
+            self.url,
+            ssl=self._ssl_context,
+            extra_headers=self._extra_headers,
         )
 
     async def _send(self, msg: AnyStr) -> None:


### PR DESCRIPTION
**Issue**
Make sure that processing reporter.event_queue does not yield `ConnectionError`.


**Approach**
We don't yield ConnectionError, but instead keep processing next events in the queue. If the `Finish` event is received, we setup the timer (60 seconds), which when reached will automatically stop the publisher thread and exit. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
