### PR TITLE
Fix issue suggester parsing fails

### DIFF
--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 from ert._c_wrappers.enkf.runpaths import replace_runpath_format
 
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class DeprecationMigrationSuggester:
-    def __init__(self, parser: "ConfigParser"):
+    def __init__(self, parser: "ConfigParser", pre_defines: Dict[str, str]):
         self._parser = parser
+        self._pre_defines = pre_defines
         self._add_deprecated_keywords_to_parser()
 
     REPLACE_WITH_GEN_KW = [
@@ -50,7 +51,9 @@ class DeprecationMigrationSuggester:
 
     def suggest_migrations(self, filename: str):
         suggestions = []
-        content = self._parser.parse(filename)
+        content = self._parser.parse(
+            filename, pre_defined_kw_map=self._pre_defines, validate=False
+        )
         defines = config_content_as_dict(content, {}).get("DEFINE", [])
 
         def add_suggestion(kw, suggestion):

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -127,7 +127,7 @@ class ResConfig:
     @staticmethod
     def _create_pre_defines(
         config_file_path: str,
-    ) -> dict:
+    ) -> Dict[str, str]:
         date_string = date.today().isoformat()
         config_file_dir = os.path.abspath(os.path.dirname(config_file_path))
         config_file_name = os.path.basename(config_file_path)
@@ -166,7 +166,8 @@ class ResConfig:
     @classmethod
     def make_suggestion_list(cls, config_file):
         return DeprecationMigrationSuggester(
-            ResConfig._create_user_config_parser()
+            ResConfig._create_user_config_parser(),
+            ResConfig._create_pre_defines(config_file),
         ).suggest_migrations(config_file)
 
     @classmethod


### PR DESCRIPTION
The suggester parsing did not include pre-defines and so could fail to validate in the c validation step.

**Issue**
Resolves #4733 



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
