### PR TITLE
Make forward_model only called from python

### DIFF
--- a/src/clib/lib/enkf/enkf_main.cpp
+++ b/src/clib/lib/enkf/enkf_main.cpp
@@ -52,52 +52,20 @@ void ecl_write(const ensemble_config_type *ens_config,
     value_export(export_value);
     value_export_free(export_value);
 }
-
-/**
- * @brief Initializes an active run.
- *
- *  * Instantiate res_config_templates which substitutes arg_list from the template
- *      and from run_arg into each template and writes it to runpath;
- *  * substitutes sampled parameters into the parameter nodes and write to runpath;
- *  * substitutes DATAKW into the eclipse data file template and write it to runpath;
- *  * write the job script.
- *
- * @param run_path The runpath string
- * @param iens The realization number.
- * @param fs The file system to write to
- * @param run_id Unique id of run
- * @param subst_list The substitutions to perform for that run.
- */
-void init_active_run(const model_config_type *model_config,
-                     ensemble_config_type *ens_config,
-                     const env_varlist_type *env_varlist, char *run_path,
-                     int iens, enkf_fs_type *fs, char *run_id, char *job_name,
-                     const subst_list_type *subst_list) {
-    ecl_write(ens_config, model_config_get_gen_kw_export_name(model_config),
-              run_path, iens, fs);
-
-    // Create the job script
-    forward_model_formatted_fprintf(
-        model_config_get_forward_model(model_config), run_id, run_path,
-        model_config_get_data_root(model_config), subst_list, env_varlist);
-}
 } // namespace enkf_main
 
 ERT_CLIB_SUBMODULE("enkf_main", m) {
     using namespace py::literals;
     m.def(
-        "init_active_run",
+        "ecl_write",
         [](Cwrap<model_config_type> model_config,
-           Cwrap<ensemble_config_type> ensemble_config,
-           Cwrap<env_varlist_type> env_varlist, char *run_path, int iens,
-           Cwrap<enkf_fs_type> sim_fs, char *run_id, char *job_name,
-           Cwrap<subst_list_type> subst_list) {
-            enkf_main::init_active_run(model_config, ensemble_config,
-                                       env_varlist, run_path, iens, sim_fs,
-                                       run_id, job_name, subst_list);
+           Cwrap<ensemble_config_type> ensemble_config, char *run_path,
+           int iens, Cwrap<enkf_fs_type> sim_fs) {
+            enkf_main::ecl_write(
+                ensemble_config,
+                model_config_get_gen_kw_export_name(model_config), run_path,
+                iens, sim_fs);
         },
         py::arg("model_config"), py::arg("ensemble_config"),
-        py::arg("env_varlist"), py::arg("run_path"), py::arg("iens"),
-        py::arg("sim_fs"), py::arg("run_id"), py::arg("job_name"),
-        py::arg("subst_list"));
+        py::arg("run_path"), py::arg("iens"), py::arg("sim_fs"));
 }

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -455,16 +455,21 @@ class EnKFMain:
                         )
                     target.write_text(result)
 
-                _clib.enkf_main.init_active_run(
-                    model_config=self.resConfig().model_config,
-                    ensemble_config=self.resConfig().ensemble_config,
-                    env_varlist=self.resConfig().site_config.env_vars,
+                res_config = self.resConfig()
+                model_config = res_config.model_config
+                _clib.enkf_main.ecl_write(
+                    model_config=model_config,
+                    ensemble_config=res_config.ensemble_config,
                     run_path=run_arg.runpath,
                     iens=run_arg.iens,
                     sim_fs=run_arg.sim_fs,
-                    run_id=run_arg.get_run_id(),
-                    job_name=run_arg.job_name,
-                    subst_list=subst_list,
+                )
+                model_config.getForwardModel().formatted_fprintf(
+                    run_arg.get_run_id(),
+                    run_arg.runpath,
+                    model_config.data_root(),
+                    subst_list,
+                    res_config.site_config.env_vars,
                 )
 
         active_list = [


### PR DESCRIPTION
This is as a prelude to making forward model be python only


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
