### PR TITLE
Fix bug where updates using SURFACE/FIELD failed after iter-0

### DIFF
--- a/src/ert/ensemble_evaluator/callbacks.py
+++ b/src/ert/ensemble_evaluator/callbacks.py
@@ -23,7 +23,7 @@ def _ensemble_config_forward_init(
             continue
 
         node = EnkfNode(config_node)
-        node_id = NodeId(report_step=0, realization_number=run_arg.iens)
+        node_id = NodeId(report_step=0, iens=run_arg.iens)
 
         if node.has_data(run_arg.sim_fs, node_id):
             # Already initialised, ignore


### PR DESCRIPTION
Added a test case that does smoother update with Surface, it is identical to the poly example, except it uses SURFACE instead of GEN_KW

<img width="1072" alt="Skjermbilde 2022-12-08 kl  21 31 27" src="https://user-images.githubusercontent.com/44577479/206561608-31ff594b-252f-4d65-aea5-90614efd81ed.png">


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
