### PR TITLE
Fix argc in qstat call

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -543,7 +543,7 @@ torque_driver_get_qstat_status(torque_driver_type *driver,
         int max_sleep_time = 2 * 2 * 2 * 2; /* max 4 attempts */
         while ((return_value != 0) & (sleep_time < max_sleep_time)) {
             return_value =
-                util_spawn_blocking(driver->qstat_cmd, 1, (const char **)argv,
+                util_spawn_blocking(driver->qstat_cmd, 2, (const char **)argv,
                                     tmp_std_file, tmp_err_file);
             if (return_value != 0) {
                 torque_debug(driver,

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -230,4 +230,5 @@ def test_that_torque_driver_passes_dash_x_to_qstat(
     job, _runpath = _build_jobqueuenode(dummy_config)
     job.run(driver, BoundedSemaphore())
     job.wait_for()
-    assert Path("qstat_options").read_text(encoding="utf-8").strip() == "-x"
+    # qstat job id = 10001
+    assert Path("qstat_options").read_text(encoding="utf-8").strip() == "-x 10001"


### PR DESCRIPTION
Resolves #4150 
Fix number of arguments when calling qstat.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
