### PR TITLE
Always print blob for failing hypothesis tests

### DIFF
--- a/tests/test_config_parsing/conftest.py
+++ b/tests/test_config_parsing/conftest.py
@@ -1,4 +1,8 @@
 import pytest
+from hypothesis import settings
+
+settings.register_profile("blobs", print_blob=True)
+settings.load_profile("blobs")
 
 
 @pytest.fixture()


### PR DESCRIPTION
Resolves #4230

Doesn't change anything when tests pass, ~~makes it (theoretically) possible to reproduce failures in CI,~~ and makes it unnecessary to write `@settings(print_blob=True)` above a failing test, and rerunning, in oder to get the blob during local development.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).