### PR TITLE
Remove HistorySourceEnum.SCHEDULE

### DIFF
--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -95,13 +95,6 @@ class ModelConfig(BaseCClass):
                 "Error: Unable to create ModelConfig with multiple config objects"
             )
 
-        hist_src_enum = ModelConfig._get_history_src_enum(config_dict, config_content)
-        if hist_src_enum == HistorySourceEnum.SCHEDULE:
-            raise ValueError(
-                f"{HistorySourceEnum.SCHEDULE} as "
-                f"{ConfigKeys.HISTORY_SOURCE} is not supported"
-            )
-
         if config_dict is None:
             c_ptr = self._alloc(config_content, data_root, joblist, refcase)
         else:

--- a/src/ert/_c_wrappers/sched/history_source_enum.py
+++ b/src/ert/_c_wrappers/sched/history_source_enum.py
@@ -3,13 +3,11 @@ from cwrap import BaseCEnum
 
 class HistorySourceEnum(BaseCEnum):
     TYPE_NAME = "history_source_enum"
-    SCHEDULE = None
     REFCASE_SIMULATED = None
     REFCASE_HISTORY = None
     HISTORY_SOURCE_INVALID = None
 
 
-HistorySourceEnum.addEnum("SCHEDULE", 0)
 HistorySourceEnum.addEnum("REFCASE_SIMULATED", 1)
 HistorySourceEnum.addEnum("REFCASE_HISTORY", 2)
 HistorySourceEnum.addEnum("HISTORY_SOURCE_INVALID", 10)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
@@ -106,15 +106,3 @@ def test_model_config_dict_constructor(setup_case):
             ],
         },
     )
-
-
-def test_schedule_file_as_history_is_disallowed(setup_case):
-    with pytest.raises(ValueError) as cm:
-        setup_case("configuration_tests", "sched_file_as_history_source.ert")
-
-        # Any assert should per the unittest documentation be outside the
-        # scope of the assertRaises with-block.
-        assert (
-            f"{HistorySourceEnum.SCHEDULE} as "
-            f"{ConfigKeys.HISTORY_SOURCE} is not supported"
-        ) in str(cm.exception)


### PR DESCRIPTION
**Issue**
SCHEDULE is not allowed to be used as a history source


**Approach**
Remove it!


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
