### PR TITLE
Avoid ambiguity by renaming to `StorageService`

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -27,7 +27,7 @@ from ert.cli.main import ErtCliError, ErtTimeoutError, run_cli
 from ert.logging import LOGGING_CONFIG
 from ert.logging._log_util_abort import _log_util_abort
 from ert.namespace import Namespace
-from ert.services import Storage, WebvizErt
+from ert.services import StorageService, WebvizErt
 from ert.shared.feature_toggling import FeatureToggling
 from ert.shared.ide.keywords.data.validation_status import ValidationStatus
 from ert.shared.ide.keywords.definitions import (
@@ -48,7 +48,7 @@ def run_ert_storage(args: Namespace) -> None:
     if args.database_url is not None:
         kwargs["database_url"] = args.database_url
 
-    with Storage.start_server(**kwargs) as server:
+    with StorageService.start_server(**kwargs) as server:
         server.wait()
 
 
@@ -75,7 +75,7 @@ def run_webviz_ert(args: Namespace) -> None:
     if args.database_url is not None:
         kwargs["database_url"] = args.database_url
 
-    with Storage.init_service(**kwargs) as storage:
+    with StorageService.init_service(**kwargs) as storage:
         storage.wait_until_ready()
         print(
             """
@@ -483,7 +483,7 @@ def start_ert_server(mode: str) -> Generator[None, None, None]:
         yield
         return
 
-    with Storage.start_server():
+    with StorageService.start_server():
         yield
 
 

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -28,7 +28,7 @@ from ert.gui.tools.run_analysis import RunAnalysisTool
 from ert.gui.tools.workflows import WorkflowsTool
 from ert.libres_facade import LibresFacade
 from ert.namespace import Namespace
-from ert.services import Storage
+from ert.services import StorageService
 
 
 def run_gui(args: Namespace):
@@ -54,7 +54,7 @@ def run_gui(args: Namespace):
         )
         try:
             storage_lock.acquire(timeout=5)
-            with Storage.init_service(
+            with StorageService.init_service(
                 res_config=args.config,
                 project=os.path.abspath(ens_path),
             ):

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -9,7 +9,7 @@ import pandas as pd
 import requests
 from pandas.errors import ParserError
 
-from ert.services import Storage
+from ert.services import StorageService
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class PlotApi:
         self._reset_storage_facade()
 
     def _reset_storage_facade(self):
-        with Storage.session() as client:
+        with StorageService.session() as client:
             client.post("/updates/facade", timeout=self._timeout)
 
     def _get_case(self, name: str) -> Optional[dict]:
@@ -35,7 +35,7 @@ class PlotApi:
             return self._all_cases
 
         self._all_cases = []
-        with Storage.session() as client:
+        with StorageService.session() as client:
             try:
                 response = client.get("/experiments", timeout=self._timeout)
                 self._check_response(response)
@@ -69,7 +69,7 @@ class PlotApi:
             )
 
     def _get_experiment(self) -> dict:
-        with Storage.session() as client:
+        with StorageService.session() as client:
             response: requests.Response = client.get(
                 "/experiments", timeout=self._timeout
             )
@@ -78,7 +78,7 @@ class PlotApi:
             return response_json[0]
 
     def _get_ensembles(self, experiement_id) -> List:
-        with Storage.session() as client:
+        with StorageService.session() as client:
             response: requests.Response = client.get(
                 f"/experiments/{experiement_id}/ensembles", timeout=self._timeout
             )
@@ -97,7 +97,7 @@ class PlotApi:
         all_keys = {}
         experiment = self._get_experiment()
 
-        with Storage.session() as client:
+        with StorageService.session() as client:
             for ensemble in self._get_ensembles(experiment["id"]):
                 response: requests.Response = client.get(
                     f"/ensembles/{ensemble['id']}/responses", timeout=self._timeout
@@ -148,7 +148,7 @@ class PlotApi:
 
         case = self._get_case(case_name)
 
-        with Storage.session() as client:
+        with StorageService.session() as client:
             response: requests.Response = client.get(
                 f"/ensembles/{case['id']}/records/{key}",
                 headers={"accept": "application/x-parquet"},
@@ -178,7 +178,7 @@ class PlotApi:
 
         case = self._get_case(case_name)
 
-        with Storage.session() as client:
+        with StorageService.session() as client:
             response = client.get(
                 f"/ensembles/{case['id']}/records/{key}/observations",
                 timeout=self._timeout,

--- a/src/ert/services/__init__.py
+++ b/src/ert/services/__init__.py
@@ -1,4 +1,4 @@
-from .storage_service import Storage
+from .storage_service import StorageService
 from .webviz_ert_service import WebvizErt
 
-__all__ = ["Storage", "WebvizErt"]
+__all__ = ["StorageService", "WebvizErt"]

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -11,7 +11,7 @@ from ert_storage.client import Client, ConnInfo
 from ert.services._base_service import BaseService, _Context, local_exec_args
 
 
-class Storage(BaseService):
+class StorageService(BaseService):
     service_name = "storage"
 
     def __init__(
@@ -46,7 +46,7 @@ class Storage(BaseService):
         return ("__token__", self.fetch_conn_info()["authtoken"])
 
     @classmethod
-    def init_service(cls, *args: Any, **kwargs: Any) -> _Context[Storage]:
+    def init_service(cls, *args: Any, **kwargs: Any) -> _Context[StorageService]:
         try:
             service = cls.connect(timeout=0, project=kwargs.get("project"))
             # Check the server is up and running

--- a/src/ert/shared/storage/connection.py
+++ b/src/ert/shared/storage/connection.py
@@ -1,11 +1,11 @@
 import os
 from typing import Optional
 
-from ert.services import Storage
+from ert.services import StorageService
 
 
 def get_info(project_id: Optional[os.PathLike] = None):
-    client = Storage.connect(project=project_id)
+    client = StorageService.connect(project=project_id)
     return {
         "baseurl": client.fetch_url(),
         "auth": client.fetch_auth(),

--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -12,7 +12,7 @@ from ert._c_wrappers.enkf.enums import (
     RealizationStateEnum,
 )
 from ert.data import MeasuredData
-from ert.services import Storage
+from ert.services import StorageService
 from ert.shared.feature_toggling import feature_enabled
 
 if TYPE_CHECKING:
@@ -291,7 +291,7 @@ def create_priors(ert) -> Mapping[str, dict]:
 def _get_from_server(url, headers=None, status_code=200) -> requests.Response:
     if headers is None:
         headers = {}
-    session = Storage.session()
+    session = StorageService.session()
     resp = session.get(
         url,
         headers=headers,
@@ -307,7 +307,7 @@ def _post_to_server(
 ) -> requests.Response:
     if headers is None:
         headers = {}
-    session = Storage.session()
+    session = StorageService.session()
     resp = session.post(
         url,
         headers=headers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from ert.__main__ import ert_parser
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
 from ert.cli import ENSEMBLE_EXPERIMENT_MODE
 from ert.cli.main import run_cli
-from ert.services import Storage
+from ert.services import StorageService
 from ert.shared.feature_toggling import FeatureToggling
 
 from .utils import SOURCE_DIR
@@ -137,14 +137,14 @@ def use_tmpdir(tmp_path, monkeypatch):
 @pytest.fixture()
 def mock_start_server(monkeypatch):
     start_server = MagicMock()
-    monkeypatch.setattr(Storage, "start_server", start_server)
+    monkeypatch.setattr(StorageService, "start_server", start_server)
     yield start_server
 
 
 @pytest.fixture()
 def mock_connect(monkeypatch):
     connect = MagicMock()
-    monkeypatch.setattr(Storage, "connect", connect)
+    monkeypatch.setattr(StorageService, "connect", connect)
     yield connect
 
 

--- a/tests/unit_tests/dark_storage/conftest.py
+++ b/tests/unit_tests/dark_storage/conftest.py
@@ -84,12 +84,12 @@ def reset_enkf():
 def new_storage_client(monkeypatch, ert_storage_client):
     from ert.shared.storage import extraction
 
-    class MockStorage:
+    class MockStorageService:
         @staticmethod
         def session():
             return ert_storage_client
 
-    monkeypatch.setattr(extraction, "Storage", MockStorage)
+    monkeypatch.setattr(extraction, "StorageService", MockStorageService)
 
     return ert_storage_client
 

--- a/tests/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/unit_tests/gui/tools/plot/conftest.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from ert.gui.tools.plot.plot_api import PlotApi
-from ert.services import Storage
+from ert.services import StorageService
 
 
 class MockResponse:
@@ -36,7 +36,7 @@ def api(tmpdir, source_root, monkeypatch):
     def session():
         yield MagicMock(get=mocked_requests_get)
 
-    monkeypatch.setattr(Storage, "session", session)
+    monkeypatch.setattr(StorageService, "session", session)
 
     with tmpdir.as_cwd():
         test_data_root = source_root / "test-data"

--- a/tests/unit_tests/services/test_storage_service.py
+++ b/tests/unit_tests/services/test_storage_service.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import requests
 
-from ert.services import Storage, _storage_main
+from ert.services import StorageService, _storage_main
 from ert.shared import port_handler
 
 
@@ -19,13 +19,13 @@ def test_integration(tmp_path, monkeypatch):
     # an unloaded M1-based Mac using local disk. On the CI-server
     # we have less control of available resources, so set timeout-
     # value large to allow time for sqlite to get ready
-    with Storage.start_server(timeout=120) as server:
+    with StorageService.start_server(timeout=120) as server:
         resp = requests.get(
             f"{server.fetch_url()}/healthcheck", auth=server.fetch_auth()
         )
         assert "ALL OK!" in resp.json()
 
-        with Storage.session() as session:
+        with StorageService.session() as session:
             session.get("/healthcheck")
 
     assert not (tmp_path / "storage_server.json").exists()
@@ -39,7 +39,7 @@ def test_integration_timeout(tmp_path, monkeypatch):
 
     with pytest.raises(TimeoutError):
         # Note timeout-value here in context of note above
-        with Storage.start_server(timeout=0.01) as server:
+        with StorageService.start_server(timeout=0.01) as server:
             requests.get(f"{server.fetch_url()}/healthcheck", auth=server.fetch_auth())
 
     assert not (tmp_path / "storage_server.json").exists()
@@ -64,7 +64,7 @@ def test_create_connection_string(monkeypatch):
 @pytest.mark.requires_ert_storage
 def test_init_service_no_server_start(tmpdir, mock_start_server, mock_connect):
     with tmpdir.as_cwd():
-        Storage.init_service(project=str(tmpdir))
+        StorageService.init_service(project=str(tmpdir))
         mock_connect.assert_called_once_with(project=str(tmpdir), timeout=0)
         mock_start_server.assert_not_called()
 
@@ -72,19 +72,19 @@ def test_init_service_no_server_start(tmpdir, mock_start_server, mock_connect):
 @pytest.mark.requires_ert_storage
 def test_init_service_server_start_if_no_conf_file(tmpdir, mock_start_server):
     with tmpdir.as_cwd():
-        Storage.init_service(project=str(tmpdir))
+        StorageService.init_service(project=str(tmpdir))
         mock_start_server.assert_called_once_with(project=str(tmpdir))
 
 
 @pytest.mark.requires_ert_storage
 def test_init_service_server_start_conf_info_is_stale(tmpdir, mock_start_server):
     with tmpdir.as_cwd():
-        config_file = f"{Storage.service_name}_server.json"
+        config_file = f"{StorageService.service_name}_server.json"
         with open(config_file, "w", encoding="utf-8") as f:
             f.write(
                 """
             {"authtoken": "test123", "urls": ["http://127.0.0.1:51821"]}
             """
             )
-        Storage.init_service(project=str(tmpdir))
+        StorageService.init_service(project=str(tmpdir))
         mock_start_server.assert_called_once_with(project=str(tmpdir))

--- a/tests/unit_tests/storage/conftest.py
+++ b/tests/unit_tests/storage/conftest.py
@@ -16,12 +16,12 @@ def _enable_new_storage(monkeypatch):
 def client(monkeypatch, ert_storage_client):
     from ert.shared.storage import extraction
 
-    class MockStorage:
+    class MockStorageService:
         @staticmethod
         def session():
             return ert_storage_client
 
-    monkeypatch.setattr(extraction, "Storage", MockStorage)
+    monkeypatch.setattr(extraction, "StorageService", MockStorageService)
     monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "ON")
 
     # Store a list of experiment IDs that exist in the database, in case the


### PR DESCRIPTION
The `ert.services.Storage` is ambiguous when compared to other notions of "storage"