### PR TITLE
Move warning about deprecated defines without angle brackets to the suggester

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import os
-import sys
 import warnings
 from datetime import date
 from os.path import isfile
@@ -56,8 +55,6 @@ class ResConfig:
         else:
             self._alloc_from_dict(config_dict=config_dict)
 
-        self._validate()
-
     def _assert_input(self, user_config_file, config_dict):
         user_config_file_given = user_config_file is not None
         config_dict_given = config_dict is not None
@@ -76,22 +73,6 @@ class ResConfig:
 
         if user_config_file_given and not isfile(user_config_file):
             raise IOError(f'No such configuration file "{user_config_file}".')
-
-    def _validate(self):
-        for key, _ in self.substitution_list:
-            if (
-                key.count("<") != 1
-                or key.count(">") != 1
-                or key[0] != "<"
-                or key[-1] != ">"
-            ):
-                print(
-                    "Using DEFINE or DATA_KW with substitution"
-                    " strings that are not of the form '<KEY>' is deprecated"
-                    " and can result in undefined behavior. "
-                    f"Please change {key} to <{key.replace('<', '').replace('>', '')}>",
-                    file=sys.stderr,
-                )
 
     def _log_config_file(self, config_file: str) -> None:
         """
@@ -176,13 +157,6 @@ class ResConfig:
         init_user_config_parser(config_parser)
         return config_parser
 
-    def _display_suggestions(self, config_file):
-        suggestions = DeprecationMigrationSuggester(
-            ResConfig._create_user_config_parser()
-        ).suggest_migrations(config_file)
-        for suggestion in suggestions:
-            warnings.warn(suggestion, category=ConfigWarning)
-
     @classmethod
     def make_suggestion_list(cls, config_file):
         return DeprecationMigrationSuggester(
@@ -212,7 +186,6 @@ class ResConfig:
         site_config_content = site_config_parser.parse(site_config_location())
 
         config_parser = ResConfig._create_user_config_parser()
-        init_user_config_parser(config_parser)
         self.config_path = os.path.abspath(os.path.dirname(user_config_file))
         user_config_content = config_parser.parse(
             user_config_file,

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -96,25 +96,6 @@ def test_res_config_throws_on_missing_forward_model_job(
             ResConfig(config_dict=config_dict)
 
 
-@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
-@pytest.mark.parametrize(
-    "bad_define", ["DEFINE A B", "DEFINE <A<B>> C", "DEFINE <A><B> C"]
-)
-def test_that_non_bracketed_defines_warns(bad_define, capsys):
-    with open("test.ert", "w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
-                NUM_REALIZATIONS  1
-                {bad_define}
-                """
-            )
-        )
-
-    _ = ResConfig("test.ert")
-    assert "Using DEFINE or DATA_KW with substitution" in capsys.readouterr().err
-
-
 def test_default_ens_path(tmpdir):
     with tmpdir.as_cwd():
         config_file = "test.ert"

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -123,3 +123,19 @@ def test_suggester_gives_plot_settings_migration(suggester, tmp_path):
         "The keyword PLOT_SETTINGS was removed in 2019 and has no effect"
         in suggestions[0]
     )
+
+
+def test_suggester_gives_deprecated_define_migration_hint(suggester, tmp_path):
+    (tmp_path / "config.ert").write_text(
+        "NUM_REALIZATIONS 1\n"
+        "DEFINE <KEY1> x1\n"
+        "DEFINE A B\n"
+        "DEFINE <A<B>> C\n"
+        "DEFINE <A><B> C\n"
+    )
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 3
+    assert "Please change A to <A>" in suggestions[0]
+    assert "Please change <A<B>> to <AB>" in suggestions[1]
+    assert "Please change <A><B> to <AB>" in suggestions[2]


### PR DESCRIPTION
**Issue**
Resolves #4679 


**Approach**
Move warning about deprecated defines without angle brackets to the suggester

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
