### PR TITLE
Add default jobname and raise more descriptive config validation exception

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -10,6 +10,7 @@ import yaml
 from ecl import set_abort_handler
 
 import ert.shared
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import ResConfig
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
@@ -548,6 +549,9 @@ def main():
     except (ErtCliError, ErtTimeoutError) as err:
         logger.exception(str(err))
         sys.exit(str(err))
+    except ConfigValidationError as err:
+        logger.exception(str(err))
+        sys.exit(f"Error in configuration file: {err}")
     except BaseException as err:
         logger.exception(f'ERT crashed unexpectedly with "{err}"')
 

--- a/src/ert/_c_wrappers/config/__init__.py
+++ b/src/ert/_c_wrappers/config/__init__.py
@@ -1,6 +1,6 @@
 from .config_content import ConfigContent, ContentItem, ContentNode
 from .config_error import ConfigError
-from .config_parser import ConfigParser
+from .config_parser import ConfigParser, ConfigValidationError
 from .config_path_elm import ConfigPathElm
 from .content_type_enum import ContentTypeEnum
 from .schema_item import SchemaItem
@@ -16,4 +16,5 @@ __all__ = [
     "ContentItem",
     "ContentNode",
     "ConfigParser",
+    "ConfigValidationError",
 ]

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -9,6 +9,10 @@ from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.unrecognized_enum import UnrecognizedEnum
 
 
+class ConfigValidationError(ValueError):
+    pass
+
+
 class ConfigParser(BaseCClass):
     TYPE_NAME = "config_parser"
 
@@ -105,7 +109,7 @@ class ConfigParser(BaseCClass):
             sys.stderr.write(f"Errors parsing:{config_file} \n")
             for count, error in enumerate(config_content.getErrors()):
                 sys.stderr.write(f"  {count:02d}:{error}\n")
-            raise ValueError(f"Parsing:{config_file} failed")
+            raise ConfigValidationError(f"Parsing:{config_file} failed")
 
         return config_content
 

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -180,7 +180,7 @@ class EnKFMain:
         self._ensemble_size = self.res_config.model_config.num_realizations
         self._substituter = Substituter(dict(self.getDataKW()))
         self._runpaths = Runpaths(
-            self.getModelConfig().getJobnameFormat(),
+            self.resConfig().preferred_job_fmt(),
             self.getModelConfig().getRunpathFormat().format_string,
             Path(config.runpath_file),
             self.substituter.substitute,

--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from cwrap import BaseCClass
 from ecl.summary import EclSum
@@ -225,7 +226,8 @@ class ModelConfig(BaseCClass):
     def runpathRequiresIterations(self) -> bool:
         return self._runpath_requires_iterations()
 
-    def getJobnameFormat(self) -> str:
+    def getJobnameFormat(self) -> Optional[str]:
+        """Returns None if no job name format given in config file."""
         return self._get_jobname_fmt()
 
     @property

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -795,6 +795,13 @@ class ResConfig:
             return self.num_cpu_from_data_file
         return 1
 
+    def preferred_job_fmt(self) -> str:
+        in_config = self.model_config.getJobnameFormat()
+        if in_config is None:
+            return "JOB%d"
+        else:
+            return in_config
+
     @property
     def errors(self):
         return self._errors

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -10,6 +10,7 @@ from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 from ecl.util.util import StringList
 
 from ert._c_wrappers.config import ConfigContent, ConfigParser
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf.analysis_config import AnalysisConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert._c_wrappers.enkf.ensemble_config import EnsembleConfig
@@ -198,7 +199,9 @@ class ResConfig:
 
         if self.errors:
             logging.error(f"Error loading configuration: {str(self._errors)}")
-            raise ValueError("Error loading configuration: " + str(self._errors))
+            raise ConfigValidationError(
+                "Error loading configuration: " + str(self._errors)
+            )
 
         self.num_cpu_from_data_file = (
             get_num_cpu_from_data_file(
@@ -309,7 +312,9 @@ class ResConfig:
                 self.ensemble_config.getNode(key).get_init_file_fmt() != None
                 and "%" not in self.ensemble_config.getNode(key).get_init_file_fmt()
             ):
-                raise ValueError("Loading GEN_KW from files requires %d in file format")
+                raise ConfigValidationError(
+                    "Loading GEN_KW from files requires %d in file format"
+                )
 
         self.model_config = ModelConfig(
             data_root=self.config_path,
@@ -394,7 +399,9 @@ class ResConfig:
                 self.ensemble_config.getNode(key).get_init_file_fmt() != None
                 and "%" not in self.ensemble_config.getNode(key).get_init_file_fmt()
             ):
-                raise ValueError("Loading GEN_KW from files requires %d in file format")
+                raise ConfigValidationError(
+                    "Loading GEN_KW from files requires %d in file format"
+                )
 
         self.model_config = ModelConfig(
             data_root=self.config_path,

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import ResConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 
@@ -45,3 +46,22 @@ def test_res_config_minimal_dict_init(tmpdir):
         config_dict = {ConfigKeys.NUM_REALIZATIONS: 1}
         res_config = ResConfig(config_dict=config_dict)
         assert res_config is not None
+
+
+def test_bad_user_config_file_error_message(tmp_path):
+    (tmp_path / "test.ert").write_text("NUM_REL 10\n")
+
+    rconfig = None
+    with pytest.raises(ConfigValidationError, match=r"Parsing.*failed"):
+        rconfig = ResConfig(user_config_file=str(tmp_path / "test.ert"))
+
+    assert rconfig is None
+
+
+def test_bad_config_provide_error_message(tmp_path):
+    rconfig = None
+    with pytest.raises(ConfigValidationError, match=r"Error loading configuration.*"):
+        testDict = {"GEN_KW": "a"}
+        rconfig = ResConfig(config=testDict)
+
+    assert rconfig is None

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -12,6 +12,7 @@ from ecl.eclfile import EclKW
 from ecl.grid import EclGrid
 from ecl.util.geometry import Surface
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
 from ert._clib import update
 from ert._clib.update import Parameter
@@ -69,7 +70,9 @@ def load_from_forward_model(ert):
             "GEN_KW KW_NAME template.txt kw.txt prior.txt INIT_FILES:custom_param0",  # noqa
             "Not expecting a file",
             [],
-            pytest.raises(ValueError, match="Loading GEN_KW from files requires %d"),
+            pytest.raises(
+                ConfigValidationError, match="Loading GEN_KW from files requires %d"
+            ),
         ),
     ],
 )

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -11,6 +11,7 @@ import pytest
 
 import ert.shared
 from ert.__main__ import ert_parser
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -379,3 +380,17 @@ def test_experiment_server_mda(tmpdir, source_root, capsys):
         assert "Successful realizations: 5\n" in captured.out
 
     FeatureToggling.reset()
+
+
+def test_bad_config_error_message(tmp_path):
+    (tmp_path / "test.ert").write_text("NUM_REL 10\n")
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            TEST_RUN_MODE,
+            str(tmp_path / "test.ert"),
+        ],
+    )
+    with pytest.raises(ConfigValidationError, match=r"Parsing.*failed"):
+        run_cli(parsed)


### PR DESCRIPTION
Resolves #4174 and adds the potentially breaking change of default jobnames.

There will be squashing later on.
- Is the placement of the exception acceptable? I had some issues with circular dependencies on the original placement.
- Verify label

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
