### PR TITLE
Remove Equinor test-data softlink

### DIFF
--- a/ci/jenkins/testkomodo-ERT.sh
+++ b/ci/jenkins/testkomodo-ERT.sh
@@ -20,10 +20,6 @@ install_package () {
 }
 
 start_tests () {
-    if [[ ${CI_KOMODO_RELEASE} =~ py27$  ]]
-    then
-        export PYTEST_QT_API=pyqt4v2
-    fi
     export NO_PROXY=localhost,127.0.0.1
 
     pytest --hypothesis-profile=ci -m "not requires_window_manager" tests/

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -16,13 +16,8 @@ install_test_dependencies () {
 }
 
 start_tests () {
-    if [[ ${CI_KOMODO_RELEASE} =~ py27$  ]]
-    then
-        export PYTEST_QT_API=pyqt4v2
-    fi
     export NO_PROXY=localhost,127.0.0.1
 
-    ln -s /project/res-testdata/ErtTestData ${CI_TEST_ROOT}/test-data/Equinor
     export ECL_SKIP_SIGNAL=ON
 
     # The existence of a running xvfb process will produce


### PR DESCRIPTION
**Issue**
We can remove soft-link to equinor test-data since it is no longer in use.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
