### PR TITLE
Do substitution until fixed point

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -112,6 +112,8 @@ class ResConfig:
         else:
             self._alloc_from_dict(config_dict=config_dict)
 
+        self._validate()
+
     def _assert_input(self, user_config_file, config, config_dict):
         configs = sum(
             1 for x in [user_config_file, config, config_dict] if x is not None
@@ -135,6 +137,21 @@ class ResConfig:
 
         if user_config_file is not None and not isfile(user_config_file):
             raise IOError(f'No such configuration file "{user_config_file}".')
+
+    def _validate(self):
+        for key, _ in self.substitution_list:
+            if (
+                key.count("<") != 1
+                or key.count(">") != 1
+                or key[0] != "<"
+                or key[-1] != ">"
+            ):
+                logger.warning(
+                    "Using DEFINE or DATA_KW with substitution"
+                    " strings that are not of the form '<KEY>' is deprecated"
+                    " and can result in undefined behavior."
+                    f" Please change {key} to <{key.replace('<', '').replace('>', '')}>"
+                )
 
     def _log_config_file(self, config_file: str) -> None:
         """

--- a/tests/test_config_parsing/test_defines.py
+++ b/tests/test_config_parsing/test_defines.py
@@ -1,0 +1,64 @@
+import pytest
+
+from ert._c_wrappers.enkf import EnKFMain, ResConfig
+
+
+def read_jobname(config_file):
+    res_config = ResConfig(config_file)
+    ert = EnKFMain(res_config)
+    run_context = ert.create_ensemble_experiment_run_context(0)
+    ert.createRunPath(run_context)
+    return run_context[0].job_name
+
+
+@pytest.mark.parametrize(
+    "defines, expected",
+    [
+        pytest.param(
+            """
+NUM_REALIZATIONS 1
+DEFINE <A> <B><C>
+DEFINE <B> my
+DEFINE <C> name
+JOBNAME <A>%d""",
+            "myname0",
+            id="Testing of use before declaration works for defines",
+        ),
+        pytest.param(
+            """
+NUM_REALIZATIONS 1
+DATA_KW <A> <B><C>
+DATA_KW <B> my
+DATA_KW <C> name
+JOBNAME <A>%d""",
+            "myname0",
+            id="Testing of use before declaration works for data_kw",
+        ),
+        pytest.param(
+            """
+NUM_REALIZATIONS 1
+DEFINE <B> my
+DEFINE <C> name
+DEFINE <A> <B><C>
+JOBNAME <A>%d""",
+            "myname0",
+            id="Testing of declaration before use works for defines",
+        ),
+        pytest.param(
+            """
+NUM_REALIZATIONS 1
+DATA_KW <B> my
+DATA_KW <C> name
+DATA_KW <A> <B><C>
+JOBNAME <A>%d""",
+            "myname0",
+            id="Testing of declaration before use works for data_kw",
+        ),
+    ],
+)
+def test_some_stuff(defines, expected, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "config_file.ert"
+    config_file.write_text(defines)
+
+    assert read_jobname(str(config_file)) == expected

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -114,3 +114,23 @@ def test_res_config_throws_on_missing_forward_model_job(config_dict):
         ResConfig(user_config_file=filename)
     with pytest.raises(expected_exception=ValueError, match="Could not find job"):
         ResConfig(config_dict=config_dict)
+
+
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
+@pytest.mark.parametrize(
+    "bad_define", ["DEFINE A B", "DEFINE <A<B>> C", "DEFINE <A><B> C"]
+)
+def test_that_non_bracketed_defines_warns(bad_define, caplog):
+    with open("test.ert", "w", encoding="utf-8") as fh:
+        fh.write(
+            dedent(
+                f"""
+                NUM_REALIZATIONS  1
+                {bad_define}
+                """
+            )
+        )
+
+    _ = ResConfig("test.ert")
+    assert len(caplog.records) == 1
+    assert "Using DEFINE or DATA_KW with substitution" in caplog.records[0].message


### PR DESCRIPTION
**Issue**
Resolves #4400 

This ensures that order of defines/data_kws do not impact substitution by doing it until fixed-point (with an upper limit on number of iterations to ensure termination).

This means that if keywords are not checked, DEFINES are very complex computationally. In order to restrict how complicated a config can be, we should give warnings if:

1. DEFINE/DATA_KW keywords do not start with `<` and end with `>`.
1. If keywords are nested, e.g. `<ENS-<ITER>>`.

If the above is not followed, there is potential for undefined behavior.

Such a check should probably be done by some mechanism for suggesting migration paths for deprecated configs, and unconventional keywords eventually resulting in hard fails.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
