### PR TITLE
Add test to check duplicate node names raises an expected error.

### DIFF
--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,7 +1,6 @@
 import pytest
 from hypothesis import assume, given
 
-from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import ConfigKeys, ResConfig
 
 from .config_dict_generator import config_generators, to_config_file
@@ -28,32 +27,3 @@ def test_ensemble_config_errors_on_unknown_function_in_field(
             match=f"unknown function.*{silly_function_name}",
         ):
             ResConfig(user_config_file=filename)
-
-
-@pytest.mark.skip(reason="github.com/equinor/ert/issues/4071")
-@given(config_generators())
-def test_ensemble_config_errors_on_identical_name_for_two_enkf_config_nodes(
-    tmp_path_factory,
-    config_generator,
-):
-    filename = "config.ert"
-    with config_generator(tmp_path_factory, filename) as config_dict:
-        two_keys = [ConfigKeys.FIELD_KEY, ConfigKeys.GEN_DATA]
-        for key in two_keys:
-            assume(key in config_dict and len(config_dict[key]) > 0)
-        one_node = config_dict[two_keys[0]][0]
-        other_node = config_dict[two_keys[1]][0]
-        one_node[ConfigKeys.NAME] = other_node[ConfigKeys.NAME]
-
-        to_config_file(filename, config_dict)
-        err_msg_match = "duplicate key"
-        with pytest.raises(
-            expected_exception=ConfigValidationError,
-            match=err_msg_match,
-        ):
-            ResConfig(user_config_file=filename)
-        with pytest.raises(
-            expected_exception=ConfigValidationError,
-            match=err_msg_match,
-        ):
-            ResConfig(config_dict=config_dict)


### PR DESCRIPTION
**Issue**
Resolves #4071


**Approach**
Just add a test to check an expected error message is raised when duplicate names are added in the config file for keywords like GEN_DATA, GEN_KW, FILED, etc.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
