### PR TITLE
Fix test_config_parsing generation and site config

### DIFF
--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -267,18 +267,22 @@ def config_dicts(draw):
     should_exist_files.append(config_dict[ConfigKeys.DATA_FILE])
     should_exist_files.append(config_dict[ConfigKeys.JOB_SCRIPT])
 
-    should_be_executable_files = []
+    should_be_executable_files = [
+        job[ConfigKeys.PATH] for job in config_dict[ConfigKeys.INSTALL_JOB]
+    ]
     should_be_executable_files.append(config_dict[ConfigKeys.JOB_SCRIPT])
+
+    config_dict[ConfigKeys.JOB_SCRIPT] = os.path.abspath(
+        config_dict[ConfigKeys.JOB_SCRIPT]
+    )
 
     for filename in should_exist_files:
         if not os.path.isfile(filename):
-            print(f"touch {filename}")
             touch(filename)
 
     should_exist_directories = config_dict[ConfigKeys.INSTALL_JOB_DIRECTORY]
     for dirname in should_exist_directories:
         if not os.path.isdir(dirname):
-            print(f"mkdir {dirname}")
             os.mkdir(dirname)
 
     for filename in should_be_executable_files:

--- a/tests/test_config_parsing/conftest.py
+++ b/tests/test_config_parsing/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture()
+def set_site_config(monkeypatch, tmp_path):
+    test_site_config = tmp_path / "test_site_config.ert"
+    test_site_config.write_text("JOB_SCRIPT job_dispatch.py\nQUEUE_SYSTEM LOCAL\n")
+    monkeypatch.setenv("ERT_SITE_CONFIG", str(test_site_config))

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -8,8 +8,7 @@ from ert._c_wrappers.enkf import ConfigKeys, ResConfig
 from .config_dict_generator import config_dicts, to_config_file
 
 
-@pytest.mark.skip(reason="https://github.com/equinor/ert/issues/2571")
-@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 @given(config_dicts())
 def test_queue_config_dict_same_as_from_file(config_dict):
     cwd = os.getcwd()


### PR DESCRIPTION
**Issue**
Resolves #2571 


**Approach**

This fixes the config data generation so that 1) It generates valid input for queue_config and 2) It sets `ERT_SITE_CONFIG` so that we can inject a minimal site config to avoid system defaults being picked up.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
