### PR TITLE
Align user config content dict and config dict handling in res config

### DIFF
--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -1,7 +1,11 @@
-from typing import Any, Dict, List
+import logging
+from typing import Any, Dict, List, Optional, Tuple
 
 from ert._c_wrappers.config import ConfigContent
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
+
+logger = logging.getLogger(__name__)
 
 # keywords that have one argument and
 # the last occurrence of the keyword in the file
@@ -108,6 +112,12 @@ def config_content_as_dict(
                     occurrence[join_at] = " ".join(occurrence[join_at:])
                     del occurrence[join_at + 1 :]
 
+    if ConfigKeys.FORWARD_MODEL in content_dict:
+        parsed_jobs = []
+        for model in content_dict[ConfigKeys.FORWARD_MODEL]:
+            job_name, args = parse_signature_job("".join(model))
+            parsed_jobs.append([job_name, args])
+        content_dict[ConfigKeys.FORWARD_MODEL] = parsed_jobs
     # Add the defines if they exits
     defines = []
     if isinstance(site_config_content, ConfigContent):
@@ -122,3 +132,44 @@ def config_content_as_dict(
         content_dict[ConfigKeys.DEFINE_KEY] = defines
 
     return content_dict
+
+
+def parse_signature_job(signature: str) -> Tuple[str, Optional[str]]:
+    """Parses the job description as a signature type job.
+
+    A signature is on the form job(arg1=val1, arg2=val2, arg3=val3). This is used
+    in the FORWARD_MODEL keyword:
+
+        FORWARD_MODEL job(arg1=val1, arg2=val2, arg3=val3)
+
+    :returns: Tuple of the job name, and the string of argument assignments.
+
+
+    >>> parse_signature_job("job(arg1=val1, arg2=val2, arg3=val3)")
+    ('job', 'arg1=val1, arg2=val2, arg3=val3')
+
+    Function without arguments has arglist set to None:
+
+    >>> parse_signature_job("job")
+    ('job', None)
+
+
+    For backwards compatability, text after first closing parenthesis is closed,
+    but a warning is displayed.
+    """
+
+    open_paren = signature.find("(")
+    if open_paren == -1:
+        return signature, None
+    job_name = signature[:open_paren]
+    close_paren = signature.find(")")
+    if close_paren == -1:
+        raise ConfigValidationError(
+            errors=[f"Missing ) in FORWARD_MODEL job description {signature}"]
+        )
+    if close_paren < len(signature) - 1:
+        logger.warning(
+            f'Arguments after closing ) in "{signature}"'
+            f' ("{signature[close_paren:]}") is ignored.'
+        )
+    return job_name, signature[open_paren + 1 : close_paren]

--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -49,11 +49,7 @@ class SubstitutionList(BaseCClass):
         else:
             config_dir = subst_list["<CONFIG_PATH>"]
 
-        runpath_file_name = config_dict.get("RUNPATH_FILE", ".ert_runpath_list")
-        runpath_file_path = os.path.normpath(
-            os.path.join(config_dir, runpath_file_name)
-        )
-        subst_list.addItem("<RUNPATH_FILE>", runpath_file_path)
+        subst_list.addItem("<RUNPATH_FILE>", config_dict.get("RUNPATH_FILE"))
 
         num_cpus = config_dict.get("NUM_CPU")
         if num_cpus is None and "DATA_FILE" in config_dict:

--- a/tests/test_config_parsing/test_num_cpu.py
+++ b/tests/test_config_parsing/test_num_cpu.py
@@ -7,7 +7,7 @@ from ert._c_wrappers.enkf import ConfigKeys, EnKFMain, ResConfig
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_default_num_cpu():
-    with open("file.ert", "w") as f:
+    with open("file.ert", mode="w", encoding="utf-8") as f:
         f.write(f"{ConfigKeys.NUM_REALIZATIONS} 1")
     res_config = ResConfig(user_config_file="file.ert")
     enkf_main = EnKFMain(res_config)
@@ -30,6 +30,7 @@ def test_num_cpu_from_config_preferred():
         ConfigKeys.NUM_CPU: config_num_cpu,
         ConfigKeys.DATA_FILE: os.path.join(os.getcwd(), data_file),
         ConfigKeys.ENSPATH: ".",
+        ConfigKeys.RUNPATH_FILE: os.path.join(os.getcwd(), "runpath.file"),
     }
     res_config = ResConfig(config_dict=config_dict)
     enkf_main: EnKFMain = EnKFMain(res_config)
@@ -52,6 +53,7 @@ PARALLEL
         ConfigKeys.NUM_REALIZATIONS: 1,
         ConfigKeys.DATA_FILE: data_file,
         ConfigKeys.ENSPATH: ".",
+        ConfigKeys.RUNPATH_FILE: os.path.join(os.getcwd(), "runpath.file"),
     }
     res_config = ResConfig(config_dict=config_dict)
     enkf_main: EnKFMain = EnKFMain(res_config)

