### PR TITLE
Remove target_fs from RunContext and create posterior instead

### DIFF
--- a/docs/reference/workflows/internal.rst
+++ b/docs/reference/workflows/internal.rst
@@ -45,7 +45,7 @@ of this kind must:
 
             # Get a handle to the case / filesystem we are interested in;
             # this should ideally come as an argument - not just use current.
-            fs = ert.getEnkfFsManager().getCurrentFileSystem()
+            fs = ert.storage_manager.current_case
 
 
             # How many realisations:

--- a/src/clib/lib/enkf/enkf_state.cpp
+++ b/src/clib/lib/enkf/enkf_state.cpp
@@ -171,7 +171,6 @@ enkf_state_internalize_dynamic_eclipse_results(
     // data, and if there are observations for them. That is a problem.
     return enkf_state_check_for_missing_eclipse_summary_data(
         ens_config, matcher, smspec, iens);
-    return {LOAD_SUCCESSFUL, ""};
 }
 
 static fw_load_status enkf_state_load_gen_data_node(

--- a/src/clib/lib/enkf/time_map.cpp
+++ b/src/clib/lib/enkf/time_map.cpp
@@ -173,7 +173,6 @@ void TimeMap::read_binary(const std::filesystem::path &path) {
    @returns status, empty string if success, error message otherwise
 */
 std::string TimeMap::summary_update(const ecl_sum_type *ecl_sum) {
-    bool updateOK = true;
     std::vector<Inconsistency> errors;
 
     int first_step = ecl_sum_get_first_report_step(ecl_sum);

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -470,13 +470,9 @@ class EnKFMain:
                     res_config.env_vars,
                 )
 
-        active_list = [
-            run_context[i] for i in range(len(run_context)) if run_context.is_active(i)
-        ]
-        iterations = sorted({runarg.iter_id for runarg in active_list})
-        realizations = sorted({runarg.iens for runarg in active_list})
-
-        run_context.runpaths.write_runpath_list(iterations, realizations)
+        run_context.runpaths.write_runpath_list(
+            [run_context.iteration], run_context.active_realizations
+        )
 
     def runWorkflows(self, runtime: int) -> None:
         workflow_list = self.getWorkflowList()

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -404,16 +404,6 @@ class EnKFMain:
         "Will return the random number generator used for updates."
         return self._shared_rng
 
-    def getFileSystem(self, case_name: str) -> "EnkfFs":
-        try:
-            case = self.storage_manager[case_name]
-        except KeyError:
-            case = self.storage_manager.add_case(case_name)
-        if self.res_config.ensemble_config.refcase:
-            time_map = case.getTimeMap()
-            time_map.attach_refcase(self.res_config.ensemble_config.refcase)
-        return case
-
     def switchFileSystem(self, case_name: str) -> None:
         if isinstance(case_name, EnkfFs):
             case_name = case_name.case_name

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -248,9 +248,6 @@ class EnKFMain:
     def runpath_list_filename(self):
         return self._runpaths.runpath_list_filename
 
-    def getEnkfFsManager(self) -> "EnKFMain":
-        return self
-
     def getLocalConfig(self) -> "UpdateConfiguration":
         return self.update_configuration
 
@@ -258,9 +255,7 @@ class EnKFMain:
         self, realization: List[bool], iteration: int, fs: "EnkfFs"
     ) -> int:
         """Returns the number of loaded realizations"""
-        run_context = self.create_ensemble_experiment_run_context(
-            active_mask=realization, iteration=iteration, source_filesystem=fs
-        )
+        run_context = self.load_ensemble_context(fs.case_name, realization, iteration)
         nr_loaded = fs.load_from_run_path(
             self.getEnsembleSize(),
             self.ensembleConfig(),
@@ -271,63 +266,34 @@ class EnKFMain:
         fs.sync()
         return nr_loaded
 
-    def create_ensemble_experiment_run_context(
-        self, iteration: int, active_mask: List[bool] = None, source_filesystem=None
+    def create_ensemble_context(
+        self, case_name, active_realizations, iteration
     ) -> RunContext:
-        """Creates an ensemble experiment run context
-        :param fs: The source filesystem, defaults to
-            getEnkfFsManager().getCurrentFileSystem().
-        :param active_mask: Whether a realization is active or not,
-            defaults to all active.
-        """
-        return self._create_run_context(
-            iteration=iteration,
-            active_mask=active_mask,
-            source_filesystem=source_filesystem,
-            target_fs=None,
-        )
-
-    def create_ensemble_smoother_run_context(
-        self,
-        iteration: int,
-        target_filesystem,
-        active_mask: List[bool] = None,
-        source_filesystem=None,
-    ) -> RunContext:
-        """Creates an ensemble smoother run context
-        :param fs: The source filesystem, defaults to
-            getEnkfFsManager().getCurrentFileSystem().
-        """
-        return self._create_run_context(
-            iteration=iteration,
-            active_mask=active_mask,
-            source_filesystem=source_filesystem,
-            target_fs=target_filesystem,
-        )
-
-    def _create_run_context(
-        self,
-        iteration: int = 0,
-        active_mask: List[bool] = None,
-        source_filesystem=None,
-        target_fs=None,
-    ) -> RunContext:
-        if active_mask is None:
-            active_mask = [True] * self.getEnsembleSize()
-        if source_filesystem is None:
-            source_filesystem = self.getCurrentFileSystem()
-
-        realizations = list(range(len(active_mask)))
-        paths = self.runpaths.get_paths(realizations, iteration)
-        jobnames = self.runpaths.get_jobnames(realizations, iteration)
-
+        """This creates a new case in storage
+        and returns the run information for that case"""
         return RunContext(
-            sim_fs=source_filesystem,
-            target_fs=target_fs,
-            mask=active_mask,
+            sim_fs=self.storage_manager.add_case(case_name),
+            path_format=self.resConfig().preferred_job_fmt(),
+            format_string=self.getModelConfig().runpath_format_string,
+            runpath_file=self.resConfig().runpath_file,
+            initial_mask=active_realizations,
+            global_substitutions=dict(self.get_context()),
             iteration=iteration,
-            paths=paths,
-            jobnames=jobnames,
+        )
+
+    def load_ensemble_context(
+        self, case_name, active_realizations, iteration
+    ) -> RunContext:
+        """This loads an existing case from storage
+        and creates run information for that case"""
+        return RunContext(
+            sim_fs=self.storage_manager[case_name],
+            path_format=self.resConfig().preferred_job_fmt(),
+            format_string=self.getModelConfig().runpath_format_string,
+            runpath_file=self.resConfig().runpath_file,
+            initial_mask=active_realizations,
+            global_substitutions=dict(self.get_context()),
+            iteration=iteration,
         )
 
     def write_runpath_list(self, iterations: List[int], realizations: List[int]):
@@ -338,9 +304,6 @@ class EnKFMain:
 
     def get_num_cpu(self) -> int:
         return self.res_config.preferred_num_cpu()
-
-    def set_geo_id(self, geo_id: str, realization: int, iteration: int):
-        self.addDataKW(f"<GEO_ID_{realization}_{iteration}>", str(geo_id))
 
     def __repr__(self):
         return f"EnKFMain(size: {self.getEnsembleSize()}, config: {self.res_config})"
@@ -451,10 +414,6 @@ class EnKFMain:
             time_map.attach_refcase(self.res_config.ensemble_config.refcase)
         return case
 
-    def getCurrentFileSystem(self) -> "EnkfFs":
-        """Returns the currently selected file system"""
-        return self.getFileSystem(self.storage_manager.active_case)
-
     def switchFileSystem(self, case_name: str) -> None:
         if isinstance(case_name, EnkfFs):
             case_name = case_name.case_name
@@ -476,10 +435,10 @@ class EnKFMain:
                 )
 
                 for source_file, target_file in self.res_config.ert_templates:
-                    target_file = self.get_context().substitute_real_iter(
+                    target_file = run_context.substituter.substitute_real_iter(
                         target_file, run_arg.iens, run_context.iteration
                     )
-                    result = self.get_context().substitute_real_iter(
+                    result = run_context.substituter.substitute_real_iter(
                         Path(source_file).read_text("utf-8"),
                         run_arg.iens,
                         run_context.iteration,
@@ -499,7 +458,7 @@ class EnKFMain:
                     model_config.gen_kw_export_name,
                     run_arg.runpath,
                     run_arg.iens,
-                    run_arg.sim_fs,
+                    run_context.sim_fs,
                 )
                 res_config.forward_model.formatted_fprintf(
                     run_arg.get_run_id(),
@@ -507,7 +466,7 @@ class EnKFMain:
                     model_config.data_root,
                     iens,
                     run_context.iteration,
-                    self.get_context(),
+                    run_context.substituter,
                     res_config.env_vars,
                 )
 
@@ -517,7 +476,7 @@ class EnKFMain:
         iterations = sorted({runarg.iter_id for runarg in active_list})
         realizations = sorted({runarg.iens for runarg in active_list})
 
-        self.runpaths.write_runpath_list(iterations, realizations)
+        run_context.runpaths.write_runpath_list(iterations, realizations)
 
     def runWorkflows(self, runtime: int) -> None:
         workflow_list = self.getWorkflowList()

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -188,6 +188,7 @@ class EnKFMain:
             config.ensemble_config,
             self.getEnsembleSize(),
             read_only=read_only,
+            refcase=self.res_config.ensemble_config.refcase,
         )
         self.switchFileSystem(self.storage_manager.active_case)
 

--- a/src/ert/_c_wrappers/enkf/ert_run_context.py
+++ b/src/ert/_c_wrappers/enkf/ert_run_context.py
@@ -1,52 +1,78 @@
 import uuid
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Iterator, List
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Iterator, List
 
-from ert._c_wrappers.enkf.enkf_fs import EnkfFs
 from ert._c_wrappers.enkf.run_arg import RunArg
+from ert._c_wrappers.enkf.runpaths import Runpaths
+from ert._c_wrappers.util import SubstitutionList
+
+if TYPE_CHECKING:
+    from ert._c_wrappers.enkf.enkf_fs import EnkfFs
 
 
 @dataclass
 class RunContext:
-    sim_fs: EnkfFs
-    target_fs: EnkfFs = None
-    mask: List[bool] = field(default_factory=list)
-    paths: List[str] = field(default_factory=list)
-    jobnames: List[str] = field(default_factory=list)
+    sim_fs: "EnkfFs"
+    path_format: str
+    format_string: str
+    runpath_file: Path
+    initial_mask: List[bool] = field(default_factory=list)
     iteration: int = 0
+    global_substitutions: InitVar[Dict[str, str]] = None
 
-    def __post_init__(self):
-        self.run_id = f"{uuid.uuid4()}:{datetime.now().strftime('%Y-%m-%dT%H%M')}"
+    def __post_init__(self, global_substitutions):
+        subst_list = SubstitutionList()
+        if global_substitutions:
+            for k, v in global_substitutions.items():
+                subst_list.addItem(k, v)
+        self.substituter = subst_list
+        self.runpaths = Runpaths(
+            self.path_format,
+            self.format_string,
+            self.runpath_file,
+            self.substituter.substitute_real_iter,
+        )
+        self.run_id = uuid.uuid4()
         self.run_args = []
-        if self.jobnames and self.paths:
-            for iens, (job_name, path) in enumerate(zip(self.jobnames, self.paths)):
-                self.run_args.append(
-                    RunArg(
-                        str(self.run_id),
-                        self.sim_fs,
-                        iens,
-                        self.iteration,
-                        path,
-                        job_name,
-                    )
+        paths = self.runpaths.get_paths(
+            list(range(len(self.initial_mask))), self.iteration
+        )
+        job_names = self.runpaths.get_jobnames(
+            list(range(len(self.initial_mask))), self.iteration
+        )
+        for iens, (run_path, job_name, active) in enumerate(
+            zip(paths, job_names, self.initial_mask)
+        ):
+            self.substituter.addItem("<RUNPATH>", run_path)
+            self.substituter.addItem("<ECL_BASE>", job_name)
+            self.substituter.addItem("<ECLBASE>", job_name)
+            self.substituter.addItem("<ITER>", str(self.iteration))
+            self.run_args.append(
+                RunArg(
+                    str(self.run_id),
+                    self.sim_fs,
+                    iens,
+                    self.iteration,
+                    run_path,
+                    job_name,
+                    active,
                 )
+            )
 
-        if not self.target_fs:
-            self.target_fs = self.sim_fs
+    @property
+    def mask(self):
+        return [real.active for real in self]
 
     def is_active(self, index: int) -> bool:
-        try:
-            return self.mask[index]
-        except IndexError:
-            return False
+        return self[index].active
 
     @property
     def active_realizations(self):
-        return [i for i, _ in enumerate(self) if self.is_active(i)]
+        return [i for i, real in enumerate(self) if real.active]
 
     def __len__(self):
-        return len(self.mask)
+        return len(self.initial_mask)
 
     def __getitem__(self, item) -> RunArg:
         return self.run_args[item]
@@ -55,4 +81,4 @@ class RunContext:
         yield from self.run_args
 
     def deactivate_realization(self, realization_nr):
-        self.mask[realization_nr] = False
+        self[realization_nr].active = False

--- a/src/ert/_c_wrappers/enkf/run_arg.py
+++ b/src/ert/_c_wrappers/enkf/run_arg.py
@@ -8,11 +8,12 @@ if TYPE_CHECKING:
 @dataclass
 class RunArg:
     run_id: str
-    sim_fs: "EnkfFs"
+    ensemble_storage: "EnkfFs"
     iens: int
     itr: int
     runpath: str
     job_name: str
+    active: bool = True
     # Below here is legacy related to Everest
     queue_index: Optional[int] = None
     submitted: bool = False

--- a/src/ert/ensemble_evaluator/callbacks.py
+++ b/src/ert/ensemble_evaluator/callbacks.py
@@ -24,12 +24,12 @@ def forward_model_ok(
             node = EnkfNode(config_node)
             node_id = NodeId(report_step=0, iens=run_arg.iens)
 
-            if node.has_data(run_arg.sim_fs, node_id):
+            if node.has_data(run_arg.ensemble_storage, node_id):
                 # Already initialised, ignore
                 continue
 
             if node.forward_init(run_arg.runpath, run_arg.iens):
-                node.save(run_arg.sim_fs, node_id)
+                node.save(run_arg.ensemble_storage, node_id)
             else:
                 if "%d" in config_node.get_init_file_fmt():
                     init_file = Path(config_node.get_init_file_fmt() % (run_arg.iens,))
@@ -55,10 +55,10 @@ def forward_model_ok(
             run_arg.job_name,
             run_arg.iens,
             run_arg.runpath,
-            run_arg.sim_fs,
+            run_arg.ensemble_storage,
         )
 
-    run_arg.sim_fs.getStateMap()[run_arg.iens] = (
+    run_arg.ensemble_storage.getStateMap()[run_arg.iens] = (
         RealizationStateEnum.STATE_HAS_DATA
         if result[0] == LoadStatus.LOAD_SUCCESSFUL
         else RealizationStateEnum.STATE_LOAD_FAILURE
@@ -68,4 +68,6 @@ def forward_model_ok(
 
 
 def forward_model_exit(run_arg: "RunArg", *_: Tuple[Any]):
-    run_arg.sim_fs.getStateMap()[run_arg.iens] = RealizationStateEnum.STATE_LOAD_FAILURE
+    run_arg.ensemble_storage.getStateMap()[
+        run_arg.iens
+    ] = RealizationStateEnum.STATE_LOAD_FAILURE

--- a/src/ert/ensemble_evaluator/evaluator_tracker.py
+++ b/src/ert/ensemble_evaluator/evaluator_tracker.py
@@ -114,7 +114,6 @@ class EvaluatorTracker:
         self._work_queue.put(EvaluatorTracker.DONE)
         self._work_queue.join()
         drainer_logger.debug("tasks complete")
-        self._model.teardown_context()
 
     def track(
         self,

--- a/src/ert/gui/ertwidgets/caselist.py
+++ b/src/ert/gui/ertwidgets/caselist.py
@@ -110,7 +110,18 @@ class CaseList(QWidget):
         )
         new_case_name = dialog.showAndTell()
         if not new_case_name == "":
-            self.facade.select_or_create_new_case(new_case_name)
+            try:
+                self.facade._enkf_main.storage_manager.add_case(new_case_name)
+                self.facade._enkf_main.switchFileSystem(new_case_name)
+            except KeyError:
+                msg = QMessageBox(
+                    QMessageBox.Critical,
+                    "Duplicate case",
+                    f"Case name {new_case_name} already exists",
+                    QMessageBox.Ok,
+                    self,
+                )
+                msg.exec_()
             self.notifier.ertChanged.emit()
 
     def removeItem(self):

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -251,7 +251,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
 
     def _showInfoForCase(self, case_name=None):
         if case_name is None:
-            case_name = self.ert.getEnkfFsManager().getCurrentFileSystem().getCaseName()
+            case_name = self.ert.storage_manager.current_case.case_name
 
         states = list(self.ert.storage_manager.state_map(case_name))
 

--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -1,6 +1,7 @@
+import uuid
+
 from qtpy.QtWidgets import QMessageBox
 
-from ert._c_wrappers.enkf import RunContext
 from ert.analysis import ErtAnalysisError, ESUpdate
 from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
@@ -11,16 +12,13 @@ from ert.gui.tools.run_analysis import RunAnalysisPanel
 def analyse(ert, target, source):
     """Runs analysis using target and source cases. Returns whether or not
     the analysis was successful."""
-    fs_manager = ert.getEnkfFsManager()
+    fs_manager = ert.storage_manager
     es_update = ESUpdate(ert)
 
-    target_fs = fs_manager.getFileSystem(target)
-    source_fs = fs_manager.getFileSystem(source)
-    run_context = RunContext(
-        source_fs,
-        target_fs,
-    )
-    es_update.smootherUpdate(run_context)
+    target_fs = fs_manager.add_case(target)
+    source_fs = fs_manager[source]
+
+    es_update.smootherUpdate(source_fs, target_fs, uuid.uuid4())
 
 
 class RunAnalysisTool(Tool):

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -7,7 +7,7 @@ from ecl.grid import EclGrid
 from pandas import DataFrame, MultiIndex, Series
 
 from ert import _clib
-from ert._c_wrappers.enkf import EnKFMain, EnkfNode, ErtImplType, ResConfig, RunContext
+from ert._c_wrappers.enkf import EnKFMain, EnkfNode, ErtImplType, ResConfig
 from ert._c_wrappers.enkf.config import GenKwConfig
 from ert._c_wrappers.enkf.enums import (
     EnkfObservationImplementationType,
@@ -44,13 +44,21 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     ) -> None:
         self._enkf_main.write_runpath_list(iterations, realizations)
 
-    def smoother_update(self, prior_context: RunContext) -> None:
-        self._es_update.smootherUpdate(prior_context)
+    def smoother_update(
+        self, prior_storage: "EnkfFs", posterior_storage: "EnkfFs", run_id: str
+    ) -> None:
+        self._es_update.smootherUpdate(prior_storage, posterior_storage, run_id)
 
     def iterative_smoother_update(
-        self, run_context: RunContext, ies: "IterativeEnsembleSmoother"
+        self,
+        prior_storage: "EnkfFs",
+        posterior_storage: "EnkfFs",
+        ies: "IterativeEnsembleSmoother",
+        run_id: str,
     ) -> None:
-        self._es_update.iterative_smoother_update(run_context, ies)
+        self._es_update.iterative_smoother_update(
+            prior_storage, posterior_storage, ies, run_id
+        )
 
     def set_global_std_scaling(self, weight: float) -> None:
         self._enkf_main.analysisConfig().set_global_std_scaling(weight)
@@ -78,13 +86,6 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def number_of_iterations(self) -> int:
         return self._enkf_main.analysisConfig().num_iterations
 
-    def get_run_context(self, prior_name: str, target_name: str) -> RunContext:
-        fs_manager = self._enkf_main.getEnkfFsManager()
-        return RunContext(
-            fs_manager.getFileSystem(prior_name),
-            fs_manager.getFileSystem(target_name),
-        )
-
     def get_field_parameters(self) -> List[str]:
         return list(
             self._enkf_main.ensembleConfig().getKeylistFromImplType(ErtImplType.FIELD)
@@ -106,7 +107,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def export_field_parameter(
         self, parameter_name: str, case_name: str, filepath: str
     ) -> None:
-        file_system = self._enkf_main.getFileSystem(case_name)
+        file_system = self._enkf_main.storage_manager[case_name]
         config_node = self._enkf_main.ensembleConfig()[parameter_name]
         ext = config_node.get_enkf_outfile().rsplit(".")[-1]
         EnkfNode.exportMany(
@@ -135,10 +136,10 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         return self._enkf_main.getEnsembleSize()
 
     def get_current_case_name(self) -> str:
-        return str(self._enkf_main.getCurrentFileSystem().getCaseName())
+        return str(self.get_current_fs().case_name)
 
     def get_active_realizations(self, case_name: str) -> List[int]:
-        fs = self._enkf_main.getFileSystem(case_name)
+        fs = self._enkf_main.storage_manager[case_name]
         state_map = fs.getStateMap()
         ens_mask = state_map.selectMatching(RealizationStateEnum.STATE_HAS_DATA)
         return [index for index, element in enumerate(ens_mask) if element]
@@ -178,7 +179,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def load_from_forward_model(
         self, case: str, realisations: List[bool], iteration: int
     ) -> int:
-        fs = self._enkf_main.getFileSystem(case)
+        fs = self._enkf_main.storage_manager[case]
         return self._enkf_main.loadFromForwardModel(realisations, iteration, fs)
 
     def get_observations(self) -> "EnkfObs":
@@ -201,7 +202,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         )
 
     def get_current_fs(self) -> "EnkfFs":
-        return self._enkf_main.getCurrentFileSystem()
+        return self._enkf_main.storage_manager.current_case
 
     def get_data_key_for_obs_key(self, observation_key: Union[str, int]) -> str:
         return self._enkf_main.getObservations()[observation_key].getDataKey()
@@ -219,7 +220,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         report_step: int,
         realization_index: Optional[int] = None,
     ) -> DataFrame:
-        fs = self._enkf_main.getFileSystem(case_name)
+        fs = self._enkf_main.storage_manager[case_name]
         realizations = fs.realizationList(RealizationStateEnum.STATE_HAS_DATA)
         if realization_index is not None:
             if realization_index not in realizations:
@@ -282,7 +283,10 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
 
     def select_or_create_new_case(self, case_name: str) -> None:
         if self.get_current_case_name() != case_name:
-            fs = self._enkf_main.getFileSystem(case_name)
+            if case_name not in self._enkf_main.storage_manager:
+                fs = self._enkf_main.storage_manager.add_case(case_name)
+            else:
+                fs = self._enkf_main.storage_manager[case_name]
             self._enkf_main.switchFileSystem(fs.case_name)
 
     def cases(self) -> List[str]:
@@ -357,7 +361,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         keys: Optional[List[str]] = None,
         realization_index: Optional[int] = None,
     ) -> DataFrame:
-        fs = self._enkf_main.getFileSystem(case_name)
+        fs = self._enkf_main.storage_manager[case_name]
 
         ens_mask = fs.getStateMap().selectMatching(
             RealizationStateEnum.STATE_INITIALIZED
@@ -410,7 +414,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         keys: Optional[List[str]] = None,
         realization_index: Optional[int] = None,
     ) -> DataFrame:
-        fs = self._enkf_main.getFileSystem(case_name)
+        fs = self._enkf_main.storage_manager[case_name]
 
         time_map = fs.getTimeMap()
         dates = [time_map[index] for index in range(1, len(time_map))]
@@ -462,6 +466,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
 
     def load_all_misfit_data(self, case_name: str) -> DataFrame:
         realizations = self.get_active_realizations(case_name)
+        fs = self._enkf_main.storage_manager[case_name]
         misfit_keys = []
         for obs_vector in self._enkf_main.getObservations():
             misfit_keys.append(f"MISFIT:{obs_vector.getObservationKey()}")
@@ -480,7 +485,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
 
             for realization_index, realization_number in enumerate(realizations):
                 misfit = obs_vector.getTotalChi2(
-                    self._enkf_main.getFileSystem(case_name),
+                    fs,
                     realization_number,
                 )
 

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -281,13 +281,14 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
                         df[f"STD_{key}"][obs_time] = std
         return df
 
-    def select_or_create_new_case(self, case_name: str) -> None:
+    def select_or_create_new_case(self, case_name: str) -> "EnkfFs":
+        if case_name not in self._enkf_main.storage_manager:
+            fs = self._enkf_main.storage_manager.add_case(case_name)
+        else:
+            fs = self._enkf_main.storage_manager[case_name]
         if self.get_current_case_name() != case_name:
-            if case_name not in self._enkf_main.storage_manager:
-                fs = self._enkf_main.storage_manager.add_case(case_name)
-            else:
-                fs = self._enkf_main.storage_manager[case_name]
             self._enkf_main.switchFileSystem(fs.case_name)
+        return fs
 
     def cases(self) -> List[str]:
         def sort_key(s: str) -> List[Union[int, str]]:

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -20,7 +20,7 @@ class ExportMisfitDataJob(ErtScript):
 
     def run(self, target_file=None):
         ert = self.ert()
-        fs = ert.getEnkfFsManager().getCurrentFileSystem()
+        fs = ert.storage_manager.current_case
 
         if target_file is None:
             target_file = "misfit.hdf"

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -496,10 +496,13 @@ class BaseRunModel:
         return self._run_context
 
     @feature_enabled("new-storage")
-    def _post_ensemble_data(self, update_id: Optional[str] = None) -> str:
+    def _post_ensemble_data(
+        self, case_name: str, update_id: Optional[str] = None
+    ) -> str:
         self.setPhaseName("Uploading data...")
         ensemble_id = post_ensemble_data(
             ert=self.facade,
+            case_name=case_name,
             ensemble_size=self._ensemble_size,
             update_id=update_id,
             active_realizations=self._active_realizations,
@@ -508,9 +511,11 @@ class BaseRunModel:
         return ensemble_id
 
     @feature_enabled("new-storage")
-    def _post_ensemble_results(self, ensemble_id: str) -> None:
+    def _post_ensemble_results(self, case_name: str, ensemble_id: str) -> None:
         self.setPhaseName("Uploading results...")
-        post_ensemble_results(ert=self.facade, ensemble_id=ensemble_id)
+        post_ensemble_results(
+            ert=self.facade, case_name=case_name, ensemble_id=ensemble_id
+        )
         self.setPhaseName("Uploading done")
 
     @feature_enabled("new-storage")

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -99,8 +99,6 @@ class BaseRunModel:
         self._initial_realizations_mask: List[bool] = []
         self._completed_realizations_mask: List[bool] = []
         self.support_restart: bool = True
-        self._run_context: Optional[RunContext] = None
-        self._last_run_iteration: int = -1
         self._ert = ert
         self.facade = LibresFacade(ert)
         self._simulation_arguments = simulation_arguments
@@ -205,11 +203,6 @@ class BaseRunModel:
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:
         raise NotImplementedError("Method must be implemented by inheritors!")
-
-    def teardown_context(self) -> None:
-        # Used particularly to delete last active run_context to notify
-        # fs_manager that storage is not being written to.
-        self._run_context = None
 
     def phaseCount(self) -> int:
         return self._phase_count
@@ -491,9 +484,6 @@ class BaseRunModel:
 
     def get_forward_model(self) -> ForwardModel:
         return self.ert().resConfig().forward_model
-
-    def get_run_context(self) -> Optional[RunContext]:
-        return self._run_context
 
     @feature_enabled("new-storage")
     def _post_ensemble_data(

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -387,13 +387,6 @@ class BaseRunModel:
         )
 
         with concurrent.futures.ThreadPoolExecutor() as pool:
-            await loop.run_in_executor(
-                pool,
-                self.ert().sample_prior,
-                run_context.sim_fs,
-                [i for i, _ in enumerate(run_context) if run_context.is_active(i)],
-            )
-
             await ensemble.evaluate_async(ee_config, self.id_)
 
             await ensemble_listener

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -53,7 +53,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.ert().createRunPath(run_context)
         self.ert().runWorkflows(HookRuntime.PRE_SIMULATION)
         # create ensemble
-        ensemble_id = self._post_ensemble_data(update_id=update_id)
+        ensemble_id = self._post_ensemble_data(
+            case_name=run_context.sim_fs.case_name, update_id=update_id
+        )
         self.setPhaseName("Running forecast...", indeterminate=False)
         num_successful_realizations = self.run_ensemble_evaluator(
             run_context, evaluator_server_config
@@ -63,21 +65,21 @@ class IteratedEnsembleSmoother(BaseRunModel):
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().runWorkflows(HookRuntime.POST_SIMULATION)
-        self._post_ensemble_results(ensemble_id)
+        self._post_ensemble_results(run_context.sim_fs.case_name, ensemble_id)
         return ensemble_id
 
-    def createTargetCaseFileSystem(self, phase: int, target_case_format: str) -> EnkfFs:
-        target_fs = self.ert().getFileSystem(target_case_format % phase)
-        return target_fs
-
-    def analyzeStep(self, run_context: RunContext, ensemble_id: str) -> str:
+    def analyzeStep(
+        self, prior_storage: "EnkfFs", posterior_storage: "EnkfFs", ensemble_id: str
+    ) -> str:
         self.setPhaseName("Analyzing...", indeterminate=True)
 
         self.setPhaseName("Pre processing update...", indeterminate=True)
         self.ert().runWorkflows(HookRuntime.PRE_UPDATE)
 
         try:
-            self.facade.iterative_smoother_update(run_context, self._w_container)
+            self.facade.iterative_smoother_update(
+                prior_storage, posterior_storage, self._w_container, ensemble_id
+            )
         except ErtAnalysisError as e:
             raise ErtRunError(
                 f"Analysis of simulation failed with the following error: {e}"
@@ -100,97 +102,61 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.setPhaseCount(phase_count)
 
         target_case_format = self._simulation_arguments["target_case"]
-        run_context = self.create_context(0)
+        prior_context = self.ert().create_ensemble_context(
+            target_case_format % 0,
+            self._simulation_arguments["active_realizations"],
+            iteration=0,
+        )
 
         self.ert().analysisConfig().set_case_format(target_case_format)
 
-        self.ert().sample_prior(run_context.sim_fs, run_context.active_realizations)
-        ensemble_id = self._runAndPostProcess(run_context, evaluator_server_config)
+        self.ert().sample_prior(prior_context.sim_fs, prior_context.active_realizations)
+        ensemble_id = self._runAndPostProcess(prior_context, evaluator_server_config)
 
         analysis_config = self.ert().analysisConfig()
-        num_retries_per_iteration = analysis_config.num_retries_per_iter
-        num_retries = 0
-        current_iter = 0
-
-        while (
-            current_iter < self.facade.get_number_of_iterations()
-            and num_retries < num_retries_per_iteration
-        ):
-            pre_analysis_iter_num = self._w_container.iteration_nr - 1
-            # We run the PRE_FIRST_UPDATE hook here because the current_iter is
-            # explicitly available, versus in the run_context inside analyzeStep
-            if current_iter == 0:
-                self.ert().runWorkflows(HookRuntime.PRE_FIRST_UPDATE)
-            update_id = self.analyzeStep(run_context, ensemble_id)
-            current_iter = self._w_container.iteration_nr - 1
-
-            analysis_success = current_iter > pre_analysis_iter_num
-            if analysis_success:
-                run_context = self.create_context(
-                    current_iter, prior_context=run_context
-                )
-                ensemble_id = self._runAndPostProcess(
-                    run_context, evaluator_server_config, update_id
-                )
-                num_retries = 0
-            else:
-                run_context = self.create_context(
-                    current_iter, prior_context=run_context, rerun=True
-                )
-                ensemble_id = self._runAndPostProcess(
-                    run_context, evaluator_server_config, update_id
-                )
-                num_retries += 1
-
-        if current_iter == (phase_count - 1):
-            self.setPhase(phase_count, "Simulations completed.")
-        else:
-            raise ErtRunError(
-                (
-                    "Iterated ensemble smoother stopped: "
-                    "maximum number of iteration retries "
-                    f"({num_retries_per_iteration} retries) reached "
-                    f"for iteration {current_iter}"
-                )
-            )
-
-        return run_context
-
-    def create_context(
-        self,
-        itr: int,
-        prior_context: Optional[RunContext] = None,
-        rerun: bool = False,
-    ) -> RunContext:
-
-        target_case_format = self._simulation_arguments["target_case"]
-
-        sim_fs = self.createTargetCaseFileSystem(itr, target_case_format)
-
-        if prior_context is None:
-            mask = self._simulation_arguments["active_realizations"]
-        else:
-            state: RealizationStateEnum = (
+        self.ert().runWorkflows(HookRuntime.PRE_FIRST_UPDATE)
+        for current_iter in range(1, self.facade.get_number_of_iterations() + 1):
+            state = (
                 RealizationStateEnum.STATE_HAS_DATA  # type: ignore
                 | RealizationStateEnum.STATE_INITIALIZED
             )
-            mask = sim_fs.getStateMap().createMask(state)
+            posterior_context = self.ert().create_ensemble_context(
+                target_case_format % current_iter,
+                prior_context.sim_fs.getStateMap().createMask(state),
+                iteration=current_iter,
+            )
+            update_success = False
+            for iteration in range(analysis_config.num_retries_per_iter):
+                update_id = self.analyzeStep(
+                    prior_context.sim_fs,
+                    posterior_context.sim_fs,
+                    ensemble_id,
+                )
 
-        if rerun or itr >= self.facade.get_number_of_iterations():
-            target_fs = None
-        else:
-            target_fs = self.createTargetCaseFileSystem(itr + 1, target_case_format)
+                analysis_success = current_iter < self._w_container.iteration_nr
+                if analysis_success:
+                    update_success = True
+                    break
+                ensemble_id = self._runAndPostProcess(
+                    prior_context, evaluator_server_config, update_id
+                )
+            if update_success:
+                ensemble_id = self._runAndPostProcess(
+                    posterior_context, evaluator_server_config
+                )
+                self.setPhase(phase_count, "Simulations completed.")
+            else:
+                raise ErtRunError(
+                    (
+                        "Iterated ensemble smoother stopped: "
+                        "maximum number of iteration retries "
+                        f"({analysis_config.num_retries_per_iter} retries) reached "
+                        f"for iteration {current_iter}"
+                    )
+                )
+            prior_context = posterior_context
 
-        run_context = self.ert().create_ensemble_smoother_run_context(
-            source_filesystem=sim_fs,
-            target_filesystem=target_fs,
-            active_mask=mask,
-            iteration=itr,
-        )
-        self._run_context = run_context
-        self._last_run_iteration = run_context.iteration
-        self.ert().getEnkfFsManager().switchFileSystem(sim_fs.case_name)
-        return run_context
+        return posterior_context
 
     @classmethod
     def name(cls) -> str:

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -102,7 +102,7 @@ class CSVExportJob(ErtPlugin):
                 cases = case_list.split(",")
 
         if case_list is None or len(cases) == 0:
-            cases = [self.ert().getCurrentFileSystem().getCaseName()]
+            cases = [facade.get_current_fs().case_name]
 
         if design_matrix_path is not None:
             if not os.path.exists(design_matrix_path):

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -142,7 +142,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
             cases = case_list.split(",")
 
         if case_list is None or len(cases) == 0:
-            cases = [self.ert().getEnkfFsManager().getCurrentFileSystem().getCaseName()]
+            cases = [facade.get_current_fs().case_name]
 
         data_frame = pandas.DataFrame()
         for index, case in enumerate(cases):
@@ -169,7 +169,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                 obs_node = obs_vector.getNode(report_step)
 
                 rft_data = facade.load_gen_data(case, data_key, report_step)
-                fs = self.ert().getFileSystem(case)
+                fs = self.ert().storage_manager[case]
                 realizations = fs.realizationList(RealizationStateEnum.STATE_HAS_DATA)
 
                 # Trajectory

--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -25,8 +25,8 @@ def create_experiment(ert) -> dict:
 
 
 def create_ensemble(
-    ert,
     size: int,
+    case_name: str,
     active_realizations: List[int],
     parameter_names: List[str],
     response_names: List[str],
@@ -37,7 +37,7 @@ def create_ensemble(
         parameter_names=parameter_names,
         response_names=response_names,
         update_id=update_id,
-        userdata={"name": ert.get_current_case_name()},
+        userdata={"name": case_name},
         active_realizations=active_realizations,
     )
 
@@ -347,15 +347,15 @@ def post_update_data(
 
 
 @feature_enabled("new-storage")
-def post_ensemble_results(ert: "LibresFacade", ensemble_id: str) -> None:
+def post_ensemble_results(
+    ert: "LibresFacade", case_name: str, ensemble_id: str
+) -> None:
 
     observations = _get_from_server(
         f"ensembles/{ensemble_id}/observations",
     ).json()
 
-    for record in create_response_records(
-        ert, ert.get_current_case_name(), observations
-    ):
+    for record in create_response_records(ert, case_name, observations):
         realizations = record["data"]
         name = record["name"]
         for index, data in realizations.items():
@@ -378,6 +378,7 @@ def post_ensemble_results(ert: "LibresFacade", ensemble_id: str) -> None:
 @feature_enabled("new-storage")
 def post_ensemble_data(
     ert: "LibresFacade",
+    case_name: str,
     ensemble_size: int,
     update_id: Optional[str] = None,
     active_realizations: Optional[List[int]] = None,
@@ -410,8 +411,8 @@ def post_ensemble_data(
     ens_response = _post_to_server(
         f"experiments/{experiment_id}/ensembles",
         json=create_ensemble(
-            ert,
             size=ensemble_size,
+            case_name=case_name,
             parameter_names=[param["name"] for param in parameters],
             response_names=response_names,
             update_id=update_id,

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -207,7 +207,7 @@ class BatchSimulator:
         """
 
         self.ert.addDataKW("<CASE_NAME>", _slug(case_name))
-        file_system = self.ert.getEnkfFsManager().getFileSystem(case_name)
+        file_system = self.ert.storage_manager.add_case(case_name)
         for sim_id, (geo_id, controls) in enumerate(case_data):
             assert isinstance(geo_id, int)
             self._setup_sim(sim_id, controls, file_system)

--- a/tests/performance_tests/enkf/test_enkf_fs_performance.py
+++ b/tests/performance_tests/enkf/test_enkf_fs_performance.py
@@ -2,8 +2,8 @@ from ert._c_wrappers.enkf import EnKFMain, ResConfig
 
 
 def mount_and_umount(ert, case_name):
-    fs_manager = ert.getEnkfFsManager()
-    mount_point = fs_manager.getFileSystem(case_name)
+    fs_manager = ert.storage_manager
+    mount_point = fs_manager[case_name]
     del mount_point
 
 

--- a/tests/performance_tests/enkf/test_load_state.py
+++ b/tests/performance_tests/enkf/test_load_state.py
@@ -13,8 +13,7 @@ def test_load_from_context(benchmark, template_config):
     with template_config["folder"].as_cwd():
         config = ResConfig("poly.ert")
         ert = EnKFMain(config)
-        load_into = ert.getEnkfFsManager().getFileSystem("A1")
-        ert.getEnkfFsManager().getFileSystem("default")
+        load_into = ert.storage_manager.add_case("A1")
         expected_reals = template_config["reals"]
         realisations = [True] * expected_reals
         loaded_reals = benchmark(ert.loadFromForwardModel, realisations, 0, load_into)
@@ -29,7 +28,7 @@ def test_load_from_fs(benchmark, template_config):
     with template_config["folder"].as_cwd():
         config = ResConfig("poly.ert")
         ert = EnKFMain(config)
-        load_from = ert.getEnkfFsManager().getFileSystem("default")
+        load_from = ert.storage_manager["default"]
         expected_reals = template_config["reals"]
         realisations = [True] * expected_reals
         loaded_reals = benchmark(ert.loadFromForwardModel, realisations, 0, load_from)

--- a/tests/test_config_parsing/test_defines.py
+++ b/tests/test_config_parsing/test_defines.py
@@ -6,7 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain, ResConfig
 def read_jobname(config_file):
     res_config = ResConfig(config_file)
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(0)
+    run_context = ert.create_ensemble_context("prior", range(ert.getEnsembleSize()), 0)
     ert.createRunPath(run_context)
     return run_context[0].job_name
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -29,11 +29,8 @@ def test_update_report(snake_oil_case_storage, snapshot):
     """
     ert = snake_oil_case_storage
     es_update = ESUpdate(ert)
-    fsm = ert.getEnkfFsManager()
-    sim_fs = fsm.getFileSystem("default_0")
-    target_fs = fsm.getFileSystem("target")
-    run_context = RunContext(sim_fs, target_fs)
-    es_update.smootherUpdate(run_context)
+    fsm = ert.storage_manager
+    es_update.smootherUpdate(fsm["default_0"], fsm.add_case("target"), "id")
     log_file = Path(ert.analysisConfig().get_log_path()) / "deprecated"
     snapshot.assert_match(log_file.read_text("utf-8"), "update_log")
 
@@ -81,16 +78,15 @@ def test_update_snapshot(snake_oil_case_storage, module, expected_gen_kw):
     ert = snake_oil_case_storage
     es_update = ESUpdate(ert)
     ert.analysisConfig().select_module(module)
-    fsm = ert.getEnkfFsManager()
-    sim_fs = fsm.getFileSystem("default_0")
-    target_fs = fsm.getFileSystem("target")
-    run_context = RunContext(sim_fs, target_fs)
+    fsm = ert.storage_manager
+    sim_fs = fsm["default_0"]
+    target_fs = fsm.add_case("target")
 
     if module == "IES_ENKF":
         w_container = IterativeEnsembleSmoother(ert.getEnsembleSize())
-        es_update.iterative_smoother_update(run_context, w_container)
+        es_update.iterative_smoother_update(sim_fs, target_fs, w_container, "id")
     else:
-        es_update.smootherUpdate(run_context)
+        es_update.smootherUpdate(sim_fs, target_fs, "id")
 
     conf = ert.ensembleConfig()["SNAKE_OIL_PARAM"]
     sim_node = EnkfNode(conf)
@@ -217,25 +213,25 @@ def test_localization(snake_oil_case_storage, expected_target_gen_kw, update_ste
     """
     ert = snake_oil_case_storage
     es_update = ESUpdate(ert)
-    fsm = ert.getEnkfFsManager()
-    sim_fs = fsm.getFileSystem("default_0")
-    target_fs = fsm.getFileSystem("target")
     # perform localization
 
     ert.update_configuration = update_step
 
-    run_context = ert.create_ensemble_smoother_run_context(
-        source_filesystem=sim_fs, target_filesystem=target_fs, iteration=0
+    prior = ert.load_ensemble_context(
+        "default_0", [True] * ert.getEnsembleSize(), iteration=0
     )
-    es_update.smootherUpdate(run_context)
+    posterior = ert.create_ensemble_context(
+        "target", [True] * ert.getEnsembleSize(), iteration=1
+    )
+    es_update.smootherUpdate(prior.sim_fs, posterior.sim_fs, prior.run_id)
 
     conf = ert.ensembleConfig()["SNAKE_OIL_PARAM"]
     sim_node = EnkfNode(conf)
     target_node = EnkfNode(conf)
 
     node_id = NodeId(0, 0)
-    sim_node.load(sim_fs, node_id)
-    target_node.load(target_fs, node_id)
+    sim_node.load(prior.sim_fs, node_id)
+    target_node.load(posterior.sim_fs, node_id)
 
     sim_gen_kw = list(sim_node.asGenKw())
     target_gen_kw = list(target_node.asGenKw())
@@ -304,14 +300,13 @@ SUMMARY_OBSERVATION EXTREMELY_HIGH_STD
     ert = EnKFMain(res_config)
     es_update = ESUpdate(ert)
     ert.analysisConfig().select_module("IES_ENKF")
-    fsm = ert.getEnkfFsManager()
-    sim_fs = fsm.getFileSystem("default_0")
-    target_fs = fsm.getFileSystem("target")
-    run_context = RunContext(sim_fs, target_fs)
+    fsm = ert.storage_manager
+    sim_fs = fsm["default_0"]
+    target_fs = fsm.add_case("target")
     ert.analysisConfig().set_enkf_alpha(alpha)
     w_container = IterativeEnsembleSmoother(ert.getEnsembleSize())
-    es_update.iterative_smoother_update(run_context, w_container)
-    result_snapshot = es_update.update_snapshots[run_context.run_id]
+    es_update.iterative_smoother_update(sim_fs, target_fs, w_container, "id")
+    result_snapshot = es_update.update_snapshots["id"]
     assert result_snapshot.alpha == alpha
     assert result_snapshot.update_step_snapshots["ALL_ACTIVE"].obs_status == expected
 
@@ -338,14 +333,11 @@ def test_update_multiple_param(copy_case):
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)
     es_update = ESUpdate(ert)
-    fsm = ert.getEnkfFsManager()
-    sim_fs = fsm.getFileSystem("default")
-    target_fs = fsm.getFileSystem("target")
+    fsm = ert.storage_manager
+    sim_fs = fsm["default"]
+    target_fs = fsm.add_case("target")
 
-    run_context = ert.create_ensemble_smoother_run_context(
-        source_filesystem=sim_fs, target_filesystem=target_fs, iteration=0
-    )
-    es_update.smootherUpdate(run_context)
+    es_update.smootherUpdate(sim_fs, target_fs, "an id")
 
     prior = _create_temporary_parameter_storage(
         sim_fs, ert.ensembleConfig(), list(range(10))

--- a/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_kw_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_kw_config.py
@@ -182,9 +182,9 @@ def test_gen_kw_is_log_or_not(tmpdir, distribution, expect_log, parameters_regex
         gen_kw_config = node.getModelConfig()
         assert isinstance(gen_kw_config, GenKwConfig)
         assert gen_kw_config.shouldUseLogScale(0) is expect_log
-        run_context = ert.create_ensemble_experiment_run_context(0)
-        ert.sample_prior(run_context.sim_fs, run_context.active_realizations)
-        ert.createRunPath(run_context)
+        prior = ert.create_ensemble_context("prior", [True], 0)
+        ert.sample_prior(prior.sim_fs, prior.active_realizations)
+        ert.createRunPath(prior)
         assert re.match(
             parameters_regex,
             Path("simulations/realization-0/iter-0/parameters.txt").read_text(),

--- a/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_data.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/data/test_gen_data.py
@@ -6,7 +6,7 @@ def test_load_active_masks(snake_oil_case_storage):
     case1 = "default_0"
     ert = snake_oil_case_storage
 
-    fs1 = ert.getEnkfFsManager().getFileSystem(case1)
+    fs1 = ert.storage_manager[case1]
     config_node = ert.ensembleConfig().getNode("SNAKE_OIL_OPR_DIFF")
     data_node = EnkfNode(config_node)
     data_node.tryLoad(fs1, NodeId(199, 0))
@@ -35,7 +35,7 @@ def test_load_active_masks(snake_oil_case_storage):
 
 def test_create(snake_oil_case_storage):
     ert = snake_oil_case_storage
-    fs1 = ert.getEnkfFsManager().getCurrentFileSystem()
+    fs1 = ert.storage_manager.current_case
     config_node = ert.ensembleConfig().getNode("SNAKE_OIL_OPR_DIFF")
 
     data_node = EnkfNode(config_node)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_runpath.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_runpath.py
@@ -12,12 +12,9 @@ def test_with_gen_kw(copy_case):
     copy_case("snake_oil")
     res_config = ResConfig("snake_oil.ert")
     main = EnKFMain(res_config)
-    fs = main.getEnkfFsManager().getCurrentFileSystem()
-    run_context = main.create_ensemble_experiment_run_context(
-        source_filesystem=fs, active_mask=[True], iteration=0
-    )
-    main.sample_prior(fs, run_context.active_realizations)
-    main.createRunPath(run_context)
+    prior = main.create_ensemble_context("prior", [True], 0)
+    main.sample_prior(prior.sim_fs, prior.active_realizations)
+    main.createRunPath(prior)
     assert os.path.exists(
         "storage/snake_oil/runpath/realization-0/iter-0/parameters.txt"
     )
@@ -35,11 +32,9 @@ def test_without_gen_kw():
     assert "GEN_KW" not in Path("snake_oil.ert").read_text("utf-8")
     res_config = ResConfig("snake_oil.ert")
     main = EnKFMain(res_config)
-    fs = main.getEnkfFsManager().getCurrentFileSystem()
-    run_context = main.create_ensemble_experiment_run_context(
-        source_filesystem=fs, active_mask=[True], iteration=0
-    )
-    main.createRunPath(run_context)
+    prior = main.create_ensemble_context("prior", [True], 0)
+    main.sample_prior(prior.sim_fs, prior.active_realizations)
+    main.createRunPath(prior)
     assert os.path.exists("storage/snake_oil/runpath/realization-0/iter-0")
     assert not os.path.exists(
         "storage/snake_oil/runpath/realization-0/iter-0/parameters.txt"

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ert_run_context.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ert_run_context.py
@@ -1,31 +1,24 @@
+from pathlib import Path
+
 import pytest
 
 from ert._c_wrappers.enkf import RunContext
-from ert._c_wrappers.enkf.runpaths import Runpaths
-
-
-def test_case_init():
-    mask = [True] * 100
-    RunContext(None, mask=mask)
+from ert._c_wrappers.enkf.enkf_fs import EnkfFs
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_create():
     mask = [True] * 100
     mask[50] = False
-    runpaths = Runpaths(
-        runpath_format="path/to/sim%d",
-        job_name_format="job%d",
-    )
     itr = 0
     realizations = list(range(len(mask)))
     run_context1 = RunContext(
-        None,
-        None,
+        EnkfFs.createFileSystem("test", True, len(realizations)),
+        "path/to/sim%d",
+        "job%d",
+        Path("runpath_file_name"),
         mask,
-        runpaths.get_paths(realizations, itr),
-        runpaths.get_jobnames(realizations, itr),
-        itr,
+        iteration=itr,
     )
     run_id1 = run_context1.run_id
 
@@ -34,15 +27,15 @@ def test_create():
         run_arg0.getQueueIndex()
 
     assert run_arg0.iter_id == itr
-    assert run_arg0.get_run_id() == run_id1
+    assert run_arg0.get_run_id() == str(run_id1)
 
     run_context2 = RunContext(
-        None,
-        None,
+        EnkfFs.createFileSystem("test", True, len(realizations)),
+        "path/to/sim%d",
+        "job%d",
+        Path("runpath_file_name"),
         mask,
-        runpaths.get_paths(realizations, itr),
-        runpaths.get_jobnames(realizations, itr),
-        itr,
+        iteration=itr,
     )
     run_id2 = run_context2.run_id
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -32,12 +32,12 @@ def test_field_basics(snake_oil_field_example):
 
 def test_field_export(snake_oil_field_example):
     ert = snake_oil_field_example
-    fs_manager = ert.getEnkfFsManager()
+    fs_manager = ert.storage_manager
     ens_config = ert.ensembleConfig()
     config_node = ens_config["PERMX"]
     data_node = EnkfNode(config_node)
     node_id = NodeId(0, 0)
-    fs = fs_manager.getCurrentFileSystem()
+    fs = fs_manager.current_case
     data_node.tryLoad(fs, node_id)
 
     data_node.export("export/with/path/PERMX.grdecl")
@@ -46,11 +46,11 @@ def test_field_export(snake_oil_field_example):
 
 def test_field_export_many(snake_oil_field_example):
     ert = snake_oil_field_example
-    fs_manager = ert.getEnkfFsManager()
+    fs_manager = ert.storage_manager
     ens_config = ert.ensembleConfig()
     config_node = ens_config["PERMX"]
 
-    fs = fs_manager.getCurrentFileSystem()
+    fs = fs_manager.current_case
     ert.sample_prior(fs, list(range(ert.getEnsembleSize())))
     # Filename without embedded %d - TypeError
     with pytest.raises(TypeError):

--- a/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
@@ -151,13 +151,11 @@ def test_load_forward_model_summary(summary_configuration, expected, caplog):
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     facade = LibresFacade(ert)
     with caplog.at_level(logging.ERROR):
-        loaded = facade.load_from_forward_model("default", [True], 0)
+        loaded = facade.load_from_forward_model("prior", [True], 0)
     expected_loaded, expected_log_message = expected
     assert loaded == expected_loaded
     if expected_log_message:

--- a/tests/unit_tests/c_wrappers/res/enkf/test_priors.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_priors.py
@@ -7,12 +7,13 @@ from ert._c_wrappers.enkf import EnKFMain, ResConfig
 
 def test_adding_priors(poly_case):
     m = poly_case
-    run_context = m.create_ensemble_experiment_run_context(
-        active_mask=[True] * 10,
+    prior = m.create_ensemble_context(
+        "prior",
+        [True] * 10,
         iteration=0,
     )
-    m.sample_prior(run_context.sim_fs, run_context.active_realizations)
-    m.createRunPath(run_context)
+    m.sample_prior(prior.sim_fs, prior.active_realizations)
+    m.createRunPath(prior)
     del m
     gc.collect()
 
@@ -20,8 +21,9 @@ def test_adding_priors(poly_case):
         f.write("COEFF_D UNIFORM 0 5\n")
     m = EnKFMain(ResConfig("poly.ert"))
 
-    run_context = m.create_ensemble_experiment_run_context(
-        active_mask=[True] * 10,
+    prior = m.load_ensemble_context(
+        "prior",
+        [True] * 10,
         iteration=0,
     )
     with pytest.raises(
@@ -29,4 +31,4 @@ def test_adding_priors(poly_case):
         match="The configuration of GEN_KW "
         "parameter COEFFS is of size 4, expected 3",
     ):
-        m.createRunPath(run_context)
+        m.createRunPath(prior)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_run_path_creation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_run_path_creation.py
@@ -30,10 +30,8 @@ def test_that_run_template_replace_symlink_does_not_write_to_source():
     Path("config.ert").write_text(config_text)
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
-    run_path = Path(run_context.paths[0])
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
+    run_path = Path(run_context[0].runpath)
     os.makedirs(run_path)
     # Write a file that will be symlinked into the run run path with the
     # same name as the target_file
@@ -64,12 +62,10 @@ def test_run_template_replace_in_file_with_custom_define():
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     assert (
-        Path(run_context.paths[0]) / "result.txt"
+        Path(run_context[0].runpath) / "result.txt"
     ).read_text() == "I WANT TO REPLACE:my_custom_variable"
 
 
@@ -102,12 +98,10 @@ def test_run_template_replace_in_file(key, expected):
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     assert (
-        Path(run_context.paths[0]) / "result.txt"
+        Path(run_context[0].runpath) / "result.txt"
     ).read_text() == f"I WANT TO REPLACE:{expected}"
 
 
@@ -134,12 +128,10 @@ def test_run_template_replace_in_ecl(ecl_base, expected_file):
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     assert (
-        Path(run_context.paths[0]) / expected_file
+        Path(run_context[0].runpath) / expected_file
     ).read_text() == "I WANT TO REPLACE:1"
 
 
@@ -177,12 +169,10 @@ def test_run_template_replace_in_ecl_data_file(key, expected):
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     assert (
-        Path(run_context.paths[0]) / "ECL_CASE0.DATA"
+        Path(run_context[0].runpath) / "ECL_CASE0.DATA"
     ).read_text() == f"I WANT TO REPLACE:{expected}"
 
 
@@ -205,12 +195,10 @@ def test_run_template_replace_in_file_name():
 
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     ert.createRunPath(run_context)
     assert (
-        Path(run_context.paths[0]) / "result.txt"
+        Path(run_context[0].runpath) / "result.txt"
     ).read_text() == "Not important, name of the file is important"
 
 
@@ -235,13 +223,11 @@ def test_that_sampling_prior_makes_initialized_fs():
         fh.writelines("MY_KEYWORD NORMAL 0 1")
     res_config = ResConfig("config.ert")
     ert = EnKFMain(res_config)
-    run_context = ert.create_ensemble_experiment_run_context(
-        iteration=0, active_mask=[True]
-    )
+    run_context = ert.create_ensemble_context("prior", [True], iteration=0)
     storage_manager = ert.storage_manager
-    assert not storage_manager["default"].is_initalized
+    assert not storage_manager["prior"].is_initalized
     ert.sample_prior(run_context.sim_fs, run_context.active_realizations)
-    assert storage_manager["default"].is_initalized
+    assert storage_manager["prior"].is_initalized
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/c_wrappers/res/enkf/test_simulation_batch.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_simulation_batch.py
@@ -32,8 +32,8 @@ def test_run_simulation_batch(setup_case):
     injection_node = EnkfNode(injection_control)
     injection_node_ext = injection_node.as_ext_param()
 
-    fs_manager = ert.getEnkfFsManager()
-    sim_fs = fs_manager.getFileSystem("sim_fs")
+    fs_manager = ert.storage_manager
+    sim_fs = fs_manager.add_case("sim_fs")
     state_map = sim_fs.getStateMap()
     batch_size = ens_size
     for iens in range(batch_size):
@@ -50,9 +50,7 @@ def test_run_simulation_batch(setup_case):
         state_map[iens] = RealizationStateEnum.STATE_INITIALIZED
 
     mask = [True] * batch_size
-    run_context = ert.create_ensemble_experiment_run_context(
-        source_filesystem=sim_fs, active_mask=mask, iteration=0
-    )
+    run_context = ert.load_ensemble_context(sim_fs.case_name, mask, iteration=0)
     ert.createRunPath(run_context)
     job_queue = ert.get_queue_config().create_job_queue()
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_summary_key_set.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_summary_key_set.py
@@ -78,7 +78,7 @@ def test_with_enkf_fs():
     fs.sync()
 
     ert = EnKFMain(res_config)
-    fs = ert.getEnkfFsManager().getCurrentFileSystem()
+    fs = ert.storage_manager.current_case
     summary_key_set = fs.getSummaryKeySet()
     assert "FOPT" in summary_key_set
     assert "WWCT" in summary_key_set

--- a/tests/unit_tests/c_wrappers/test_integration_config.py
+++ b/tests/unit_tests/c_wrappers/test_integration_config.py
@@ -13,7 +13,9 @@ def _create_runpath(enkf_main: EnKFMain) -> RunContext:
     """
     Instantiate an ERT runpath. This will create the parameter coefficients.
     """
-    run_context = enkf_main.create_ensemble_experiment_run_context(iteration=0)
+    run_context = enkf_main.create_ensemble_context(
+        "prior", [True] * enkf_main.getEnsembleSize(), iteration=0
+    )
     enkf_main.createRunPath(run_context)
     return run_context
 

--- a/tests/unit_tests/cli/test_model_factory.py
+++ b/tests/unit_tests/cli/test_model_factory.py
@@ -57,18 +57,6 @@ def test_custom_realizations(poly_case):
     assert model_factory._realizations(args, ensemble_size) == active_mask
 
 
-def test_init_iteration_number(poly_case):
-    ert = poly_case
-    facade = LibresFacade(ert)
-    args = Namespace(iter_num=10, realizations=None)
-    model = model_factory._setup_ensemble_experiment(
-        ert, args, facade.get_ensemble_size(), "experiment_id"
-    )
-    run_context = model.create_context()
-    assert model._simulation_arguments["iter_num"] == 10
-    assert run_context.iteration == 10
-
-
 def test_setup_single_test_run(poly_case):
     ert = poly_case
 
@@ -76,8 +64,6 @@ def test_setup_single_test_run(poly_case):
     assert isinstance(model, SingleTestRun)
     assert len(model._simulation_arguments.keys()) == 1
     assert "active_realizations" in model._simulation_arguments
-
-    model.create_context()
 
 
 def test_setup_ensemble_experiment(poly_case):
@@ -90,8 +76,6 @@ def test_setup_ensemble_experiment(poly_case):
     assert isinstance(model, EnsembleExperiment)
     assert len(model._simulation_arguments.keys()) == 2
     assert "active_realizations" in model._simulation_arguments
-
-    model.create_context()
 
 
 def test_setup_ensemble_smoother(poly_case):
@@ -112,8 +96,6 @@ def test_setup_ensemble_smoother(poly_case):
     assert "active_realizations" in model._simulation_arguments
     assert "target_case" in model._simulation_arguments
     assert "analysis_module" in model._simulation_arguments
-
-    model.create_context()
 
 
 def test_setup_multiple_data_assimilation(poly_case):
@@ -165,5 +147,3 @@ def test_setup_iterative_ensemble_smoother(poly_case):
     assert "analysis_module" in model._simulation_arguments
     assert "num_iterations" in model._simulation_arguments
     assert facade.get_number_of_iterations() == 10
-
-    model.create_context(0)

--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -79,7 +79,7 @@ class MockWContainer:
 
 
 class MockEsUpdate:
-    def iterative_smoother_update(self, _, w_container):
+    def iterative_smoother_update(self, _, posterior_storage, w_container, run_id):
         w_container.iteration_nr += 1
 
 

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -22,7 +22,7 @@ def fixture_patch_enkf_main(monkeypatch, tmp_path):
     mocked_enkf_main = Mock()
     mocked_enkf_main.getWorkflowList.return_value = plugins_mock
     mocked_enkf_main.getEnsembleSize.return_value = 10
-    mocked_enkf_main.storage_manager = []
+    mocked_enkf_main.storage_manager = MagicMock()
 
     mocked_enkf_main.getWorkflowList.return_value.getWorkflowNames.return_value = [
         "my_workflow"

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -18,7 +18,7 @@ from ert.gui.tools.manage_cases.case_init_configuration import (
 @pytest.mark.usefixtures("copy_poly_case")
 def test_case_tool_init_prior(qtbot):
     ert = EnKFMain(ResConfig("poly.ert"))
-    storage = ert.getCurrentFileSystem()
+    storage = ert.storage_manager.current_case
     assert (
         list(storage.getStateMap())
         == [RealizationStateEnum.STATE_UNDEFINED] * ert.getEnsembleSize()

--- a/tests/unit_tests/models/test_base_run_model.py
+++ b/tests/unit_tests/models/test_base_run_model.py
@@ -64,13 +64,9 @@ def test_failed_realizations(initials, completed, any_failed, failures):
 def test_run_ensemble_evaluator():
     run_arg = MagicMock()
     run_arg.run_status = RunStatusType.JOB_LOAD_FAILURE
-
-    run_context = RunContext(
-        None, mask=[True], paths=["some%d/path%d"], jobnames=["some_job%d"], iteration=0
-    )
-    run_context.run_args = [run_arg]
-    run_context.deactivate_realization = MagicMock()
-
+    run_context = MagicMock()
+    run_context.__iter__.return_value = [run_arg]
+    run_context.is_active.return_value = True
     BaseRunModel.deactivate_failed_jobs(run_context)
 
     run_context.deactivate_realization.assert_called_with(0)

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -12,9 +12,9 @@ def test_simulation_context(setup_case):
     even_mask = [True, False] * (size // 2)
     odd_mask = [False, True] * (size // 2)
 
-    fs_manager = ert.getEnkfFsManager()
-    even_half = fs_manager.getFileSystem("even_half")
-    odd_half = fs_manager.getFileSystem("odd_half")
+    fs_manager = ert.storage_manager
+    even_half = fs_manager.add_case("even_half")
+    odd_half = fs_manager.add_case("odd_half")
 
     case_data = [(geo_id, {}) for geo_id in range(size)]
     even_ctx = SimulationContext(ert, even_half, even_mask, 0, case_data)

--- a/tests/unit_tests/test_libres_facade.py
+++ b/tests/unit_tests/test_libres_facade.py
@@ -39,10 +39,13 @@ def test_data_fetching(snake_oil_case_storage):
 
 
 def test_data_fetching_missing_case(facade):
+    with pytest.raises(KeyError, match="No such case name: nocase in"):
+        facade.gather_summary_data("nocase", "BPR:1,3,8")
+    with pytest.raises(KeyError, match="No such case name: nocase in"):
+        facade.gather_gen_kw_data("nocase", "SNAKE_OIL_PARAM:BPR_138_PERSISTENCE")
+
     data = [
         facade.gather_gen_data_data("nocase", "SNAKE_OIL_GPR_DIFF@199"),
-        facade.gather_summary_data("nocase", "BPR:1,3,8"),
-        facade.gather_gen_kw_data("nocase", "SNAKE_OIL_PARAM:BPR_138_PERSISTENCE"),
     ]
 
     for dataframe in data:
@@ -52,9 +55,9 @@ def test_data_fetching_missing_case(facade):
 
 def test_data_fetching_missing_key(facade):
     data = [
-        facade.gather_gen_data_data("default_0", "nokey"),
-        facade.gather_summary_data("default_0", "nokey"),
-        facade.gather_gen_kw_data("default_0", "nokey"),
+        facade.gather_gen_data_data("default", "nokey"),
+        facade.gather_summary_data("default", "nokey"),
+        facade.gather_gen_kw_data("default", "nokey"),
     ]
 
     for dataframe in data:


### PR DESCRIPTION
Port of: https://github.com/equinor/ert/pull/4331

The way the RunContext were handled in the run models were very statefull and hard to read. This refactors it to be more explicit, where the main goal was to remove the notion of source and target file system, and instead make one context for each file system.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
