### PR TITLE
Fix ext joblist

### DIFF
--- a/src/clib/lib/include/ert/job_queue/ext_joblist.hpp
+++ b/src/clib/lib/include/ert/job_queue/ext_joblist.hpp
@@ -27,7 +27,4 @@ void ext_joblist_add_jobs_in_directory(ext_joblist_type *joblist,
                                        const char *license_root_path,
                                        bool user_mode, bool search_path);
 extern "C" int ext_joblist_get_size(const ext_joblist_type *joblist);
-
-extern "C" hash_type *ext_joblist_get_jobs(const ext_joblist_type *joblist);
-
 #endif

--- a/src/clib/lib/job_queue/ext_joblist.cpp
+++ b/src/clib/lib/job_queue/ext_joblist.cpp
@@ -115,10 +115,6 @@ bool ext_joblist_del_job(ext_joblist_type *joblist, const char *job_name) {
         return false;
 }
 
-hash_type *ext_joblist_get_jobs(const ext_joblist_type *joblist) {
-    return joblist->jobs;
-}
-
 void ext_joblist_add_jobs_in_directory(ext_joblist_type *joblist,
                                        const char *path,
                                        const char *license_root_path,

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -1,8 +1,8 @@
 import os.path
-from typing import List
+from typing import Dict, List, Optional
 
 from cwrap import BaseCClass
-from ecl.util.util import StringHash, StringList
+from ecl.util.util import StringList
 
 from ert._c_wrappers import ResPrototype
 from ert._c_wrappers.config import ContentTypeEnum
@@ -19,7 +19,7 @@ class ExtJob(BaseCClass):
     _set_private_args_as_string = ResPrototype(
         "void ext_job_set_private_args_from_string(ext_job, char*)"
     )
-    _is_private = ResPrototype("int ext_job_is_private(ext_job)")
+    _is_private = ResPrototype("bool ext_job_is_private(ext_job)")
     _get_config_file = ResPrototype("char* ext_job_get_config_file(ext_job)")
     _set_config_file = ResPrototype("void ext_job_set_config_file(ext_job, char*)")
     _get_stdin_file = ResPrototype("char* ext_job_get_stdin_file(ext_job)")
@@ -61,7 +61,12 @@ class ExtJob(BaseCClass):
     _save = ResPrototype("void ext_job_save(ext_job)")
 
     def __init__(
-        self, config_file, private, name=None, license_root_path=None, search_PATH=True
+        self,
+        config_file: str,
+        private: bool,
+        name: Optional[str] = None,
+        license_root_path: Optional[str] = None,
+        search_PATH: bool = True,
     ):
         if os.path.isfile(config_file):
             if name is None:
@@ -88,22 +93,22 @@ class ExtJob(BaseCClass):
         else:
             return "UNINITIALIZED ExtJob"
 
-    def set_private_args_as_string(self, args):
+    def set_private_args_as_string(self, args: str):
         self._set_private_args_as_string(args)
 
     def get_help_text(self):
         return self._get_help_text()
 
-    def is_private(self):
+    def is_private(self) -> bool:
         return self._is_private()
 
-    def get_config_file(self):
+    def get_config_file(self) -> str:
         return self._get_config_file()
 
-    def set_config_file(self, config_file):
+    def set_config_file(self, config_file: str):
         self._set_config_file(config_file)
 
-    def get_stdin_file(self):
+    def get_stdin_file(self) -> str:
         return self._get_stdin_file()
 
     def set_stdin_file(self, filename):
@@ -115,54 +120,52 @@ class ExtJob(BaseCClass):
     def set_stdout_file(self, filename):
         self._set_stdout_file(filename)
 
-    def get_stderr_file(self):
+    def get_stderr_file(self) -> str:
         return self._get_stderr_file()
 
-    def set_stderr_file(self, filename):
+    def set_stderr_file(self, filename: str):
         self._set_stderr_file(filename)
 
-    def get_target_file(self):
+    def get_target_file(self) -> str:
         return self._get_target_file()
 
-    def set_target_file(self, filename):
+    def set_target_file(self, filename: str):
         self._set_target_file(filename)
 
-    def get_executable(self):
+    def get_executable(self) -> str:
         return self._get_executable()
 
-    def set_executable(self, executable):
+    def set_executable(self, executable: str):
         self._set_executable(executable)
 
-    def get_max_running(self):
+    def get_max_running(self) -> int:
         return self._get_max_running()
 
-    def set_max_running(self, max_running):
+    def set_max_running(self, max_running: int):
         self._set_max_running(max_running)
 
-    def get_error_file(self):
+    def get_error_file(self) -> str:
         return self._get_error_file()
 
-    def get_start_file(self):
+    def get_start_file(self) -> str:
         return self._get_start_file()
 
-    def get_max_running_minutes(self):
+    def get_max_running_minutes(self) -> int:
         return self._get_max_running_minutes()
 
-    def set_max_running_minutes(self, min_value):
+    def set_max_running_minutes(self, min_value: int):
         self._set_max_running_minutes(min_value)
 
     @property
-    def min_arg(self):
+    def min_arg(self) -> int:
         return self._min_arg()
 
     @property
-    def max_arg(self):
+    def max_arg(self) -> int:
         return self._max_arg()
 
     @property
     def arg_types(self) -> List[ContentTypeEnum]:
-        """@rtype: list of type"""
-
         result = []
         for index in range(self.max_arg):
             result.append(self._arg_type(index))
@@ -170,32 +173,30 @@ class ExtJob(BaseCClass):
         return result
 
     @staticmethod
-    def valid_args(arg_types, arg_list, runtime=False):
+    def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
         for index, arg_type in enumerate(arg_types):
             arg = arg_list[index]
             if not arg_type.valid_string(arg, runtime):
                 return False
             return True
 
-    def get_environment(self) -> StringHash:
-        return self._get_environment()
+    def get_environment(self) -> Dict[str, str]:
+        return dict(**self._get_environment())
 
-    def set_environment(self, key, value):
+    def set_environment(self, key: str, value: str):
         self._set_environment(key, value)
 
-    def get_license_path(self):
+    def get_license_path(self) -> Optional[str]:
         return self._get_license_path()
 
-    def get_arglist(self):
-        # The return type is cast from a <StringList> to a regular Python list.
+    def get_arglist(self) -> List[str]:
         return list(self._get_arglist())
 
-    def get_argvalues(self):
-        # The return type is cast from a <StringList> to a regular Python list.
+    def get_argvalues(self) -> List[str]:
         return list(self._get_argvalues())
 
-    def set_arglist(self, args: StringList):
-        return self._set_arglist(args)
+    def set_arglist(self, args: List[str]):
+        return self._set_arglist(StringList(args))
 
     def clear_environment(self):
         self._clear_environment()
@@ -209,10 +210,10 @@ class ExtJob(BaseCClass):
     def name(self) -> str:
         return self._get_name()
 
-    def __ne__(self, other):
+    def __ne__(self, other: "ExtJob") -> bool:
         return not self == other
 
-    def __eq__(self, other):
+    def __eq__(self, other: "ExtJob") -> bool:
         if self.name() != other.name():
             return False
 

--- a/src/ert/_c_wrappers/job_queue/ext_joblist.py
+++ b/src/ert/_c_wrappers/job_queue/ext_joblist.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
@@ -14,18 +16,16 @@ class ExtJoblist(BaseCClass):
     _del_job = ResPrototype("int ext_joblist_del_job(ext_joblist, char*)")
     _has_job = ResPrototype("int ext_joblist_has_job(ext_joblist, char*)")
     _add_job = ResPrototype("void ext_joblist_add_job(ext_joblist, char*, ext_job)")
-    _get_jobs = ResPrototype("hash_ref ext_joblist_get_jobs(ext_joblist)")
     _size = ResPrototype("int ext_joblist_get_size(ext_joblist)")
 
     def __init__(self):
         c_ptr = self._alloc()
         super().__init__(c_ptr)
 
-    def get_jobs(self):
-        """@rtype: Hash"""
-        jobs = self._get_jobs()
-        jobs.setParent(self)
-        return jobs
+    def get_jobs(self) -> Dict[str, ExtJob]:
+        return {
+            job_name: self.get_job(job_name) for job_name in self.getAvailableJobNames()
+        }
 
     def __len__(self):
         return self._size()

--- a/tests/libres_tests/res/job_queue/test_ext_job.py
+++ b/tests/libres_tests/res/job_queue/test_ext_job.py
@@ -127,3 +127,15 @@ def test_valid_args():
     run_arg_list = ["Trjue", "76"]
     assert ExtJob.valid_args(run_arg_types, run_arg_list)
     assert not ExtJob.valid_args(run_arg_types, run_arg_list, True)
+
+
+def test_ext_job_optionals(tmp_path):
+    executable = tmp_path / "exec"
+    executable.write_text("")
+    st = os.stat(executable)
+    os.chmod(executable, st.st_mode | stat.S_IEXEC)
+    config_file = tmp_path / "config_file"
+    config_file.write_text("EXECUTABLE exec\n")
+    ext_job = ExtJob(str(config_file), False)
+    assert ext_job.get_license_path() == None
+    assert ext_job.name() == "config_file"


### PR DESCRIPTION
**Issue**
As a part of #4003 we need to have a consistent ExtJoblist. This PR fixes its operators and the `get_jobs()` function.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
