### PR TITLE
Ignore expected exception from file-parsing in c++ in torque driver

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -658,8 +658,7 @@ job_status_type torque_driver_parse_status(const char *qstat_file,
             }
         }
     } catch (const std::ios::failure &) {
-        fprintf(stderr, "** Warning: Failed to parse file %s, is it empty?\n",
-                qstat_file);
+        // end-of-file
     }
     switch (job_state[0]) {
     case 'R':

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -564,8 +564,10 @@ torque_driver_get_qstat_status(torque_driver_type *driver,
 
     if (fs::exists(tmp_std_file)) {
         status = torque_driver_parse_status(tmp_std_file, jobnr_char);
-        unlink(tmp_std_file);
-        unlink(tmp_err_file);
+        if (status != JOB_QUEUE_STATUS_FAILURE) {
+            unlink(tmp_std_file);
+            unlink(tmp_err_file);
+        }
     } else
         fprintf(stderr,
                 "No such file: %s - reading qstat status failed\n"


### PR DESCRIPTION
**Issue**
Resolves spamming the terminal with:
```
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-429759, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-780383, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-558744, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-237647, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-361596, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-92518, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-866519, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-212679, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-943649, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-1849, is it empty?
** Warning: Failed to parse file /tmp/ert-qstat-std-12678-99291, is it empty?
```

when running ert on Azure.

Bonus fix: Skip deleting a tmp-file if there is an error to be debugged.

**Approach**
Ignore the expected exception at end-of-file.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
