### PR TITLE
Refactor num_cpu

### DIFF
--- a/src/clib/lib/enkf/subst_config.cpp
+++ b/src/clib/lib/enkf/subst_config.cpp
@@ -22,7 +22,8 @@ subst_config_install_config_directory(subst_config_type *subst_config,
                                       const char *user_config_file);
 
 static void subst_config_init_load(subst_config_type *subst_config,
-                                   const config_content_type *content);
+                                   const config_content_type *content,
+                                   int num_cpu);
 
 static subst_config_type *subst_config_alloc_empty() {
     subst_config_type *subst_config =
@@ -45,11 +46,12 @@ static subst_config_type *subst_config_alloc_default() {
     return subst_config;
 }
 
-subst_config_type *subst_config_alloc(const config_content_type *user_config) {
+subst_config_type *subst_config_alloc(const config_content_type *user_config,
+                                      int num_cpu) {
     subst_config_type *subst_config = subst_config_alloc_default();
 
     if (user_config)
-        subst_config_init_load(subst_config, user_config);
+        subst_config_init_load(subst_config, user_config, num_cpu);
 
     return subst_config;
 }
@@ -190,7 +192,8 @@ static void subst_config_install_data_kw(subst_config_type *subst_config,
 }
 
 static void subst_config_init_load(subst_config_type *subst_config,
-                                   const config_content_type *content) {
+                                   const config_content_type *content,
+                                   int num_cpu) {
 
     if (config_content_has_item(content, CONFIG_DIRECTORY_KEY)) {
         const char *work_dir =
@@ -223,21 +226,7 @@ static void subst_config_init_load(subst_config_type *subst_config,
         subst_config, "RUNPATH_FILE", runpath_file,
         "The name of a file with a list of run directories.");
 
-    if (config_content_has_item(content, DATA_FILE_KEY)) {
-        const char *data_file =
-            config_content_get_value_as_abspath(content, DATA_FILE_KEY);
-
-        if (!fs::exists(data_file))
-            util_abort("%s: Could not find ECLIPSE data file: %s\n", __func__,
-                       data_file ? data_file : "NULL");
-
-        int num_cpu = ecl_util_get_num_cpu(data_file);
-        subst_config_install_num_cpu(subst_config, num_cpu);
-    }
-
-    // The NUM_CPU keyword in the user's config overrides the one set by the DATA_FILE above
-    if (config_content_has_item(content, NUM_CPU_KEY)) {
-        int num_cpu = config_content_get_value_as_int(content, NUM_CPU_KEY);
+    if (num_cpu > 0) {
         subst_config_install_num_cpu(subst_config, num_cpu);
     }
 }

--- a/src/clib/lib/include/ert/enkf/subst_config.hpp
+++ b/src/clib/lib/include/ert/enkf/subst_config.hpp
@@ -1,12 +1,13 @@
 #ifndef ERT_SUBST_CONFIG_H
 #define ERT_SUBST_CONFIG_H
 
+#include <ert/config/config_content.hpp>
 #include <ert/tooling.hpp>
 
 typedef struct subst_config_struct subst_config_type;
 
 extern "C" subst_config_type *
-subst_config_alloc(const config_content_type *user_config);
+subst_config_alloc(const config_content_type *user_config, int num_cpu);
 extern "C" PY_USED subst_config_type *
 subst_config_alloc_full(const subst_list_type *define_list);
 extern "C" void subst_config_free(subst_config_type *subst_config);

--- a/src/ert/_c_wrappers/enkf/ecl_config.py
+++ b/src/ert/_c_wrappers/enkf/ecl_config.py
@@ -2,7 +2,6 @@ import os
 from typing import Optional, Union
 
 from ecl.ecl_util import EclFileEnum, get_file_type
-from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
 
@@ -12,11 +11,9 @@ from ert._c_wrappers.enkf.config_keys import ConfigKeys
 class EclConfig:
     def __init__(
         self,
-        data_file: Optional[str] = None,
         grid_file: Optional[str] = None,
         refcase_file: Optional[str] = None,
     ):
-        self._data_file = data_file
         self._grid_file = grid_file
         self._refcase_file = refcase_file
         self.grid = self._load_grid() if grid_file else None
@@ -24,16 +21,9 @@ class EclConfig:
 
     @classmethod
     def from_dict(cls, config_dict) -> "EclConfig":
-        data_file = _get_value(config_dict.get(ConfigKeys.DATA_FILE))
         grid_file = _get_value(config_dict.get(ConfigKeys.GRID))
         refcase_file = _get_value(config_dict.get(ConfigKeys.REFCASE))
-        return cls(data_file, grid_file, refcase_file)
-
-    @property
-    def num_cpu(self) -> Optional[int]:
-        if not self._data_file:
-            return None
-        return get_num_cpu_from_data_file(self._data_file)
+        return cls(grid_file, refcase_file)
 
     def _load_grid(self) -> Optional[EclGrid]:
         ecl_grid_file_types = [
@@ -59,23 +49,16 @@ class EclConfig:
     def __repr__(self):
         return (
             "EclConfig(\n"
-            f"\tdata_file={self._data_file},\n"
             f"\tgrid_file={self._grid_file},\n"
             f"\trefcase_file={self._refcase_file},\n"
             ")"
         )
 
     def __eq__(self, other):
-        if self._data_file != other._data_file:
-            return False
-
         if self._grid_file != other._grid_file:
             return False
 
         if self._refcase_file != other._refcase_file:
-            return False
-
-        if self.num_cpu != other.num_cpu:
             return False
 
         return True

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -257,13 +257,7 @@ class EnKFMain:
         return self.resConfig().queue_config
 
     def get_num_cpu(self) -> int:
-        queue_num_cpus = self.res_config.get_num_cpu()
-        if queue_num_cpus is not None:
-            return queue_num_cpus
-        ecl_num_cpus = self.eclConfig().num_cpu
-        if ecl_num_cpus is not None:
-            return ecl_num_cpus
-        return 1
+        return self.res_config.preferred_num_cpu()
 
     def __repr__(self):
         return f"EnKFMain(size: {self.getEnsembleSize()}, config: {self.res_config})"

--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -9,7 +9,6 @@ from ert._c_wrappers.job_queue import Driver, JobQueue, QueueDriverEnum
 class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
     max_submit: int = 2
-    num_cpu: int = 0
     queue_system: QueueDriverEnum = QueueDriverEnum.NULL_DRIVER
     queue_options: Dict[QueueDriverEnum, List[Union[Tuple[str, str], str]]] = field(
         default_factory=dict
@@ -33,7 +32,6 @@ class QueueConfig:
         return QueueConfig(
             self.job_script,
             self.max_submit,
-            self.num_cpu,
             QueueDriverEnum.LOCAL_DRIVER,
             self.queue_options,
         )

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -5,6 +5,7 @@ from os.path import isfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 from ecl.util.util import StringList
 
 from ert._c_wrappers.config import ConfigContent, ConfigParser
@@ -161,7 +162,22 @@ class ResConfig:
             logging.error(f"Error loading configuration: {str(self._errors)}")
             raise ValueError("Error loading configuration: " + str(self._errors))
 
-        self.subst_config = SubstConfig(config_content=user_config_content)
+        self.num_cpu_from_data_file = (
+            get_num_cpu_from_data_file(
+                user_config_content.getValue(ConfigKeys.DATA_FILE)
+            )
+            if user_config_content.hasKey(ConfigKeys.DATA_FILE)
+            else None
+        )
+        self.num_cpu_from_config = (
+            user_config_content.getValue(ConfigKeys.NUM_CPU)
+            if user_config_content.hasKey(ConfigKeys.NUM_CPU)
+            else None
+        )
+
+        self.subst_config = SubstConfig(
+            config_content=user_config_content, num_cpu=self.preferred_num_cpu()
+        )
         self.site_config = SiteConfig.from_config_content(
             user_config_content=user_config_content,
             site_config_content=site_config_content,
@@ -189,7 +205,6 @@ class ResConfig:
 
         set_value("job_script", ConfigKeys.JOB_SCRIPT)
         set_value("max_submit", ConfigKeys.MAX_SUBMIT)
-        set_value("num_cpu", ConfigKeys.NUM_CPU)
         set_value(
             "queue_system",
             ConfigKeys.QUEUE_SYSTEM,
@@ -276,7 +291,19 @@ class ResConfig:
             self.config_path = config_dict[ConfigKeys.CONFIG_DIRECTORY]
         config_dict[ConfigKeys.CONFIG_DIRECTORY] = self.config_path
 
-        self.subst_config = SubstConfig(config_dict=config_dict)
+        self.num_cpu_from_config = config_dict.get(ConfigKeys.NUM_CPU, None)
+        self.num_cpu_from_data_file = (
+            get_num_cpu_from_data_file(config_dict[ConfigKeys.DATA_FILE])
+            if (
+                ConfigKeys.DATA_FILE in config_dict
+                and os.path.exists(config_dict[ConfigKeys.DATA_FILE])
+            )
+            else None
+        )
+
+        self.subst_config = SubstConfig(
+            config_dict=config_dict, num_cpu=self.preferred_num_cpu()
+        )
         self.site_config = SiteConfig.from_config_dict(
             config_dict=config_dict, site_config_content=site_config_content
         )
@@ -288,8 +315,6 @@ class ResConfig:
             queue_config_args["job_script"] = config_dict[ConfigKeys.JOB_SCRIPT]
         if ConfigKeys.MAX_SUBMIT in config_dict:
             queue_config_args["max_submit"] = config_dict[ConfigKeys.MAX_SUBMIT]
-        if ConfigKeys.NUM_CPU in config_dict:
-            queue_config_args["num_cpu"] = config_dict[ConfigKeys.NUM_CPU]
         if ConfigKeys.QUEUE_SYSTEM in config_dict:
             queue_config_args["queue_system"] = config_dict[ConfigKeys.QUEUE_SYSTEM]
         queue_config_args["queue_options"] = defaultdict(list)
@@ -625,6 +650,13 @@ class ResConfig:
     def free(self):
         self._free()  # pylint: disable=no-member
 
+    def preferred_num_cpu(self) -> int:
+        if self.num_cpu_from_config is not None:
+            return self.num_cpu_from_config
+        if self.num_cpu_from_data_file is not None:
+            return self.num_cpu_from_data_file
+        return 1
+
     @property
     def errors(self):
         return self._errors
@@ -637,18 +669,14 @@ class ResConfig:
     def ert_templates(self):
         return self._templates
 
-    def get_num_cpu(self) -> Optional[int]:
-        queue_num_cpu = self.queue_config.num_cpu
-        if queue_num_cpu == 0:
-            return None
-        return queue_num_cpu
-
     def __eq__(self, other):
         # compare each config separatelly
         config_eqs = (
             (self.subst_config == other.subst_config),
             (self.site_config == other.site_config),
             (self.random_seed == other.random_seed),
+            (self.num_cpu_from_config == other.num_cpu_from_config),
+            (self.num_cpu_from_data_file == other.num_cpu_from_data_file),
             (self.analysis_config == other.analysis_config),
             (self.ert_workflow_list == other.ert_workflow_list),
             (self.ert_templates == other.ert_templates),
@@ -674,6 +702,8 @@ class ResConfig:
             f"SubstConfig: {self.subst_config},\n"
             f"SiteConfig: {self.site_config},\n"
             f"RandomSeed: {self.random_seed},\n"
+            f"Config Num CPUs: {self.num_cpu_from_config},\n"
+            f"Data File Num CPUs: {self.num_cpu_from_data_file},\n"
             f"AnalysisConfig: {self.analysis_config},\n"
             f"ErtWorkflowList: {self.ert_workflow_list},\n"
             f"ErtTemplates: {self.ert_templates},\n"

--- a/src/ert/_c_wrappers/enkf/subst_config.py
+++ b/src/ert/_c_wrappers/enkf/subst_config.py
@@ -1,7 +1,7 @@
 import os.path
+from typing import Optional
 
 from cwrap import BaseCClass
-from ecl import EclPrototype
 
 from ert._c_wrappers import ResPrototype
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
@@ -10,15 +10,16 @@ from ert._c_wrappers.util import SubstitutionList
 
 class SubstConfig(BaseCClass):
     TYPE_NAME = "subst_config"
-    _alloc = ResPrototype("void* subst_config_alloc(config_content)", bind=False)
+    _alloc = ResPrototype("void* subst_config_alloc(config_content,int)", bind=False)
     _alloc_full = ResPrototype("void* subst_config_alloc_full(subst_list)", bind=False)
     _free = ResPrototype("void  subst_config_free(subst_config)")
     _get_subst_list = ResPrototype(
         "subst_list_ref subst_config_get_subst_list( subst_config )"
     )
-    _get_num_cpu = EclPrototype("int ecl_util_get_num_cpu(char*)", bind=False)
 
-    def __init__(self, config_content=None, config_dict=None):
+    def __init__(
+        self, config_content=None, config_dict=None, num_cpu: Optional[int] = None
+    ):
         if not (config_content is not None) ^ (config_dict is not None):
             raise ValueError(
                 "SubstConfig must be instansiated with exactly one"
@@ -76,33 +77,18 @@ class SubstConfig(BaseCClass):
                 runpath_file_path,
                 "The name of a file with a list of run directories.",
             )
-
-            if ConfigKeys.NUM_CPU in config_dict:
+            if num_cpu is not None:
                 subst_list.addItem(
                     "<NUM_CPU>",
-                    str(config_dict[ConfigKeys.NUM_CPU]),
+                    str(num_cpu),
                     "The number of CPU used for one forward model.",
                 )
-            # Read num_cpu from Eclipse DATA_FILE
-            elif ConfigKeys.DATA_FILE in config_dict:
-                file_path = os.path.join(
-                    config_directory, config_dict[ConfigKeys.DATA_FILE]
-                )
-
-                if os.path.isfile(file_path) and os.access(file_path, os.R_OK):
-                    num_cpu = self._get_num_cpu(file_path)
-                    subst_list.addItem(
-                        "<NUM_CPU>",
-                        str(num_cpu),
-                        "The number of CPU used for one forward model.",
-                    )
-                else:
-                    raise IOError(f"Could not find ECLIPSE data file: {file_path}")
 
             c_ptr = self._alloc_full(subst_list)
 
         else:
-            c_ptr = self._alloc(config_content)
+            num_cpu_as_int = num_cpu if num_cpu is not None else 0
+            c_ptr = self._alloc(config_content, num_cpu_as_int)
 
         if c_ptr is None:
             raise ValueError("Failed to construct Substonfig instance")

--- a/tests/test_config_parsing/test_num_cpu.py
+++ b/tests/test_config_parsing/test_num_cpu.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from ert._c_wrappers.enkf import ConfigKeys, EnKFMain, ResConfig
@@ -5,46 +7,45 @@ from ert._c_wrappers.enkf import ConfigKeys, EnKFMain, ResConfig
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_default_num_cpu():
-    config_dict = {ConfigKeys.NUM_REALIZATIONS: 1}
+    config_num_cpu = 1
+    config_dict = {ConfigKeys.NUM_REALIZATIONS: config_num_cpu}
     res_config = ResConfig(config_dict=config_dict)
     enkf_main = EnKFMain(res_config)
-    assert enkf_main.get_num_cpu() == 1
+    assert enkf_main.get_num_cpu() == config_num_cpu
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_num_cpu_from_queue_config_preferred():
+def test_num_cpu_from_config_preferred():
     data_file = "dfile"
-    queue_num_cpu = 17
-    ecl_num_cpu = 4
+    config_num_cpu = 17
+    data_file_num_cpu = 4
     with open(data_file, "w") as data_file_hander:
         data_file_hander.write(
-            f"""
-PARALLEL
- {ecl_num_cpu} DISTRIBUTED/
+            f"""PARALLEL
+ {data_file_num_cpu} DISTRIBUTED/
 """
         )
     config_dict = {
         ConfigKeys.NUM_REALIZATIONS: 1,
-        ConfigKeys.NUM_CPU: queue_num_cpu,
-        ConfigKeys.DATA_FILE: data_file,
+        ConfigKeys.NUM_CPU: config_num_cpu,
+        ConfigKeys.DATA_FILE: os.path.join(os.getcwd(), data_file),
     }
     res_config = ResConfig(config_dict=config_dict)
     enkf_main: EnKFMain = EnKFMain(res_config)
-    assert enkf_main.get_queue_config().num_cpu == queue_num_cpu
-    assert enkf_main.eclConfig().num_cpu == ecl_num_cpu
-    assert queue_num_cpu == enkf_main.get_num_cpu()
+    assert enkf_main.resConfig().num_cpu_from_config == config_num_cpu
+    assert enkf_main.resConfig().num_cpu_from_data_file == data_file_num_cpu
+    assert enkf_main.get_num_cpu() == config_num_cpu
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_num_cpu_from_ecl_used_if_queue_num_cpu_not_set():
+def test_num_cpu_from_data_file_used_if_config_num_cpu_not_set():
     data_file = "dfile"
-    default_queue_num_cpu = 0
-    ecl_num_cpu = 4
+    data_file_num_cpu = 4
     with open(data_file, "w") as data_file_hander:
         data_file_hander.write(
             f"""
 PARALLEL
- {ecl_num_cpu} DISTRIBUTED/
+ {data_file_num_cpu} DISTRIBUTED/
 """
         )
     config_dict = {
@@ -53,6 +54,6 @@ PARALLEL
     }
     res_config = ResConfig(config_dict=config_dict)
     enkf_main: EnKFMain = EnKFMain(res_config)
-    assert enkf_main.get_queue_config().num_cpu == default_queue_num_cpu
-    assert enkf_main.eclConfig().num_cpu == ecl_num_cpu
-    assert ecl_num_cpu == enkf_main.get_num_cpu()
+    assert enkf_main.resConfig().num_cpu_from_config is None
+    assert enkf_main.resConfig().num_cpu_from_data_file == data_file_num_cpu
+    assert enkf_main.get_num_cpu() == data_file_num_cpu

--- a/tests/test_config_parsing/test_num_cpu.py
+++ b/tests/test_config_parsing/test_num_cpu.py
@@ -19,7 +19,7 @@ def test_num_cpu_from_config_preferred():
     data_file = "dfile"
     config_num_cpu = 17
     data_file_num_cpu = 4
-    with open(data_file, "w") as data_file_hander:
+    with open(file=data_file, mode="w", encoding="utf-8") as data_file_hander:
         data_file_hander.write(
             f"""PARALLEL
  {data_file_num_cpu} DISTRIBUTED/
@@ -41,7 +41,7 @@ def test_num_cpu_from_config_preferred():
 def test_num_cpu_from_data_file_used_if_config_num_cpu_not_set():
     data_file = "dfile"
     data_file_num_cpu = 4
-    with open(data_file, "w") as data_file_hander:
+    with open(file=data_file, mode="w", encoding="utf-8") as data_file_hander:
         data_file_hander.write(
             f"""
 PARALLEL

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -19,20 +19,3 @@ def test_queue_config_dict_same_as_from_file(config_dict):
         ResConfig(filename).queue_config
         == ResConfig(config_dict=config_dict).queue_config
     )
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@given(config_dicts())
-def test_queue_config_dict_works_without_num_cpu(config_dict):
-    filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
-    cwd = os.getcwd()
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
-    config_dict.pop(ConfigKeys.NUM_CPU)
-    to_config_file(filename, config_dict)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
-
-    queue_config_from_dict = ResConfig(config_dict=config_dict).queue_config
-    res_config_from_file: ResConfig = ResConfig(filename)
-
-    assert queue_config_from_dict.num_cpu == 0
-    assert res_config_from_file.get_num_cpu() is None

--- a/tests/test_config_parsing/test_subst_config.py
+++ b/tests/test_config_parsing/test_subst_config.py
@@ -30,14 +30,14 @@ def test_from_dict_and_from_file_creates_equal_config(config_dict):
     filename = config_dict[ConfigKeys.CONFIG_FILE_KEY]
     to_config_file(filename, config_dict)
     res_config_from_file = ResConfig(user_config_file=filename)
-    subst_config_from_dict = SubstConfig(config_dict=config_dict)
+    subst_config_from_dict = ResConfig(config_dict=config_dict).subst_config
     assert res_config_from_file.subst_config == subst_config_from_dict
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_complete_config_reads_correct_values(config_dict):
-    subst_config = SubstConfig(config_dict=config_dict)
+    subst_config = ResConfig(config_dict=config_dict).subst_config
     assert subst_config["<CWD>"] == config_dict[ConfigKeys.CONFIG_DIRECTORY]
     assert subst_config["<CONFIG_PATH>"] == config_dict[ConfigKeys.CONFIG_DIRECTORY]
     for key, value in config_dict[ConfigKeys.DEFINE_KEY].items():
@@ -73,14 +73,4 @@ def test_empty_config_raises_error():
 def test_missing_config_directory_raises_error(config_dict):
     config_dict.pop(ConfigKeys.CONFIG_DIRECTORY)
     with pytest.raises(ValueError):
-        SubstConfig(config_dict=config_dict)
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@given(config_dicts())
-def test_data_file_not_found_raises_error(config_dict):
-    config_dict[ConfigKeys.DATA_FILE] = "not_a_file"
-    # subst config only tries to read data file if num cpu is not given
-    del config_dict[ConfigKeys.NUM_CPU]
-    with pytest.raises(IOError):
         SubstConfig(config_dict=config_dict)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ecl_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ecl_config.py
@@ -6,18 +6,6 @@ from ecl.summary import EclSum
 from ert._c_wrappers.enkf import ConfigKeys, EclConfig
 
 
-def test_ecl_config_default_num_cpu_value(source_root):
-    dfile = str(source_root / "test-data/eclipse/SPE1.DATA")
-    ec = EclConfig(data_file=dfile)
-    assert ec._data_file == dfile
-    assert ec.num_cpu == 1
-
-
-def test_num_cpu_is_none_when_datafile_not_given(source_root):
-    ec = EclConfig()
-    assert ec.num_cpu is None
-
-
 def test_refcase(source_root):
     refcase_file = str(source_root / "test-data/snake_oil/refcase/SNAKE_OIL_FIELD")
     ec = EclConfig(refcase_file=refcase_file)
@@ -35,7 +23,6 @@ def test_wrongly_configured_refcase_path():
 def test_ecl_config_constructors(setup_case):
     res_config = setup_case("configuration_tests", "ecl_config.ert")
     config_dict = {
-        ConfigKeys.DATA_FILE: "input/SPE1.DATA",
         ConfigKeys.GRID: "input/CASE.EGRID",
         ConfigKeys.REFCASE: "input/refcase/SNAKE_OIL_FIELD",
     }

--- a/tests/unit_tests/c_wrappers/res/enkf/test_queue_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_queue_config.py
@@ -16,7 +16,6 @@ def test_queue_config_constructor(minimum_case):
         job_script="script.sh",
         queue_system=QueueDriverEnum(2),
         max_submit=2,
-        num_cpu=0,
         queue_options={
             QueueDriverEnum.LOCAL_DRIVER: [
                 ("MAX_RUNNING", "1"),
@@ -29,7 +28,6 @@ def test_queue_config_constructor(minimum_case):
         job_script=os.path.abspath("script.sh"),
         queue_system=QueueDriverEnum(2),
         max_submit=2,
-        num_cpu=0,
         queue_options={
             QueueDriverEnum.LOCAL_DRIVER: [
                 ("MAX_RUNNING", "1"),
@@ -48,7 +46,6 @@ def test_set_and_unset_option():
         job_script="script.sh",
         queue_system=QueueDriverEnum(2),
         max_submit=2,
-        num_cpu=0,
         queue_options={
             QueueDriverEnum.LOCAL_DRIVER: [
                 ("MAX_RUNNING", "50"),

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -120,13 +120,16 @@ snake_oil_structure_config = {
     },
 }
 
-# Expand all strings in snake_oil_structure_config according to config_defines.
-for define_key, define_value in config_defines.items():
-    for data_key, data_value in snake_oil_structure_config.items():
-        if isinstance(data_value, str):
-            snake_oil_structure_config[data_key] = data_value.replace(
-                define_key, define_value
-            )
+
+def expand_config_defs(defines, config):
+    for define_key, define_value in defines.items():
+        for data_key, data_value in config.items():
+            if isinstance(data_value, str):
+                config[data_key] = data_value.replace(define_key, define_value)
+
+
+# Expand all strings in snake oil structure config according to defines.
+expand_config_defs(config_defines, snake_oil_structure_config)
 
 
 def test_invalid_user_config():
@@ -322,7 +325,7 @@ def test_res_config_dict_constructor(setup_case):
     _ = setup_case("snake_oil_structure", relative_config_path)
     # create script file
     script_file = "script.sh"
-    with open(script_file, "w") as f:
+    with open(file=script_file, mode="w", encoding="utf-8") as f:
         f.write("""#!/bin/sh\nls""")
 
     st = os.stat(script_file)
@@ -488,7 +491,7 @@ def test_res_config_dict_constructor(setup_case):
     os.chdir(absolute_config_dir)
 
     # add missing entries to config file
-    with open(config_file_name, "a+") as ert_file:
+    with open(file=config_file_name, mode="a+", encoding="utf-8") as ert_file:
         ert_file.write(f"JOB_SCRIPT ../../{script_file}\n")
 
     # load res_file
@@ -738,6 +741,6 @@ SUMMARY WBHP:PROD
 SUMMARY WWIR:INJ
 SUMMARY WWIT:INJ
 SUMMARY WBHP:INJ
-SUMMARY ROE:1"""  # noqa: E501
+SUMMARY ROE:1"""  # noqa: E501 pylint: disable=line-too-long
         in caplog.text
     )

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -257,10 +257,6 @@ def test_extensive_config(setup_case):
         assert exp_job_data["STDOUT"] == job_list[job_name].get_stdout_file()
 
     ecl_config = res_config.ecl_config
-    assert (
-        Path(snake_oil_structure_config["DATA_FILE"]).resolve()
-        == Path(ecl_config._data_file).resolve()
-    )
     for extension in ["SMSPEC", "UNSMRY"]:
         assert (
             Path(snake_oil_structure_config["REFCASE"] + "." + extension).resolve()

--- a/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
@@ -17,8 +17,8 @@ def without_key(a_dict, key):
     return {index: value for index, value in a_dict.items() if index != key}
 
 
-@pytest.fixture
-def snake_oil_structure_config(copy_case):
+@pytest.fixture(name="snake_oil_structure_config")
+def fixture_snake_oil_structure_config(copy_case):
     copy_case("snake_oil_structure")
     return {
         ConfigKeys.RUNPATH_FILE: "runpath",
@@ -29,10 +29,10 @@ def snake_oil_structure_config(copy_case):
     }
 
 
-@pytest.fixture
-def snake_oil_structure_config_file(snake_oil_structure_config):
+@pytest.fixture(name="snake_oil_structure_config_file")
+def fixture_snake_oil_structure_config_file(snake_oil_structure_config):
     filename = snake_oil_structure_config[ConfigKeys.CONFIG_FILE_KEY]
-    with open(filename, "w+") as config:
+    with open(file=filename, mode="w+", encoding="utf-8") as config:
         # necessary in the file, but irrelevant to this test
         config.write("JOBNAME  Job%d\n")
         config.write("NUM_REALIZATIONS  1\n")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
@@ -26,7 +26,6 @@ def snake_oil_structure_config(copy_case):
         ConfigKeys.CONFIG_FILE_KEY: "config",
         ConfigKeys.DEFINE_KEY: {"keyA": "valA", "keyB": "valB"},
         ConfigKeys.DATA_KW_KEY: {"keyC": "valC", "keyD": "valD"},
-        ConfigKeys.DATA_FILE: "eclipse/model/SNAKE_OIL.DATA",
     }
 
 
@@ -55,10 +54,6 @@ def snake_oil_structure_config_file(snake_oil_structure_config):
                     ConfigKeys.DATA_KW_KEY, key, val
                 )
             )
-        config.write(
-            f"{ConfigKeys.DATA_FILE}"
-            f" {snake_oil_structure_config[ConfigKeys.DATA_FILE]}\n"
-        )
 
     return filename
 
@@ -115,14 +110,5 @@ def test_missing_config_directory_raises_error(snake_oil_structure_config):
         SubstConfig(
             config_dict=without_key(
                 snake_oil_structure_config, ConfigKeys.CONFIG_DIRECTORY
-            )
-        )
-
-
-def test_data_file_not_found_raises_error(snake_oil_structure_config):
-    with pytest.raises(IOError):
-        SubstConfig(
-            config_dict=with_key(
-                snake_oil_structure_config, ConfigKeys.DATA_FILE, "not_a_file"
             )
         )

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -65,7 +65,6 @@ def queue_config():
     return QueueConfig(
         job_script="job_dispatch.py",
         max_submit=100,
-        num_cpu=10,
         queue_system=LOCAL_DRIVER,
         queue_options=[("MAX_RUNNING", "50")],
     )


### PR DESCRIPTION
We make the two instances of num cpu that can occur in the two different sources, namely user config and data file, available in res config, and also move the logic for choosing between the two different to res config.

We remove now redundant occurances of num cpu, data file, and said logic.

Also minor linting fixes in a test file.

Closes #4005

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).