### PR TITLE
Skip test_report_with_reconnected_reporter_but_finished_jobs if macos

### DIFF
--- a/tests/unit_tests/c_wrappers/job_runner/test_event_reporter.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_event_reporter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 from unittest.mock import patch
 
@@ -199,6 +200,9 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
     assert len(lines) == 0, "expected 0 Job running messages"
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Performance can be flaky"
+)
 def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
     # this is to show when the reporter fails but reconnects
     # reporter still manages to send events and completes fine


### PR DESCRIPTION
**Issue**
Resolves #4418


**Approach**
Skip test_report_with_reconnected_reporter_but_finished_jobs on Mac: it fails due to flaky performance.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
