### PR TITLE
Use wheel in test runners

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -28,9 +28,14 @@ jobs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install ert and test dependencies
+    - name: Get wheels
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
+
+    - name: Install wheel and test dependencies
       run: |
-        pip install .
+        find . -name "*.whl" -exec pip install {} \;
         pip install -r dev-requirements.txt
 
     - name: Test GUI


### PR DESCRIPTION
I made an error in the recent restructuring of github test workflow, where tests no longer use the wheel, but rather does a pip install. 

This fixes it, so that the test runners will install the wheel that was built.


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
