### PR TITLE
Revert "Add memory threshold change to yield Running event"

### DIFF
--- a/src/_ert_job_runner/cli.py
+++ b/src/_ert_job_runner/cli.py
@@ -8,7 +8,7 @@ import typing
 from datetime import datetime
 
 from _ert_job_runner import reporting
-from _ert_job_runner.reporting.message import Finish, RunningNoMemChange
+from _ert_job_runner.reporting.message import Finish
 from _ert_job_runner.runner import JobRunner
 
 JOBS_FILE = "jobs.json"
@@ -118,8 +118,6 @@ def main(args):
     job_runner = JobRunner(jobs_data)
 
     for job_status in job_runner.run(parsed_args.job):
-        if isinstance(job_status, RunningNoMemChange):
-            continue
         logger.info(f"Job status: {job_status}")
         for reporter in reporters:
             reporter.report(job_status)

--- a/src/_ert_job_runner/job.py
+++ b/src/_ert_job_runner/job.py
@@ -8,14 +8,11 @@ from subprocess import Popen
 from psutil import AccessDenied, NoSuchProcess, Process, TimeoutExpired, ZombieProcess
 
 from _ert_job_runner.io import assert_file_executable
-from _ert_job_runner.reporting.message import Exited, Running, RunningNoMemChange, Start
+from _ert_job_runner.reporting.message import Exited, Running, Start
 
 
 class Job:
-    # Seconds between memory polls
-    MEMORY_POLL_PERIOD = 5
-    # Number of bytes required to yield a change
-    MEMORY_INCREASE_THRESHOLD = 1e7
+    MEMORY_POLL_PERIOD = 5  # Seconds between memory polls
 
     def __init__(self, job_data, index, sleep_interval=1):
         self.sleep_interval = sleep_interval
@@ -25,9 +22,7 @@ class Job:
         self.std_out = job_data.get("stdout")
 
     def run(self):
-        # pylint: disable=too-many-branches
         # pylint: disable=consider-using-with
-        # pylint: disable=too-many-statements
         start_message = Start(self)
 
         errors = self._check_job_files()
@@ -104,7 +99,6 @@ class Job:
 
         process = Process(proc.pid)
         max_memory_usage = 0
-        last_memory_usage = -self.MEMORY_INCREASE_THRESHOLD
         while exit_code is None:
             try:
                 memory = process.memory_info().rss
@@ -114,13 +108,10 @@ class Job:
                 #
                 # See https://github.com/giampaolo/psutil/issues/1044#issuecomment-298745532  # noqa
                 memory = 0
-            max_memory_usage = max(memory, max_memory_usage)
+            if memory > max_memory_usage:
+                max_memory_usage = memory
 
-            if abs(memory - last_memory_usage) >= self.MEMORY_INCREASE_THRESHOLD:
-                last_memory_usage = memory
-                yield Running(self, max_memory_usage, memory)
-            else:
-                yield RunningNoMemChange(self, max_memory_usage, memory)
+            yield Running(self, max_memory_usage, memory)
 
             try:
                 exit_code = process.wait(timeout=self.MEMORY_POLL_PERIOD)

--- a/src/_ert_job_runner/reporting/message.py
+++ b/src/_ert_job_runner/reporting/message.py
@@ -83,10 +83,6 @@ class Running(Message):
         self.current_memory_usage = current_memory_usage
 
 
-class RunningNoMemChange(Running):
-    pass
-
-
 class Exited(Message):
     def __init__(self, job, exit_code):
         super().__init__(job)

--- a/src/_ert_job_runner/runner.py
+++ b/src/_ert_job_runner/runner.py
@@ -62,6 +62,7 @@ class JobRunner:
         for job in job_queue:
             for status_update in job.run():
                 yield status_update
+
                 if not status_update.success():
                     yield Finish().with_error("Not all jobs completed successfully.")
                     return


### PR DESCRIPTION
This reverts commit ccef0d1769199450d6a2460963332762581145b0.

See https://github.com/equinor/ert/issues/4334

## Pre review checklist

- [x] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
