### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     uses: ./.github/workflows/build-wheels-linux.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     uses: ./.github/workflows/build-wheels-macos.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest ]
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         exclude:
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ macos-latest ]
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         exclude:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install with dependencies
       run: |

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-python@v4
       id: setup_python
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: "pip"
         cache-dependency-path: |
           setup.py

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -20,10 +20,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest]
         exclude:
         - python-version: '3.10'
+          os: macos-latest
+        - python-version: '3.11'
           os: macos-latest
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/ci/github/build_linux_wheel.sh
+++ b/ci/github/build_linux_wheel.sh
@@ -5,6 +5,7 @@ case "$1" in
     3.8) pyver=cp38-cp38 ;;
     3.9) pyver=cp39-cp39 ;;
     3.10) pyver=cp310-cp310 ;;
+    3.11) pyver=cp311-cp311 ;;
     *)
         echo "Unknown Python version $1"
         exit 1

--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ args = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],


### PR DESCRIPTION
**Issue**
Resolves Python 3.11 support


**Approach**
Build and test against Python 3.11


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
