### PR TITLE
Fix pylint issue on unspecified encoding

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -126,6 +126,7 @@ jobs:
             unnecessary-lambda,\
             unnecessary-lambda-assignment,\
             unneeded-not,\
+            unspecified-encoding,\
             unsubscriptable-object,\
             unsupported-assignment-operation,\
             unsupported-binary-operation,\

--- a/docs/getting_started/configuration/poly_new/with_observations/poly_eval.py
+++ b/docs/getting_started/configuration/poly_new/with_observations/poly_eval.py
@@ -2,7 +2,7 @@
 
 import json
 
-with open("coeffs.json") as f:
+with open("coeffs.json", encoding="utf-8") as f:
     coeffs = json.load(f)
 
 
@@ -11,5 +11,5 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly_0.out", "w") as f:
+with open("poly_0.out", "w", encoding="utf-8") as f:
     f.write("\n".join(map(str, output)))

--- a/docs/getting_started/configuration/poly_new/with_parameters/poly_eval.py
+++ b/docs/getting_started/configuration/poly_new/with_parameters/poly_eval.py
@@ -2,7 +2,7 @@
 
 import json
 
-with open("coeffs.json") as f:
+with open("coeffs.json", encoding="utf-8") as f:
     coeffs = json.load(f)
 
 
@@ -11,5 +11,5 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly_0.out", "w") as f:
+with open("poly_0.out", "w", encoding="utf-8") as f:
     f.write("\n".join(map(str, output)))

--- a/docs/getting_started/configuration/poly_new/with_results/poly_eval.py
+++ b/docs/getting_started/configuration/poly_new/with_results/poly_eval.py
@@ -2,7 +2,7 @@
 
 import json
 
-with open("coeffs.json") as f:
+with open("coeffs.json", encoding="utf-8") as f:
     coeffs = json.load(f)
 
 
@@ -11,5 +11,5 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly_0.out", "w") as f:
+with open("poly_0.out", "w", encoding="utf-8") as f:
     f.write("\n".join(map(str, output)))

--- a/docs/getting_started/configuration/poly_new/with_simple_script/poly_eval.py
+++ b/docs/getting_started/configuration/poly_new/with_simple_script/poly_eval.py
@@ -8,5 +8,5 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly_0.out", "w") as f:
+with open("poly_0.out", "w", encoding="utf-8") as f:
     f.write("\n".join(map(str, output)))

--- a/src/_ert_job_runner/cli.py
+++ b/src/_ert_job_runner/cli.py
@@ -93,9 +93,9 @@ def main(args):
     # Make sure that logging is setup _after_ we have moved to the runpath directory
     _setup_logging()
 
-    ens_id = None
+    # ens_id = None
     try:
-        with open(JOBS_FILE, "r") as json_file:
+        with open(JOBS_FILE, "r", encoding="utf-8") as json_file:
             jobs_data = json.load(json_file)
             experiment_id = jobs_data.get("experiment_id")
             ens_id = jobs_data.get("ens_id")

--- a/src/_ert_job_runner/reporting/file.py
+++ b/src/_ert_job_runner/reporting/file.py
@@ -171,7 +171,7 @@ class File(Reporter):
             stderr_file = None
             if job.std_err:
                 if os.path.exists(job.std_err):
-                    with open(job.std_err, "r") as error_file_handler:
+                    with open(job.std_err, "r", encoding="utf-8") as error_file_handler:
                         stderr = error_file_handler.read()
                         if stderr:
                             stderr_file = os.path.join(os.getcwd(), job.std_err)
@@ -189,11 +189,11 @@ class File(Reporter):
             file.write("</error>\n")
 
     def _dump_ok_file(self):
-        with open(OK_file, "w") as f:
+        with open(OK_file, "w", encoding="utf-8") as f:
             f.write(
                 f"All jobs complete {time.strftime(TIME_FORMAT, time.localtime())} \n"
             )
 
     def _dump_status_json(self):
-        with open(STATUS_json, "w") as fp:
+        with open(STATUS_json, "w", encoding="utf-8") as fp:
             json.dump(self.status_dict, fp, indent=4)

--- a/src/_ert_job_runner/util/__init__.py
+++ b/src/_ert_job_runner/util/__init__.py
@@ -16,7 +16,7 @@ def read_os_release(pfx="LSB_"):
         return None
 
     props = {}
-    with open(fname, "r") as f:
+    with open(fname, "r", encoding="utf-8") as f:
         for line in f:
             kv = splitline(processline(line), pfx=pfx)
             if kv:

--- a/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs_manager.py
@@ -85,9 +85,9 @@ class FileSystemManager:
         version_file = self.storage_path / FS_VERSION_FILE
         if not version_file.exists():
             # If the version file does not exist it uses old fs
-            with open(version_file, "w") as f:
+            with open(version_file, "w", encoding="utf-8") as f:
                 json.dump({"version": 0}, f)
