### PR TITLE
Remove MULTFLT as a recognized config keyword

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -198,12 +198,6 @@ static void add_havana_fault_keyword(config_parser_type *config_parser) {
     config_schema_item_set_argc_minmax(item, 2, 2);
 }
 
-static void add_multflt_keyword(config_parser_type *config_parser) {
-    auto item = config_add_schema_item(config_parser, "MULTFLT", false);
-    config_schema_item_set_argc_minmax(item, 3, 3);
-    config_schema_item_iset_type(item, 2, CONFIG_EXISTING_PATH);
-}
-
 static void add_gen_kw_keyword(config_parser_type *config_parser) {
     auto item = config_add_schema_item(config_parser, GEN_KW_KEY, false);
     config_schema_item_set_argc_minmax(item, 4, 6);
@@ -295,7 +289,6 @@ ERT_CLIB_SUBMODULE("config_keywords", m) {
             // the two fault types are just added to the config object only to
             // be able to print suitable messages before exiting.
             add_havana_fault_keyword(config_parser);
-            add_multflt_keyword(config_parser);
             add_gen_kw_keyword(config_parser);
             add_schedule_prediction_file_keyword(config_parser);
             add_string_keyword(config_parser, GEN_KW_TAG_FORMAT_KEY);


### PR DESCRIPTION
**Issue**
#2535 


**Approach**
As per the documentation

        Previously ERT supported a datatype MULTFLT for estimating fault
        transmissibility multipliers. This has now been deprecated, as the
        functionality can be easily achieved with the help of GEN_KW. In the ERT
        config file:

No functionality related to backwards compatability with MULTFLT keyword has been removed. Also it should be noted that MULTFLT is an eclipse keyword so there are references to this as a eclipse keyword several places.

What is being removed is MULTFLT as a recognized keyword by the parser.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
