### PR TITLE
Ensure bin in path for pytest

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,5 +1,7 @@
 # This conftest still exists so that tests files can import ert_utils
 import logging
+import os
+import sys
 
 import pytest
 
@@ -32,3 +34,16 @@ def no_cert_in_test(monkeypatch):
             super().__init__(*args, **kwargs)
 
     monkeypatch.setattr("ert.cli.main.EvaluatorServerConfig", MockESConfig)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_bin_in_path():
+    """
+    Running pytest directly without enabling a virtualenv is perfectly valid.
+    However, our tests assume that `job_dispatch.py` is in PATH which it may not be.
+    This fixture prepends the path to the current Python for tests to pass when not
+    in a virtualenv.
+    """
+    path = os.environ["PATH"]
+    exec_path = os.path.dirname(sys.executable)
+    os.environ["PATH"] = exec_path + ":" + path


### PR DESCRIPTION
Co-authored-by: Zohar Malamant <git@wah.pink>

**Issue**
When running pytest, the path was not properly set and could not find job_dispatch.py even if it was available in the virtual environment.


**Approach**
Pre-append the PATH that has python.


## Pre review checklist

- [x] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
