### PR TITLE
Setup UI before suggester to extend Qt components lifetime

### DIFF
--- a/src/ert/gui/gert_main.py
+++ b/src/ert/gui/gert_main.py
@@ -78,7 +78,7 @@ def _start_initial_gui_window(args, log_handler):
         messages += ResConfig.make_suggestion_list(args.config)
     except Exception as error:
         messages.append(str(error))
-        return _setup_suggester(messages, args, None, log_handler), None
+        return _setup_suggester(messages, args, log_handler), None
 
     # Create logger inside function to make sure all handlers have been added to
     # the root-logger.
@@ -95,14 +95,16 @@ def _start_initial_gui_window(args, log_handler):
         ert = EnKFMain(res_config)
     except Exception as error:
         messages.append(str(error))
-        return _setup_suggester(messages, args, None, log_handler), None
+        return _setup_suggester(messages, args, log_handler), None
 
     locale_msg = _check_locale()
     if locale_msg is not None:
         messages.append(locale_msg)
     if messages:
         return (
-            _setup_suggester(messages, args, ert, log_handler),
+            _setup_suggester(
+                messages, args, log_handler, _setup_main_window(ert, args, log_handler)
+            ),
             res_config.model_config.ens_path,
         )
     else:
@@ -134,7 +136,7 @@ def _check_locale():
         return None
 
 
-def _setup_suggester(suggestions, args, ert, log_handler):
+def _setup_suggester(suggestions, args, log_handler, ert_window=None):
     suggest = QWidget()
     layout = QVBoxLayout()
     suggest.setWindowTitle("Some problems detected")
@@ -155,13 +157,12 @@ def _setup_suggester(suggestions, args, ert, log_handler):
 
     run = QPushButton("Run ert")
     run.setObjectName("run_ert_button")
-    run.setEnabled(ert is not None)
+    run.setEnabled(ert_window is not None)
 
     def run_pressed():
-        window = _setup_main_window(ert, args, log_handler)
-        window.show()
-        window.activateWindow()
-        window.raise_()
+        ert_window.show()
+        ert_window.activateWindow()
+        ert_window.raise_()
         suggest.close()
 
     run.pressed.connect(run_pressed)

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -179,8 +179,9 @@ def test_that_gui_gives_suggestions_when_you_have_umask_in_config(
 
     args = Mock()
     args.config = str(config_file)
-    gui, _ = ert.gui.gert_main._start_initial_gui_window(args, None)
-    assert gui.windowTitle() == "Some problems detected"
+    with add_gui_log_handler() as log_handler:
+        gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "Some problems detected"
 
 
 def test_that_errors_are_shown_in_the_suggester_window_when_present(
@@ -191,8 +192,9 @@ def test_that_errors_are_shown_in_the_suggester_window_when_present(
 
     args = Mock()
     args.config = str(config_file)
-    gui, _ = ert.gui.gert_main._start_initial_gui_window(args, None)
-    assert gui.windowTitle() == "Some problems detected"
+    with add_gui_log_handler() as log_handler:
+        gui, _ = ert.gui.gert_main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "Some problems detected"
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
Setup UI before suggester to extend Qt components lifetime
Update unit-tests to use new function signature


backports #4655 


## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
