### PR TITLE
Remove Wildcard summary keyword warning for missing refcase

### DIFF
--- a/src/clib/lib/enkf/ensemble_config.cpp
+++ b/src/clib/lib/enkf/ensemble_config.cpp
@@ -134,14 +134,7 @@ void ensemble_config_init_SUMMARY_full(ensemble_config_type *ensemble_config,
                 ensemble_config_add_summary(ensemble_config,
                                             stringlist_iget(keys, k),
                                             LOAD_FAIL_SILENT);
-
             stringlist_free(keys);
-        } else {
-            fprintf(stderr,
-                    "** Warning: Cannot expand %s due to missing refcase file."
-                    " Provide refcase file or add fully expanded SUMMARY key"
-                    " to configuration\n",
-                    key);
         }
     } else {
         ensemble_config_add_summary(ensemble_config, key, LOAD_FAIL_SILENT);


### PR DESCRIPTION
The code has been updated to allow users to use wildcard without a REFCASE, so removing the extra message, as it was incorrect.

**Issue**
Resolves #4747



## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
