### PR TITLE
Add context to circular define warnings

### DIFF
--- a/src/clib/lib/config/config_content.cpp
+++ b/src/clib/lib/config/config_content.cpp
@@ -266,8 +266,9 @@ config_content_iget_stringlist_ref(const config_content_type *content,
 
 void config_content_add_define(config_content_type *content, const char *key,
                                const char *value) {
-    char *filtered_value =
-        subst_list_alloc_filtered_string(content->define_list, value);
+    std::string context_msg = fmt::format("adding DEFINE `{}={}`", key, value);
+    char *filtered_value = subst_list_alloc_filtered_string(
+        content->define_list, value, context_msg.c_str());
     subst_list_append_copy(content->define_list, key, filtered_value);
     free(filtered_value);
 }

--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -126,11 +126,19 @@ static config_content_node_type *config_content_item_set_arg__(
         /* Filtering based on DEFINE statements */
         if (subst_list_get_size(define_list) > 0 &&
             config_schema_item_substitutions_enabled(schema_item)) {
+            char *parsing_line =
+                stringlist_alloc_joined_string(token_list, " ");
+            char *config_file_path =
+                config_path_elm_alloc_abspath(path_elm, config_file);
+            std::string context =
+                fmt::format("parsing config file `{}` line: `{}`",
+                            config_file_path, parsing_line);
             int iarg;
             for (iarg = 0; iarg < argc; iarg++) {
 
                 char *filtered_copy = subst_list_alloc_filtered_string(
-                    define_list, stringlist_iget(token_list, iarg + 1));
+                    define_list, stringlist_iget(token_list, iarg + 1),
+                    context.c_str());
                 stringlist_iset_owned_ref(token_list, iarg + 1, filtered_copy);
             }
         }

--- a/src/clib/lib/include/ert/res_util/subst_list.hpp
+++ b/src/clib/lib/include/ert/res_util/subst_list.hpp
@@ -19,7 +19,7 @@ void subst_list_append_owned_ref(subst_list_type *, const char *, const char *);
 extern "C" bool subst_list_filter_file(const subst_list_type *, const char *,
                                        const char *);
 extern "C" char *subst_list_alloc_filtered_string(const subst_list_type *,
-                                                  const char *);
+                                                  const char *, const char *);
 extern "C" int subst_list_get_size(const subst_list_type *);
 extern "C" const char *subst_list_get_value(const subst_list_type *subst_list,
                                             const char *key);

--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -52,14 +52,20 @@ class ForwardModel:
         context: "SubstitutionList",
         env_varlist: EnvironmentVarlist,
     ) -> Dict[str, Any]:
-        def substitute(job, string):
+        def substitute(job, string: str):
+            job_args = ",".join([f"{key}={value}" for key, value in job.private_args])
+            job_description = f"{job.name}({job_args})"
+            substitution_context = (
+                f"parsing forward model job `FORWARD_MODEL {job_description}` - "
+                "reconstructed, with defines applied during parsing"
+            )
             if string is not None:
                 copy_private_args = SubstitutionList()
                 for key, val in job.private_args:
                     copy_private_args.addItem(
                         key, context.substitute_real_iter(val, iens, itr)
                     )
-                string = copy_private_args.substitute(string)
+                string = copy_private_args.substitute(string, substitution_context)
                 return context.substitute_real_iter(string, iens, itr)
             else:
                 return string

--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -18,7 +18,7 @@ class SubstitutionList(BaseCClass):
     _has_key = ResPrototype("bool subst_list_has_key(subst_list, char*)")
     _append_copy = ResPrototype("void subst_list_append_copy(subst_list, char*, char*)")
     _alloc_filtered_string = ResPrototype(
-        "char* subst_list_alloc_filtered_string(subst_list, char*)"
+        "char* subst_list_alloc_filtered_string(subst_list, char*, char*)"
     )
     _filter_file = ResPrototype("bool subst_list_filter_file(subst_list, char*,char*)")
     _add_from_string = ResPrototype(
@@ -109,8 +109,8 @@ class SubstitutionList(BaseCClass):
 
         return None  # Should never happen!
 
-    def substitute(self, to_substitute: str) -> str:
-        return self._alloc_filtered_string(to_substitute)
+    def substitute(self, to_substitute: str, context: str = "") -> str:
+        return self._alloc_filtered_string(to_substitute, context)
 
     def substitute_file(self, to_substitute: str, tmp_file: str):
         self._filter_file(to_substitute, tmp_file)


### PR DESCRIPTION
**Issue**
Related to #4566 and #4599


**Approach**
The warning messages that are emitted upon hitting the max iterations when resolving defines are quite limited in information as they only have access to the immediate local scope.
While adding line numbers (and config file names) will be a part of rewriting the parser, we already know with little effort add more context to the warning messages, by passing information down the stack. 

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
