### PR TITLE
Validate jobname as a required keyword

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -42,6 +42,11 @@ add_single_arg_keyword(config_parser_type *config_parser, std::string keyword) {
     return item;
 }
 
+static void add_jobname_keyword(config_parser_type *config_parser) {
+    auto item = config_add_schema_item(config_parser, JOBNAME_KEY, true);
+    config_schema_item_set_argc_minmax(item, 1, 1);
+}
+
 static void add_num_realizations_keyword(config_parser_type *config_parser) {
     auto item =
         config_add_schema_item(config_parser, NUM_REALIZATIONS_KEY, true);
@@ -317,7 +322,7 @@ ERT_CLIB_SUBMODULE("config_keywords", m) {
             add_path_keyword(config_parser, RUNPATH_KEY);
             add_path_keyword(config_parser, DATA_ROOT_KEY);
             add_path_keyword(config_parser, ENSPATH_KEY);
-            add_single_arg_keyword(config_parser, JOBNAME_KEY);
+            add_jobname_keyword(config_parser);
             add_forward_model_keyword(config_parser);
             add_simulation_job_keyword(config_parser);
             add_data_kw_keyword(config_parser);

--- a/tests/libres_tests/res/enkf/test_res_config.py
+++ b/tests/libres_tests/res/enkf/test_res_config.py
@@ -624,6 +624,18 @@ def test_that_unknown_queue_option_gives_error_message(monkeypatch, tmp_path, ca
     assert "UNKNOWN_QUEUE" in err
 
 
+def test_that_missing_jobname_gives_error_message(tmp_path, capsys):
+    test_user_config = tmp_path / "user_config.ert"
+    test_user_config.write_text("NUM_REALIZATIONS 10\n")
+
+    with pytest.raises(ValueError, match="Parsing"):
+        _ = ResConfig(str(test_user_config))
+
+    err = capsys.readouterr().err
+    assert "Errors parsing" in err
+    assert "JOBNAME" in err
+
+
 @pytest.mark.parametrize(
     "run_mode",
     [


### PR DESCRIPTION
config files without jobname would before give a bad error message. This commit makes it a required keyword and gives an early error message.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
