### PR TITLE
Fix bug where extra case is created when running ies

### DIFF
--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -169,6 +169,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         prior_context: Optional[RunContext] = None,
         rerun: bool = False,
     ) -> RunContext:
+
         target_case_format = self._simulation_arguments["target_case"]
 
         sim_fs = self.createTargetCaseFileSystem(itr, target_case_format)
@@ -182,7 +183,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
             )
             mask = sim_fs.getStateMap().createMask(state)
 
-        if rerun:
+        if rerun or itr >= self.facade.get_number_of_iterations():
             target_fs = None
         else:
             target_fs = self.createTargetCaseFileSystem(itr + 1, target_case_format)


### PR DESCRIPTION
**Issue**
Resolves #3949


**Approach**
Avoid creating target_fs when running the last ensemble in ies

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
