### PR TITLE
Fix missing config_node free function

### DIFF
--- a/src/clib/lib/include/ert/config/config_content_node.hpp
+++ b/src/clib/lib/include/ert/config/config_content_node.hpp
@@ -20,7 +20,7 @@ void config_content_node_set(config_content_node_type *node,
 char *
 config_content_node_alloc_joined_string(const config_content_node_type *node,
                                         const char *sep);
-void config_content_node_free(config_content_node_type *node);
+extern "C" void config_content_node_free(config_content_node_type *node);
 void config_content_node_free__(void *arg);
 extern "C" const char *
 config_content_node_get_full_string(const config_content_node_type *node,

--- a/src/ert/_c_wrappers/config/config_content.py
+++ b/src/ert/_c_wrappers/config/config_content.py
@@ -48,6 +48,8 @@ class ContentNode(BaseCClass):
         "time_t config_content_node_iget_as_isodate( content_node , int)"
     )
 
+    _free = ResPrototype("void config_content_node_free( content_node )")
+
     typed_get = {
         ContentTypeEnum.CONFIG_STRING: _iget_as_string,
         ContentTypeEnum.CONFIG_INT: _iget_as_int,
@@ -103,6 +105,9 @@ class ContentNode(BaseCClass):
     def igetString(self, index):
         index = self.__assertIndex(index)
         return self._iget(index)
+
+    def free(self):
+        self._free()
 
 
 class ContentItem(BaseCClass):


### PR DESCRIPTION
ConfigNode was missing a free method which would cause an unhandled exception during 
gc.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
