### PR TITLE
Make enkf config node keys unique in test config dict generator

### DIFF
--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -246,7 +246,7 @@ def config_dicts(draw):
                 ConfigKeys.FIELD_KEY: st.lists(
                     st.fixed_dictionaries(
                         {
-                            ConfigKeys.NAME: words,
+                            ConfigKeys.NAME: st.just("FIELD-" + draw(words)),
                             ConfigKeys.VAR_TYPE: st.just("PARAMETER"),
                             ConfigKeys.OUT_FILE: file_names,
                             # ConfigKeys.ENKF_INFILE: file_names, only used in general
@@ -264,7 +264,7 @@ def config_dicts(draw):
                 ConfigKeys.GEN_DATA: st.lists(
                     st.fixed_dictionaries(
                         {
-                            ConfigKeys.NAME: words,
+                            ConfigKeys.NAME: st.just("GEN_DATA-" + draw(words)),
                             ConfigKeys.RESULT_FILE: format_file_names,
                             ConfigKeys.INPUT_FORMAT: st.just(GenDataFileType.ASCII),
                             ConfigKeys.REPORT_STEPS: st.lists(


### PR DESCRIPTION
The name, or key, of enkf config nodes need to be unique across all nodes in an ensemble config, i.e. the different object, like fields and surfaces and GEN_DATAs, which are instances of enkf config nodes, need to have pairwise different names / keys.

We rectify this for the config dict generator used in tests.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).