### PR TITLE
Add actionlint to lint the workflow files

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,16 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    name: Check all workflow files
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -44,8 +44,10 @@ jobs:
 
     - name: find changed files
       id: find_changed_files
-      run: echo ::set-output name=changed_files::$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' | xargs ls -d 2>/dev/null | grep -E '\.(hpp|cpp)$' | tr '\n' ' ')
+      run: echo "changed_files=$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' | xargs ls -d 2>/dev/null | grep -E '\.(hpp|cpp)$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
     - run: echo ::add-matcher::.github/clang-tidy-matcher.json
+
     - name: run clang-tidy
       run: clang-tidy -p cmake-build/ ${{steps.find_changed_files.outputs.changed_files}}
       if: steps.find_changed_files.outputs.changed_files != ''

--- a/.github/workflows/annotate_python.yml
+++ b/.github/workflows/annotate_python.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install .
       - name: find changed files
         id: find_changed_files
-        run: echo ::set-output name=changed_files::$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' |  xargs ls -d 2>/dev/null | grep -E ".py$" | tr '\n' ' ')
+        run: echo "changed_files=$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' |  xargs ls -d 2>/dev/null | grep -E '.py$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       - run: echo ::add-matcher::.github/flake8-matcher.json
       - name: run flake8
         run: flake8 --exit-zero ${{steps.find_changed_files.outputs.changed_files}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies from PyPI
       run: |
         python3 -m pip install conan pybind11
-        echo "PIP_PKGS_PATH=$(python3 -m pip show conan | grep Location | cut -d ' ' -f 2 | sed -e 's@/lib/.*site-packages$@/bin@')" >> $GITHUB_ENV
+        echo "PIP_PKGS_PATH=$(python3 -m pip show conan | grep Location | cut -d ' ' -f 2 | sed -e 's@/lib/.*site-packages$@/bin@')" >> "$GITHUB_ENV"
 
     - name: Build libecl
       run: |


### PR DESCRIPTION
**Issue**
Resolves wasted time waiting for workflow files to fail, and to get an early overview if any workflow files contain errors (including deprecation warnings).

**Approach**
Follow documentation at https://github.com/rhysd/actionlint/blob/main/docs/usage.md

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
