### PR TITLE
Remove special casing from AnalysisConfig

### DIFF
--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -49,11 +49,7 @@ class AnalysisConfig:
 
     def _copy_modules(self):
         for element in self._analysis_copy:
-            if isinstance(element, list):
-                src_name, dst_name = element
-            else:
-                src_name = element[ConfigKeys.SRC_NAME]
-                dst_name = element[ConfigKeys.DST_NAME]
+            src_name, dst_name = element
 
             module = self._modules.get(src_name)
             if module is not None:
@@ -69,12 +65,7 @@ class AnalysisConfig:
 
     def _set_modules_var_list(self):
         for set_var in self._analysis_set_var:
-            if isinstance(set_var, list):
-                module_name, var_name, value = set_var
-            else:
-                module_name = set_var[ConfigKeys.MODULE_NAME]
-                var_name = set_var[ConfigKeys.VAR_NAME]
-                value = set_var[ConfigKeys.VALUE]
+            module_name, var_name, value = set_var
 
             module = self.get_module(module_name)
             module.set_var(var_name, value)

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -304,20 +304,16 @@ def generate_config(draw):
                     queue_options(st.just(queue_system))
                 ),
                 ConfigKeys.ANALYSIS_COPY: small_list(
-                    st.fixed_dictionaries(
-                        {
-                            ConfigKeys.SRC_NAME: st.just("STD_ENKF"),
-                            ConfigKeys.DST_NAME: words,
-                        }
+                    st.tuples(
+                        st.just("STD_ENKF"),
+                        words,
                     )
                 ),
                 ConfigKeys.ANALYSIS_SET_VAR: small_list(
-                    st.fixed_dictionaries(
-                        {
-                            ConfigKeys.MODULE_NAME: st.just("STD_ENKF"),
-                            ConfigKeys.VAR_NAME: st.just("ENKF_NCOMP"),
-                            ConfigKeys.VALUE: st.integers(),
-                        }
+                    st.tuples(
+                        st.just("STD_ENKF"),
+                        st.just("ENKF_NCOMP"),
+                        st.integers(),
                     )
                 ),
                 ConfigKeys.ANALYSIS_SELECT: st.just("STD_ENKF"),
@@ -538,17 +534,11 @@ def to_config_file(filename, config_dict):  # pylint: disable=too-many-branches
                     config.write(f"{keyword} {install_dir}\n")
             elif keyword == ConfigKeys.ANALYSIS_COPY:
                 for statement in keyword_value:
-                    config.write(
-                        f"{keyword}"
-                        f" {statement[ConfigKeys.SRC_NAME]}"
-                        f" {statement[ConfigKeys.DST_NAME]}\n"
-                    )
+                    config.write(f"{keyword} {statement[0]} {statement[1]}\n")
             elif keyword == ConfigKeys.ANALYSIS_SET_VAR:
                 for statement in keyword_value:
                     config.write(
-                        f"{keyword} {statement[ConfigKeys.MODULE_NAME]}"
-                        f" {statement[ConfigKeys.VAR_NAME]}"
-                        f" {statement[ConfigKeys.VALUE]}\n"
+                        f"{keyword} {statement[0]} {statement[1]} {statement[2]}\n"
                     )
             elif keyword == ConfigKeys.QUEUE_OPTION:
                 for setting in keyword_value:

--- a/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
@@ -45,22 +45,22 @@ def test_analysis_config_constructor(setup_case):
             ConfigKeys.MAX_RUNTIME: 0,
             ConfigKeys.MIN_REALIZATIONS: 10,
             ConfigKeys.ANALYSIS_COPY: [
-                {
-                    ConfigKeys.SRC_NAME: "STD_ENKF",
-                    ConfigKeys.DST_NAME: "ENKF_HIGH_TRUNCATION",
-                }
+                (
+                    "STD_ENKF",
+                    "ENKF_HIGH_TRUNCATION",
+                )
             ],
             ConfigKeys.ANALYSIS_SET_VAR: [
-                {
-                    ConfigKeys.MODULE_NAME: "STD_ENKF",
-                    ConfigKeys.VAR_NAME: "ENKF_NCOMP",
-                    ConfigKeys.VALUE: 2,
-                },
-                {
-                    ConfigKeys.MODULE_NAME: "ENKF_HIGH_TRUNCATION",
-                    ConfigKeys.VAR_NAME: "ENKF_TRUNCATION",
-                    ConfigKeys.VALUE: 0.99,
-                },
+                (
+                    "STD_ENKF",
+                    "ENKF_NCOMP",
+                    2,
+                ),
+                (
+                    "ENKF_HIGH_TRUNCATION",
+                    "ENKF_TRUNCATION",
+                    0.99,
+                ),
             ],
             ConfigKeys.ANALYSIS_SELECT: "ENKF_HIGH_TRUNCATION",
         }


### PR DESCRIPTION
While working on a parsing prototype, found that there is some code paths that in only used in testing. Removing those and updating tests.


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
