### PR TITLE
Fix incorrect printing of enum in case info

### DIFF
--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -257,7 +257,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
 
         html = "<table>"
         for index, value in enumerate(states):
-            html += f"<tr><td width=30>{index:d}.</td><td>{value}</td></tr>"
+            html += f"<tr><td width=30>{index:d}.</td><td>{value.name}</td></tr>"
 
         html += "</table>"
 


### PR DESCRIPTION
Changes the following view in the gui
![this_is_the_bug](https://user-images.githubusercontent.com/596662/202711805-c8fb555a-ad1a-483a-9a6a-c3367818000c.png)
211c656ff.png)

to

![this_is_the_fix](https://user-images.githubusercontent.com/596662/202712166-32a3f3f4-331c-41df-bd72-a1e4820f8a32.png)


## Pre review checklist
- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
