### PR TITLE
Fix default value for max_running in driver

### DIFF
--- a/src/ert/_c_wrappers/job_queue/driver.py
+++ b/src/ert/_c_wrappers/job_queue/driver.py
@@ -47,7 +47,7 @@ class Driver(BaseCClass):
     def __init__(
         self,
         driver_type: QueueDriverEnum,
-        max_running: int = 1,
+        max_running: int = 0,
         options: List[Tuple[str, str]] = None,
     ):
         c_ptr = self._alloc(driver_type)

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -1,5 +1,6 @@
 import os
 
+import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
@@ -19,3 +20,13 @@ def test_queue_config_dict_same_as_from_file(config_dict):
         ResConfig(filename).queue_config
         == ResConfig(config_dict=config_dict).queue_config
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
+@given(st.integers(min_value=1, max_value=300))
+def test_queue_config_default_max_running_is_unlimited(num_real):
+    filename = "config.ert"
+    with open(filename, "w") as f:
+        f.write(f"NUM_REALIZATIONS {num_real}\nQUEUE_SYSTEM SLURM\n")
+    # get_max_running() == 0 means unlimited
+    assert ResConfig(filename).queue_config.create_job_queue().get_max_running() == 0


### PR DESCRIPTION
Fixes a bug where max_running is set to 1 instead of 0 (unlimited)
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
