### PR TITLE
Move some tests to doctest

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -31,6 +31,30 @@ def _get_filename(file):
 
 
 def _option_dict(option_list: List[str], offset: int) -> Dict[str, str]:
+    """Gets the list of options given to a keywords such as GEN_DATA.
+
+    The first step of parsing will separate a line such as
+
+      GEN_DATA NAME INPUT_FORMAT:ASCII RESULT_FILE:file.txt REPORT_STEPS:3
+
+    into
+
+    >>> opts = ["NAME", "INPUT_FORMAT:ASCII", "RESULT_FILE:file.txt", "REPORT_STEPS:3"]
+
+    From there, _option_dict can be used to get a dictionary of the options:
+
+    >>> _option_dict(opts, 1)
+    {'INPUT_FORMAT': 'ASCII', 'RESULT_FILE': 'file.txt', 'REPORT_STEPS': '3'}
+
+    Errors are reported to the log, and erroring fields ignored:
+
+    >>> import sys
+    >>> logger.addHandler(logging.StreamHandler(sys.stdout))
+    >>> _option_dict(opts + [":T"], 1)
+    Ignoring argument :T not properly formatted should be of type ARG:VAL
+    {'INPUT_FORMAT': 'ASCII', 'RESULT_FILE': 'file.txt', 'REPORT_STEPS': '3'}
+
+    """
     option_dict = {}
     for option_pair in option_list[offset:]:
         if not isinstance(option_pair, str):
@@ -53,8 +77,8 @@ def _option_dict(option_list: List[str], offset: int) -> Dict[str, str]:
 
 
 def _str_to_bool(txt: str) -> bool:
-    """This function converts truthy text to boolean values according to the rules
-    of the FORWARD_INIT keyword.
+    """This function converts text to boolean values according to the rules of
+    the FORWARD_INIT keyword.
 
     The rules for str_to_bool is keep for backwards compatability
 
@@ -77,8 +101,6 @@ def _str_to_bool(txt: str) -> bool:
     Any text which is not correctly identified as true or false returns False, but
     with a failure message written to the log:
 
-    >>> import sys
-    >>> logger.addHandler(logging.StreamHandler(sys.stdout))
     >>> _str_to_bool("fail")
     Failed to parse fail as bool! Using FORWARD_INIT:FALSE
     False

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -52,9 +52,37 @@ def _option_dict(option_list: List[str], offset: int) -> Dict[str, str]:
     return option_dict
 
 
-def _str_to_bool(txt: Optional[str]) -> bool:
-    if txt is None:
-        return False
+def _str_to_bool(txt: str) -> bool:
+    """This function converts truthy text to boolean values according to the rules
+    of the FORWARD_INIT keyword.
+
+    The rules for str_to_bool is keep for backwards compatability
+
+    First, any upper/lower case true/false value is converted to the corresponding
+    boolean value:
+
+    >>> _str_to_bool("TRUE")
+    True
+    >>> _str_to_bool("true")
+    True
+    >>> _str_to_bool("True")
+    True
+    >>> _str_to_bool("FALSE")
+    False
+    >>> _str_to_bool("false")
+    False
+    >>> _str_to_bool("False")
+    False
+
+    Any text which is not correctly identified as true or false returns False, but
+    with a failure message written to the log:
+
+    >>> import sys
+    >>> logger.addHandler(logging.StreamHandler(sys.stdout))
+    >>> _str_to_bool("fail")
+    Failed to parse fail as bool! Using FORWARD_INIT:FALSE
+    False
+    """
     if txt.lower() == "true":
         return True
     elif txt.lower() == "false":
