### PR TITLE
Check if init_file contains %d after forward_init fails

### DIFF
--- a/src/ert/ensemble_evaluator/callbacks.py
+++ b/src/ert/ensemble_evaluator/callbacks.py
@@ -32,7 +32,10 @@ def _ensemble_config_forward_init(
         if node.forward_init(run_arg.runpath, iens):
             node.save(run_arg.sim_fs, node_id)
         else:
-            init_file = Path(config_node.get_init_file_fmt() % (iens,))
+            if "%d" in config_node.get_init_file_fmt():
+                init_file = Path(config_node.get_init_file_fmt() % (iens,))
+            else:
+                init_file = Path(config_node.get_init_file_fmt())
             if not init_file.exists():
                 error_msg = (
                     "Failed to initialize node "

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -230,10 +230,22 @@ def test_field_param(tmpdir, config_str, expect_forward_init):
             "",
         ),
         (
+            "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:../../../surf.irap BASE_SURFACE:surf0.irap FORWARD_INIT:True",  # noqa
+            True,
+            1,
+            "",
+        ),
+        (
             "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:surf%d.irap BASE_SURFACE:surf0.irap FORWARD_INIT:True",  # noqa
             True,
             0,
             "surf0.irap - failed to initialize node: MY_PARAM",
+        ),
+        (
+            "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:surf.irap BASE_SURFACE:surf0.irap FORWARD_INIT:True",  # noqa
+            True,
+            0,
+            "surf.irap - failed to initialize node: MY_PARAM",
         ),
     ],
 )


### PR DESCRIPTION


**Issue**
Resolves #4425 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
