### PR TITLE
Bump doc timelimit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,6 @@ jobs:
   docs-ert:
     name: Test ert docs
     needs: [build-linux]
-    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Because of transient dependency lazy-object-proxy not having wheels for linux, it needs to built in order to get docs in. This PR temporarily removes the time limit on doc building in order to have enough time to get that built.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
