### PR TITLE
Fix a bug with fixed point substitution

### DIFF
--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 from cwrap import BaseCClass
@@ -117,14 +118,13 @@ class SubstitutionList(BaseCClass):
     def substitute_real_iter(
         self, to_substitute: str, realization: int, iteration: int
     ) -> str:
-        to_substitute = self._alloc_filtered_string(to_substitute)
+        copy_substituter = copy.deepcopy(self)
         geo_id_key = f"<GEO_ID_{realization}_{iteration}>"
-        to_substitute = to_substitute.replace(
-            "<GEO_ID>", self.get(geo_id_key, "<GEO_ID>")
-        )
-        to_substitute = to_substitute.replace("<IENS>", str(realization))
-        to_substitute = to_substitute.replace("<ITER>", str(iteration))
-        return to_substitute
+        if geo_id_key in self:
+            copy_substituter.addItem("<GEO_ID>", self[geo_id_key])
+        copy_substituter.addItem("<IENS>", str(realization))
+        copy_substituter.addItem("<ITER>", str(iteration))
+        return copy_substituter.substitute(to_substitute)
 
     def __eq__(self, other):
         if self.keys() != other.keys():

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -101,6 +101,17 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             ["DEFAULT_ARGA_VALUE", "<ARGUMENTB>", "<ARGUMENTC>"],
             id="No args, gives default argument A",
         ),
+        pytest.param(
+            dedent(
+                """
+            EXECUTABLE echo
+            ARGLIST <ITER>
+            """
+            ),
+            "FORWARD_MODEL job_name(<ITER>=<ITER>)",
+            ["0"],
+            id="This style of args works without infinite substitution loop.",
+        ),
     ],
 )
 def test_forward_model_job(job, forward_model, expected_args):


### PR DESCRIPTION
**Issue**
Resolves #4473 


**Approach**

Adds a warning in case `<ITER>=<ITER>` or `<IENS>=<IENS>` is added to the argument list of a job, which is a common misperception of how the argument list works. In effect, we ignore this assignment. If the user has specified `<ITER>=1` in the argument list that gets priority. If nothing is inserted, then iteration number is inputed.

Also, `substitute_real_iter` is changed to avoid some non-terminating substitutions (the `<ITER>` substitution could be starved before).



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
