### PR TITLE
Change default runpath

### DIFF
--- a/src/clib/lib/include/ert/enkf/enkf_defaults.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_defaults.hpp
@@ -96,7 +96,7 @@
 #define DEFAULT_ITER_RETRY_COUNT 4
 
 /* Default directories. */
-#define DEFAULT_RUNPATH "simulations/realization%d"
+#define DEFAULT_RUNPATH "simulations/realization-<IENS>/iter-<ITER>"
 #define DEFAULT_ENSPATH "storage"
 
 #define SUMMARY_KEY_JOIN_STRING ":"

--- a/tests/ert_tests/status/test_tracking_integration.py
+++ b/tests/ert_tests/status/test_tracking_integration.py
@@ -282,7 +282,7 @@ def test_tracking_time_map(
         # We create a reference case
         run_sim(datetime(2014, 9, 10))
         cwd = Path().absolute()
-        sim_path = Path("simulations") / "realization0"
+        sim_path = Path("simulations") / "realization-0" / "iter-0"
         sim_path.mkdir(parents=True, exist_ok=True)
         os.chdir(sim_path)
         # We are a bit sneaky here, there is no forward model creating any responses
@@ -429,7 +429,8 @@ def test_tracking_missing_ecl(
         assert (
             f"Realization: 0 failed after reaching max submit with: Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
-            f"{Path().absolute()}/simulations/realization0/ECLIPSE_CASE.UNSMRY"
+            f"{Path().absolute()}/simulations/realization-0/"
+            "iter-0/ECLIPSE_CASE.UNSMRY"
         ) in caplog.messages
 
         # Just also check that it failed for the expected reason
@@ -437,7 +438,8 @@ def test_tracking_missing_ecl(
         assert (
             f"Realization: 0 failed after reaching max submit with: Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
-            f"{Path().absolute()}/simulations/realization0/ECLIPSE_CASE.UNSMRY"
+            f"{Path().absolute()}/simulations/realization-0/"
+            "iter-0/ECLIPSE_CASE.UNSMRY"
         ) in failures[0].failed_msg
 
         thread.join()

--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -526,7 +526,9 @@ def _create_runpath(ert: LibresFacade, iteration: int = 0) -> RunContext:
 def _get_parameters() -> pd.DataFrame:
     params_json = [
         json.loads(path.read_text())
-        for path in sorted(Path.cwd().glob("simulations/realization*/coeffs.json"))
+        for path in sorted(
+            Path.cwd().glob("simulations/realization-*/iter-*/coeffs.json")
+        )
     ]
 
     return pd.DataFrame(params_json)

--- a/tests/libres_tests/integration/test_parameter_sample_types.py
+++ b/tests/libres_tests/integration/test_parameter_sample_types.py
@@ -77,7 +77,8 @@ def test_gen_kw(tmpdir, config_str, expected, extra_files, expectation):
         create_runpath("config.ert")
         with expectation:
             assert (
-                Path("simulations/realization0/kw.txt").read_text("utf-8") == expected
+                Path("simulations/realization-0/iter-0/kw.txt").read_text("utf-8")
+                == expected
             )
 
 
@@ -85,7 +86,7 @@ def test_gen_kw(tmpdir, config_str, expected, extra_files, expectation):
     "config_str, expected",
     [
         (
-            "FIELD MY_PARAM PARAMETER my_param.grdecl INIT_FILES:../../my_param_0.grdecl FORWARD_INIT:True",  # noqa
+            "FIELD MY_PARAM PARAMETER my_param.grdecl INIT_FILES:../../../my_param_0.grdecl FORWARD_INIT:True",  # noqa
             True,
         ),
         (
@@ -148,7 +149,7 @@ def test_field_param(tmpdir, config_str, expected):
             "",
         ),
         (
-            "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:../../surf%d.irap BASE_SURFACE:surf0.irap FORWARD_INIT:True",  # noqa
+            "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:../../../surf%d.irap BASE_SURFACE:surf0.irap FORWARD_INIT:True",  # noqa
             True,
             1,
             "",
@@ -272,7 +273,9 @@ def test_initialize_random_seed(tmpdir, caplog, check_random_seed, expectation):
                 fh.writelines("MY_KEYWORD NORMAL 0 1")
             create_runpath("config.ert")
             # We read the first parameter value as a reference value
-            expected = Path("simulations/realization0/kw.txt").read_text("utf-8")
+            expected = Path("simulations/realization-0/iter-0/kw.txt").read_text(
+                "utf-8"
+            )
 
             # Make a clean directory for the second case, which is identical
             # to the first, except that it uses the random seed from the first
@@ -295,7 +298,7 @@ def test_initialize_random_seed(tmpdir, caplog, check_random_seed, expectation):
             create_runpath("config_2.ert")
             with expectation:
                 assert (
-                    Path("simulations/realization0/kw.txt").read_text("utf-8")
+                    Path("simulations/realization-0/iter-0/kw.txt").read_text("utf-8")
                     == expected
                 )
 

--- a/tests/libres_tests/res/enkf/config/test_gen_kw_config.py
+++ b/tests/libres_tests/res/enkf/config/test_gen_kw_config.py
@@ -185,5 +185,5 @@ def test_gen_kw_is_log_or_not(tmpdir, distribution, expect_log, parameters_regex
         ert.createRunPath(ert.create_ensemble_experiment_run_context(0))
         assert re.match(
             parameters_regex,
-            Path("simulations/realization0/parameters.txt").read_text(),
+            Path("simulations/realization-0/iter-0/parameters.txt").read_text(),
         )

--- a/tests/libres_tests/res/enkf/test_enkf_main.py
+++ b/tests/libres_tests/res/enkf/test_enkf_main.py
@@ -107,7 +107,8 @@ def test_create_run_context(monkeypatch, enkf_main):
     assert run_context.target_fs == enkf_main.getCurrentFileSystem()
     assert run_context.mask == [True] * ensemble_size
     assert run_context.paths == [
-        f"{Path().absolute()}/simulations/realization{i}" for i in range(ensemble_size)
+        f"{Path().absolute()}/simulations/realization-{i}/iter-0"
+        for i in range(ensemble_size)
     ]
     assert run_context.jobnames == [f"name{i}" for i in range(ensemble_size)]
 

--- a/tests/libres_tests/res/enkf/test_enkf_transfer_env.py
+++ b/tests/libres_tests/res/enkf/test_enkf_transfer_env.py
@@ -28,7 +28,7 @@ def test_transfer_var():
 
     run_context = ert.create_ensemble_experiment_run_context(iteration=0)
     ert.createRunPath(run_context)
-    os.chdir("simulations/realization0")
+    os.chdir("simulations/realization-0/iter-0")
     with open("jobs.json", "r") as f:
         data = json.load(f)
         env_data = data["global_environment"]

--- a/tests/libres_tests/res/enkf/test_runpaths.py
+++ b/tests/libres_tests/res/enkf/test_runpaths.py
@@ -177,5 +177,5 @@ def test_assert_export():
     assert runpath_list_file.name == "test_runpath_list.txt"
     assert (
         runpath_list_file.read_text("utf-8")
-        == f"000  {os.getcwd()}/simulations/realization0  a_name_0  000\n"
+        == f"000  {os.getcwd()}/simulations/realization-0/iter-0  a_name_0  000\n"
     )

--- a/tests/libres_tests/test_integration_config.py
+++ b/tests/libres_tests/test_integration_config.py
@@ -42,5 +42,5 @@ def test_num_cpu_subst(monkeypatch, tmp_path, append, numcpu):
     enkf_main = EnKFMain(config)
     _create_runpath(enkf_main)
 
-    with open("simulations/realization0/jobs.json") as f:
+    with open("simulations/realization-0/iter-0/jobs.json") as f:
         assert f'"argList" : ["{numcpu}"]' in f.read()


### PR DESCRIPTION
**Issue**
Resolves #3600


**Approach**

The default runpath did not create separate directories for each iteration, which create surprising behavior if e.g. realizations fail.

It is still possible to keep the behavior of the previous default runpath by explicitly setting it in the config file ie.

    RUNPATH simulations/realization%d


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
