### PR TITLE
Fix wrong time step nr in mismach error message

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_state.py
+++ b/src/ert/_c_wrappers/enkf/enkf_state.py
@@ -80,10 +80,10 @@ def _internalize_SUMMARY_DATA(ens_config: "EnsembleConfig", run_arg: "RunArg"):
             logger.warning(
                 f"Realization: {run_arg.iens}, load warning: {len(missing)} "
                 "inconsistencies in time map, first: "
-                f"Time mismatch for step: 1, response time: {missing[0][0]}, reference "
-                f"case: {missing[0][1]}, last: Time mismatch for step: "
-                f"{missing[-1][2]}, response time: {missing[-1][0]}, reference "
-                f"case: {missing[-1][1]} from: {run_arg.runpath}/"
+                f"Time mismatch for step: {missing[0][2]}, response time: "
+                f"{missing[0][0]}, reference case: {missing[0][1]}, last: Time "
+                f"mismatch for step: {missing[-1][2]}, response time: {missing[-1][0]}"
+                f", reference case: {missing[-1][1]} from: {run_arg.runpath}/"
                 f"{run_arg.job_name}.UNSMRY"
             )
 


### PR DESCRIPTION
Error message was always pointing to time step 1


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
