### PR TITLE
Fix false positive warning

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -83,7 +83,7 @@ def parse_signature_job(signature: str) -> Tuple[str, Optional[str]]:
         raise ConfigValidationError(
             f"Missing ) in FORWARD_MODEL job description {signature}"
         )
-    if close_paren < len(signature):
+    if close_paren < len(signature) - 1:
         logger.warning(
             f'Arguments after closing ) in "{signature}"'
             f' ("{signature[close_paren:]}") is ignored.'


### PR DESCRIPTION
**Issue**
Fixes that a warning about extra characters were shown when there were none.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
