### PR TITLE
Avoid util_abort when INCLUDEing non existing file in config

### DIFF
--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -547,11 +547,11 @@ config_parse__(config_parser_type *config, config_content_type *content,
                     std::string error_message = util_alloc_sprintf(
                         "%s file:%s not found", include_kw, include_file);
                     content->parse_errors.push_back(error_message);
+                } else {
+                    config_parse__(config, content, path_stack, include_file,
+                                   comment_string, include_kw, define_kw,
+                                   unrecognized, false);
                 }
-
-                config_parse__(config, content, path_stack, include_file,
-                               comment_string, include_kw, define_kw,
-                               unrecognized, false);
             }
 
             // Add define


### PR DESCRIPTION
**Issue**
Resolves #4640


**Approach**
Do not parse non-existing include file from the config file and throw `ConfigValidationError` if non existing file is included. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
