### PR TITLE
Fix gui not keeping storage running

### DIFF
--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -34,14 +34,43 @@ from ert.services import Storage
 def run_gui(args: Namespace):
     app = QApplication([])  # Early so that QT is initialized before other imports
     app.setWindowIcon(resourceIcon("application/window_icon_cutout"))
-    window = _start_initial_gui_window(args)
-    window.show()
-    window.activateWindow()
-    window.raise_()
-    return app.exec_()
+    with add_gui_log_handler() as log_handler:
+        window, ens_path = _start_initial_gui_window(args, log_handler)
+
+        def show_window():
+            window.show()
+            window.activateWindow()
+            window.raise_()
+            return app.exec_()
+
+        # ens_path is None indicates that there was an error in the setup and
+        # window is now just showing that error message, in which
+        # case display it and don't show an error message
+        if ens_path is None:
+            return show_window()
+
+        storage_lock = filelock.FileLock(
+            Path(ens_path) / (Path(ens_path).stem + ".lock")
+        )
+        try:
+            storage_lock.acquire(timeout=5)
+            with Storage.init_service(
+                res_config=args.config,
+                project=os.path.abspath(ens_path),
+            ):
+                return show_window()
+        except filelock.Timeout:
+            raise ErtTimeoutError(
+                f"Not able to acquire lock for: {ens_path}. You may already be running"
+                f" ert, or another user is using the same ENSPATH."
+            )
+        finally:
+            if storage_lock.is_locked:
+                storage_lock.release()
+                os.remove(storage_lock.lock_file)
 
 
-def _start_initial_gui_window(args):
+def _start_initial_gui_window(args, log_handler):
     messages = []
     res_config = None
     try:
@@ -49,7 +78,7 @@ def _start_initial_gui_window(args):
         messages += ResConfig.make_suggestion_list(args.config)
     except Exception as error:
         messages.append(str(error))
-        return _setup_suggester(messages, args, None)
+        return _setup_suggester(messages, args, None, log_handler), None
 
     # Create logger inside function to make sure all handlers have been added to
     # the root-logger.
@@ -66,7 +95,7 @@ def _start_initial_gui_window(args):
         ert = EnKFMain(res_config)
     except Exception as error:
         messages.append(str(error))
-        return _setup_suggester(messages, args, None)
+        return _setup_suggester(messages, args, None, log_handler), None
     if not ert.have_observations():
         messages.append("No observations loaded. Model update algorithms disabled!")
 
@@ -74,35 +103,9 @@ def _start_initial_gui_window(args):
     if locale_msg is not None:
         messages.append(locale_msg)
     if messages:
-        return _setup_suggester(messages, args, ert)
+        return _setup_suggester(messages, args, ert, log_handler), res_config.ens_path
     else:
-        return _start_main_gui_window(ert, args)
-
-
-def _start_main_gui_window(ert, args):
-
-    facade = LibresFacade(ert)
-    ens_path = Path(facade.enspath)
-    storage_lock = filelock.FileLock(ens_path / (ens_path.stem + ".lock"))
-
-    try:
-        storage_lock.acquire(timeout=5)
-        with Storage.init_service(
-            res_config=args.config,
-            project=os.path.abspath(facade.enspath),
-        ), add_gui_log_handler() as log_handler:
-            notifier = ErtNotifier(args.config)
-            # window reference must be kept until app.exec returns:
-            return _setup_main_window(ert, notifier, args, log_handler)
-    except filelock.Timeout:
-        raise ErtTimeoutError(
-            f"Not able to acquire lock for: {ens_path}. You may already be running ert,"
-            f" or another user is using the same ENSPATH."
-        )
-    finally:
-        if storage_lock.is_locked:
-            storage_lock.release()
-            os.remove(storage_lock.lock_file)
+        return _setup_main_window(ert, args, log_handler), res_config.ens_path
 
 
 def _check_locale():
@@ -127,7 +130,7 @@ def _check_locale():
         return None
 
 
-def _setup_suggester(suggestions, args, ert):
+def _setup_suggester(suggestions, args, ert, log_handler):
     suggest = QWidget()
     layout = QVBoxLayout()
     suggest.setWindowTitle("Some problems detected")
@@ -151,7 +154,7 @@ def _setup_suggester(suggestions, args, ert):
     run.setEnabled(ert is not None)
 
     def run_pressed():
-        window = _start_main_gui_window(ert, args)
+        window = _setup_main_window(ert, args, log_handler)
         window.show()
         window.activateWindow()
         window.raise_()
@@ -173,12 +176,13 @@ def _setup_suggester(suggestions, args, ert):
 
 def _setup_main_window(
     ert: EnKFMain,
-    notifier: ErtNotifier,
     args: Namespace,
     log_handler: GUILogHandler,
 ):
+    # window reference must be kept until app.exec returns:
     facade = LibresFacade(ert)
     config_file = args.config
+    notifier = ErtNotifier(config_file)
     window = GertMainWindow(config_file)
     window.setWidget(SimulationPanel(ert, notifier, config_file))
     plugin_handler = PluginHandler(ert, ert.getWorkflowList().getPluginJobs(), window)

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -8,9 +8,9 @@ from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QDialog, QMessageBox, QPushButton, QWidget
 
 import ert.gui
-from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets.message_box import ErtMessageBox
 from ert.gui.gert_main import GUILogHandler, _setup_main_window, run_gui
