### PR TITLE
Add timeout option to the Torque driver

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -669,7 +669,7 @@ and/or history matching project.
 .. topic:: FIELD
 
         The FIELD keyword is used to parametrize quantities which have extent over the
-        full grid. 
+        full grid.
 
         A parameter field (e.g. porosity or permeability or Gaussian Random Fields from APS) is defined as follows:
 
@@ -692,8 +692,8 @@ and/or history matching project.
         ERT and need an embedded %d.
 
         The input arguments MIN, MAX, INIT_TRANSFORM and OUTPUT_TRANSFORM are all
-        optional. 
-        
+        optional.
+
         MIN and MAX allows you to add a minimum and/or a maximum value with MIN:X and MAX:Y.
 
         For Assisted history matching, the variables in ERT should be normally
@@ -1855,6 +1855,22 @@ bjobs.
 
                 QUEUE_OPTION TORQUE DEBUG_OUTPUT torque_log.txt
 
+.. _torque_timeout:
+.. topic:: TIMEOUT
+
+        The driver allows the backend Torque system to be flaky, i.e. it may
+        intermittently not respond and give error messages when submitting jobs
+        or asking for job statuses. The timeout (in seconds) determines how long
+        ERT will wait before it will give up. Applies to job submission (qsub)
+        and job status queries (qstat). Default is 62 seconds.
+
+        ERT will do exponential sleeps, starting at 2 seconds, and the provided
+        timeout is a maximum. Let the timeout be sums of series like 2+4+8+16+32+64
+        in order to be explicit about the number of retries. Set to zero to disallow
+        flakyness.
+
+        ::
+                QUEUE_OPTION TORQUE TIMEOUT 126
 
 .. _configuring_the_slurm_queue:
 

--- a/src/clib/lib/include/ert/job_queue/torque_driver.hpp
+++ b/src/clib/lib/include/ert/job_queue/torque_driver.hpp
@@ -5,9 +5,7 @@
 
 #include <ert/job_queue/queue_driver.hpp>
 
-/*
-    The options supported by the Torque driver.
-   */
+/* The options supported by the Torque driver. */
 #define TORQUE_QSUB_CMD "QSUB_CMD"
 #define TORQUE_QSTAT_CMD "QSTAT_CMD"
 #define TORQUE_QSTAT_OPTIONS "QSTAT_OPTIONS"
@@ -20,12 +18,14 @@
 #define TORQUE_JOB_PREFIX_KEY "JOB_PREFIX"
 #define TORQUE_SUBMIT_SLEEP "SUBMIT_SLEEP"
 #define TORQUE_DEBUG_OUTPUT "DEBUG_OUTPUT"
+#define TORQUE_TIMEOUT "TIMEOUT"
 
 #define TORQUE_DEFAULT_QSUB_CMD "qsub"
 #define TORQUE_DEFAULT_QSTAT_CMD "qstat_proxy.sh"
 #define TORQUE_DEFAULT_QSTAT_OPTIONS "-x"
 #define TORQUE_DEFAULT_QDEL_CMD "qdel"
 #define TORQUE_DEFAULT_SUBMIT_SLEEP "0"
+#define TORQUE_DEFAULT_TIMEOUT "62"
 
 typedef struct torque_driver_struct torque_driver_type;
 typedef struct torque_job_struct torque_job_type;
@@ -55,6 +55,7 @@ void torque_job_create_submit_script(const char *run_path,
                                      const char *submit_cmd, int argc,
                                      const char *const *job_argv);
 int torque_driver_get_submit_sleep(const torque_driver_type *driver);
+int torque_driver_get_timeout(const torque_driver_type *driver);
 FILE *torque_driver_get_debug_stream(const torque_driver_type *driver);
 job_status_type torque_driver_parse_status(const char *qstat_file,
                                            const char *jobnr);

