### PR TITLE
pin scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ args = dict(
         "qtpy",
         "requests",
         "SALib",
-        "scipy",
+        "scipy<1.9.2",
         "sqlalchemy",
         "uvicorn >= 0.17.0",
         "websockets >= 9.0.1",


### PR DESCRIPTION
To fix the failing test_gui_load

To kinda reproduce the issue (allthough failing slightly differently locally):
`PYTHONMALLOC=malloc valgrind pytest tests/unit_tests/gui/test_gui_load.py::test_gui_load`

This locally fails with:

```
________________________________________________________ ERROR collecting tests/unit_tests/gui/test_gui_load.py _________________________________________________________
tests/unit_tests/gui/test_gui_load.py:13: in <module>
    from ert.gui.gert_main import GUILogHandler, _start_window, run_gui
src/ert/gui/gert_main.py:16: in <module>
    from ert.gui.simulation import SimulationPanel
src/ert/gui/simulation/__init__.py:1: in <module>
    from .simulation_panel import SimulationPanel
src/ert/gui/simulation/simulation_panel.py:27: in <module>
    from .run_dialog import RunDialog
src/ert/gui/simulation/run_dialog.py:34: in <module>
    from ert.gui.tools.plot.plot_tool import PlotTool
src/ert/gui/tools/plot/__init__.py:4: in <module>
    from .plot_tool import PlotTool
src/ert/gui/tools/plot/plot_tool.py:4: in <module>
    from .plot_window import PlotWindow
src/ert/gui/tools/plot/plot_window.py:20: in <module>
    from ert.gui.plottery.plots.gaussian_kde import GaussianKDEPlot
src/ert/gui/plottery/plots/gaussian_kde.py:2: in <module>
    from scipy.stats import gaussian_kde
../envs/ert/lib64/python3.8/site-packages/scipy/stats/__init__.py:467: in <module>
    from ._stats_py import *
../envs/ert/lib64/python3.8/site-packages/scipy/stats/_stats_py.py:46: in <module>
    from . import distributions
../envs/ert/lib64/python3.8/site-packages/scipy/stats/distributions.py:10: in <module>
    from . import _continuous_distns
../envs/ert/lib64/python3.8/site-packages/scipy/stats/_continuous_distns.py:31: in <module>
    import scipy.stats._boost as _boost
../envs/ert/lib64/python3.8/site-packages/scipy/stats/_boost/__init__.py:1: in <module>
    from scipy.stats._boost.beta_ufunc import (
E   SystemError: initialization of beta_ufunc raised unreported exception
```

On github the test fails with:
```tests/unit_tests/gui/test_gui_load.py::test_gui_load FAILED
Fatal Python error: Segmentation fault

Current thread 0x00007f0f17068b80 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pytestqt/plugin.py", line 209 in _process_events
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pytestqt/plugin.py", line 179 in pytest_runtest_call
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 55 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 260 in <lambda>
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 339 in from_call
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 259 in call_runtest_hook
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 220 in call_and_report
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 131 in runtestprotocol
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/runner.py", line 112 in pytest_runtest_protocol
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/main.py", line 349 in pytest_runtestloop
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/main.py", line 324 in _main
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/main.py", line 270 in wrap_session
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/main.py", line 317 in pytest_cmdline_main
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 167 in main
  File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 190 in console_main
  File "/opt/hostedtoolcache/Python/3.8.14/x64/bin/pytest", line 8 in <module>
/home/runner/work/_temp/1c69098d-9f35-402b-b1d3-d639547ed164.sh: line 3:  2965 Segmentation fault      (core dumped) pytest tests -sv --hypothesis-profile=ci -m "requires_window_manager"
Error: Process completed with exit code 139.
```

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