-        with open(version_file, "r") as f:
+        with open(version_file, "r", encoding="utf-8") as f:
             version_data = json.load(f)
         if version_data["version"] < FS_VERSION:
             raise FileSystemError(

--- a/src/ert/_c_wrappers/enkf/runpaths.py
+++ b/src/ert/_c_wrappers/enkf/runpaths.py
@@ -7,7 +7,7 @@ class Runpaths:
     """The Runpaths are the ensemble workspace directories.
 
     Generally the is one runpath for each realization and iteration, although
-    depending on the given format string for the paths they may coinside. There
+    depending on the given format string for the paths they may coincide. There
     is one job name for each of the runpaths.
 
     :param job_name_format: The format of the job name, e.g., "job_%d"
@@ -102,7 +102,7 @@ class Runpaths:
 
     def _create_and_open_file(self, mode="w"):
         Path(self.runpath_list_filename).parent.mkdir(parents=True, exist_ok=True)
-        return open(self.runpath_list_filename, mode)
+        return open(self.runpath_list_filename, mode, encoding="utf-8")
 
     def format_job_name(self) -> str:
         return _maybe_format(self._job_name_format)

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -621,9 +621,11 @@ class JobQueue(BaseCClass):
         for q_index, q_node in enumerate(self.job_list):
             if cert is not None:
                 cert_path = f"{q_node.run_path}/{CERT_FILE}"
-                with open(cert_path, "w") as cert_file:
+                with open(cert_path, "w", encoding="utf-8") as cert_file:
                     cert_file.write(cert)
-            with open(f"{q_node.run_path}/{JOBS_FILE}", "r+") as jobs_file:
+            with open(
+                f"{q_node.run_path}/{JOBS_FILE}", "r+", encoding="utf-8"
+            ) as jobs_file:
                 data = json.load(jobs_file)
 
                 data["ens_id"] = ens_id

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -281,7 +281,7 @@ def _write_update_report(fname: Path, snapshot: SmootherSnapshot) -> None:
     # Make sure log file parents exist
     fname.parent.mkdir(parents=True, exist_ok=True)
     for update_step_name, update_step in snapshot.update_step_snapshots.items():
-        with open(fname, "w") as fout:
+        with open(fname, "w", encoding="utf-8") as fout:
             fout.write("=" * 127 + "\n")
             fout.write("Report step...: deprecated\n")
             fout.write(f"Update step......: {update_step_name:<10}\n")

--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -181,12 +181,12 @@ class EvaluatorServerConfig:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = pathlib.Path(tmp_dir)
                 cert_path = tmp_path / "ee.crt"
-                with open(cert_path, "w") as f1:
-                    f1.write(self.cert)
+                with open(cert_path, "w", encoding="utf-8") as filehandle_1:
+                    filehandle_1.write(self.cert)
 
                 key_path = tmp_path / "ee.key"
-                with open(key_path, "wb") as f2:
-                    f2.write(self._key)
+                with open(key_path, "wb") as filehandle_2:
+                    filehandle_2.write(self._key)
                 context = ssl.SSLContext(protocol=protocol)
                 context.load_cert_chain(cert_path, key_path, self._key_pw)
                 return context

--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -339,7 +339,7 @@ class BaseService:
             path = f"{self.service_name}_server.json"
 
         if isinstance(info, Mapping):
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 json.dump(info, f, indent=4)
 
         self._conn_info_event.set()

--- a/src/ert/shared/_doc_utils/ert_jobs.py
+++ b/src/ert/shared/_doc_utils/ert_jobs.py
@@ -32,7 +32,7 @@ class _ForwardModelDocumentation:
             section_id=self.name + "-job-config", title="Job configuration used by ERT"
         )
 
-        with open(self.job_config_file) as fh:
+        with open(self.job_config_file, encoding="utf-8") as fh:
             job_config_text = fh.read()
         job_config_text_node = nodes.literal_block(text=job_config_text)
         config_section_node.append(job_config_text_node)

--- a/src/ert/shared/hook_implementations/jobs.py
+++ b/src/ert/shared/hook_implementations/jobs.py
@@ -32,7 +32,7 @@ def _get_jobs_from_directories(directories):
 
 def _get_file_content_if_exists(file_name, default=""):
     if os.path.isfile(file_name):
-        with open(file_name) as fh:
+        with open(file_name, encoding="utf-8") as fh:
             return fh.read()
     return default
 

--- a/src/ert/shared/plugins/plugin_manager.py
+++ b/src/ert/shared/plugins/plugin_manager.py
@@ -251,7 +251,7 @@ class ErtPluginContext:
         if site_config_content is not None:
             logging.debug("Creating temporary site-config")
             tmp_site_config_filename = os.path.join(self.tmp_dir, "site-config")
-            with open(tmp_site_config_filename, "w") as fh:
+            with open(tmp_site_config_filename, "w", encoding="utf-8") as fh:
                 fh.write(site_config_content)
             logging.debug(f"Temporary site-config created: {tmp_site_config_filename}")
         return tmp_site_config_filename

--- a/src/ert/shared/plugins/workflow_config.py
+++ b/src/ert/shared/plugins/workflow_config.py
@@ -110,7 +110,7 @@ class WorkflowConfig:
 
     def _write_workflow_config(self, output_dir):
         file_path = os.path.join(output_dir, self.name.upper())
-        with open(file_path, "w") as f_out:
+        with open(file_path, "w", encoding="utf-8") as f_out:
             f_out.write("INTERNAL      True\n")
             f_out.write(f"SCRIPT        {self.function_dir}")
         return file_path

--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
@@ -77,7 +77,7 @@ class EclConfig:
     """
 
     def __init__(self, config_file, simulator_name="not_set"):
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             try:
                 config = yaml.safe_load(f)
             except yaml.YAMLError:

--- a/src/ert/shared/share/ert/forward-models/res/script/rms.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/rms.py
@@ -18,7 +18,7 @@ class RMSConfig:
 
     def __init__(self):
         config_file = os.getenv("RMS_SITE_CONFIG", default=self.DEFAULT_CONFIG_FILE)
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             try:
                 config = yaml.safe_load(f)
             except yaml.YAMLError:
@@ -121,10 +121,10 @@ class RMSRun:
 
             if os.path.exists(single_seed_file):
                 # Using existing single seed file
-                with open(single_seed_file) as fileH:
+                with open(single_seed_file, encoding="utf-8") as fileH:
                     seed = int(float(fileH.readline()))
             elif os.path.exists(multi_seed_file):
-                with open(multi_seed_file) as fileH:
+                with open(multi_seed_file, encoding="utf-8") as fileH:
                     seed_list = [int(x) for x in fileH.readlines()]
                 seed = seed_list[iens + 1]
             else:
@@ -148,7 +148,7 @@ class RMSRun:
         exec_env_file = f"{self_exe}_exec_env.json"
         user_env = {}
         if os.path.isfile(exec_env_file):
-            with open(exec_env_file) as f:
+            with open(exec_env_file, encoding="utf-8") as f:
                 user_env = json.load(f)
 
         for var in set(config_env.keys()) | set(user_env.keys()):

--- a/src/ert/shared/share/ert/forward-models/templating/script/template_render.py
+++ b/src/ert/shared/share/ert/forward-models/templating/script/template_render.py
@@ -16,7 +16,7 @@ def load_data(filename):
     """
     yaml_err = ""
     json_err = ""
-    with open(filename) as fin:
+    with open(filename, encoding="utf-8") as fin:
         try:
             return yaml.safe_load(fin)
         except yaml.YAMLError as err:
@@ -96,7 +96,7 @@ def render_template(input_files, template_file, output_file):
 
     template = _load_template(template_file)
     data = _load_input(all_input_files)
-    with open(output_file, "w") as fout:
+    with open(output_file, "w", encoding="utf-8") as fout:
         fout.write(template.render(**data))
 
 

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -23,7 +23,7 @@ except ImportError:
 def load_args(filename, column_names=None):
     rows = 0
     columns = 0
-    with open(filename, "r") as fileH:
+    with open(filename, "r", encoding="utf-8") as fileH:
         for line in fileH.readlines():
             rows += 1
             columns = max(columns, len(line.split()))
@@ -38,7 +38,7 @@ def load_args(filename, column_names=None):
     data.fill(numpy.nan)
 
     row = 0
-    with open(filename) as fileH:
+    with open(filename, encoding="utf-8") as fileH:
         for line in fileH.readlines():
             tmp = line.split()
             print(tmp)

--- a/test-data/batch_sim/jobs/square_params.py
+++ b/test-data/batch_sim/jobs/square_params.py
@@ -7,7 +7,7 @@ keys = ["W1", "W2", "W3"]
 
 
 def square_file(input_file, output_file):
-    with open(input_file) as fin:
+    with open(input_file, encoding="utf-8") as fin:
         data0 = json.load(fin)
     out = []
     for key in keys:
@@ -16,7 +16,7 @@ def square_file(input_file, output_file):
             out.extend([str(v**2) for _, v in data1.items()])
         except AttributeError:
             out.append(str(data1**2))
-    with open(output_file, "w") as fout:
+    with open(output_file, "w", encoding="utf-8") as fout:
         fout.write("\n".join(out))
 
 

--- a/test-data/configuration_tests/input/jobs/snake_oil_simulator.py
+++ b/test-data/configuration_tests/input/jobs/snake_oil_simulator.py
@@ -12,7 +12,7 @@ def globalIndex(i, j, k, nx=10, ny=10, nz=10):
 
 def readParameters(filename):
     params = {}
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding="utf-8") as f:
         for line in f:
             key, value = line.split(":", 1)
             params[key] = value.strip()

--- a/test-data/poly_example/assert_runpath_file.py
+++ b/test-data/poly_example/assert_runpath_file.py
@@ -17,7 +17,7 @@ def run():
         "{pwd}/poly_out/realization-{iens}/iter-{iter}  "
         "poly_{iens}  {iter:03d}\n"
     )
-    with open(runpath_file) as fh:
+    with open(runpath_file, encoding="utf-8") as fh:
         rpf = "".join(
             [
                 runpath_line.format(iens=iens, iter=iteration, pwd=curdir)
@@ -26,7 +26,7 @@ def run():
         )
         assert fh.read() == rpf
 
-    with open(ok_filename.format(iteration), "w") as fh:
+    with open(ok_filename.format(iteration), "w", encoding="utf-8") as fh:
         fh.write(":)")
 
 

--- a/test-data/poly_example/poly_eval.py
+++ b/test-data/poly_example/poly_eval.py
@@ -4,7 +4,7 @@ import json
 
 
 def _load_coeffs(filename):
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -15,5 +15,5 @@ def _evaluate(coeffs, x):
 if __name__ == "__main__":
     coeffs = _load_coeffs("coeffs.json")
     output = [_evaluate(coeffs, x) for x in range(10)]
-    with open("poly_0.out", "w") as f:
+    with open("poly_0.out", "w", encoding="utf-8") as f:
         f.write("\n".join(map(str, output)))

--- a/test-data/snake_oil/jobs/snake_oil_simulator.py
+++ b/test-data/snake_oil/jobs/snake_oil_simulator.py
@@ -11,7 +11,7 @@ def globalIndex(i, j, k, nx=10, ny=10, nz=10):
 
 def readParameters(filename):
     params = {}
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding="utf-8") as f:
         for line in f:
             key, value = line.split(":", 1)
             params[key] = value.strip()
@@ -199,6 +199,6 @@ if __name__ == "__main__":
 
     ecl_sum.fwrite()
 
-    with open("time_map.txt", "w") as f:
+    with open("time_map.txt", "w", encoding="utf-8") as f:
         for t in time_map:
             f.write(f"{t}\n")

--- a/test-data/snake_oil_field/jobs/snake_oil_simulator.py
+++ b/test-data/snake_oil_field/jobs/snake_oil_simulator.py
@@ -12,7 +12,7 @@ def globalIndex(i, j, k, nx=10, ny=10):
 
 def read_seed(filename):
     params = {}
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding="utf-8") as f:
         for line in f:
             key, value = line.split(":")
             params[key] = value.strip()
@@ -22,7 +22,7 @@ def read_seed(filename):
 
 def read_parameters(filename):
     params = {}
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding="utf-8") as f:
         for line in f:
             key, value = line.split(" ")
             _, name = key.split(":")

--- a/test-data/snake_oil_structure/snake_oil/jobs/snake_oil_diff.py
+++ b/test-data/snake_oil_structure/snake_oil/jobs/snake_oil_diff.py
@@ -3,7 +3,7 @@ from ecl.summary import EclSum
 
 
 def writeDiff(filename, ecl_sum, key1, key2):
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         for v1, v2 in zip(ecl_sum.numpy_vector(key1), ecl_sum.numpy_vector(key2)):
             diff = v1 - v2
             f.write(f"{diff}\n")

--- a/tests/performance_tests/performance_utils.py
+++ b/tests/performance_tests/performance_utils.py
@@ -48,7 +48,7 @@ def write_summary_data(file, x_size, keywords, update_steps):
 def render_template(folder, template, target, **kwargs):
     output = template.render(kwargs)
     file = folder / target
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         f.write(output)
 
 

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -22,7 +22,7 @@ def test_queue_config_dict_same_as_from_file(tmp_path_factory, config_generator)
 @given(st.integers(min_value=1, max_value=300))
 def test_queue_config_default_max_running_is_unlimited(num_real):
     filename = "config.ert"
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(f"NUM_REALIZATIONS {num_real}\nQUEUE_SYSTEM SLURM\n")
     # get_max_running() == 0 means unlimited
     assert ResConfig(filename).queue_config.create_job_queue().get_max_running() == 0

--- a/tests/unit_tests/all/plugins/test_parameter_disable.py
+++ b/tests/unit_tests/all/plugins/test_parameter_disable.py
@@ -29,11 +29,11 @@ def test_disable_parameters_is_loaded():
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_we_can_disable_a_parameter():
-    with open("poly.ert", "a") as fh:
+    with open("poly.ert", "a", encoding="utf-8") as fh:
         fh.writelines("GEN_KW DONT_UPDATE_KW template.txt kw.txt prior.txt")
-    with open("template.txt", "w") as fh:
+    with open("template.txt", "w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-    with open("prior.txt", "w") as fh:
+    with open("prior.txt", "w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD NORMAL 0 1")
     ert = EnKFMain(ResConfig("poly.ert"))
 

--- a/tests/unit_tests/all/plugins/test_plugin_context.py
+++ b/tests/unit_tests/all/plugins/test_plugin_context.py
@@ -30,7 +30,7 @@ def test_no_plugins(monkeypatch):
             os.environ["RMS_SITE_CONFIG"]
 
         assert os.path.isfile(os.environ["ERT_SITE_CONFIG"])
-        with open(os.environ["ERT_SITE_CONFIG"]) as f:
+        with open(os.environ["ERT_SITE_CONFIG"], encoding="utf-8") as f:
             assert c.plugin_manager.get_site_config_content() == f.read()
 
         path = os.environ["ERT_SITE_CONFIG"]
@@ -57,7 +57,7 @@ def test_with_plugins(monkeypatch):
             os.environ["RMS_SITE_CONFIG"]
 
         assert os.path.isfile(os.environ["ERT_SITE_CONFIG"])
-        with open(os.environ["ERT_SITE_CONFIG"]) as f:
+        with open(os.environ["ERT_SITE_CONFIG"], encoding="utf-8") as f:
             assert c.plugin_manager.get_site_config_content() == f.read()
 
         path = os.environ["ERT_SITE_CONFIG"]

--- a/tests/unit_tests/all/plugins/test_workflow_config.py
+++ b/tests/unit_tests/all/plugins/test_workflow_config.py
@@ -90,7 +90,7 @@ def test_workflow_config_write_workflow_config(tmpdir, monkeypatch):
     with tmpdir.as_cwd():
         assert os.path.isfile("DEFAULT_NAME")
 
-        with open("DEFAULT_NAME") as fin:
+        with open("DEFAULT_NAME", encoding="utf-8") as fin:
             content = fin.read()
 
         assert content == expected_config

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -16,7 +16,7 @@ from ert.cli.main import run_cli
 
 @pytest.fixture()
 def minimal_config(use_tmpdir):
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         fout.write("NUM_REALIZATIONS 1")
     res_config = ResConfig("config_file.ert")
     yield res_config
@@ -270,7 +270,7 @@ def test_snapshot_alpha(alpha, expected):
     res_config = ResConfig("snake_oil.ert")
 
     obs_file = Path("observations") / "observations.txt"
-    with obs_file.open(mode="w") as fin:
+    with obs_file.open(mode="w", encoding="utf-8") as fin:
         fin.write(
             """
 SUMMARY_OBSERVATION LOW_STD

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -101,7 +101,9 @@ def test_gen_kw(tmpdir, config_str, expected, extra_files, expectation):
         with expectation:
             create_runpath("config.ert")
             assert (
-                Path("simulations/realization-0/iter-0/kw.txt").read_text("utf-8")
+                Path("simulations/realization-0/iter-0/kw.txt").read_text(
+                    encoding="utf-8"
+                )
                 == expected
             )
 
@@ -486,11 +488,11 @@ def test_that_sampling_is_fixed_from_name(tmpdir, template, prior, num_realisati
         GEN_KW KW_NAME template.txt kw.txt prior.txt
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("template.txt", "w") as fh:
+        with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines(template)
-        with open("prior.txt", "w") as fh:
+        with open("prior.txt", "w", encoding="utf-8") as fh:
             fh.writelines(prior)
 
         res_config = ResConfig("config.ert")
@@ -548,11 +550,11 @@ def test_that_sub_sample_maintains_order(tmpdir, mask, expected):
         GEN_KW KW_NAME template.txt kw.txt prior.txt
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("template.txt", "w") as fh:
+        with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w") as fh:
+        with open("prior.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD NORMAL 0 1")
 
         res_config = ResConfig("config.ert")
@@ -596,7 +598,7 @@ TIME_MAP time_map
         )
         expect_surface.write("surf.irap")
 
-        with open("forward_model", "w") as f:
+        with open("forward_model", "w", encoding="utf-8") as f:
             f.write(
                 dedent(
                     """#!/usr/bin/env python
@@ -625,9 +627,9 @@ if __name__ == "__main__":
             | stat.S_IXGRP
             | stat.S_IXOTH,
         )
-        with open("POLY_EVAL", "w") as fout:
+        with open("POLY_EVAL", "w", encoding="utf-8") as fout:
             fout.write("EXECUTABLE forward_model")
-        with open("observations", "w") as fout:
+        with open("observations", "w", encoding="utf-8") as fout:
             fout.write(
                 dedent(
                     """
@@ -640,7 +642,7 @@ if __name__ == "__main__":
                 )
             )
 
-        with open("obs.txt", "w") as fobs:
+        with open("obs.txt", "w", encoding="utf-8") as fobs:
             fobs.write(
                 dedent(
                     """
@@ -652,10 +654,10 @@ if __name__ == "__main__":
                 )
             )
 
-        with open("time_map", "w") as fobs:
+        with open("time_map", "w", encoding="utf-8") as fobs:
             fobs.write("2014-09-10")
 
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
 
         parser = ArgumentParser(prog="test_main")

--- a/tests/unit_tests/c_wrappers/job_runner/test_file_reporter.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_file_reporter.py
@@ -21,9 +21,9 @@ def test_report_with_init_message_argument(reporter):
 
     r.report(Init([job1], 1, 19))
 
-    with open(STATUS_file, "r") as f:
+    with open(STATUS_file, "r", encoding="utf-8") as f:
         assert "Current host" in f.readline(), "STATUS file missing expected value"
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"name": "job1"' in content, "status.json missing job1"
         assert '"status": "Waiting"' in content, "status.json missing Waiting status"
@@ -47,14 +47,14 @@ def test_report_with_successful_start_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, "r") as f:
+    with open(STATUS_file, "r", encoding="utf-8") as f:
         assert "job1" in f.readline(), "STATUS file missing job1"
-    with open(LOG_file, "r") as f:
+    with open(LOG_file, "r", encoding="utf-8") as f:
         assert (
             "Calling: /bin/bash --foo 1 --bar 2" in f.readline()
         ), """JOB_LOG file missing executable and arguments"""
 
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Running"' in content, "status.json missing Running status"
         assert '"start_time": null' not in content, "start_time not set"
@@ -67,11 +67,11 @@ def test_report_with_failed_start_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, "r") as f:
+    with open(STATUS_file, "r", encoding="utf-8") as f:
         assert (
             "EXIT: -10/massive_failure" in f.readline()
         ), "STATUS file missing EXIT message"
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Failure"' in content, "status.json missing Failure status"
         assert (
@@ -89,7 +89,7 @@ def test_report_with_successful_exit_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Success"' in content, "status.json missing Success status"
 
@@ -101,9 +101,9 @@ def test_report_with_failed_exit_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, "r") as f:
+    with open(STATUS_file, "r", encoding="utf-8") as f:
         assert "EXIT: 1/massive_failure" in f.readline()
-    with open(ERROR_file, "r") as f:
+    with open(ERROR_file, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert "<job>job1</job>" in content, "ERROR file missing job"
         assert (
@@ -112,7 +112,7 @@ def test_report_with_failed_exit_message_argument(reporter):
         assert (
             "<stderr: Not redirected>" in content
         ), "ERROR had invalid stderr information"
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Failure"' in content, "status.json missing Failure status"
         assert (
@@ -128,7 +128,7 @@ def test_report_with_running_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_json, "r") as f:
+    with open(STATUS_json, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Running"' in content, "status.json missing status"
         assert (
@@ -154,7 +154,7 @@ def test_dump_error_file_with_stderr(reporter):
     that constitutes the ERROR file.
     The report system is left out, since this was tested in the fail case.
     """
-    with open("stderr.out.0", "a") as stderr:
+    with open("stderr.out.0", "a", encoding="utf-8") as stderr:
         stderr.write("Error:\n")
         stderr.write("E_MASSIVE_FAILURE\n")
 
@@ -162,7 +162,7 @@ def test_dump_error_file_with_stderr(reporter):
         Job({"name": "job1", "stderr": "stderr.out.0"}, 0), "massive_failure"
     )
 
-    with open(ERROR_file, "r") as f:
+    with open(ERROR_file, "r", encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert "E_MASSIVE_FAILURE" in content, "ERROR file missing stderr content"
         assert "<stderr_file>" in content, "ERROR missing stderr_file part"
@@ -210,7 +210,7 @@ def test_status_file_is_correct(reporter):
         f"EXIT: {exited_j_2.exit_code}/{exited_j_2.error_message}\n"
     )
 
-    with open(STATUS_file, "r") as f:
+    with open(STATUS_file, "r", encoding="utf-8") as f:
         for expected in [
             "Current host",
             expected_j1_line,

--- a/tests/unit_tests/c_wrappers/job_runner/test_job.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_job.py
@@ -75,7 +75,7 @@ def test_run_with_defined_executable_but_missing():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_no_exec_bit():
     non_executable = os.path.join(os.getcwd(), "foo")
-    with open(non_executable, "a"):
+    with open(non_executable, "a", encoding="utf-8"):
         pass
 
     job = Job(

--- a/tests/unit_tests/c_wrappers/job_runner/test_job_dispatch.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_job_dispatch.py
@@ -21,7 +21,7 @@ from tests.utils import _mock_ws_thread, wait_until
 def test_terminate_jobs():
 
     # Executes it self recursively and sleeps for 100 seconds
-    with open("dummy_executable", "w") as f:
+    with open("dummy_executable", "w", encoding="utf-8") as f:
         f.write(
             """#!/usr/bin/env python
 import sys, os, time
@@ -65,11 +65,11 @@ else:
         "ert_pid": "",
     }
 
-    with open("jobs.json", "w") as f:
+    with open("jobs.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(job_list))
 
     # macOS doesn't provide /usr/bin/setsid, so we roll our own
-    with open("setsid", "w") as f:
+    with open("setsid", "w", encoding="utf-8") as f:
         f.write(
             dedent(
                 """\
@@ -111,12 +111,12 @@ else:
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_job_dispatch_run_subset_specified_as_parmeter():
-    with open("dummy_executable", "w") as f:
+    with open("dummy_executable", "w", encoding="utf-8") as f:
         f.write(
             "#!/usr/bin/env python\n"
             "import sys, os\n"
             'filename = "job_{}.out".format(sys.argv[1])\n'
-            'f = open(filename, "w")\n'
+            'f = open(filename, "w", encoding="utf-8")\n'
             "f.close()\n"
         )
 
@@ -190,11 +190,11 @@ def test_job_dispatch_run_subset_specified_as_parmeter():
         "ert_pid": "",
     }
 
-    with open("jobs.json", "w") as f:
+    with open("jobs.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(job_list))
 
     # macOS doesn't provide /usr/bin/setsid, so we roll our own
-    with open("setsid", "w") as f:
+    with open("setsid", "w", encoding="utf-8") as f:
         f.write(
             dedent(
                 """\
@@ -242,7 +242,7 @@ def test_no_json_jobs_json_file():
     path = os.path.realpath(os.curdir)
     jobs_file = os.path.join(path, "jobs.json")
 
-    with open(jobs_file, "w") as f:
+    with open(jobs_file, "w", encoding="utf-8") as f:
         f.write("not json")
 
     with pytest.raises(OSError):

--- a/tests/unit_tests/c_wrappers/job_runner/test_job_manager_runtime_kw.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_job_manager_runtime_kw.py
@@ -36,7 +36,7 @@ def test_run_one_job_with_an_integer_arg_is_actually_a_fractional():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_given_one_job_with_missing_file_and_one_file_present():
-    with open("a_file", "w") as f:
+    with open("a_file", "w", encoding="utf-8") as f:
         f.write("Hello")
 
     executable = "echo"

--- a/tests/unit_tests/c_wrappers/job_runner/test_jobmanager.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_jobmanager.py
@@ -166,7 +166,7 @@ def test_given_global_env_and_update_path_executable_env_is_updated():
     executable = "./x.py"
     outfile = "outfile.stdout.0"
 
-    with open(executable, "w") as f:
+    with open(executable, "w", encoding="utf-8") as f:
         f.write("#!/usr/bin/env python\n")
         f.write("import os\n")
         f.write("print(os.environ['KEY_ONE'])\n")
@@ -208,7 +208,7 @@ def test_given_global_env_and_update_path_executable_env_is_updated():
         number_of_finished_scripts == 1
     ), "guard check, script must finish successfully"
 
-    with open(outfile, "r") as out0:
+    with open(outfile, "r", encoding="utf-8") as out0:
         content = list(out0.read().splitlines())
         assert content[0] == "FirstValue"
         assert content[1] == "SecondValue"
@@ -221,7 +221,7 @@ def test_given_global_env_and_update_path_executable_env_is_updated():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_exec_env():
-    with open("exec_env.py", "w") as f:
+    with open("exec_env.py", "w", encoding="utf-8") as f:
         f.write(
             """#!/usr/bin/env python\n
 import os
@@ -234,7 +234,7 @@ assert exec_env["NOT_SET"] is None
         )
     os.chmod("exec_env.py", stat.S_IEXEC + stat.S_IREAD)
 
-    with open("EXEC_ENV", "w") as f:
+    with open("EXEC_ENV", "w", encoding="utf-8") as f:
         f.write("EXECUTABLE exec_env.py\n")
         f.write("EXEC_ENV TEST_ENV 123\n")
         f.write("EXEC_ENV NOT_SET 42\n")
@@ -246,12 +246,12 @@ assert exec_env["NOT_SET"] is None
         "run_id", ".", "data_root", 0, 0, SubstitutionList(), EnvironmentVarlist()
     )
 
-    with open("jobs.json", "r") as f:
+    with open("jobs.json", "r", encoding="utf-8") as f:
         jobs_json = json.load(f)
 
     for msg in list(JobRunner(jobs_json).run([])):
         if isinstance(msg, Start):
-            with open("exec_env_exec_env.json") as f:
+            with open("exec_env_exec_env.json", encoding="utf-8") as f:
                 exec_env = json.load(f)
                 assert exec_env["TEST_ENV"] == "123"
                 assert exec_env["NOT_SET"] is None

--- a/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_parser.py
@@ -13,7 +13,7 @@ from ert._c_wrappers.config import (
 
 
 def test_item_types(tmp_path):
-    with open(tmp_path / "config", "w") as f:
+    with open(tmp_path / "config", "w", encoding="utf-8") as f:
         f.write("TYPE_ITEM 10 3.14 TruE  String  file\n")
 
     conf = ConfigParser()
@@ -63,7 +63,7 @@ FIELD    SWAT          DYNAMIC   MIN:0   MAX:1
 FIELD    SGAS          DYNAMIC   MIN:0   MAX:1
 FIELD    RS            DYNAMIC   MIN:0
 FIELD    RV            DYNAMIC   MIN:0.0034"""
-    with open("simple_config", "w") as fout:
+    with open("simple_config", "w", encoding="utf-8") as fout:
         fout.write(config_file)
     conf = ConfigParser()
     conf.add("FIELD", False)
@@ -101,7 +101,7 @@ FIELD    RV            DYNAMIC   MIN:0.0034"""
 def test_parse_invalid():
     conf = ConfigParser()
     conf.add("INT", value_type=ContentTypeEnum.CONFIG_INT)
-    with open("config", "w") as fileH:
+    with open("config", "w", encoding="utf-8") as fileH:
         fileH.write("INT xx\n")
 
     with pytest.raises(ValueError):
@@ -118,7 +118,7 @@ def test_parse_deprecated():
     item = conf.add("INT", value_type=ContentTypeEnum.CONFIG_INT)
     msg = "ITEM INT IS DEPRECATED"
     item.setDeprecated(msg)
-    with open("config", "w") as fileH:
+    with open("config", "w", encoding="utf-8") as fileH:
         fileH.write("INT 100\n")
 
     content = conf.parse("config")
@@ -138,10 +138,10 @@ def test_parse_dotdot_relative(monkeypatch):
     os.makedirs("cwd/jobs")
     os.makedirs("eclipse/bin")
     script_path = os.path.join(os.getcwd(), "eclipse/bin/script.sh")
-    with open(script_path, "w") as f:
+    with open(script_path, "w", encoding="utf-8") as f:
         f.write("This is a test script")
 
-    with open("cwd/jobs/JOB", "w") as fileH:
+    with open("cwd/jobs/JOB", "w", encoding="utf-8") as fileH:
         fileH.write("EXECUTABLE ../../eclipse/bin/script.sh\n")
 
     os.makedirs("cwd/ert")
@@ -163,7 +163,7 @@ def test_parser_content():
     schema_item.iset_type(5, ContentTypeEnum.CONFIG_PATH)
     schema_item = conf.add("NOT_IN_CONTENT", False)
 
-    with open("config", "w") as fileH:
+    with open("config", "w", encoding="utf-8") as fileH:
         fileH.write("KEY VALUE1 VALUE2 100  True  3.14  path/file.txt\n")
 
     cwd0 = os.getcwd()
@@ -252,7 +252,7 @@ def test_schema():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_add_unknown_keyowrds():
     parser = ConfigParser()
-    with open("config", "w") as fileH:
+    with open("config", "w", encoding="utf-8") as fileH:
         fileH.write("SETTINGS A 100.1\n")
         fileH.write("SETTINGS B 200  STRING1 STRING2\n")
         fileH.write("SETTINGS C 300\n")
@@ -285,7 +285,7 @@ def test_add_unknown_keyowrds():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_valid_string_runtime_file():
-    with open("some_file", "w") as f:
+    with open("some_file", "w", encoding="utf-8") as f:
         f.write("This i.")
     assert ContentTypeEnum.CONFIG_RUNTIME_FILE.valid_string("no_file")
     assert ContentTypeEnum.CONFIG_RUNTIME_FILE.valid_string("some_file", True)

--- a/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_kw_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_kw_config.py
@@ -9,13 +9,13 @@ from ert._c_wrappers.enkf import EnKFMain, GenKwConfig, ResConfig
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_config():
-    with open("template.txt", "w") as f:
+    with open("template.txt", "w", encoding="utf-8") as f:
         f.write("Hello")
 
-    with open("parameters.txt", "w") as f:
+    with open("parameters.txt", "w", encoding="utf-8") as f:
         f.write("KEY  UNIFORM 0 1 \n")
 
-    with open("parameters_with_comments.txt", "w") as f:
+    with open("parameters_with_comments.txt", "w", encoding="utf-8") as f:
         f.write("KEY1  UNIFORM 0 1 -- COMMENT\n")
         f.write("\n\n")  # Two blank lines
         f.write("KEY2  UNIFORM 0 1\n")
@@ -41,10 +41,10 @@ def test_gen_kw_config_get_priors():
     parameter_file = "parameters.txt"
     template_file = "template.txt"
 
-    with open(template_file, "w") as f:
+    with open(template_file, "w", encoding="utf-8") as f:
         f.write("Hello")
 
-    with open(parameter_file, "w") as f:
+    with open(parameter_file, "w", encoding="utf-8") as f:
         f.write("KEY1  NORMAL 0 1\n")
         f.write("KEY2  LOGNORMAL 2 3\n")
         f.write("KEY3  TRUNCATED_NORMAL 4 5 6 7\n")
@@ -168,11 +168,11 @@ def test_gen_kw_is_log_or_not(tmpdir, distribution, expect_log, parameters_regex
         GEN_KW KW_NAME template.txt kw.txt prior.txt
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("template.txt", "w") as fh:
+        with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w") as fh:
+        with open("prior.txt", "w", encoding="utf-8") as fh:
             fh.writelines(f"MY_KEYWORD {distribution}")
 
         res_config = ResConfig("config.ert")
@@ -187,5 +187,7 @@ def test_gen_kw_is_log_or_not(tmpdir, distribution, expect_log, parameters_regex
         ert.createRunPath(prior)
         assert re.match(
             parameters_regex,
-            Path("simulations/realization-0/iter-0/parameters.txt").read_text(),
+            Path("simulations/realization-0/iter-0/parameters.txt").read_text(
+                encoding="utf-8"
+            ),
         )

--- a/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_kw.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_kw.py
@@ -7,12 +7,12 @@ from ert._c_wrappers.enkf.data import GenKw
 def create_gen_kw(tmp_path):
     parameter_file = str(tmp_path / "MULTFLT.txt")
     template_file = str(tmp_path / "MULTFLT.tmpl")
-    with open(parameter_file, "w") as f:
+    with open(parameter_file, "w", encoding="utf-8") as f:
         f.write("MULTFLT1  NORMAL  0   1\n")
         f.write("MULTFLT2  RAW \n")
         f.write("MULTFLT3  NORMAL  0   1\n")
 
-    with open(template_file, "w") as f:
+    with open(template_file, "w", encoding="utf-8") as f:
         f.write("<MULTFLT1> <MULTFLT2> <MULTFLT3>\n")
         f.write("/\n")
 

--- a/tests/unit_tests/c_wrappers/res/enkf/observations/test_gen_observation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/observations/test_gen_observation.py
@@ -8,7 +8,7 @@ def test_create(tmp_path):
     with pytest.raises(ValueError):
         gen_obs = GenObservation("KEY", data_config)
 
-    with open(tmp_path / "obs1.txt", "w") as f:
+    with open(tmp_path / "obs1.txt", "w", encoding="utf-8") as f:
         f.write("10  5  12 6\n")
 
     with pytest.raises(ValueError):

--- a/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
@@ -14,8 +14,8 @@ def test_config_content_as_dict(tmpdir):
         conf = ConfigParser()
         existing_file_1 = "test_1.t"
         existing_file_2 = "test_2.t"
-        Path(existing_file_2).write_text("something")
-        Path(existing_file_1).write_text("not important")
+        Path(existing_file_2).write_text("something", encoding="utf-8")
+        Path(existing_file_1).write_text("not important", encoding="utf-8")
         init_user_config_parser(conf)
 
         schema_item = conf.add("MULTIPLE_KEY_VALUE", False)
@@ -24,7 +24,7 @@ def test_config_content_as_dict(tmpdir):
         schema_item = conf.add("KEY", False)
         schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
 
-        with open("config", "w") as fileH:
+        with open("config", "w", encoding="utf-8") as fileH:
             fileH.write(f"{ConfigKeys.NUM_REALIZATIONS} 42\n")
             fileH.write(f"{ConfigKeys.DATA_FILE} {existing_file_2} \n")
             fileH.write(f"{ConfigKeys.REFCASE} {existing_file_1} \n")
@@ -92,8 +92,8 @@ def test_config_content_as_dict_single_value_keys(tmpdir):
         conf = ConfigParser()
         existing_file_1 = "test_1.t"
         existing_file_2 = "test_2.t"
-        Path(existing_file_2).write_text("something")
-        Path(existing_file_1).write_text("not important")
+        Path(existing_file_2).write_text("something", encoding="utf-8")
+        Path(existing_file_1).write_text("not important", encoding="utf-8")
         init_user_config_parser(conf)
         type_value_map = {
             "str": "abc",
@@ -105,7 +105,7 @@ def test_config_content_as_dict_single_value_keys(tmpdir):
             "history_enum": "REFCASE_SIMULATED",
         }
 
-        with open("config.file", "w") as fileH:
+        with open("config.file", "w", encoding="utf-8") as fileH:
             for key in SINGLE_OCCURRENCE_SINGLE_ARG_KEYS:
                 key_type = SINGLE_OCCURRENCE_KEY_TYPES[key]
                 value = type_value_map[key_type]

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -79,7 +79,7 @@ def test_that_current_case_file_is_written():
         JOBNAME my_case%d
         """
     )
-    Path("config.ert").write_text(config_text)
+    Path("config.ert").write_text(config_text, encoding="utf-8")
     res_config = ResConfig("config.ert")
     EnKFMain(res_config)
     assert (Path("storage") / "current_case").read_text() == "default"
@@ -93,12 +93,12 @@ def test_that_current_case_file_can_have_newline():
         JOBNAME my_case%d
         """
     )
-    Path("config.ert").write_text(config_text)
+    Path("config.ert").write_text(config_text, encoding="utf-8")
     res_config = ResConfig("config.ert")
     EnKFMain(res_config)
-    assert (Path("storage") / "current_case").read_text() == "default"
+    assert (Path("storage") / "current_case").read_text(encoding="utf-8") == "default"
     del res_config
-    (Path("storage") / "current_case").write_text("default\n")
+    (Path("storage") / "current_case").write_text("default\n", encoding="utf-8")
     res_config = ResConfig("config.ert")
     EnKFMain(res_config)
 
@@ -246,7 +246,7 @@ def test_random_seed_initialization_of_rngs(random_seed, tmpdir):
         RANDOM_SEED {random_seed}
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
 
         res_config = ResConfig("config.ert")
@@ -257,7 +257,7 @@ def test_random_seed_initialization_of_rngs(random_seed, tmpdir):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_context():
     # Write a minimal config file with DEFINE
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         fout.write("NUM_REALIZATIONS 1\nDEFINE MY_PATH <CONFIG_PATH>")
     res_config = ResConfig("config_file.ert")
     ert = EnKFMain(res_config)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -115,10 +115,10 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
     ],
 )
 def test_forward_model_job(job, forward_model, expected_args):
-    with open("job_file", "w") as fout:
+    with open("job_file", "w", encoding="utf-8") as fout:
         fout.write(job)
 
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         # Write a minimal config file
         fout.write(
             dedent(
@@ -195,10 +195,10 @@ def test_forward_model_job(job, forward_model, expected_args):
     ],
 )
 def test_simulation_job(job, forward_model, expected_args):
-    with open("job_file", "w") as fout:
+    with open("job_file", "w", encoding="utf-8") as fout:
         fout.write(job)
 
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         # Write a minimal config file
         fout.write("NUM_REALIZATIONS 1\n")
         fout.write("INSTALL_JOB job_name job_file\n")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_config.py
@@ -11,7 +11,7 @@ def test_create():
 
 def test_field_guess_filetype(tmp_path):
     fname = str(tmp_path / "test.kw.grdecl")
-    with open(fname, "w") as f:
+    with open(fname, "w", encoding="utf-8") as f:
         f.write("-- my comment\n")
         f.write("-- more comments\n")
         f.write("SOWCR\n")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
@@ -144,7 +144,7 @@ def test_load_forward_model_summary(summary_configuration, expected, caplog):
     )
     if summary_configuration:
         config_text += summary_configuration
-    Path("config.ert").write_text(config_text)
+    Path("config.ert").write_text(config_text, encoding="utf-8")
     # Create refcase
     ecl_sum = run_simulator(1, datetime(2014, 9, 10))
     ecl_sum.fwrite()

--- a/tests/unit_tests/c_wrappers/res/enkf/test_priors.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_priors.py
@@ -17,7 +17,7 @@ def test_adding_priors(poly_case):
     del m
     gc.collect()
 
-    with open("coeff_priors", "a") as f:
+    with open("coeff_priors", "a", encoding="utf-8") as f:
         f.write("COEFF_D UNIFORM 0 5\n")
     m = EnKFMain(ResConfig("poly.ert"))
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_run_path_creation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_run_path_creation.py
@@ -26,8 +26,8 @@ def test_that_run_template_replace_symlink_does_not_write_to_source():
         RUN_TEMPLATE template.tmpl result.txt
         """
     )
-    Path("template.tmpl").write_text("I want to replace: <IENS>")
-    Path("config.ert").write_text(config_text)
+    Path("template.tmpl").write_text("I want to replace: <IENS>", encoding="utf-8")
+    Path("config.ert").write_text(config_text, encoding="utf-8")
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
     run_context = ert.create_ensemble_context("prior", [True], iteration=0)
@@ -35,12 +35,19 @@ def test_that_run_template_replace_symlink_does_not_write_to_source():
     os.makedirs(run_path)
     # Write a file that will be symlinked into the run run path with the
     # same name as the target_file
-    Path("start.txt").write_text("I dont want to replace in this file")
+    Path("start.txt").write_text(
+        "I dont want to replace in this file", encoding="utf-8"
+    )
     os.symlink("start.txt", run_path / "result.txt")
     ert.createRunPath(run_context)
-    assert (run_path / "result.txt").read_text() == "I want to replace: 0"
+    assert (run_path / "result.txt").read_text(
+        encoding="utf-8"
+    ) == "I want to replace: 0"
     # Check that the source of the symlinked file is not updated
-    assert Path("start.txt").read_text() == "I dont want to replace in this file"
+    assert (
+        Path("start.txt").read_text(encoding="utf-8")
+        == "I dont want to replace in this file"
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -57,8 +64,8 @@ def test_run_template_replace_in_file_with_custom_define():
         RUN_TEMPLATE template.tmpl result.txt
         """
     )
-    Path("template.tmpl").write_text("I WANT TO REPLACE:<MY_VAR>")
-    Path("config.ert").write_text(config_text)
+    Path("template.tmpl").write_text("I WANT TO REPLACE:<MY_VAR>", encoding="utf-8")
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -93,16 +100,16 @@ def test_run_template_replace_in_file(key, expected):
         RUN_TEMPLATE template.tmpl result.txt
         """
     )
-    Path("template.tmpl").write_text(f"I WANT TO REPLACE:{key}")
-    Path("config.ert").write_text(config_text)
+    Path("template.tmpl").write_text(f"I WANT TO REPLACE:{key}", encoding="utf-8")
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
     run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
-    assert (
-        Path(run_context[0].runpath) / "result.txt"
-    ).read_text() == f"I WANT TO REPLACE:{expected}"
+    assert (Path(run_context[0].runpath) / "result.txt").read_text(
+        encoding="utf-8"
+    ) == f"I WANT TO REPLACE:{expected}"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -123,8 +130,10 @@ def test_run_template_replace_in_ecl(ecl_base, expected_file):
         RUN_TEMPLATE BASE_ECL_FILE.DATA <ECLBASE>.DATA
         """
     )
-    Path("BASE_ECL_FILE.DATA").write_text("I WANT TO REPLACE:<NUM_CPU>")
-    Path("config.ert").write_text(config_text)
+    Path("BASE_ECL_FILE.DATA").write_text(
+        "I WANT TO REPLACE:<NUM_CPU>", encoding="utf-8"
+    )
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -164,16 +173,16 @@ def test_run_template_replace_in_ecl_data_file(key, expected):
         DATA_FILE MY_DATA_FILE.DATA
         """
     )
-    Path("MY_DATA_FILE.DATA").write_text(f"I WANT TO REPLACE:{key}")
-    Path("config.ert").write_text(config_text)
+    Path("MY_DATA_FILE.DATA").write_text(f"I WANT TO REPLACE:{key}", encoding="utf-8")
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
     run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
-    assert (
-        Path(run_context[0].runpath) / "ECL_CASE0.DATA"
-    ).read_text() == f"I WANT TO REPLACE:{expected}"
+    assert (Path(run_context[0].runpath) / "ECL_CASE0.DATA").read_text(
+        encoding="utf-8"
+    ) == f"I WANT TO REPLACE:{expected}"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -190,8 +199,10 @@ def test_run_template_replace_in_file_name():
         RUN_TEMPLATE template.tmpl <MY_FILE_NAME>
         """
     )
-    Path("template.tmpl").write_text("Not important, name of the file is important")
-    Path("config.ert").write_text(config_text)
+    Path("template.tmpl").write_text(
+        "Not important, name of the file is important", encoding="utf-8"
+    )
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -215,11 +226,13 @@ def test_that_sampling_prior_makes_initialized_fs():
         GEN_KW KW_NAME template.txt kw.txt prior.txt
         """
     )
-    Path("template.tmpl").write_text("Not important, name of the file is important")
-    Path("config.ert").write_text(config_text)
-    with open("template.txt", "w") as fh:
+    Path("template.tmpl").write_text(
+        "Not important, name of the file is important", encoding="utf-8"
+    )
+    Path("config.ert").write_text(config_text, encoding="utf-8")
+    with open("template.txt", "w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-    with open("prior.txt", "w") as fh:
+    with open("prior.txt", "w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD NORMAL 0 1")
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -261,8 +274,8 @@ def test_that_data_file_sets_num_cpu(eclipse_data, expected_cpus):
         DATA_FILE MY_DATA_FILE.DATA
         """
     )