--- a/src/clib/old_tests/job_queue/test_job_torque.cpp
+++ b/src/clib/old_tests/job_queue/test_job_torque.cpp
@@ -7,7 +7,6 @@
 
 void test_option(torque_driver_type *driver, const char *option,
                  const char *value) {
-    printf("test_option %s %s\n", option, value);
     test_assert_true(torque_driver_set_option(driver, option, value));
     test_assert_string_equal(
         (const char *)torque_driver_get_option(driver, option), value);

--- a/src/clib/old_tests/job_queue/test_job_torque.cpp
+++ b/src/clib/old_tests/job_queue/test_job_torque.cpp
@@ -7,6 +7,7 @@
 
 void test_option(torque_driver_type *driver, const char *option,
                  const char *value) {
+    printf("test_option %s %s\n", option, value);
     test_assert_true(torque_driver_set_option(driver, option, value));
     test_assert_string_equal(
         (const char *)torque_driver_get_option(driver, option), value);
@@ -26,6 +27,7 @@ void setoption_setalloptions_optionsset() {
     test_option(driver, TORQUE_KEEP_QSUB_OUTPUT, "0");
     test_option(driver, TORQUE_CLUSTER_LABEL, "thecluster");
     test_option(driver, TORQUE_JOB_PREFIX_KEY, "coolJob");
+    test_option(driver, TORQUE_TIMEOUT, "128");
 
     test_assert_int_equal(0, torque_driver_get_submit_sleep(driver));
     test_assert_NULL(torque_driver_get_debug_stream(driver));
@@ -33,6 +35,9 @@ void setoption_setalloptions_optionsset() {
     test_assert_true(
         torque_driver_set_option(driver, TORQUE_SUBMIT_SLEEP, "0.25"));
     test_assert_int_equal(250000, torque_driver_get_submit_sleep(driver));
+
+    test_assert_true(torque_driver_set_option(driver, TORQUE_TIMEOUT, "5"));
+    test_assert_int_equal(5, torque_driver_get_timeout(driver));
 
     char tmp_path[] = "/tmp/torque_debug_XXXXXX";
     // We do not strictly need the file, we are only interested in a path name
@@ -64,6 +69,7 @@ void setoption_setalloptions_optionsset() {
     torque_driver_set_option(driver, TORQUE_NUM_CPUS_PER_NODE, NULL);
     torque_driver_set_option(driver, TORQUE_NUM_NODES, NULL);
     torque_driver_set_option(driver, TORQUE_KEEP_QSUB_OUTPUT, NULL);
+    torque_driver_set_option(driver, TORQUE_TIMEOUT, NULL);
     test_assert_string_equal((const char *)torque_driver_get_option(
                                  driver, TORQUE_NUM_CPUS_PER_NODE),
                              "42");
@@ -72,6 +78,8 @@ void setoption_setalloptions_optionsset() {
     test_assert_string_equal(
         (const char *)torque_driver_get_option(driver, TORQUE_KEEP_QSUB_OUTPUT),
         "0");
+    test_assert_string_equal(
+        (const char *)torque_driver_get_option(driver, TORQUE_TIMEOUT), "5");
 
     torque_driver_free(driver);
 }
@@ -98,6 +106,7 @@ void setoption_set_typed_options_wrong_format_returns_false() {
         torque_driver_set_option(driver, TORQUE_KEEP_QSUB_OUTPUT, "1.1"));
     test_assert_false(
         torque_driver_set_option(driver, TORQUE_SUBMIT_SLEEP, "X45"));
+    test_assert_false(torque_driver_set_option(driver, TORQUE_TIMEOUT, "X45"));
 }
 
 void getoption_nooptionsset_defaultoptionsreturned() {


### PR DESCRIPTION
This lets the timeout in the driver be user adjustable via the config file, as opposed to hard-coded in the source code.
The timeout specification has been simplified, and effectively bumps the default timeout from 14 to 62 seconds.

**Issue**
Resolves #4601 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
