### PR TITLE
Provide better error messages for subst failures

### DIFF
--- a/src/clib/lib/include/ert/res_util/subst_list.hpp
+++ b/src/clib/lib/include/ert/res_util/subst_list.hpp
@@ -18,7 +18,6 @@ void subst_list_append_owned_ref(subst_list_type *, const char *, const char *);
 
 extern "C" bool subst_list_filter_file(const subst_list_type *, const char *,
                                        const char *);
-bool subst_list_update_string(const subst_list_type *, char **);
 extern "C" char *subst_list_alloc_filtered_string(const subst_list_type *,
                                                   const char *);
 extern "C" int subst_list_get_size(const subst_list_type *);


### PR DESCRIPTION
**Issue**
Because of #4566 , we found out that we need better error messages.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