-    Path("MY_DATA_FILE.DATA").write_text(eclipse_data)
-    Path("config.ert").write_text(config_text)
+    Path("MY_DATA_FILE.DATA").write_text(eclipse_data, encoding="utf-8")
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -282,7 +295,7 @@ def test_that_runpath_substitution_remain_valid():
         FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/, <TO>=<RUNPATH>/)
         """
     )
-    Path("config.ert").write_text(config_text)
+    Path("config.ert").write_text(config_text, encoding="utf-8")
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
@@ -291,7 +304,6 @@ def test_that_runpath_substitution_remain_valid():
     ert.createRunPath(run_context)
 
     for i, realization in enumerate(run_context):
-        assert (
-            str(Path().absolute()) + "/realization-" + str(i) + "/iter-0"
-            in Path(realization.runpath + "/jobs.json").read_text()
-        )
+        assert str(Path().absolute()) + "/realization-" + str(i) + "/iter-0" in Path(
+            realization.runpath + "/jobs.json"
+        ).read_text(encoding="utf-8")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_runpaths.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_runpaths.py
@@ -148,7 +148,7 @@ def test_write_snakeoil_runpath_file(snake_oil_case, itr):
     ]
     exp_runpaths = list(map(os.path.realpath, exp_runpaths))
 
-    with open(runpath_list_path, "r") as f:
+    with open(runpath_list_path, "r", encoding="utf-8") as f:
         dumped_runpaths = list(zip(*[line.split() for line in f.readlines()]))[1]
 
     assert list(exp_runpaths) == list(dumped_runpaths)
@@ -157,7 +157,7 @@ def test_write_snakeoil_runpath_file(snake_oil_case, itr):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_assert_export():
     # Write a minimal config file with env
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         fout.write(
             dedent(
                 """

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ert_script.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ert_script.py
@@ -51,13 +51,13 @@ def test_ert_script_failed_implementation():
 def test_ert_script_from_file():
     WorkflowCommon.createErtScriptsJob()
 
