### PR TITLE
Fix extjoblist eq

### DIFF
--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -210,10 +210,13 @@ class ExtJob(BaseCClass):
     def name(self) -> str:
         return self._get_name()
 
-    def __ne__(self, other: "ExtJob") -> bool:
+    def __ne__(self, other) -> bool:
         return not self == other
 
-    def __eq__(self, other: "ExtJob") -> bool:
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ExtJob):
+            return False
+
         if self.name() != other.name():
             return False
 

--- a/src/ert/_c_wrappers/job_queue/ext_joblist.py
+++ b/src/ert/_c_wrappers/job_queue/ext_joblist.py
@@ -66,5 +66,7 @@ class ExtJoblist(BaseCClass):
     def __repr__(self) -> str:
         return self._create_repr(f"size={len(self)}, joblist={self.get_jobs()}")
 
-    def __eq__(self, other: "ExtJoblist") -> bool:
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ExtJoblist):
+            return False
         return self.get_jobs() == other.get_jobs()

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ext_joblist.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ext_joblist.py
@@ -1,0 +1,5 @@
+from ert._c_wrappers.job_queue import ExtJoblist
+
+
+def test_that_eq_works_with_non_homogenous_lists():
+    assert [1, 2, 3, ExtJoblist()].index(ExtJoblist()) == 3


### PR DESCRIPTION
mypy was complaining about the typing of ext_joblist so it was changed.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
