### PR TITLE
Bump mypy-protobuf<v3.4

### DIFF
--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -1,5 +1,5 @@
 mypy
-mypy-protobuf
+mypy-protobuf<3.4
 types-aiofiles
 types-requests
 types-pkg_resources


### PR DESCRIPTION
**Issue**
Solves: #4136 

Solve a conflict of requirements between `ert` and `mypy-protobuf` in `types-requirements.txt`.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
