### PR TITLE
Use stderr for deprecation warnings in config file

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import sys
 from collections import defaultdict
 from collections.abc import Mapping
 from datetime import date
@@ -146,11 +147,12 @@ class ResConfig:
                 or key[0] != "<"
                 or key[-1] != ">"
             ):
-                logger.warning(
+                print(
                     "Using DEFINE or DATA_KW with substitution"
                     " strings that are not of the form '<KEY>' is deprecated"
-                    " and can result in undefined behavior."
-                    f" Please change {key} to <{key.replace('<', '').replace('>', '')}>"
+                    " and can result in undefined behavior. "
+                    f"Please change {key} to <{key.replace('<', '').replace('>', '')}>",
+                    file=sys.stderr,
                 )
 
     def _log_config_file(self, config_file: str) -> None:

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -120,7 +120,7 @@ def test_res_config_throws_on_missing_forward_model_job(config_dict):
 @pytest.mark.parametrize(
     "bad_define", ["DEFINE A B", "DEFINE <A<B>> C", "DEFINE <A><B> C"]
 )
-def test_that_non_bracketed_defines_warns(bad_define, caplog):
+def test_that_non_bracketed_defines_warns(bad_define, capsys):
     with open("test.ert", "w", encoding="utf-8") as fh:
         fh.write(
             dedent(
@@ -132,5 +132,4 @@ def test_that_non_bracketed_defines_warns(bad_define, caplog):
         )
 
     _ = ResConfig("test.ert")
-    assert len(caplog.records) == 1
-    assert "Using DEFINE or DATA_KW with substitution" in caplog.records[0].message
+    assert "Using DEFINE or DATA_KW with substitution" in capsys.readouterr().err


### PR DESCRIPTION
As logging is set to critical for ert deployed via komodo, we need to use stderr for now.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
