### PR TITLE
Update workflow docs

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -2069,43 +2069,37 @@ Workflow hooks
 .. _hook_workflow:
 .. topic:: HOOK_WORKFLOW
 
-    With the keyword :code:`HOOK_WORKFLOW` you can configure workflow
-    'hooks'; meaning workflows which will be run automatically at
-    certain points during ERTs execution. Currently there are five
-    points in ERTs flow of execution where you can hook in a workflow,
-    before the simulations start, :code:`PRE_SIMULATION`; after all
-    the simulations have completed, :code:`POST_SIMULATION`; before the
-    update step, :code:`PRE_UPDATE`; :code:`POST_UPDATE`; after the update
-    step and :code:`PRE_FIRST_UPDATE` only before the first update.
-    :code:`PRE_FIRST_UPDATE` will run before :code:`PRE_UPDATE`.
-    For non iterative algorithms, :code:`PRE_FIRST_UPDATE` is equal to
-    :code:`PRE_UPDATE`. The :code:`POST_SIMULATION` hook is
-    typically used to trigger QC workflows:
+        With the keyword :code:`HOOK_WORKFLOW` you can configure workflow
+        'hooks'; meaning workflows which will be run automatically at certain
+        points during ERTs execution. Currently there are five points in ERTs
+        flow of execution where you can hook in a workflow:
 
-    ::
+        - Before the simulations (all forward models for a realization) start using :code:`PRE_SIMULATION`,
+        - after all the simulations have completed using :code:`POST_SIMULATION`,
+        - before the update step using :code:`PRE_UPDATE`
+        - after the update step using :code:`POST_UPDATE` and
+        - only before the first update using :code:`PRE_FIRST_UPDATE`.
 
-        HOOK_WORKFLOW initWFLOW        PRE_SIMULATION
-        HOOK_WORKFLOW preUpdateWFLOW   PRE_UPDATE
-        HOOK_WORKFLOW postUpdateWFLOW  POST_UPDATE
-        HOOK_WORKFLOW QC_WFLOW1        POST_SIMULATION
-        HOOK_WORKFLOW QC_WFLOW2        POST_SIMULATION
+        For non interactive algorithms, :code:`PRE_FIRST_UPDATE` is equal to :code:`PRE_UPDATE`.
+        The :code:`POST_SIMULATION` hook is typically used to trigger QC workflows.
 
+        ::
 
-    In this example the workflow :code:`initWFLOW` will run after all
-    the simulation directories have been created, just before the
-    forward model is submitted to the queue. The workflow
-    :code:`preUpdateWFLOW` will be run before the update step and
-    :code:`postUpdateWFLOW` will be run after the update step. When
-    all the simulations are complete the two workflows
-    :code:`QC_WFLOW1` and :code:`QC_WFLOW2` will be run.
+           HOOK_WORKFLOW initWFLOW        PRE_SIMULATION
+           HOOK_WORKFLOW preUpdateWFLOW   PRE_UPDATE
+           HOOK_WORKFLOW postUpdateWFLOW  POST_UPDATE
+           HOOK_WORKFLOW QC_WFLOW1        POST_SIMULATION
+           HOOK_WORKFLOW QC_WFLOW2        POST_SIMULATION
 
-    Observe that the workflows being 'hooked in' with the
-    :code:`HOOK_WORKFLOW` must be loaded with the
-    :code:`LOAD_WORKFLOW` keyword.
+        In this example the workflow :code:`initWFLOW` will run after all the
+        simulation directories have been created, just before the forward
+        model is submitted to the queue. The workflow :code:`preUpdateWFLOW`
+        will be run before the update step and :code:`postUpdateWFLOW` will be
+        run after the update step. When all the simulations have completed the
+        two workflows :code:`QC_WFLOW1` and :code:`QC_WFLOW2` will be run.
 
-    Currently, :code:`PRE_UPDATE` and :code:`POST_UPDATE` are only
-    available from python.
-
+        Observe that the workflows being 'hooked in' with the
+        :code:`HOOK_WORKFLOW` must be loaded with the :code:`LOAD_WORKFLOW` keyword.
 
 .. _load_workflow:
 .. topic:: LOAD_WORKFLOW

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -2104,20 +2104,54 @@ Workflow hooks
 .. _load_workflow:
 .. topic:: LOAD_WORKFLOW
 
