### PR TITLE
Turn off c optimizations when building for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         export PATH=$PATH:${{ env.PIP_PKGS_PATH }}
         mkdir cmake-build
-        cmake -S src/clib -B cmake-build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON -DCOVERAGE=ON
+        cmake -S src/clib -B cmake-build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DCOVERAGE=ON
         cmake --build cmake-build "-j$(nproc)"
 
     - name: Run tests

--- a/ci/jenkins/test_libres_jenkins.sh
+++ b/ci/jenkins/test_libres_jenkins.sh
@@ -54,7 +54,7 @@ build_ert_clib () {
 	mkdir ${ERT_SOURCE_ROOT}/build
 	pushd ${ERT_SOURCE_ROOT}/build
 	cmake ${ERT_SOURCE_ROOT}/src/clib \
-		  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+		  -DCMAKE_BUILD_TYPE=Debug
 	make -j$(nproc)
 	popd
 }

--- a/ci/jenkins/testkomodo-libres-ctest.sh
+++ b/ci/jenkins/testkomodo-libres-ctest.sh
@@ -1,6 +1,6 @@
 build() {
     mkdir build
-    cmake -S src/clib -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    cmake -S src/clib -B build -DCMAKE_BUILD_TYPE=Debug \
           -DEQUINOR_TESTDATA_ROOT=/project/res-testdata/ErtTestData
     cmake --build build
 }


### PR DESCRIPTION
Speeds up testing of c code by building with Debug. This was built with Relwithdebug before as tests involving Eigen would take a long time. These tests has since been moved to the `iterative_ensemble_smoother` package so that it is no longer an issue.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
