### PR TITLE
Move Eclipse Grid and Refcase to EnsembleConfig

### DIFF
--- a/src/clib/lib/enkf/model_config.cpp
+++ b/src/clib/lib/enkf/model_config.cpp
@@ -171,16 +171,6 @@ const char *model_config_get_enspath(const model_config_type *model_config) {
     return model_config->enspath;
 }
 
-const ecl_sum_type *
-model_config_get_refcase(const model_config_type *model_config) {
-    return model_config->refcase;
-}
-
-void model_config_set_refcase(model_config_type *model_config,
-                              const ecl_sum_type *refcase) {
-    model_config->refcase = refcase;
-}
-
 history_source_type
 model_config_get_history_source(const model_config_type *model_config) {
     return model_config->history;
@@ -348,7 +338,7 @@ void model_config_init(model_config_type *model_config,
     model_config->forward_model = forward_model_alloc(joblist);
     const subst_list_type *define_list =
         config_content_get_const_define_list(config);
-    model_config_set_refcase(model_config, refcase);
+    model_config->refcase = refcase;
     model_config_set_default_data_root(model_config, data_root);
 
     if (config_content_has_item(config, NUM_REALIZATIONS_KEY))

--- a/src/clib/lib/include/ert/enkf/model_config.hpp
+++ b/src/clib/lib/include/ert/enkf/model_config.hpp
@@ -36,8 +36,6 @@ void model_config_set_enspath(model_config_type *model_config,
                               const char *enspath);
 extern "C" const char *
 model_config_get_enspath(const model_config_type *model_config);
-const ecl_sum_type *
-model_config_get_refcase(const model_config_type *model_config);
 bool model_config_has_prediction(const model_config_type *);
 extern "C" PY_USED bool
 model_config_has_history(const model_config_type *config);
@@ -71,8 +69,6 @@ extern "C" const char *
 model_config_get_runpath_as_char(const model_config_type *model_config);
 extern "C" PY_USED history_source_type
 model_config_get_history_source(const model_config_type *model_config);
-void model_config_set_refcase(model_config_type *model_config,
-                              const ecl_sum_type *refcase);
 model_config_type *model_config_alloc_empty();
 extern "C" model_config_type *model_config_alloc(const config_content_type *,
                                                  const char *data_root,

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -62,8 +62,8 @@ class EnKFMain:
         self._observations = EnkfObs(
             config.model_config.get_history_source(),
             config.model_config.get_time_map(),
-            config.ecl_config.grid,
-            config.ecl_config.refcase,
+            config.ensemble_config.grid,
+            config.ensemble_config.refcase,
             config.ensemble_config,
         )
         if config.model_config.obs_config_file:
@@ -379,9 +379,9 @@ class EnKFMain:
             case = self.storage_manager[case_name]
         except KeyError:
             case = self.storage_manager.add_case(case_name)
-        if self.res_config.ecl_config.refcase:
+        if self.res_config.ensemble_config.refcase:
             time_map = case.getTimeMap()
-            time_map.attach_refcase(self.res_config.ecl_config.refcase)
+            time_map.attach_refcase(self.res_config.ensemble_config.refcase)
         return case
 
     def caseExists(self, case_name: str) -> bool:

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -11,7 +11,7 @@ from ert._c_wrappers import ResPrototype
 from ert._c_wrappers.config import ConfigContent
 from ert._c_wrappers.enkf.config import EnkfConfigNode
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
-from ert._c_wrappers.enkf.enums import EnkfVarType, ErtImplType
+from ert._c_wrappers.enkf.enums import EnkfVarType, ErtImplType, GenDataFileType
 
 
 def _get_abs_path(file):

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -245,11 +245,7 @@ class ResConfig:
             for template in user_config_content[ConfigKeys.RUN_TEMPLATE]:
                 self._templates.append(list(template))
 
-        self.ensemble_config = EnsembleConfig(
-            config_content=user_config_content,
-            grid=self.ecl_config.grid,
-            refcase=self.ecl_config.refcase,
-        )
+        self.ensemble_config = EnsembleConfig(config_content=user_config_content)
 
         for key in self.ensemble_config.getKeylistFromImplType(ErtImplType.GEN_KW):
             if self.ensemble_config.getNode(key).get_init_file_fmt() != None:
@@ -261,7 +257,7 @@ class ResConfig:
         self.model_config = ModelConfig(
             data_root=self.config_path,
             joblist=self.site_config.job_list,
-            refcase=self.ecl_config.refcase,
+            refcase=self.ensemble_config.refcase,
             config_content=user_config_content,
         )
 
@@ -322,11 +318,7 @@ class ResConfig:
         for source_file, target_file, *_ in templates:
             self._templates.append([os.path.abspath(source_file), target_file])
 
-        self.ensemble_config = EnsembleConfig(
-            grid=self.ecl_config.grid,
-            refcase=self.ecl_config.refcase,
-            config_dict=config_dict,
-        )
+        self.ensemble_config = EnsembleConfig(config_dict=config_dict)
 
         for key in self.ensemble_config.getKeylistFromImplType(ErtImplType.GEN_KW):
             if self.ensemble_config.getNode(key).get_init_file_fmt() != None:
@@ -338,7 +330,7 @@ class ResConfig:
         self.model_config = ModelConfig(
             data_root=self.config_path,
             joblist=self.site_config.job_list,
-            refcase=self.ecl_config.refcase,
+            refcase=self.ensemble_config.refcase,
             config_dict=config_dict,
         )
 
@@ -652,7 +644,6 @@ class ResConfig:
             (self.analysis_config == other.analysis_config),
             (self.ert_workflow_list == other.ert_workflow_list),
             (self.ert_templates == other.ert_templates),
-            (self.ecl_config == other.ecl_config),
             (self.ensemble_config == other.ensemble_config),
             (self.model_config == other.model_config),
             (self.queue_config == other.queue_config),
@@ -677,7 +668,6 @@ class ResConfig:
             f"AnalysisConfig: {self.analysis_config},\n"
             f"ErtWorkflowList: {self.ert_workflow_list},\n"
             f"ErtTemplates: {self.ert_templates},\n"
-            f"EclConfig: {self.ecl_config},\n"
             f"EnsembleConfig: {self.ensemble_config},\n"
             f"ModelConfig: {self.model_config},\n"
             f"QueueConfig: {self.queue_config}"

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -98,11 +98,11 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
 
     @property
     def grid_file(self) -> Optional[str]:
-        return self._enkf_main.eclConfig()._grid_file
+        return self._enkf_main.ensembleConfig().get_grid_file
 
     @property
     def grid(self) -> Optional[EclGrid]:
-        return self._enkf_main.eclConfig().grid
+        return self._enkf_main.ensembleConfig().grid
 
     def export_field_parameter(
         self, parameter_name: str, case_name: str, filepath: str
@@ -472,7 +472,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         return misfit_data
 
     def refcase_data(self, key: str) -> DataFrame:
-        refcase = self._enkf_main.eclConfig().refcase
+        refcase = self._enkf_main.ensembleConfig().refcase
 
         if refcase is None or key not in refcase:
             return DataFrame()

--- a/test-data/row_scaling/workflows/scripts/row_scaling_job1.py
+++ b/test-data/row_scaling/workflows/scripts/row_scaling_job1.py
@@ -31,7 +31,7 @@ class RowScalingJob1(ErtScript):
         field_config = poro_config.getFieldModelConfig()
 
         # -------------------------------------------------------------------------------------
-        grid = main.eclConfig().grid
+        grid = ens_config.grid
         obs_pos = grid.get_xyz(ijk=(5, 5, 1))
         length_scale = (2, 1, 0.50)
         gaussian = partial(gaussian_decay, obs_pos, length_scale, grid)

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -7,6 +7,7 @@ import hypothesis.strategies as st
 from hypothesis import assume
 
 from ert._c_wrappers.enkf import ConfigKeys
+from ert._c_wrappers.enkf.enums import GenDataFileType
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.util.enums import MessageLevelEnum
 
@@ -30,16 +31,37 @@ def define_keys(draw):
 
 
 def touch(filename):
-    with open(filename, "w") as fh:
+    with open(file=filename, mode="w", encoding="utf-8") as fh:
         fh.write(" ")
 
 
 file_names = words
+format_file_names = st.builds(lambda file_name: file_name + "-%d", file_names)
 
 
 @st.composite
 def directory_names(draw):
     return "dir" + draw(words)
+
+
+transforms = st.sampled_from(
+    [
+        "DENORMALIZE_PERMX",
+        "NORMALIZE_PORO",
+        "LN",
+        "LOG10",
+        "EXP0",
+        "LOG",
+        "EXP",
+        "TRUNC_POW10",
+        "LN0",
+        "DENORMALIZE_PORO",
+        "NORMALIZE_PERMZ",
+        "NORMALIZE_PERMX",
+        "DENORMALIZE_PERMZ",
+        "POW10",
+    ]
+)
 
 
 small_floats = st.floats(min_value=1.0, max_value=10.0, allow_nan=False)
@@ -74,6 +96,7 @@ def queue_name(queue_driver):
         return "TORQUE"
     if queue_driver == QueueDriverEnum.SLURM_DRIVER:
         return "SLURM"
+    raise ValueError(f"unexpected driver `{queue_driver}`")
 
 
 def valid_queue_options(queue_system):
@@ -176,8 +199,8 @@ def valid_queue_values(option_name):
 
 
 @st.composite
-def queue_options(draw, queue_systems):
-    queue_system = draw(queue_systems)
+def queue_options(draw, systems):
+    queue_system = draw(systems)
     name = draw(st.sampled_from(valid_queue_options(queue_system)))
     do_set = draw(st.booleans())
     if do_set:
@@ -220,6 +243,40 @@ def config_dicts(draw):
                 ConfigKeys.DATA_FILE: st.just(draw(file_names) + ".DATA"),
                 ConfigKeys.GRID: st.just(draw(words) + ".EGRID"),
                 ConfigKeys.JOB_SCRIPT: st.just(draw(file_names) + "job_script"),
+                ConfigKeys.FIELD_KEY: st.lists(
+                    st.fixed_dictionaries(
+                        {
+                            ConfigKeys.NAME: words,
+                            ConfigKeys.VAR_TYPE: st.just("PARAMETER"),
+                            ConfigKeys.OUT_FILE: file_names,
+                            # ConfigKeys.ENKF_INFILE: file_names, only used in general
+                            ConfigKeys.FORWARD_INIT: st.booleans(),
+                            ConfigKeys.INIT_TRANSFORM: transforms,
+                            ConfigKeys.OUTPUT_TRANSFORM: transforms,
+                            # ConfigKeys.INPUT_TRANSFORM: func, only used in general
+                            ConfigKeys.MIN_KEY: small_floats,
+                            ConfigKeys.MAX_KEY: small_floats,
+                            ConfigKeys.INIT_FILES: file_names,
+                        }
+                    ),
+                    unique_by=lambda field_dict: field_dict[ConfigKeys.NAME],
+                ),
+                ConfigKeys.GEN_DATA: st.lists(
+                    st.fixed_dictionaries(
+                        {
+                            ConfigKeys.NAME: words,
+                            ConfigKeys.RESULT_FILE: format_file_names,
+                            ConfigKeys.INPUT_FORMAT: st.just(GenDataFileType.ASCII),
+                            ConfigKeys.REPORT_STEPS: st.lists(
+                                st.integers(min_value=0, max_value=100),
+                                min_size=2,
+                                unique=True,
+                            ),  # should this be sorted?!
+                        }
+                    ),
+                    unique_by=lambda field_dict: field_dict[ConfigKeys.NAME],
+                ),
+                # ConfigKeys.GEN_KW_TAG_FORMAT: TODO,
                 ConfigKeys.MAX_SUBMIT: positives,
                 ConfigKeys.NUM_CPU: positives,
                 ConfigKeys.QUEUE_SYSTEM: st.just(queue_system),
@@ -310,8 +367,8 @@ def config_dicts(draw):
     return config_dict
 
 
-def to_config_file(filename, config_dict):
-    with open(filename, "w+") as config:
+def to_config_file(filename, config_dict):  # pylint: disable=too-many-branches
+    with open(file=filename, mode="w+", encoding="utf-8") as config:
         config.write(
             f"{ConfigKeys.RUNPATH_FILE} {config_dict[ConfigKeys.RUNPATH_FILE]}\n"
         )
@@ -319,6 +376,70 @@ def to_config_file(filename, config_dict):
             if keyword == ConfigKeys.DATA_KW_KEY:
                 for define_key, define_value in keyword_value.items():
                     config.write(f"{keyword} {define_key} {define_value}\n")
+            elif keyword == ConfigKeys.FIELD_KEY:
+                # keyword_value is a list of dicts, each defining a field
+                for field_dict in keyword_value:
+                    config.write(
+                        " ".join(
+                            [
+                                keyword,
+                                field_dict.get(ConfigKeys.NAME, ""),
+                                field_dict.get(ConfigKeys.VAR_TYPE, ""),
+                                field_dict.get(ConfigKeys.OUT_FILE, ""),
+                                f"INIT_FILES:{field_dict.get(ConfigKeys.INIT_FILES)}"
+                                if ConfigKeys.INIT_FILES in field_dict
+                                else "",
+                                f"MIN:{field_dict.get(ConfigKeys.MIN_KEY)}"
+                                if ConfigKeys.MIN_KEY in field_dict
+                                else "",
+                                f"MAX:{field_dict.get(ConfigKeys.MAX_KEY)}"
+                                if ConfigKeys.MAX_KEY in field_dict
+                                else "",
+                                (
+                                    "OUTPUT_TRANSFORM:"
+                                    f"{field_dict.get(ConfigKeys.OUTPUT_TRANSFORM)}"
+                                )
+                                if ConfigKeys.OUTPUT_TRANSFORM in field_dict
+                                else "",
+                                (
+                                    "INIT_TRANSFORM:"
+                                    f"{field_dict.get(ConfigKeys.INIT_TRANSFORM)}"
+                                )
+                                if ConfigKeys.INIT_TRANSFORM in field_dict
+                                else "",
+                                (
+                                    "FORWARD_INIT:"
+                                    f"{field_dict.get(ConfigKeys.FORWARD_INIT)}"
+                                )
+                                if ConfigKeys.FORWARD_INIT in field_dict
+                                else "",
+                                field_dict.get(ConfigKeys.ENKF_INFILE, ""),
+                                field_dict.get(ConfigKeys.INPUT_TRANSFORM, ""),
+                            ]
+                        )
+                        + "\n"
+                    )
+            elif keyword == ConfigKeys.GEN_DATA:
+                # keyword_value is a list of dicts, each defining a field
+                for field_dict in keyword_value:
+                    report_steps_as_string = ",".join(
+                        map(str, field_dict.get(ConfigKeys.REPORT_STEPS))
+                    )
+                    config.write(
+                        " ".join(
+                            [
+                                keyword,
+                                field_dict.get(ConfigKeys.NAME, ""),
+                                f"RESULT_FILE:{field_dict.get(ConfigKeys.RESULT_FILE)}",
+                                (
+                                    "INPUT_FORMAT:"
+                                    f"{field_dict.get(ConfigKeys.INPUT_FORMAT)}"
+                                ),
+                                f"REPORT_STEPS:{report_steps_as_string}",
+                            ]
+                        )
+                        + "\n"
+                    )
             elif keyword == ConfigKeys.INSTALL_JOB_DIRECTORY:
                 for install_dir in keyword_value:
                     config.write(f"{keyword} {install_dir}\n")

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,0 +1,73 @@
+import os
+import os.path
+
+import pytest
+from hypothesis import given, settings
+
+from ert._c_wrappers.enkf import ConfigKeys, EnsembleConfig, ResConfig
+
+from .config_dict_generator import config_dicts, to_config_file
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@settings(print_blob=True)
+@given(config_dicts())
+def test_ensemble_config_works_without_grid(config_dict):
+    cwd = os.getcwd()
+    filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
+    # config_dict.pop(ConfigKeys.GRID)
+    to_config_file(filename, config_dict)
+    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
+
+    res_config_from_file = ResConfig(user_config_file=filename)
+    res_config_from_dict = ResConfig(config_dict=config_dict)
+
+    with open(filename, "r+") as file_handler:
+        print(file_handler.read())
+
+    print(config_dict[ConfigKeys.FIELD_KEY])
+    print(res_config_from_file.ensemble_config)
+    assert res_config_from_file.ensemble_config == res_config_from_dict.ensemble_config
+    # assert False
+
+
+@pytest.mark.skip(reason="github.com/equinor/ert/issues/4070")
+@pytest.mark.usefixtures("use_tmpdir")
+@given(config_dicts())
+def test_ensemble_config_errors_on_unknown_function_in_field(config_dict):
+    filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
+    if ConfigKeys.FIELD_KEY not in config_dict:
+        return
+    silly_function_name = "NORMALIZE_EGGS"
+    config_dict[ConfigKeys.FIELD_KEY][ConfigKeys.INIT_TRANSFORM] = silly_function_name
+    to_config_file(filename, config_dict)
+    with pytest.raises(
+        expected_exception=ValueError, match=f"unknown function.*{silly_function_name}"
+    ):
+        ResConfig(user_config_file=filename)
+
+
+@pytest.mark.skip(reason="github.com/equinor/ert/issues/4071")
+@pytest.mark.usefixtures("use_tmpdir")
+@given(config_dicts())
+def test_ensemble_config_errors_on_double_field(config_dict):
+    # TODO in the logs i see a doubled OUT_FILE, not two fields with equal
+    # name, as i first suspected - figure out what's going on here!
+    filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
+    if ConfigKeys.FIELD_KEY not in config_dict:
+        return
+    # TODO manipulate FIELD to be degenerate in the desired way
+    to_config_file(filename, config_dict)
+    with pytest.raises(
+        expected_exception=ValueError, match="TODO this should be a meaningful message"
+    ):
+        ResConfig(user_config_file=filename)
+
+
+@pytest.mark.skip(reason="github.com/equinor/ert/issues/4072")
+@pytest.mark.usefixtures("use_tmpdir")
+@given(config_dicts())
+def test_ensemble_config_gen_data_report_steps_and_gen_obs_restart_dependency(
+    config_dict,
+):
+    pass

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -33,10 +33,10 @@ from ert._c_wrappers.enkf.observations.summary_observation import SummaryObserva
 @pytest.mark.unstable
 def test_ecl_config_creation(minimum_case):
     assert isinstance(minimum_case.analysisConfig(), AnalysisConfig)
-    assert isinstance(minimum_case.eclConfig(), EclConfig)
+    assert isinstance(minimum_case.ensembleConfig(), EnsembleConfig)
 
     with pytest.raises(AssertionError):  # Null pointer!
-        assert isinstance(minimum_case.eclConfig().refcase, EclSum)
+        assert isinstance(minimum_case.ensembleConfig().refcase, EclSum)
 
     file_system = minimum_case.getEnkfFsManager().getCurrentFileSystem()
     assert file_system.getCaseName() == "default"

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_obs.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_obs.py
@@ -63,8 +63,8 @@ def test_that_correct_key_observation_is_loaded(extra_config, expected):
     observations = EnkfObs(
         res_config.model_config.get_history_source(),
         res_config.model_config.get_time_map(),
-        res_config.ecl_config.grid,
-        res_config.ecl_config.refcase,
+        res_config.ensemble_config.grid,
+        res_config.ensemble_config.refcase,
         res_config.ensemble_config,
     )
     observations.load(

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -83,6 +83,7 @@ def test_ensemble_config_constructor(setup_case):
                     ConfigKeys.PARAMETER_KEY: None,
                 }
             ],
+            ConfigKeys.GRID: "grid/CASE.EGRID",  # ecl
+            # ConfigKeys.REFCASE: "../input/refcase/SNAKE_OIL_FIELD",  # ecl
         },
-        grid=res_config.ecl_config.grid,
     )

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -87,3 +87,39 @@ def test_ensemble_config_constructor(setup_case):
             # ConfigKeys.REFCASE: "../input/refcase/SNAKE_OIL_FIELD",  # ecl
         },
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_ensemble_config_fails_on_non_sensical_refcase_file():
+    refcase_file = "CEST_PAS_UNE_REFCASE"
+    refcase_file_content = """
+_________________________________________     _____    ____________________
+\\______   \\_   _____/\\_   _____/\\_   ___ \\   /  _  \\  /   _____/\\_   _____/
+ |       _/|    __)_  |    __)  /    \\  \\/  /  /_\\  \\ \\_____  \\  |    __)_
+ |    |   \\|        \\ |     \\   \\     \\____/    |    \\/        \\ |        \\
+ |____|_  /_______  / \\___  /    \\______  /\\____|__  /_______  //_______  /
+        \\/        \\/      \\/            \\/         \\/        \\/         \\/
+"""
+    with open(refcase_file, "w+", encoding="utf-8") as refcase_file_handler:
+        refcase_file_handler.write(refcase_file_content)
+    with pytest.raises(expected_exception=IOError, match=refcase_file):
+        config_dict = {ConfigKeys.REFCASE: refcase_file}
+        EnsembleConfig(config_dict=config_dict)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_ensemble_config_fails_on_non_sensical_grid_file():
+    grid_file = "BRICKWALL"
+    # NB: this is just silly ASCII content, not even close to a correct GRID file
+    grid_file_content = """
+_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
+___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|__
+_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
+___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|__
+_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
+"""
+    with open(grid_file, "w+", encoding="utf-8") as grid_file_handler:
+        grid_file_handler.write(grid_file_content)
+    with pytest.raises(expected_exception=ValueError, match=grid_file):
+        config_dict = {ConfigKeys.GRID: grid_file}
+        EnsembleConfig(config_dict=config_dict)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
@@ -72,7 +72,7 @@ def test_model_config_dict_constructor(setup_case):
     assert res_config.model_config == ModelConfig(
         data_root="",
         joblist=res_config.site_config.job_list,
-        refcase=res_config.ecl_config.refcase,
+        refcase=res_config.ensemble_config.refcase,
         config_dict={
             ConfigKeys.MAX_RESAMPLE: 1,
             ConfigKeys.JOBNAME: "model_config_test",

--- a/tests/unit_tests/c_wrappers/res/enkf/test_row_scaling_case.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_row_scaling_case.py
@@ -468,7 +468,7 @@ TIME_MAP timemap.txt
         ens_config = main.ensembleConfig()
         poro_config = ens_config["PORO"]
         field_config = poro_config.getFieldModelConfig()
-        grid = main.eclConfig().grid
+        grid = main.ensembleConfig().grid
         row_scaling.assign(field_config.get_data_size(), ScalingTest(grid))
         es_update = ESUpdate(main)
         update_fs = main.getEnkfFsManager().getFileSystem("target2")


### PR DESCRIPTION
Resolves #4035 

Moved files and filenames for grid and refcase from Ecl config to EnsembleConfig.
Copies existing tests that cover grid and refcase contents.
Adds repr and eq functionality for comparisons.

Once this passes, and refactor num_cpu https://github.com/equinor/ert/pull/4056/, we can consider removing ecl_config altogether.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
