### PR TITLE
Fixed gui not displaying runpath correctly

### DIFF
--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -16,6 +16,10 @@ class Arguments:
     mode: str
 
 
+def escape_string(string):
+    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 class SingleTestRunPanel(SimulationConfigPanel):
     def __init__(self, ert, notifier):
         self.ert = ert
@@ -28,7 +32,7 @@ class SingleTestRunPanel(SimulationConfigPanel):
         layout.addRow("Current case:", case_selector)
 
         run_path_label = QLabel(
-            f"<b>{self.ert.getModelConfig().runpath_format_string}</b>"
+            f"<b>{escape_string(self.ert.getModelConfig().runpath_format_string)}</b>"
         )
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)


### PR DESCRIPTION
Fixes an issue reported by user where gui does not correctly display runpath.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