+from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.shared.models import BaseRunModel
 
 
@@ -30,9 +30,13 @@ def fixture_patch_enkf_main(monkeypatch, tmp_path):
 
     res_config_mock = Mock()
     type(res_config_mock).config_path = PropertyMock(return_value=tmp_path)
+    analysis_mock = Mock()
+    analysis_mock.case_format_is_set.return_value = False
     facade_mock = Mock()
     facade_mock.get_ensemble_size.return_value = 1
     facade_mock.get_number_of_iterations.return_value = 1
+    facade_mock.get_current_case_name.return_value = "default"
+    facade_mock.get_analysis_config.return_value = analysis_mock
     monkeypatch.setattr(
         ert.gui.simulation.simulation_panel,
         "LibresFacade",
@@ -79,8 +83,7 @@ def fixture_patch_enkf_main(monkeypatch, tmp_path):
 
 def test_gui_load(qtbot, patch_enkf_main):
     args = argparse.Namespace(config="does_not_matter.ert")
-    notifier = ErtNotifier(args.config)
-    gui = _setup_main_window(patch_enkf_main, notifier, args, GUILogHandler())
+    gui = _setup_main_window(patch_enkf_main, args, GUILogHandler())
     qtbot.addWidget(gui)
 
     sim_panel = gui.findChild(QWidget, name="Simulation_panel")
@@ -109,10 +112,9 @@ def test_gui_full(monkeypatch, tmp_path, qapp, mock_start_server, source_root):
 
     qapp.exec_ = lambda: None  # exec_ starts the event loop, and will stall the test.
     monkeypatch.setattr(ert.gui.gert_main, "QApplication", Mock(return_value=qapp))
-    monkeypatch.setattr(ert.gui.gert_main.LibresFacade, "enspath", tmp_path)
     run_gui(args)
     mock_start_server.assert_called_once_with(
-        project=str(tmp_path), res_config="poly.ert"
+        project=str(tmp_path / "poly_example" / "storage"), res_config="poly.ert"
     )
 
 
@@ -150,8 +152,7 @@ def test_gui_iter_num(monkeypatch, qtbot, patch_enkf_main):
         _assert_iter_in_args,
     )
 
-    notifier = ErtNotifier(args_mock.config)
-    gui = _setup_main_window(patch_enkf_main, notifier, args_mock, GUILogHandler())
+    gui = _setup_main_window(patch_enkf_main, args_mock, GUILogHandler())
     qtbot.addWidget(gui)
 
     sim_mode = gui.findChild(QWidget, name="Simulation_mode")
@@ -178,7 +179,7 @@ def test_that_gui_gives_suggestions_when_you_have_umask_in_config(
 
     args = Mock()
     args.config = str(config_file)
-    gui = ert.gui.gert_main._start_initial_gui_window(args)
+    gui, _ = ert.gui.gert_main._start_initial_gui_window(args, None)
     assert gui.windowTitle() == "Some problems detected"
 
 
@@ -190,7 +191,7 @@ def test_that_errors_are_shown_in_the_suggester_window_when_present(
 
     args = Mock()
     args.config = str(config_file)
-    gui = ert.gui.gert_main._start_initial_gui_window(args)
+    gui, _ = ert.gui.gert_main._start_initial_gui_window(args, None)
     assert gui.windowTitle() == "Some problems detected"
 
 
@@ -202,24 +203,26 @@ def test_that_the_suggester_starts_when_there_are_no_observations(
 
     args = Mock()
     args.config = str(config_file)
-    gui = ert.gui.gert_main._start_initial_gui_window(args)
-    assert gui.windowTitle() == "Some problems detected"
-    gui.show()
-    button = gui.findChild(QPushButton, name="run_ert_button")
-    qtbot.mouseClick(button, Qt.LeftButton)
+    with add_gui_log_handler() as log_handler:
+        gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "Some problems detected"
+        gui.show()
+        button = gui.findChild(QPushButton, name="run_ert_button")
+        qtbot.mouseClick(button, Qt.LeftButton)
 
-    qtbot.wait_until(
-        lambda: qapp.activeWindow() is not None
-        and qapp.activeWindow().windowTitle() == "ERT - config.ert"
-    )
+        qtbot.wait_until(
+            lambda: qapp.activeWindow() is not None
+            and qapp.activeWindow().windowTitle() == "ERT - config.ert"
+        )
 
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_gert_starts_when_there_are_no_problems(monkeypatch, qapp, tmp_path):
     args = Mock()
     args.config = "poly.ert"
-    gui = ert.gui.gert_main._start_initial_gui_window(args)
-    assert gui.windowTitle() == "ERT - poly.ert"
+    with add_gui_log_handler() as log_handler:
+        gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "ERT - poly.ert"
 
 
 def test_start_simulation_disabled(monkeypatch, qtbot, patch_enkf_main):
@@ -244,8 +247,7 @@ def test_start_simulation_disabled(monkeypatch, qtbot, patch_enkf_main):
         ert.gui.simulation.simulation_panel, "create_model", lambda *args: dummy_model
     )
 
-    notifier = MagicMock()
-    gui = _setup_main_window(patch_enkf_main, notifier, args_mock, GUILogHandler())
+    gui = _setup_main_window(patch_enkf_main, args_mock, GUILogHandler())
     qtbot.addWidget(gui)
 
     start_simulation = gui.findChild(QWidget, name="start_simulation")


### PR DESCRIPTION
**Issue**
Resolves #4542 


**Approach**
The issue was that storage service stopped too early. Fixed by moving the initialization of the storage service.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
