### PR TITLE
Restrict flake8 requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ click
 cmake-format
 decorator
 ecl_data_io
-flake8>=4.0.0
+flake8
 grpcio-tools==1.41.0
 isort
 jsonpath_ng

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,8 @@ per-file-ignores =
      src/ert/experiment_server/_server.py: E501
      # Ignore all protobuf v2 files
     *_pb2.py: E
-ignore = F401,E711,W503,E203,SIM201,SIM115
+# We ignore only things that black takes (better) care of:
+ignore =
+    E203
+    W503
 max-line-length = 88

--- a/src/_ert_com_protocol/__init__.py
+++ b/src/_ert_com_protocol/__init__.py
@@ -43,6 +43,7 @@ from ._schema_pb2 import (
     StepStatus,
 )
 from ._state_machine import ExperimentStateMachine, node_status_builder
+from .status_type_enum import queue_state_to_pbuf_type
 
 __all__ = (
     "ExperimentStateMachine",
@@ -85,5 +86,5 @@ __all__ = (
     "JobStatus",
     "StepStatus",
     "ExperimentStatus",
+    "queue_state_to_pbuf_type",
 )
-from .status_type_enum import queue_state_to_pbuf_type

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -55,7 +55,7 @@ def run_ert_storage(args: Namespace) -> None:
 def run_webviz_ert(args: Namespace) -> None:
     try:
         # pylint: disable=unused-import,import-outside-toplevel
-        import webviz_ert  # type: ignore
+        import webviz_ert  # type: ignore  # noqa
     except ImportError as err:
         raise ValueError(
             "Running `ert vis` requires that webviz_ert is installed"

--- a/src/ert/_c_wrappers/__init__.py
+++ b/src/ert/_c_wrappers/__init__.py
@@ -4,14 +4,17 @@ Ert - Ensemble Reservoir Tool - a package for reservoir modeling.
 import os.path
 import warnings
 
-import ecl  # This needs to be here for ... reasons
+import ecl
 
 warnings.filterwarnings(action="always", category=DeprecationWarning, module=r"res|ert")
 
-from cwrap import Prototype  # noqa
+from cwrap import Prototype  # noqa: E402 module level import not at top of file
 
+__all__ = [ecl, Prototype]
 try:
     from ._version import version as __version__
+
+    __all__ += [__version__]
 except ImportError:
     pass
 

--- a/src/ert/_c_wrappers/job_queue/__init__.py
+++ b/src/ert/_c_wrappers/job_queue/__init__.py
@@ -44,6 +44,8 @@ from cwrap import Prototype
 
 import ert._c_wrappers
 
+__all__ = [Prototype, ert._c_wrappers]
+
 
 def setenv(var, value):
     if not os.getenv(var):

--- a/src/ert/_c_wrappers/util/__init__.py
+++ b/src/ert/_c_wrappers/util/__init__.py
@@ -4,3 +4,5 @@ import ert._c_wrappers
 
 from .path_format import PathFormat
 from .substitution_list import SubstitutionList
+
+__all__ = [Prototype, ert._c_wrappers, PathFormat, SubstitutionList]

--- a/src/ert/data/__init__.py
+++ b/src/ert/data/__init__.py
@@ -63,5 +63,6 @@ __all__ = (
     "TarTransformation",
     "TransformationDirection",
     "TransformationType",
+    "TreeSerializationTransformation",
     "transmitter_factory",
 )

--- a/src/ert/gui/tools/__init__.py
+++ b/src/ert/gui/tools/__init__.py
@@ -1,1 +1,3 @@
 from .tool import Tool
+
+__all__ = [Tool]

--- a/src/ert/gui/tools/export/__init__.py
+++ b/src/ert/gui/tools/export/__init__.py
@@ -1,2 +1,4 @@
 from .export_panel import ExportPanel
 from .export_tool import ExportTool
+
+__all__ = [ExportPanel, ExportTool]

--- a/src/ert/gui/tools/file/__init__.py
+++ b/src/ert/gui/tools/file/__init__.py
@@ -1,2 +1,4 @@
 from .file_dialog import FileDialog
 from .file_update_worker import FileUpdateWorker
+
+__all__ = [FileDialog, FileUpdateWorker]

--- a/src/ert/gui/tools/load_results/__init__.py
+++ b/src/ert/gui/tools/load_results/__init__.py
@@ -1,2 +1,4 @@
+# flake8: noqa F401
+
 from .load_results_panel import LoadResultsPanel
 from .load_results_tool import LoadResultsTool

--- a/src/ert/gui/tools/manage_cases/__init__.py
+++ b/src/ert/gui/tools/manage_cases/__init__.py
@@ -1,1 +1,3 @@
 from .manage_cases_tool import ManageCasesTool
+
+__all__ = [ManageCasesTool]

--- a/src/ert/gui/tools/plot/widgets/__init__.py
+++ b/src/ert/gui/tools/plot/widgets/__init__.py
@@ -1,1 +1,3 @@
 from ert.gui.tools.plot.widgets.copy_style_to_dialog import CopyStyleToDialog
+
+__all__ = [CopyStyleToDialog]

--- a/src/ert/gui/tools/run_analysis/__init__.py
+++ b/src/ert/gui/tools/run_analysis/__init__.py
@@ -1,2 +1,4 @@
 from .run_analysis_panel import RunAnalysisPanel
 from .run_analysis_tool import RunAnalysisTool
+
+__all__ = [RunAnalysisPanel, RunAnalysisTool]

--- a/src/ert/gui/tools/workflows/__init__.py
+++ b/src/ert/gui/tools/workflows/__init__.py
@@ -1,2 +1,4 @@
 from .run_workflow_widget import RunWorkflowWidget
 from .workflows_tool import WorkflowsTool
+
+__all__ = [RunWorkflowWidget, WorkflowsTool]

--- a/src/ert/shared/ide/keywords/data/__init__.py
+++ b/src/ert/shared/ide/keywords/data/__init__.py
@@ -1,1 +1,3 @@
 from .validation_status import ValidationStatus
+
+__all__ = [ValidationStatus]

--- a/src/ert/shared/plugins/hook_specifications/__init__.py
+++ b/src/ert/shared/plugins/hook_specifications/__init__.py
@@ -13,3 +13,17 @@ from .jobs import (
 )
 from .logging import add_log_handle_to_root
 from .site_config import site_config_lines
+
+__all__ = [
+    add_log_handle_to_root,
+    ecl100_config_path,
+    ecl300_config_path,
+    flow_config_path,
+    help_links,
+    installable_jobs,
+    installable_workflow_jobs,
+    job_documentation,
+    legacy_ertscript_workflow,
+    rms_config_path,
+    site_config_lines,
+]

--- a/tests/unit_tests/all/test_main.py
+++ b/tests/unit_tests/all/test_main.py
@@ -274,4 +274,4 @@ def test_argparse_no_port_range():
             "path/to/config.ert",
         ],
     )
