### PR TITLE
Disable "Start simulation" button while running simulations

### DIFF
--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -140,8 +140,12 @@ class SimulationPanel(QWidget):
                     str(uuid.uuid4()),
                 ),
             )
+            self.run_button.setDisabled(True)
+            self.run_button.setText("Simulation running...")
             dialog.startSimulation()
             dialog.exec_()
+            self.run_button.setText("Start simulation")
+            self.run_button.setDisabled(False)
 
             self.notifier.emitErtChange()  # simulations may have added new cases
 

--- a/tests/ert_tests/gui/test_gui_load.py
+++ b/tests/ert_tests/gui/test_gui_load.py
@@ -1,11 +1,11 @@
 import argparse
 import os
 import shutil
-from unittest.mock import Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QDialog, QMessageBox, QWidget
 
 import ert.gui
 from ert.gui.ertnotifier import ErtNotifier
@@ -164,6 +164,41 @@ def test_gui_iter_num(monkeypatch, qtbot, patch_enkf_main):
     start_simulation = gui.findChild(QWidget, name="start_simulation")
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
     assert sim_panel.getSimulationArguments().iter_num == 10
+
+
+def test_start_simulation_disabled(monkeypatch, qtbot, patch_enkf_main):
+    args_mock = Mock()
+    type(args_mock).config = PropertyMock(return_value="config.ert")
+
+    dummy_run_dialog = QDialog(None)
+
+    setattr(dummy_run_dialog, "startSimulation", lambda *args: None)
+
+    monkeypatch.setattr(
+        ert.gui.simulation.simulation_panel.QMessageBox,
+        "question",
+        lambda *args: QMessageBox.Yes,
+    )
+    monkeypatch.setattr(
+        ert.gui.simulation.simulation_panel, "RunDialog", lambda *args: dummy_run_dialog
+    )
+    monkeypatch.setattr(
+        ert.gui.simulation.simulation_panel, "create_model", lambda *args: None
+    )
+
+    notifier = MagicMock()
+    gui = _start_window(patch_enkf_main, notifier, args_mock, GUILogHandler())
+    qtbot.addWidget(gui)
+
+    start_simulation = gui.findChild(QWidget, name="start_simulation")
+
+    def handle_dialog():
+        assert not start_simulation.isEnabled()
+        dummy_run_dialog.accept()
+
+    QTimer.singleShot(10, handle_dialog)
+    qtbot.mouseClick(start_simulation, Qt.LeftButton)
+    assert start_simulation.isEnabled()
 
 
 def test_dialog(qtbot):


### PR DESCRIPTION
**Issue**
Resolves #3817


**Approach**
Sets the "Start simulation" button as disabled while the run dialog is open. Alternative to https://github.com/equinor/ert/pull/4078


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
