### PR TITLE
Fix job queue log message

### DIFF
--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -59,8 +59,8 @@ class ForwardModel:
                     # replaced by substitute, but were not.
                     result[new_key] = new_value
                 else:
-                    logging.warning(
-                        "Environment variable {} skipped due to unmatched define {}",
+                    logger.warning(
+                        "Environment variable %s skipped due to unmatched define %s",
                         new_key,
                         new_value,
                     )

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_forward_model_formatted_print.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_forward_model_formatted_print.py
@@ -510,9 +510,9 @@ def test_status_file():
         assert isinstance(job.end_time, datetime.datetime)
 
 
-def test_that_values_with_brackets_are_ommitted(tmp_path):
-    forward_model = ForwardModel([], ExtJoblist())
-    env_vars = EnvironmentVarlist({"ENV_VAR": "<SOME_BRACKETS>"})
+def test_that_values_with_brackets_are_ommitted(tmp_path, caplog):
+    forward_model = set_up_forward_model()
+    forward_model.jobs[0].set_environment("ENV_VAR", "<SOME_BRACKETS>")
     run_id = "test_no_jobs_id"
     forward_model.formatted_fprintf(
         run_id,
@@ -521,8 +521,9 @@ def test_that_values_with_brackets_are_ommitted(tmp_path):
         0,
         0,
         Substituter(),
-        env_vars,
+        EnvironmentVarlist(),
     )
+    assert "Environment variable ENV_VAR skipped due to" in caplog.text
     with open(tmp_path / "jobs.json") as fp:
         data = json.load(fp)
-    assert "ENV_VAR" not in data["global_environment"]["ENV_VAR"]
+    assert "ENV_VAR" not in data["jobList"][0]["environment"]


### PR DESCRIPTION
**Issue**
Resolves #4217


**Approach**
Fixes the crashing log message and also fixes the issue with the test that should have captured such a failure. The test was set up incorrectly, assuming that the replacement happened in the environment_varlist instead of the jobs environment.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
