### PR TITLE
Fix config_content.as_dict()

### DIFF
--- a/src/ert/_c_wrappers/config/config_content.py
+++ b/src/ert/_c_wrappers/config/config_content.py
@@ -264,25 +264,3 @@ class ConfigContent(BaseCClass):
 
     def keys(self) -> List[str]:
         return list(self._keys())
-
-    def as_dict(self) -> Dict[str, List[Any]]:
-        # pylint: disable=consider-using-dict-items
-        # (false positive)
-        d: Dict[str, List[Any]] = {}
-        for key in self.keys():
-            item = self[key]
-            if len(item) > 1:
-                d[key] = []
-                for node in item:
-                    values = list(node)
-                    if len(values) > 1:
-                        d[key].append(values)
-                    else:
-                        d[key].append(values[0])
-            else:
-                values = list(item[0])
-                if len(values) > 1:
-                    d[key] = [values]
-                else:
-                    d[key] = values[0]
-        return d

--- a/src/ert/_c_wrappers/config/config_content.py
+++ b/src/ert/_c_wrappers/config/config_content.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List
+from typing import TYPE_CHECKING, Iterator, List
 
 from cwrap import BaseCClass
 

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -101,9 +101,6 @@ class AnalysisConfig:
         if min_realization == 0:
             min_realization = num_realization
         min_realization = min(min_realization, num_realization)
-        max_runtime = config_dict.get(ConfigKeys.MAX_RUNTIME, 0)
-        if isinstance(max_runtime, list):
-            max_runtime = max_runtime[-1]
 
         config = cls(
             alpha=config_dict.get(ConfigKeys.ALPHA_KEY, 3.0),
@@ -112,7 +109,7 @@ class AnalysisConfig:
             std_cutoff=config_dict.get(ConfigKeys.STD_CUTOFF_KEY, 1e-6),
             stop_long_running=config_dict.get(ConfigKeys.STOP_LONG_RUNNING, False),
             global_std_scaling=config_dict.get(ConfigKeys.GLOBAL_STD_SCALING, 1.0),
-            max_runtime=max_runtime,
+            max_runtime=config_dict.get(ConfigKeys.MAX_RUNTIME, 0),
             min_realization=min_realization,
             update_log_path=config_dict.get(ConfigKeys.UPDATE_LOG_PATH, "update_log"),
             analysis_iter_config=AnalysisIterConfig.from_dict(config_dict),

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -118,13 +118,14 @@ class EnsembleConfig(BaseCClass):
         )
 
         if config_content is not None:
