### PR TITLE
Stop parsing workflow during init

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -466,4 +466,4 @@ class EnKFMain:
 
     def runWorkflows(self, runtime: int) -> None:
         for workflow in self.res_config.hooked_workflows[runtime]:
-            workflow.run(self, context=self.res_config.substitution_list)
+            workflow.run(self)

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -350,7 +350,9 @@ class ResConfig:
 
         for work in workflow_info:
             filename = os.path.basename(work[0]) if len(work) == 1 else work[1]
-            self.workflows[filename] = Workflow(work[0], self.workflow_jobs)
+            self.workflows[filename] = Workflow.from_file(
+                work[0], self.substitution_list, self.workflow_jobs
+            )
 
         for hook_name, mode_name in hook_workflow_info:
             if mode_name not in [runtime.name for runtime in HookRuntime.enums()]:

--- a/src/ert/_c_wrappers/job_queue/workflow_runner.py
+++ b/src/ert/_c_wrappers/job_queue/workflow_runner.py
@@ -2,7 +2,6 @@ from concurrent import futures
 from typing import TYPE_CHECKING, Optional
 
 from ert._c_wrappers.job_queue import Workflow
-from ert._c_wrappers.util.substitution_list import SubstitutionList
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain
@@ -13,17 +12,12 @@ class WorkflowRunner:
         self,
         workflow: Workflow,
         ert: Optional["EnKFMain"] = None,
-        context: Optional[SubstitutionList] = None,
     ):
         super().__init__()
 
         self.__workflow = workflow
         self.__ert = ert
 
-        if context is None:
-            context = SubstitutionList()
-
-        self.__context = context
         self.__workflow_result = None
         self._workflow_executor = futures.ThreadPoolExecutor(max_workers=1)
         self._workflow_job = None
@@ -41,7 +35,7 @@ class WorkflowRunner:
         self._workflow_job = self._workflow_executor.submit(self.__runWorkflow)
 
     def __runWorkflow(self):
-        self.__workflow_result = self.__workflow.run(self.__ert, context=self.__context)
+        self.__workflow_result = self.__workflow.run(self.__ert)
 
     def isRunning(self) -> bool:
         if self.__workflow.isRunning():
@@ -78,13 +72,3 @@ class WorkflowRunner:
     def workflowReport(self):
         """@rtype: {dict}"""
         return self.__workflow.getJobsReport()
-
-    def workflowError(self) -> str:
-        error = self.__workflow.getLastError()
-
-        error_message = ""
-
-        for error_line in error:
-            error_message += error_line + "\n"
-
-        return error_message

--- a/src/ert/cli/workflow.py
+++ b/src/ert/cli/workflow.py
@@ -9,7 +9,6 @@ def execute_workflow(ert, workflow_name):
         msg = "Workflow {} is not in the list of available workflows"
         logger.error(msg.format(workflow_name))
         return
-    context = ert.get_context()
-    workflow.run(ert=ert, verbose=True, context=context)
+    workflow.run(ert=ert, verbose=True)
     if not all(v["completed"] for v in workflow.getJobsReport().values()):
         logger.error(f"Workflow {workflow_name} failed!")

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -120,8 +120,7 @@ class RunWorkflowWidget(QWidget):
         workflow_list = self.ert.getWorkflowList()
 
         workflow = workflow_list[self.getCurrentWorkflowName()]
-        context = self.ert.get_context()
-        self._workflow_runner = WorkflowRunner(workflow, self.ert, context)
+        self._workflow_runner = WorkflowRunner(workflow, self.ert)
         self._workflow_runner.run()
 
         workflow_thread.start()
@@ -163,12 +162,10 @@ class RunWorkflowWidget(QWidget):
     def workflowFinishedWithFail(self):
         workflow_name = self.getCurrentWorkflowName()
 
-        error = self._workflow_runner.workflowError()
-
         QMessageBox.critical(
             self,
             "Workflow failed!",
-            f"The workflow '{workflow_name}' failed!\n\n{error}",
+            f"The workflow '{workflow_name}' failed!\n\n",
         )
         self._running_workflow_dialog.reject()
         self._running_workflow_dialog = None

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
@@ -16,7 +16,7 @@ def test_workflow():
     with pytest.raises(ConfigValidationError, match="Could not open config_file"):
         _ = WorkflowJob.fromFile("knock_job", name="KNOCK")
 
