### PR TITLE
Add release notes label for user facing changes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,42 +6,21 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - release-notes:breaking-change
-      exclude:
-        labels:
-          - release-notes:ert3
     - title: New Features 🎉
       labels:
         - release-notes:new-feature
-      exclude:
-        labels:
-          - release-notes:ert3
     - title: Improvements
       labels:
         - release-notes:improvement
-      exclude:
-        labels:
-          - release-notes:ert3
     - title: Bug Fixes
       labels:
         - release-notes:bug-fix
-      exclude:
-        labels:
-          - release-notes:ert3
     - title: Maintenance
       labels:
         - release-notes:maintenance
-      exclude:
-        labels:
-          - release-notes:ert3
     - title: Dependencies
       labels:
         - release-notes:dependency
-      exclude:
-        labels:
-          - release-notes:ert3
-    - title: ert3
-      labels:
-        - release-notes:ert3
     - title: Other Changes
       labels:
         - release-notes:misc

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 changelog:
   categories:
+    - title: User impact 🛠
+      labels:
+        - release-notes:user-impact
     - title: Breaking Changes 🛠
       labels:
         - release-notes:breaking-change


### PR DESCRIPTION
Alternative names are received with thanks


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
