### PR TITLE
Substitute deprecated iteritems to items

### DIFF
--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -99,7 +99,7 @@ def create_response_records(ert, ensemble_name: str, observations: List[dict]):
     records = []
     for key, response in data.items():
         realizations = {}
-        for index, values in response.iteritems():
+        for index, values in response.items():
             df = pd.DataFrame(values.to_list())
             df = df.transpose()
             df.columns = _prepare_x_axis(response.index.tolist())


### PR DESCRIPTION
**Issue**
Substituting a deprecation warning observed in GitHub actions.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
