### PR TITLE
Use the Self type to resolve typing problems with `ert.ensemble_builder`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ args = dict(
         "filelock",
         "graphlib_backport; python_version < '3.9'",
         "iterative_ensemble_smoother>=0.0.5",
+        "typing_extensions>=4.4",
         "jinja2",
         "matplotlib",
         "numpy",

--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -4,6 +4,7 @@ import ssl
 from typing import Any, AnyStr, Dict, Optional, Union
 
 import cloudevents
+from typing_extensions import Self
 from websockets.client import WebSocketClientProtocol, connect
 from websockets.datastructures import Headers
 from websockets.exceptions import (
@@ -25,7 +26,7 @@ class ClientConnectionClosedOK(Exception):
 
 
 class Client:  # pylint: disable=too-many-instance-attributes
-    def __enter__(self) -> "Client":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:

--- a/src/ert/ensemble_evaluator/_builder/_ensemble_builder.py
+++ b/src/ert/ensemble_evaluator/_builder/_ensemble_builder.py
@@ -2,6 +2,8 @@ import copy
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from typing_extensions import Self
+
 from ert._c_wrappers.enkf import QueueConfig
 from ert._c_wrappers.enkf.analysis_config import AnalysisConfig
 
@@ -36,7 +38,7 @@ class EnsembleBuilder:  # pylint: disable=too-many-instance-attributes
         self._executor: str = "local"
         self._id: Optional[str] = None
 
-    def set_forward_model(self, forward_model: RealizationBuilder) -> "EnsembleBuilder":
+    def set_forward_model(self, forward_model: RealizationBuilder) -> Self:
         if self._reals:
             raise ValueError(
                 "Cannot set forward model when realizations are already specified"
@@ -44,18 +46,18 @@ class EnsembleBuilder:  # pylint: disable=too-many-instance-attributes
         self._forward_model = forward_model
         return self
 
-    def add_realization(self, real: RealizationBuilder) -> "EnsembleBuilder":
+    def add_realization(self, real: RealizationBuilder) -> Self:
         if self._forward_model:
             raise ValueError("Cannot add realization when forward model is specified")
 
         self._reals.append(real)
         return self
 
-    def set_metadata(self, key: str, value: Any) -> "EnsembleBuilder":
+    def set_metadata(self, key: str, value: Any) -> Self:
         self._metadata[key] = value
         return self
 
-    def set_ensemble_size(self, size: int) -> "EnsembleBuilder":
+    def set_ensemble_size(self, size: int) -> Self:
         """Duplicate the ensemble members that existed at build time so as to
         get the desired state."""
         self._size = size
@@ -63,39 +65,39 @@ class EnsembleBuilder:  # pylint: disable=too-many-instance-attributes
 
     def set_legacy_dependencies(
         self, queue_config: QueueConfig, analysis_config: AnalysisConfig
-    ) -> "EnsembleBuilder":
+    ) -> Self:
         self._legacy_dependencies = (queue_config, analysis_config)
         return self
 
-    def set_inputs(self, inputs: InputMap) -> "EnsembleBuilder":
+    def set_inputs(self, inputs: InputMap) -> Self:
         self._inputs = inputs.to_dict()
         return self
 
-    def set_outputs(self, outputs: OutputMap) -> "EnsembleBuilder":
+    def set_outputs(self, outputs: OutputMap) -> Self:
         self._outputs = outputs.to_dict()
         return self
 
-    def set_custom_port_range(self, custom_port_range: range) -> "EnsembleBuilder":
+    def set_custom_port_range(self, custom_port_range: range) -> Self:
         self._custom_port_range = custom_port_range
         return self
 
-    def set_max_running(self, max_running: int) -> "EnsembleBuilder":
+    def set_max_running(self, max_running: int) -> Self:
         self._max_running = max_running
         return self
 
-    def set_max_retries(self, max_retries: int) -> "EnsembleBuilder":
+    def set_max_retries(self, max_retries: int) -> Self:
         self._max_retries = max_retries
         return self
 
-    def set_retry_delay(self, retry_delay: int) -> "EnsembleBuilder":
+    def set_retry_delay(self, retry_delay: int) -> Self:
         self._retry_delay = retry_delay
         return self
 
-    def set_executor(self, executor: str) -> "EnsembleBuilder":
+    def set_executor(self, executor: str) -> Self:
         self._executor = executor
         return self
 
-    def set_id(self, id_: str) -> "EnsembleBuilder":
+    def set_id(self, id_: str) -> Self:
         self._id = id_
         return self
 

--- a/src/ert/ensemble_evaluator/_builder/_io_.py
+++ b/src/ert/ensemble_evaluator/_builder/_io_.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Dict, Optional, Type, cast
 
+from typing_extensions import Self
+
 from ert.data import TransformationDirection
 
 if TYPE_CHECKING:
@@ -42,13 +44,13 @@ class IOBuilder:
         self._transformation: Optional["ert.data.RecordTransformation"] = None
         self._transmitter_factories: Dict[int, "ert.data.transmitter_factory"] = {}
 
-    def set_name(self: "IOBuilder", name: str) -> "IOBuilder":
+    def set_name(self, name: str) -> Self:
         self._name = name
         return self
 
     def set_transformation(
         self, transformation: "ert.data.RecordTransformation"
-    ) -> "IOBuilder":
+    ) -> Self:
         # Validate that a transformation can transform in the required direction.
         # The constraints are in tuple form: (IO type, required direction).
         constraints = (
@@ -69,7 +71,7 @@ class IOBuilder:
 
     def set_transmitter_factory(
         self, factory: "ert.data.transmitter_factory", index: Optional[int] = None
-    ) -> "IOBuilder":
+    ) -> Self:
         """Fix the transmitter factory for this IO to index if index is >= 0. If the
         index is omitted or is < 0, it the factory will be called for all indices not
         fixed to an index. So either one transmitter factory is used for all indices

--- a/src/ert/ensemble_evaluator/_builder/_io_map.py
+++ b/src/ert/ensemble_evaluator/_builder/_io_map.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from beartype import beartype
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     import ert.data
@@ -25,7 +26,7 @@ class _IOMap:
 
     def set_transmitter(
         self, iens: int, io_name: str, transmitter: "ert.data.RecordTransmitter"
-    ) -> "_IOMap":
+    ) -> Self:
         if self._validated:
             raise RuntimeError("mutating validated iomap")
         self._matrix[iens][io_name] = transmitter
@@ -37,7 +38,7 @@ class _IOMap:
                 if trans is None:
                     raise ValueError(f"'{name}' for real {real_id} was not set")
 
-    def validate(self) -> "_IOMap":
+    def validate(self) -> Self:
         self._assert_all_transmitters_specified()
         self._validated = True
         return self
@@ -59,7 +60,7 @@ class _IOMap:
 
 
 class InputMap(_IOMap):
-    def validate(self) -> "_IOMap":
+    def validate(self) -> Self:
         super().validate()
         for real_id, ios in self._matrix.items():
             for name, trans in ios.items():
@@ -72,7 +73,7 @@ class InputMap(_IOMap):
 
 
 class OutputMap(_IOMap):
-    def validate(self) -> "_IOMap":
+    def validate(self) -> Self:
         super().validate()
         for real_id, ios in self._matrix.items():
             for name, trans in ios.items():

--- a/src/ert/ensemble_evaluator/_builder/_job.py
+++ b/src/ert/ensemble_evaluator/_builder/_job.py
@@ -3,6 +3,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+from typing_extensions import Self
+
 from ert._c_wrappers.job_queue.ext_job import ExtJob
 
 SOURCE_TEMPLATE_JOB = "/job/{job_id}/index/{job_index}"
@@ -69,19 +71,19 @@ class BaseJobBuilder:
         self._name: Optional[str] = None
         self._parent_source: Optional[str] = None
 
-    def set_id(self: "BaseJobBuilder", id_: str) -> "BaseJobBuilder":
+    def set_id(self, id_: str) -> Self:
         self._id = id_
         return self
 
-    def set_parent_source(self: "BaseJobBuilder", source: str) -> "BaseJobBuilder":
+    def set_parent_source(self, source: str) -> Self:
         self._parent_source = source
         return self
 
-    def set_name(self: "BaseJobBuilder", name: str) -> "BaseJobBuilder":
+    def set_name(self, name: str) -> Self:
         self._name = name
         return self
 
-    def set_index(self: "BaseJobBuilder", index: str) -> "BaseJobBuilder":
+    def set_index(self, index: str) -> Self:
         self._index = index
         return self
 
@@ -95,11 +97,11 @@ class JobBuilder(BaseJobBuilder):
         self._executable: Optional[_callable_or_path] = None
         self._args: Optional[Tuple[str, ...]] = None
 
-    def set_executable(self, executable: _callable_or_path) -> "JobBuilder":
+    def set_executable(self, executable: _callable_or_path) -> Self:
         self._executable = executable
         return self
 
-    def set_args(self, args: Tuple[str, ...]) -> "JobBuilder":
+    def set_args(self, args: Tuple[str, ...]) -> Self:
         self._args = args
         return self
 
@@ -154,7 +156,7 @@ class LegacyJobBuilder(BaseJobBuilder):
         self._callback_arguments: Optional[List[Any]] = None
         self._max_runtime: Optional[int] = None
 
-    def set_ext_job(self, ext_job: ExtJob) -> "LegacyJobBuilder":
+    def set_ext_job(self, ext_job: ExtJob) -> Self:
         self._ext_job = ext_job
         return self
 

--- a/src/ert/ensemble_evaluator/_builder/_realization.py
+++ b/src/ert/ensemble_evaluator/_builder/_realization.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from graphlib import TopologicalSorter
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
+from typing_extensions import Self
+
 from ._step import Step, StepBuilder
 
 SOURCE_TEMPLATE_REAL = "/real/{iens}"
@@ -97,23 +99,23 @@ class RealizationBuilder:
         self._iens: Optional[int] = None
         self._parent_source: Optional[str] = None
 
-    def active(self, active: bool) -> "RealizationBuilder":
+    def active(self, active: bool) -> Self:
         self._active = active
         return self
 
-    def add_step(self, step: StepBuilder) -> "RealizationBuilder":
+    def add_step(self, step: StepBuilder) -> Self:
         self._steps.append(step)
         return self
 
-    def add_stage(self, stage: "StageBuilder") -> "RealizationBuilder":
+    def add_stage(self, stage: "StageBuilder") -> Self:
         self._stages.append(stage)
         return self
 
-    def set_iens(self, iens: int) -> "RealizationBuilder":
+    def set_iens(self, iens: int) -> Self:
         self._iens = iens
         return self
 
-    def set_parent_source(self, source: str) -> "RealizationBuilder":
+    def set_parent_source(self, source: str) -> Self:
         self._parent_source = source
         return self
 

--- a/src/ert/ensemble_evaluator/_builder/_stage.py
+++ b/src/ert/ensemble_evaluator/_builder/_stage.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from typing import MutableSequence, Sequence
 
+from typing_extensions import Self
+
 from ._io_ import IO, DummyIOBuilder, IOBuilder
 
 logger = logging.getLogger(__name__)
@@ -24,19 +26,19 @@ class StageBuilder:
         self._inputs: MutableSequence[IOBuilder] = []
         self._outputs: MutableSequence[IOBuilder] = []
 
-    def set_id(self, id_: str) -> "StageBuilder":
+    def set_id(self, id_: str) -> Self:
         self._id = id_
         return self
 
-    def set_name(self, name: str) -> "StageBuilder":
+    def set_name(self, name: str) -> Self:
         self._name = name
         return self
 
-    def add_output(self, output: IOBuilder) -> "StageBuilder":
+    def add_output(self, output: IOBuilder) -> Self:
         self._outputs.append(output)
         return self
 
-    def add_input(self, input_: IOBuilder) -> "StageBuilder":
+    def add_input(self, input_: IOBuilder) -> Self:
         self._inputs.append(input_)
         return self
 
@@ -49,7 +51,7 @@ class StageBuilder:
         outputs = [builder.build() for builder in self._outputs]
         return Stage(self._id, self._name, inputs, outputs)
 
-    def set_dummy_io(self) -> "StageBuilder":
+    def set_dummy_io(self) -> Self:
         self.add_input(DummyIOBuilder())
         self.add_output(DummyIOBuilder())
         return self

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -346,7 +346,7 @@ class BaseRunModel:
                         .set_id(str(index))
                         .set_index(str(index))
                         .set_name(ext_job.name)
-                        .set_ext_job(ext_job)  # type: ignore
+                        .set_ext_job(ext_job)
                     )
                 step.set_max_runtime(
                     self.ert().analysisConfig().get_max_runtime()


### PR DESCRIPTION
Use the Self type which is mypy treats correctly as of version 1.0.0. This means functions returning self is now correctly typed for subclasses. This means we can remove the ignored typed lines in base run model, and likely correctly type `ert.ensemble_evaluator`.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
