### PR TITLE
Move error message if missing REFCASE/TIME_MAP from C to python

### DIFF
--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -549,10 +549,6 @@ static void enkf_obs_reinterpret_DT_FILE(const char *errors) {
 void enkf_obs_load(enkf_obs_type *enkf_obs, const char *config_file,
                    double std_cutoff) {
 
-    if (!enkf_obs_is_valid(enkf_obs))
-        util_abort("%s cannot load invalid enkf observation config %s.\n",
-                   __func__, config_file);
-
     conf_class_type *enkf_conf_class = enkf_obs_get_obs_conf_class();
     conf_instance_type *enkf_conf = conf_instance_alloc_from_file(
         enkf_conf_class, "enkf_conf", config_file);

--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -146,7 +146,7 @@ struct enkf_obs_struct {
     /** For fast lookup of report_step -> obs_time */
     std::vector<time_t> obs_time;
 
-    bool valid;
+    std::string error;
     /* Several shared resources - can generally be NULL*/
     history_source_type history;
     const ecl_sum_type *refcase;
@@ -167,7 +167,7 @@ enkf_obs_type *enkf_obs_alloc(const history_source_type history,
     enkf_obs->refcase = refcase;
     enkf_obs->grid = grid;
     enkf_obs->ensemble_config = ensemble_config;
-    enkf_obs->valid = true;
+    enkf_obs->error = "";
 
     /* Initialize obs time: */
     if (enkf_obs->refcase) {
@@ -181,13 +181,15 @@ enkf_obs_type *enkf_obs_alloc(const history_source_type history,
     } else if (external_time_map) {
         enkf_obs->obs_time = *external_time_map;
     } else {
-        enkf_obs->valid = false;
+        enkf_obs->error = "Missing REFCASE or TIMEMAP";
     }
 
     return enkf_obs;
 }
 
-bool enkf_obs_is_valid(const enkf_obs_type *obs) { return obs->valid; }
+const char *enkf_obs_get_error(const enkf_obs_type *obs) {
+    return obs->error.c_str();
+}
 
 void enkf_obs_free(enkf_obs_type *enkf_obs) {
     hash_free(enkf_obs->obs_hash);

--- a/src/clib/lib/include/ert/enkf/enkf_obs.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_obs.hpp
@@ -17,7 +17,7 @@
 #include <ert/enkf/obs_vector.hpp>
 #include <ert/enkf/time_map.hpp>
 
-extern "C" bool enkf_obs_is_valid(const enkf_obs_type *);
+extern "C" const char *enkf_obs_get_error(const enkf_obs_type *obs);
 
 enkf_obs_type *enkf_obs_alloc(const history_source_type history,
                               std::shared_ptr<TimeMap> external_time_map,

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -157,6 +157,11 @@ class EnKFMain:
             config.ensemble_config,
         )
         if config.model_config.obs_config_file:
+            if not self._observations.valid:
+                raise ValueError(
+                    f"Incorrect observations file: "
+                    f"{config.model_config.obs_config_file}"
+                )
             self._observations.load(
                 config.model_config.obs_config_file,
                 config.analysis_config.get_std_cutoff(),

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -157,10 +157,11 @@ class EnKFMain:
             config.ensemble_config,
         )
         if config.model_config.obs_config_file:
-            if not self._observations.valid:
+            if self._observations.error:
                 raise ValueError(
                     f"Incorrect observations file: "
                     f"{config.model_config.obs_config_file}"
+                    f": {self._observations.error}"
                 )
             self._observations.load(
                 config.model_config.obs_config_file,

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -14,7 +14,7 @@ class EnkfObs(BaseCClass):
 
     _free = ResPrototype("void enkf_obs_free(enkf_obs)")
     _get_size = ResPrototype("int enkf_obs_get_size( enkf_obs )")
-    _valid = ResPrototype("bool enkf_obs_is_valid(enkf_obs)")
+    _error = ResPrototype("char* enkf_obs_get_error(enkf_obs)")
     _load = ResPrototype("void enkf_obs_load(enkf_obs, char*, double)")
     _clear = ResPrototype("void enkf_obs_clear( enkf_obs )")
     _alloc_typed_keylist = ResPrototype(
@@ -121,12 +121,11 @@ class EnkfObs(BaseCClass):
         self._load(config_file, std_cutoff)
 
     @property
-    def valid(self):
-        return self._valid()
+    def error(self):
+        return self._error()
 
     def clear(self):
         self._clear()
 
     def __repr__(self):
-        validity = "valid" if self.valid else "invalid"
-        return self._create_repr(f"{validity}, len={len(self)}")
+        return self._create_repr(f"{self.error}, len={len(self)}")


### PR DESCRIPTION
This used to cause util_abort if the user forgot to add TIME_MAP or REFCASE, now it is a python exception with an understandable error message.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