--- a/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
+++ b/tests/unit_tests/c_wrappers/integration/test_parameter_sample_types.py
@@ -347,7 +347,7 @@ def test_gen_kw_forward_init(tmpdir, load_forward_init):
 
         if load_forward_init:
             with pytest.raises(
-                KeyError,
+                ConfigValidationError,
                 match=(
                     "Loading GEN_KW from files created by "
                     "the forward model is not supported."

--- a/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
@@ -107,24 +107,19 @@ def test_model_config_dict_constructor(setup_case):
         ConfigKeys.HISTORY_SOURCE: "REFCASE_HISTORY",
         ConfigKeys.GEN_KW_EXPORT_NAME: "parameter_test.json",
         ConfigKeys.FORWARD_MODEL: [
-            {
-                ConfigKeys.NAME: "COPY_FILE",
-                ConfigKeys.ARGLIST: (
-                    "<FROM>=input/schedule.sch,<TO>=output/schedule_copy.sch"
-                ),
-            },
-            {
-                ConfigKeys.NAME: "SNAKE_OIL_SIMULATOR",
-                ConfigKeys.ARGLIST: "",
-            },
-            {
-                ConfigKeys.NAME: "SNAKE_OIL_NPV",
-                ConfigKeys.ARGLIST: "",
-            },
-            {
-                ConfigKeys.NAME: "SNAKE_OIL_DIFF",
-                ConfigKeys.ARGLIST: "",
-            },
+            ["COPY_FILE", "<FROM>=input/schedule.sch,<TO>=output/schedule_copy.sch"],
+            [
+                "SNAKE_OIL_SIMULATOR",
+                "",
+            ],
+            [
+                "SNAKE_OIL_NPV",
+                "",
+            ],
+            [
+                "SNAKE_OIL_DIFF",
+                "",
+            ],
         ],
         # needed to make up for lack of site config handling on config dict path
         ConfigKeys.INSTALL_JOB: [

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -10,7 +10,8 @@ import pytest
 from ecl.util.enums import RngAlgTypeEnum
 
 from ert._c_wrappers.enkf import AnalysisConfig, ConfigKeys, HookRuntime, ResConfig
-from ert._c_wrappers.enkf.res_config import parse_signature_job, site_config_location
+from ert._c_wrappers.enkf._config_content_as_dict import parse_signature_job
+from ert._c_wrappers.enkf.res_config import site_config_location
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum
 
@@ -317,7 +318,9 @@ def test_res_config_dict_constructor(setup_case):
             ["LSF", "LSF_QUEUE", "mr"],
         ],
         ConfigKeys.MAX_RUNNING: "100",
-        ConfigKeys.DATA_FILE: "../../eclipse/model/SNAKE_OIL.DATA",
+        ConfigKeys.DATA_FILE: os.path.normpath(
+            os.path.join(absolute_config_dir, "../../eclipse/model/SNAKE_OIL.DATA")
+        ),
         # "START"             : date(2017, 1, 1), no clue where this comes from
         ConfigKeys.GEN_KW_TAG_FORMAT: "<%s>",
         ConfigKeys.SUMMARY: [
@@ -353,8 +356,9 @@ def test_res_config_dict_constructor(setup_case):
         ConfigKeys.ENSPATH: os.path.realpath("../output/storage/<CASE_DIR>"),  # model
         "PLOT_PATH": "../output/results/plot/<CASE_DIR>",
         ConfigKeys.UPDATE_LOG_PATH: "../output/update_log/<CASE_DIR>",  # analysis
-        ConfigKeys.RUNPATH_FILE: (
-            "../output/run_path_file/.ert-runpath-list_<CASE_DIR>"
+        ConfigKeys.RUNPATH_FILE: str(
+            Path(absolute_config_dir).parent
+            / "output/run_path_file/.ert-runpath-list_the_extensive_case"
         ),  # subst
         ConfigKeys.DEFINE_KEY: [
             ("<CONFIG_PATH>", absolute_config_dir),
@@ -393,15 +397,15 @@ def test_res_config_dict_constructor(setup_case):
             ),
         ],
         ConfigKeys.FORWARD_MODEL: [
-            {
-                ConfigKeys.NAME: "SNAKE_OIL_SIMULATOR",
-                ConfigKeys.ARGLIST: "",
-            },
-            {
-                ConfigKeys.NAME: "SNAKE_OIL_NPV",
-                ConfigKeys.ARGLIST: "",
-            },
-            {ConfigKeys.NAME: "SNAKE_OIL_DIFF", ConfigKeys.ARGLIST: ""},  # model
+            [
+                "SNAKE_OIL_SIMULATOR",
+                "",
+            ],
+            [
+                "SNAKE_OIL_NPV",
+                "",
+            ],
+            ["SNAKE_OIL_DIFF", ""],
         ],
         ConfigKeys.HISTORY_SOURCE: "REFCASE_HISTORY",
         ConfigKeys.OBS_CONFIG: os.path.realpath(
@@ -418,10 +422,14 @@ def test_res_config_dict_constructor(setup_case):
         ConfigKeys.RANDOM_SEED: "3593114179000630026631423308983283277868",  # rng
         ConfigKeys.GRID: "../../eclipse/include/grid/CASE.EGRID",  # ecl
         ConfigKeys.RUN_TEMPLATE: [
-            (
-                "../input/templates/seed_template.txt",
+            [
+                os.path.normpath(
+                    os.path.join(
+                        absolute_config_dir, "../input/templates/seed_template.txt"
+                    )
+                ),
                 "seed.txt",
-            )  # ert_templates not sure about this we might do a proper dict instead?
+            ]
         ],
     }
 


### PR DESCRIPTION
**Issue**
Resolves #4401


**Approach**
- extend the confic dict generator
- replace `user_config_content` with its dict
- remove path resolution in (res) config


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
