### PR TITLE
Warn when expanding keywords with no refcase available

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1175,7 +1175,7 @@ and/or history matching project.
         The SUMMARY keyword has limited support for '*' wildcards, if your key
         contains one or more '*' characters all matching variables from the refcase
         are selected. Observe that if your summary key contains wildcards you must
-        supply a refcase with the REFCASE key - otherwise it will fail hard.
+        supply a refcase with the REFCASE key - otherwise only fully expanded keywords will be used.
 
         **Note:** Properties added using the SUMMARY keyword are only
         diagnostic. I.e. they have no effect on the sensitivity analysis or

--- a/src/clib/lib/enkf/ensemble_config.cpp
+++ b/src/clib/lib/enkf/ensemble_config.cpp
@@ -451,6 +451,12 @@ void ensemble_config_init_SUMMARY_full(ensemble_config_type *ensemble_config,
                                             LOAD_FAIL_SILENT);
 
             stringlist_free(keys);
+        } else {
+            fprintf(stderr,
+                    "** Warning: Cannot expand %s due to missing refcase file."
+                    " Provide refcase file or add fully expanded SUMMARY key"
+                    " to configuration\n",
+                    key);
         }
     } else {
         ensemble_config_add_summary(ensemble_config, key, LOAD_FAIL_SILENT);


### PR DESCRIPTION
Resolves #4096 

According to the docs, using SUMMARY keywords containing wildcards is not supported IF no refcase was provided in the configuration.
Updates documentation to match current ERT behaviour.
Adds warning if wildcard SUMMARY keywords are used and no refcase was provided.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
