### PR TITLE
script/build: Try both cxx and cxx.resolve()

### DIFF
--- a/script/build
+++ b/script/build
@@ -41,20 +41,25 @@ def check_cxx_version() -> None:
     """
     Check that the user's compiler is compatible with ERT.
     """
-    cxx = Path(shutil.which(os.environ.get("CXX", "c++"))).resolve()
+    cxx_path = Path(shutil.which(os.environ.get("CXX", "c++")))
     print_info(f"Using C++ compiler: {cxx}")
 
-    version_line = subprocess.check_output([cxx, "--version"]).splitlines()[0].decode()
-    version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_line)
-    if version_match is None:
-        print_error("Could not extract version information from C++ compiler")
-        sys.exit(1)
-    version = tuple(int(version_match[x + 1]) for x in range(3))
+    for cxx in cxx_path, cxx_path.resolve():
+        version_line = (
+            subprocess.check_output([cxx, "--version"]).splitlines()[0].decode()
+        )
+        version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_line)
+        if version_match is None:
+            print_error("Could not extract version information from C++ compiler")
+            sys.exit(1)
+        version = tuple(int(version_match[x + 1]) for x in range(3))
 
-    if "GCC" in version_line or "g++" in version_line:
-        min_version = MIN_GCC_VERSION
-    elif "clang" in version_line:
-        min_version = MIN_CLANG_VERSION
+        if "GCC" in version_line or "g++" in version_line:
+            min_version = MIN_GCC_VERSION
+            break
+        elif "clang" in version_line:
+            min_version = MIN_CLANG_VERSION
+            break
     else:
         print_error("Unknown C++ compiler. (Neither GCC nor clang)")
         sys.exit(1)


### PR DESCRIPTION
`ccache` is a caching utility for C and co and makes recompilation a tad faster. The easiest way to make it work is by adding `/usr/lib/ccache` to cache, which contains symlinks from eg. `c++` to `/usr/bin/ccache`. Then, the application uses its executable name (`argv[0]`) to determine which program to forward to.

Resolving the `c++` symlink doesn't work since `ccache` isn't a C++ compiler by itself and thus fails the version check.

This commit changes it so that we test both the unresolved and resolved `c++` symlink. This would cover both the Debian/Ubuntu case and ccache case. (This might not work for ccache on Ubuntu though. If that becomes an issue we can just not version-check on Debian-derived distros as was proposed before.)