### PR TITLE
Use requires window manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,11 +119,19 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
-        test-type: ['integration-tests', 'unit-tests']
+        test-type: ['integration-tests', 'unit-tests', 'gui-test']
         # Excluded to keep build times down on Github actions
         exclude:
           - os: macos-latest
             python-version: '3.9'
+          - os: macos-latest
+            test-type: 'gui-test'
+          - os: ubuntu-latest
+            python-version: '3.9'
+            test-type: 'gui-test'
+          - os: ubuntu-latest
+            python-version: '3.10'
+            test-type: 'gui-test'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -132,6 +140,7 @@ jobs:
         fetch-depth: 0
 
     - uses: './.github/actions/install_dependencies'
+      if: matrix.test-type == 'gui-test'
       with:
         os: ${{ matrix.os }}
 
@@ -149,37 +158,39 @@ jobs:
         find . -name "*.whl" -exec pip install {} \;
         pip install -r dev-requirements.txt
 
-    - name: Test Ubuntu
-      if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit-tests'
+    - name: Test GUI
+      if: matrix.test-type == 'gui-test'
       env:
         DISPLAY: ':99.0'
       run: |
         ci/github/start_herbstluftwm.sh &
         sleep 5
         pushd tests
-        pytest ert_tests -sv --durations=0 -m "not integration_test"
+        pytest ert_tests -sv -m "requires_window_manager"
+
+    - name: Test Ubuntu
+      if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit-tests'
+      run: |
+        pushd tests
+        pytest ert_tests -sv -m "not integration_test and not requires_window_manager"
 
     - name: Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'unit-tests'
       run: |
         pushd tests
-        pytest ert_tests -sv --durations=0 -m "not integration_test"
+        pytest ert_tests -sv -m "not integration_test and not requires_window_manager"
 
     - name: Integration Test Ubuntu
       if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'integration-tests'
-      env:
-        DISPLAY: ':99.0'
       run: |
-        ci/github/start_herbstluftwm.sh &
-        sleep 5
         pushd tests
-        pytest ert_tests performance_tests -sv --durations=5 -m "integration_test"
+        pytest ert_tests performance_tests -sv --durations=5 -m "integration_test and not requires_window_manager"
 
     - name: Integration Test MacOS
       if: matrix.os == 'macos-latest' && matrix.test-type == 'integration-tests'
       run: |
         pushd tests
-        pytest ert_tests performance_tests -sv --durations=5 -m "integration_test"
+        pytest ert_tests performance_tests -sv --durations=5 -m "integration_test and not requires_window_manager"
 
     - name: Test for a clean repository
       run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,11 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
+    for item in items:
+        fixtures = getattr(item, "fixturenames", ())
+        if "qtbot" in fixtures or "qtmodeltester" in fixtures:
+            item.add_marker("requires_window_manager")
+
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
         skip_quick = pytest.mark.skip(

--- a/tests/ert_tests/gui/model/test_job_list.py
+++ b/tests/ert_tests/gui/model/test_job_list.py
@@ -48,6 +48,7 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     qtmodeltester.check(model, force_py=True)
 
 
+@pytest.mark.requires_window_manager
 def test_changes(full_snapshot):
     source_model = SnapshotModel()
 
@@ -87,6 +88,7 @@ def test_changes(full_snapshot):
     )
 
 
+@pytest.mark.requires_window_manager
 @pytest.mark.parametrize("timezone", [(None), (tz.gettz("UTC"))])
 @patch("ert.gui.model.snapshot.datetime", wraps=datetime)
 def test_duration(mock_datetime, timezone, full_snapshot):
@@ -136,6 +138,7 @@ def test_duration(mock_datetime, timezone, full_snapshot):
     mock_datetime.datetime.now.assert_called_once_with(timezone)
 
 
+@pytest.mark.requires_window_manager
 def test_no_cross_talk(full_snapshot):
     source_model = SnapshotModel()
 

--- a/tests/ert_tests/gui/model/test_progress_proxy.py
+++ b/tests/ert_tests/gui/model/test_progress_proxy.py
@@ -1,3 +1,4 @@
+import pytest
 from PyQt5.QtCore import QModelIndex
 from pytestqt.qt_compat import qt_api
 
@@ -32,6 +33,7 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     qtmodeltester.check(model, force_py=True)
 
 
+@pytest.mark.requires_window_manager
 def test_progression(full_snapshot):
     source_model = SnapshotModel()
     model = ProgressProxyModel(source_model, parent=None)
@@ -58,6 +60,7 @@ def test_progression(full_snapshot):
     }
 
 
+@pytest.mark.requires_window_manager
 def test_progression_start_iter_not_zero(full_snapshot):
     source_model = SnapshotModel()
     model = ProgressProxyModel(source_model, parent=None)

--- a/tests/ert_tests/gui/run_analysis/test_run_analysis.py
+++ b/tests/ert_tests/gui/run_analysis/test_run_analysis.py
@@ -26,6 +26,7 @@ def mock_tool():
         yield tool
 
 
+@pytest.mark.requires_window_manager
 @patch("ert.gui.tools.run_analysis.run_analysis_tool.analyse", return_value=None)
 @patch("ert.gui.tools.run_analysis.run_analysis_tool.QMessageBox")
 def test_show_dialogue_at_success(mock_messagebox, mock_analyse, mock_tool):
@@ -43,6 +44,7 @@ def test_show_dialogue_at_success(mock_messagebox, mock_analyse, mock_tool):
     mock_tool._dialog.accept.assert_called_once_with()
 
 
+@pytest.mark.requires_window_manager
 @patch(
     "ert.gui.tools.run_analysis.run_analysis_tool.analyse",
     side_effect=ErtAnalysisError("some error"),

--- a/tests/ert_tests/gui/simulation/view/test_realization.py
+++ b/tests/ert_tests/gui/simulation/view/test_realization.py
@@ -1,4 +1,3 @@
-import pytest
 from qtpy import QtCore
 from qtpy.QtCore import QModelIndex, QSize
 from qtpy.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
@@ -21,7 +20,6 @@ class MockDelegate(QStyledItemDelegate):
         return self._size
 
 
-@pytest.mark.requires_window_manager
 def test_delegate_drawing_count(small_snapshot, qtbot):
     it = 0
     widget = RealizationWidget(it)
@@ -50,7 +48,6 @@ def test_delegate_drawing_count(small_snapshot, qtbot):
         )
 
 
-@pytest.mark.requires_window_manager
 def test_selection_success(large_snapshot, qtbot):
     it = 0
     widget = RealizationWidget(it)

--- a/tests/ert_tests/gui/test_gui_load.py
+++ b/tests/ert_tests/gui/test_gui_load.py
@@ -94,6 +94,7 @@ def test_gui_load(qtbot, patch_enkf_main):
     assert sim_panel.getCurrentSimulationModel() == ensemble_panel.getSimulationModel()
 
 
+@pytest.mark.requires_window_manager
 def test_gui_full(monkeypatch, tmp_path, qapp, mock_start_server, source_root):
     shutil.copytree(
         os.path.join(source_root, "test-data", "poly_example"),
@@ -113,6 +114,7 @@ def test_gui_full(monkeypatch, tmp_path, qapp, mock_start_server, source_root):
     )
 
 
+@pytest.mark.requires_window_manager
 def test_that_loading_gui_creates_a_single_storage_folder(
     monkeypatch, tmp_path, qapp, source_root
 ):


### PR DESCRIPTION
By using the `requires_window_manger` mark, we do not need to install and start `herbsluftwm` before starting unit tests. Gui tests are ran on a separate runner. Saving about 1.5 minute total.
