### PR TITLE
Fix an issue with arglist with simulation job

### DIFF
--- a/src/clib/lib/include/ert/job_queue/ext_job.hpp
+++ b/src/clib/lib/include/ert/job_queue/ext_job.hpp
@@ -14,7 +14,8 @@ extern "C" const char *ext_job_get_help_text(const ext_job_type *job);
 void ext_job_set_help_text(ext_job_type *job, const char *help_text);
 
 ext_job_type *ext_job_alloc_copy(const ext_job_type *);
-void ext_job_free_deprecated_argv(ext_job_type *ext_job); //DEPRECATED
+extern "C" void
+ext_job_free_deprecated_argv(ext_job_type *ext_job); //DEPRECATED
 ext_job_type *ext_job_alloc(const char *, const char *license_root_path,
                             bool private_job);
 extern "C" const char *ext_job_get_name(const ext_job_type *);

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -320,6 +320,7 @@ class ResConfig:
             job = self.site_config.job_list.get_job_copy(job_description[0])
             job.set_arglist(job_description[1:])
             job.set_define_args(self.substitution_list)
+            job.clear_deprecated_argv()
             job.convertToCReference(None)
             jobs.append(job)
 

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -68,6 +68,7 @@ class ExtJob(BaseCClass):
     _set_define_args = ResPrototype(
         "subst_list_ref ext_job_set_define_args(ext_job, subst_list)"
     )
+    _free_deprecated_argv = ResPrototype("void ext_job_free_deprecated_argv(ext_job)")
 
     def __init__(
         self,
@@ -101,6 +102,9 @@ class ExtJob(BaseCClass):
             )
         else:
             return "UNINITIALIZED ExtJob"
+
+    def clear_deprecated_argv(self):
+        self._free_deprecated_argv()
 
     def set_define_args(self, subst_list: SubstitutionList) -> None:
         self._set_define_args(subst_list)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -153,6 +153,21 @@ def test_forward_model_job(job, forward_model, expected_args):
             ["word", "<ECLBASE>"],
             id="Some args",
         ),
+        pytest.param(
+            dedent(
+                """
+            EXECUTABLE echo
+            MIN_ARG    1
+            MAX_ARG    2
+            ARG_TYPE 0 STRING
+            ARG_TYPE 0 STRING
+            ARGLIST <ARGUMENTA> <ARGUMENTB>
+                    """
+            ),
+            "SIMULATION_JOB job_name arga argb",
+            ["arga", "argb"],
+            id="simulation job with arglist",
+        ),
     ],
 )
 def test_simulation_job(job, forward_model, expected_args):


### PR DESCRIPTION

**Issue**
Resolves #4248 

In 9809fefbc4b3655fbb3df89676959d93fa645672 the call to ext_job_free_deprecated_argv was erronously omitted while 
reimplementing the creation of ext_job from the SIMULATION_JOB keyword in python. This lead to simulation job not working correctly when the job has an ARGLIST.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
