### PR TITLE
Catch mismatch between expected and given arguments for forward model jobs

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -20,6 +20,7 @@ from ert._c_wrappers.enkf.queue_config import QueueConfig
 from ert._c_wrappers.job_queue import (
     EnvironmentVarlist,
     ExtJob,
+    ExtJobInvalidArgsException,
     ForwardModel,
     Workflow,
     WorkflowJob,
@@ -279,6 +280,10 @@ class ResConfig:
                     raise ConfigValidationError(err_string)
 
                 job.define_args = self.substitution_list
+            try:
+                job.validate_args(self.substitution_list)
+            except ExtJobInvalidArgsException as err:
+                logger.warning(str(err))
             jobs.append(job)
 
         for job_description in config_dict.get(ConfigKeys.SIMULATION_JOB, []):

--- a/src/ert/_c_wrappers/job_queue/__init__.py
+++ b/src/ert/_c_wrappers/job_queue/__init__.py
@@ -65,7 +65,7 @@ from .driver import Driver, LocalDriver, LSFDriver, QueueDriverEnum  # noqa
 from .environment_varlist import EnvironmentVarlist  # noqa
 from .ert_plugin import CancelPluginException, ErtPlugin  # noqa
 from .ert_script import ErtScript  # noqa
-from .ext_job import ExtJob  # noqa
+from .ext_job import ExtJob, ExtJobInvalidArgsException  # noqa
 from .external_ert_script import ExternalErtScript  # noqa
 from .forward_model import ForwardModel  # noqa
 from .function_ert_script import FunctionErtScript  # noqa
@@ -97,6 +97,7 @@ __all__ = [
     "LSFDriver",
     "LocalDriver",
     "ExtJob",
+    "ExtJobInvalidArgsException",
     "EnvironmentVarlist",
     "ForwardModel",
     "ErtScript",

--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -55,7 +55,7 @@ class ForwardModel:
         def substitute(job, string: str):
             job_args = ",".join([f"{key}={value}" for key, value in job.private_args])
             job_description = f"{job.name}({job_args})"
-            substitution_context = (
+            substitution_context_hint = (
                 f"parsing forward model job `FORWARD_MODEL {job_description}` - "
                 "reconstructed, with defines applied during parsing"
             )
@@ -65,7 +65,7 @@ class ForwardModel:
                     copy_private_args.addItem(
                         key, context.substitute_real_iter(val, iens, itr)
                     )
-                string = copy_private_args.substitute(string, substitution_context)
+                string = copy_private_args.substitute(string, substitution_context_hint)
                 return context.substitute_real_iter(string, iens, itr)
             else:
                 return string

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -84,10 +84,7 @@ def test_res_config_throws_on_missing_forward_model_job(
         config_dict.pop(ConfigKeys.INSTALL_JOB)
         config_dict.pop(ConfigKeys.INSTALL_JOB_DIRECTORY)
         config_dict[ConfigKeys.FORWARD_MODEL].append(
-            {
-                ConfigKeys.NAME: "this-is-not-the-job-you-are-looking-for",
-                ConfigKeys.ARGLIST: "<WAVE-HAND>=casually",
-            }
+            ["this-is-not-the-job-you-are-looking-for", "<WAVE-HAND>=casually"]
         )
 
         to_config_file(filename, config_dict)


### PR DESCRIPTION
**Issue**
Resolves #4694 


**Approach**
We warn if

- any magic string in the arg list of a job referenced by a forward model could not be resolved with substitutions or defauklts, and
- a private arg key=value substitution is given in the forward model definition that has no effect 

## Pre review checklist

- [X] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).