### PR TITLE
Revert summary keys and remove deprecation of DATA_FILE in version 4.0

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -98,11 +98,12 @@ These keywords must be set to make ERT function properly.
 .. _data_file:
 .. topic:: DATA_FILE
 
-        ``DATA_FILE`` has been deprecated, use: :ref:`RUN_TEMPLATE <run_template>` instead
         Name of the template ECLIPSE data file used to control the simulations.
         A modified realization specific version of this file will be prepared by ERT,
         named according to :ref:`ECLBASE <ECLBASE>` and copied to the runpath
-        folder.
+        folder. Note that support for parsing the ECLIPSE data file is limited,
+        and using explicit templating with :ref:`RUN_TEMPLATE <run_template>` is
+        recommended.
 
 
         *Example:*
@@ -112,16 +113,23 @@ These keywords must be set to make ERT function properly.
                 -- Load the data file called ECLIPSE.DATA
                 DATA_FILE ECLIPSE.DATA
 
-        Necessary preparations to this file include:
+        See the ``DATA_KW`` keyword which can be used to utilize more template
+        functionality in the eclipse datafile.
 
-        1. Insert ``INCLUDE`` statements to include the various uncertainty
-           parameters in use at the right place in the datafile.
+        This is used to replace ERT magic strings into the data file, as well as
+        update the number of cpus that are reserved for ERT in the queue system.
 
-        2. Make sure that the include files used in the datafiles can be
-           correctly resolved from the runpath location.
+        It searches for PARALLEL in the data file, and if that is not found it
+        will search for SLAVE and update <NUM_CPU> according to how many nodes are
+        found, note that it does *not* parse the data files of the nodes, and will
+        assume one cpu per node.
 
-        3. See the ``DATA_KW`` keyword which can be used to utilize more template
-           functionality in the eclipse datafile.
+        It is strongly recommended to use the :ref:`RUN_TEMPLATE <run_template>`
+        for magic string replacement and resource allocation instead. Combined
+        with :ref:`NUM_CPU <num_cpu>` the resources for the cluster are specified
+        directly in the ERT configuration, and can be templated into the ECLIPSE
+        data file, see  :ref:`RUN_TEMPLATE <run_template>`.
+
 
 
 
@@ -584,6 +592,23 @@ possible to do with ERT.
 
                 ECLBASE BASE_ECL_NAME-<IENS>
                 RUN_TEMPLATE MY_DATA_FILE.DATA <ECLBASE>.DATA
+
+
+
+        To control the number of CPUs that are reserved for ECLIPSE use `RUN_TEMPLATE` with
+        :ref:`NUM_CPU <num_cpu>` and keep them in sync:
+
+        ::
+
+                NUM_CPU 4
+                ECLBASE BASE_ECL_NAME-<IENS>
+                RUN_TEMPLATE MY_DATA_FILE.DATA <ECLBASE>.DATA
+
+        In the ECLIPSE data file:
+
+        ::
+
+                PARALLEL <NUM_CPU>
 
 
 Keywords controlling the simulations

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -198,6 +198,8 @@ class EnKFMain:
     def storage(self, file_system):
         self.addDataKW("<ERT-CASE>", file_system.getCaseName())
         self.addDataKW("<ERTCASE>", file_system.getCaseName())
+        for key in file_system.getSummaryKeySet().keys():
+            self.ensembleConfig().add_summary(key)
         if self.config_file.ecl_config.getRefcase():
             time_map = file_system.getTimeMap()
             time_map.attach_refcase(self.config_file.ecl_config.getRefcase())

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -14,7 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import os
-import warnings
 from os.path import isfile
 from typing import Any, Dict, Optional
 
@@ -32,13 +31,6 @@ from ert._c_wrappers.enkf.queue_config import QueueConfig
 from ert._c_wrappers.enkf.site_config import SiteConfig
 from ert._c_wrappers.enkf.subst_config import SubstConfig
 from ert._clib.config_keywords import init_res_config_parser
-
-
-def format_warning_message(message, category, *args, **kwargs):
-    return f"{category.__name__}: {message}\n"
-
-
-warnings.formatwarning = format_warning_message
 
 
 class ResConfig:
@@ -140,12 +132,6 @@ class ResConfig:
             # This replicates the behavior of the DATA_FILE implementation
             # in C, it adds the .DATA extension and facilitates magic string
             # replacement in the data file
-            warning = (
-                "DATA_FILE is deprecated and will be removed, use: "
-                "RUN_TEMPLATE MY_DATA_FILE.DATA <ECLBASE>.DATA instead if you "
-                "want to template magic strings into the data file"
-            )
-            warnings.warn(warning, DeprecationWarning)
             source_file = config_content[ConfigKeys.DATA_FILE]
             target_file = config_content[ConfigKeys.ECLBASE]
             target_file = target_file.getValue(0).replace("%d", "<IENS>")
@@ -192,12 +178,6 @@ class ResConfig:
             # This replicates the behavior of the DATA_FILE implementation
             # in C, it adds the .DATA extension and facilitates magic string
             # replacement in the data file
-            warning = (
-                "DATA_FILE is deprecated and will be removed, use: "
-                "RUN_TEMPLATE MY_DATA_FILE.DATA <ECLBASE>.DATA instead if you "
-                "want to template magic strings into the data file"
-            )
-            warnings.warn(warning, DeprecationWarning)
             source_file = config_dict[ConfigKeys.DATA_FILE]
             target_file = config_dict[ConfigKeys.ECLBASE].replace("%d", "<IENS>")
             self._templates.append(

--- a/tests/ert_tests/test_libres_facade.py
+++ b/tests/ert_tests/test_libres_facade.py
@@ -116,6 +116,7 @@ def test_all_data_type_keys(facade):
         "FWPRH",
         "FWPT",
         "FWPTH",
+        "TIME",
         "WGOR:OP1",
         "WGOR:OP2",
         "WGORH:OP1",

--- a/tests/libres_tests/res/enkf/test_key_manager.py
+++ b/tests/libres_tests/res/enkf/test_key_manager.py
@@ -5,7 +5,7 @@ def test_summary_keys(snake_oil_case):
     ert = snake_oil_case
     key_man = KeyManager(ert)
 
-    assert len(key_man.summaryKeys()) == 46
+    assert len(key_man.summaryKeys()) == 47
     assert "FOPT" in key_man.summaryKeys()
 
     assert len(key_man.summaryKeysWithObservations()) == 2

--- a/tests/libres_tests/res/enkf/test_summary_key_set.py
+++ b/tests/libres_tests/res/enkf/test_summary_key_set.py
@@ -85,4 +85,6 @@ def test_with_enkf_fs(copy_case):
     ensemble_config = ert.ensembleConfig()
 
     assert "FOPT" in ensemble_config
+    assert "WWCT" in ensemble_config
+    assert "WOPR" in ensemble_config
     assert "TCPU" not in ensemble_config


### PR DESCRIPTION
**Issue**
Reverting a commit to fix version 4.0, the underlying issue:  https://github.com/equinor/ert/issues/4096 still needs to be fixed for > 4.0, also removing deprecation of DATA_FILE


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
