### PR TITLE
Account for instance where ERT config file has `MAX_RUNTIME` defined multiple times

### DIFF
--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -101,6 +101,9 @@ class AnalysisConfig:
         if min_realization == 0:
             min_realization = num_realization
         min_realization = min(min_realization, num_realization)
+        max_runtime = config_dict.get(ConfigKeys.MAX_RUNTIME, 0)
+        if isinstance(max_runtime, list):
+            max_runtime = max_runtime[-1]
 
         config = cls(
             alpha=config_dict.get(ConfigKeys.ALPHA_KEY, 3.0),
@@ -109,7 +112,7 @@ class AnalysisConfig:
             std_cutoff=config_dict.get(ConfigKeys.STD_CUTOFF_KEY, 1e-6),
             stop_long_running=config_dict.get(ConfigKeys.STOP_LONG_RUNNING, False),
             global_std_scaling=config_dict.get(ConfigKeys.GLOBAL_STD_SCALING, 1.0),
-            max_runtime=config_dict.get(ConfigKeys.MAX_RUNTIME, 0),
+            max_runtime=max_runtime,
             min_realization=min_realization,
             update_log_path=config_dict.get(ConfigKeys.UPDATE_LOG_PATH, "update_log"),
             analysis_iter_config=AnalysisIterConfig.from_dict(config_dict),

--- a/test-data/simple_config/minimum_config
+++ b/test-data/simple_config/minimum_config
@@ -6,5 +6,8 @@ JOB_SCRIPT script.sh
 QUEUE_SYSTEM LOCAL
 QUEUE_OPTION LOCAL MAX_RUNNING 50
 
+MAX_RUNTIME 24
+MAX_RUNTIME 42
+
 -- This is not strictly necessary, a sensible default will be used if not given.
 ENSPATH  Ensemble

--- a/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
@@ -16,6 +16,9 @@ def test_keywords_for_monitoring_simulation_runtime(analysis_config):
     assert not analysis_config.have_enough_realisations(5)
     assert analysis_config.have_enough_realisations(10)
 
+    assert analysis_config.get_max_runtime() < 50
+    assert analysis_config.get_max_runtime() == 42
+
     analysis_config.set_max_runtime(50)
     assert analysis_config.get_max_runtime() == 50
 


### PR DESCRIPTION
Localized fix for the case when the MAX_RUNTIME is defined multiple times in the config file. 

More general fix coming later. 


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
