### PR TITLE
Remove deprecated config keyword PORTABLE_EXE

### DIFF
--- a/src/clib/lib/job_queue/ext_job.cpp
+++ b/src/clib/lib/job_queue/ext_job.cpp
@@ -656,9 +656,6 @@ ext_job_type *ext_job_fscanf_alloc(const char *name, bool private_job,
             item = config_add_schema_item(config, EXECUTABLE_KEY, false);
             config_schema_item_set_argc_minmax(item, 1, 1);
             config_schema_item_iset_type(item, 0, CONFIG_PATH);
-            item = config_add_schema_item(config, "PORTABLE_EXE", false);
-            config_schema_item_set_argc_minmax(item, 1, 1);
-            config_schema_item_iset_type(item, 0, CONFIG_PATH);
             item = config_add_schema_item(config, "TARGET_FILE", false);
             config_schema_item_set_argc_minmax(item, 1, 1);
             item = config_add_schema_item(config, "ERROR_FILE", false);
@@ -696,9 +693,6 @@ ext_job_type *ext_job_fscanf_alloc(const char *name, bool private_job,
 
             config_schema_item_set_indexed_selection_set(item, 1, var_types);
             stringlist_free(var_types);
-            config_parser_deprecate(
-                config, "PORTABLE_EXE",
-                "'PORTABLE_EXE' is deprecated. Use 'EXECUTABLE' instead.");
         }
         {
             config_content_type *content =
@@ -781,19 +775,10 @@ ext_job_type *ext_job_fscanf_alloc(const char *name, bool private_job,
                 char exec_key[20] = EXECUTABLE_KEY;
                 bool have_executable =
                     config_content_has_item(content, EXECUTABLE_KEY);
-                bool have_portable_exe =
-                    config_content_has_item(content, "PORTABLE_EXE");
-                if (!have_executable && !have_portable_exe) {
+                if (!have_executable) {
                     fprintf(stderr, "%s: ** '%s' must be set\n", config_file,
                             EXECUTABLE_KEY);
                     ext_job->__valid = false;
-                } else if (!have_executable && have_portable_exe) {
-                    strcpy(exec_key, "PORTABLE_EXE");
-                } else if (have_executable && have_portable_exe) {
-                    fprintf(stderr,
-                            "%s: ** Ignoring 'PORTABLE_EXE' and using '%s' as "
-                            "both were given.\n",
-                            config_file, EXECUTABLE_KEY);
                 }
 
                 if (ext_job->__valid) {


### PR DESCRIPTION
**Issue**
Resolves #4352 which blocks #4337


**Approach**
we remove the long deprecated keyword, cf. #1718


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