-    Load a workflow into ERT.
+        Workflows are loaded with the configuration option :code:`LOAD_WORKFLOW`:
 
+        ::
+
+            LOAD_WORKFLOW  /path/to/workflow/WFLOW1
+            LOAD_WORKFLOW  /path/to/workflow/workflow2  WFLOW2
+
+        The :code:`LOAD_WORKFLOW` takes the path to a workflow file as the first
+        argument. By default the workflow will be labeled with the filename
+        internally in ERT, but you can optionally supply a second extra argument
+        which will be used as the name for the workflow.  Alternatively,
+        you can load a workflow interactively.
 
 .. _load_workflow_job:
 .. topic:: LOAD_WORKFLOW_JOB
 
-    Load a workflow job into ERT.
+        Before the jobs can be used in workflows they must be "loaded" into
+        ERT. This can be done either by specifying jobs by name,
+        or by specifying a directory containing jobs.
 
+        Use the keyword :code:`LOAD_WORKFLOW_JOB` to specify jobs by name:
+
+        ::
+
+            LOAD_WORKFLOW_JOB     jobConfigFile     JobName
+
+        The :code:`LOAD_WORKFLOW_JOB` keyword will load one workflow job.
+        The name of the job is optional, and will be fetched from the configuration file if not provided.
 
 .. _workflow_job_directory:
 .. topic:: WORKFLOW_JOB_DIRECTORY
 
-        Directory containing workflow jobs.
+        Alternatively, you can use the command
+        :code:`WORKFLOW_JOB_DIRECTORY` which will load all the jobs in a
+        directory.
 
+        Use the keyword :code:`WORKFLOW_JOB_DIRECTORY` to specify a directory containing jobs:
+
+        ::
+
+            WORKFLOW_JOB_DIRECTORY /path/to/jobs
+
+        The :code:`WORKFLOW_JOB_DIRECTORY` loads all workflow jobs found in the `/path/to/jobs` directory.
+        Observe that all the files in the `/path/to/jobs` directory
+        should be job configuration files. The jobs loaded in this way will
+        all get the name of the file as the name of the job. The
+        :code:`WORKFLOW_JOB_DIRECTORY` keyword will *not* load configuration
+        files recursively.
 
 Manipulating the Unix environment
 ---------------------------------

--- a/docs/reference/workflows/complete_workflows.rst
+++ b/docs/reference/workflows/complete_workflows.rst
@@ -39,18 +39,22 @@ you can load a workflow interactively.
 
 .. _hook_workflow:
 
-Automatically run workflows : :code:`HOOK_WORKFLOW`
+Automatically run workflows
 ---------------------------------------------------
 
 With the keyword :code:`HOOK_WORKFLOW` you can configure workflow
 'hooks'; meaning workflows which will be run automatically at certain
-points during ERTs execution. Currently there are four points in ERTs
+points during ERTs execution. Currently there are five points in ERTs
 flow of execution where you can hook in a workflow:
 
-- Before the simulations start using :code:`PRE_SIMULATION`,
+- Before the simulations (all forward models for a realization) start using :code:`PRE_SIMULATION`,
 - after all the simulations have completed using :code:`POST_SIMULATION`,
-- before the update step using :code:`PRE_UPDATE` and
-- after the update step using :code:`POST_UPDATE`. 
+- before the update step using :code:`PRE_UPDATE`
+- after the update step using :code:`POST_UPDATE` and
+- only before the first update using :code:`PRE_FIRST_UPDATE`.
+
+For non interactive algorithms, :code:`PRE_FIRST_UPDATE` is equal to :code:`PRE_UPDATE`.
+The :code:`POST_SIMULATION` hook is typically used to trigger QC workflows.
 
 ::
 


### PR DESCRIPTION
**Issue**
Resolves #4255

Syncronized documentation for HOOK_WORKFLOW.
Added missing documentation parts for LOAD_WORKFLOW, LOAD_WORKFLOW_JOB, WORKFLOW_JOB_DIRECTORY.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
