### PR TITLE
Switch to netcdf for GEN_DATA and SUMMARY vectors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ args = dict(
         "websockets >= 9.0.1",
         "httpx",
         "tables",
+        "xarray",
         "xtgeo",
     ],
     entry_points={

--- a/src/clib/lib/enkf/gen_kw_config.cpp
+++ b/src/clib/lib/enkf/gen_kw_config.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <ert/python.hpp>
 #include <ert/util/hash.h>
 #include <ert/util/util.h>
 #include <ert/util/vector.h>
@@ -292,7 +293,7 @@ gen_kw_config_iget_function_parameter_names(const gen_kw_config_type *config,
     return trans_func_get_param_names(parameter->trans_func);
 }
 
-double_vector_type *
+std::vector<double>
 gen_kw_config_iget_function_parameter_values(const gen_kw_config_type *config,
                                              int index) {
     const gen_kw_parameter_type *parameter =
@@ -303,3 +304,12 @@ gen_kw_config_iget_function_parameter_values(const gen_kw_config_type *config,
 
 VOID_FREE(gen_kw_config)
 VOID_GET_DATA_SIZE(gen_kw)
+
+ERT_CLIB_SUBMODULE("gen_kw_config", m) {
+    m.def(
+        "get_function_parameter_values",
+        [](Cwrap<gen_kw_config_type> self, int index) {
+            return gen_kw_config_iget_function_parameter_values(self, index);
+        },
+        py::arg("self"), py::arg("index"));
+}

--- a/src/clib/lib/include/ert/enkf/gen_kw_config.hpp
+++ b/src/clib/lib/include/ert/enkf/gen_kw_config.hpp
@@ -42,7 +42,7 @@ void gen_kw_config_update_tag_format(gen_kw_config_type *config,
                                      const char *tag_format);
 extern "C" PY_USED const char *
 gen_kw_config_iget_function_type(const gen_kw_config_type *config, int index);
-extern "C" double_vector_type *
+std::vector<double>
 gen_kw_config_iget_function_parameter_values(const gen_kw_config_type *config,
                                              int index);
 extern "C" stringlist_type *

--- a/src/clib/lib/include/ert/enkf/trans_func.hpp
+++ b/src/clib/lib/include/ert/enkf/trans_func.hpp
@@ -1,14 +1,13 @@
 #ifndef ERT_TRANS_FUNC_H
 #define ERT_TRANS_FUNC_H
+#include <ert/enkf/enkf_types.hpp>
+#include <ert/util/stringlist.h>
 #include <stdbool.h>
 #include <stdio.h>
-
-#include <ert/util/double_vector.h>
-
-#include <ert/enkf/enkf_types.hpp>
+#include <vector>
 
 typedef struct trans_func_struct trans_func_type;
-typedef double(transform_ftype)(double, const double_vector_type *);
+typedef double(transform_ftype)(double, const std::vector<double>);
 typedef bool(validate_ftype)(const trans_func_type *);
 
 trans_func_type *trans_func_alloc(const stringlist_type *args);
@@ -17,7 +16,7 @@ double trans_func_eval(const trans_func_type *trans_func, double x);
 void trans_func_free(trans_func_type *trans_func);
 bool trans_func_use_log_scale(const trans_func_type *trans_func);
 stringlist_type *trans_func_get_param_names(const trans_func_type *trans_func);
-double_vector_type *trans_func_get_params(const trans_func_type *trans_func);
+std::vector<double> trans_func_get_params(const trans_func_type *trans_func);
 const char *trans_func_get_name(const trans_func_type *trans_func);
 
 #endif

--- a/src/ert/_c_wrappers/enkf/config/gen_kw_config.py
+++ b/src/ert/_c_wrappers/enkf/config/gen_kw_config.py
@@ -10,6 +10,7 @@ from cwrap import BaseCClass
 from ecl.util.util import StringList
 
 from ert._c_wrappers import ResPrototype
+from ert._clib import gen_kw_config
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -54,9 +55,6 @@ class GenKwConfig(BaseCClass):
     )
     _get_function_parameter_names = ResPrototype(
         "stringlist_ref gen_kw_config_iget_function_parameter_names(gen_kw_config, int)"
-    )
-    _get_function_parameter_values = ResPrototype(
-        "double_vector_ref gen_kw_config_iget_function_parameter_values(gen_kw_config, int)"  # noqa
     )
 
     _transform = ResPrototype(
@@ -147,7 +145,7 @@ class GenKwConfig(BaseCClass):
         for i, key in enumerate(keys):
             function_type = self._get_function_type(i)
             parameter_names = self._get_function_parameter_names(i)
-            parameter_values = self._get_function_parameter_values(i)
+            parameter_values = gen_kw_config.get_function_parameter_values(self, i)
             priors.append(
                 {
                     "key": key,

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 import xtgeo
 
 from ert._c_wrappers.enkf.enums import RealizationStateEnum
@@ -147,9 +148,9 @@ class EnkfFs:
         if not summary_folders:
             return []
         summary_path = summary_folders[0]
-        with open(summary_path / "keys", "r", encoding="utf-8") as f:
-            keys = [k.strip() for k in f.readlines()]
-        return sorted(keys)
+        with xr.open_dataset(summary_path / "data.nc", engine="scipy") as ds_disk:
+            keys = sorted(ds_disk["key"].values)
+        return keys
 
     def realizationList(self, state: RealizationStateEnum) -> List[int]:
         """
@@ -397,10 +398,8 @@ class EnkfFs:
     ) -> pd.DataFrame:
         return self._storage.load_summary_data_as_df(summary_keys, realizations)
 
-    def save_gen_data(
-        self, key: str, data: List[List[float]], realization: int
-    ) -> None:
-        self._storage.save_gen_data(key, data, realization)
+    def save_gen_data(self, data: Dict[str, List[float]], realization: int) -> None:
+        self._storage.save_gen_data(data, realization)
 
     def load_gen_data(
         self, key: str, realizations: List[int]

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -8,7 +8,7 @@ import shutil
 from datetime import datetime
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import numpy as np
 import pandas as pd
@@ -122,7 +122,7 @@ class EnkfFs:
 
     @property
     def is_initalized(self) -> bool:
-        return self._has_parameters()
+        return self._storage.has_parameters()
 
     @classmethod
     def createFileSystem(
@@ -157,47 +157,32 @@ class EnkfFs:
         """
         return [i for i, s in enumerate(self._state_map) if s == state]
 
-    def _has_parameters(self) -> bool:
-        """
-        Checks if a parameter folder has been created
-        """
-        for path in self.mount_point.iterdir():
-            if "gen-kw" in str(path):
-                return True
-        return False
-
     def save_gen_kw(
         self,
         parameter_name: str,
         parameter_keys: List[str],
-        realization: int,
+        parameter_transfer_functions: List[TypedDict],
+        realizations: List[int],
         data: npt.ArrayLike,
     ) -> None:
-        self._storage.save_gen_kw(parameter_name, parameter_keys, realization, data)
-
-        self.update_realization_state(
-            realization,
-            [RealizationStateEnum.STATE_UNDEFINED],
-            RealizationStateEnum.STATE_INITIALIZED,
+        self._storage.save_gen_kw(
+            parameter_name,
+            parameter_keys,
+            parameter_transfer_functions,
+            realizations,
+            data,
         )
-
-    def _load_gen_kw_realization(
-        self, key: str, realization: int
-    ) -> Tuple[npt.NDArray[np.double], List[str]]:
-        input_path = self.mount_point / f"gen-kw-{realization}"
-        if not input_path.exists():
-            raise KeyError(f"Unable to load GEN_KW for key: {key}")
-
-        np_data = np.load(input_path / f"{key}.npy")
-        with open(input_path / f"{key}-keys", "r", encoding="utf-8") as f:
-            keys = [k.strip() for k in f.readlines()]
-
-        return np_data, keys
+        for realization in realizations:
+            self.update_realization_state(
+                realization,
+                [RealizationStateEnum.STATE_UNDEFINED],
+                RealizationStateEnum.STATE_INITIALIZED,
+            )
 
     def load_gen_kw_as_dict(
         self, key: str, realization: int, gen_kw_config: GenKwConfig
     ) -> Dict[str, Dict[str, float]]:
-        data, keys = self._load_gen_kw_realization(key, realization)
+        data, keys = self._storage.load_gen_kw_realization(key, realization)
 
         transformed = {
             parameter_key: gen_kw_config.transform(index, value)
@@ -218,7 +203,7 @@ class EnkfFs:
     def load_gen_kw(self, key: str, realizations: List[int]) -> npt.NDArray[np.double]:
         result = []
         for realization in realizations:
-            data, _ = self._load_gen_kw_realization(key, realization)
+            data, _ = self._storage.load_gen_kw_realization(key, realization)
             result.append(data)
         return np.stack(result).T
 
@@ -339,25 +324,14 @@ class EnkfFs:
         Copies selected parameter files from one storage to another.
         Filters on realization and parameter keys
         """
-        for gen_kw_folder in self.mount_point.glob("gen-kw-*"):
-            files_to_copy = []
-            realization = int(str(gen_kw_folder).rsplit("-", maxsplit=1)[-1])
-            if realization in realizations:
-                for parameter_file in gen_kw_folder.iterdir():
-                    base_name = str(parameter_file.stem)
-                    if base_name in parameter_keys:
-                        files_to_copy.append(parameter_file.name)
-                        files_to_copy.append(f"{base_name}-keys")
 
-            if not files_to_copy:
+        for f in ["gen-kw.nc", "gen-kw-priors.json"]:
+            if not (self.mount_point / f).exists():
                 continue
-
-            Path.mkdir(to.mount_point / gen_kw_folder.stem)
-            for f in files_to_copy:
-                shutil.copy(
-                    src=self.mount_point / gen_kw_folder.stem / f,
-                    dst=to.mount_point / gen_kw_folder.stem / f,
-                )
+            shutil.copy(
+                src=self.mount_point / f,
+                dst=to.mount_point / f,
+            )
 
         for surface_folder in self.mount_point.glob("surface-*"):
             files_to_copy = []

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -37,7 +37,6 @@ def _load_realization(
     sim_fs: EnkfFs,
     realisation: int,
     ensemble_config: EnsembleConfig,
-    history_length: int,
     run_args: List[RunArg],
 ) -> Tuple[LoadStatus, int]:
 
@@ -46,7 +45,7 @@ def _load_realization(
         [RealizationStateEnum.STATE_UNDEFINED],
         RealizationStateEnum.STATE_INITIALIZED,
     )
-    status = forward_model_ok(run_args[realisation], ensemble_config, history_length)
+    status = forward_model_ok(run_args[realisation], ensemble_config)
     sim_fs.state_map[realisation] = (
         RealizationStateEnum.STATE_HAS_DATA
         if status[0] == LoadStatus.LOAD_SUCCESSFUL
@@ -415,7 +414,6 @@ class EnkfFs:
         self,
         ensemble_size: int,
         ensemble_config: EnsembleConfig,
-        history_length: int,
         run_args: List[RunArg],
         active_realizations: List[bool],
     ) -> int:
@@ -425,7 +423,7 @@ class EnkfFs:
         async_result = [
             pool.apply_async(
                 _load_realization,
-                (self, iens, ensemble_config, history_length, run_args),
+                (self, iens, ensemble_config, run_args),
             )
             for iens in range(ensemble_size)
             if active_realizations[iens]

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -18,6 +18,7 @@ import xtgeo
 from ert._c_wrappers.enkf.enums import RealizationStateEnum
 from ert._c_wrappers.enkf.model_callbacks import LoadStatus
 from ert._c_wrappers.enkf.time_map import TimeMap
+from ert._clib import trans_func
 from ert.ensemble_evaluator.callbacks import forward_model_ok
 from ert.storage import Storage
 
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from ecl.summary import EclSum
     from xtgeo import RegularSurface
 
-    from ert._c_wrappers.enkf.config import FieldConfig, GenKwConfig
+    from ert._c_wrappers.enkf.config import FieldConfig
     from ert._c_wrappers.enkf.res_config import EnsembleConfig
     from ert._c_wrappers.enkf.run_arg import RunArg
 
@@ -52,6 +53,21 @@ def _load_realization(
         else RealizationStateEnum.STATE_LOAD_FAILURE
     )
     return status, realisation
+
+
+PRIOR_FUNCTIONS = {
+    "NORMAL": trans_func.normal,
+    "LOGNORMAL": trans_func.log_normal,
+    "TRUNCATED_NORMAL": trans_func.truncated_normal,
+    "TRIANGULAR": trans_func.triangular,
+    "UNIFORM": trans_func.uniform,
+    "DUNIF": trans_func.dunform,
+    "ERRF": trans_func.errf,
+    "DERRF": trans_func.derrf,
+    "LOGUNIF": trans_func.log_uniform,
+    "CONST": trans_func.const,
+    "RAW": trans_func.raw,
+}
 
 
 class EnkfFs:
@@ -180,21 +196,24 @@ class EnkfFs:
             )
 
     def load_gen_kw_as_dict(
-        self, key: str, realization: int, gen_kw_config: GenKwConfig
+        self, key: str, realization: int
     ) -> Dict[str, Dict[str, float]]:
         data, keys = self._storage.load_gen_kw_realization(key, realization)
+        priors = {p["key"]: p for p in self._storage.load_gen_kw_priors()[key]}
 
         transformed = {
-            parameter_key: gen_kw_config.transform(index, value)
-            for index, (parameter_key, value) in enumerate(zip(keys, data))
+            parameter_key: PRIOR_FUNCTIONS[priors[parameter_key]["function"]](
+                value, list(priors[parameter_key]["parameters"].values())
+            )
+            for parameter_key, value in zip(keys, data)
         }
 
         result = {key: transformed}
 
         log10 = {
             parameter_key: math.log(value, 10)
-            for index, (parameter_key, value) in enumerate(transformed.items())
-            if gen_kw_config.shouldUseLogScale(index)
+            for parameter_key, value in transformed.items()
+            if "LOG" in priors[parameter_key]["function"]
         }
         if log10:
             result.update({f"LOG10_{key}": log10})

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -98,7 +98,7 @@ def _generate_gen_kw_parameter_file(
     exports: Dict[str, Dict[str, float]],
 ) -> None:
     key = config.getKey()
-    gen_kw_dict = fs.load_gen_kw_as_dict(key, realization, config)
+    gen_kw_dict = fs.load_gen_kw_as_dict(key, realization)
     transformed = gen_kw_dict[key]
     if not len(transformed) == len(config):
         raise ValueError(

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -510,13 +510,14 @@ class EnKFMain:
                         active_realizations,
                         self.getEnsembleSize(),
                     )
-                for index, real in enumerate(active_realizations):
-                    storage.save_gen_kw(
-                        parameter_name=parameter,
-                        parameter_keys=keys,
-                        realization=real,
-                        data=parameter_values[:, index],
-                    )
+
+                storage.save_gen_kw(
+                    parameter_name=parameter,
+                    parameter_keys=keys,
+                    parameter_transfer_functions=gen_kw_config.get_priors(),
+                    realizations=active_realizations,
+                    data=parameter_values,
+                )
             elif impl_type == ErtImplType.SURFACE:
                 for realization_nr in active_realizations:
                     init_file = config_node.get_init_file_fmt()

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -374,7 +374,6 @@ class EnKFMain:
         nr_loaded = fs.load_from_run_path(
             self.getEnsembleSize(),
             self.ensembleConfig(),
-            self.getHistoryLength(),
             run_context.run_args,
             run_context.mask,
         )

--- a/src/ert/_c_wrappers/enkf/enkf_state.py
+++ b/src/ert/_c_wrappers/enkf/enkf_state.py
@@ -23,6 +23,7 @@ def _internalize_GEN_DATA(
 
     run_path = Path(run_arg.runpath)
     errors = []
+    all_data = {}
     for key in keys:
         config_node = ensemble_config[key]
         filename_fmt = config_node.get_enkf_infile()
@@ -34,9 +35,9 @@ def _internalize_GEN_DATA(
 
             with open(run_path / filename, "r", encoding="utf-8") as f:
                 data = [float(v.strip()) for v in f.readlines()]
+            all_data[f"{key}@{i}"] = np.array(data)
 
-            run_arg.ensemble_storage.save_gen_data(f"{key}@{i}", data, run_arg.iens)
-
+    run_arg.ensemble_storage.save_gen_data(all_data, run_arg.iens)
     if errors:
         return (LoadStatus.LOAD_FAILURE, "\n".join(errors))
     return (LoadStatus.LOAD_SUCCESSFUL, "")

--- a/src/ert/_c_wrappers/enkf/enkf_state.py
+++ b/src/ert/_c_wrappers/enkf/enkf_state.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _internalize_GEN_DATA(
-    ensemble_config: "EnsembleConfig", run_arg: "RunArg", last_report: int
-):
+def _internalize_GEN_DATA(ensemble_config: "EnsembleConfig", run_arg: "RunArg"):
     keys = ensemble_config.getKeylistFromImplType(ErtImplType.GEN_DATA)
 
     run_path = Path(run_arg.runpath)
@@ -107,17 +105,14 @@ def _internalize_SUMMARY_DATA(ens_config: "EnsembleConfig", run_arg: "RunArg"):
 
 
 def _internalize_results(
-    ens_config: "EnsembleConfig", num_reports: int, run_arg: "RunArg"
+    ens_config: "EnsembleConfig", run_arg: "RunArg"
 ) -> Tuple[LoadStatus, str]:
 
     status = _internalize_SUMMARY_DATA(ens_config, run_arg)
     if status[0] != LoadStatus.LOAD_SUCCESSFUL:
         return status
 
-    num_timestamps = len(run_arg.ensemble_storage.getTimeMap())
-    if num_timestamps > 0:
-        num_reports = num_timestamps
-    result = _internalize_GEN_DATA(ens_config, run_arg, num_reports)
+    result = _internalize_GEN_DATA(ens_config, run_arg)
 
     if result[0] == LoadStatus.LOAD_FAILURE:
         return (LoadStatus.LOAD_FAILURE, "Failed to internalize GEN_DATA")

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -122,8 +122,7 @@ def _save_temporary_storage_to_disk(
         if config_node.getImplementationType() == ErtImplType.GEN_KW:
             gen_kw_config = config_node.getKeywordModelConfig()
             parameter_keys = list(gen_kw_config)
-            for i, realization in enumerate(iens_active_index):
-                target_fs.save_gen_kw(key, parameter_keys, realization, matrix[:, i])
+            target_fs.save_gen_kw(key, parameter_keys, [], iens_active_index, matrix)
         elif config_node.getImplementationType() == ErtImplType.SURFACE:
             surface_config = config_node.getSurfaceModelConfig()
             for i, realization in enumerate(iens_active_index):

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -122,7 +122,13 @@ def _save_temporary_storage_to_disk(
         if config_node.getImplementationType() == ErtImplType.GEN_KW:
             gen_kw_config = config_node.getKeywordModelConfig()
             parameter_keys = list(gen_kw_config)
-            target_fs.save_gen_kw(key, parameter_keys, [], iens_active_index, matrix)
+            target_fs.save_gen_kw(
+                key,
+                parameter_keys,
+                gen_kw_config.get_priors(),
+                iens_active_index,
+                matrix,
+            )
         elif config_node.getImplementationType() == ErtImplType.SURFACE:
             surface_config = config_node.getSurfaceModelConfig()
             for i, realization in enumerate(iens_active_index):

--- a/src/ert/ensemble_evaluator/callbacks.py
+++ b/src/ert/ensemble_evaluator/callbacks.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 def forward_model_ok(
     run_arg: "RunArg",
     ens_conf: "EnsembleConfig",
-    num_steps: int,
 ) -> Tuple[LoadStatus, str]:
     result = (LoadStatus.LOAD_SUCCESSFUL, "")
 
@@ -78,7 +77,7 @@ def forward_model_ok(
             )
 
     if result[0] == LoadStatus.LOAD_SUCCESSFUL:
-        result = _internalize_results(ens_conf, num_steps, run_arg)
+        result = _internalize_results(ens_conf, run_arg)
 
     run_arg.ensemble_storage.state_map[run_arg.iens] = (
         RealizationStateEnum.STATE_HAS_DATA

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -361,7 +361,6 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
             realizations = [realization_index]
 
         gen_kw_keys = self.get_gen_kw()
-        ensemble_config = self._enkf_main.ensembleConfig()
         all_data = {}
 
         def _flatten(_gen_kw_dict: Dict[str, Any]) -> Dict[str, float]:
@@ -377,8 +376,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         for realization in realizations:
             realization_data = {}
             for key in gen_kw_keys:
-                gen_kw_config = ensemble_config[key].getKeywordModelConfig()
-                gen_kw_dict = fs.load_gen_kw_as_dict(key, realization, gen_kw_config)
+                gen_kw_dict = fs.load_gen_kw_as_dict(key, realization)
                 realization_data.update(gen_kw_dict)
             all_data[realization] = _flatten(realization_data)
         gen_kw_df = DataFrame(all_data).T

--- a/src/ert/shared/models/base_run_model.py
+++ b/src/ert/shared/models/base_run_model.py
@@ -352,7 +352,6 @@ class BaseRunModel:
                     (
                         run_arg,
                         self.ert().resConfig().ensemble_config,
-                        self.ert().resConfig().model_config.get_history_num_steps(),
                     )
                 ).set_done_callback(
                     lambda x: forward_model_ok(*x)

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -20,7 +20,6 @@ def done_callback(args: Tuple["RunArg", "ResConfig"]) -> Tuple[LoadStatus, str]:
     return forward_model_ok(
         args[0],
         args[1].ensemble_config,
-        args[1].model_config.get_history_num_steps(),
     )
 
 

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -21,28 +22,56 @@ class Storage:
     def __init__(self, mount_point: Path) -> None:
         self.mount_point = mount_point
 
-    def _has_parameters(self) -> bool:
+    def has_parameters(self) -> bool:
         """
         Checks if a parameter folder has been created
         """
-        for path in self.mount_point.iterdir():
-            if "gen-kw" in str(path):
-                return True
+        if Path(self.mount_point / "gen-kw.nc").exists():
+            return True
+
         return False
 
-    def save_gen_kw(
+    def save_gen_kw(  # pylint: disable=R0913
         self,
         parameter_name: str,
         parameter_keys: List[str],
-        realization: int,
+        parameter_transfer_functions: List[Dict[str, Union[str, Dict[str, float]]]],
+        realizations: List[int],
         data: npt.ArrayLike,
     ) -> None:
-        output_path = self.mount_point / f"gen-kw-{realization}"
-        Path.mkdir(output_path, exist_ok=True)
 
-        np.save(output_path / parameter_name, data)
-        with open(output_path / f"{parameter_name}-keys", "w", encoding="utf-8") as f:
-            f.write("\n".join(parameter_keys))
+        ds = xr.Dataset(
+            {
+                parameter_name: ((f"{parameter_name}_keys", "iens"), data),
+            },
+            coords={f"{parameter_name}_keys": parameter_keys, "iens": realizations},
+        )
+        mode: Literal["a", "w"] = (
+            "a" if Path.exists(self.mount_point / "gen-kw.nc") else "w"
+        )
+
+        ds.to_netcdf(self.mount_point / "gen-kw.nc", mode=mode, engine="scipy")
+        priors = {}
+        if Path.exists(self.mount_point / "gen-kw-priors.json"):
+            with open(
+                self.mount_point / "gen-kw-priors.json", "r", encoding="utf-8"
+            ) as f:
+                priors = json.load(f)
+        priors.update({parameter_name: parameter_transfer_functions})
+        with open(self.mount_point / "gen-kw-priors.json", "w", encoding="utf-8") as f:
+            json.dump(priors, f)
+
+    def load_gen_kw_realization(
+        self, key: str, realization: int
+    ) -> Tuple[npt.NDArray[np.double], List[str]]:
+        input_file = self.mount_point / "gen-kw.nc"
+        if not input_file.exists():
+            raise KeyError(f"Unable to load GEN_KW for key: {key}")
+        with xr.open_dataset(input_file, engine="scipy") as ds_disk:
+            np_data = ds_disk.sel(iens=realization)[key].to_numpy()
+            keys = list(ds_disk[key][f"{key}_keys"].values)
+
+        return np_data, keys
 
     def save_summary_data(
         self,

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -61,6 +61,15 @@ class Storage:
         with open(self.mount_point / "gen-kw-priors.json", "w", encoding="utf-8") as f:
             json.dump(priors, f)
 
+    def load_gen_kw_priors(
+        self,
+    ) -> Dict[str, List[Dict[str, Union[str, Dict[str, float]]]]]:
+        with open(self.mount_point / "gen-kw-priors.json", "r", encoding="utf-8") as f:
+            priors: Dict[
+                str, List[Dict[str, Union[str, Dict[str, float]]]]
+            ] = json.load(f)
+        return priors
+
     def load_gen_kw_realization(
         self, key: str, realization: int
     ) -> Tuple[npt.NDArray[np.double], List[str]]:


### PR DESCRIPTION
**Issue**
Using netcdf we can reduce the amount of files required to store responses, as it allows for additional meta-data to be included. There is a slight performance hit compared to pure python.


**Performance**
Testing "load from run-path" with 1046 summary vectors of length 2000 for 25 realizations. Write time is the time 
it takes to write all data from run-path into storage. Load time is the time to construct a dataframes with the 
corresponding size: 

numpy files + text files:
[2092000 rows x 25 columns]
Total runtime: 20.061269521713257
Write time: 18.932803869247437 
Load time: 1.1284642219543457

netcdf files:
[2092000 rows x 25 columns]
Total runtime: 22.232534885406494
Write time: 20.287401914596558
Load time: 1.945131540298462

block_fs:
[50000 rows x 1044 columns] 
Total runtime: 27.011279582977295
Write time: 26.289878606796265
Load time: 0.7213988304138184


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
