### PR TITLE
Remove TEST_CONFIG_FILE_KEY testing keyword

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -174,6 +174,22 @@ class ResConfig:
         logger.info("Content of the config_content:")
         logger.info(tmp_dict)
 
+    @staticmethod
+    def _create_pre_defines(
+        config_file_path: str,
+    ) -> dict:
+        date_string = date.today().isoformat()
+        config_file_dir = os.path.abspath(os.path.dirname(config_file_path))
+        config_file_name = os.path.basename(config_file_path)
+        config_file_basename = os.path.splitext(config_file_name)[0]
+        return {
+            "<DATE>": date_string,
+            "<CWD>": config_file_dir,
+            "<CONFIG_PATH>": config_file_dir,
+            "<CONFIG_FILE>": config_file_name,
+            "<CONFIG_FILE_BASE>": config_file_basename,
+        }
+
     # build configs from config file or everest dict
     def _alloc_from_content(self, user_config_file=None, config=None):
         site_config_parser = ConfigParser()
@@ -186,15 +202,7 @@ class ResConfig:
             self.config_path = os.path.abspath(os.path.dirname(user_config_file))
             user_config_content = config_parser.parse(
                 user_config_file,
-                pre_defined_kw_map={
-                    "<CWD>": self.config_path,
-                    "<DATE>": self._current_date_string(),
-                    "<CONFIG_PATH>": self.config_path,
-                    "<CONFIG_FILE>": os.path.basename(user_config_file),
-                    "<CONFIG_FILE_BASE>": os.path.basename(user_config_file).split(".")[
-                        0
-                    ],
-                },
+                pre_defined_kw_map=ResConfig._create_pre_defines(user_config_file),
             )
         else:
             self.config_path = os.getcwd()
@@ -773,10 +781,6 @@ class ResConfig:
         return config_content
 
     @staticmethod
-    def _current_date_string() -> str:
-        return date.today().isoformat()
-
-    @staticmethod
     def _create_substitution_list(
         defines: Dict[str, str],
         data_kw: Dict[str, str],
@@ -786,8 +790,7 @@ class ResConfig:
     ) -> SubstitutionList:
         subst_list = SubstitutionList()
 
-        today_date_string = ResConfig._current_date_string()
-        subst_list.addItem("<DATE>", today_date_string)
+        # only needed by everest's init from `config` path
         subst_list.addItem("<CONFIG_PATH>", config_dir)
 
         for key, value in defines.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,6 @@ from ert.shared.feature_toggling import FeatureToggling
 
 from .utils import SOURCE_DIR
 
-
-def pytest_configure():
-    pytest.TEST_CONFIG_FILE_KEY = "__TEST_CONFIG_FILE"
-
-
 # CI runners produce unreliable test timings
 # so too_slow healthcheck and deadline has to
 # be supressed to avoid flaky behavior
@@ -122,8 +117,8 @@ def copy_snake_oil_case(copy_case):
     copy_case("snake_oil")
 
 
