### PR TITLE
log_process_usage in finally rather than atexit

### DIFF
--- a/src/ert/shared/main.py
+++ b/src/ert/shared/main.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 import logging.config
 import os
@@ -479,7 +478,6 @@ def start_ert_server(mode: str):
         yield
 
 
-@atexit.register
 def log_process_usage():
     try:
         import resource
@@ -563,6 +561,7 @@ def main():
 
         sys.exit(msg)
     finally:
+        log_process_usage()
         os.environ.pop("ERT_LOG_DIR")
 
 


### PR DESCRIPTION
Simply importing ert.shared.main should not have the side-effect of logging things when you exit Python. This may also solve some race conditions where the logging sink is closed before we try to log using this function.