### PR TITLE
Pin sphinx<6

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,7 @@ pytest>6
 requests
 scikit-build
 setuptools_scm
-sphinx
+sphinx<6
 sphinx-argparse
 sphinx-autoapi
 sphinx_rtd_theme


### PR DESCRIPTION
**Issue**
Sphinx version 6 removes jquery, which the sphinx read-the-docs theme needs to work (search function is broken without it).

**Approach**
Pin sphinx<6

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
