### PR TITLE
Remove false positive warning for INSTALL_JOB_DIRECTORY

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -476,7 +476,17 @@ class ResConfig:
             if not os.path.isdir(job_path):
                 logger.warning(f"Unable to locate job directory {job_path}")
                 continue
+
             files = os.listdir(job_path)
+
+            if not [
+                f
+                for f in files
+                if os.path.isfile(os.path.abspath(os.path.join(job_path, f)))
+            ]:
+                logger.warning(f"No files found in job directory {job_path}")
+                continue
+
             for file_name in files:
                 full_path = os.path.abspath(os.path.join(job_path, file_name))
                 new_job = ResConfig._create_job(full_path)

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -488,13 +488,12 @@ class ResConfig:
 
     @staticmethod
     def _create_job(job_path, job_name=None):
-        if not os.path.isfile(job_path):
-            logger.warning(f"Unable to locate job file {job_path}")
-            return None
-        return ExtJob.from_config_file(
-            name=job_name,
-            config_file=job_path,
-        )
+        if os.path.isfile(job_path):
+            return ExtJob.from_config_file(
+                name=job_name,
+                config_file=job_path,
+            )
+        return None
 
     def _extract_defines(self, config):
         defines = {}


### PR DESCRIPTION
**Issue**
Backporting `Remove false positive warning for INSTALL_JOB_DIRECTORY` to version-4.2
#4537

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
