### PR TITLE
Fix runpath format displayed in QT GUI

### DIFF
--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -14,7 +14,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import IntegerArgument, RangeStringArgument
 from ert.shared.models import EnsembleExperiment
 
-from .simulation_config_panel import SimulationConfigPanel
+from .simulation_config_panel import SimulationConfigPanel, escape_string
 
 
 @dataclass
@@ -35,8 +35,7 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
 
         self._case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", self._case_selector)
-
-        run_path_label = QLabel(f"<b>{self.facade.run_path}</b>")
+        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -14,7 +14,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import ProperNameArgument, RangeStringArgument
 from ert.shared.models import EnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel
+from .simulation_config_panel import SimulationConfigPanel, escape_string
 
 
 @dataclass
@@ -34,7 +34,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         self._case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", self._case_selector)
 
-        run_path_label = QLabel(f"<b>{facade.run_path}</b>")
+        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -14,7 +14,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import IteratedEnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel
+from .simulation_config_panel import SimulationConfigPanel, escape_string
 
 
 @dataclass
@@ -36,7 +36,8 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{self.facade.run_path}</b>")
+        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
+
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -24,7 +24,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import MultipleDataAssimilation
 
-from .simulation_config_panel import SimulationConfigPanel
+from .simulation_config_panel import SimulationConfigPanel, escape_string
 
 
 @dataclass
@@ -45,7 +45,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{facade.run_path}</b>")
+        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 

--- a/src/ert/gui/simulation/simulation_config_panel.py
+++ b/src/ert/gui/simulation/simulation_config_panel.py
@@ -2,6 +2,20 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget
 
 
+def escape_string(string):
+    """
+    Designed to replace/escape invalid html characters for
+    correct display in Qt QWidgets
+
+    >>> escape_string("realization-<IENS>/iteration-<ITER>")
+    'realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;'
+
+    >>> escape_string("<some>&<thing>")
+    '&lt;some&gt;&amp;&lt;thing&gt;'
+    """
+    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 class SimulationConfigPanel(QWidget):
     simulationConfigurationChanged = Signal()
 

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -8,16 +8,12 @@ from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizations
 from ert.libres_facade import LibresFacade
 from ert.shared.models import SingleTestRun
 
-from .simulation_config_panel import SimulationConfigPanel
+from .simulation_config_panel import SimulationConfigPanel, escape_string
 
 
 @dataclass
 class Arguments:
     mode: str
-
-
-def escape_string(string):
-    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 class SingleTestRunPanel(SimulationConfigPanel):
@@ -31,9 +27,7 @@ class SingleTestRunPanel(SimulationConfigPanel):
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(
-            f"<b>{escape_string(self.ert.getModelConfig().runpath_format_string)}</b>"
-        )
+        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 


### PR DESCRIPTION
**Issue**
Resolves #4577 


**Approach**
Format the runpath for all the simulation modes

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
