### PR TITLE
Use caching of github actions

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -1,8 +1,6 @@
 on:
   workflow_call:
     inputs:
-      os:
-        type: string
       python-version:
         type: string
 jobs:
@@ -12,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ${{ inputs.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -28,14 +26,9 @@ jobs:
       with:
         entrypoint: /github/workspace/ci/github/build_linux_wheel.sh
         args: ${{ inputs.python-version }}
-      if: inputs.os == 'ubuntu-latest'
-
-    - name: Build macOS Wheel
-      run: pip wheel . --no-deps -w dist
-      if: inputs.os == 'macos-latest'
 
     - name: Upload wheel as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
+        name: ubuntu-latest Python ${{ inputs.python-version }} wheel
         path: dist/*

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -1,0 +1,38 @@
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+jobs:
+
+  build-wheels:
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v4
+      id: setup_python
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - uses: actions/cache@v3
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-${{ inputs.python-version }}-build-venv-${{ hashFiles('setup.py', 'pyproject.toml') }}
+    - run:  if [ -d .venv ]; then echo "cache hit"; else python -m venv ./.venv && source ./.venv/bin/activate && pip install toml && python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip install -r /dev/stdin ; fi
+    - name: Build macOS Wheel
+      run: source ./.venv/bin/activate && python -m pip wheel . --no-deps --no-build-isolation -w dist
+
+
+    - name: Upload wheel as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: macos-latest Python ${{ inputs.python-version }} wheel
+        path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,10 +83,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
-        os: [ ubuntu-latest ]
-    uses: ./.github/workflows/build-wheels.yml
+    uses: ./.github/workflows/build-wheels-linux.yml
     with:
-      os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
   build-mac:
@@ -94,10 +92,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
-        os: [ macos-latest ]
-    uses: ./.github/workflows/build-wheels.yml
+    uses: ./.github/workflows/build-wheels-macos.yml
     with:
-      os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
   test-linux:
@@ -166,18 +162,26 @@ jobs:
         sudo apt-get install plantuml
 
     - uses: actions/setup-python@v4
+      id: setup_python
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"
+        cache-dependency-path: |
+          setup.py
+          pyproject.toml
+          dev-requirements.txt
 
     - name: Get wheels
       uses: actions/download-artifact@v3
       with:
         name: ${{ matrix.os }} Python ${{ matrix.python-version }} wheel
 
-    - name: Install wheel and test dependencies
+    - name: Install wheel
       run: |
         find . -name "*.whl" -exec pip install {} \;
-        pip install -r dev-requirements.txt
+
+    - name: Install dependencies
+      run: pip install -r dev-requirements.txt
 
     - name: Make test directory
       run: |

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -23,12 +23,18 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
+      id: setup_python
       with:
         python-version: '3.10'
+        cache: "pip"
+        cache-dependency-path: |
+          setup.py
+          pyproject.toml
+          dev-requirements.txt
+    - run: pip install -e .
 
     - name: Install with dependencies
       run: |
-        pip install -e .
         pip install -r dev-requirements.txt
 
     - name: Test doctest

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -25,18 +25,26 @@ jobs:
         os: ${{ inputs.os }}
 
     - uses: actions/setup-python@v4
+      id: setup_python
       with:
         python-version: ${{ inputs.python-version }}
+        cache: "pip"
+        cache-dependency-path: |
+          setup.py
+          pyproject.toml
+          dev-requirements.txt
 
     - name: Get wheels
       uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
 
-    - name: Install wheel and test dependencies
+    - name: Install wheel
       run: |
         find . -name "*.whl" -exec pip install {} \;
-        pip install -r dev-requirements.txt
+
+    - name: Install dependencies
+      run: pip install -r dev-requirements.txt
 
     - name: Test GUI
       if: inputs.test-type == 'gui-test'


### PR DESCRIPTION
Sets up caching of pip dependencies. There is currently no automatic invalidation of the cache, which will have to be done manually through github.com/equinor/ert/actions/caches.

This uses the pip cache on bottleneck places in order to speed up the building. Note, this just reuses the pip cache of locally built wheels and some downloads.

The pip caching did not manage to speed up the mac os building which was slowing down throughput significantly (taking up to 15 minutes total). The reason is that `pip wheel` does an isolated build. In order to fix this, the build dependencies are installed into a virtual environment which caches the build dependencies.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
