### PR TITLE
Job runner yields Running event only when memory consumption has significant change

### DIFF
--- a/src/_ert_job_runner/cli.py
+++ b/src/_ert_job_runner/cli.py
@@ -7,7 +7,7 @@ import sys
 import typing
 
 from _ert_job_runner import reporting
-from _ert_job_runner.reporting.message import Finish
+from _ert_job_runner.reporting.message import Finish, RunningNoMemChange
 from _ert_job_runner.runner import JobRunner
 
 JOBS_FILE = "jobs.json"
@@ -97,6 +97,8 @@ def main(args):
     job_runner = JobRunner(jobs_data)
 
     for job_status in job_runner.run(parsed_args.job):
+        if isinstance(job_status, RunningNoMemChange):
+            continue
         logger.info(f"Job status: {job_status}")
         for reporter in reporters:
             reporter.report(job_status)

--- a/src/_ert_job_runner/reporting/message.py
+++ b/src/_ert_job_runner/reporting/message.py
@@ -83,6 +83,10 @@ class Running(Message):
         self.current_memory_usage = current_memory_usage
 
 
+class RunningNoMemChange(Running):
+    pass
+
+
 class Exited(Message):
     def __init__(self, job, exit_code):
         super().__init__(job)

--- a/src/_ert_job_runner/runner.py
+++ b/src/_ert_job_runner/runner.py
@@ -62,7 +62,6 @@ class JobRunner:
         for job in job_queue:
             for status_update in job.run():
                 yield status_update
-
                 if not status_update.success():
                     yield Finish().with_error("Not all jobs completed successfully.")
                     return

--- a/tests/libres_tests/job_runner/test_job.py
+++ b/tests/libres_tests/job_runner/test_job.py
@@ -4,7 +4,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 
 from _ert_job_runner.job import Job
-from _ert_job_runner.reporting.message import Exited, Running, Start
+from _ert_job_runner.reporting.message import Exited, Running, RunningNoMemChange, Start
 
 
 @patch("_ert_job_runner.job.assert_file_executable")
@@ -27,6 +27,39 @@ def test_run_with_process_failing(
     exited = next(run)
     assert isinstance(exited, Exited), "run did not yield Exited message"
     assert exited.exit_code == 9, "Exited message had unexpected exit code"
+
+    with pytest.raises(StopIteration):
+        next(run)
+
+
+@patch("_ert_job_runner.job.assert_file_executable")
+@patch("_ert_job_runner.job.Popen")
+@patch("_ert_job_runner.job.Process")
+@pytest.mark.usefixtures("use_tmpdir")
+def test_run_with_memory_consumption_increase(
+    mock_process, mock_popen, mock_assert_file_executable
+):
+    job = Job({}, 0)
+    type(mock_process.return_value.memory_info.return_value).rss = PropertyMock(
+        return_value=10
+    )
+    mock_process.return_value.wait.return_value = None
+
+    run = job.run()
+
+    assert isinstance(next(run), Start), "run did not yield Start message"
+    assert isinstance(next(run), Running), "run did not yield Running message"
+    assert isinstance(
+        next(run), RunningNoMemChange
+    ), "run did not yield RunningNoMemChange message"
+    type(mock_process.return_value.memory_info.return_value).rss = PropertyMock(
+        return_value=job.MEMORY_INCREASE_THRESHOLD + 10
+    )
+    assert isinstance(next(run), Running), "run did not yield Running message"
+    mock_process.return_value.wait.return_value = 1
+    exited = next(run)
+    assert isinstance(exited, Exited), "run did not yield Exited message"
+    assert exited.exit_code == 1, "Exited message had unexpected exit code"
 
     with pytest.raises(StopIteration):
         next(run)


### PR DESCRIPTION
Job runner yields `Running` event only when memory consumption has significant change. If there is a small change job runner yields `RunningNoMemChange` instead.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
