### PR TITLE
Type-check `ert.data`

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -18,9 +18,6 @@ ignore_errors = True
 [mypy-ert.gui.*]
 ignore_errors = True
 
-[mypy-ert.data.*]
-ignore_errors = True
-
 [mypy-_ert_com_protocol._schema_pb2]
 ignore_errors = True
 

--- a/src/ert/_c_wrappers/enkf/observations/obs_vector.py
+++ b/src/ert/_c_wrappers/enkf/observations/obs_vector.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Union
 
 from cwrap import BaseCClass
 
@@ -85,7 +85,7 @@ class ObsVector(BaseCClass):
         for step in self.getStepList():
             yield self.getNode(step)
 
-    def getStepList(self):
+    def getStepList(self) -> List[int]:
         """
         Will return an IntVector with the active report steps.
         """

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -5,6 +5,7 @@ The main goal is to facilitate data-analysis using scipy and similar tools,
 instead of having to implement analysis-functionality into ERT using C/C++.
 The API is typically meant used as part of workflows.
 """
+from __future__ import annotations
 
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional
@@ -84,7 +85,7 @@ class MeasuredData:
         self._set_data(filtered_dataset)
 
     def is_empty(self) -> bool:
-        return self.data.empty
+        return bool(self.data.empty)
 
     def _get_data(
         self, observation_keys: List[str], load_data: bool, case_name: str
@@ -173,4 +174,4 @@ class MeasuredData:
                 index_cond = [data_index == index for index in index_list]
                 index_cond = np.logical_or.reduce(index_cond)
                 conditions.append(np.logical_and(index_cond, (names == obs_key)))
-        return np.logical_or.reduce(conditions)
+        return np.logical_or.reduce(conditions)  # type: ignore

--- a/tests/unit_tests/data/test_loader.py
+++ b/tests/unit_tests/data/test_loader.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, Mock
 
-import deprecation
 import pandas as pd
 import pytest
 
@@ -78,51 +77,7 @@ def test_load_general_obs(facade, monkeypatch):
     assert all(result.values.flatten() == [10.0, 20.0, 30.0, 1.0, 2.0, 3.0])
 
 
-@pytest.mark.parametrize("func", [loader.load_general_data])
-def test_load_general_data(facade, monkeypatch, func):
-    def side_effect(val):
-        if val == "some_key@2":
-            return True
-        return False
-
-    mock_node = MagicMock()
-    mock_node.__len__.return_value = 3
-    mock_node.get_data_points.return_value = [10.0, 20.0, 30.0]
-    mock_node.get_std.return_value = [1.0, 2.0, 3.0]
-    mock_node.getIndex.side_effect = mocked_obs_node_get_index_nr
-
-    obs_mock = Mock()
-    obs_mock.getDataKey.return_value = "test_data_key"
-    obs_mock.getStepList.return_value = [1]
-    facade.get_observations.return_value = {"some_key": obs_mock}
-
-    facade.all_data_type_keys.return_value = ["some_key@2", "not_related_key@3"]
-    facade.is_gen_data_key.side_effect = side_effect
-
-    facade.load_gen_data.return_value = pd.DataFrame(data=[9.9, 19.9, 29.9, 39.9])
-    facade.get_observations()["some_key"].getNode.return_value = mock_node
-
-    facade.get_impl_type_name_for_obs_key.return_value = "GEN_OBS"
-
-    result = func(facade, "some_key", "a_random_name")
-
-    mock_node.get_data_points.assert_called_once_with()
-    mock_node.get_std.assert_called_once_with()
-
-    assert result.columns.to_list() == [
-        ("some_key", 0, 0),
-        ("some_key", 2, 2),
-        ("some_key", 3, 3),
-    ]
-    assert result.index.to_list() == ["OBS", "STD", 0]
-    assert all(
-        result.values.flatten() == [10.0, 20.0, 30.0, 1.0, 2.0, 3.0, 9.9, 29.9, 39.9]
-    )
-
-
-@pytest.mark.parametrize(
-    "func", [loader.data_loader_factory("SUMMARY_OBS"), loader.load_summary_data]
-)
+@pytest.mark.parametrize("func", [loader.data_loader_factory("SUMMARY_OBS")])
 def test_load_summary_data(facade, monkeypatch, func):
     obs_mock = Mock()
     obs_mock.getStepList.return_value = [1, 2]
@@ -250,12 +205,3 @@ def test_different_data_key(facade):
             Mock(),
             "SUMMARY_OBS",
         )
-
-
-@deprecation.fail_if_not_removed
-@pytest.mark.parametrize("func", [loader.load_general_data, loader.load_summary_data])
-def test_deprecated_entry_points(facade, monkeypatch, func):
-    facade = MagicMock()
-    extract_data = MagicMock()
-    monkeypatch.setattr(loader, "_extract_data", extract_data)
-    func(facade, ["obs_1", "obs_2"], "case_name", include_data=False)


### PR DESCRIPTION
**Achtung!** This deletes some `@deprecated` functions that I cannot find in use anywhere else other than in our test suite. I have checked current semeio, equilibrium, subscript, and everest.