-@pytest.fixture()
-def copy_snake_oil_case_storage(_shared_snake_oil_case, tmp_path, monkeypatch):
+@pytest.fixture(name="copy_snake_oil_case_storage")
+def fixture_copy_snake_oil_case_storage(_shared_snake_oil_case, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     shutil.copytree(_shared_snake_oil_case, "test_data")
     os.chdir("test_data")

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import glob
 import os
 import os.path
@@ -7,7 +8,6 @@ import stat
 from pathlib import Path
 
 import hypothesis.strategies as st
-import pytest
 from hypothesis import assume
 
 from ert._c_wrappers.enkf import ConfigKeys
@@ -273,6 +273,7 @@ def defines(draw, config_files, cwds):
     pre_defined_kw_map = draw(
         st.fixed_dictionaries(
             {
+                "<DATE>": st.just(datetime.date.today().isoformat()),
                 "<CWD>": cwds,
                 "<CONFIG_PATH>": cwds,
                 "<CONFIG_FILE>": st.just(config_file_name),
@@ -292,7 +293,6 @@ def config_dicts(draw):
     config_dict = draw(
         st.fixed_dictionaries(
             {
-                pytest.TEST_CONFIG_FILE_KEY: config_file_name,
                 ConfigKeys.NUM_REALIZATIONS: positives,
                 ConfigKeys.ECLBASE: st.just(draw(words) + "%d"),
                 ConfigKeys.RUNPATH_FILE: st.just(draw(file_names) + "runpath"),
@@ -305,7 +305,6 @@ def config_dicts(draw):
                 ConfigKeys.UPDATE_LOG_PATH: directory_names(),
                 ConfigKeys.STD_CUTOFF_KEY: small_floats,
                 ConfigKeys.MAX_RUNTIME: positives,
-                ConfigKeys.CONFIG_DIRECTORY: st.just(cwd),
                 ConfigKeys.MIN_REALIZATIONS: positives,
                 ConfigKeys.DEFINE_KEY: defines(config_file_name, st.just(cwd)),
                 ConfigKeys.DATA_KW_KEY: st.dictionaries(words, words),

--- a/tests/test_config_parsing/test_analysis_config.py
+++ b/tests/test_config_parsing/test_analysis_config.py
@@ -1,9 +1,7 @@
-import os
-
 import pytest
 from hypothesis import given
 
-from ert._c_wrappers.enkf import AnalysisConfig, ConfigKeys, ResConfig
+from ert._c_wrappers.enkf import AnalysisConfig, ResConfig
 
 from .config_dict_generator import config_dicts, to_config_file
 
@@ -11,10 +9,8 @@ from .config_dict_generator import config_dicts, to_config_file
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_analysis_config_config_same_as_from_file(config_dict):
-    cwd = os.getcwd()
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     to_config_file(filename, config_dict)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
 
     analysis_config_from_file = ResConfig(filename).analysis_config
     analysis_config_from_dict = AnalysisConfig.from_dict(config_dict=config_dict)

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,6 +1,3 @@
-import os
-import os.path
-
 import pytest
 from hypothesis import assume, given
 
@@ -13,10 +10,8 @@ from .config_dict_generator import config_dicts, to_config_file
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_ensemble_config_from_file_and_dict_coincide(config_dict):
-    cwd = os.getcwd()
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     to_config_file(filename, config_dict)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
 
     res_config_from_file = ResConfig(user_config_file=filename)
     res_config_from_dict = ResConfig(config_dict=config_dict)
@@ -28,7 +23,7 @@ def test_ensemble_config_from_file_and_dict_coincide(config_dict):
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_ensemble_config_errors_on_unknown_function_in_field(config_dict):
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     assume(
         ConfigKeys.FIELD_KEY in config_dict
         and len(config_dict[ConfigKeys.FIELD_KEY]) > 0
@@ -48,7 +43,7 @@ def test_ensemble_config_errors_on_unknown_function_in_field(config_dict):
 def test_ensemble_config_errors_on_identical_name_for_two_enkf_config_nodes(
     config_dict,
 ):
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     two_keys = [ConfigKeys.FIELD_KEY, ConfigKeys.GEN_DATA]
     for key in two_keys:
         assume(key in config_dict and len(config_dict[key]) > 0)

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -1,9 +1,7 @@
-import os
-
 import pytest
 from hypothesis import given
 
-from ert._c_wrappers.enkf import ConfigKeys, ResConfig
+from ert._c_wrappers.enkf import ResConfig
 
 from .config_dict_generator import config_dicts, to_config_file
 
@@ -11,10 +9,8 @@ from .config_dict_generator import config_dicts, to_config_file
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 @given(config_dicts())
 def test_queue_config_dict_same_as_from_file(config_dict):
-    cwd = os.getcwd()
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     to_config_file(filename, config_dict)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
     assert (
         ResConfig(filename).queue_config
         == ResConfig(config_dict=config_dict).queue_config

--- a/tests/test_config_parsing/test_site_config.py
+++ b/tests/test_config_parsing/test_site_config.py
@@ -1,9 +1,7 @@
-import os
-
 import pytest
 from hypothesis import given
 
-from ert._c_wrappers.enkf import ConfigKeys, ResConfig
+from ert._c_wrappers.enkf import ResConfig
 
 from .config_dict_generator import config_dicts, to_config_file
 
@@ -11,10 +9,8 @@ from .config_dict_generator import config_dicts, to_config_file
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 @given(config_dicts())
 def test_site_config_dict_same_as_from_file(config_dict):
-    cwd = os.getcwd()
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     to_config_file(filename, config_dict)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
     assert (
         ResConfig(config_dict=config_dict).site_config
         == ResConfig(filename).site_config

--- a/tests/test_config_parsing/test_substitution_list.py
+++ b/tests/test_config_parsing/test_substitution_list.py
@@ -22,7 +22,7 @@ def test_different_defines_give_different_subst_lists(config_dict1, config_dict2
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_from_dict_and_from_file_creates_equal_subst_lists(config_dict):
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = config_dict[ConfigKeys.DEFINE_KEY]["<CONFIG_FILE>"]
     to_config_file(filename, config_dict)
     res_config_from_file = ResConfig(user_config_file=filename)
     res_config_from_dict = ResConfig(config_dict=config_dict)
@@ -34,11 +34,13 @@ def test_from_dict_and_from_file_creates_equal_subst_lists(config_dict):
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_complete_config_reads_correct_values(config_dict):
+    filename = config_dict[ConfigKeys.DEFINE_KEY]["<CONFIG_FILE>"]
     substitution_list = ResConfig(config_dict=config_dict).substitution_list
-    assert substitution_list["<CWD>"] == config_dict[ConfigKeys.CONFIG_DIRECTORY]
-    assert (
-        substitution_list["<CONFIG_PATH>"] == config_dict[ConfigKeys.CONFIG_DIRECTORY]
-    )
+    cwd = os.getcwd()
+    assert substitution_list["<CWD>"] == cwd
+    assert substitution_list["<CONFIG_PATH>"] == cwd
+    assert substitution_list["<CONFIG_FILE>"] == filename
+    assert substitution_list["<CONFIG_FILE_BASE>"] == os.path.splitext(filename)[0]
     for key, value in config_dict[ConfigKeys.DEFINE_KEY].items():
         assert substitution_list[key] == value
     for key, value in config_dict[ConfigKeys.DATA_KW_KEY].items():

--- a/tests/test_config_parsing/test_workflow_list.py
+++ b/tests/test_config_parsing/test_workflow_list.py
@@ -1,9 +1,7 @@
-import os
-
 import pytest
 from hypothesis import given
 
-from ert._c_wrappers.enkf import ConfigKeys, ErtWorkflowList, ResConfig
+from ert._c_wrappers.enkf import ErtWorkflowList, ResConfig
 
 from .config_dict_generator import config_dicts, to_config_file
 
@@ -12,11 +10,9 @@ from .config_dict_generator import config_dicts, to_config_file
 @pytest.mark.usefixtures("use_tmpdir")
 @given(config_dicts())
 def test_ert_workflow_list_dict_creates_equal_config(config_dict):
-    cwd = os.getcwd()
-    filename = config_dict[pytest.TEST_CONFIG_FILE_KEY]
+    filename = "config.ert"
     to_config_file(filename, config_dict)
     res_config = ResConfig(user_config_file=filename)
-    config_dict[ConfigKeys.CONFIG_DIRECTORY] = cwd
     assert res_config.ert_workflow_list == ErtWorkflowList(
         config_dict=config_dict,
     )

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -329,7 +329,6 @@ def test_res_config_dict_constructor(setup_case):
     st = os.stat(script_file)
     os.chmod(script_file, stat.S_IEXEC | st.st_mode)
 
-    # split config_file to path and filename
     absolute_config_dir, _ = os.path.split(os.path.realpath(relative_config_path))
 
     config_data_new = {
@@ -415,6 +414,7 @@ def test_res_config_dict_constructor(setup_case):
             "<CONFIG_PATH>": absolute_config_dir,
             "<CONFIG_FILE>": config_file_name,
             "<CONFIG_FILE_BASE>": config_file_name.split(".", maxsplit=1)[0],
+            "<DATE>": date.today().isoformat(),
             "<USER>": "TEST_USER",
             "<SCRATCH>": "scratch/ert",
             "<CASE_DIR>": "the_extensive_case",
@@ -664,11 +664,11 @@ def test_logging_config(caplog, config_content, expected):
 
     with patch("builtins.open", mock_open(read_data=config_content)), patch(
         "os.path.isfile", MagicMock(return_value=True)
+    ), caplog.at_level(logging.INFO), patch.object(
+        ResConfig, "__init__", lambda x: None
     ):
-        with caplog.at_level(logging.INFO):
-            with patch.object(ResConfig, "__init__", lambda x: None):
-                res_config = ResConfig()
-                res_config._log_config_file(config_path)
+        res_config = ResConfig()
+        res_config._log_config_file(config_path)
     expected = base_content.format(expected)
     assert expected in caplog.messages
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_subst_config.py
@@ -25,8 +25,8 @@ def fixture_snake_oil_structure_config(copy_case):
     return {
         ConfigKeys.NUM_REALIZATIONS: 1,
         ConfigKeys.RUNPATH_FILE: "runpath",
-        pytest.TEST_CONFIG_FILE_KEY: config_file_name,
         ConfigKeys.DEFINE_KEY: {
+            "<DATE>": datetime.date.today().isoformat(),
             "<CWD>": cwd,
             "<CONFIG_PATH>": cwd,
             "<CONFIG_FILE>": config_file_name,
@@ -40,7 +40,7 @@ def fixture_snake_oil_structure_config(copy_case):
 
 @pytest.fixture(name="snake_oil_structure_config_file")
 def fixture_snake_oil_structure_config_file(snake_oil_structure_config):
-    filename = snake_oil_structure_config[pytest.TEST_CONFIG_FILE_KEY]
+    filename = snake_oil_structure_config[ConfigKeys.DEFINE_KEY]["<CONFIG_FILE>"]
     with open(file=filename, mode="w+", encoding="utf-8") as config:
         # necessary in the file, but irrelevant to this test
         config.write("JOBNAME  Job%d\n")
@@ -91,6 +91,8 @@ def test_complete_config_reads_correct_values(snake_oil_structure_config):
     ).substitution_list
     assert substitution_list["<CWD>"] == os.getcwd()
     assert substitution_list["<CONFIG_PATH>"] == os.getcwd()
+    assert substitution_list["<CONFIG_FILE_BASE>"] == "config"
+    assert substitution_list["<CONFIG_FILE>"] == "config"
     assert substitution_list["<DATE>"] == datetime.datetime.now().date().isoformat()
     assert substitution_list["keyA"] == "valA"
     assert substitution_list["keyB"] == "valB"


### PR DESCRIPTION
Resolves #4229 

~~The config key `TEST_CONFIG_FILE_KEY` is only used in the context of tests, in test code. Writing it to the config file leads to warnings about an unknown config key. This change should suppress those warnings.~~

After a long discussion, with many good ideas, I have arrived at a different solution, please [see below](https://github.com/equinor/ert/pull/4215#issuecomment-1312809102)

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