-    with open("syntax_error_script.py", "w") as f:
+    with open("syntax_error_script.py", "w", encoding="utf-8") as f:
         f.write("from ert._c_wrappers.enkf not_legal_syntax ErtScript\n")
 
-    with open("import_error_script.py", "w") as f:
+    with open("import_error_script.py", "w", encoding="utf-8") as f:
         f.write("from ert._c_wrappers.enkf import DoesNotExist\n")
 
-    with open("empty_script.py", "w") as f:
+    with open("empty_script.py", "w", encoding="utf-8") as f:
         f.write("from ert._c_wrappers.enkf import ErtScript\n")
 
     script_object = ErtScript.loadScriptFromFile("subtract_script.py")

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_forward_model_formatted_print.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_forward_model_formatted_print.py
@@ -177,7 +177,7 @@ def default_name_if_none(name):
 
 
 def load_configs(config_file):
-    with open(config_file, "r") as cf:
+    with open(config_file, "r", encoding="utf-8") as cf:
         jobs = json.load(cf)
 
     return jobs
@@ -301,7 +301,7 @@ def test_no_jobs():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_transfer_arg_types():
-    with open("FWD_MODEL", "w") as f:
+    with open("FWD_MODEL", "w", encoding="utf-8") as f:
         f.write("EXECUTABLE ls\n")
         f.write("MIN_ARG 2\n")
         f.write("MAX_ARG 6\n")
@@ -453,7 +453,7 @@ def test_status_file():
         EnvironmentVarlist(),
     )
 
