### PR TITLE
Make use of node_status_builder in protobuf reporter

### DIFF
--- a/src/_ert_job_runner/reporting/protobuf.py
+++ b/src/_ert_job_runner/reporting/protobuf.py
@@ -9,13 +9,7 @@ from _ert_com_protocol import (
     JOB_RUNNING,
     JOB_START,
     JOB_SUCCESS,
-    DispatcherMessage,
-    EnsembleId,
-    ExperimentId,
-    Job,
-    JobId,
-    RealizationId,
-    StepId,
+    node_status_builder,
 )
 from _ert_job_runner.client import Client
 from _ert_job_runner.reporting.base import Reporter
@@ -58,8 +52,7 @@ class Protobuf(Reporter):
         if msg is None:
             self._event_queue.put(None)
         else:
-            message = DispatcherMessage(job=msg)
-            self._event_queue.put(message.SerializeToString())
+            self._event_queue.put(msg.SerializeToString())
 
     def _publish_event(self):
         logger.debug("Publishing event.")
@@ -82,37 +75,30 @@ class Protobuf(Reporter):
 
     def _job_handler(self, msg: Union[Start, Running, Exited]):
         job_name = msg.job.name()
-        pjob = Job(
-            id=JobId(
-                index=msg.job.index,
-                step=StepId(
-                    step=self._step_id,
-                    realization=RealizationId(
-                        realization=self._real_id,
-                        ensemble=EnsembleId(
-                            id=self._ens_id,
-                            experiment=ExperimentId(id=self._experiment_id),
-                        ),
-                    ),
-                ),
-            )
+        event = node_status_builder(
+            status="JOB_START",
+            experiment_id=self._experiment_id,
+            ensemble_id=self._ens_id,
+            realization_id=self._real_id,
+            step_id=self._step_id,
+            job_id=msg.job.index,
         )
         if isinstance(msg, Start):
             logger.debug(f"Job {job_name} was successfully started")
-            pjob.status = JOB_START
-            pjob.stdout = str(Path(msg.job.std_out).resolve())
-            pjob.stderr = str(Path(msg.job.std_err).resolve())
-            self._dump_event(pjob)
+            event.job.status = JOB_START
+            event.job.stdout = str(Path(msg.job.std_out).resolve())
+            event.job.stderr = str(Path(msg.job.std_err).resolve())
+            self._dump_event(event)
             if not msg.success():
                 logger.error(f"Job {job_name} FAILED to start")
-                pjob.status = JOB_FAILURE
-                pjob.error = msg.error_message
-                self._dump_event(pjob)
+                event.job.status = JOB_FAILURE
+                event.job.error = msg.error_message
+                self._dump_event(event)
 
         elif isinstance(msg, Exited):
             if msg.success():
                 logger.debug(f"Job {job_name} exited successfully")
-                pjob.status = JOB_SUCCESS
+                event.job.status = JOB_SUCCESS
             else:
                 logger.error(
                     _JOB_EXIT_FAILED_STRING.format(
@@ -121,17 +107,17 @@ class Protobuf(Reporter):
                         error_message=msg.error_message,
                     )
                 )
-                pjob.status = JOB_FAILURE
-                pjob.exit_code = msg.exit_code
-                pjob.error = msg.error_message
-            self._dump_event(pjob)
+                event.job.status = JOB_FAILURE
+                event.job.exit_code = msg.exit_code
+                event.job.error = msg.error_message
+            self._dump_event(event)
 
         elif isinstance(msg, Running):
             logger.debug(f"{job_name} job is running")
-            pjob.status = JOB_RUNNING
-            pjob.current_memory = msg.current_memory_usage
-            pjob.max_memory = msg.max_memory_usage
-            self._dump_event(pjob)
+            event.job.status = JOB_RUNNING
+            event.job.current_memory = msg.current_memory_usage
+            event.job.max_memory = msg.max_memory_usage
+            self._dump_event(event)
 
     def _finished_handler(self, msg):
         self._dump_event(None)


### PR DESCRIPTION
The goal is to simplify creation of pb2.Job protobuf nodes  from protobuf reporter.


**Approach**
Make use of `node_status_builder` utility


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
