### PR TITLE
Up the timeout limit when testing the job runner startup overhead

### DIFF
--- a/tests/performance_tests/test_forward_model_script_overhead.py
+++ b/tests/performance_tests/test_forward_model_script_overhead.py
@@ -11,7 +11,7 @@ forward_models_path = os.path.join(
 )
 
 
-@pytest.mark.timeout(12)
+@pytest.mark.timeout(30)
 @pytest.mark.skipif(
     sys.platform.startswith("darwin"), reason="Performance can be flaky"
 )


### PR DESCRIPTION
This test introduced some flakyness due to a too narrow timeout limit. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
