### PR TITLE
Type-check ert.services

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -5,7 +5,6 @@ exclude = (?x)(
     src/ert/logging
     | src/ert/shared
     | src/ert/dark_storage
-    | src/ert/services
     | src/ert/_c_wrappers
     | src/ert/__main__.py
     | src/ert/ensemble_evaluator
@@ -18,9 +17,6 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-ert.cli.*]
-ignore_errors = True
-
-[mypy-ert.services.*]
 ignore_errors = True
 
 [mypy-ert.gui.*]

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -2,13 +2,14 @@ import os
 import pathlib
 from datetime import datetime
 from logging import FileHandler
+from typing import Any
 
 LOGGING_CONFIG = pathlib.Path(__file__).parent.resolve() / "logger.conf"
 STORAGE_LOG_CONFIG = pathlib.Path(__file__).parent.resolve() / "storage_log.conf"
 
 
 class TimestampedFileHandler(FileHandler):
-    def __init__(self, filename: str, *args, **kwargs) -> None:
+    def __init__(self, filename: str, *args: Any, **kwargs: Any) -> None:
 
         filename, extension = os.path.splitext(filename)
         filename = (

--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import os
@@ -156,7 +158,7 @@ class _Proc(threading.Thread):
         self.join()
         return self._childproc.returncode
 
-    def _read_conn_info(self, proc: Popen) -> Optional[str]:
+    def _read_conn_info(self, proc: Popen[bytes]) -> Optional[str]:
         comm_buf = io.StringIO()
         first_iter = True
         while first_iter or proc.poll() is None:
@@ -272,7 +274,7 @@ class BaseService:
     def connect(
         cls: Type[T],
         *,
-        project: Optional[os.PathLike] = None,
+        project: Optional[os.PathLike[str]] = None,
         timeout: Optional[int] = None,
     ) -> T:
         if cls._instance is not None:

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -18,7 +18,7 @@ from ert.shared.plugins import ErtPluginContext
 from ert.shared.storage.command import add_parser_options
 
 
-class Server(uvicorn.Server):
+class Server(uvicorn.Server):  # type: ignore
     def __init__(
         self,
         config: uvicorn.Config,
@@ -27,7 +27,7 @@ class Server(uvicorn.Server):
         super().__init__(config)
         self.connection_info = connection_info
 
-    async def startup(self, sockets: list = None) -> None:
+    async def startup(self, sockets: Optional[List[socket.socket]] = None) -> None:
         """Overridden startup that also sends connection information"""
         await super().startup(sockets)
         if not self.started:

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from os import PathLike
 from typing import Any, Optional, Tuple
@@ -14,7 +16,7 @@ class Storage(BaseService):
 
     def __init__(
         self,
-        res_config: Optional[PathLike] = None,
+        res_config: Optional[PathLike[str]] = None,
         database_url: str = "sqlite:///ert.db",
         verbose: bool = False,
         *args: Any,
@@ -44,7 +46,7 @@ class Storage(BaseService):
         return ("__token__", self.fetch_conn_info()["authtoken"])
 
     @classmethod
-    def init_service(cls, *args: Any, **kwargs: Any) -> _Context:
+    def init_service(cls, *args: Any, **kwargs: Any) -> _Context[Storage]:
         try:
             service = cls.connect(timeout=0, project=kwargs.get("project"))
             # Check the server is up and running
@@ -63,7 +65,7 @@ class Storage(BaseService):
                 resp = requests.get(f"{url}/healthcheck", auth=self.fetch_auth())
                 if resp.status_code == 200:
                     self._url = url
-                    return url
+                    return str(url)
                 logging.getLogger(__name__).info(
                     f"Connecting to {url} got status: "
                     f"{resp.status_code}, {resp.headers}, {resp.reason}, {resp.text}"


### PR DESCRIPTION
Fixes typing issues with ert.services, allowing it to be automatically type-checked with mypy.

I use the `annotations` from `__future__` (ie, backporting features from future Python versions). This is a 3.11 feature that makes type annotations lazy. In particular, this means that we don't need to wrap types in quotes (so that they're string literals). This should have a marginal performance improvement as generic types are no longer instantiated. (Ie, `List` is a normal Python class, and you pay a start-up penalty for doing `List[str]` as it actually creates this object when the module is initialised, whether you actually use this type at runtime or not)