-    assert parsed.port_range == None
+    assert parsed.port_range is None

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -7,7 +7,7 @@ from iterative_ensemble_smoother import IterativeEnsembleSmoother
 
 from ert import LibresFacade
 from ert.__main__ import ert_parser
-from ert._c_wrappers.enkf import EnKFMain, EnkfNode, NodeId, ResConfig, RunContext
+from ert._c_wrappers.enkf import EnKFMain, EnkfNode, NodeId, ResConfig
 from ert.analysis import ErtAnalysisError, ESUpdate
 from ert.analysis._es_update import _create_temporary_parameter_storage
 from ert.cli import ENSEMBLE_EXPERIMENT_MODE, ENSEMBLE_SMOOTHER_MODE

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -15,8 +15,8 @@ def test_create():
     conf_from_dict = EnsembleConfig.from_dict({})
 
     assert empty_ens_conf == conf_from_dict
-    assert conf_from_dict.get_refcase_file == None
-    assert conf_from_dict.grid_file == None
+    assert conf_from_dict.get_refcase_file is None
+    assert conf_from_dict.grid_file is None
     assert conf_from_dict.parameters == []
 
     assert "XYZ" not in conf_from_dict

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -26,8 +26,8 @@ def test_field_basics(snake_oil_field_example):
     assert fc.get_truncation_mode() == 0
     assert fc.get_truncation_min() == -1.0
     assert fc.get_truncation_max() == -1.0
