### PR TITLE
Use src version of qstat proxy script during testing

### DIFF
--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
@@ -3,7 +3,6 @@ import enum
 import fcntl
 import json
 import os
-import shutil
 import subprocess
 import sys
 import time
@@ -12,7 +11,9 @@ from pathlib import Path
 import pytest
 import testpath
 
-PROXYSCRIPT = shutil.which("qstat_proxy.sh")
+PROXYSCRIPT = os.path.normpath(
+    os.path.join(__file__, "../../../../../../src/clib/lib/job_queue/qstat_proxy.sh")
+)
 
 EXAMPLE_QSTAT_CONTENT = """
 Job Id: 15399.s034-lcam


### PR DESCRIPTION
The build script doesn't run a full setup if only the C code needs to rebuilt. If there are changes in the qstat script, these are not caught by running `script/build` unless the `_skbuild` directory is deleted.

~~We simply copy the script during quick setup, making sure that changes are always caught.~~
We simply use the src version of the script during testing, which solves the problem.

**Issue**
Resolves #4317

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).