### PR TITLE
Update versions of actions and python in ci

### DIFF
--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: -1
 

--- a/.github/workflows/annotate_python.yml
+++ b/.github/workflows/annotate_python.yml
@@ -10,13 +10,13 @@ jobs:
   annotate-python-linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: -1
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install flake8
         run: pip install flake8 flake8-bugbear flake8-simplify flake8-debugger flake8-pep3101
       - name: install mypy

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ${{ inputs.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
       if: inputs.os == 'macos-latest'
 
     - name: Upload wheel as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
         path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -73,7 +73,7 @@ jobs:
         gcovr -r src/clib/ --exclude-directories ".*tests" cmake-build/ --xml -o cov.xml
 
     - name: Upload c coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: cov.xml
@@ -154,7 +154,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -166,12 +166,12 @@ jobs:
       run: |
         sudo apt-get install plantuml
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Get wheels
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ matrix.os }} Python ${{ matrix.python-version }} wheel
 
@@ -202,7 +202,7 @@ jobs:
 
     steps:
       - name: Get wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -212,7 +212,7 @@ jobs:
           find artifacts -name "*.whl" -exec mv '{}' dist/ \;
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: statoil-travis
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         test-type: ['integration-tests', 'unit-tests', 'gui-tests']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -32,9 +32,9 @@ jobs:
         os: ubuntu-latest
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install with dependencies
       run: |
@@ -61,7 +61,7 @@ jobs:
         pytest tests/ --cov=ert --hypothesis-profile=ci -m "not integration_test and not requires_window_manager" --cov-report=xml:cov.xml
 
     - name: Upload python coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: tests/cov.xml

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install with dependencies
       run: |

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ inputs.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -24,12 +24,12 @@ jobs:
       with:
         os: ${{ inputs.os }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Get wheels
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
 

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install ert
       run: |

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -17,15 +17,15 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install ERT and dependencies


### PR DESCRIPTION
Updates versions of actions as we are getting deprecation warnings. Also updates the version of python to 3.10 in environments where the python version is not related to the wheels built. We are unable to upgrade to 3.11 because there is no wheel distribution for protobuf and it fails to build from source.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
