### PR TITLE
Make sim panel run dialogs parent

### DIFF
--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -128,7 +128,6 @@ class SimulationPanel(QWidget):
         )
 
         if start_simulations == QMessageBox.Yes:
-
             arguments = self.getSimulationArguments()
             dialog = RunDialog(
                 self._config_file,
@@ -139,11 +138,13 @@ class SimulationPanel(QWidget):
                     arguments,
                     str(uuid.uuid4()),
                 ),
+                parent=self
             )
             dialog.startSimulation()
             dialog.exec_()
 
             self.notifier.emitErtChange()  # simulations may have added new cases
+
 
     def toggleSimulationMode(self):
         current_model = self.getCurrentSimulationModel()


### PR DESCRIPTION
This will make it impossible to run multiple simulations at once.

**Issue**
Resolves #3817


**Approach**

One possible approach is to make the simulation panel be the parent of the run dialog.
This means that by default at least, you have to close the run dialog to be able to run another simulation.
Probably too restrictive so will investigate other approaches.

<img width="1312" alt="Screenshot 2022-10-14 at 15 08 36 1" src="https://user-images.githubusercontent.com/45088507/195855185-e23ff159-3bfe-41b8-b000-4943ddce7911.png">



## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
