### PR TITLE
Cache conan in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y valgrind
+    
+    - uses: actions/cache@v3
+      with:
+        path: ~/.conan/
+        key: ${{ matrix.os }}-conan-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: Install dependencies from PyPI
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,16 +69,19 @@ jobs:
         ctest --output-on-failure
 
     - name: Install gcovr
+      if: matrix.os == 'ubuntu-latest'
       run: |
         python3 -m pip install gcovr
 
     - name: generate coverage report
+      if: matrix.os == 'ubuntu-latest'
       run: |
         export PATH=$PATH:${{ env.PIP_PKGS_PATH }}
         gcovr -r src/clib/ --exclude-directories ".*tests" cmake-build/ --xml -o cov.xml
 
     - name: Upload c coverage to Codecov
       uses: codecov/codecov-action@v3
+      if: matrix.os == 'ubuntu-latest'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: cov.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,4 @@ fixes:
 comment:
     # The code coverage is made up of 5 test runs so only after all coverage
     # reports have been uploaded will the comparison be sane
-    after_n_builds: 5
+    after_n_builds: 4


### PR DESCRIPTION
Currently the bottleneck is the mac-os ctest workflow. Attempting to cache the conan directory to see if that speeds things up.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
