### PR TITLE
Deprecate schedule prediction file config keyword

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -72,7 +72,7 @@ Keyword name                                                            Required
 :ref:`RUNPATH <runpath>`                                                NO                                      simulations/realization%d       Directory to run simulations
 :ref:`RUNPATH_FILE <runpath_file>`                                      NO                                      .ert_runpath_list               Name of file with path for all forward models that ERT has run. To be used by user defined scripts to find the realizations
 :ref:`RUN_TEMPLATE <run_template>`                                      NO                                                                      Install arbitrary files in the runpath directory
-:ref:`SCHEDULE_PREDICTION_FILE <schedule_prediction_file>`              NO                                                                      Schedule prediction file
+:ref:`SCHEDULE_PREDICTION_FILE <schedule_prediction_file>`              NO                                                                      Deprecated: Schedule prediction file
 :ref:`SETENV <setenv>`                                                  NO                                                                      You can modify the UNIX environment with SETENV calls
 :ref:`SIMULATION_JOB <simulation_job>`                                  NO                                                                      Experimental alternative to FORWARD_MODEL
 :ref:`STOP_LONG_RUNNING <stop_long_running>`                            NO                                      FALSE                           Stop long running realizations after minimum number of realizations (MIN_REALIZATIONS) have run
@@ -1503,6 +1503,7 @@ but required when installing ERT at a new site.
 .. _schedule_prediction_file:
 .. topic:: SCHEDULE_PREDICTION_FILE
 
+        This keyword is deprecated and will be removed.
         This is the name of a schedule prediction file. It can contain %d to get
         different files for different members. Observe that the ECLIPSE datafile
         should include only one schedule file, even if you are doing predictions.

--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -206,6 +206,8 @@ add_schedule_prediction_file_keyword(config_parser_type *config_parser) {
     /* scedhule_prediction_file   filename  <parameters:> <init_files:> */
     config_schema_item_set_argc_minmax(item, 1, 3);
     config_schema_item_iset_type(item, 0, CONFIG_EXISTING_PATH);
+    config_schema_item_set_deprecated(
+        item, "The SCHEDULE_PREDICTION_FILE config key is deprecated.");
 }
 
 static void add_summary_keyword(config_parser_type *config_parser) {

--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -73,7 +73,6 @@ static void add_history_source_keyword(config_parser_type *config_parser) {
     auto item = add_single_arg_keyword(config_parser, HISTORY_SOURCE_KEY);
 
     stringlist_type *argv = stringlist_alloc_new();
-    stringlist_append_copy(argv, "SCHEDULE");
     stringlist_append_copy(argv, "REFCASE_SIMULATED");
     stringlist_append_copy(argv, "REFCASE_HISTORY");
 

--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -663,12 +663,3 @@ void config_install_message(config_parser_type *config, const char *kw,
     hash_insert_hash_owned_ref(config->messages, kw,
                                util_alloc_string_copy(message), free);
 }
-
-void config_parser_deprecate(config_parser_type *config, const char *kw,
-                             const char *msg) {
-    if (config_has_schema_item(config, kw)) {
-        config_schema_item_type *item = config_get_schema_item(config, kw);
-        config_schema_item_set_deprecated(item, msg);
-    } else
-        util_abort("%s: item:%s not recognized \n", __func__, kw);
-}

--- a/src/clib/lib/include/ert/config/config_parser.hpp
+++ b/src/clib/lib/include/ert/config/config_parser.hpp
@@ -43,8 +43,6 @@ config_schema_item_type *config_add_key_value(config_parser_type *config,
                                               config_item_types item_type);
 
 extern "C" int config_get_schema_size(const config_parser_type *config);
-void config_parser_deprecate(config_parser_type *config, const char *kw,
-                             const char *msg);
 
 extern "C" void config_validate(config_parser_type *config,
                                 config_content_type *content);


### PR DESCRIPTION
**Issue**
Resolves #4288

**Approach**
We deprecate the keyword.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