-    workflow = Workflow("dump_workflow", {"DUMP": dump_job})
+    workflow = Workflow.from_file("dump_workflow", None, {"DUMP": dump_job})
 
     assert len(workflow) == 2
 
@@ -34,14 +34,14 @@ def test_workflow_run():
 
     dump_job = WorkflowJob.fromFile("dump_job", name="DUMP")
 
-    workflow = Workflow("dump_workflow", {"DUMP": dump_job})
-
-    assert len(workflow) == 2
-
     context = SubstitutionList()
     context.addItem("<PARAM>", "text")
 
-    assert workflow.run(None, verbose=True, context=context)
+    workflow = Workflow.from_file("dump_workflow", context, {"DUMP": dump_job})
+
+    assert len(workflow) == 2
+
+    assert workflow.run(None, verbose=True)
 
     with open("dump1", "r", encoding="utf-8") as f:
         assert f.read() == "dump_text_1"
@@ -54,4 +54,4 @@ def test_workflow_run():
 def test_failing_workflow_run():
     WorkflowCommon.createExternalDumpJob()
     with pytest.raises(ValueError, match="does not exist"):
-        _ = Workflow("undefined", {})
+        _ = Workflow.from_file("undefined", None, {})

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_runner.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow_runner.py
@@ -16,7 +16,9 @@ def test_workflow_thread_cancel_ert_script():
 
     wait_job = WorkflowJob.fromFile("wait_job", name="WAIT")
 
-    workflow = Workflow("wait_workflow", {"WAIT": wait_job})
+    workflow = Workflow.from_file(
+        "wait_workflow", SubstitutionList(), {"WAIT": wait_job}
+    )
 
     assert len(workflow) == 3
 
@@ -54,11 +56,13 @@ def test_workflow_thread_cancel_external():
         name="WAIT",
         config_file="wait_job",
     )
-    workflow = Workflow("wait_workflow", {"WAIT": wait_job})
+    workflow = Workflow.from_file(
+        "wait_workflow", SubstitutionList(), {"WAIT": wait_job}
+    )
 
     assert len(workflow) == 3
 
-    workflow_runner = WorkflowRunner(workflow, ert=None, context=SubstitutionList())
+    workflow_runner = WorkflowRunner(workflow, ert=None)
 
     assert not workflow_runner.isRunning()
 
@@ -84,10 +88,12 @@ def test_workflow_failed_job():
         name="DUMP",
         config_file="dump_job",
     )
-    workflow = Workflow("dump_workflow", {"DUMP": dump_job})
+    workflow = Workflow.from_file(
+        "dump_workflow", SubstitutionList(), {"DUMP": dump_job}
+    )
     assert len(workflow) == 2
 
-    workflow_runner = WorkflowRunner(workflow, ert=None, context=SubstitutionList())
+    workflow_runner = WorkflowRunner(workflow, ert=None)
 
     assert not workflow_runner.isRunning()
     with patch.object(
@@ -108,13 +114,15 @@ def test_workflow_success():
         name="WAIT",
         config_file="wait_job",
     )
-    workflow = Workflow(
-        "fast_wait_workflow", {"WAIT": wait_job, "EXTERNAL_WAIT": external_job}
+    workflow = Workflow.from_file(
+        "fast_wait_workflow",
+        SubstitutionList(),
+        {"WAIT": wait_job, "EXTERNAL_WAIT": external_job},
     )
 
     assert len(workflow) == 2
 
-    workflow_runner = WorkflowRunner(workflow, ert=None, context=SubstitutionList())
+    workflow_runner = WorkflowRunner(workflow, ert=None)
 
     assert not workflow_runner.isRunning()
     with workflow_runner:


### PR DESCRIPTION
**Issue**
Resolves #4726 


**Approach**
There was a bug where parsing of workflow would fail during init because it didn't have context. This is fixed by changing the time at which parsing happens.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
