### PR TITLE
Default iteration wrong in manual load dialog

### DIFF
--- a/src/ert/gui/ertwidgets/closabledialog.py
+++ b/src/ert/gui/ertwidgets/closabledialog.py
@@ -17,6 +17,7 @@ class ClosableDialog(QDialog):
 
         self.__button_layout = QHBoxLayout()
         self.close_button = QPushButton("Close")
+        self.close_button.setAutoDefault(False)
         self.close_button.setObjectName("CLOSE")
         self.close_button.clicked.connect(self.accept)
         self.__button_layout.addStretch()

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -48,7 +48,7 @@ class LoadResultsPanel(QWidget):
         self._active_realizations_field.setValidator(RangeStringArgument())
         layout.addRow("Realizations to load:", self._active_realizations_field)
 
-        self._iterations_model = ValueModel(self.facade.get_number_of_iterations())
+        self._iterations_model = ValueModel(0)
         self._iterations_field = StringBox(
             self._iterations_model, "load_results_manually/iterations"
         )

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -31,6 +31,3 @@ class LoadResultsTool(Tool):
         self.__dialog.toggleButton(caption="Load", enabled=False)
         self.__import_widget.load()
         self.__dialog.accept()
-
-    def is_valid_run_path(self) -> bool:
-        return self.facade.is_valid_runpath()

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -160,14 +160,6 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def have_observations(self) -> bool:
         return self._enkf_main.have_observations()
 
-    def is_valid_runpath(self) -> bool:
-        iter_0_paths = set(self.get_run_paths([True] * self.get_ensemble_size(), 0))
-        iter_1_paths = set(self.get_run_paths([True] * self.get_ensemble_size(), 1))
-        return (
-            len(iter_0_paths) == self.get_ensemble_size()
-            and iter_0_paths != iter_1_paths
-        )
-
     @property
     def run_path(self) -> str:
         return self._enkf_main.getModelConfig().runpath_format_string

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -5,11 +5,9 @@ import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton
 
-from ert import LibresFacade
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
 from ert._clib.state_map import RealizationStateEnum
 from ert._clib.update import Parameter
-from ert.gui.tools.load_results import LoadResultsTool
 from ert.gui.tools.manage_cases.case_init_configuration import (
     CaseInitializationConfigurationPanel,
 )
@@ -72,19 +70,3 @@ def test_that_case_tool_can_copy_case_state(qtbot):
     assert new_case.load_parameter(config_node, [0], parameter,).flatten()[
         0
     ] == pytest.approx(-0.8814227775506998)
-
-
-@pytest.mark.parametrize(
-    "run_path, expected",
-    [
-        ("valid_%d", False),
-        ("valid_%d/iter_%d", True),
-        ("real-<IENS>/iter-<ITER>", True),
-        ("invalid", False),
-    ],
-)
-def test_results_tool_valid_runpath(run_path, expected, tmp_path):
-    config_file = tmp_path / "config.ert"
-    config_file.write_text(f"NUM_REALIZATIONS 1\nRUNPATH {run_path}\n")
-    tool = LoadResultsTool(LibresFacade.from_config_file(str(config_file)))
-    assert tool.is_valid_run_path() is expected


### PR DESCRIPTION
**Issue**
Resolves #4721 

- Sets default value for iterations in load manual dialog to zero.
- Sets default focus for `Cancel` button to false, meaning that the `Load` button is in focus.
- Set the `Load results manually` button to always true, and just remove everything related to the is_valid_runpath function.

**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
