### PR TITLE
Remove erroneous error message

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -656,8 +656,7 @@ job_status_type torque_driver_parse_status(const char *qstat_file,
             }
         }
     } catch (const std::ios::failure &) {
-        fprintf(stderr, "** Warning: Failed to parse file %s, is it empty?\n",
-                qstat_file);
+        // end-of-file
     }
     switch (job_state[0]) {
     case 'R':


### PR DESCRIPTION
getline() triggers a std::ios::failure at end-of-file. Ignore this.

**Issue**
Backporting of  #4325 

- [ ] Not added appropriate release note label. Should be skipped in release notes
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
