### PR TITLE
Add validation for non-existing surface input file

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/enkf_config_node.py
+++ b/src/ert/_c_wrappers/enkf/config/enkf_config_node.py
@@ -309,18 +309,27 @@ class EnkfConfigNode(BaseCClass):
         if init_file_fmt is None:
             msg = msg + f"{ConfigKeys.INIT_FILES}:/path/to/input/files%d\n"
             valid = False
+        elif (
+            not forward_init
+            and "%d" not in init_file_fmt
+            and not os.path.exists(os.path.realpath(init_file_fmt))
+        ):
+            msg += f"{ConfigKeys.INIT_FILES}: {init_file_fmt} File not found "
+            valid = False
         if output_file is None:
             msg = msg + "OUTPUT_FILE:name_of_output_file\n"
             valid = False
         if base_surface_file is None:
             valid = False
             msg = msg + f"{ConfigKeys.BASE_SURFACE_KEY}:base_surface_file\n"
+        elif not os.path.exists(os.path.realpath(base_surface_file)):
+            msg += f"{ConfigKeys.BASE_SURFACE_KEY}: {base_surface_file} File not found "
+            valid = False
         if not valid:
             logger.error(msg)
             raise ValueError(msg)
 
-        if base_surface_file is not None:
-            base_surface_file = os.path.realpath(base_surface_file)
+        base_surface_file = os.path.realpath(base_surface_file)
         config_node = cls._alloc_surface_full(
             key,
             forward_init,

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -355,14 +355,14 @@ def test_update_multiple_param(copy_case):
 
 @pytest.mark.integration_test
 def test_gen_data_obs_data_mismatch(snake_oil_case_storage):
-    with open("observations/observations.txt", "r") as file:
+    with open("observations/observations.txt", "r", encoding="utf-8") as file:
         obs_text = file.read()
     obs_text = obs_text.replace(
         "INDEX_LIST = 400,800,1200,1800;", "INDEX_LIST = 400,800,1200,1800,2400;"
     )
-    with open("observations/observations.txt", "w") as file:
+    with open("observations/observations.txt", "w", encoding="utf-8") as file:
         file.write(obs_text)
-    with open("observations/wpr_diff_obs.txt", "a") as file:
+    with open("observations/wpr_diff_obs.txt", "a", encoding="utf-8") as file:
         file.write("0.0 0.05\n")
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -246,3 +246,20 @@ def test_get_surface_node(setup_case, caplog):
     surface_str += " FORWARD_INIT:TRUE"
     surface_node = EnsembleConfig.get_surface_node(surface_str.split(" "))
     assert surface_node.getUseForwardInit()
+
+
+def test_surface_bad_init_values(setup_case):
+    _ = setup_case("configuration_tests", "ensemble_config.ert")
+    surface_in = "path/42"
+    surface_out = "surface/small_out.irap"
+    surface_str = (
+        f"TOP INIT_FILES:{surface_in}"
+        f" OUTPUT_FILE:{surface_out}"
+        f" BASE_SURFACE:{surface_in}"
+    )
+    error = (
+        f"INIT_FILES: {surface_in} File not found"
+        f" BASE_SURFACE: {surface_in} File not found "
+    )
+    with pytest.raises(ValueError, match=error):
+        EnsembleConfig.get_surface_node(surface_str.split(" "))


### PR DESCRIPTION
**Issue**
Resolves #4533


**Approach**
Check if the init file exists before initializing the surface config node, and throw a value error regarding the missing file that is picked up and shown in the GUI suggester 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
