### PR TITLE
Remove warn indication icon when observations not present

### DIFF
--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -56,21 +56,7 @@ class SimulationPanel(QWidget):
             self._simulation_mode_combo, 0, Qt.AlignVCenter
         )
 
-        if not self.facade.have_observations:
-            self.warn_button = QToolButton()
-            self.warn_button.setObjectName("Warn_icon_button")
-            self.warn_button.setIcon(
-                self.style().standardIcon(QStyle.SP_MessageBoxWarning)
-            )
-            self.warn_button.setStyleSheet("border: 0px solid;")
-            self.warn_button.setToolTip(
-                "Some simulation modes are disabled due to no observations found"
-            )
-            height = 20
-            self.warn_button.setIconSize(QSize(height, height))
-            simulation_mode_layout.addWidget(self.warn_button)
-        else:
-            simulation_mode_layout.addSpacing(20)
+        simulation_mode_layout.addSpacing(20)
 
         self.run_button = QToolButton()
         self.run_button.setObjectName("start_simulation")

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtWidgets import QComboBox, QDialog, QMessageBox, QToolButton, QWidget
+from qtpy.QtWidgets import QComboBox, QDialog, QMessageBox, QWidget
 
 import ert.gui
 from ert.gui.ertwidgets.message_box import ErtMessageBox
@@ -196,15 +196,11 @@ def test_that_errors_are_shown_in_the_suggester_window_when_present(
 
 
 @pytest.mark.usefixtures("copy_poly_case")
-def test_that_the_ui_show_no_warnings_when_observations_found(
-    monkeypatch, qapp, tmp_path
-):
+def test_that_the_ui_show_no_warnings_when_observations_found(qapp):
     args = Mock()
     args.config = "poly.ert"
     with add_gui_log_handler() as log_handler:
         gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
-        button = gui.findChild(QToolButton, name="Warn_icon_button")
-        assert not button
         combo_box = gui.findChild(QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
 
@@ -214,9 +210,7 @@ def test_that_the_ui_show_no_warnings_when_observations_found(
         assert gui.windowTitle() == "ERT - poly.ert"
 
 
-def test_that_the_ui_show_warnings_when_there_are_no_observations(
-    monkeypatch, qapp, tmp_path
-):
+def test_that_the_ui_show_warnings_when_there_are_no_observations(qapp, tmp_path):
     config_file = tmp_path / "config.ert"
     config_file.write_text("NUM_REALIZATIONS 1\n")
 
@@ -224,12 +218,6 @@ def test_that_the_ui_show_warnings_when_there_are_no_observations(
     args.config = str(config_file)
     with add_gui_log_handler() as log_handler:
         gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
-        button = gui.findChild(QToolButton, name="Warn_icon_button")
-        assert button
-        assert (
-            button.toolTip()
-            == "Some simulation modes are disabled due to no observations found"
-        )
         combo_box = gui.findChild(QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
 


### PR DESCRIPTION
**Issue**
Resolves #4606 

Removes the warning icon shown in the UI when no observations are loaded.

Screenshot shows tooltip provided when hovering one of the disabled items.

![screenshot_no_warn](https://user-images.githubusercontent.com/114403625/212631169-598d538a-6b1d-4133-902f-447d40d528f5.png)

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