-            config_content_dict = config_content.as_dict()
-            self._grid_file = self._get_file_str(
-                config_content_dict.get(ConfigKeys.GRID)
-            )
-            self._refcase_file = self._get_file_str(
-                config_content_dict.get(ConfigKeys.REFCASE)
-            )
+            if config_content.hasKey(ConfigKeys.GRID):
+                self._grid_file = self._get_file_str(
+                    config_content.getValue(ConfigKeys.GRID)
+                )
+            if config_content.hasKey(ConfigKeys.REFCASE):
+                self._refcase_file = self._get_file_str(
+                    config_content.getValue(ConfigKeys.REFCASE)
+                )
 
         self.grid = self._load_grid(self._grid_file) if self._grid_file else None
         self.refcase = (

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -27,7 +27,6 @@ SINGLE_VALUE_KEYS = [
     ConfigKeys.ALPHA_KEY,
     ConfigKeys.ANALYSIS_SELECT,
     ConfigKeys.CONFIG_DIRECTORY,
-    ConfigKeys.CONFIG_FILE_KEY,
     ConfigKeys.DATAROOT,
     ConfigKeys.DATA_FILE,
     ConfigKeys.ECLBASE,

--- a/tests/unit_tests/c_wrappers/res/config/test_config_content.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_content.py
@@ -1,12 +1,8 @@
-from pathlib import Path
-
 from ecl.util.util import StringList
 
 from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.config_parser import ConfigParser
 from ert._c_wrappers.config.content_type_enum import ContentTypeEnum
-from ert._c_wrappers.enkf.config_keys import ConfigKeys
-from ert._clib.config_keywords import init_user_config_parser
 
 
 def test_get_executable_list(tmpdir):
@@ -38,45 +34,3 @@ def test_get_executable_list(tmpdir):
     assert " does not exist" in errors[0]
     assert "MY_EXECUTABLE2" in errors[1]
     assert " does not exist" in errors[1]
-
-
-def test_config_content_as_dict(tmpdir):
-    with tmpdir.as_cwd():
-        conf = ConfigParser()
-        existing_file_1 = "test_1.t"
-        existing_file_2 = "test_2.t"
-        Path(existing_file_2).write_text("something")
-        Path(existing_file_1).write_text("not important")
-        init_user_config_parser(conf)
-
-        schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
-        schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
-
-        schema_item = conf.add("KEY", False)
-        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
-
-        with open("config", "w") as fileH:
-            fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
-            fileH.write(f"DATA_FILE {existing_file_2} \n")
-            fileH.write(f"DATA_FILE {existing_file_1} \n")
-            fileH.write(f"REFCASE {existing_file_1} \n")
-
-            fileH.write("MULTIPLE_KEY_VALUE 6\n")
-            fileH.write("MULTIPLE_KEY_VALUE 24\n")
-            fileH.write("MULTIPLE_KEY_VALUE 12\n")
-            fileH.write("QUEUE_OPTION SLURM MAX_RUNNING 50\n")
-            fileH.write("KEY VALUE1 VALUE1 100\n")
-            fileH.write("KEY VALUE2 VALUE2 200\n")
-        content = conf.parse("config")
-        content_as_dict = content.as_dict()
-        assert content_as_dict == {
-            "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
-            ConfigKeys.NUM_REALIZATIONS: 42,
-            ConfigKeys.QUEUE_OPTION: [["SLURM", "MAX_RUNNING", "50"]],
-            "MULTIPLE_KEY_VALUE": [6, 24, 12],
-            ConfigKeys.DATA_FILE: [
-                str(Path.cwd() / existing_file_2),
-                str(Path.cwd() / existing_file_1),
-            ],
-            ConfigKeys.REFCASE: str(Path.cwd() / existing_file_1),
-        }

--- a/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
@@ -170,7 +170,6 @@ def test_parser_content():
     os.makedirs("tmp")
     os.chdir("tmp")
     content = conf.parse("../config")
-    d = content.as_dict()
     assert content.isValid()
     assert "KEY" in content
     assert "NOKEY" not in content
@@ -179,11 +178,9 @@ def test_parser_content():
     keys = content.keys()
     assert len(keys) == 1
     assert "KEY" in keys
-    d = content.as_dict()
-    assert "KEY" in d
-    item_list = d["KEY"]
+    item_list = content["KEY"]
     assert len(item_list) == 1
-    line = item_list[0]
+    line = list(item_list[0])
     assert line[0] == "VALUE1"
     assert line[1] == "VALUE2"
     assert line[2] == 100

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -10,6 +10,7 @@ import pytest
 from cwrap import Prototype, load
 from ecl.util.enums import RngAlgTypeEnum
 
+from ert._c_wrappers.config import ConfigParser, ContentTypeEnum
 from ert._c_wrappers.enkf import (
     AnalysisConfig,
     ConfigKeys,
@@ -18,9 +19,10 @@ from ert._c_wrappers.enkf import (
     SiteConfig,
 )
 from ert._c_wrappers.enkf.enums import HookRuntime
-from ert._c_wrappers.enkf.res_config import site_config_location
+from ert._c_wrappers.enkf.res_config import SINGLE_VALUE_KEYS, site_config_location
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum
+from ert._clib.config_keywords import init_user_config_parser
 
 # The res_config object should set the environment variable
 # 'DATA_ROOT' to the root directory with the config
@@ -118,6 +120,45 @@ snake_oil_structure_config = {
             "TARGET_FILE": "seed.txt",
         }
     },
+}
+
+SINGLE_VALUE_KEY_TYPES = {
+    ConfigKeys.ALPHA_KEY: "int",
+    ConfigKeys.ANALYSIS_SELECT: "str",
+    ConfigKeys.CONFIG_DIRECTORY: "path",
+    ConfigKeys.CONFIG_FILE_KEY: "file_path",
+    ConfigKeys.DATAROOT: "file_path",
+    ConfigKeys.DATA_FILE: "file_path",
+    ConfigKeys.ECLBASE: "file_path",
+    ConfigKeys.ENSPATH: "path",
+    ConfigKeys.GEN_KW_EXPORT_NAME: "str",
+    ConfigKeys.GEN_KW_TAG_FORMAT: "str",
+    ConfigKeys.GRID: "file_path",
+    ConfigKeys.HISTORY_SOURCE: "history_enum",
+    ConfigKeys.ITER_CASE: "str",
+    ConfigKeys.ITER_COUNT: "int",
+    ConfigKeys.ITER_RETRY_COUNT: "int",
+    ConfigKeys.JOBNAME: "str",
+    ConfigKeys.JOB_SCRIPT: "file_path",
+    ConfigKeys.LICENSE_PATH: "file_path",
+    ConfigKeys.MAX_RESAMPLE: "int",
+    ConfigKeys.MAX_RUNTIME: "int",
+    ConfigKeys.MAX_SUBMIT: "int",
+    ConfigKeys.MIN_REALIZATIONS: "int",
+    ConfigKeys.NUM_CPU: "int",
+    ConfigKeys.NUM_REALIZATIONS: "int",
+    ConfigKeys.OBS_CONFIG: "file_path",
+    ConfigKeys.QUEUE_SYSTEM: "str",
+    ConfigKeys.RANDOM_SEED: "str",
+    ConfigKeys.REFCASE: "file_path",
+    ConfigKeys.RERUN_KEY: "bool",
+    ConfigKeys.RERUN_START_KEY: "int",
+    ConfigKeys.RUNPATH: "path",
+    ConfigKeys.RUNPATH_FILE: "file_path",
+    ConfigKeys.STD_CUTOFF_KEY: "float",
+    ConfigKeys.STOP_LONG_RUNNING: "bool",
+    ConfigKeys.TIME_MAP: "file_path",
+    ConfigKeys.UPDATE_LOG_PATH: "file_path",
 }
 
 
@@ -742,3 +783,71 @@ SUMMARY WBHP:INJ
 SUMMARY ROE:1"""  # noqa: E501 pylint: disable=line-too-long
         in caplog.text
     )
+
+
+def test_config_content_as_dict(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+
+        schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
+        schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
+
+        schema_item = conf.add("KEY", False)
+        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
+
+        with open("config", "w") as fileH:
+            fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
+            fileH.write(f"{ConfigKeys.DATA_FILE} {existing_file_2} \n")
+            fileH.write(f"{ConfigKeys.REFCASE} {existing_file_1} \n")
+
+            fileH.write("MULTIPLE_KEY_VALUE 6\n")
+            fileH.write("MULTIPLE_KEY_VALUE 24\n")
+            fileH.write("MULTIPLE_KEY_VALUE 12\n")
+            fileH.write("QUEUE_OPTION SLURM MAX_RUNNING 50\n")
+            fileH.write("KEY VALUE1 VALUE1 100\n")
+            fileH.write("KEY VALUE2 VALUE2 200\n")
+        content = conf.parse("config")
+        content_as_dict = ResConfig._config_content_as_dict(content)
+        assert content_as_dict == {
+            "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
+            ConfigKeys.NUM_REALIZATIONS: 42,
+            ConfigKeys.QUEUE_OPTION: [["SLURM", "MAX_RUNNING", "50"]],
+            "MULTIPLE_KEY_VALUE": [6, 24, 12],
+            ConfigKeys.DATA_FILE: str(Path.cwd() / existing_file_2),
+            ConfigKeys.REFCASE: str(Path.cwd() / existing_file_1),
+        }
+
+
+def test_config_content_as_dict_single_value_keys(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+        type_value_map = {
+            "str": "abc",
+            "path": tmpdir,
+            "file_path": existing_file_1,
+            "bool": "TRUE",
+            "float": 4.2,
+            "int": 2,
+            "history_enum": "REFCASE_SIMULATED",
+        }
+
+        with open("config.file", "w") as fileH:
+            for key in SINGLE_VALUE_KEYS:
+                key_type = SINGLE_VALUE_KEY_TYPES[key]
+                value = type_value_map[key_type]
+                fileH.write(f"{key} {value}\n{key} {value}\n")
+
+        content = conf.parse("config.file")
+        content_as_dict = ResConfig._config_content_as_dict(content)
+        for _, value in content_as_dict.items():
+            assert not isinstance(value, list)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -126,7 +126,6 @@ SINGLE_VALUE_KEY_TYPES = {
     ConfigKeys.ALPHA_KEY: "int",
     ConfigKeys.ANALYSIS_SELECT: "str",
     ConfigKeys.CONFIG_DIRECTORY: "path",
-    ConfigKeys.CONFIG_FILE_KEY: "file_path",
     ConfigKeys.DATAROOT: "file_path",
     ConfigKeys.DATA_FILE: "file_path",
     ConfigKeys.ECLBASE: "file_path",


### PR DESCRIPTION
**Issue**
Resolves #4148


**Approach**
Add a list of single-value config keys for each of the keys in the list config_content.as_dict() will return a single value for the resulting dictionary item.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
