### PR TITLE
Disable simulation models choices when no observations

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -157,6 +157,15 @@ class EnKFMain:
             config.ensemble_config,
         )
         if config.model_config.obs_config_file:
+            if (
+                os.path.isfile(config.model_config.obs_config_file)
+                and os.path.getsize(config.model_config.obs_config_file) == 0
+            ):
+                raise ValueError(
+                    f"Empty observations file: "
+                    f"{config.model_config.obs_config_file}"
+                )
+
             if self._observations.error:
                 raise ValueError(
                     f"Incorrect observations file: "

--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -96,8 +96,6 @@ def _start_initial_gui_window(args, log_handler):
     except Exception as error:
         messages.append(str(error))
         return _setup_suggester(messages, args, None, log_handler), None
-    if not ert.have_observations():
-        messages.append("No observations loaded. Model update algorithms disabled!")
 
     locale_msg = _check_locale()
     if locale_msg is not None:

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -246,6 +246,29 @@ def test_observations(minimum_case):
         assert summary_observation_node.getSummaryKey() == summary_key
 
 
+def test_empty_observations_file_cause_exception(tmpdir):
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        JOBNAME my_name%d
+        NUM_REALIZATIONS 10
+        OBS_CONFIG observations
+        """
+        )
+        with open("config.ert", "w", encoding="utf-8") as fh:
+            fh.writelines(config)
+        with open("observations", "w", encoding="utf-8") as fh:
+            fh.writelines("")
+
+        res_config = ResConfig("config.ert")
+
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Empty observations file.*",
+        ):
+            EnKFMain(res_config)
+
+
 def test_config(minimum_case):
 
     assert isinstance(minimum_case.ensembleConfig(), EnsembleConfig)

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, PropertyMock
 
 import pytest
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtWidgets import QDialog, QMessageBox, QPushButton, QWidget
+from qtpy.QtWidgets import QComboBox, QDialog, QMessageBox, QToolButton, QWidget
 
 import ert.gui
 from ert.gui.ertwidgets.message_box import ErtMessageBox
@@ -195,8 +195,27 @@ def test_that_errors_are_shown_in_the_suggester_window_when_present(
     assert gui.windowTitle() == "Some problems detected"
 
 
-def test_that_the_suggester_starts_when_there_are_no_observations(
-    monkeypatch, qapp, qtbot, tmp_path
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_the_ui_show_no_warnings_when_observations_found(
+    monkeypatch, qapp, tmp_path
+):
+    args = Mock()
+    args.config = "poly.ert"
+    with add_gui_log_handler() as log_handler:
+        gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
+        button = gui.findChild(QToolButton, name="Warn_icon_button")
+        assert not button
+        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        assert combo_box.count() == 5
+
+        for i in range(combo_box.count()):
+            assert combo_box.model().item(i).isEnabled()
+
+        assert gui.windowTitle() == "ERT - poly.ert"
+
+
+def test_that_the_ui_show_warnings_when_there_are_no_observations(
+    monkeypatch, qapp, tmp_path
 ):
     config_file = tmp_path / "config.ert"
     config_file.write_text("NUM_REALIZATIONS 1\n")
@@ -205,15 +224,21 @@ def test_that_the_suggester_starts_when_there_are_no_observations(
     args.config = str(config_file)
     with add_gui_log_handler() as log_handler:
         gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
-        assert gui.windowTitle() == "Some problems detected"
-        gui.show()
-        button = gui.findChild(QPushButton, name="run_ert_button")
-        qtbot.mouseClick(button, Qt.LeftButton)
-
-        qtbot.wait_until(
-            lambda: qapp.activeWindow() is not None
-            and qapp.activeWindow().windowTitle() == "ERT - config.ert"
+        button = gui.findChild(QToolButton, name="Warn_icon_button")
+        assert button
+        assert (
+            button.toolTip()
+            == "Some simulation modes are disabled due to no observations found"
         )
+        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        assert combo_box.count() == 5
+
+        for i in range(2):
+            assert combo_box.model().item(i).isEnabled()
+        for i in range(2, 5):
+            assert not combo_box.model().item(i).isEnabled()
+
+        assert gui.windowTitle() == "ERT - config.ert"
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
Remove suggestor feedback for no observations
Add warning icon with tooltip when sim modes disabled Add unit tests for verifying enabled sim modes
Verify that observations file has content
Add unit-test to check exception thrown on empty file

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
