### PR TITLE
Align test config_dict with dict generated from config content

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -228,48 +228,33 @@ class EnsembleConfig(BaseCClass):
             self.addNode(schedule_file_node)
 
     @staticmethod
-    def gen_data_node(gen_data: Union[dict, list]) -> Optional[EnkfConfigNode]:
-        if isinstance(gen_data, dict):
-            name = gen_data.get(ConfigKeys.NAME)
-            res_file = gen_data.get(ConfigKeys.RESULT_FILE)
-            input_format = gen_data.get(ConfigKeys.INPUT_FORMAT)
-            report_steps = gen_data.get(ConfigKeys.REPORT_STEPS)
-        else:
-            options = _option_dict(gen_data, 1)
-            name = gen_data[0]
-            res_file = options.get(ConfigKeys.RESULT_FILE)
-            input_format_str = options.get(ConfigKeys.INPUT_FORMAT)
-            if input_format_str != "ASCII":
-                logger.error("The only supported INPUT_FORMAT is ASCII")
-                return None
-            input_format = GenDataFileType.from_string(input_format_str)
-            report_steps_str = options.get(ConfigKeys.REPORT_STEPS, "")
-            report_steps = rangestring_to_list(report_steps_str)
+    def gen_data_node(gen_data: List[str]) -> Optional[EnkfConfigNode]:
+        options = _option_dict(gen_data, 1)
+        name = gen_data[0]
+        res_file = options.get(ConfigKeys.RESULT_FILE)
+        input_format_str = options.get(ConfigKeys.INPUT_FORMAT)
+        if input_format_str != "ASCII":
+            logger.error("The only supported INPUT_FORMAT is ASCII")
+            return None
+        report_steps_str = options.get(ConfigKeys.REPORT_STEPS, "")
+        report_steps = rangestring_to_list(report_steps_str)
 
         return EnkfConfigNode.create_gen_data_full(
             name,
             res_file,
-            input_format,
+            GenDataFileType.ASCII,
             report_steps,
         )
 
     @staticmethod
-    def gen_kw_node(gen_kw: Union[dict, list], tag_format: str) -> EnkfConfigNode:
-        if isinstance(gen_kw, dict):
-            name = gen_kw.get(ConfigKeys.NAME)
-            tmpl_path = _get_abs_path(gen_kw.get(ConfigKeys.TEMPLATE))
-            out_file = _get_filename(gen_kw.get(ConfigKeys.OUT_FILE))
-            param_file_path = _get_abs_path(gen_kw.get(ConfigKeys.PARAMETER_FILE))
-            forward_init = gen_kw.get(ConfigKeys.FORWARD_INIT)
-            init_files = _get_abs_path(gen_kw.get(ConfigKeys.INIT_FILES))
-        else:
-            options = _option_dict(gen_kw, 4)
-            name = gen_kw[0]
-            tmpl_path = _get_abs_path(gen_kw[1])
-            out_file = _get_filename(_get_abs_path(gen_kw[2]))
-            param_file_path = _get_abs_path(gen_kw[3])
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
-            init_files = _get_abs_path(options.get(ConfigKeys.INIT_FILES))
+    def gen_kw_node(gen_kw: List[str], tag_format: str) -> EnkfConfigNode:
+        options = _option_dict(gen_kw, 4)
+        name = gen_kw[0]
+        tmpl_path = _get_abs_path(gen_kw[1])
+        out_file = _get_filename(_get_abs_path(gen_kw[2]))
+        param_file_path = _get_abs_path(gen_kw[3])
+        forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
+        init_files = _get_abs_path(options.get(ConfigKeys.INIT_FILES))
         return EnkfConfigNode.create_gen_kw(
             name,
             tmpl_path,
@@ -281,20 +266,13 @@ class EnsembleConfig(BaseCClass):
         )
 
     @staticmethod
