### PR TITLE
Add error context information to FORWARD_MODEL parsing

### DIFF
--- a/src/clib/old_tests/res_util/test_ert_util_subst_list_add_from_string.cpp
+++ b/src/clib/old_tests/res_util/test_ert_util_subst_list_add_from_string.cpp
@@ -1,13 +1,8 @@
 #include <ert/res_util/subst_list.hpp>
 #include <ert/util/test_util.hpp>
 #include <stdarg.h>
+#include <stdexcept>
 #include <stdlib.h>
-
-void call_func_util_abort(void *args) {
-    subst_list_type *subst_list = subst_list_alloc();
-    subst_list_add_from_string(subst_list, (char *)args);
-    subst_list_free(subst_list);
-}
 
 void test_valid_arg_string(const char *arg_string, int arg_count, ...) {
     va_list ap;
@@ -25,11 +20,19 @@ void test_valid_arg_string(const char *arg_string, int arg_count, ...) {
     subst_list_free(subst_list);
 }
 
-void test_invalid_arg_string(const char *arg_string) {
-    char *tmp = util_alloc_substring_copy(arg_string, 0, strlen(arg_string));
-    test_assert_util_abort("subst_list_add_from_string", call_func_util_abort,
-                           tmp);
-    free(tmp);
+void expect_exception(const char *arg_string, const char *err_msg) {
+    subst_list_type *subst_list = subst_list_alloc();
+    bool success = false;
+
+    try {
+        subst_list_add_from_string(subst_list, arg_string);
+    } catch (const std::invalid_argument &err) {
+        if (strcmp(err.what(), err_msg) == 0)
+            success = true;
+    }
+
+    test_assert_true(success);
+    subst_list_free(subst_list);
 }
 
 int main(int argc, char **argv) {
@@ -47,16 +50,15 @@ int main(int argc, char **argv) {
                           "\"a,b\"",
                           2, "x", "'a'", "y", "\"a,b\"");
     test_valid_arg_string("x='a' 'b'", 1, "x", "'a' 'b'");
-
-    test_invalid_arg_string(",");
-    test_invalid_arg_string(", x=1");
-    test_invalid_arg_string("x=1,");
-    test_invalid_arg_string("x=1,,y=2");
-    test_invalid_arg_string("x");
-    test_invalid_arg_string("x=");
-    test_invalid_arg_string("=x");
-    test_invalid_arg_string("x='a");
-    test_invalid_arg_string("x=a'");
-    test_invalid_arg_string("'x'=1");
-    test_invalid_arg_string("\"x\"=1");
+    expect_exception(",", "Missing '=' in argument");
+    expect_exception("x", "Missing '=' in argument");
+    expect_exception(", x=1", "Missing '=' in argument");
+    expect_exception("x=1,,y=2", "Missing '=' in argument");
+    expect_exception("x=1,", "Trailing comma in argument list");
+    expect_exception("x=", "Missing value in argument list");
+    expect_exception("=x", "Missing key in argument list");
+    expect_exception("x='a", "Missing string delimiter in argument");
+    expect_exception("x=a'", "Missing string delimiter in argument");
+    expect_exception("'x'=1", "Key cannot contain quotation marks");
+    expect_exception("\"x\"=1", "Key cannot contain quotation marks");
 }

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -284,7 +284,21 @@ class ResConfig:
                 ) from err
             if args:
                 job.private_args = SubstitutionList()
-                job.private_args.add_from_string(args)
+
+                try:
+                    job.private_args.add_from_string(args)
+                except ValueError as e:
+                    conffile = self.substitution_list.get("<CONFIG_FILE>", "")
+                    confpath = self.substitution_list.get("<CONFIG_PATH>", "")
+
+                    err_string = f"{e}: FORWARD_MODEL {job_name} ({args})\n"
+                    err_string += (
+                        f"Occurred in configuration file: {confpath}/{conffile}"
+                        if conffile and confpath
+                        else ""
+                    )
+                    raise ConfigValidationError(err_string)
+
                 job.define_args = self.substitution_list
             jobs.append(job)
 

--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -4,6 +4,7 @@ import os
 from cwrap import BaseCClass
 from ecl.ecl_util import get_num_cpu as get_num_cpu_from_data_file
 
+from ert import _clib
 from ert._c_wrappers import ResPrototype
 
 
@@ -21,9 +22,6 @@ class SubstitutionList(BaseCClass):
         "char* subst_list_alloc_filtered_string(subst_list, char*, char*)"
     )
     _filter_file = ResPrototype("bool subst_list_filter_file(subst_list, char*,char*)")
-    _add_from_string = ResPrototype(
-        "void subst_list_add_from_string(subst_list, char*)"
-    )
     _deep_copy = ResPrototype("subst_list_obj subst_list_alloc_deep_copy(subst_list)")
 
     def __init__(self):
@@ -94,7 +92,7 @@ class SubstitutionList(BaseCClass):
             raise KeyError(f"No such key:{key}")
 
     def add_from_string(self, string):
-        self._add_from_string(string)
+        _clib.subst_list.subst_list_add_from_string(self, string)
 
     def get(self, key, default=None):
         return self[key] if key in self else default


### PR DESCRIPTION
**Issue**
Resolves #4657

:warning: pybind maps std::invalid_argument to ValueError exception

Using this in configfile:
```
FORWARD_MODEL ECLIPSE100(<VERSION>2020.2)
```

Returns error;

```
Missing '=' in argument: FORWARD_MODEL ECLIPSE100 <VERSION>2020.2
Configuration file: /private/andrli/project/ert/test-data/poly_example/poly.ert
```

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
