### PR TITLE
Make `<DATE>` magic string substitution available for ert config file

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -183,6 +183,7 @@ class ResConfig:
                 user_config_file,
                 pre_defined_kw_map={
                     "<CWD>": self.config_path,
+                    "<DATE>": self._current_date_string(),
                     "<CONFIG_PATH>": self.config_path,
                     "<CONFIG_FILE>": os.path.basename(user_config_file),
                     "<CONFIG_FILE_BASE>": os.path.basename(user_config_file).split(".")[
@@ -715,6 +716,10 @@ class ResConfig:
         return content_dict
 
     @staticmethod
+    def _current_date_string() -> str:
+        return date.today().isoformat()
+
+    @staticmethod
     def _create_substitution_list(
         defines: Dict[str, str],
         data_kw: Dict[str, str],
@@ -724,7 +729,7 @@ class ResConfig:
     ) -> SubstitutionList:
         subst_list = SubstitutionList()
 
-        today_date_string = date.today().isoformat()
+        today_date_string = ResConfig._current_date_string()
         subst_list.addItem("<DATE>", today_date_string)
         subst_list.addItem("<CONFIG_PATH>", config_dir)
 


### PR DESCRIPTION
This makes it possible to use the magic string `<DATE>` for substitutions in the ert config file, and have it substituted with the current date when running ert, with the format `YYYY-MM-DD`.

A user [reported unexpected behaviour / this bug in slack](https://equinor.slack.com/archives/CDPJULWR4/p1667294063812139) [INTERNAL LINK]

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
