### PR TITLE
Extend config_content_as_dict

### DIFF
--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -1,0 +1,113 @@
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from ert._c_wrappers.enkf.config_keys import ConfigKeys
+
+if TYPE_CHECKING:
+    from ert._c_wrappers.config import ConfigContent
+
+# keywords that have one argument and
+# the last occurrence of the keyword in the file
+# is the value of which we use.
+# ie. if the config contains:
+#
+# MAX_SUBMIT 2
+# MAX_SUBMIT 3
+# ert will use the value 3 for MAX_SUBMIT
+SINGLE_OCCURRENCE_SINGLE_ARG_KEYS = [
+    ConfigKeys.ALPHA_KEY,
+    ConfigKeys.ANALYSIS_SELECT,
+    ConfigKeys.CONFIG_DIRECTORY,
+    ConfigKeys.DATAROOT,
+    ConfigKeys.DATA_FILE,
+    ConfigKeys.ECLBASE,
+    ConfigKeys.ENSPATH,
+    ConfigKeys.GEN_KW_EXPORT_NAME,
+    ConfigKeys.GEN_KW_TAG_FORMAT,
+    ConfigKeys.GRID,
+    ConfigKeys.HISTORY_SOURCE,
+    ConfigKeys.ITER_CASE,
+    ConfigKeys.ITER_COUNT,
+    ConfigKeys.ITER_RETRY_COUNT,
+    ConfigKeys.JOBNAME,
+    ConfigKeys.JOB_SCRIPT,
+    ConfigKeys.LICENSE_PATH,
+    ConfigKeys.MAX_RESAMPLE,
+    ConfigKeys.MAX_RUNTIME,
+    ConfigKeys.MAX_SUBMIT,
+    ConfigKeys.MIN_REALIZATIONS,
+    ConfigKeys.NUM_CPU,
+    ConfigKeys.NUM_REALIZATIONS,
+    ConfigKeys.OBS_CONFIG,
+    ConfigKeys.QUEUE_SYSTEM,
+    ConfigKeys.RANDOM_SEED,
+    ConfigKeys.REFCASE,
+    ConfigKeys.RERUN_KEY,
+    ConfigKeys.RERUN_START_KEY,
+    ConfigKeys.RUNPATH,
+    ConfigKeys.RUNPATH_FILE,
+    ConfigKeys.STD_CUTOFF_KEY,
+    ConfigKeys.STOP_LONG_RUNNING,
+    ConfigKeys.TIME_MAP,
+    ConfigKeys.UPDATE_LOG_PATH,
+]
+
+# Like SINGLE_OCCURRENCE_SINGLE_ARG_KEYS but
+# the keyword can take more than one argument, ie.
+# SCHEDULE_PREDICTION_FILE filename  <parameters:> <init_files:>
+SINGLE_OCCURRENCE_MULTI_ARG_KEYS = [
+    ConfigKeys.SCHEDULE_PREDICTION_FILE,
+]
+
+# Keywords that can occur more than once, but
+# the number of arguments is always one.
+MULTI_OCCURRENCE_SINGLE_ARG_KEYS = [
+    ConfigKeys.WORKFLOW_JOB_DIRECTORY,
+    ConfigKeys.INSTALL_JOB_DIRECTORY,
+]
+
+# Some keys have been split prematurely and must been
+# joined back, ie.
+
+# QUEUE_OPTION LOCAL opt the value of the option
+
+# Should be interpreted as having three arguments:
+# ["LOCAL", "opt", "the value of the option"]
+JOIN_KEYS = [
+    (ConfigKeys.QUEUE_OPTION, 2),
+    (ConfigKeys.FORWARD_MODEL, 0),
+]
+
+
+def config_content_as_dict(
+    user_config_content: "ConfigContent", site_config_content: "ConfigContent"
+) -> Dict[str, List[Any]]:
+    content_dict: Dict[str, List[Any]] = {}
+    for key in set(list(user_config_content.keys()) + list(site_config_content.keys())):
+        items = []
+        if key in site_config_content:
+            items.append(site_config_content[key])
+        if key in user_config_content:
+            items.append(user_config_content[key])
+        for item in items:
+            if key in SINGLE_OCCURRENCE_SINGLE_ARG_KEYS:
+                content_dict[key] = item.getValue()
+            elif key in SINGLE_OCCURRENCE_MULTI_ARG_KEYS:
+                for node in item:
+                    content_dict[key] = list(node)
+            elif key in MULTI_OCCURRENCE_SINGLE_ARG_KEYS:
+                if key not in content_dict:
+                    content_dict[key] = []
+                for node in item:
+                    content_dict[key].append(list(node)[0])
+            else:
+                if key not in content_dict:
+                    content_dict[key] = []
+                for node in item:
+                    values = list(node)
+                    content_dict[key].append(values)
+    for key, join_at in JOIN_KEYS:
+        if key in content_dict and len(content_dict[key]) > join_at:
+            for occurrence in content_dict[key]:
+                occurrence[join_at] = " ".join(occurrence[join_at:])
+                del occurrence[join_at + 1 :]
+    return content_dict

