### PR TITLE
Remove nonsensical error when executable does not exist

### DIFF
--- a/src/clib/lib/config/config_schema_item.cpp
+++ b/src/clib/lib/config/config_schema_item.cpp
@@ -409,19 +409,6 @@ bool config_schema_item_validate_set(const config_schema_item_type *item,
 
                         free(relocated);
 
-                        if (strstr(value, "/")) {
-                            /*
-                             * value not naked name, which means it was relative path
-                             * that wasn't found
-                             */
-
-                            error_list.push_back(std::string(
-                                util_alloc_sprintf("Path to executable:%s is "
-                                                   "actually a directory",
-                                                   value)));
-                            break;
-                        }
-
                         /*
                          * res_env_alloc_PATH_executable aborts if some parts of the path is
                          * not an existing dir, so call it only when its an absolute path

--- a/tests/unit_tests/c_wrappers/res/config/test_config_content.py
+++ b/tests/unit_tests/c_wrappers/res/config/test_config_content.py
@@ -13,24 +13,20 @@ def test_get_executable_list(tmpdir):
     path_elm = content.create_path_elm(str(tmpdir))
     content.setParser(parser)
 
-    parser.add_key_value(
-        content,
-        "MYKEYWORD",
-        StringList(["MYKEYWORD", "MY_EXECUTABLE"]),
-        path_elm=path_elm,
-    )
-    parser.add_key_value(
-        content,
-        "MYKEYWORD",
-        StringList(["MYKEYWORD", "MY_EXECUTABLE2"]),
-        path_elm=path_elm,
-    )
+    values = ["MY_EXECUTABLE", "MY_EXECUTABLE2", "PATH/MY_EXECUTABLE"]
+
+    for value in values:
+        parser.add_key_value(
+            content,
+            "MYKEYWORD",
+            StringList(["MYKEYWORD", value]),
+            path_elm=path_elm,
+        )
 
     my_keyword_sets = list(content["MYKEYWORD"])
-    assert len(my_keyword_sets) == 2
+    assert len(my_keyword_sets) == 3
 
     errors = list(content.getErrors())
-    assert "MY_EXECUTABLE" in errors[0]
-    assert " does not exist" in errors[0]
-    assert "MY_EXECUTABLE2" in errors[1]
-    assert " does not exist" in errors[1]
+    for value, error in zip(values, errors):
+        expected_error = f"Executable:{value} does not exist"
+        assert expected_error == error


### PR DESCRIPTION
**Issue**
Resolves #4673


**Approach**
Remove the code that generates the confusing error message now the error will report that the executable is not found if the executable value is not properly formatted. 

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
