### PR TITLE
Fix release notes format for the skip labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,7 @@
 changelog:
   exclude:
-    labels: release-notes:skip
+    labels:
+        - release-notes:skip
   categories:
     - title: User impact 🛠
       labels:


### PR DESCRIPTION
The format was off, so could not generate release notes. This should fix it.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
