### PR TITLE
Simplify ert config builder

### DIFF
--- a/tests/ert_tests/storage/test_extraction.py
+++ b/tests/ert_tests/storage/test_extraction.py
@@ -10,10 +10,8 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
 
+from ert import LibresFacade
 from ert._c_wrappers.enkf import RunContext
-from ert._c_wrappers.enkf.enkf_main import EnKFMain
-from ert._c_wrappers.enkf.res_config import ResConfig
-from ert.libres_facade import LibresFacade
 from ert.shared.storage import extraction
 
 
@@ -68,15 +66,7 @@ class ErtConfigBuilder:
         self._build_observations(path)
         self._build_priors(path)
 
-        config = ResConfig(str(path / "test.ert"))
-        enkfmain = EnKFMain(config)
-
-        # The C code doesn't do resource counting correctly, so we need to hook
-        # ResConfig to EnKFMain because otherwise ResConfig will be deleted and
-        # EnKFMain will use a dangling pointer.
-        enkfmain.__config = config  # pylint: disable=unused-private-member
-
-        return LibresFacade(enkfmain)
+        return LibresFacade.from_config_file(str(path / "test.ert"))
 
     def _build_ert(self, path):
         f = (path / "test.ert").open("w")


### PR DESCRIPTION
The workaround for keeping res_config around together with enkf_main has not been needed for a long while, now res_config no longer has a c struct to keep around. Also, we can get and LibresFacade directly from config file.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
