### PR TITLE
Add implementations of free to BaseCClass classes

### DIFF
--- a/src/ert/_c_wrappers/enkf/hook_workflow.py
+++ b/src/ert/_c_wrappers/enkf/hook_workflow.py
@@ -36,3 +36,6 @@ class HookWorkflow(BaseCClass):
 
     def __repr__(self):
         return f"HookWorkflow({self.getWorkflow().src_file}, {self.getRunMode()})"
+
+    def free(self):
+        pass

--- a/src/ert/_c_wrappers/enkf/observations/block_data_config.py
+++ b/src/ert/_c_wrappers/enkf/observations/block_data_config.py
@@ -20,3 +20,6 @@ class BlockDataConfig(BaseCClass):
 
         else:
             raise ValueError("Currently ONLY field data is supported")
+
+    def free(self):
+        pass

--- a/src/ert/_c_wrappers/enkf/plot_data/ensemble_plot_gen_data_vector.py
+++ b/src/ert/_c_wrappers/enkf/plot_data/ensemble_plot_gen_data_vector.py
@@ -36,3 +36,6 @@ class EnsemblePlotGenDataVector(BaseCClass):
     def __getitem__(self, index):
         """@rtype: float"""
         return self._get_value(index)
+
+    def free(self):
+        pass


### PR DESCRIPTION
For some reason semeio tests are failing, and among other things throwing an exception about something based on BaseCClass not implementing free. I cannot tell from the logs which class it is, hence we search for all classes (directly) based on BaseCClass, and add a free method, hoping that this will alleviate the errors we're seeing.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
