### PR TITLE
Change infinite substitution loop errors to warn

### DIFF
--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -128,18 +128,9 @@ static config_content_node_type *config_content_item_set_arg__(
             int iarg;
             for (iarg = 0; iarg < argc; iarg++) {
 
-                try {
-                    char *filtered_copy = subst_list_alloc_filtered_string(
-                        define_list, stringlist_iget(token_list, iarg + 1));
-                    stringlist_iset_owned_ref(token_list, iarg + 1,
-                                              filtered_copy);
-                } catch (std::runtime_error err) {
-                    std::string error_message = util_alloc_sprintf(
-                        "Could not resolve defines in %s. Defines might have "
-                        "an infinite loop",
-                        stringlist_iget(token_list, iarg + 1));
-                    parse_errors.push_back(error_message);
-                }
+                char *filtered_copy = subst_list_alloc_filtered_string(
+                    define_list, stringlist_iget(token_list, iarg + 1));
+                stringlist_iset_owned_ref(token_list, iarg + 1, filtered_copy);
             }
         }
 

--- a/src/clib/lib/res_util/subst_list.cpp
+++ b/src/clib/lib/res_util/subst_list.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include <ert/logging.hpp>
 #include <ert/res_util/file_utils.hpp>
 #include <ert/util/buffer.hpp>
 #include <ert/util/hash.hpp>
@@ -15,6 +16,8 @@
 
 #include <ert/res_util/subst_list.hpp>
 #include <fmt/format.h>
+
+static auto logger = ert::get_logger("config");
 
 namespace fs = std::filesystem;
 
@@ -311,7 +314,7 @@ bool subst_list_filter_file(const subst_list_type *subst_list,
     }
 
     if (iterations >= max_iterations) {
-        throw std::runtime_error(
+        logger->warning(
             fmt::format("Reached max iterations while trying to resolve "
                         "defines in file '{}'. Matched to '{}'",
                         src_file, fmt::join(matches, ", ")));
@@ -365,7 +368,7 @@ char *subst_list_alloc_filtered_string(const subst_list_type *subst_list,
         }
 
         if (iterations >= max_iterations) {
-            throw std::runtime_error(fmt::format(
+            logger->warning(fmt::format(
                 "Reached max iterations while trying to resolve defines in "
                 "'{}', it matched to '{}' and resulted in '{}'",
                 string, fmt::join(matches, ", "), filtered_string));

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -192,19 +192,3 @@ ENSPATH storage
         dict_set_ens_path = ResConfig(config_dict=config_dict).ens_path
 
         assert dict_set_ens_path == config_dict["ENSPATH"]
-
-
-def test_that_when_there_is_an_infinite_loop_it_goes_into_the_errors(tmp_path):
-    with open(tmp_path / "test.ert", "w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                """
-                NUM_REALIZATIONS  1
-                DEFINE <A> <A>
-                RUNPATH <A>
-                """
-            )
-        )
-
-    with pytest.raises(ConfigValidationError, match="infinite loop"):
-        _ = ResConfig(str(tmp_path / "test.ert"))


### PR DESCRIPTION
Because of how FORWARD_MODEL works, several users reported issues with uses ala.

   DEFINE <VERSION> 3
   FORWARD_MODEL job(<VERSION>=<VERSION)

which is a widespread use pattern, which coincidentally works. It is actually interpreted as

   DEFINE <VERSION> 3
   FORWARD_MODEL job(3=3)

and it works because there is no scoping of <VERSION> and it is picked up by the job. Until we have a clear course of action we are assuming that infinite loops in defines is due to defines such as 3=3, and is up to the user handle DEFINE resolution.

**Issue**
Resolves #4566


- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