-    with open("status.json", "w") as f:
+    with open("status.json", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "start_time": None,
@@ -494,6 +494,6 @@ def test_that_values_with_brackets_are_ommitted(tmp_path, caplog):
         EnvironmentVarlist(),
     )
     assert "Environment variable ENV_VAR skipped due to" in caplog.text
-    with open(tmp_path / "jobs.json") as fp:
+    with open(tmp_path / "jobs.json", encoding="utf-8") as fp:
         data = json.load(fp)
     assert "ENV_VAR" not in data["jobList"][0]["environment"]

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
@@ -48,10 +48,10 @@ def test_workflow_run():
 
     assert workflow.run(None, verbose=True, context=context)
 
-    with open("dump1", "r") as f:
+    with open("dump1", "r", encoding="utf-8") as f:
         assert f.read() == "dump_text_1"
 
-    with open("dump2", "r") as f:
+    with open("dump2", "r", encoding="utf-8") as f:
         assert f.read() == "dump_text_2"
 
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_job.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_job.py
@@ -78,7 +78,7 @@ def test_run_external_job():
     assert job.run(None, ["test", "text"]) is None
     assert job.stdoutdata() == "Hello World\n"
 
-    with open("test", "r") as f:
+    with open("test", "r", encoding="utf-8") as f:
         assert f.read() == "text"
 
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/workflow_common.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/workflow_common.py
@@ -5,18 +5,18 @@ import stat
 class WorkflowCommon:
     @staticmethod
     def createExternalDumpJob():
-        with open("dump_job", "w") as f:
+        with open("dump_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL FALSE\n")
             f.write("EXECUTABLE dump.py\n")
             f.write("MIN_ARG 2\n")
             f.write("MAX_ARG 2\n")
             f.write("ARG_TYPE 0 STRING\n")
 
-        with open("dump_failing_job", "w") as f:
+        with open("dump_failing_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL FALSE\n")
             f.write("EXECUTABLE dump_failing.py\n")
 
-        with open("dump.py", "w") as f:
+        with open("dump.py", "w", encoding="utf-8") as f:
             f.write("#!/usr/bin/env python\n")
             f.write("import sys\n")
             f.write("f = open('%s' % sys.argv[1], 'w')\n")
@@ -24,7 +24,7 @@ class WorkflowCommon:
             f.write("f.close()\n")
             f.write('print("Hello World")')
 
-        with open("dump_failing.py", "w") as f:
+        with open("dump_failing.py", "w", encoding="utf-8") as f:
             f.write("#!/usr/bin/env python\n")
             f.write('print("Hello Failing")\n')
             f.write("raise Exception")
@@ -36,13 +36,13 @@ class WorkflowCommon:
         st = os.stat("dump_failing.py")
         os.chmod("dump_failing.py", st.st_mode | stat.S_IEXEC)
 
-        with open("dump_workflow", "w") as f:
+        with open("dump_workflow", "w", encoding="utf-8") as f:
             f.write("DUMP dump1 dump_text_1\n")
             f.write("DUMP dump2 dump_<PARAM>_2\n")
 
     @staticmethod
     def createInternalFunctionJob():
-        with open("printf_job", "w") as f:
+        with open("printf_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL True\n")
             f.write("FUNCTION printf\n")
             f.write("MIN_ARG 4\n")
@@ -53,7 +53,7 @@ class WorkflowCommon:
             f.write("ARG_TYPE 3 BOOL\n")
             f.write("ARG_TYPE 4 STRING\n")
 
-        with open("compare_job", "w") as f:
+        with open("compare_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL True\n")
             f.write("FUNCTION strcmp\n")
             f.write("MIN_ARG 2\n")
@@ -63,14 +63,14 @@ class WorkflowCommon:
 
     @staticmethod
     def createErtScriptsJob():
-        with open("subtract_script.py", "w") as f:
+        with open("subtract_script.py", "w", encoding="utf-8") as f:
             f.write("from ert._c_wrappers.job_queue import ErtScript\n")
             f.write("\n")
             f.write("class SubtractScript(ErtScript):\n")
             f.write("    def run(self, arg1, arg2):\n")
             f.write("        return arg1 - arg2\n")
 
-        with open("subtract_script_job", "w") as f:
+        with open("subtract_script_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL True\n")
             f.write("SCRIPT subtract_script.py\n")
             f.write("MIN_ARG 2\n")
@@ -80,7 +80,7 @@ class WorkflowCommon:
 
     @staticmethod
     def createWaitJob():
-        with open("wait_job.py", "w") as f:
+        with open("wait_job.py", "w", encoding="utf-8") as f:
             f.write("from ert._c_wrappers.job_queue import ErtScript\n")
             f.write("import time\n")
             f.write("\n")
@@ -104,7 +104,7 @@ class WorkflowCommon:
             f.write("\n")
             f.write("        return None\n")
 
-        with open("external_wait_job.sh", "w") as f:
+        with open("external_wait_job.sh", "w", encoding="utf-8") as f:
             f.write("#!/usr/bin/env bash\n")
             f.write('echo "text" > wait_started_$1\n')
             f.write("sleep $2\n")
@@ -115,7 +115,7 @@ class WorkflowCommon:
             "external_wait_job.sh", st.st_mode | stat.S_IEXEC
         )  # | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 
-        with open("wait_job", "w") as f:
+        with open("wait_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL True\n")
             f.write("SCRIPT wait_job.py\n")
             f.write("MIN_ARG 2\n")
@@ -123,7 +123,7 @@ class WorkflowCommon:
             f.write("ARG_TYPE 0 INT\n")
             f.write("ARG_TYPE 1 INT\n")
 
-        with open("external_wait_job", "w") as f:
+        with open("external_wait_job", "w", encoding="utf-8") as f:
             f.write("INTERNAL False\n")
             f.write("EXECUTABLE external_wait_job.sh\n")
             f.write("MIN_ARG 2\n")
@@ -131,11 +131,11 @@ class WorkflowCommon:
             f.write("ARG_TYPE 0 INT\n")
             f.write("ARG_TYPE 1 INT\n")
 
-        with open("wait_workflow", "w") as f:
+        with open("wait_workflow", "w", encoding="utf-8") as f:
             f.write("WAIT 0 1\n")
             f.write("WAIT 1 10\n")
             f.write("WAIT 2 1\n")
 
-        with open("fast_wait_workflow", "w") as f:
+        with open("fast_wait_workflow", "w", encoding="utf-8") as f:
             f.write("WAIT 0 1\n")
             f.write("EXTERNAL_WAIT 1 1\n")

--- a/tests/unit_tests/c_wrappers/test_integration_config.py
+++ b/tests/unit_tests/c_wrappers/test_integration_config.py
@@ -48,7 +48,7 @@ def test_num_cpu_subst(monkeypatch, tmp_path, append, numcpu):
     enkf_main = EnKFMain(config)
     _create_runpath(enkf_main)
 
-    with open("simulations/realization-0/iter-0/jobs.json") as f:
+    with open("simulations/realization-0/iter-0/jobs.json", encoding="utf-8") as f:
         assert f'"argList": ["{numcpu}"]' in f.read()
 
 
@@ -61,7 +61,8 @@ def test_environment_var_list(tmpdir):
             SETENV SECOND $MYVAR
             SETENV THIRD  TheThirdValue
             UPDATE_PATH   FOURTH TheFourthValue
-            """
+            """,
+            encoding="utf-8",
         )
         my_var_text = "THIS_IS_MY_VAR"
         os.environ["MYVAR"] = my_var_text
@@ -75,7 +76,7 @@ def test_environment_var_list(tmpdir):
         finally:
             del os.environ["MYVAR"]
 
-        with open("simulations/realization-0/iter-0/jobs.json") as f:
+        with open("simulations/realization-0/iter-0/jobs.json", encoding="utf-8") as f:
             data = json.load(f)
             global_env = data.get("global_environment")
             global_update_path = data.get("global_update_path")

--- a/tests/unit_tests/cli/test_cli_workflow.py
+++ b/tests/unit_tests/cli/test_cli_workflow.py
@@ -11,11 +11,11 @@ from ert.shared.plugins.plugin_manager import ErtPluginContext
 @pytest.mark.usefixtures("copy_poly_case")
 def test_executing_workflow():
     with ErtPluginContext():
-        with open("test_wf", "w") as wf_file:
+        with open("test_wf", "w", encoding="utf-8") as wf_file:
             wf_file.write("EXPORT_RUNPATH")
 
         config_file = "poly.ert"
-        with open(config_file, "a") as file_handle:
+        with open(config_file, "a", encoding="utf-8") as file_handle:
             file_handle.write("LOAD_WORKFLOW test_wf")
 
         rc = ResConfig(user_config_file=config_file)

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -78,11 +78,11 @@ def make_ensemble_builder(queue_config):
             ext_job_list = []
             for job_index in range(0, num_jobs):
                 ext_job_config = Path(tmpdir) / f"EXT_JOB_{job_index}"
-                with open(ext_job_config, "w") as f:
+                with open(ext_job_config, "w", encoding="utf-8") as f:
                     f.write(f"EXECUTABLE ext_{job_index}.py\n")
 
                 ext_job_exec = Path(tmpdir) / f"ext_{job_index}.py"
-                with open(ext_job_exec, "w") as f:
+                with open(ext_job_exec, "w", encoding="utf-8") as f:
                     f.write(
                         "#!/usr/bin/env python\n"
                         "import time\n"
@@ -90,7 +90,7 @@ def make_ensemble_builder(queue_config):
                         'if __name__ == "__main__":\n'
                         f'    print("stdout from {job_index}")\n'
                         f"    time.sleep({job_sleep})\n"
-                        f"    with open('status.txt', 'a'): pass\n"
+                        f"    with open('status.txt', 'a', encoding='utf-8'): pass\n"
                     )
                 mode = os.stat(ext_job_exec).st_mode
                 mode |= stat.S_IXUSR | stat.S_IXGRP
@@ -110,7 +110,7 @@ def make_ensemble_builder(queue_config):
                 run_path = Path(tmpdir / f"real_{iens}")
                 os.mkdir(run_path)
 
-                with open(run_path / "jobs.json", "w") as f:
+                with open(run_path / "jobs.json", "w", encoding="utf-8") as f:
                     json.dump(
                         {
                             "jobList": [

--- a/tests/unit_tests/ensemble_evaluator/prefect/scripts/evaluate_coeffs.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/scripts/evaluate_coeffs.py
@@ -4,7 +4,7 @@ import json
 
 
 def _load_coeffs(filename):
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -30,7 +30,7 @@ def config_dump_entry(args=None):
 
 
 def write_to_file(data, file):
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
 

--- a/tests/unit_tests/ensemble_evaluator/prefect/scripts/poly_eval_with_args.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/scripts/poly_eval_with_args.py
@@ -4,7 +4,7 @@ import sys
 
 
 def _load_coeffs(filename):
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -19,5 +19,5 @@ if __name__ == "__main__":
         sys.exit("My error message!!!!")
     coeffs = _load_coeffs("coeffs.json")
     output = [_evaluate(coeffs, x) for x in range(10)]
-    with open("poly_0.out", "w") as f:
+    with open("poly_0.out", "w", encoding="utf-8") as f:
         f.write("\n".join(map(str, output)))

--- a/tests/unit_tests/ensemble_evaluator/prefect/scripts/sum_coeffs.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/scripts/sum_coeffs.py
@@ -3,12 +3,12 @@ import json
 
 
 def _load_coeffs(filename):
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         return json.load(f)
 
 
 def write_to_file(data, file):
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
 

--- a/tests/unit_tests/ensemble_evaluator/prefect/scripts/unix_test_retry_script.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/scripts/unix_test_retry_script.py
@@ -4,12 +4,12 @@ import sys
 
 
 def write_file(text, file):
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         f.write(text)
 
 
 def read_file(file):
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/unit_tests/ensemble_evaluator/prefect/scripts/unix_test_script.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/scripts/unix_test_script.py
@@ -13,7 +13,7 @@ def parse_args(args=None):
 
 
 def write_to_file(file, data):
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
 

--- a/tests/unit_tests/lsf_queue/test_lsf_driver.py
+++ b/tests/unit_tests/lsf_queue/test_lsf_driver.py
@@ -24,7 +24,7 @@ def mock_bjobs(tmp_path):
            # File written from the mocked bsub command which provides us with
            # the path to where the job actually runs and where we can find i.e
            # the job_id and status
-           with open("job_paths") as job_paths_file:
+           with open("job_paths", encoding="utf-8") as job_paths_file:
                job_paths = job_paths_file.read().splitlines()
 
            print("JOBID USER STAT QUEUE FROM_HOST EXEC_HOST JOB_NAME SUBMIT_TIME")
@@ -64,12 +64,12 @@ def mock_bjobs(tmp_path):
 
            # Just to have a log for test purposes what is actually thrown
            # towards the bjobs command
-           with open("bjobs_log", "a+") as f:
+           with open("bjobs_log", "a+", encoding="utf-8") as f:
                f.write(f"{str(sys.argv)}\\n")
            """
     )
     script_path = tmp_path / "mock_bjobs"
-    with open(script_path, "w") as fh:
+    with open(script_path, "w", encoding="utf-8") as fh:
         fh.write(script)
 
     os.chmod(script_path, 0o755)
@@ -90,12 +90,12 @@ def make_mock_bsub(script_path):
            # Write a file with the runpaths to where the jobs are running and
            # writing information we later need when providing statuses for the
            # jobs through the mocked bjobs command
-           with open("job_paths", "a+") as jobs_file:
+           with open("job_paths", "a+", encoding="utf-8") as jobs_file:
                jobs_file.write(f"{run_path}\\n")
 
            # Just a log for testpurposes showing what is thrown against the
            # bsub command
-           with open("bsub_log", "a+") as f:
+           with open("bsub_log", "a+", encoding="utf-8") as f:
                f.write(f"{str(sys.argv)}\\n")
 
            # Assigning a "unique" job id for each submitted job and print. This
@@ -168,7 +168,7 @@ def copy_lsf_poly_case(copy_poly_case):
         "INSTALL_JOB poly_eval POLY_EVAL\n",
         "SIMULATION_JOB poly_eval\n",
     ]
-    with open("poly.ert", "w") as fh:
+    with open("poly.ert", "w", encoding="utf-8") as fh:
         fh.writelines(config)
 
 
@@ -191,6 +191,6 @@ def test_run_mocked_lsf_queue():
             ],
         )
     )
-    log = Path("bsub_log").read_text()
+    log = Path("bsub_log").read_text(encoding="utf-8")
     for i in range(10):
         assert f"'-J', 'poly_{i}'" in log

--- a/tests/unit_tests/services/test_base_service.py
+++ b/tests/unit_tests/services/test_base_service.py
@@ -156,7 +156,7 @@ time.sleep(10)  # Wait for the test to read the JSON file
 def test_json_created(server):
     server.fetch_conn_info()  # wait for it to start
 
-    with open("dummy_server.json") as f:
+    with open("dummy_server.json", encoding="utf-8") as f:
         assert f.read()
 
 
@@ -302,14 +302,14 @@ def test_cleanup_service_files(tmpdir):
     with tmpdir.as_cwd():
         storage_service_name = "storage"
         storage_service_file = f"{storage_service_name}_server.json"
-        with open(storage_service_file, "w") as f:
+        with open(storage_service_file, "w", encoding="utf-8") as f:
             f.write("storage_service info")
         assert Path(storage_service_file).exists()
         SERVICE_CONF_PATHS.add(tmpdir / storage_service_file)
 
         webviz_service_name = "webviz-ert"
         webviz_service_file = f"{webviz_service_name}_server.json"
-        with open(webviz_service_file, "w") as f:
+        with open(webviz_service_file, "w", encoding="utf-8") as f:
             f.write("webviz-ert info")
         assert Path(webviz_service_file).exists()
         SERVICE_CONF_PATHS.add(tmpdir / webviz_service_file)

--- a/tests/unit_tests/services/test_storage_service.py
+++ b/tests/unit_tests/services/test_storage_service.py
@@ -80,7 +80,7 @@ def test_init_service_server_start_if_no_conf_file(tmpdir, mock_start_server):
 def test_init_service_server_start_conf_info_is_stale(tmpdir, mock_start_server):
     with tmpdir.as_cwd():
         config_file = f"{Storage.service_name}_server.json"
-        with open(config_file, "w") as f:
+        with open(config_file, "w", encoding="utf-8") as f:
             f.write(
                 """
             {"authtoken": "test123", "urls": ["http://127.0.0.1:51821"]}

--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -92,7 +92,7 @@ def init_ecl100_config(monkeypatch, tmpdir):
         },
     }
     with tmpdir.as_cwd():
-        with open("ecl100_config.yml", "w") as f:
+        with open("ecl100_config.yml", "w", encoding="utf-8") as f:
             f.write(yaml.dump(conf))
         monkeypatch.setenv("ECL100_SITE_CONFIG", "ecl100_config.yml")
         yield
@@ -149,19 +149,19 @@ def test_create(monkeypatch):
             }
         }
     }
