### PR TITLE
Assert that len(obs_mask)==len(obs_values)

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -251,6 +251,11 @@ def analysis_IES(
         observation_values = observation_handle.observation_values
         observation_errors = observation_handle.observation_errors
         observation_mask = observation_handle.obs_mask
+
+        assert (
+            len(observation_values) == len(observation_errors) == len(observation_mask)
+        )
+
         if len(observation_values) == 0:
             raise ErtAnalysisError(
                 f"No active observations for update step: {update_step.name}."


### PR DESCRIPTION
Do we agree that it should be the case that `obs_mask` has the same number of elements as `obs_values`?

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
