### PR TITLE
Let delete_file() in delete_directory.py delete symlinks

### DIFF
--- a/src/ert/_c_wrappers/fm/shell/shell.py
+++ b/src/ert/_c_wrappers/fm/shell/shell.py
@@ -70,7 +70,7 @@ class Shell:
 
     @staticmethod
     def __deleteFile(filename):
-        stat_info = os.stat(filename)
+        stat_info = os.lstat(filename)
         uid = stat_info.st_uid
         if uid == os.getuid():
             os.unlink(filename)

--- a/tests/unit_tests/c_wrappers/res/fm/test_shell.py
+++ b/tests/unit_tests/c_wrappers/res/fm/test_shell.py
@@ -250,6 +250,19 @@ def test_copy_directory_error():
         copy_directory("hei", "target")
 
 
+def test_that_delete_directory_can_delete_directories_with_internal_symlinks():
+    mkdir("to_be_deleted")
+    Path("to_be_deleted/link_target.txt").write_text("hei", encoding="utf-8")
+
+    os.chdir("to_be_deleted")
+    symlink("link_target.txt", "link")
+    os.chdir("..")
+    assert Path("to_be_deleted/link").exists()
+
+    delete_directory("to_be_deleted")
+    assert not Path("to_be_deleted").exists()
+
+
 @pytest.mark.usefixtures("use_tmpdir")
 def test_copy_file():
     with pytest.raises(IOError):

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -1,5 +1,5 @@
 mypy<0.990
-mypy-protobuf
+mypy-protobuf<3.4
 types-aiofiles
 types-requests
 types-pkg_resources


### PR DESCRIPTION
Since os.stat will resolve symlinks, broken links will not be deleted unless os.lstat is used instead.

Backport of #4514, solves #4513