-    assert fc.get_init_transform_name() == None
-    assert fc.get_output_transform_name() == None
+    assert fc.get_init_transform_name() is None
+    assert fc.get_output_transform_name() is None
 
 
 def test_field_export(snake_oil_field_example):

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
@@ -30,13 +30,13 @@ def test_load_forward_model():
     os.chmod(name, stat.S_IMODE(mode))
     job = ExtJob.from_config_file("CONFIG")
     assert job.name == "CONFIG"
-    assert job.stdout_file == None
-    assert job.stderr_file == None
+    assert job.stdout_file is None
+    assert job.stderr_file is None
 
     assert job.executable == os.path.join(os.getcwd(), "script.sh")
     assert os.access(job.executable, os.X_OK)
 
-    assert job.min_arg == None
+    assert job.min_arg is None
 
     job = ExtJob.from_config_file("CONFIG", name="Job")
     assert job.name == "Job"

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_runner.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_runner.py
@@ -94,7 +94,7 @@ def test_workflow_failed_job():
         Workflow, "run", side_effect=Exception("mocked workflow error")
     ), workflow_runner:
         workflow_runner.wait()
-        assert workflow_runner.exception() != None
+        assert workflow_runner.exception() is not None
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/ensemble_evaluator/prefect/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/prefect/conftest.py
@@ -432,7 +432,7 @@ def external_sum_function(tmpdir):
         # Check module is not in the python environment
         with pytest.raises(ModuleNotFoundError):
             # pylint: disable=unused-import,import-error
-            import foo.bar
+            import foo.bar  # noqa
 
         # Make sure the function is no longer available before we start creating
         # the flow and task

--- a/tests/unit_tests/gui/plottery/test_plot_limits.py
+++ b/tests/unit_tests/gui/plottery/test_plot_limits.py
@@ -7,28 +7,28 @@ from ert.gui.plottery import PlotLimits
 
 def test_plot_limits_construction():
     plot_limits = PlotLimits()
-    assert plot_limits.value_minimum == None
-    assert plot_limits.value_maximum == None
+    assert plot_limits.value_minimum is None
+    assert plot_limits.value_maximum is None
     assert plot_limits.value_limits == (None, None)
 
-    assert plot_limits.index_minimum == None
-    assert plot_limits.index_maximum == None
+    assert plot_limits.index_minimum is None
+    assert plot_limits.index_maximum is None
     assert plot_limits.index_limits == (None, None)
 
-    assert plot_limits.count_minimum == None
-    assert plot_limits.count_maximum == None
+    assert plot_limits.count_minimum is None
+    assert plot_limits.count_maximum is None
     assert plot_limits.count_limits == (None, None)
 
-    assert plot_limits.density_minimum == None
-    assert plot_limits.density_maximum == None
+    assert plot_limits.density_minimum is None
+    assert plot_limits.density_maximum is None
     assert plot_limits.density_limits == (None, None)
 
-    assert plot_limits.depth_minimum == None
-    assert plot_limits.depth_maximum == None
+    assert plot_limits.depth_minimum is None
+    assert plot_limits.depth_maximum is None
     assert plot_limits.depth_limits == (None, None)
 
-    assert plot_limits.date_minimum == None
-    assert plot_limits.date_maximum == None
+    assert plot_limits.date_minimum is None
+    assert plot_limits.date_maximum is None
     assert plot_limits.date_limits == (None, None)
 
 

--- a/tests/unit_tests/models/test_base_run_model.py
+++ b/tests/unit_tests/models/test_base_run_model.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ert._c_wrappers.enkf import EnKFMain, RunContext
+from ert._c_wrappers.enkf import EnKFMain
 from ert._c_wrappers.job_queue import RunStatusType
 from ert.shared.models import BaseRunModel
 


### PR DESCRIPTION
Add exceptions in each file where relevant instead of applying them globally

One non-important bug is fixed in data/__init__.py

**Issue**
Related to #3309 


**Approach**
Fix.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
