### PR TITLE
Dropdown warn when no observations

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -152,6 +152,15 @@ class EnKFMain:
             config.ensemble_config,
         )
         if config.model_config.obs_config_file:
+            if (
+                os.path.isfile(config.model_config.obs_config_file)
+                and os.path.getsize(config.model_config.obs_config_file) == 0
+            ):
+                raise ValueError(
+                    f"Empty observations file: "
+                    f"{config.model_config.obs_config_file}"
+                )
+
             if self._observations.error:
                 raise ValueError(
                     f"Incorrect observations file: "

--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -96,8 +96,6 @@ def _start_initial_gui_window(args, log_handler):
     except Exception as error:
         messages.append(str(error))
         return _setup_suggester(messages, args, None, log_handler), None
-    if not ert.have_observations():
-        messages.append("No observations loaded. Model update algorithms disabled!")
 
     locale_msg = _check_locale()
     if locale_msg is not None:

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -355,14 +355,14 @@ def test_update_multiple_param(copy_case):
 
 @pytest.mark.integration_test
 def test_gen_data_obs_data_mismatch(snake_oil_case_storage):
-    with open("observations/observations.txt", "r") as file:
+    with open("observations/observations.txt", "r", encoding="utf-8") as file:
         obs_text = file.read()
     obs_text = obs_text.replace(
         "INDEX_LIST = 400,800,1200,1800;", "INDEX_LIST = 400,800,1200,1800,2400;"
     )
-    with open("observations/observations.txt", "w") as file:
+    with open("observations/observations.txt", "w", encoding="utf-8") as file:
         file.write(obs_text)
-    with open("observations/wpr_diff_obs.txt", "a") as file:
+    with open("observations/wpr_diff_obs.txt", "a", encoding="utf-8") as file:
         file.write("0.0 0.05\n")
     res_config = ResConfig("snake_oil.ert")
     ert = EnKFMain(res_config)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -199,6 +199,29 @@ def test_observations(minimum_case):
         assert summary_observation_node.getSummaryKey() == summary_key
 
 
+def test_empty_observations_file_cause_exception(tmpdir):
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        JOBNAME my_name%d
+        NUM_REALIZATIONS 10
+        OBS_CONFIG observations
+        """
+        )
+        with open("config.ert", "w", encoding="utf-8") as fh:
+            fh.writelines(config)
+        with open("observations", "w", encoding="utf-8") as fh:
+            fh.writelines("")
+
+        res_config = ResConfig("config.ert")
+
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Empty observations file.*",
+        ):
+            EnKFMain(res_config)
+
+
 def test_config(minimum_case):
 
     assert isinstance(minimum_case.ensembleConfig(), EnsembleConfig)


### PR DESCRIPTION
**Issue**
Resolves #4606
Resolves #4616 

Disabled simulation algorithms that perform updates when no observations are found.
Show warn icon on disabled choices.
Show tooltip on disabled choices.
Show warning icon next to combobox.
Show tooltip on warning icon.
Removed suggestor feedback.
Validate that observations file actually contain something
Added unit-test to verify exception thrown.

Yes, -- i'll squash.

![screenshot3](https://user-images.githubusercontent.com/114403625/211814756-27ffd0c5-4696-4672-aeb4-712fd27b0749.png)

**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).



Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