-    with open("ecl100_config.yml", "w") as f:
+    with open("ecl100_config.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(conf))
 
     os.mkdir("bin")
     monkeypatch.setenv("ECL100_SITE_CONFIG", "ecl100_config.yml")
     for f in ["scalar_exe", "mpi_exe", "mpirun"]:
         fname = os.path.join("bin", f)
-        with open(fname, "w") as fh:
+        with open(fname, "w", encoding="utf-8") as fh:
             fh.write("This is an exectable ...")
 
         os.chmod(fname, stat.S_IEXEC)
 
-    with open("ECLIPSE.DATA", "w") as f:
+    with open("ECLIPSE.DATA", "w", encoding="utf-8") as f:
         f.write("Mock eclipse data file")
 
     econfig = ecl_config.Ecl100Config()
@@ -171,7 +171,7 @@ def test_create(monkeypatch):
     assert erun.runPath() == os.getcwd()
 
     os.mkdir("path")
-    with open("path/ECLIPSE.DATA", "w") as f:
+    with open("path/ECLIPSE.DATA", "w", encoding="utf-8") as f:
         f.write("Mock eclipse data file")
 
     erun = ecl_run.EclRun("path/ECLIPSE.DATA", sim)
@@ -219,7 +219,7 @@ def test_running_flow_given_env_config_can_still_read_parent_env(monkeypatch):
     version = "1111.11"
 
     # create a script that prints env vars ENV1 and ENV2 to a file
-    with open("flow", "w") as f:
+    with open("flow", "w", encoding="utf-8") as f:
         f.write("#!/bin/bash\n")
         f.write("echo $ENV1 > out.txt\n")
         f.write("echo $ENV2 >> out.txt\n")
@@ -236,17 +236,17 @@ def test_running_flow_given_env_config_can_still_read_parent_env(monkeypatch):
         },
     }
 
-    with open("flow_config.yml", "w") as f:
+    with open("flow_config.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(conf))
 
     # set the environment variable ENV1
     monkeypatch.setenv("ENV1", "VAL1")
     monkeypatch.setenv("FLOW_SITE_CONFIG", "flow_config.yml")
 
-    with open("DUMMY.DATA", "w") as f:
+    with open("DUMMY.DATA", "w", encoding="utf-8") as f:
         f.write("dummy")
 
-    with open("DUMMY.PRT", "w") as f:
+    with open("DUMMY.PRT", "w", encoding="utf-8") as f:
         f.write("Errors 0\n")
         f.write("Bugs 0\n")
 
@@ -257,7 +257,7 @@ def test_running_flow_given_env_config_can_still_read_parent_env(monkeypatch):
     flow_run.runEclipse()
 
     # assert that the script was able to read both the variables correctly
-    with open("out.txt") as f:
+    with open("out.txt", encoding="utf-8") as f:
         lines = f.readlines()
 
     assert lines == ["VAL1\n", "VAL2\n"]
@@ -268,7 +268,7 @@ def test_running_flow_given_no_env_config_can_still_read_parent_env(monkeypatch)
     version = "1111.11"
 
     # create a script that prints env vars ENV1 and ENV2 to a file
-    with open("flow", "w") as f:
+    with open("flow", "w", encoding="utf-8") as f:
         f.write("#!/bin/bash\n")
         f.write("echo $ENV1 > out.txt\n")
         f.write("echo $ENV2 >> out.txt\n")
@@ -285,7 +285,7 @@ def test_running_flow_given_no_env_config_can_still_read_parent_env(monkeypatch)
         },
     }
 
-    with open("flow_config.yml", "w") as f:
+    with open("flow_config.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(conf))
 
     # set the environment variable ENV1
@@ -293,10 +293,10 @@ def test_running_flow_given_no_env_config_can_still_read_parent_env(monkeypatch)
     monkeypatch.setenv("ENV2", "VAL2")
     monkeypatch.setenv("FLOW_SITE_CONFIG", "flow_config.yml")
 
-    with open("DUMMY.DATA", "w") as f:
+    with open("DUMMY.DATA", "w", encoding="utf-8") as f:
         f.write("dummy")
 
-    with open("DUMMY.PRT", "w") as f:
+    with open("DUMMY.PRT", "w", encoding="utf-8") as f:
         f.write("Errors 0\n")
         f.write("Bugs 0\n")
 
@@ -307,7 +307,7 @@ def test_running_flow_given_no_env_config_can_still_read_parent_env(monkeypatch)
     flow_run.runEclipse()
 
     # assert that the script was able to read both the variables correctly
-    with open("out.txt") as f:
+    with open("out.txt", encoding="utf-8") as f:
         lines = f.readlines()
 
     assert lines == ["VAL1\n", "VAL2\n"]
@@ -320,7 +320,7 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
     version = "1111.11"
 
     # create a script that prints env vars ENV1 and ENV2 to a file
-    with open("flow", "w") as f:
+    with open("flow", "w", encoding="utf-8") as f:
         f.write("#!/bin/bash\n")
         f.write("echo $ENV1 > out.txt\n")
         f.write("echo $ENV2 >> out.txt\n")
@@ -340,7 +340,7 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
         },
     }
 
