### PR TITLE
Fix bug in pylint check workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -65,79 +65,79 @@ jobs:
         pylint src/ert --ignore-paths=src/ert/_c_wrappers,src/ert/gui,src/ert/logging,src/ert/analysis/_es_update.py,src/ert/data,src/_ert_job_runner,src/ert/shared,src/ert/__main__.py,src/ert/cli,src/ert/ensemble_evaluator,src/ert/services
         pylint --disable=all \
           --enable="\
-            access-member-before-definition, \
-            arguments-differ, \
-            arguments-renamed, \
-            assert-on-string-literal, \
-            bad-classmethod-argument, \
-            bad-thread-instantiation, \
-            chained-comparison, \
-            comparison-with-callable, \
-            consider-iterating-dictionary, \
-            consider-using-dict-items, \
-            consider-using-enumerate, \
-            consider-using-f-string, \
-            consider-using-from-import, \
-            consider-using-generator, \
-            consider-using-get, \
-            consider-using-in, \
-            consider-using-max-builtin, \
-            consider-using-min-builtin, \
-            consider-using-set-comprehension, \
-            consider-using-with, \
-            dangerous-default-value, \
-            deprecated-method, \
-            duplicate-key, \
-            empty-docstring, \
-            expression-not-assigned, \
-            global-statement, \
-            global-variable-not-assigned, \
-            implicit-str-concat, \
-            logging-not-lazy, \
-            missing-final-newline, \
-            no-else-break, \
-            no-else-continue, \
-            no-else-raise, \
-            no-member, \
-            no-method-argument, \
-            no-value-for-parameter, \
-            not-async-context-manager, \
-            not-callable, \
-            parse-error, \
-            pointless-statement, \
-            pointless-string-statement, \
-            redefined-builtin, \
-            redundant-unittest-assert, \
-            reimported, \
-            simplifiable-if-statement, \
-            subprocess-run-check, \
-            super-with-arguments, \
-            superfluous-parens, \
-            too-many-lines, \
-            too-many-nested-blocks, \
-            undefined-all-variable, \
-            undefined-loop-variable, \
-            undefined-variable, \
-            unexpected-keyword-arg, \
-            ungrouped-imports, \
-            unidiomatic-typecheck, \
-            unnecessary-comprehension, \
-            unnecessary-dunder-call, \
-            unnecessary-lambda, \
-            unnecessary-lambda-assignment, \
-            unneeded-not, \
-            unsubscriptable-object, \
-            unsupported-assignment-operation, \
-            unsupported-binary-operation, \
-            unused-import, \
-            use-a-generator, \
-            use-dict-literal, \
-            use-implicit-booleaness-not-comparison, \
-            use-maxsplit-arg, \
-            used-before-assignment, \
-            useless-import-alias, \
-            useless-object-inheritance, \
-            useless-return, \
-            useless-super-delegation, \
+            access-member-before-definition,\
+            arguments-differ,\
+            arguments-renamed,\
+            assert-on-string-literal,\
+            bad-classmethod-argument,\
+            bad-thread-instantiation,\
+            chained-comparison,\
+            comparison-with-callable,\
+            consider-iterating-dictionary,\
+            consider-using-dict-items,\
+            consider-using-enumerate,\
+            consider-using-f-string,\
+            consider-using-from-import,\
+            consider-using-generator,\
+            consider-using-get,\
+            consider-using-in,\
+            consider-using-max-builtin,\
+            consider-using-min-builtin,\
+            consider-using-set-comprehension,\
+            consider-using-with,\
+            dangerous-default-value,\
+            deprecated-method,\
+            duplicate-key,\
+            empty-docstring,\
+            expression-not-assigned,\
+            global-statement,\
+            global-variable-not-assigned,\
+            implicit-str-concat,\
+            logging-not-lazy,\
+            missing-final-newline,\
+            no-else-break,\
+            no-else-continue,\
+            no-else-raise,\
+            no-member,\
+            no-method-argument,\
+            no-value-for-parameter,\
+            not-async-context-manager,\
+            not-callable,\
+            parse-error,\
+            pointless-statement,\
+            pointless-string-statement,\
+            redefined-builtin,\
+            redundant-unittest-assert,\
+            reimported,\
+            simplifiable-if-statement,\
+            subprocess-run-check,\
+            super-with-arguments,\
+            superfluous-parens,\
+            too-many-lines,\
+            too-many-nested-blocks,\
+            undefined-all-variable,\
+            undefined-loop-variable,\
+            undefined-variable,\
+            unexpected-keyword-arg,\
+            ungrouped-imports,\
+            unidiomatic-typecheck,\
+            unnecessary-comprehension,\
+            unnecessary-dunder-call,\
+            unnecessary-lambda,\
+            unnecessary-lambda-assignment,\
+            unneeded-not,\
+            unsubscriptable-object,\
+            unsupported-assignment-operation,\
+            unsupported-binary-operation,\
+            unused-import,\
+            use-a-generator,\
+            use-dict-literal,\
+            use-implicit-booleaness-not-comparison,\
+            use-maxsplit-arg,\
+            used-before-assignment,\
+            useless-import-alias,\
+            useless-object-inheritance,\
+            useless-return,\
+            useless-super-delegation,\
             " \
           docs src tests test-data

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -40,7 +40,7 @@ class EnkfFs(BaseCClass):
     def __init__(
         self,
         mount_point: Union[str, Path],
-        ensemble_config: "EnsembleConfig",
+        ensemble_config: EnsembleConfig,
         ensemble_size: int,
         read_only: bool = False,
     ):

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert._c_wrappers.enkf import EnkfVarType, RunContext
+from ert._c_wrappers.enkf import EnkfVarType
 from ert.gui.ertwidgets import addHelpToWidget, showWaitCursorWhileWaiting
 from ert.gui.ertwidgets.caselist import CaseList
 from ert.gui.ertwidgets.caseselector import CaseSelector

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -8,8 +8,8 @@ import stat
 from pathlib import Path
 
 import hypothesis.strategies as st
-import py
 from hypothesis import assume, note
+from py import path as py_path
 
 from ert._c_wrappers.enkf import ConfigKeys
 from ert._c_wrappers.enkf.enums import GenDataFileType
@@ -410,7 +410,7 @@ def config_generators(draw):
     # will write the config to that file.
     @contextlib.contextmanager
     def generate_files_and_dict(tmp_path_factory, config_file_name=None):
-        tmp = py.path.local(tmp_path_factory.mktemp("config_dict"))
+        tmp = py_path.local(tmp_path_factory.mktemp("config_dict"))
         note(f"Using tmp dir: {str(tmp)}")
         with tmp.as_cwd():
             config_dict[ConfigKeys.JOB_SCRIPT] = os.path.abspath(

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from ert._c_wrappers.enkf import NodeId, RunContext
+from ert._c_wrappers.enkf import NodeId
 from ert._c_wrappers.enkf.config import FieldTypeEnum
 from ert._c_wrappers.enkf.data import EnkfNode
 


### PR DESCRIPTION
Fix the pylint errors that have slipped through the CI while this error in the yml file has been present

**Issue**
Whitespace in the list of pylint issues to include deactivated all but the first pylint check.

**Approach**
Remove the whitespace and fix newly introduced pylint issues.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
