### PR TITLE
Fix bug where PRE_FIRST_UPDATE cannot be selected

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -129,6 +129,7 @@ static void add_hook_workflow_keyword(config_parser_type *config_parser) {
     stringlist_append_copy(argv, RUN_MODE_PRE_SIMULATION_NAME);
     stringlist_append_copy(argv, RUN_MODE_POST_SIMULATION_NAME);
     stringlist_append_copy(argv, RUN_MODE_PRE_UPDATE_NAME);
+    stringlist_append_copy(argv, RUN_MODE_PRE_FIRST_UPDATE_NAME);
     stringlist_append_copy(argv, RUN_MODE_POST_UPDATE_NAME);
     config_schema_item_set_indexed_selection_set(item, 1, argv);
     stringlist_free(argv);

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -15,6 +15,7 @@ from ert._c_wrappers.enkf import (
     ResConfig,
     SiteConfig,
 )
+from ert._c_wrappers.enkf.enums import HookRuntime
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum
 
@@ -622,3 +623,29 @@ def test_that_unknown_queue_option_gives_error_message(monkeypatch, tmp_path, ca
     err = capsys.readouterr().err
     assert "Errors parsing" in err
     assert "UNKNOWN_QUEUE" in err
+
+
+@pytest.mark.parametrize(
+    "run_mode",
+    [
+        HookRuntime.POST_SIMULATION,
+        HookRuntime.PRE_SIMULATION,
+        HookRuntime.PRE_FIRST_UPDATE,
+        HookRuntime.PRE_UPDATE,
+        HookRuntime.POST_UPDATE,
+    ],
+)
+def test_that_workflow_run_modes_can_be_selected(tmp_path, run_mode):
+    my_script = (tmp_path / "my_script").resolve()
+    my_script.write_text("")
+    st = os.stat(my_script)
+    os.chmod(my_script, st.st_mode | stat.S_IEXEC)
+    test_user_config = tmp_path / "user_config.ert"
+    test_user_config.write_text(
+        "JOBNAME  Job%d\nRUNPATH /tmp/simulations/run%d\n"
+        "NUM_REALIZATIONS 10\n"
+        f"LOAD_WORKFLOW {my_script} SCRIPT\n"
+        f"HOOK_WORKFLOW SCRIPT {run_mode}\n"
+    )
+    res_config = ResConfig(str(test_user_config))
+    assert res_config.hook_manager[0].getRunMode() == run_mode


### PR DESCRIPTION
Fixes PRE_FIRST_UPDATE not being a valid run mode option.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
