### PR TITLE
Fix parsing of forward model with quotes

### DIFF
--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -72,8 +72,8 @@ MULTI_OCCURRENCE_SINGLE_ARG_KEYS = [
 # Should be interpreted as having three arguments:
 # ["LOCAL", "opt", "the value of the option"]
 JOIN_KEYS = [
-    (ConfigKeys.QUEUE_OPTION, 2),
-    (ConfigKeys.FORWARD_MODEL, 0),
+    (ConfigKeys.QUEUE_OPTION, 2, " "),
+    (ConfigKeys.FORWARD_MODEL, 0, ""),
 ]
 
 
@@ -105,11 +105,11 @@ def config_content_as_dict(
                     values = list(node)
                     content_dict[key].append(values)
 
-    for key, join_at in JOIN_KEYS:
+    for key, join_at, join_on in JOIN_KEYS:
         if key in content_dict:
             for occurrence in content_dict[key]:
                 if len(occurrence) > join_at:
-                    occurrence[join_at] = " ".join(occurrence[join_at:])
+                    occurrence[join_at] = join_on.join(occurrence[join_at:])
                     del occurrence[join_at + 1 :]
 
     if ConfigKeys.FORWARD_MODEL in content_dict:

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -309,3 +309,28 @@ def test_that_a_config_warning_is_given_when_eclbase_and_jobname_is_given():
         fh.write(test_config_contents)
     with pytest.warns(ConfigWarning):
         _ = ResConfig(user_config_file=test_config_file_name)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_parsing_forward_model_with_quotes_does_not_introduce_spaces():
+    """this is a regression test, making sure that we do not by mistake introduce
+    spaces while parsing forward model lines that contain quotation marks
+
+    the use case is that a file name is utilized that contains two consecutive hyphens,
+    which by the ert config parser is interpreted as a comment - to circumvent the
+    comment interpretation, quotation marks are used"""
+
+    test_config_file_name = "test.ert"
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS  1
+        JOBNAME job_%d
+        FORWARD_MODEL COPY_FILE(<FROM>=foo,<TO>=something/"hello--there.txt")
+        """
+    )
+    with open(test_config_file_name, "w", encoding="utf-8") as fh:
+        fh.write(test_config_contents)
+
+    res_config = ResConfig(user_config_file=test_config_file_name)
+    for _, value in res_config.forward_model.jobs[0].private_args:
+        assert " " not in value


### PR DESCRIPTION
**Issue**
Resolves #4706


**Approach**

When quoting a proper substring of the right side of an argument assignment in a forward model, as in

```
FORWARD_MODEL COPY_FILE(<FROM>=foo,<TO>=storage/"bar--bar">)
```

the as dict method would introduce a space on the first quotation mark, which is undesired behaviour. This commit fixes that and introduces a regression test.

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
