### PR TITLE
Extend description of libres facade

### DIFF
--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
 
 
 class LibresFacade:  # pylint: disable=too-many-public-methods
-    """Facade for libres inside ERT."""
+    """The intention of this class is to expose properties or data of ert
+    commonly used in other project. It is part of the public interface of ert,
+    and as such changes here should not be taken lightly."""
 
     def __init__(self, enkf_main: EnKFMain):
         self._enkf_main = enkf_main


### PR DESCRIPTION
As part of recent changes to ecl config, someone (this guy (*μ_μ) ) removed the functions for getting a grid and grid file from libres facase, as they weren't used anywhere in ert.

This PR adds a more descriptive docstring, explaining the public api nature of libres facade. it's probably no silver bullet, because there's no guarantee that people working on it will read the docstring, but it's perhaps a start.

we could also add tests that have appropriate names, something along the lines of `test_libres_facade_API_exposes_[SOME_METHOD]` - then when someone wants to remove the test, it might hint that hey this is part of an API and should maybe not be removed.

let me know if i should add such tests within this PR.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
