### PR TITLE
Fix issue where valid RUNPATH would logged as invalid

### DIFF
--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -4,6 +4,7 @@ from typing import Optional
 from ecl.summary import EclSum
 
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
+from ert._c_wrappers.enkf.runpaths import replace_runpath_format
 from ert._c_wrappers.enkf.time_map import TimeMap
 from ert._c_wrappers.sched import HistorySourceEnum
 
@@ -42,19 +43,20 @@ class ModelConfig:
 
         if runpath_format_string is None:
             self.runpath_format_string = self.DEFAULT_RUNPATH
-        elif "%d" in runpath_format_string:
-            self.runpath_format_string = runpath_format_string
-            logger.warning(
-                "RUNPATH keyword should use syntax "
-                f"`{self.DEFAULT_RUNPATH}` "
-                "instead of deprecated syntax "
-                f"`{runpath_format_string}`"
-            )
-        elif not any(x in runpath_format_string for x in ["<ITER>, <IENS>"]):
-            self.runpath_format_string = runpath_format_string
-            logger.error(
-                "RUNPATH keyword should use syntax " f"`{self.DEFAULT_RUNPATH}`."
-            )
+        else:
+            self.runpath_format_string = replace_runpath_format(runpath_format_string)
+
+            if "%d" in runpath_format_string:
+                logger.warning(
+                    "RUNPATH keyword contains deprecated value placeholders, "
+                    f"`instead use: {self.runpath_format_string}`"
+                )
+            elif not any(x in runpath_format_string for x in ["<ITER>", "<IENS>"]):
+                logger.warning(
+                    "RUNPATH keyword contains no value placeholders: "
+                    f"`{runpath_format_string}`. Valid example: "
+                    f"`{self.DEFAULT_RUNPATH}` "
+                )
 
         self.jobname_format_string = jobname_format_string
         self.gen_kw_export_name = (

--- a/src/ert/_c_wrappers/enkf/runpaths.py
+++ b/src/ert/_c_wrappers/enkf/runpaths.py
@@ -105,13 +105,13 @@ class Runpaths:
         return open(self.runpath_list_filename, mode)
 
     def format_job_name(self) -> str:
-        return _maybe_format(self._job_name_format)
+        return replace_runpath_format(self._job_name_format)
 
     def format_runpath(self):
-        return str(Path(_maybe_format(self._runpath_format)).resolve())
+        return str(Path(replace_runpath_format(self._runpath_format)).resolve())
 
 
-def _maybe_format(format_string: str) -> str:
+def replace_runpath_format(format_string: str) -> str:
     format_string = format_string.replace("%d", "<IENS>", 1)
     format_string = format_string.replace("%d", "<ITER>", 1)
     return format_string

--- a/tests/test_config_parsing/test_model_config.py
+++ b/tests/test_config_parsing/test_model_config.py
@@ -57,9 +57,10 @@ def test_invalid_model_config_run_path(tmpdir):
 
 
 def test_deprecated_model_config_run_path(tmpdir):
+    suggested_path = "simulations/realization-<IENS>/iter-<ITER>"
     runpath = "simulations/realization-%d/iter-%d"
     mc = ModelConfig(num_realizations=1, runpath_format_string=runpath)
-    assert mc.runpath_format_string == runpath
+    assert mc.runpath_format_string == suggested_path
 
 
 @given(config_generators())


### PR DESCRIPTION
**Issue**
Relates #4746 
Backport Fix issue where valid RUNPATH would logged as invalid

**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