@@ -217,7 +245,7 @@ class EnsembleConfig(BaseCClass):
             tmpl_path = _get_abs_path(gen_kw[1])
             out_file = _get_filename(_get_abs_path(gen_kw[2]))
             param_file_path = _get_abs_path(gen_kw[3])
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT))
+            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
             init_files = _get_abs_path(options.get(ConfigKeys.INIT_FILES))
         return EnkfConfigNode.create_gen_kw(
             name,
@@ -243,7 +271,7 @@ class EnsembleConfig(BaseCClass):
             init_file = options.get(ConfigKeys.INIT_FILES)
             out_file = options.get("OUTPUT_FILE")
             base_surface = options.get(ConfigKeys.BASE_SURFACE_KEY)
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT))
+            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
 
         return EnkfConfigNode.create_surface(
             name,
@@ -277,7 +305,7 @@ class EnsembleConfig(BaseCClass):
             options = _option_dict(field, 2)
             if var_type == ConfigKeys.GENERAL_KEY:
                 enkf_infile = field[3]
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT))
+            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
             init_transform = options.get(ConfigKeys.INIT_TRANSFORM)
             output_transform = options.get(ConfigKeys.OUTPUT_TRANSFORM)
             input_transform = options.get(ConfigKeys.INPUT_TRANSFORM)

--- a/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
@@ -10,7 +10,6 @@ from ert._c_wrappers.config import (
     SchemaItem,
     UnrecognizedEnum,
 )
-from ert._c_wrappers.enkf.ensemble_config import _option_dict
 
 
 def test_item_types(tmp_path):
@@ -314,25 +313,3 @@ def test_valid_string():
     assert ContentTypeEnum.CONFIG_BOOL.convert_string("True")
     assert not ContentTypeEnum.CONFIG_BOOL.convert_string("False")
     assert not ContentTypeEnum.CONFIG_BOOL.convert_string("F")
-
-
-@pytest.mark.parametrize(
-    "option_list, offset, expected",
-    [
-        (["a:1"], 0, {"a": "1"}),
-        (["B:abc"], 0, {"B": "abc"}),
-        (["A"], 0, {}),
-        (["a:1", "B:abc"], 0, {"a": "1", "B": "abc"}),
-        (["a:1", "T:"], 0, {"a": "1"}),
-        (["a:1", ":T"], 0, {"a": "1"}),
-        (["a:1", ":-:"], 0, {"a": "1"}),
-        (["a:1", "T:"], 0, {"a": "1"}),
-        (["a:1", "b:2", "c:3"], 2, {"c": "3"}),
-        (["a", "b", "c"], 0, {}),
-        ([], 0, {}),
-        ([1, 2, 3, 4], 0, {}),
-        ([1.1, "none", 2], 0, {}),
-    ],
-)
-def test_options_dic(option_list, offset, expected):
-    assert _option_dict(option_list, offset) == expected

--- a/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
@@ -10,7 +10,7 @@ from ert._c_wrappers.config import (
     SchemaItem,
     UnrecognizedEnum,
 )
-from ert._c_wrappers.enkf.ensemble_config import _option_dict, _str_to_bool
+from ert._c_wrappers.enkf.ensemble_config import _option_dict
 
 
 def test_item_types(tmp_path):
@@ -336,27 +336,3 @@ def test_valid_string():
 )
 def test_options_dic(option_list, offset, expected):
     assert _option_dict(option_list, offset) == expected
-
-
-@pytest.mark.parametrize(
-    "text, expected, success",
-    [
-        ("True", True, True),
-        ("true", True, True),
-        ("TRUE", True, True),
-        ("False", False, True),
-        ("false", False, True),
-        ("FALSE", False, True),
-        (None, False, True),
-        ("1", False, False),
-        ("fail", False, False),
-        ("tru", False, False),
-        ("", False, False),
-    ],
-)
-def test_str_to_bool(text, expected, success, caplog):
-    assert _str_to_bool(text) == expected
-    if not success:
-        assert caplog.records[0].msg == (
-            f"Failed to parse {text} as bool! Using FORWARD_INIT:FALSE"
-        )


### PR DESCRIPTION
As part of cleaning up the tests (from retrospective), we need better documentation of what the tests are trying to verify. This PR refactors some tests to doctest so that it is clear why these checks exist.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
