### PR TITLE
Create initial implementation of migration suggester

### DIFF
--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -20,6 +20,7 @@ class DeprecationMigrationSuggester:
         "SCHEDULE_PREDICTION_FILE",
     ]
     JUST_REMOVE_KEYWORDS = ["UMASK", "LOG_FILE", "LOG_LEVEL"]
+    RSH_KEYWORDS = ["RSH_HOST", "RHS_COMMAND"]
 
     def _add_deprecated_keywords_to_parser(self):
         for kw in self.REPLACE_WITH_GEN_KW:
@@ -53,6 +54,13 @@ class DeprecationMigrationSuggester:
             add_suggestion(
                 kw,
                 f"The {kw} keyword no longer has any effect "
+                "and can safely be removed from the config file.",
+            )
+        for kw in self.RSH_KEYWORDS:
+            add_suggestion(
+                kw,
+                f"The {kw} was used for the deprecated and removed "
+                "support for RHS queues. It no longer has any effect "
                 "and can safely be removed from the config file.",
             )
         add_suggestion(

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -29,6 +29,7 @@ class DeprecationMigrationSuggester:
         self._parser.add("RFTPATH")
         self._parser.add("END_DATE")
         self._parser.add("CASE_TABLE")
+        self._parser.add("RERUN_START")
 
     def suggest_migrations(self, filename: str):
         suggestions = []
@@ -85,6 +86,13 @@ class DeprecationMigrationSuggester:
                 "The CASE_TABLE keyword was used with a deprecated sensitivity "
                 "analysis feature to give descriptive names to cases. It no longer has "
                 " any effect and can safely be removed from the config file."
+            )
+        if content.hasKey("RERUN_START"):
+            suggestions.append(
+                "The RERUN_START keyword was used for the deprecated run mode "
+                "ENKF_ASSIMILATION which was removed in 2016. It does not have "
+                "any effect on run modes currently supported by ERT, and can "
+                "be safely removed."
             )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -34,6 +34,7 @@ class DeprecationMigrationSuggester:
         self._parser.add("END_DATE")
         self._parser.add("CASE_TABLE")
         self._parser.add("RERUN_START")
+        self._parser.add("DELETE_RUNPATH")
 
     def suggest_migrations(self, filename: str):
         suggestions = []
@@ -109,6 +110,11 @@ class DeprecationMigrationSuggester:
             "ENKF_ASSIMILATION which was removed in 2016. It does not have "
             "any effect on run modes currently supported by ERT, and can "
             "be safely removed.",
+        )
+        add_suggestion(
+            "DELETE_RUNPATH",
+            "The DELETE_RUNPATH keyword would clear the runpath directories "
+            "between runs. It was removed in 2017 and no longer has any effect.",
         )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -18,6 +18,7 @@ class DeprecationMigrationSuggester:
         "EQUIL",
         "GEN_PARAM",
         "SCHEDULE_PREDICTION_FILE",
+        "MULTFLT",
     ]
     JUST_REMOVE_KEYWORDS = ["UMASK", "LOG_FILE", "LOG_LEVEL"]
     RSH_KEYWORDS = ["RSH_HOST", "RHS_COMMAND"]
@@ -27,8 +28,9 @@ class DeprecationMigrationSuggester:
             self._parser.add(kw)
         for kw in self.JUST_REMOVE_KEYWORDS:
             self._parser.add(kw)
+        for kw in self.RSH_KEYWORDS:
+            self._parser.add(kw)
         self._parser.add("HAVANA_FAULT")
-        self._parser.add("MULTFLT")
         self._parser.add("REFCASE_LIST")
         self._parser.add("RFTPATH")
         self._parser.add("END_DATE")
