### PR TITLE
Let torque driver pick up error codes from jobs

### DIFF
--- a/src/clib/old_tests/data/job_queue/qsub_emulators/qdel
+++ b/src/clib/old_tests/data/job_queue/qsub_emulators/qdel
@@ -1,5 +1,5 @@
 #!/bin/sh
 echo "#!/bin/sh" > qstat
-echo "echo \"Job id                    Name             User            Time Use S Queue\"" >> qstat
-echo "echo \"------------------------- ---------------- --------------- -------- - -----\"" >> qstat
-echo "echo \"1612427.st-lcmm            ...130getupdates fama            00:00:01 E normal\"" >> qstat
+echo "echo \"Job Id: 1612427.st-lcmm\"" >> qstat
+echo "echo \"  job_state = F\"" >> qstat
+echo "echo \"  Exit_status = 1\"" >> qsta

--- a/src/clib/old_tests/data/job_queue/qsub_emulators/qsub
+++ b/src/clib/old_tests/data/job_queue/qsub_emulators/qsub
@@ -1,6 +1,5 @@
 #!/bin/sh
 echo 1612427.greier.og.greier
 echo "#!/bin/sh" > qstat
-echo "echo \"Job id                    Name             User            Time Use S Queue\"" >> qstat
-echo "echo \"------------------------- ---------------- --------------- -------- - -----\"" >> qstat
-echo "echo \"1612427.st-lcmm            ...130getupdates fama            00:00:01 R normal\"" >> qstat
+echo "echo \"Job Id: 1612427.st-lcmm\"" >> qstat
+echo "echo \"  job_state = R\"" >> qstat

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_torque_driver.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_torque_driver.py
@@ -24,6 +24,30 @@ def test_job_create_submit_script(use_tmpdir):
     [
         (None, "", JobStatusType.JOB_QUEUE_STATUS_FAILURE),
         ("", "1234", JobStatusType.JOB_QUEUE_STATUS_FAILURE),
+        ("Job Id: 1\njob_state = R", "1", JobStatusType.JOB_QUEUE_RUNNING),
+        ("Job Id: 1.namespace\njob_state = R", "1", JobStatusType.JOB_QUEUE_RUNNING),
+        ("Job Id: 11\njob_state = R", "1", JobStatusType.JOB_QUEUE_STATUS_FAILURE),
+        ("Job Id: 1", "1", JobStatusType.JOB_QUEUE_STATUS_FAILURE),
+        ("Job Id: 1\njob_state = E", "1", JobStatusType.JOB_QUEUE_DONE),
+        ("Job Id: 1\njob_state = C", "1", JobStatusType.JOB_QUEUE_DONE),
+        ("Job Id: 1\njob_state = H", "1", JobStatusType.JOB_QUEUE_PENDING),
+        ("Job Id: 1\njob_state = Q", "1", JobStatusType.JOB_QUEUE_PENDING),
+        ("Job Id: 1\njob_state = Æ", "1", JobStatusType.JOB_QUEUE_STATUS_FAILURE),
+        (
+            "Job Id: 1\njob_state = E\nExit_status = 1",
+            "1",
+            JobStatusType.JOB_QUEUE_EXIT,
+        ),
+        (
+            "Job Id: 1\njob_state = C\nExit_status = 1",
+            "1",
+            JobStatusType.JOB_QUEUE_EXIT,
+        ),
+        (
+            "Job Id: 1\njob_state = C\nJob Id: 2\njob_state = R",
+            "2",
+            JobStatusType.JOB_QUEUE_RUNNING,
+        ),
     ],
 )
 def test_parse_status(


### PR DESCRIPTION
**Issue**
Resolves #3726 

**Approach**
Add `-f` as a hard-coded option supplied to the `qstat` command. This changes the output format from qstat from one-line pr. job to multiple lines pr. job. Only then is the exit code from the cluster made available to the torque driver.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
