### PR TITLE
Improve error message if a parameter is missing from storage

### DIFF
--- a/src/clib/lib/analysis/update.cpp
+++ b/src/clib/lib/analysis/update.cpp
@@ -60,6 +60,15 @@ void serialize_node(enkf_fs_type *fs, const enkf_config_node_type *config_node,
 
     enkf_node_type *node = enkf_node_alloc(config_node);
     node_id_type node_id = {.report_step = 0, .iens = iens};
+    try {
+        enkf_node_serialize(node, fs, node_id, active_list, A, row_offset,
+                            column);
+    } catch (const std::out_of_range &) {
+        std::string param_name = enkf_node_get_key(node);
+        enkf_node_free(node);
+        throw pybind11::key_error(
+            fmt::format("No parameter: {} in storage", param_name));
+    }
     enkf_node_serialize(node, fs, node_id, active_list, A, row_offset, column);
     enkf_node_free(node);
 }

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -128,9 +128,7 @@ def test_field_param(tmpdir, config_str, expected):
             )
             assert len(arr) == 16
         else:
-            # load_parameter should probably handle errors better than
-            # to throw an exception.
-            with pytest.raises(IndexError):
+            with pytest.raises(KeyError, match="No parameter: MY_PARAM in storage"):
                 fs.load_parameter(
                     ert.ensembleConfig(), [0], update.Parameter("MY_PARAM")
                 )
@@ -195,9 +193,7 @@ def test_surface_param(
             )
             assert len(arr) == 4
         else:
-            # load_parameter should probably handle errors better than
-            # to throw an exception.
-            with pytest.raises(IndexError):
+            with pytest.raises(KeyError, match="No parameter: MY_PARAM in storage"):
                 fs.load_parameter(
                     ert.ensembleConfig(), [0], update.Parameter("MY_PARAM")
                 )


### PR DESCRIPTION
**Issue**
Resolves #3871


**Approach**
Change error message from: `IndexError(__Map_base::at)` to including parameter name and some context.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