@@ -48,14 +50,16 @@ class DeprecationMigrationSuggester:
         for kw in self.REPLACE_WITH_GEN_KW:
             add_suggestion(
                 kw,
-                "The keyword {kw} was deprecated in 2009 in favor of using"
-                " GEN_KW and FORWARD_MODEL.",
+                f"The {kw} keyword was replaced by the GEN_KW keyword."
+                "Please see https://ert.readthedocs.io/en/latest/"
+                "reference/configuration/keywords.html#gen-kw"
+                "to see how to migrate from MULTFLT to GEN_KW.",
             )
         for kw in self.JUST_REMOVE_KEYWORDS:
             add_suggestion(
                 kw,
-                f"The {kw} keyword no longer has any effect "
-                "and can safely be removed from the config file.",
+                f"The keyword {kw} no longer has any effect, and can"
+                "be safely removed.",
             )
         for kw in self.RSH_KEYWORDS:
             add_suggestion(
@@ -69,13 +73,6 @@ class DeprecationMigrationSuggester:
             "Direct interoperability with havana was removed from ert in 2009."
             " The behavior of HAVANA_FAULT can be reproduced using"
             " GEN_KW and FORWARD_MODEL.",
-        )
-        add_suggestion(
-            "MULTFLT",
-            "The MULTFLT keyword was replaced by the GENKW keyword in 2009."
-            "Please see https://ert.readthedocs.io/en/latest/"
-            "reference/configuration/keywords.html#gen-kw"
-            "to see how to migrate from MULTFLT to GEN_KW.",
         )
         add_suggestion(
             "REFCASE_LIST",

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -1,7 +1,10 @@
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ert._c_wrappers.config import ConfigParser
+
+logger = logging.getLogger(__name__)
 
 
 class DeprecationMigrationSuggester:
@@ -33,66 +36,71 @@ class DeprecationMigrationSuggester:
 
     def suggest_migrations(self, filename: str):
         suggestions = []
-
         content = self._parser.parse(filename)
+
+        def add_suggestion(kw, suggestion):
+            if content.hasKey(kw):
+                logger.info("Deprecated keyword %s", kw)
+                suggestions.append(suggestion)
+
         for kw in self.REPLACE_WITH_GEN_KW:
-            if content.hasKey(kw):
-                suggestions.append(
-                    "The keyword {kw} was deprecated in 2009 in favor of using"
-                    " GEN_KW and FORWARD_MODEL."
-                )
+            add_suggestion(
+                kw,
+                "The keyword {kw} was deprecated in 2009 in favor of using"
+                " GEN_KW and FORWARD_MODEL.",
+            )
         for kw in self.JUST_REMOVE_KEYWORDS:
-            if content.hasKey(kw):
-                suggestions.append(
-                    f"The {kw} keyword no longer has any effect "
-                    "and can safely be removed from the config file."
-                )
-        if content.hasKey("HAVANA_FAULT"):
-            suggestions.append(
-                "Direct interoperability with havana was removed from ert in 2009."
-                " The behavior of HAVANA_FAULT can be reproduced using"
-                " GEN_KW and FORWARD_MODEL."
+            add_suggestion(
+                kw,
+                f"The {kw} keyword no longer has any effect "
+                "and can safely be removed from the config file.",
             )
-        if content.hasKey("MULTFLT"):
-            suggestions.append(
-                "The MULTFLT keyword was replaced by the GENKW keyword in 2009."
-                "Please see https://ert.readthedocs.io/en/latest/"
-                "reference/configuration/keywords.html#gen-kw"
-                "to see how to migrate from MULTFLT to GEN_KW."
-            )
-        if content.hasKey("REFCASE_LIST"):
-            suggestions.append(
-                "The REFCASE_LIST keyword was used to give a .DATA file "
-                "to be used for plotting. The corresponding plotting functionality "
-                "was removed in 2015, and this keyword can be safely removed from "
-                "the config file."
-            )
-        if content.hasKey("RFTPATH"):
-            suggestions.append(
-                "The RFTPATH keyword was used to give a path to well observations "
-                "to be used for plotting. The corresponding plotting functionality "
-                "was removed in 2015, and the RFTPATH keyword can safely be removed "
-                "from the config file."
-            )
-        if content.hasKey("END_DATE"):
-            suggestions.append(
-                "The END_DATE keyword was used to check that a the dates in a summary "
-                "file would go beyond a certaind date. This would only display a "
-                "warning in case of problems. The keyword has since been deprecated, "
-                "and can be safely removed from the config file."
-            )
-        if content.hasKey("CASE_TABLE"):
-            suggestions.append(
-                "The CASE_TABLE keyword was used with a deprecated sensitivity "
-                "analysis feature to give descriptive names to cases. It no longer has "
-                " any effect and can safely be removed from the config file."
-            )
-        if content.hasKey("RERUN_START"):
-            suggestions.append(
-                "The RERUN_START keyword was used for the deprecated run mode "
-                "ENKF_ASSIMILATION which was removed in 2016. It does not have "
-                "any effect on run modes currently supported by ERT, and can "
-                "be safely removed."
-            )
+        add_suggestion(
+            "HAVANA_FAULT",
+            "Direct interoperability with havana was removed from ert in 2009."
+            " The behavior of HAVANA_FAULT can be reproduced using"
+            " GEN_KW and FORWARD_MODEL.",
+        )
+        add_suggestion(
+            "MULTFLT",
+            "The MULTFLT keyword was replaced by the GENKW keyword in 2009."
+            "Please see https://ert.readthedocs.io/en/latest/"
+            "reference/configuration/keywords.html#gen-kw"
+            "to see how to migrate from MULTFLT to GEN_KW.",
+        )
+        add_suggestion(
+            "REFCASE_LIST",
+            "The REFCASE_LIST keyword was used to give a .DATA file "
+            "to be used for plotting. The corresponding plotting functionality "
+            "was removed in 2015, and this keyword can be safely removed from "
+            "the config file.",
+        )
+        add_suggestion(
+            "RFTPATH",
+            "The RFTPATH keyword was used to give a path to well observations "
+            "to be used for plotting. The corresponding plotting functionality "
+            "was removed in 2015, and the RFTPATH keyword can safely be removed "
+            "from the config file.",
+        )
+        add_suggestion(
+            "END_DATE",
+            "The END_DATE keyword was used to check that a the dates in a summary "
+            "file would go beyond a certaind date. This would only display a "
+            "warning in case of problems. The keyword has since been deprecated, "
+            "and can be safely removed from the config file.",
+        )
+        add_suggestion(
+            "CASE_TABLE",
+            "The CASE_TABLE keyword was used with a deprecated sensitivity "
+            "analysis feature to give descriptive names to cases. It no longer has "
+            " any effect and can safely be removed from the config file.",
+        )
+        add_suggestion(
+            "RERUN_START",
+            "The RERUN_START keyword was used for the deprecated run mode "
+            "ENKF_ASSIMILATION which was removed in 2016. It does not have "
+            "any effect on run modes currently supported by ERT, and can "
+            "be safely removed.",
+        )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -9,17 +9,82 @@ class DeprecationMigrationSuggester:
         self._parser = parser
         self._add_deprecated_keywords_to_parser()
 
+    REPLACE_WITH_GEN_KW = [
+        "RELPERM",
+        "MULTZ",
+        "EQUIL",
+        "GEN_PARAM",
+        "SCHEDULE_PREDICTION_FILE",
+    ]
+    JUST_REMOVE_KEYWORDS = ["UMASK", "LOG_FILE", "LOG_LEVEL"]
+
     def _add_deprecated_keywords_to_parser(self):
-        self._parser.add("UMASK")
+        for kw in self.REPLACE_WITH_GEN_KW:
+            self._parser.add(kw)
+        for kw in self.JUST_REMOVE_KEYWORDS:
+            self._parser.add(kw)
+        self._parser.add("HAVANA_FAULT")
+        self._parser.add("MULTFLT")
+        self._parser.add("REFCASE_LIST")
+        self._parser.add("RFTPATH")
+        self._parser.add("END_DATE")
+        self._parser.add("CASE_TABLE")
 
     def suggest_migrations(self, filename: str):
         suggestions = []
 
         content = self._parser.parse(filename)
-        if content.hasKey("UMASK"):
+        for kw in self.REPLACE_WITH_GEN_KW:
+            if content.hasKey(kw):
+                suggestions.append(
+                    "The keyword {kw} was deprecated in 2009 in favor of using"
+                    " GEN_KW and FORWARD_MODEL."
+                )
+        for kw in self.JUST_REMOVE_KEYWORDS:
+            if content.hasKey(kw):
+                suggestions.append(
+                    f"The {kw} keyword no longer has any effect "
+                    "and can safely be removed from the config file."
+                )
+        if content.hasKey("HAVANA_FAULT"):
             suggestions.append(
-                "The UMASK keyword has been removed "
-                "and has no effect, it can safely be removed"
+                "Direct interoperability with havana was removed from ert in 2009."
+                " The behavior of HAVANA_FAULT can be reproduced using"
+                " GEN_KW and FORWARD_MODEL."
+            )
+        if content.hasKey("MULTFLT"):
+            suggestions.append(
+                "The MULTFLT keyword was replaced by the GENKW keyword in 2009."
+                "Please see https://ert.readthedocs.io/en/latest/"
+                "reference/configuration/keywords.html#gen-kw"
+                "to see how to migrate from MULTFLT to GEN_KW."
+            )
+        if content.hasKey("REFCASE_LIST"):
+            suggestions.append(
+                "The REFCASE_LIST keyword was used to give a .DATA file "
+                "to be used for plotting. The corresponding plotting functionality "
+                "was removed in 2015, and this keyword can be safely removed from "
+                "the config file."
+            )
+        if content.hasKey("RFTPATH"):
+            suggestions.append(
+                "The RFTPATH keyword was used to give a path to well observations "
+                "to be used for plotting. The corresponding plotting functionality "
+                "was removed in 2015, and the RFTPATH keyword can safely be removed "
+                "from the config file."
+            )
+        if content.hasKey("END_DATE"):
+            suggestions.append(
+                "The END_DATE keyword was used to check that a the dates in a summary "
+                "file would go beyond a certaind date. This would only display a "
+                "warning in case of problems. The keyword has since been deprecated, "
+                "and can be safely removed from the config file."
+            )
+        if content.hasKey("CASE_TABLE"):
+            suggestions.append(
+                "The CASE_TABLE keyword was used with a deprecated sensitivity "
+                "analysis feature to give descriptive names to cases. It no longer has "
+                " any effect and can safely be removed from the config file."
             )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ert._c_wrappers.config import ConfigParser
+
+
+class DeprecationMigrationSuggester:
+    def __init__(self, parser: "ConfigParser"):
+        self._parser = parser
+        self._add_deprecated_keywords_to_parser()
+
+    def _add_deprecated_keywords_to_parser(self):
+        self._parser.add("UMASK")
+
+    def suggest_migrations(self, filename: str):
+        suggestions = []
+
+        content = self._parser.parse(filename)
+        if content.hasKey("UMASK"):
+            suggestions.append(
+                "The UMASK keyword has been removed "
+                "and has no effect, it can safely be removed"
+            )
+
+        return suggestions

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -16,4 +16,51 @@ def test_that_suggester_gives_umask_migration(suggester, tmp_path):
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 1
-    assert suggestions[0].startswith("The UMASK keyword has been removed")
+    assert suggestions[0].startswith("The UMASK keyword no longer")
+
+
+def test_that_suggester_gives_havana_fault_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nHAVANA_FAULT\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert "The behavior of HAVANA_FAULT can be reproduced using" in suggestions[0]
+
+
+def test_that_suggester_gives_multflt_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nMULTFLT\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert (
+        "ert.readthedocs.io/en/latest/reference/configuration/keywords.html#gen-kw"
+        in suggestions[0]
+    )
+
+
+def test_that_suggester_gives_refcase_list_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nREFCASE_LIST case.DATA\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert (
+        "The corresponding plotting functionality was removed in 2015" in suggestions[0]
+    )
+
+
+def test_that_suggester_gives_rftpath_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRFTPATH rfts/\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert (
+        "The corresponding plotting functionality was removed in 2015" in suggestions[0]
+    )
+
+
+def test_that_suggester_gives_end_date_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nEND_DATE 2023.01.01\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert "only display a warning in case of problems" in suggestions[0]

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -11,12 +11,13 @@ def suggester():
     return DeprecationMigrationSuggester(ConfigParser())
 
 
-def test_that_suggester_gives_umask_migration(suggester, tmp_path):
-    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nUMASK 0222\n")
+@pytest.mark.parametrize("kw", DeprecationMigrationSuggester.JUST_REMOVE_KEYWORDS)
+def test_that_suggester_gives_simple_migrations(suggester, tmp_path, kw):
+    (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 1
-    assert suggestions[0].startswith("The UMASK keyword no longer")
+    assert suggestions[0].startswith(f"The keyword {kw} no longer")
 
 
 def test_that_suggester_gives_havana_fault_migration(suggester, tmp_path):
@@ -27,8 +28,9 @@ def test_that_suggester_gives_havana_fault_migration(suggester, tmp_path):
     assert "The behavior of HAVANA_FAULT can be reproduced using" in suggestions[0]
 
 
-def test_that_suggester_gives_multflt_migration(suggester, tmp_path):
-    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nMULTFLT\n")
+@pytest.mark.parametrize("kw", DeprecationMigrationSuggester.REPLACE_WITH_GEN_KW)
+def test_that_suggester_gives_gen_kw_migrations(suggester, tmp_path, kw):
+    (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 1
@@ -36,6 +38,15 @@ def test_that_suggester_gives_multflt_migration(suggester, tmp_path):
         "ert.readthedocs.io/en/latest/reference/configuration/keywords.html#gen-kw"
         in suggestions[0]
     )
+
+
+@pytest.mark.parametrize("kw", DeprecationMigrationSuggester.RSH_KEYWORDS)
+def test_that_suggester_gives_rsh_migrations(suggester, tmp_path, kw):
+    (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert "deprecated and removed support for RHS queues." in suggestions[0]
 
 
 def test_that_suggester_gives_refcase_list_migration(suggester, tmp_path):
@@ -64,3 +75,19 @@ def test_that_suggester_gives_end_date_migration(suggester, tmp_path):
 
     assert len(suggestions) == 1
     assert "only display a warning in case of problems" in suggestions[0]
+
+
+def test_that_suggester_gives_rerun_start_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRERUN_START 2023.01.01\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert "used for the deprecated run mode ENKF_ASSIMILATION" in suggestions[0]
+
+
+def test_that_suggester_gives_delete_runpath_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nDELETE_RUNPATH TRUE\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert "It was removed in 2017" in suggestions[0]

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ert._c_wrappers.config import ConfigParser
+from ert._c_wrappers.enkf._deprecation_migration_suggester import (
+    DeprecationMigrationSuggester,
+)
+
+
+@pytest.fixture
+def suggester():
+    return DeprecationMigrationSuggester(ConfigParser())
+
+
+def test_that_suggester_gives_umask_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nUMASK 0222\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert suggestions[0].startswith("The UMASK keyword has been removed")


### PR DESCRIPTION
**Issue**
Resolves #4453 


Currently gives no suggestions for `GEN_KW` and `GEN_DATA` fields. I am planning to do that in a separate PR, but it requires separating the parsing of `GEN_KW` from ensemble_config.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
