### PR TITLE
Remove storage data from snake oil

### DIFF
--- a/src/clib/lib/enkf/block_fs_driver.cpp
+++ b/src/clib/lib/enkf/block_fs_driver.cpp
@@ -125,9 +125,9 @@ void ert::block_fs_driver::save_node(const char *node_key, int report_step,
     free(key);
 }
 
-void ert::block_fs_driver::save_node(const char *node_key, int iens,
+void ert::block_fs_driver::save_node(const char *node_key, int report_step, int iens,
                                      const void *ptr, size_t data_size) {
-    auto key = fmt::format("{}.0.{}", node_key, iens);
+    auto key = fmt::format("{}.{}.{}", node_key, report_step, iens);
     bfs_type *bfs = this->get_fs(iens);
     block_fs_fwrite_file(bfs->block_fs, key.c_str(), ptr, data_size);
 }

--- a/src/clib/lib/include/ert/enkf/block_fs_driver.hpp
+++ b/src/clib/lib/include/ert/enkf/block_fs_driver.hpp
@@ -31,8 +31,8 @@ public:
                    buffer_type *buffer);
     void save_node(const char *node_key, int report_step, int iens,
                    buffer_type *buffer);
-    void save_node(const char *node_key, int iens, const void *ptr,
-                   size_t data_size);
+    void save_node(const char *node_key, int report_step, int iens,
+                   const void *ptr, size_t data_size);
 
     bool has_vector(const char *node_key, int iens);
     void load_vector(const char *node_key, int iens, buffer_type *buffer);

--- a/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_data.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_data.py
@@ -1,3 +1,6 @@
+import pytest
+import numpy as np
+
 from ert._c_wrappers.enkf.data.enkf_node import EnkfNode
 from ert._c_wrappers.enkf.node_id import NodeId
 
@@ -6,19 +9,25 @@ def test_load_active_masks(snake_oil_case_storage):
     case1 = "default_0"
     ert = snake_oil_case_storage
 
+    array_size = 15  # arbitrary size
+    report_step = 199
+    realization = 0
+    node_id = NodeId(report_step, realization)
+
     fs1 = ert.getEnkfFsManager().getFileSystem(case1)
     config_node = ert.ensembleConfig().getNode("SNAKE_OIL_OPR_DIFF")
+    fs1.save_gen_data(
+        config_node.getKey(), np.ndarray(array_size), report_step, realization
+    )
+
     data_node = EnkfNode(config_node)
-    data_node.tryLoad(fs1, NodeId(199, 0))
+    data_node.tryLoad(fs1, node_id)
 
     active_mask = config_node.getDataModelConfig().getActiveMask()
-    first_active_mask_length = len(active_mask)
-    assert first_active_mask_length == 2000
+    assert len(active_mask) == array_size
 
     active_mask = config_node.getDataModelConfig().getActiveMask()
-    second_active_mask_len = len(active_mask)
-    assert second_active_mask_len == 2000
-    assert first_active_mask_length == second_active_mask_len
+    assert len(active_mask) == array_size
 
     # Setting one element to False, load different case, check, reload,
     # and check.
@@ -28,7 +37,7 @@ def test_load_active_masks(snake_oil_case_storage):
 
     # Load first - check element is true
     data_node = EnkfNode(config_node)
-    data_node.tryLoad(fs1, NodeId(199, 0))
+    data_node.tryLoad(fs1, node_id)
     active_mask = config_node.getDataModelConfig().getActiveMask()
     assert active_mask[10]
 
@@ -38,10 +47,14 @@ def test_create(snake_oil_case_storage):
     fs1 = ert.getEnkfFsManager().getCurrentFileSystem()
     config_node = ert.ensembleConfig().getNode("SNAKE_OIL_OPR_DIFF")
 
+    fs1.save_gen_data(
+        config_node.getKey(), np.ndarray(array_size), report_step, realization
+    )
+
     data_node = EnkfNode(config_node)
-    data_node.tryLoad(fs1, NodeId(199, 0))
+    assert data_node.tryLoad(fs1, NodeId(report_step, realization))
 
     gen_data = data_node.asGenData()
     data = gen_data.getData()
 
-    assert len(data) == 2000
+    assert len(data) == array_size

--- a/tests/unit_tests/c_wrappers/res/enkf/test_summary_key_set.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_summary_key_set.py
@@ -1,6 +1,6 @@
 import os
-
 import pytest
+import numpy as np
 
 from ert._c_wrappers.enkf import EnKFMain, ResConfig, SummaryKeySet
 from ert._c_wrappers.enkf.enkf_fs import EnkfFs
@@ -68,8 +68,8 @@ def test_write_to_and_read_from_file(tmp_path):
 def test_with_enkf_fs():
     res_config = ResConfig("snake_oil.ert")
 
-    fs = EnkfFs(
-        "storage/snake_oil/ensemble/default_0", res_config.ensemble_config, 4, False
+    fs = EnkfFs.createFileSystem(
+        "storage/snake_oil/ensemble/default", res_config.ensemble_config, 4, False
     )
     summary_key_set = fs.getSummaryKeySet()
     summary_key_set.addSummaryKey("FOPT")


### PR DESCRIPTION
Snake oil remains, but with no `storage/` directory. A lot of tests had to be rewritten to create only the data that is explicitly necessary to test its functionality.

Todo:
- [ ] `unit_tests/all/plugins/test_export_misfit.py::test_export_misfit` _[create synthetic response data for snapshot test]_
- [ ] `unit_tests/analysis/test_es_update.py` _[create synthetic data for snapshot tests]_
- [ ] `unit_tests/c_wrappers/res/enkf/test_load_forward_model.py::test_load_forward_model` _[loads 0 instead of 1, no idea how this work]_
- [ ] `unit_tests/data/test_integration_data.py` _[tests expect data to load, so we need to create it]_
- [ ] `unit_tests/test_libres_facade.py` _[assumes snake_oil is populated]_
- [ ] `test_config_parsing/test_substitution_list.py::test_different_defines_give_different_subst_lists` _[slow hypothesis generation]_