### PR TITLE
Provide better error message when there are infinite loops in the defines

### DIFF
--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -127,9 +127,19 @@ static config_content_node_type *config_content_item_set_arg__(
         if (subst_list_get_size(define_list) > 0) {
             int iarg;
             for (iarg = 0; iarg < argc; iarg++) {
-                char *filtered_copy = subst_list_alloc_filtered_string(
-                    define_list, stringlist_iget(token_list, iarg + 1));
-                stringlist_iset_owned_ref(token_list, iarg + 1, filtered_copy);
+
+                try {
+                    char *filtered_copy = subst_list_alloc_filtered_string(
+                        define_list, stringlist_iget(token_list, iarg + 1));
+                    stringlist_iset_owned_ref(token_list, iarg + 1,
+                                              filtered_copy);
+                } catch (std::runtime_error err) {
+                    std::string error_message = util_alloc_sprintf(
+                        "Could not resolve defines in %s. Defines might have "
+                        "an infinite loop",
+                        stringlist_iget(token_list, iarg + 1));
+                    parse_errors.push_back(error_message);
+                }
             }
         }
 

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -156,3 +156,19 @@ def test_site_config_dict_same_as_from_file(tmp_path_factory, config_generator):
         assert (
             ResConfig(config_dict=config_dict).env_vars == ResConfig(filename).env_vars
         )
+
+
+def test_that_when_there_is_an_infinite_loop_it_goes_into_the_errors(tmp_path):
+    with open(tmp_path / "test.ert", "w", encoding="utf-8") as fh:
+        fh.write(
+            dedent(
+                """
+                NUM_REALIZATIONS  1
+                DEFINE <A> <A>
+                RUNPATH <A>
+                """
+            )
+        )
+
+    with pytest.raises(ConfigValidationError, match="infinite loop"):
+        _ = ResConfig(str(tmp_path / "test.ert"))


### PR DESCRIPTION
Backports #4546 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
