### PR TITLE
More sensible runpath format feedback

### DIFF
--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+from ert._c_wrappers.enkf.runpaths import replace_runpath_format
+
 if TYPE_CHECKING:
     from ert._c_wrappers.config import ConfigParser
 
@@ -37,7 +39,6 @@ class DeprecationMigrationSuggester:
         self._parser.add("CASE_TABLE")
         self._parser.add("RERUN_START")
         self._parser.add("DELETE_RUNPATH")
-        self._parser.add("RUNPATH")
 
     def suggest_migrations(self, filename: str):
         suggestions = []
@@ -49,11 +50,11 @@ class DeprecationMigrationSuggester:
                 suggestions.append(suggestion)
 
         if content.hasKey("RUNPATH") and "%d" in content.getValue("RUNPATH"):
+            runpath = replace_runpath_format(content.getValue("RUNPATH"))
             add_suggestion(
                 "RUNPATH",
-                "The use of %d in RUNPATH has been deprecated. "
-                "Instead use the <IENS>, <ITER> keywords, "
-                "e.g.: realization-<IENS>/iter-<ITER>",
+                "RUNPATH keyword contains deprecated value placeholders, "
+                f"instead use: {runpath}",
             )
 
         for kw in self.REPLACE_WITH_GEN_KW:

--- a/src/ert/_c_wrappers/enkf/ert_workflow_list.py
+++ b/src/ert/_c_wrappers/enkf/ert_workflow_list.py
@@ -172,7 +172,6 @@ class ErtWorkflowList:
         )
         if new_job is not None:
             self._workflow_jobs[new_job.name] = new_job
-            logger.info(f"Adding workflow job:{new_job.name}")
 
     def _add_workflow_job_dir(self, job_path):
         if not os.path.isdir(job_path):

--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -4,6 +4,7 @@ from typing import Optional
 from ecl.summary import EclSum
 
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
+from ert._c_wrappers.enkf.runpaths import replace_runpath_format
 from ert._c_wrappers.enkf.time_map import TimeMap
 from ert._c_wrappers.sched import HistorySourceEnum
 
@@ -40,17 +41,17 @@ class ModelConfig:
         if runpath_format_string is None:
             self.runpath_format_string = self.DEFAULT_RUNPATH
         elif "%d" in runpath_format_string:
-            self.runpath_format_string = runpath_format_string
+            self.runpath_format_string = replace_runpath_format(runpath_format_string)
             logger.warning(
-                "RUNPATH keyword should use syntax "
-                f"`{self.DEFAULT_RUNPATH}` "
-                "instead of deprecated syntax "
-                f"`{runpath_format_string}`"
+                "RUNPATH keyword contains deprecated value placeholders, "
+                f"`instead use: {self.runpath_format_string}`"
             )
         elif not any(x in runpath_format_string for x in ["<ITER>, <IENS>"]):
             self.runpath_format_string = runpath_format_string
-            logger.error(
-                "RUNPATH keyword should use syntax " f"`{self.DEFAULT_RUNPATH}`."
+            logger.warning(
+                "RUNPATH keyword contains no value placeholders: "
+                f"`{runpath_format_string}`. Valid example: "
+                f"`{self.DEFAULT_RUNPATH}` "
             )
 
         self.jobname_format_string = jobname_format_string

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -180,7 +180,7 @@ class ResConfig:
             ResConfig._create_user_config_parser()
         ).suggest_migrations(config_file)
         for suggestion in suggestions:
-            logging.error(suggestion)
+            logging.warning(suggestion)
 
     @classmethod
     def make_suggestion_list(cls, config_file):

--- a/src/ert/_c_wrappers/enkf/runpaths.py
+++ b/src/ert/_c_wrappers/enkf/runpaths.py
@@ -105,13 +105,13 @@ class Runpaths:
         return open(self.runpath_list_filename, mode, encoding="utf-8")
 
     def format_job_name(self) -> str:
-        return _maybe_format(self._job_name_format)
+        return replace_runpath_format(self._job_name_format)
 
     def format_runpath(self):
-        return str(Path(_maybe_format(self._runpath_format)).resolve())
+        return str(Path(replace_runpath_format(self._runpath_format)).resolve())
 
 
-def _maybe_format(format_string: str) -> str:
+def replace_runpath_format(format_string: str) -> str:
     format_string = format_string.replace("%d", "<IENS>", 1)
     format_string = format_string.replace("%d", "<ITER>", 1)
     return format_string

--- a/tests/test_config_parsing/test_model_config.py
+++ b/tests/test_config_parsing/test_model_config.py
@@ -13,7 +13,8 @@ def test_invalid_model_config_run_path(tmpdir):
     assert mc.runpath_format_string == "realization-no-specifier"
 
 
-def test_deprecated_model_config_run_path(tmpdir):
+def test_suggested_deprecated_model_config_run_path(tmpdir):
     runpath = "simulations/realization-%d/iter-%d"
+    suggested_path = "simulations/realization-<IENS>/iter-<ITER>"
     mc = ModelConfig(num_realizations=1, runpath_format_string=runpath)
-    assert mc.runpath_format_string == runpath
+    assert mc.runpath_format_string == suggested_path

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -1,14 +1,14 @@
 import pytest
 
-from ert._c_wrappers.config import ConfigParser
 from ert._c_wrappers.enkf._deprecation_migration_suggester import (
     DeprecationMigrationSuggester,
 )
+from ert._c_wrappers.enkf.res_config import ResConfig
 
 
 @pytest.fixture
 def suggester():
-    return DeprecationMigrationSuggester(ConfigParser())
+    return DeprecationMigrationSuggester(ResConfig._create_user_config_parser())
 
 
 @pytest.mark.parametrize("kw", DeprecationMigrationSuggester.JUST_REMOVE_KEYWORDS)
@@ -100,7 +100,7 @@ def test_suggester_gives_runpath_deprecated_specifier_migration(suggester, tmp_p
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 1
-    assert "Instead use the <IENS>, <ITER> keywords" in suggestions[0]
+    assert "RUNPATH keyword contains deprecated value placeholders" in suggestions[0]
 
 
 def test_suggester_gives_no_runpath_deprecated_specifier_migration(suggester, tmp_path):


### PR DESCRIPTION
**Issue**
Resolves [#1735](https://github.com/equinor/everest/issues/1735)

- Changed logger level for runpath related issues to warning
- Changed warning text to something (hopefully) better worded
- Use 'maybe' function to return actual suggestions
- Lowered logger level for suggester reported issues. It feels more correct that they are warnings?
- Removed very verbose printout for generating workflow jobs

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
