### PR TITLE
Backporting blocking issues into version-4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-10.15']
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1203,7 +1203,7 @@ and/or history matching project.
         The SUMMARY keyword has limited support for '*' wildcards, if your key
         contains one or more '*' characters all matching variables from the refcase
         are selected. Observe that if your summary key contains wildcards you must
-        supply a refcase with the REFCASE key - otherwise it will fail hard.
+        supply a refcase with the REFCASE key - otherwise only fully expanded keywords will be used.
 
         **Note:** Properties added using the SUMMARY keyword are only
         diagnostic. I.e. they have no effect on the sensitivity analysis or

--- a/src/clib/lib/enkf/ensemble_config.cpp
+++ b/src/clib/lib/enkf/ensemble_config.cpp
@@ -451,6 +451,12 @@ void ensemble_config_init_SUMMARY_full(ensemble_config_type *ensemble_config,
                                             LOAD_FAIL_SILENT);
 
             stringlist_free(keys);
+        } else {
+            fprintf(stderr,
+                    "** Warning: Cannot expand %s due to missing refcase file."
+                    " Provide refcase file or add fully expanded SUMMARY key"
+                    " to configuration\n",
+                    key);
         }
     } else {
         ensemble_config_add_summary(ensemble_config, key, LOAD_FAIL_SILENT);

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -10,6 +10,7 @@ import yaml
 from ecl import set_abort_handler
 
 import ert.shared
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import ResConfig
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
@@ -548,6 +549,9 @@ def main():
     except (ErtCliError, ErtTimeoutError) as err:
         logger.exception(str(err))
         sys.exit(str(err))
+    except ConfigValidationError as err:
+        logger.exception(str(err))
+        sys.exit(f"Error in configuration file: {err}")
     except BaseException as err:
         logger.exception(f'ERT crashed unexpectedly with "{err}"')
 

--- a/src/ert/_c_wrappers/config/__init__.py
+++ b/src/ert/_c_wrappers/config/__init__.py
@@ -1,6 +1,6 @@
 from .config_content import ConfigContent, ContentItem, ContentNode
 from .config_error import ConfigError
-from .config_parser import ConfigParser
+from .config_parser import ConfigParser, ConfigValidationError
 from .config_path_elm import ConfigPathElm
 from .content_type_enum import ContentTypeEnum
 from .schema_item import SchemaItem
@@ -16,4 +16,5 @@ __all__ = [
     "ContentItem",
     "ContentNode",
     "ConfigParser",
+    "ConfigValidationError",
 ]

--- a/src/ert/_c_wrappers/config/config_content.py
+++ b/src/ert/_c_wrappers/config/config_content.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List
+from typing import TYPE_CHECKING, Iterator, List
 
 from cwrap import BaseCClass
 
@@ -257,25 +257,3 @@ class ConfigContent(BaseCClass):
 
     def keys(self) -> List[str]:
         return list(self._keys())
-
-    def as_dict(self) -> Dict[str, List[Any]]:
-        # pylint: disable=consider-using-dict-items
-        # (false positive)
-        d: Dict[str, List[Any]] = {}
-        for key in self.keys():
-            item = self[key]
-            if len(item) > 1:
-                d[key] = []
-                for node in item:
-                    values = list(node)
-                    if len(values) > 1:
-                        d[key].append(values)
-                    else:
-                        d[key].append(values[0])
-            else:
-                values = list(item[0])
-                if len(values) > 1:
-                    d[key] = [values]
-                else:
-                    d[key] = values[0]
-        return d

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -9,6 +9,10 @@ from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.unrecognized_enum import UnrecognizedEnum
 
 
+class ConfigValidationError(ValueError):
+    pass
+
+
 class ConfigParser(BaseCClass):
     TYPE_NAME = "config_parser"
 
@@ -105,7 +109,7 @@ class ConfigParser(BaseCClass):
             sys.stderr.write(f"Errors parsing:{config_file} \n")
             for count, error in enumerate(config_content.getErrors()):
                 sys.stderr.write(f"  {count:02d}:{error}\n")
-            raise ValueError(f"Parsing:{config_file} failed")
+            raise ConfigValidationError(f"Parsing:{config_file} failed")
 
         return config_content
 

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -101,9 +101,6 @@ class AnalysisConfig:
         if min_realization == 0:
             min_realization = num_realization
         min_realization = min(min_realization, num_realization)
-        max_runtime = config_dict.get(ConfigKeys.MAX_RUNTIME, 0)
-        if isinstance(max_runtime, list):
-            max_runtime = max_runtime[-1]
 
         config = cls(
             alpha=config_dict.get(ConfigKeys.ALPHA_KEY, 3.0),
@@ -112,7 +109,7 @@ class AnalysisConfig:
             std_cutoff=config_dict.get(ConfigKeys.STD_CUTOFF_KEY, 1e-6),
             stop_long_running=config_dict.get(ConfigKeys.STOP_LONG_RUNNING, False),
             global_std_scaling=config_dict.get(ConfigKeys.GLOBAL_STD_SCALING, 1.0),
-            max_runtime=max_runtime,
+            max_runtime=config_dict.get(ConfigKeys.MAX_RUNTIME, 0),
             min_realization=min_realization,
             update_log_path=config_dict.get(ConfigKeys.UPDATE_LOG_PATH, "update_log"),
             analysis_iter_config=AnalysisIterConfig.from_dict(config_dict),

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -118,13 +118,14 @@ class EnsembleConfig(BaseCClass):
         )
 
         if config_content is not None:
-            config_content_dict = config_content.as_dict()
-            self._grid_file = self._get_file_str(
-                config_content_dict.get(ConfigKeys.GRID)
-            )
-            self._refcase_file = self._get_file_str(
-                config_content_dict.get(ConfigKeys.REFCASE)
-            )
+            if config_content.hasKey(ConfigKeys.GRID):
+                self._grid_file = self._get_file_str(
+                    config_content.getValue(ConfigKeys.GRID)
+                )
+            if config_content.hasKey(ConfigKeys.REFCASE):
+                self._refcase_file = self._get_file_str(
+                    config_content.getValue(ConfigKeys.REFCASE)
+                )
 
         self.grid = self._load_grid(self._grid_file) if self._grid_file else None
         self.refcase = (

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -9,6 +9,7 @@ from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 from ecl.util.util import StringList
 
 from ert._c_wrappers.config import ConfigContent, ConfigParser
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf.analysis_config import AnalysisConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert._c_wrappers.enkf.ensemble_config import EnsembleConfig
@@ -197,7 +198,9 @@ class ResConfig:
 
         if self.errors:
             logging.error(f"Error loading configuration: {str(self._errors)}")
-            raise ValueError("Error loading configuration: " + str(self._errors))
+            raise ConfigValidationError(
+                "Error loading configuration: " + str(self._errors)
+            )
 
         self.num_cpu_from_data_file = (
             get_num_cpu_from_data_file(
@@ -304,6 +307,13 @@ class ResConfig:
                     "Loading GEN_KW from files created by the forward model "
                     "is not supported."
                 )
+            if (
+                self.ensemble_config.getNode(key).get_init_file_fmt() != None
+                and "%" not in self.ensemble_config.getNode(key).get_init_file_fmt()
+            ):
+                raise ConfigValidationError(
+                    "Loading GEN_KW from files requires %d in file format"
+                )
 
         self.model_config = ModelConfig(
             data_root=self.config_path,
@@ -386,6 +396,13 @@ class ResConfig:
                 raise KeyError(
                     "Loading GEN_KW from files created by the forward model "
                     "is not supported."
+                )
+            if (
+                self.ensemble_config.getNode(key).get_init_file_fmt() != None
+                and "%" not in self.ensemble_config.getNode(key).get_init_file_fmt()
+            ):
+                raise ConfigValidationError(
+                    "Loading GEN_KW from files requires %d in file format"
                 )
 
         self.model_config = ModelConfig(

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -261,7 +261,7 @@ class ResConfig:
         self.ensemble_config = EnsembleConfig(config_content=user_config_content)
 
         for key in self.ensemble_config.getKeylistFromImplType(ErtImplType.GEN_KW):
-            if self.ensemble_config.getNode(key).get_init_file_fmt() != None:
+            if self.ensemble_config.getNode(key).getUseForwardInit():
                 raise KeyError(
                     "Loading GEN_KW from files created by the forward model "
                     "is not supported."
@@ -344,7 +344,7 @@ class ResConfig:
         self.ensemble_config = EnsembleConfig(config_dict=config_dict)
 
         for key in self.ensemble_config.getKeylistFromImplType(ErtImplType.GEN_KW):
-            if self.ensemble_config.getNode(key).get_init_file_fmt() != None:
+            if self.ensemble_config.getNode(key).getUseForwardInit():
                 raise KeyError(
                     "Loading GEN_KW from files created by the forward model "
                     "is not supported."

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -3,7 +3,7 @@ import os
 from collections import defaultdict
 from os.path import isfile
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 from ecl.util.util import StringList
@@ -22,6 +22,44 @@ from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._clib.config_keywords import init_site_config_parser, init_user_config_parser
 
 logger = logging.getLogger(__name__)
+
+SINGLE_VALUE_KEYS = [
+    ConfigKeys.ALPHA_KEY,
+    ConfigKeys.ANALYSIS_SELECT,
+    ConfigKeys.CONFIG_DIRECTORY,
+    ConfigKeys.DATAROOT,
+    ConfigKeys.DATA_FILE,
+    ConfigKeys.ECLBASE,
+    ConfigKeys.ENSPATH,
+    ConfigKeys.GEN_KW_EXPORT_NAME,
+    ConfigKeys.GEN_KW_TAG_FORMAT,
+    ConfigKeys.GRID,
+    ConfigKeys.HISTORY_SOURCE,
+    ConfigKeys.ITER_CASE,
+    ConfigKeys.ITER_COUNT,
+    ConfigKeys.ITER_RETRY_COUNT,
+    ConfigKeys.JOBNAME,
+    ConfigKeys.JOB_SCRIPT,
+    ConfigKeys.LICENSE_PATH,
+    ConfigKeys.MAX_RESAMPLE,
+    ConfigKeys.MAX_RUNTIME,
+    ConfigKeys.MAX_SUBMIT,
+    ConfigKeys.MIN_REALIZATIONS,
+    ConfigKeys.NUM_CPU,
+    ConfigKeys.NUM_REALIZATIONS,
+    ConfigKeys.OBS_CONFIG,
+    ConfigKeys.QUEUE_SYSTEM,
+    ConfigKeys.RANDOM_SEED,
+    ConfigKeys.REFCASE,
+    ConfigKeys.RERUN_KEY,
+    ConfigKeys.RERUN_START_KEY,
+    ConfigKeys.RUNPATH,
+    ConfigKeys.RUNPATH_FILE,
+    ConfigKeys.STD_CUTOFF_KEY,
+    ConfigKeys.STOP_LONG_RUNNING,
+    ConfigKeys.TIME_MAP,
+    ConfigKeys.UPDATE_LOG_PATH,
+]
 
 
 def site_config_location():
@@ -119,7 +157,7 @@ class ResConfig:
             )
 
     def _log_config_content(self, config_content: ConfigContent) -> None:
-        tmp_dict = config_content.as_dict().copy()
+        tmp_dict = self._config_content_as_dict(config_content).copy()
         tmp_dict.pop("FORWARD_MODEL", None)
         tmp_dict.pop("LOAD_WORKFLOW", None)
         tmp_dict.pop("LOAD_WORKFLOW_JOB", None)
@@ -186,7 +224,7 @@ class ResConfig:
         else:
             self.random_seed = None
 
-        config_content_dict = user_config_content.as_dict()
+        config_content_dict = self._config_content_as_dict(user_config_content)
         self.analysis_config = AnalysisConfig.from_dict(config_content_dict)
 
         queue_config_args = {}
@@ -636,6 +674,30 @@ class ResConfig:
         self._errors = list(config_content.getErrors())
 
         return config_content
+
+    @staticmethod
+    def _config_content_as_dict(config_content: ConfigContent) -> Dict[str, List[Any]]:
+        content_dict: Dict[str, List[Any]] = {}
+        for key in config_content.keys():
+            item = config_content[key]
+            if key in SINGLE_VALUE_KEYS:
+                content_dict[key] = item.getValue()
+                continue
+            if len(item) > 1:
+                content_dict[key] = []
+                for node in item:
+                    values = list(node)
+                    if len(values) > 1:
+                        content_dict[key].append(values)
+                    else:
+                        content_dict[key].append(values[0])
+            else:
+                values = list(item[0])
+                if len(values) > 1:
+                    content_dict[key] = [values]
+                else:
+                    content_dict[key] = values[0]
+        return content_dict
 
     def free(self):
         self._free()  # pylint: disable=no-member

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import ResConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 
@@ -45,3 +46,22 @@ def test_res_config_minimal_dict_init(tmpdir):
         config_dict = {ConfigKeys.NUM_REALIZATIONS: 1}
         res_config = ResConfig(config_dict=config_dict)
         assert res_config is not None
+
+
+def test_bad_user_config_file_error_message(tmp_path):
+    (tmp_path / "test.ert").write_text("NUM_REL 10\n")
+
+    rconfig = None
+    with pytest.raises(ConfigValidationError, match=r"Parsing.*failed"):
+        rconfig = ResConfig(user_config_file=str(tmp_path / "test.ert"))
+
+    assert rconfig is None
+
+
+def test_bad_config_provide_error_message(tmp_path):
+    rconfig = None
+    with pytest.raises(ConfigValidationError, match=r"Error loading configuration.*"):
+        testDict = {"GEN_KW": "a"}
+        rconfig = ResConfig(config=testDict)
+
+    assert rconfig is None

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -12,6 +12,7 @@ from ecl.eclfile import EclKW
 from ecl.grid import EclGrid
 from ecl.util.geometry import Surface
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
 from ert._clib import update
 from ert._clib.update import Parameter
@@ -51,6 +52,26 @@ def load_from_forward_model(ert):
             "MY_KEYWORD 0.379773",
             [],
             does_not_raise(),
+        ),
+        (
+            "GEN_KW KW_NAME template.txt kw.txt prior.txt INIT_FILES:custom_param%d",
+            "MY_KEYWORD 1.31",
+            [("custom_param0", "MY_KEYWORD 1.31")],
+            does_not_raise(),
+        ),
+        (
+            "GEN_KW KW_NAME template.txt kw.txt prior.txt INIT_FILES:custom_param%d",
+            "MY_KEYWORD 1.31",
+            [("custom_param0", "1.31")],
+            does_not_raise(),
+        ),
+        (
+            "GEN_KW KW_NAME template.txt kw.txt prior.txt INIT_FILES:custom_param0",  # noqa
+            "Not expecting a file",
+            [],
+            pytest.raises(
+                ConfigValidationError, match="Loading GEN_KW from files requires %d"
+            ),
         ),
     ],
 )

--- a/tests/unit_tests/c_wrappers/res/config/test_config_content.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_content.py
@@ -1,12 +1,8 @@
-from pathlib import Path
-
 from ecl.util.util import StringList
 
 from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.config_parser import ConfigParser
 from ert._c_wrappers.config.content_type_enum import ContentTypeEnum
-from ert._c_wrappers.enkf.config_keys import ConfigKeys
-from ert._clib.config_keywords import init_user_config_parser
 
 
 def test_get_executable_list(tmpdir):
@@ -38,45 +34,3 @@ def test_get_executable_list(tmpdir):
     assert " does not exist" in errors[0]
     assert "MY_EXECUTABLE2" in errors[1]
     assert " does not exist" in errors[1]
-
-
-def test_config_content_as_dict(tmpdir):
-    with tmpdir.as_cwd():
-        conf = ConfigParser()
-        existing_file_1 = "test_1.t"
-        existing_file_2 = "test_2.t"
-        Path(existing_file_2).write_text("something")
-        Path(existing_file_1).write_text("not important")
-        init_user_config_parser(conf)
-
-        schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
-        schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
-
-        schema_item = conf.add("KEY", False)
-        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
-
-        with open("config", "w") as fileH:
-            fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
-            fileH.write(f"DATA_FILE {existing_file_2} \n")
-            fileH.write(f"DATA_FILE {existing_file_1} \n")
-            fileH.write(f"REFCASE {existing_file_1} \n")
-
-            fileH.write("MULTIPLE_KEY_VALUE 6\n")
-            fileH.write("MULTIPLE_KEY_VALUE 24\n")
-            fileH.write("MULTIPLE_KEY_VALUE 12\n")
-            fileH.write("QUEUE_OPTION SLURM MAX_RUNNING 50\n")
-            fileH.write("KEY VALUE1 VALUE1 100\n")
-            fileH.write("KEY VALUE2 VALUE2 200\n")
-        content = conf.parse("config")
-        content_as_dict = content.as_dict()
-        assert content_as_dict == {
-            "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
-            ConfigKeys.NUM_REALIZATIONS: 42,
-            ConfigKeys.QUEUE_OPTION: [["SLURM", "MAX_RUNNING", "50"]],
-            "MULTIPLE_KEY_VALUE": [6, 24, 12],
-            ConfigKeys.DATA_FILE: [
-                str(Path.cwd() / existing_file_2),
-                str(Path.cwd() / existing_file_1),
-            ],
-            ConfigKeys.REFCASE: str(Path.cwd() / existing_file_1),
-        }

--- a/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
@@ -170,7 +170,6 @@ def test_parser_content():
     os.makedirs("tmp")
     os.chdir("tmp")
     content = conf.parse("../config")
-    d = content.as_dict()
     assert content.isValid()
     assert "KEY" in content
     assert "NOKEY" not in content
@@ -179,11 +178,9 @@ def test_parser_content():
     keys = content.keys()
     assert len(keys) == 1
     assert "KEY" in keys
-    d = content.as_dict()
-    assert "KEY" in d
-    item_list = d["KEY"]
+    item_list = content["KEY"]
     assert len(item_list) == 1
-    line = item_list[0]
+    line = list(item_list[0])
     assert line[0] == "VALUE1"
     assert line[1] == "VALUE2"
     assert line[2] == 100

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -10,6 +10,7 @@ import pytest
 from cwrap import Prototype, load
 from ecl.util.enums import RngAlgTypeEnum
 
+from ert._c_wrappers.config import ConfigParser, ContentTypeEnum
 from ert._c_wrappers.enkf import (
     AnalysisConfig,
     ConfigKeys,
@@ -18,9 +19,10 @@ from ert._c_wrappers.enkf import (
     SiteConfig,
 )
 from ert._c_wrappers.enkf.enums import HookRuntime
-from ert._c_wrappers.enkf.res_config import site_config_location
+from ert._c_wrappers.enkf.res_config import SINGLE_VALUE_KEYS, site_config_location
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum
+from ert._clib.config_keywords import init_user_config_parser
 
 # The res_config object should set the environment variable
 # 'DATA_ROOT' to the root directory with the config
@@ -118,6 +120,44 @@ snake_oil_structure_config = {
             "TARGET_FILE": "seed.txt",
         }
     },
+}
+
+SINGLE_VALUE_KEY_TYPES = {
+    ConfigKeys.ALPHA_KEY: "int",
+    ConfigKeys.ANALYSIS_SELECT: "str",
+    ConfigKeys.CONFIG_DIRECTORY: "path",
+    ConfigKeys.DATAROOT: "file_path",
+    ConfigKeys.DATA_FILE: "file_path",
+    ConfigKeys.ECLBASE: "file_path",
+    ConfigKeys.ENSPATH: "path",
+    ConfigKeys.GEN_KW_EXPORT_NAME: "str",
+    ConfigKeys.GEN_KW_TAG_FORMAT: "str",
+    ConfigKeys.GRID: "file_path",
+    ConfigKeys.HISTORY_SOURCE: "history_enum",
+    ConfigKeys.ITER_CASE: "str",
+    ConfigKeys.ITER_COUNT: "int",
+    ConfigKeys.ITER_RETRY_COUNT: "int",
+    ConfigKeys.JOBNAME: "str",
+    ConfigKeys.JOB_SCRIPT: "file_path",
+    ConfigKeys.LICENSE_PATH: "file_path",
+    ConfigKeys.MAX_RESAMPLE: "int",
+    ConfigKeys.MAX_RUNTIME: "int",
+    ConfigKeys.MAX_SUBMIT: "int",
+    ConfigKeys.MIN_REALIZATIONS: "int",
+    ConfigKeys.NUM_CPU: "int",
+    ConfigKeys.NUM_REALIZATIONS: "int",
+    ConfigKeys.OBS_CONFIG: "file_path",
+    ConfigKeys.QUEUE_SYSTEM: "str",
+    ConfigKeys.RANDOM_SEED: "str",
+    ConfigKeys.REFCASE: "file_path",
+    ConfigKeys.RERUN_KEY: "bool",
+    ConfigKeys.RERUN_START_KEY: "int",
+    ConfigKeys.RUNPATH: "path",
+    ConfigKeys.RUNPATH_FILE: "file_path",
+    ConfigKeys.STD_CUTOFF_KEY: "float",
+    ConfigKeys.STOP_LONG_RUNNING: "bool",
+    ConfigKeys.TIME_MAP: "file_path",
+    ConfigKeys.UPDATE_LOG_PATH: "file_path",
 }
 
 
@@ -739,3 +779,71 @@ SUMMARY WBHP:INJ
 SUMMARY ROE:1"""  # noqa: E501 pylint: disable=line-too-long
         in caplog.text
     )
+
+
+def test_config_content_as_dict(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+
+        schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
+        schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
+
+        schema_item = conf.add("KEY", False)
+        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
+
+        with open("config", "w") as fileH:
+            fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
+            fileH.write(f"{ConfigKeys.DATA_FILE} {existing_file_2} \n")
+            fileH.write(f"{ConfigKeys.REFCASE} {existing_file_1} \n")
+
+            fileH.write("MULTIPLE_KEY_VALUE 6\n")
+            fileH.write("MULTIPLE_KEY_VALUE 24\n")
+            fileH.write("MULTIPLE_KEY_VALUE 12\n")
+            fileH.write("QUEUE_OPTION SLURM MAX_RUNNING 50\n")
+            fileH.write("KEY VALUE1 VALUE1 100\n")
+            fileH.write("KEY VALUE2 VALUE2 200\n")
+        content = conf.parse("config")
+        content_as_dict = ResConfig._config_content_as_dict(content)
+        assert content_as_dict == {
+            "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
+            ConfigKeys.NUM_REALIZATIONS: 42,
+            ConfigKeys.QUEUE_OPTION: [["SLURM", "MAX_RUNNING", "50"]],
+            "MULTIPLE_KEY_VALUE": [6, 24, 12],
+            ConfigKeys.DATA_FILE: str(Path.cwd() / existing_file_2),
+            ConfigKeys.REFCASE: str(Path.cwd() / existing_file_1),
+        }
+
+
+def test_config_content_as_dict_single_value_keys(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+        type_value_map = {
+            "str": "abc",
+            "path": tmpdir,
+            "file_path": existing_file_1,
+            "bool": "TRUE",
+            "float": 4.2,
+            "int": 2,
+            "history_enum": "REFCASE_SIMULATED",
+        }
+
+        with open("config.file", "w") as fileH:
+            for key in SINGLE_VALUE_KEYS:
+                key_type = SINGLE_VALUE_KEY_TYPES[key]
+                value = type_value_map[key_type]
+                fileH.write(f"{key} {value}\n{key} {value}\n")
+
+        content = conf.parse("config.file")
+        content_as_dict = ResConfig._config_content_as_dict(content)
+        for _, value in content_as_dict.items():
+            assert not isinstance(value, list)

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -11,6 +11,7 @@ import pytest
 
 import ert.shared
 from ert.__main__ import ert_parser
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -379,3 +380,17 @@ def test_experiment_server_mda(tmpdir, source_root, capsys):
         assert "Successful realizations: 5\n" in captured.out
 
     FeatureToggling.reset()
+
+
+def test_bad_config_error_message(tmp_path):
+    (tmp_path / "test.ert").write_text("NUM_REL 10\n")
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            TEST_RUN_MODE,
+            str(tmp_path / "test.ert"),
+        ],
+    )
+    with pytest.raises(ConfigValidationError, match=r"Parsing.*failed"):
+        run_cli(parsed)


### PR DESCRIPTION
Backporting issues:

#4055 GEN_KW INIT_FILES is used by an asset. We have to reintroduce it.
#4148 Improve config_content.as_dict()
#4096 Plot vectors missing in recent Komodo update (2022-10-02)
#4174 Add separate exception handling of config checking

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
