### PR TITLE
Fix a bug with WorkflowJob.isPlugin

### DIFF
--- a/src/ert/_c_wrappers/job_queue/workflow_job.py
+++ b/src/ert/_c_wrappers/job_queue/workflow_job.py
@@ -7,6 +7,8 @@ from ert._c_wrappers.config import ConfigParser, ConfigValidationError, ContentT
 from ert._c_wrappers.job_queue import ErtScript, ExternalErtScript, FunctionErtScript
 from ert._clib.job_kw import type_from_kw
 
+from .ert_plugin import ErtPlugin
+
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain
 
@@ -91,7 +93,9 @@ class WorkflowJob:
             raise ConfigValidationError(f"Could not open config_file:{config_file}")
 
     def isPlugin(self) -> bool:
-        return self.internal and self.script is not None
+        if self.script is not None:
+            return issubclass(ErtScript.loadScriptFromFile(self.script), ErtPlugin)
+        return False
 
     def argumentTypes(self) -> List["ContentTypes"]:
         def content_to_type(c: Optional[ContentTypeEnum]):


### PR DESCRIPTION
In f77645597ce911ce583be7adead02de3dba3b4ee a bug was introduced where WorkflowJob did not correctly determine whether a job was a plugin or not.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
