### PR TITLE
Show loading cursor when loading from runpath

### DIFF
--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -1,4 +1,4 @@
-from ert.gui.ertwidgets import resourceIcon
+from ert.gui.ertwidgets import resourceIcon, showWaitCursorWhileWaiting
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.load_results import LoadResultsPanel
@@ -26,7 +26,10 @@ class LoadResultsTool(Tool):
         self.__dialog.addButton("Load", self.load)
         self.__dialog.exec_()
 
-    def load(self):
+    @showWaitCursorWhileWaiting
+    def load(self, _):
+        self.__dialog.disableCloseButton()
+        self.__dialog.toggleButton(caption="Load", enabled=False)
         self.__import_widget.load()
         self.__dialog.accept()
 


### PR DESCRIPTION
**Issue**
Resolves #4091


**Approach**
Add loading cursor and disable buttons.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