-    def get_surface_node(surface: Union[dict, list]) -> EnkfConfigNode:
-        if isinstance(surface, dict):
-            name = surface.get(ConfigKeys.NAME)
-            init_file = surface.get(ConfigKeys.INIT_FILES)
-            out_file = surface.get(ConfigKeys.OUT_FILE)
-            base_surface = surface.get(ConfigKeys.BASE_SURFACE_KEY)
-            forward_init = surface.get(ConfigKeys.FORWARD_INIT)
-        else:
-            options = _option_dict(surface, 1)
-            name = surface[0]
-            init_file = options.get(ConfigKeys.INIT_FILES)
-            out_file = options.get("OUTPUT_FILE")
-            base_surface = options.get(ConfigKeys.BASE_SURFACE_KEY)
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
+    def get_surface_node(surface: List[str]) -> EnkfConfigNode:
+        options = _option_dict(surface, 1)
+        name = surface[0]
+        init_file = options.get(ConfigKeys.INIT_FILES)
+        out_file = options.get("OUTPUT_FILE")
+        base_surface = options.get(ConfigKeys.BASE_SURFACE_KEY)
+        forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
 
         return EnkfConfigNode.create_surface(
             name,
@@ -308,33 +286,20 @@ class EnsembleConfig(BaseCClass):
     def get_field_node(
         field: Union[dict, list], grid: Optional[EclGrid]
     ) -> EnkfConfigNode:
-        if isinstance(field, dict):
-            name = field.get(ConfigKeys.NAME)
-            var_type = field.get(ConfigKeys.VAR_TYPE)
-            out_file = field.get(ConfigKeys.OUT_FILE)
-            enkf_infile = field.get(ConfigKeys.ENKF_INFILE)
-            forward_init = field.get(ConfigKeys.FORWARD_INIT)
-            init_transform = field.get(ConfigKeys.INIT_TRANSFORM)
-            output_transform = field.get(ConfigKeys.OUTPUT_TRANSFORM)
-            input_transform = field.get(ConfigKeys.INPUT_TRANSFORM)
-            min_ = field.get(ConfigKeys.MIN_KEY)
-            max_ = field.get(ConfigKeys.MAX_KEY)
-            init_files = field.get(ConfigKeys.INIT_FILES)
-        else:
-            name = field[0]
-            var_type = field[1]
-            out_file = field[2]
-            enkf_infile = None
-            options = _option_dict(field, 2)
-            if var_type == ConfigKeys.GENERAL_KEY:
-                enkf_infile = field[3]
-            forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
-            init_transform = options.get(ConfigKeys.INIT_TRANSFORM)
-            output_transform = options.get(ConfigKeys.OUTPUT_TRANSFORM)
-            input_transform = options.get(ConfigKeys.INPUT_TRANSFORM)
-            min_ = options.get(ConfigKeys.MIN_KEY)
-            max_ = options.get(ConfigKeys.MAX_KEY)
-            init_files = options.get(ConfigKeys.INIT_FILES)
+        name = field[0]
+        var_type = field[1]
+        out_file = field[2]
+        enkf_infile = None
+        options = _option_dict(field, 2)
+        if var_type == ConfigKeys.GENERAL_KEY:
+            enkf_infile = field[3]
+        forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
+        init_transform = options.get(ConfigKeys.INIT_TRANSFORM)
+        output_transform = options.get(ConfigKeys.OUTPUT_TRANSFORM)
+        input_transform = options.get(ConfigKeys.INPUT_TRANSFORM)
+        min_ = options.get(ConfigKeys.MIN_KEY)
+        max_ = options.get(ConfigKeys.MAX_KEY)
+        init_files = options.get(ConfigKeys.INIT_FILES)
         return EnkfConfigNode.create_field(
             name,
             var_type,
@@ -354,17 +319,11 @@ class EnsembleConfig(BaseCClass):
     def _get_schedule_file_node(
         schedule_file: Union[dict, list], tag_format: str
     ) -> EnkfConfigNode:
-        if isinstance(schedule_file, dict):
-            file_path = schedule_file.get(ConfigKeys.TEMPLATE)
-            file_name = _get_filename(file_path)
-            parameter = schedule_file.get(ConfigKeys.PARAMETER_KEY)
-            init_files = schedule_file.get(ConfigKeys.INIT_FILES)
-        else:
-            file_path = schedule_file[0]
-            file_name = _get_filename(file_path)
-            options = _option_dict(schedule_file, 1)
-            parameter = options.get(ConfigKeys.PARAMETER_KEY)
-            init_files = options.get(ConfigKeys.INIT_FILES)
+        file_path = _get_abs_path(schedule_file[0])
+        file_name = _get_filename(file_path)
+        options = _option_dict(schedule_file, 1)
+        parameter = options.get(ConfigKeys.PARAMETER_KEY)
+        init_files = options.get(ConfigKeys.INIT_FILES)
 
         return EnkfConfigNode.create_gen_kw(
             ConfigKeys.PRED_KEY,

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -36,6 +36,14 @@ def directory_names(draw):
     return "dir" + draw(words)
 
 
+@st.composite
+def report_steps(draw):
+    rep_steps = draw(
+        st.lists(st.integers(min_value=0, max_value=100), min_size=4, unique=True)
+    )
+    return ",".join(str(step) for step in sorted(rep_steps))
+
+
 transforms = st.sampled_from(
     [
         "DENORMALIZE_PERMX",
@@ -280,37 +288,27 @@ def generate_config(draw):
                     "gen-kw-export-name-" + draw(file_names)
                 ),
                 ConfigKeys.FIELD_KEY: st.lists(
-                    st.fixed_dictionaries(
-                        {
-                            ConfigKeys.NAME: st.just("FIELD-" + draw(words)),
-                            ConfigKeys.VAR_TYPE: st.just("PARAMETER"),
-                            ConfigKeys.OUT_FILE: file_names,
-                            # ConfigKeys.ENKF_INFILE: file_names, only used in general
-                            ConfigKeys.FORWARD_INIT: st.booleans(),
-                            ConfigKeys.INIT_TRANSFORM: transforms,
-                            ConfigKeys.OUTPUT_TRANSFORM: transforms,
-                            # ConfigKeys.INPUT_TRANSFORM: func, only used in general
-                            ConfigKeys.MIN_KEY: small_floats,
-                            ConfigKeys.MAX_KEY: small_floats,
-                            ConfigKeys.INIT_FILES: file_names,
-                        }
+                    st.tuples(
+                        st.just("FIELD-" + draw(words)),
+                        st.just("PARAMETER"),
+                        file_names,
+                        st.just(f"FORWARD_INIT:{draw(st.booleans())}"),
+                        st.just(f"INIT_TRANSFORM:{draw(transforms)}"),
+                        st.just(f"OUTPUT_TRANSFORM:{draw(transforms)}"),
+                        st.just(f"MIN:{draw(small_floats)}"),
+                        st.just(f"MAX:{draw(small_floats)}"),
+                        st.just(f"INIT_FILES:{draw(file_names)}"),
                     ),
-                    unique_by=lambda field_dict: field_dict[ConfigKeys.NAME],
+                    unique_by=lambda element: element[0],
                 ),
                 ConfigKeys.GEN_DATA: st.lists(
-                    st.fixed_dictionaries(
-                        {
-                            ConfigKeys.NAME: st.just("GEN_DATA-" + draw(words)),
-                            ConfigKeys.RESULT_FILE: format_file_names,
-                            ConfigKeys.INPUT_FORMAT: st.just(GenDataFileType.ASCII),
-                            ConfigKeys.REPORT_STEPS: st.lists(
-                                st.integers(min_value=0, max_value=100),
-                                min_size=2,
-                                unique=True,
-                            ),
-                        }
+                    st.tuples(
+                        st.just(f"GEN_DATA-{draw(words)}"),
+                        st.just(f"{ConfigKeys.RESULT_FILE}:{draw(format_file_names)}"),
+                        st.just(f"{ConfigKeys.INPUT_FORMAT}:ASCII"),
+                        st.just(f"{ConfigKeys.REPORT_STEPS}:{draw(report_steps())}"),
                     ),
-                    unique_by=lambda field_dict: field_dict[ConfigKeys.NAME],
+                    unique_by=lambda tup: tup[0],
                 ),
                 ConfigKeys.MAX_SUBMIT: positives,
                 ConfigKeys.NUM_CPU: positives,
@@ -511,68 +509,12 @@ def to_config_file(filename, config_dict):  # pylint: disable=too-many-branches
                     config.write(f"{keyword} {job_name}({job_args})\n")
             elif keyword == ConfigKeys.FIELD_KEY:
                 # keyword_value is a list of dicts, each defining a field
-                for field_dict in keyword_value:
-                    config.write(
-                        " ".join(
-                            [
-                                keyword,
-                                field_dict.get(ConfigKeys.NAME, ""),
-                                field_dict.get(ConfigKeys.VAR_TYPE, ""),
-                                field_dict.get(ConfigKeys.OUT_FILE, ""),
-                                f"INIT_FILES:{field_dict.get(ConfigKeys.INIT_FILES)}"
-                                if ConfigKeys.INIT_FILES in field_dict
-                                else "",
-                                f"MIN:{field_dict.get(ConfigKeys.MIN_KEY)}"
-                                if ConfigKeys.MIN_KEY in field_dict
-                                else "",
-                                f"MAX:{field_dict.get(ConfigKeys.MAX_KEY)}"
-                                if ConfigKeys.MAX_KEY in field_dict
-                                else "",
-                                (
-                                    "OUTPUT_TRANSFORM:"
-                                    f"{field_dict.get(ConfigKeys.OUTPUT_TRANSFORM)}"
-                                )
-                                if ConfigKeys.OUTPUT_TRANSFORM in field_dict
-                                else "",
-                                (
-                                    "INIT_TRANSFORM:"
-                                    f"{field_dict.get(ConfigKeys.INIT_TRANSFORM)}"
-                                )
-                                if ConfigKeys.INIT_TRANSFORM in field_dict
-                                else "",
-                                (
-                                    "FORWARD_INIT:"
-                                    f"{field_dict.get(ConfigKeys.FORWARD_INIT)}"
-                                )
-                                if ConfigKeys.FORWARD_INIT in field_dict
-                                else "",
-                                field_dict.get(ConfigKeys.ENKF_INFILE, ""),
-                                field_dict.get(ConfigKeys.INPUT_TRANSFORM, ""),
-                            ]
-                        )
-                        + "\n"
-                    )
+                for field_vals in keyword_value:
+                    config.write(" ".join([keyword, *field_vals]) + "\n")
             elif keyword == ConfigKeys.GEN_DATA:
                 # keyword_value is a list of dicts, each defining a field
-                for field_dict in keyword_value:
-                    report_steps_as_string = ",".join(
-                        map(str, field_dict.get(ConfigKeys.REPORT_STEPS))
-                    )
-                    config.write(
-                        " ".join(
-                            [
-                                keyword,
-                                field_dict.get(ConfigKeys.NAME, ""),
-                                f"RESULT_FILE:{field_dict.get(ConfigKeys.RESULT_FILE)}",
-                                (
-                                    "INPUT_FORMAT:"
-                                    f"{field_dict.get(ConfigKeys.INPUT_FORMAT)}"
-                                ),
-                                f"REPORT_STEPS:{report_steps_as_string}",
-                            ]
-                        )
-                        + "\n"
-                    )
+                for gen_data_entry in keyword_value:
+                    config.write(" ".join([keyword, *gen_data_entry]) + "\n")
             elif keyword == ConfigKeys.INSTALL_JOB_DIRECTORY:
                 for install_dir in keyword_value:
                     config.write(f"{keyword} {install_dir}\n")

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -12,7 +12,6 @@ from hypothesis import assume, note
 from py import path as py_path
 
 from ert._c_wrappers.enkf import ConfigKeys
-from ert._c_wrappers.enkf.enums import GenDataFileType
 from ert._c_wrappers.job_queue import QueueDriverEnum
 
 from .egrid_generator import egrids

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, given, reproduce_failure
 
 from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import ConfigKeys, ResConfig

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import assume, given, reproduce_failure
+from hypothesis import assume, given
 
 from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import ConfigKeys, ResConfig

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -30,37 +30,36 @@ def test_ensemble_config_constructor(setup_case):
         config_dict={
             ConfigKeys.GEN_KW_TAG_FORMAT: "<%s>",
             ConfigKeys.GEN_DATA: [
-                {
-                    ConfigKeys.NAME: "SNAKE_OIL_OPR_DIFF",
-                    ConfigKeys.INPUT_FORMAT: GenDataFileType.ASCII,
-                    ConfigKeys.RESULT_FILE: "snake_oil_opr_diff_%d.txt",
-                    ConfigKeys.REPORT_STEPS: [0, 1, 2, 199],
-                },
-                {
-                    ConfigKeys.NAME: "SNAKE_OIL_GPR_DIFF",
-                    ConfigKeys.INPUT_FORMAT: GenDataFileType.ASCII,
-                    ConfigKeys.RESULT_FILE: "snake_oil_gpr_diff_%d.txt",
-                    ConfigKeys.REPORT_STEPS: [199],
-                },
+                [
+                    "SNAKE_OIL_OPR_DIFF",
+                    "INPUT_FORMAT:ASCII",
+                    "RESULT_FILE:snake_oil_opr_diff_%d.txt",
+                    "REPORT_STEPS:0,1,2,199",
+                ],
+                [
+                    "SNAKE_OIL_GPR_DIFF",
+                    "INPUT_FORMAT:ASCII",
+                    "RESULT_FILE:snake_oil_gpr_diff_%d.txt",
+                    "REPORT_STEPS:199",
+                ],
             ],
             ConfigKeys.GEN_KW: [
-                {
-                    ConfigKeys.NAME: "MULTFLT",
-                    ConfigKeys.TEMPLATE: "FAULT_TEMPLATE",
-                    ConfigKeys.OUT_FILE: "MULTFLT.INC",
-                    ConfigKeys.PARAMETER_FILE: "MULTFLT.TXT",
-                    ConfigKeys.INIT_FILES: None,
-                    ConfigKeys.FORWARD_INIT: False,
-                }
+                [
+                    "MULTFLT",
+                    "FAULT_TEMPLATE",
+                    "MULTFLT.INC",
+                    "MULTFLT.TXT",
+                    "FORWARD_INIT:FALSE",
+                ]
             ],
             ConfigKeys.SURFACE_KEY: [
-                {
-                    ConfigKeys.NAME: "TOP",
-                    ConfigKeys.INIT_FILES: "surface/small.irap",
-                    ConfigKeys.OUT_FILE: "surface/small_out.irap",
-                    ConfigKeys.BASE_SURFACE_KEY: ("surface/small.irap"),
-                    ConfigKeys.FORWARD_INIT: False,
-                }
+                [
+                    "TOP",
+                    "INIT_FILES:surface/small.irap",
+                    "OUTPUT_FILE:surface/small_out.irap",
+                    "BASE_SURFACE:surface/small.irap",
+                    "FORWARD_INIT:FALSE",
+                ]
             ],
             ConfigKeys.SUMMARY: [
                 "WOPR:OP_1",
@@ -76,25 +75,19 @@ def test_ensemble_config_constructor(setup_case):
                 "ROE:1",
             ],
             ConfigKeys.FIELD_KEY: [
-                {
-                    ConfigKeys.NAME: "PERMX",
-                    ConfigKeys.VAR_TYPE: "PARAMETER",
-                    ConfigKeys.INIT_FILES: "fields/permx%d.grdecl",
-                    ConfigKeys.OUT_FILE: "permx.grdcel",
-                    ConfigKeys.ENKF_INFILE: None,
-                    ConfigKeys.INIT_TRANSFORM: None,
-                    ConfigKeys.OUTPUT_TRANSFORM: None,
-                    ConfigKeys.INPUT_TRANSFORM: None,
-                    ConfigKeys.MIN_KEY: None,
-                    ConfigKeys.MAX_KEY: None,
-                    ConfigKeys.FORWARD_INIT: False,
-                }
+                [
+                    "PERMX",
+                    "PARAMETER",
+                    "permx.grdcel",
+                    "FORWARD_INIT:FALSE",
+                    "INIT_FILES:fields/permx%d.grdecl",
+                ],
             ],
-            ConfigKeys.SCHEDULE_PREDICTION_FILE: {
-                ConfigKeys.TEMPLATE: "input/schedule.sch",
-                ConfigKeys.INIT_FILES: "fields/permx%d.grdecl",
-                ConfigKeys.PARAMETER_KEY: "MULTFLT.TXT",
-            },
+            ConfigKeys.SCHEDULE_PREDICTION_FILE: [
+                "input/schedule.sch",
+                "PARAMETER:MULTFLT.TXT",
+                "INIT_FILES:fields/permx%d.grdecl",
+            ],
             ConfigKeys.GRID: "grid/CASE.EGRID",
             # ConfigKeys.REFCASE: "input/refcase/SNAKE_OIL_FIELD",
         },

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -9,12 +9,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from ecl.util.enums import RngAlgTypeEnum
 
-from ert._c_wrappers.enkf import (
-    AnalysisConfig,
-    ConfigKeys,
-    HookRuntime,
-    ResConfig,
-)
+from ert._c_wrappers.enkf import AnalysisConfig, ConfigKeys, HookRuntime, ResConfig
 from ert._c_wrappers.enkf.res_config import parse_signature_job, site_config_location
 from ert._c_wrappers.job_queue import QueueDriverEnum
 from ert._c_wrappers.sched import HistorySourceEnum

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -12,7 +12,6 @@ from ecl.util.enums import RngAlgTypeEnum
 from ert._c_wrappers.enkf import (
     AnalysisConfig,
     ConfigKeys,
-    GenDataFileType,
     HookRuntime,
     ResConfig,
 )

--- a/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_res_config.py
@@ -339,22 +339,21 @@ def test_res_config_dict_constructor(setup_case):
             "ROE:1",
         ],  # ensemble
         ConfigKeys.GEN_KW: [
-            {
-                ConfigKeys.NAME: "SIGMA",
-                ConfigKeys.TEMPLATE: "../input/templates/sigma.tmpl",
-                ConfigKeys.OUT_FILE: "coarse.sigma",
-                ConfigKeys.PARAMETER_FILE: "../input/distributions/sigma.dist",
-                ConfigKeys.INIT_FILES: None,
-                ConfigKeys.FORWARD_INIT: False,
-            }  # ensemble
+            [
+                "SIGMA",
+                "../input/templates/sigma.tmpl",
+                "coarse.sigma",
+                "../input/distributions/sigma.dist",
+                f"{ConfigKeys.FORWARD_INIT}:FALSE",
+            ]
         ],
         ConfigKeys.GEN_DATA: [
-            {
-                ConfigKeys.NAME: "super_data",
-                ConfigKeys.INPUT_FORMAT: GenDataFileType.ASCII,
-                ConfigKeys.RESULT_FILE: "super_data_%d",
-                ConfigKeys.REPORT_STEPS: [1],
-            }  # ensemble
+            [
+                "super_data",
+                f"{ConfigKeys.INPUT_FORMAT}:ASCII",
+                f"{ConfigKeys.RESULT_FILE}:super_data_%d",
+                f"{ConfigKeys.REPORT_STEPS}:1",
+            ]  # ensemble
         ],
         ConfigKeys.ECLBASE: "eclipse/model/<ECLIPSE_NAME>-%d",  # model, ecl
         ConfigKeys.ENSPATH: os.path.realpath("../output/storage/<CASE_DIR>"),  # model


### PR DESCRIPTION
**Issue**
Resolves differences in how the test config_dict looks and the dict generated from config content 


**Approach**
Make the two dictionaries match 


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
