### PR TITLE
Resubmit the same event when failed connection

### DIFF
--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import pytest
 
-from _ert_job_runner.client import Client
+from _ert_job_runner.client import Client, ClientConnectionError
 
 from .ensemble_evaluator_utils import _mock_ws
 
@@ -14,7 +14,7 @@ def test_invalid_server():
     url = f"ws://{host}:{port}"
 
     with Client(url, max_retries=2, timeout_multiplier=2) as c1:
-        with pytest.raises((ConnectionRefusedError, OSError)):
+        with pytest.raises(ClientConnectionError):
             c1.send("hei")
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -80,10 +80,10 @@ def _mock_ws_thread(host, port, messages):
     mock_ws_thread.start()
     try:
         yield
+    # Make sure to join the thread even if an exception occurs
+    finally:
         url = f"ws://{host}:{port}"
         with Client(url) as client:
             client.send("stop")
-    # Make sure to join the thread even if an exception occurs
-    finally:
         mock_ws_thread.join()
         messages.pop()


### PR DESCRIPTION
**Issue**
Do not pick up new events when Event was not sent due to the connection error

**Solution**
The event from job_dispatch will not be lost , event reporter tries to resubmit until either it
succeed or Finish event was received. This triggers timeout to give it some extra time to submit the event.

Additionally, Client gets ClientConnectionError exception, which bundles / hides all 3rd party
exceptions raised by either while establishing a new connection or sending the event data.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
