### PR TITLE
Fix implicit typing of optional in substituter

### DIFF
--- a/src/ert/_c_wrappers/enkf/substituter.py
+++ b/src/ert/_c_wrappers/enkf/substituter.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 
 class Substituter:
@@ -10,7 +10,7 @@ class Substituter:
         <IENS>: The realization number, provided when substitution is performed.
     """
 
-    def __init__(self, global_substitutions: Dict[str, str] = None):
+    def __init__(self, global_substitutions: Optional[Dict[str, str]] = None):
         """
         :param global_substitutions: List of substitutions that should be
             performed, in the same way regardless of realization and iteration, ie.


### PR DESCRIPTION
Newer version of mypy does not allow implicit Optional typing by default. This PR resolves that issue for substituter.py.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
