### PR TITLE
Make sure that processing reporter.event_queue does not yield ConnectionError

### DIFF
--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -61,7 +61,9 @@ class Client:  # pylint: disable=too-many-instance-attributes
 
     async def get_websocket(self) -> WebSocketClientProtocol:
         return await connect(
-            self.url, ssl=self._ssl_context, extra_headers=self._extra_headers
+            self.url,
+            ssl=self._ssl_context,
+            extra_headers=self._extra_headers,
         )
 
     async def _send(self, msg: AnyStr) -> None:

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -1,4 +1,4 @@
-mypy
+mypy<0.990
 mypy-protobuf
 types-aiofiles
 types-requests


### PR DESCRIPTION
Add exiting strategy when Finish event was recieved. We don't yield ConnectionError, but instead keep processing next events in the queue. When the Finish event is received, we setup the timer (60 seconds), which when reached will automatically stop the publisher thread and exits.

This includes tests for failed and reconnected reporter with sucessful finished jobs

Co-authored-by: Lars Petter Hauge <lpha@equinor.com>
