### PR TITLE
Let delete_file delete broken symlinks

### DIFF
--- a/src/ert/shared/share/ert/shell_scripts/delete_directory.py
+++ b/src/ert/shared/share/ert/shell_scripts/delete_directory.py
@@ -4,7 +4,7 @@ import sys
 
 
 def delete_file(filename):
-    stat_info = os.stat(filename)
+    stat_info = os.lstat(filename)
     uid = stat_info.st_uid
     if uid == os.getuid():
         os.unlink(filename)
@@ -56,7 +56,7 @@ def delete_directory(path):
 
         delete_empty_directory(path)
     else:
-        sys.stderr.write(f"Directory:'{path}' not exist - delete ignored\n")
+        sys.stderr.write(f"Directory:'{path}' does not exist - delete ignored\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since os.stat will resolve symlinks, broken links will not be deleted unless os.lstat is used instead.

This causes issues with deletion of directories with internal symlink, if the link target is deleted prior to the link, the directory deletion will fail.

**Issue**
Resolves #4513 


**Approach**
Change delete_file() to not try to resolve symlinks

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
