### PR TITLE
Add startup suggestion for removing deprecated keyword PLOT_SETTINGS

### DIFF
--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -22,7 +22,12 @@ class DeprecationMigrationSuggester:
         "SCHEDULE_PREDICTION_FILE",
         "MULTFLT",
     ]
-    JUST_REMOVE_KEYWORDS = ["UMASK", "LOG_FILE", "LOG_LEVEL", "ENKF_RERUN"]
+    JUST_REMOVE_KEYWORDS = [
+        "UMASK",
+        "LOG_FILE",
+        "LOG_LEVEL",
+        "ENKF_RERUN",
+    ]
     RSH_KEYWORDS = ["RSH_HOST", "RHS_COMMAND"]
 
     def _add_deprecated_keywords_to_parser(self):
@@ -32,6 +37,7 @@ class DeprecationMigrationSuggester:
             self._parser.add(kw)
         for kw in self.RSH_KEYWORDS:
             self._parser.add(kw)
+        self._parser.add("PLOT_SETTINGS")
         self._parser.add("HAVANA_FAULT")
         self._parser.add("REFCASE_LIST")
         self._parser.add("RFTPATH")
@@ -122,6 +128,13 @@ class DeprecationMigrationSuggester:
             "DELETE_RUNPATH",
             "The DELETE_RUNPATH keyword would clear the runpath directories "
             "between runs. It was removed in 2017 and no longer has any effect.",
+        )
+        add_suggestion(
+            "PLOT_SETTINGS",
+            f"The keyword {kw} no longer has any effect, and can be safely removed."
+            " The PLOT_SETTINGS keyword was once used to set up parameters for"
+            " visualising results after running ERT. This is now done in the graphical"
+            " user interface instead.",
         )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -131,11 +131,11 @@ class DeprecationMigrationSuggester:
         )
         add_suggestion(
             "PLOT_SETTINGS",
-            f"The keyword PLOT_SETTINGS was removed in 2019 and has no effect. It can"
-            f" safely be removed. It was used for controlling settings for outputting"
-            f" qc plots to disk and what plots were shown in the GUI. All plots can now"
-            f" be selected on request from the GUI, and there is also an alternative"
-            f" view accessible by using ert viz in the commandline.",
+            "The keyword PLOT_SETTINGS was removed in 2019 and has no effect. It can"
+            " safely be removed. It was used for controlling settings for outputting"
+            " qc plots to disk and what plots were shown in the GUI. All plots can now"
+            " be selected on request from the GUI, and there is also an alternative"
+            " view accessible by using ert viz in the commandline.",
         )
 
         return suggestions

--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -131,10 +131,11 @@ class DeprecationMigrationSuggester:
         )
         add_suggestion(
             "PLOT_SETTINGS",
-            f"The keyword {kw} no longer has any effect, and can be safely removed."
-            " The PLOT_SETTINGS keyword was once used to set up parameters for"
-            " visualising results after running ERT. This is now done in the graphical"
-            " user interface instead.",
+            f"The keyword PLOT_SETTINGS was removed in 2019 and has no effect. It can"
+            f" safely be removed. It was used for controlling settings for outputting"
+            f" qc plots to disk and what plots were shown in the GUI. All plots can now"
+            f" be selected on request from the GUI, and there is also an alternative"
+            f" view accessible by using ert viz in the commandline.",
         )
 
         return suggestions

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -110,3 +110,15 @@ def test_suggester_gives_no_runpath_deprecated_specifier_migration(suggester, tm
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 0
+
+
+def test_suggester_gives_plot_settings_migration(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text(
+        "NUM_REALIZATIONS 1\nPLOT_SETTINGS some args\n"
+    )
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert (
+        "The PLOT_SETTINGS keyword was once used to set up parameters" in suggestions[0]
+    )

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -120,5 +120,6 @@ def test_suggester_gives_plot_settings_migration(suggester, tmp_path):
 
     assert len(suggestions) == 1
     assert (
-        "The PLOT_SETTINGS keyword was once used to set up parameters" in suggestions[0]
+        "The keyword PLOT_SETTINGS was removed in 2019 and has no effect"
+        in suggestions[0]
     )


### PR DESCRIPTION
**Issue**
Resolves #4658

This should give a user confidence to take action towards removing the keyword.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
