### PR TITLE
Removed duplicate of rangestring test and more doc

### DIFF
--- a/src/ert/_c_wrappers/config/rangestring.py
+++ b/src/ert/_c_wrappers/config/rangestring.py
@@ -5,20 +5,21 @@ of active realizations. The are of the form "0, 2-4" meaning, for instance,
 that realization 0, 2, 3, and 4 are active.
 
 The ranges can overlap. The end of each range is inclusive.
-
-Example:
-
-    >>> mask_to_rangestring([True, True, True])
-    '0-2'
-    >>> mask_to_rangestring([True, False, True, True])
-    '0, 2-3'
 """
 from typing import Collection, List, Optional, Union
 
 
 def mask_to_rangestring(mask: Collection[Union[bool, int]]) -> str:
     """Convert a mask (ordered collection of booleans or int) into a rangestring.
-    For instance, `0 1 0 1 1 1` would be converted to `1, 3-5`.
+
+    >>> mask_to_rangestring([0, 1, 0, 1, 1, 1])
+    '1, 3-5'
+    >>> mask_to_rangestring([True, False, True, True])
+    '0, 2-3'
+    >>> mask_to_rangestring([])
+    ''
+    >>> mask_to_rangestring([False, False, False])
+    ''
 
     The length of the collection is not encoded in the resulting string and
     must be stored elsewhere.
@@ -49,7 +50,17 @@ def mask_to_rangestring(mask: Collection[Union[bool, int]]) -> str:
 
 def rangestring_to_mask(rangestring: str, length: int) -> List[bool]:
     """Convert a string specifying ranges of elements, and the number of elements,
-    into a list of booleans. The ranges are end-inclusive."""
+    into a list of booleans. The ranges are end-inclusive.
+
+    >>> rangestring_to_mask("1, 3-5", 6)
+    [False, True, False, True, True, True]
+    >>> rangestring_to_mask("", 0)
+    []
+    >>> rangestring_to_mask("", 1)
+    [False]
+    >>> rangestring_to_mask("1", 2)
+    [False, True]
+    """
     mask = [False] * length
     if rangestring == "":
         # An empty string means no active indecies. Note that an
@@ -78,7 +89,16 @@ def rangestring_to_mask(rangestring: str, length: int) -> List[bool]:
 
 def rangestring_to_list(rangestring: str) -> List[int]:
     """Convert a string specifying ranges of elements, and the number of elements,
-    into a list of ints. The ranges are end-inclusive."""
+    into a list of ints. The ranges are end-inclusive.
+
+    >>> rangestring_to_list("0-1, 4-6, 8")
+    [0, 1, 4, 5, 6, 8]
+    >>> rangestring_to_list("")
+    []
+    >>> rangestring_to_list("1,2")
+    [1, 2]
+
+    """
     result = set()
     if rangestring == "":
         return []

--- a/tests/unit_tests/c_wrappers/res/config/test_rangestring.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_rangestring.py
@@ -7,29 +7,6 @@ from ert._c_wrappers.config.rangestring import (
 )
 
 
-def testMaskToRangeConversion():
-    cases = (
-        ([0, 1, 0, 1, 1, 1, 0], "1, 3-5"),
-        ([0, 1, 0, 1, 1, 1, 1], "1, 3-6"),
-        ([0, 1, 0, 1, 0, 1, 0], "1, 3, 5"),
-        ([1, 1, 0, 0, 1, 1, 1, 0, 1], "0-1, 4-6, 8"),
-        ([1, 1, 1, 1, 1, 1, 1], "0-6"),
-        ([0, 0, 0, 0, 0, 0, 0], ""),
-        ([True, False, True, True], "0, 2-3"),
-        ([], ""),
-    )
-
-    def nospaces(s):
-        return "".join(s.split())
-
-    for mask, expected in cases:
-        rngstr = mask_to_rangestring(mask)
-        assert nospaces(rngstr) == nospaces(expected), (
-            f"Mask {mask} was converted to {rngstr} which is different "
-            f"from the expected range {expected}"
-        )
-
-
 @pytest.mark.parametrize(
     "mask, expected_string",
     [


### PR DESCRIPTION
There was some duplication of tests in rangestring so removed one of the tests for mask conversion. Also moved some doctests around.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