-    with open("flow_config.yml", "w") as f:
+    with open("flow_config.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(conf))
 
     # set the environment variable ENV1
@@ -348,10 +348,10 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
     monkeypatch.setenv("ENV2", "VAL2")
     monkeypatch.setenv("FLOW_SITE_CONFIG", "flow_config.yml")
 
-    with open("DUMMY.DATA", "w") as f:
+    with open("DUMMY.DATA", "w", encoding="utf-8") as f:
         f.write("dummy")
 
-    with open("DUMMY.PRT", "w") as f:
+    with open("DUMMY.PRT", "w", encoding="utf-8") as f:
         f.write("Errors 0\n")
         f.write("Bugs 0\n")
 
@@ -362,7 +362,7 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
     flow_run.runEclipse()
 
     # assert that the script was able to read both the variables correctly
-    with open("out.txt") as f:
+    with open("out.txt", encoding="utf-8") as f:
         lines = f.readlines()
 
     assert lines == ["OVERWRITTEN1\n", "OVERWRITTEN2\n"]

--- a/tests/unit_tests/shared/share/test_ecl_run_new_config.py
+++ b/tests/unit_tests/shared/share/test_ecl_run_new_config.py
@@ -54,7 +54,7 @@ def eclrun_conf():
 
 @pytest.fixture
 def init_eclrun_config(tmp_path, monkeypatch, eclrun_conf):
-    with open(tmp_path / "ecl100_config.yml", "w") as f:
+    with open(tmp_path / "ecl100_config.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(eclrun_conf))
     monkeypatch.setenv("ECL100_SITE_CONFIG", "ecl100_config.yml")
 
@@ -71,7 +71,9 @@ def test_get_version_raise():
 @pytest.mark.usefixtures("use_tmpdir", "init_eclrun_config")
 @mock.patch.dict(os.environ, {"LSB_JOBID": "some-id"})
 def test_env(eclrun_conf):
-    with open("eclrun", "w") as f, open("DUMMY.DATA", "w"):
+    with open("eclrun", "w", encoding="utf-8") as f, open(
+        "DUMMY.DATA", "w", encoding="utf-8"
+    ):
         f.write(
             """#!/usr/bin/env python
 import os
@@ -88,7 +90,7 @@ with open("env.json", "w") as f:
         erun, "_get_run_command", mock.MagicMock(return_value="./eclrun")
     ):
         erun.runEclipse(eclrun_config=eclrun_config)
-    with open("env.json") as f:
+    with open("env.json", encoding="utf-8") as f:
         run_env = json.load(f)
 
     eclrun_env = eclrun_conf["eclrun_env"]

--- a/tests/unit_tests/shared/share/test_ecl_versioning_config.py
+++ b/tests/unit_tests/shared/share/test_ecl_versioning_config.py
@@ -44,7 +44,7 @@ def test_load(monkeypatch):
         os.path.join(ecl_config_path, "ecl100_config.yml"),
     )
     conf = ecl_config.Ecl100Config()
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("this:\n -should\n-be\ninvalid:yaml?")
 
     monkeypatch.setenv("ECL100_SITE_CONFIG", "file.yml")
@@ -58,7 +58,7 @@ def test_load(monkeypatch):
     os.mkdir("bin")
     for f in ["scalar_exe", "mpi_exe", "mpi_run"]:
         fname = os.path.join("bin", f)
-        with open(fname, "w") as fh:
+        with open(fname, "w", encoding="utf-8") as fh:
             fh.write("This is an exectable ...")
 
         os.chmod(fname, stat.S_IEXEC)
@@ -99,7 +99,7 @@ def test_load(monkeypatch):
         },
     }
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(d))
 
     conf = ecl_config.Ecl100Config()
@@ -151,7 +151,7 @@ def test_load(monkeypatch):
 def test_default(monkeypatch):
     os.mkdir("bin")
     scalar_exe = "bin/scalar_exe"
-    with open(scalar_exe, "w") as fh:
+    with open(scalar_exe, "w", encoding="utf-8") as fh:
         fh.write("This is an exectable ...")
     os.chmod(scalar_exe, stat.S_IEXEC)
 
@@ -171,7 +171,7 @@ def test_default(monkeypatch):
     }
 
     monkeypatch.setenv("ECL100_SITE_CONFIG", os.path.join("file.yml"))
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(d1))
 
     conf = ecl_config.Ecl100Config()
@@ -185,7 +185,7 @@ def test_default(monkeypatch):
     sim = conf.sim("default")
     assert sim.version == "2015"
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write(yaml.dump(d0))
 
     conf = ecl_config.Ecl100Config()

--- a/tests/unit_tests/shared/share/test_forward_models.py
+++ b/tests/unit_tests/shared/share/test_forward_models.py
@@ -4,7 +4,7 @@ import pkg_resources
 
 
 def extract_executable(filename):
-    with open(filename, "r") as filehandle:
+    with open(filename, "r", encoding="utf-8") as filehandle:
         for line in filehandle.readlines():
             splitline = line.strip().split()
             if len(splitline) > 1 and splitline[0] == "EXECUTABLE":

--- a/tests/unit_tests/shared/share/test_rms.py
+++ b/tests/unit_tests/shared/share/test_rms.py
@@ -58,7 +58,7 @@ $@
     ],
 )
 def test_run_class_multi_seed(monkeypatch, test_input, expected_result, source_root):
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(f"executable:  {os.getcwd()}/bin/rms")
 
     os.mkdir("test_run_multi_seed")
@@ -69,11 +69,11 @@ def test_run_class_multi_seed(monkeypatch, test_input, expected_result, source_r
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     seed_file = ["3", "422851785", "723121249", "132312123"]
-    with open("run_path/random.seeds", "w") as f:
+    with open("run_path/random.seeds", "w", encoding="utf-8") as f:
         f.write("\n".join(seed_file))
 
     r = rms.RMSRun(test_input, "project", "workflow", run_path="run_path")
@@ -91,7 +91,7 @@ def test_create():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_class(monkeypatch, source_root):
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(f"executable:  {os.getcwd()}/bin/rms")
 
     os.mkdir("run_path")
@@ -101,14 +101,14 @@ def test_run_class(monkeypatch, source_root):
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     r = rms.RMSRun(0, "project", "workflow", run_path="run_path", allow_no_env=True)
     r.run()
 
     action = {"exit_status": 1}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     r = rms.RMSRun(0, "project", "workflow", run_path="run_path", allow_no_env=True)
@@ -116,7 +116,7 @@ def test_run_class(monkeypatch, source_root):
         r.run()
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     r = rms.RMSRun(
@@ -134,7 +134,7 @@ def test_run_class(monkeypatch, source_root):
         "exit_status": 0,
         "target_file": os.path.join(os.getcwd(), "some_file"),
     }
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     r = rms.RMSRun(
@@ -150,7 +150,7 @@ def test_run_class(monkeypatch, source_root):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run(monkeypatch, source_root):
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(f"executable:  {os.getcwd()}/bin/rms")
 
     os.mkdir("run_path")
@@ -160,20 +160,20 @@ def test_run(monkeypatch, source_root):
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     rms_run(0, "project", "workflow", run_path="run_path", allow_no_env=True)
 
     action = {"exit_status": 1}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     with pytest.raises(rms.RMSRunException):
         rms_run(0, "project", "workflow", run_path="run_path", allow_no_env=True)
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     with pytest.raises(rms.RMSRunException):
@@ -191,7 +191,7 @@ def test_run(monkeypatch, source_root):
         "target_file": os.path.join(os.getcwd(), "some_file"),
     }
 
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
     rms_run(
         0,
@@ -215,7 +215,7 @@ def test_run(monkeypatch, source_root):
 )
 def test_rms_load_env(monkeypatch, source_root, val, carry_over):
     # Setup RMS project
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "executable": os.path.realpath("bin/rms"),
@@ -223,7 +223,7 @@ def test_rms_load_env(monkeypatch, source_root, val, carry_over):
             f,
         )
 
-    with open("rms_exec_env.json", "w") as f:
+    with open("rms_exec_env.json", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "RMS_TEST_VAR": val,
@@ -241,7 +241,7 @@ def test_rms_load_env(monkeypatch, source_root, val, carry_over):
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     rms_exec = pkg_resources.resource_filename(
@@ -265,7 +265,7 @@ def test_rms_load_env(monkeypatch, source_root, val, carry_over):
         ]
     )
 
-    with open("run_path/env.json") as f:
+    with open("run_path/env.json", encoding="utf-8") as f:
         env = json.load(f)
 
     if carry_over:
@@ -286,7 +286,7 @@ def test_rms_load_env(monkeypatch, source_root, val, carry_over):
 )
 def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
     # Setup RMS project
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "executable": os.path.realpath("bin/rms"),
@@ -294,7 +294,7 @@ def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
             f,
         )
 
-    with open("rms_exec_env.json", "w") as f:
+    with open("rms_exec_env.json", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "RMS_TEST_VAR": val,
@@ -312,7 +312,7 @@ def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     rms_exec = pkg_resources.resource_filename(
@@ -336,7 +336,7 @@ def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
         ]
     )
 
-    with open("run_path/env.json") as f:
+    with open("run_path/env.json", encoding="utf-8") as f:
         env = json.load(f)
 
     if carry_over:
@@ -347,7 +347,7 @@ def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_class_with_existing_target_file(monkeypatch, source_root):
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(f"executable:  {os.getcwd()}/bin/rms")
 
     os.mkdir("run_path")
@@ -361,10 +361,10 @@ def test_run_class_with_existing_target_file(monkeypatch, source_root):
         "exit_status": 0,
         "target_file": target_file,
     }
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
-    with open(target_file, "w") as f:
+    with open(target_file, "w", encoding="utf-8") as f:
         f.write("This is a dummy target file")
 
     r = rms.RMSRun(
@@ -381,7 +381,7 @@ def test_run_class_with_existing_target_file(monkeypatch, source_root):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_wrapper(monkeypatch, source_root):
     wrapper_file_name = f"{os.getcwd()}/bin/rms_wrapper"
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(f"executable:  {os.getcwd()}/bin/rms\n")
         f.write(f"wrapper:  {wrapper_file_name}")
 
@@ -390,7 +390,7 @@ def test_run_wrapper(monkeypatch, source_root):
     os.mkdir("project")
     shutil.copy(os.path.join(source_root, "tests/unit_tests/shared/share/rms"), "bin")
 
-    with open(wrapper_file_name, "w") as f:
+    with open(wrapper_file_name, "w", encoding="utf-8") as f:
         f.write("#!/bin/bash\n")
         f.write("exec ${@:1}")
     st = os.stat(wrapper_file_name)
@@ -399,20 +399,20 @@ def test_run_wrapper(monkeypatch, source_root):
     monkeypatch.setenv("PATH", f"{os.getcwd()}/bin:{os.environ['PATH']}")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     rms_run(0, "project", "workflow", run_path="run_path", allow_no_env=True)
 
     action = {"exit_status": 1}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     with pytest.raises(rms.RMSRunException):
         rms_run(0, "project", "workflow", run_path="run_path", allow_no_env=True)
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     with pytest.raises(rms.RMSRunException):
@@ -430,7 +430,7 @@ def test_run_wrapper(monkeypatch, source_root):
         "target_file": os.path.join(os.getcwd(), "some_file"),
     }
 
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
     rms_run(
         0,
@@ -445,7 +445,7 @@ def test_run_wrapper(monkeypatch, source_root):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_version_env(monkeypatch, source_root):
     wrapper_file_name = f"{os.getcwd()}/bin/rms_wrapper"
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(
             f"""\
 executable: {os.getcwd()}/bin/rms
@@ -462,7 +462,7 @@ env:
     os.mkdir("project")
     shutil.copy(os.path.join(source_root, "tests/unit_tests/shared/share/rms"), "bin")
 
-    with open(wrapper_file_name, "w") as f:
+    with open(wrapper_file_name, "w", encoding="utf-8") as f:
         f.write(
             TEST_ENV_WRAPPER.format(
                 expected_path_prefix="/some/path",
@@ -481,7 +481,7 @@ env:
         "target_file": os.path.join(os.getcwd(), "some_file"),
     }
 
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
     rms_run(
         0,
@@ -496,7 +496,7 @@ env:
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_version_env_with_user_env(monkeypatch, source_root):
     wrapper_file_name = f"{os.getcwd()}/bin/rms_wrapper"
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(
             f"""\
 executable: {os.getcwd()}/bin/rms
@@ -513,14 +513,14 @@ env:
     os.mkdir("project")
     shutil.copy(os.path.join(source_root, "tests/unit_tests/shared/share/rms"), "bin")
 
-    with open(wrapper_file_name, "w") as f:
+    with open(wrapper_file_name, "w", encoding="utf-8") as f:
         f.write(
             TEST_ENV_WRAPPER.format(
                 expected_path_prefix="/some/other/path:/some/path",
                 expected_pythonpath="/some/other/pythonpath",
             )
         )
-    with open("rms_exec_env.json", "w") as f:
+    with open("rms_exec_env.json", "w", encoding="utf-8") as f:
         f.write(
             """\
 {
@@ -541,7 +541,7 @@ env:
             "target_file": os.path.join(os.getcwd(), "some_file"),
         }
 
-        with open("run_path/action.json", "w") as f:
+        with open("run_path/action.json", "w", encoding="utf-8") as f:
             f.write(json.dumps(action))
         rms_run(
             0,
@@ -555,7 +555,7 @@ env:
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_allow_no_env(monkeypatch, source_root):
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         f.write(
             f"""\
 executable: {os.getcwd()}/bin/rms
@@ -578,7 +578,7 @@ env:
         "target_file": os.path.join(os.getcwd(), "some_file"),
     }
 
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     with pytest.raises(rms.RMSRunException) as e:
@@ -606,7 +606,7 @@ env:
 @pytest.mark.usefixtures("use_tmpdir")
 def test_rms_job_script_parser(monkeypatch, source_root):
     # Setup RMS project
-    with open("rms_config.yml", "w") as f:
+    with open("rms_config.yml", "w", encoding="utf-8") as f:
         json.dump(
             {
                 "executable": os.path.realpath("bin/rms"),
@@ -624,7 +624,7 @@ def test_rms_job_script_parser(monkeypatch, source_root):
     monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
 
     action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
+    with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
     rms_exec = pkg_resources.resource_filename(
@@ -676,7 +676,7 @@ def test_load(monkeypatch):
         # pylint: disable=pointless-statement
         conf.executable
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("this:\n -should\n-be\ninvalid:yaml?")
 
     monkeypatch.setenv("RMS_SITE_CONFIG", "file.yml")
@@ -684,25 +684,25 @@ def test_load(monkeypatch):
         conf = rms.RMSConfig()
 
     os.mkdir("bin")
-    with open("bin/rms", "w") as f:
+    with open("bin/rms", "w", encoding="utf-8") as f:
         f.write("This is an RMS executable ...")
     os.chmod("bin/rms", stat.S_IEXEC)
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("executable: bin/rms")
 
     conf = rms.RMSConfig()
     assert conf.executable == "bin/rms"
     assert conf.threads is None
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("executable: bin/rms\n")
         f.write("threads: 17")
 
     conf = rms.RMSConfig()
     assert conf.threads == 17
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("executable: bin/rms\n")
         f.write("wrapper: not-exisiting-exec")
 
@@ -712,7 +712,7 @@ def test_load(monkeypatch):
         # pylint: disable=pointless-statement
         conf.wrapper
 
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write("executable: bin/rms\n")
         f.write("wrapper: bash")
 
@@ -723,7 +723,7 @@ def test_load(monkeypatch):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_env(monkeypatch):
     monkeypatch.setenv("RMS_SITE_CONFIG", "file.yml")
-    with open("file.yml", "w") as f:
+    with open("file.yml", "w", encoding="utf-8") as f:
         f.write(
             """\
 executable: bin/rms\n

--- a/tests/unit_tests/shared/share/test_shell.py
+++ b/tests/unit_tests/shared/share/test_shell.py
@@ -77,14 +77,14 @@ def shell(source_root):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_symlink(shell):
     assert b"must exist" in shell.symlink("target/does/not/exist", "link").stderr
-    with open("target", "w") as fileH:
+    with open("target", "w", encoding="utf-8") as fileH:
         fileH.write("target ...")
 
     shell.symlink("target", "link")
     assert os.path.islink("link")
     assert os.readlink("link") == "target"
 
-    with open("target2", "w") as fileH:
+    with open("target2", "w", encoding="utf-8") as fileH:
         fileH.write("target ...")
 
     assert b"File exists" in shell.symlink("target2", "target").stderr
@@ -109,7 +109,7 @@ def test_symlink(shell):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_symlink2(shell):
     os.makedirs("path")
-    with open("path/target", "w") as f:
+    with open("path/target", "w", encoding="utf-8") as f:
         f.write("1234")
 
     shell.symlink("path/target", "link")
@@ -119,14 +119,14 @@ def test_symlink2(shell):
     shell.symlink("path/target", "link")
     assert os.path.islink("link")
     assert os.path.isfile("path/target")
-    with open("link") as f:
+    with open("link", encoding="utf-8") as f:
         s = f.read()
         assert s == "1234"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_mkdir(shell):
-    with open("file", "w") as f:
+    with open("file", "w", encoding="utf-8") as f:
         f.write("Hei")
 
     assert b"File exists" in shell.mkdir("file").stderr
@@ -141,7 +141,7 @@ def test_mkdir(shell):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_file(shell):
-    with open("file", "w") as f:
+    with open("file", "w", encoding="utf-8") as f:
         f.write("Hei")
 
     shell.move_file("file", "file2")
@@ -159,7 +159,7 @@ def test_move_file(shell):
 
     assert b"not an existing file" in shell.move_file("not_existing", "target").stderr
 
-    with open("file2", "w") as f:
+    with open("file2", "w", encoding="utf-8") as f:
         f.write("123")
 
     shell.move_file("file2", "path/file2")
@@ -167,7 +167,7 @@ def test_move_file(shell):
     assert not os.path.isfile("file2")
 
     shell.mkdir("rms/ipl")
-    with open("global_variables.ipl", "w") as f:
+    with open("global_variables.ipl", "w", encoding="utf-8") as f:
         f.write("123")
 
     shell.move_file("global_variables.ipl", "rms/ipl/global_variables.ipl")
@@ -176,18 +176,18 @@ def test_move_file(shell):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_file_into_folder_file_exists(shell):
     shell.mkdir("dst_folder")
-    with open("dst_folder/file", "w") as f:
+    with open("dst_folder/file", "w", encoding="utf-8") as f:
         f.write("old")
 
-    with open("file", "w") as f:
+    with open("file", "w", encoding="utf-8") as f:
         f.write("new")
 
-    with open("dst_folder/file", "r") as f:
+    with open("dst_folder/file", "r", encoding="utf-8") as f:
         content = f.read()
         assert content == "old"
 
     shell.move_file("file", "dst_folder")
-    with open("dst_folder/file", "r") as f:
+    with open("dst_folder/file", "r", encoding="utf-8") as f:
         content = f.read()
         assert content == "new"
 
@@ -198,11 +198,11 @@ def test_move_file_into_folder_file_exists(shell):
 def test_move_pathfile_into_folder(shell):
     shell.mkdir("dst_folder")
     shell.mkdir("source1/source2/")
-    with open("source1/source2/file", "w") as f:
+    with open("source1/source2/file", "w", encoding="utf-8") as f:
         f.write("stuff")
 
     shell.move_file("source1/source2/file", "dst_folder")
-    with open("dst_folder/file", "r") as f:
+    with open("dst_folder/file", "r", encoding="utf-8") as f:
         content = f.read()
         assert content == "stuff"
 
@@ -213,14 +213,14 @@ def test_move_pathfile_into_folder(shell):
 def test_move_pathfile_into_folder_file_exists(shell):
     shell.mkdir("dst_folder")
     shell.mkdir("source1/source2/")
-    with open("source1/source2/file", "w") as f:
+    with open("source1/source2/file", "w", encoding="utf-8") as f:
         f.write("stuff")
 
-    with open("dst_folder/file", "w") as f:
+    with open("dst_folder/file", "w", encoding="utf-8") as f:
         f.write("garbage")
 
     shell.move_file("source1/source2/file", "dst_folder")
-    with open("dst_folder/file", "r") as f:
+    with open("dst_folder/file", "r", encoding="utf-8") as f:
         content = f.read()
         assert content == "stuff"
 
@@ -267,14 +267,14 @@ def test_that_delete_directory_on_regular_file_fails(shell):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_delete_directory_does_not_follow_symlinks(shell):
     shell.mkdir("link_target/subpath")
-    with open("link_target/link_file", "w") as f:
+    with open("link_target/link_file", "w", encoding="utf-8") as f:
         f.write("hei")
 
     shell.mkdir("path/subpath")
-    with open("path/file", "w") as f:
+    with open("path/file", "w", encoding="utf-8") as f:
         f.write("hei")
 
-    with open("path/subpath/file", "w") as f:
+    with open("path/subpath/file", "w", encoding="utf-8") as f:
         f.write("hei")
 
     shell.symlink("../link_target", "path/link")
@@ -303,7 +303,7 @@ def test_copy_directory_error(shell):
         b"existing directory" in shell.copy_directory("does/not/exist", "target").stderr
     )
 
-    with open("file", "w") as f:
+    with open("file", "w", encoding="utf-8") as f:
         f.write("hei")
 
     assert b"existing directory" in shell.copy_directory("hei", "target").stderr
@@ -316,7 +316,7 @@ def test_copy_file(shell):
     shell.mkdir("path")
     assert b"existing file" in shell.copy_file("path", "target").stderr
 
-    with open("file1", "w") as f:
+    with open("file1", "w", encoding="utf-8") as f:
         f.write("hei")
 
     shell.copy_file("file1", "file2")
@@ -333,13 +333,13 @@ def test_copy_file(shell):
 def test_copy_file2(shell):
     shell.mkdir("root/sub/path")
 
-    with open("file", "w") as f:
+    with open("file", "w", encoding="utf-8") as f:
         f.write("Hei ...")
 
     shell.copy_file("file", "root/sub/path/file")
     assert os.path.isfile("root/sub/path/file")
 
-    with open("file2", "w") as f:
+    with open("file2", "w", encoding="utf-8") as f:
         f.write("Hei ...")
 
     with pushd("root/sub/path"):
@@ -351,7 +351,7 @@ def test_copy_file2(shell):
 def test_copy_file3(shell):
     shell.mkdir("rms/output")
 
-    with open("file.txt", "w") as f:
+    with open("file.txt", "w", encoding="utf-8") as f:
         f.write("Hei")
 
     shell.copy_file("file.txt", "rms/output/")
@@ -360,13 +360,13 @@ def test_copy_file3(shell):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_careful_copy_file(shell):
-    with open("file1", "w") as f:
+    with open("file1", "w", encoding="utf-8") as f:
         f.write("hei")
-    with open("file2", "w") as f:
+    with open("file2", "w", encoding="utf-8") as f:
         f.write("hallo")
 
     shell.careful_copy_file("file1", "file2")
-    with open("file2", "r") as f:
+    with open("file2", "r", encoding="utf-8") as f:
         assert f.readline() == "hallo"
 
     print(shell.careful_copy_file("file1", "file3"))
@@ -406,7 +406,7 @@ FORWARD_MODEL DELETE_DIRECTORY(<DIRECTORY>=mydir)
 
         subprocess.run(["ert", "test_run", ert_config_fname], check=True)
 
-        with open("realization-0/iter-0/moved.txt") as output_file:
+        with open("realization-0/iter-0/moved.txt", encoding="utf-8") as output_file:
             assert output_file.read() == "something"
         assert not os.path.exists("realization-0/iter-0/copied.txt")
         assert not os.path.exists("realization-0/iter-0/copied2.txt")
@@ -418,7 +418,7 @@ FORWARD_MODEL DELETE_DIRECTORY(<DIRECTORY>=mydir)
 @pytest.fixture
 def minimal_case(tmpdir):
     with tmpdir.as_cwd():
-        with open("config.ert", "w") as fout:
+        with open("config.ert", "w", encoding="utf-8") as fout:
             fout.write("NUM_REALIZATIONS 1")
         yield
 

--- a/tests/unit_tests/shared/share/test_templating.py
+++ b/tests/unit_tests/shared/share/test_templating.py
@@ -67,11 +67,11 @@ default_parameters = {
 def test_render_invalid():
     prod_wells = {f"PROD{idx}": 0.3 * idx for idx in range(4)}
     prod_in = "well_drill.json"
-    with open(prod_in, "w") as fout:
+    with open(prod_in, "w", encoding="utf-8") as fout:
         json.dump(prod_wells, fout)
-    with open("parameters.json", "w") as fout:
+    with open("parameters.json", "w", encoding="utf-8") as fout:
         json.dump(default_parameters, fout)
-    with open("template_file", "w") as fout:
+    with open("template_file", "w", encoding="utf-8") as fout:
         fout.write(well_drill_tmpl)
 
     wells_out = "wells.out"
@@ -108,11 +108,11 @@ def test_render():
     wells_tmpl = "well_drill_tmpl"
     wells_out = "wells.out"
 
-    with open(wells_in, "w") as fout:
+    with open(wells_in, "w", encoding="utf-8") as fout:
         json.dump(wells, fout)
-    with open("parameters.json", "w") as fout:
+    with open("parameters.json", "w", encoding="utf-8") as fout:
         json.dump(default_parameters, fout)
-    with open(wells_tmpl, "w") as fout:
+    with open(wells_tmpl, "w", encoding="utf-8") as fout:
         fout.write(well_drill_tmpl)
 
     render_template(wells_in, wells_tmpl, wells_out)
@@ -126,7 +126,7 @@ def test_render():
         "INJ4 takes value 0.2, implying off",
     ]
 
-    with open(wells_out) as fin:
+    with open(wells_out, encoding="utf-8") as fin:
         output = fin.readlines()
 
     assert output == expected_template_out
@@ -134,16 +134,16 @@ def test_render():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_template_multiple_input():
-    with open("template", "w") as template_file:
+    with open("template", "w", encoding="utf-8") as template_file:
         template_file.write(mulitple_input_template)
 
-    with open("parameters.json", "w") as json_file:
+    with open("parameters.json", "w", encoding="utf-8") as json_file:
         json_file.write(json.dumps(default_parameters))
 
-    with open("second.json", "w") as json_file:
+    with open("second.json", "w", encoding="utf-8") as json_file:
         parameters = {"key1": {"subkey2": 1400}}
         json.dump(parameters, json_file)
-    with open("third.json", "w") as json_file:
+    with open("third.json", "w", encoding="utf-8") as json_file:
         parameters = {
             "key1": {
                 "subkey1": 3000.22,
@@ -153,7 +153,7 @@ def test_template_multiple_input():
 
     render_template(["second.json", "third.json"], "template", "out_file")
 
-    with open("out_file", "r") as parameter_file:
+    with open("out_file", "r", encoding="utf-8") as parameter_file:
         expected_output = (
             "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
         )
@@ -163,16 +163,16 @@ def test_template_multiple_input():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_no_parameters_json():
-    with open("template", "w") as template_file:
+    with open("template", "w", encoding="utf-8") as template_file:
         template_file.write(mulitple_input_template_no_param)
 
-    with open("not_the_standard_parameters.json", "w") as json_file:
+    with open("not_the_standard_parameters.json", "w", encoding="utf-8") as json_file:
         json_file.write(json.dumps(default_parameters))
 
-    with open("second.json", "w") as json_file:
+    with open("second.json", "w", encoding="utf-8") as json_file:
         parameters = {"key1": {"subkey2": 1400}}
         json.dump(parameters, json_file)
-    with open("third.json", "w") as json_file:
+    with open("third.json", "w", encoding="utf-8") as json_file:
         parameters = {
             "key1": {
                 "subkey1": 3000.22,
@@ -186,7 +186,7 @@ def test_no_parameters_json():
         "out_file",
     )
 
-    with open("out_file", "r") as parameter_file:
+    with open("out_file", "r", encoding="utf-8") as parameter_file:
         expected_output = (
             "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
         )
@@ -196,17 +196,17 @@ def test_no_parameters_json():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_template_executable():
-    with open("template", "w") as template_file:
+    with open("template", "w", encoding="utf-8") as template_file:
         template_file.write(
             "FILENAME\n"
             + "F1 {{parameters.key1.subkey1}}\n"
             + "F2 {{other.key1.subkey1}}"
         )
 
-    with open("parameters.json", "w") as json_file:
+    with open("parameters.json", "w", encoding="utf-8") as json_file:
         json_file.write(json.dumps(default_parameters))
 
-    with open("other.json", "w") as json_file:
+    with open("other.json", "w", encoding="utf-8") as json_file:
         parameters = {
             "key1": {
                 "subkey1": 200,
@@ -226,14 +226,14 @@ def test_template_executable():
 
     subprocess.call(template_render_exec + params, shell=True, stdout=subprocess.PIPE)
 
-    with open("out_file", "r") as parameter_file:
+    with open("out_file", "r", encoding="utf-8") as parameter_file:
         expected_output = "FILENAME\n" + "F1 1999.22\n" + "F2 200"
         assert parameter_file.read() == expected_output
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_parameters():
-    with open("parameters.json", "w") as json_file:
+    with open("parameters.json", "w", encoding="utf-8") as json_file:
         json_file.write(json.dumps(default_parameters))
 
     assert load_parameters() == default_parameters

--- a/tests/unit_tests/simulator/test_batch_sim.py
+++ b/tests/unit_tests/simulator/test_batch_sim.py
@@ -357,7 +357,7 @@ def test_batch_simulation_suffixes(batch_sim_example):
 
 def test_stop_sim(copy_case):
     copy_case("batch_sim")
-    with open("sleepy_time.ert", "a") as f:
+    with open("sleepy_time.ert", "a", encoding="utf-8") as f:
         f.write(
             """
 LOAD_WORKFLOW_JOB workflows/jobs/REALIZATION_NUMBER
@@ -408,7 +408,7 @@ LOAD_WORKFLOW_JOB workflows/jobs/REALIZATION_NUMBER
     )
     for idx, path in enumerate(paths):
         assert os.path.isfile(path)
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             assert f.readline(1) == str(idx)
 
 

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -156,7 +156,7 @@ def test_tracking(
     ]
 
     with tmpdir.as_cwd():
-        with open(f"{experiment_folder}/poly.ert", "a") as fh:
+        with open(f"{experiment_folder}/poly.ert", "a", encoding="utf-8") as fh:
             fh.writelines(config_lines)
 
         with fileinput.input(f"{experiment_folder}/poly_eval.py", inplace=True) as fin:
@@ -273,7 +273,7 @@ def test_tracking_time_map(
 
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
         # We create a reference case
         run_sim(datetime(2014, 9, 10))
@@ -370,7 +370,7 @@ def test_tracking_missing_ecl(
 
         """
         )
-        with open("config.ert", "w") as fh:
+        with open("config.ert", "w", encoding="utf-8") as fh:
             fh.writelines(config)
         # We create a reference case, but there will be no response
         run_sim(datetime(2014, 9, 10))

--- a/tests/unit_tests/test_libres_facade.py
+++ b/tests/unit_tests/test_libres_facade.py
@@ -317,7 +317,7 @@ def test_gen_kw_collector(snake_oil_case_storage, snapshot):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_data_report_steps():
-    with open("config_file.ert", "w") as fout:
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
         # Write a minimal config file
         fout.write(
             dedent(
@@ -329,15 +329,15 @@ def test_gen_data_report_steps():
         """
             )
         )
-    with open("obs_data_0.txt", "w") as fout:
+    with open("obs_data_0.txt", "w", encoding="utf-8") as fout:
         fout.write("1.0 0.1")
-    with open("obs_data_1.txt", "w") as fout:
+    with open("obs_data_1.txt", "w", encoding="utf-8") as fout:
         fout.write("2.0 0.1")
 
-    with open("time_map", "w") as fout:
+    with open("time_map", "w", encoding="utf-8") as fout:
         fout.write("2014-09-10\n2017-02-05")
 
-    with open("observations", "w") as fout:
+    with open("observations", "w", encoding="utf-8") as fout:
         fout.write(
             dedent(
                 """


### PR DESCRIPTION
Declare everywhere where we open text files that we want utf-8 and nothing else

Context: https://peps.python.org/pep-0597/

**Issue**
#3309 


**Approach**
Be explicit about the encoding

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