--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -105,9 +105,11 @@ def config_content_as_dict(
                 for node in item:
                     values = list(node)
                     content_dict[key].append(values)
+
     for key, join_at in JOIN_KEYS:
-        if key in content_dict and len(content_dict[key]) > join_at:
+        if key in content_dict:
             for occurrence in content_dict[key]:
-                occurrence[join_at] = " ".join(occurrence[join_at:])
-                del occurrence[join_at + 1 :]
+                if len(occurrence) > join_at:
+                    occurrence[join_at] = " ".join(occurrence[join_at:])
+                    del occurrence[join_at + 1 :]
     return content_dict

--- a/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+from ert._c_wrappers.config import ConfigParser, ContentTypeEnum
+from ert._c_wrappers.enkf import ConfigKeys
+from ert._c_wrappers.enkf._config_content_as_dict import (
+    SINGLE_OCCURRENCE_SINGLE_ARG_KEYS,
+    config_content_as_dict,
+)
+from ert._clib.config_keywords import init_user_config_parser
+
+
+def test_config_content_as_dict(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+
+        schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
+        schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
+
+        schema_item = conf.add("KEY", False)
+        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
+
+        with open("config", "w") as fileH:
+            fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
+            fileH.write(f"{ConfigKeys.DATA_FILE} {existing_file_2} \n")
+            fileH.write(f"{ConfigKeys.REFCASE} {existing_file_1} \n")
+
+            fileH.write("MULTIPLE_KEY_VALUE 6\n")
+            fileH.write("MULTIPLE_KEY_VALUE 24\n")
+            fileH.write("MULTIPLE_KEY_VALUE 12\n")
+            fileH.write("QUEUE_OPTION SLURM MAX_RUNNING 50\n")
+            fileH.write("KEY VALUE1 VALUE1 100\n")
+            fileH.write("KEY VALUE2 VALUE2 200\n")
+        content = conf.parse("config")
+        content_as_dict = config_content_as_dict(content, {})
+        assert content_as_dict == {
+            "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
+            ConfigKeys.NUM_REALIZATIONS: 42,
+            ConfigKeys.QUEUE_OPTION: [["SLURM", "MAX_RUNNING", "50"]],
+            "MULTIPLE_KEY_VALUE": [[6], [24], [12]],
+            ConfigKeys.DATA_FILE: str(Path.cwd() / existing_file_2),
+            ConfigKeys.REFCASE: str(Path.cwd() / existing_file_1),
+        }
+
+
+SINGLE_OCCURRENCE_KEY_TYPES = {
+    ConfigKeys.ALPHA_KEY: "int",
+    ConfigKeys.ANALYSIS_SELECT: "str",
+    ConfigKeys.CONFIG_DIRECTORY: "path",
+    ConfigKeys.DATAROOT: "file_path",
+    ConfigKeys.DATA_FILE: "file_path",
+    ConfigKeys.ECLBASE: "file_path",
+    ConfigKeys.ENSPATH: "path",
+    ConfigKeys.GEN_KW_EXPORT_NAME: "str",
+    ConfigKeys.GEN_KW_TAG_FORMAT: "str",
+    ConfigKeys.GRID: "file_path",
+    ConfigKeys.HISTORY_SOURCE: "history_enum",
+    ConfigKeys.ITER_CASE: "str",
+    ConfigKeys.ITER_COUNT: "int",
+    ConfigKeys.ITER_RETRY_COUNT: "int",
+    ConfigKeys.JOBNAME: "str",
+    ConfigKeys.JOB_SCRIPT: "file_path",
+    ConfigKeys.LICENSE_PATH: "file_path",
+    ConfigKeys.MAX_RESAMPLE: "int",
+    ConfigKeys.MAX_RUNTIME: "int",
+    ConfigKeys.MAX_SUBMIT: "int",
+    ConfigKeys.MIN_REALIZATIONS: "int",
+    ConfigKeys.NUM_CPU: "int",
+    ConfigKeys.NUM_REALIZATIONS: "int",
+    ConfigKeys.OBS_CONFIG: "file_path",
+    ConfigKeys.QUEUE_SYSTEM: "str",
+    ConfigKeys.RANDOM_SEED: "str",
+    ConfigKeys.REFCASE: "file_path",
+    ConfigKeys.RERUN_KEY: "bool",
+    ConfigKeys.RERUN_START_KEY: "int",
+    ConfigKeys.RUNPATH: "path",
+    ConfigKeys.RUNPATH_FILE: "file_path",
+    ConfigKeys.STD_CUTOFF_KEY: "float",
+    ConfigKeys.STOP_LONG_RUNNING: "bool",
+    ConfigKeys.TIME_MAP: "file_path",
+    ConfigKeys.UPDATE_LOG_PATH: "file_path",
+}
+
+
+def test_config_content_as_dict_single_value_keys(tmpdir):
+    with tmpdir.as_cwd():
+        conf = ConfigParser()
+        existing_file_1 = "test_1.t"
+        existing_file_2 = "test_2.t"
+        Path(existing_file_2).write_text("something")
+        Path(existing_file_1).write_text("not important")
+        init_user_config_parser(conf)
+        type_value_map = {
+            "str": "abc",
+            "path": tmpdir,
+            "file_path": existing_file_1,
+            "bool": "TRUE",
+            "float": 4.2,
+            "int": 2,
+            "history_enum": "REFCASE_SIMULATED",
+        }
+
+        with open("config.file", "w") as fileH:
+            for key in SINGLE_OCCURRENCE_SINGLE_ARG_KEYS:
+                key_type = SINGLE_OCCURRENCE_KEY_TYPES[key]
+                value = type_value_map[key_type]
+                fileH.write(f"{key} {value}\n{key} {value}\n")
+
+        content = conf.parse("config.file")
+        content_as_dict = config_content_as_dict(content, {})
+        for _, value in content_as_dict.items():
+            assert not isinstance(value, list)
+
+
+def test_that_as_dict_adds_site_config_first():
+    user_config_content = {"SET_ENV": [["var2", "val2"]]}
+    site_config_content = {"SET_ENV": [["var1", "val1"]]}
+    assert config_content_as_dict(user_config_content, site_config_content) == {
+        "SET_ENV": [["var1", "val1"], ["var2", "val2"]]
+    }
+
+
+def test_that_as_dict_joins_queue_option_values():
+    assert config_content_as_dict(
+        {
+            ConfigKeys.QUEUE_OPTION: [
+                ["queue_type", "opt", "rest", "of", "the", "values"]
+            ]
+        },
+        {},
+    ) == {ConfigKeys.QUEUE_OPTION: [["queue_type", "opt", "rest of the values"]]}

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -18,12 +18,12 @@ from ert._c_wrappers.enkf import (
     ResConfig,
     SiteConfig,
 )
-from ert._c_wrappers.enkf.enums import HookRuntime
-from ert._c_wrappers.enkf.res_config import (
-    SINGLE_VALUE_KEYS,
-    parse_signature_job,
-    site_config_location,
+from ert._c_wrappers.enkf._config_content_as_dict import (
+    SINGLE_OCCURRENCE_SINGLE_ARG_KEYS,
+    config_content_as_dict,
 )
+from ert._c_wrappers.enkf.enums import HookRuntime
+from ert._c_wrappers.enkf.res_config import parse_signature_job, site_config_location
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum
 from ert._clib.config_keywords import init_user_config_parser
@@ -126,7 +126,7 @@ snake_oil_structure_config = {
     },
 }
 
-SINGLE_VALUE_KEY_TYPES = {
+SINGLE_OCCURRENCE_KEY_TYPES = {
     ConfigKeys.ALPHA_KEY: "int",
     ConfigKeys.ANALYSIS_SELECT: "str",
     ConfigKeys.CONFIG_DIRECTORY: "path",
@@ -815,7 +815,7 @@ def test_config_content_as_dict(tmpdir):
             fileH.write("KEY VALUE1 VALUE1 100\n")
             fileH.write("KEY VALUE2 VALUE2 200\n")
         content = conf.parse("config")
-        content_as_dict = ResConfig._config_content_as_dict(content)
+        content_as_dict = config_content_as_dict(content, {})
         assert content_as_dict == {
             "KEY": [["VALUE1", "VALUE1", 100], ["VALUE2", "VALUE2", 200]],
             ConfigKeys.NUM_REALIZATIONS: 42,
@@ -845,13 +845,13 @@ def test_config_content_as_dict_single_value_keys(tmpdir):
         }
 
         with open("config.file", "w") as fileH:
-            for key in SINGLE_VALUE_KEYS:
-                key_type = SINGLE_VALUE_KEY_TYPES[key]
+            for key in SINGLE_OCCURRENCE_SINGLE_ARG_KEYS:
+                key_type = SINGLE_OCCURRENCE_KEY_TYPES[key]
                 value = type_value_map[key_type]
                 fileH.write(f"{key} {value}\n{key} {value}\n")
 
         content = conf.parse("config.file")
-        content_as_dict = ResConfig._config_content_as_dict(content)
+        content_as_dict = config_content_as_dict(content, {})
         for _, value in content_as_dict.items():
             assert not isinstance(value, list)
 


### PR DESCRIPTION
Fixes config_content_as_dict so that it correctly handles more types of keywords. This is done so that it correctly handles "INSTALL_JOB_DIRECTORY" which is required for #4197 .

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
