### PR TITLE
Rename badly named test

### DIFF
--- a/tests/test_config_parsing/test_defines.py
+++ b/tests/test_config_parsing/test_defines.py
@@ -56,7 +56,9 @@ JOBNAME <A>%d""",
         ),
     ],
 )
-def test_some_stuff(defines, expected, tmp_path, monkeypatch):
+def test_that_user_defined_substitution_works_as_expected(
+    defines, expected, tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     config_file = tmp_path / "config_file.ert"
     config_file.write_text(defines)


### PR DESCRIPTION
Fixes badly named test `test_some_stuff`.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
