### PR TITLE
Make private args be substituted only once

### DIFF
--- a/src/clib/lib/config/config_content.cpp
+++ b/src/clib/lib/config/config_content.cpp
@@ -268,7 +268,7 @@ void config_content_add_define(config_content_type *content, const char *key,
                                const char *value) {
     std::string context_msg = fmt::format("adding DEFINE `{}={}`", key, value);
     char *filtered_value = subst_list_alloc_filtered_string(
-        content->define_list, value, context_msg.c_str());
+        content->define_list, value, context_msg.c_str(), 1000);
     subst_list_append_copy(content->define_list, key, filtered_value);
     free(filtered_value);
 }

--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -138,7 +138,7 @@ static config_content_node_type *config_content_item_set_arg__(
 
                 char *filtered_copy = subst_list_alloc_filtered_string(
                     define_list, stringlist_iget(token_list, iarg + 1),
-                    context.c_str());
+                    context.c_str(), 1000);
                 stringlist_iset_owned_ref(token_list, iarg + 1, filtered_copy);
             }
         }

--- a/src/clib/lib/include/ert/res_util/subst_list.hpp
+++ b/src/clib/lib/include/ert/res_util/subst_list.hpp
@@ -19,7 +19,8 @@ void subst_list_append_owned_ref(subst_list_type *, const char *, const char *);
 extern "C" bool subst_list_filter_file(const subst_list_type *, const char *,
                                        const char *);
 extern "C" char *subst_list_alloc_filtered_string(const subst_list_type *,
-                                                  const char *, const char *);
+                                                  const char *, const char *,
+                                                  const int);
 extern "C" int subst_list_get_size(const subst_list_type *);
 extern "C" const char *subst_list_get_value(const subst_list_type *subst_list,
                                             const char *key);

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -270,7 +270,7 @@ class ExtJob:
     ) -> None:
         """raises InvalidArgsException if validation fails"""
         args_substituted_with_private_list = [
-            (arg, self.private_args.substitute(arg)) for arg in self.arglist
+            (arg, self.private_args.substitute(arg, "", 1)) for arg in self.arglist
         ]
         args_substituted_with_context_and_private_list = [
             (orig_arg, context.substitute(modified_arg))

--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -65,7 +65,9 @@ class ForwardModel:
                     copy_private_args.addItem(
                         key, context.substitute_real_iter(val, iens, itr)
                     )
-                string = copy_private_args.substitute(string, substitution_context_hint)
+                string = copy_private_args.substitute(
+                    string, substitution_context_hint, 1
+                )
                 return context.substitute_real_iter(string, iens, itr)
             else:
                 return string

--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -19,7 +19,7 @@ class SubstitutionList(BaseCClass):
     _has_key = ResPrototype("bool subst_list_has_key(subst_list, char*)")
     _append_copy = ResPrototype("void subst_list_append_copy(subst_list, char*, char*)")
     _alloc_filtered_string = ResPrototype(
-        "char* subst_list_alloc_filtered_string(subst_list, char*, char*)"
+        "char* subst_list_alloc_filtered_string(subst_list, char*, char*, int)"
     )
     _filter_file = ResPrototype("bool subst_list_filter_file(subst_list, char*,char*)")
     _deep_copy = ResPrototype("subst_list_obj subst_list_alloc_deep_copy(subst_list)")
@@ -97,8 +97,10 @@ class SubstitutionList(BaseCClass):
     def get(self, key, default=None):
         return self[key] if key in self else default
 
-    def substitute(self, to_substitute: str, context: str = "") -> str:
-        return self._alloc_filtered_string(to_substitute, context)
+    def substitute(
+        self, to_substitute: str, context: str = "", max_iterations: int = 1000
+    ) -> str:
+        return self._alloc_filtered_string(to_substitute, context, max_iterations)
 
     def substitute_file(self, to_substitute: str, tmp_file: str):
         self._filter_file(to_substitute, tmp_file)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -126,6 +126,17 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             ["0"],
             id="This style of args works without infinite substitution loop.",
         ),
+        pytest.param(
+            dedent(
+                """
+            EXECUTABLE echo
+            ARGLIST <ECLBASE>
+            """
+            ),
+            "FORWARD_MODEL job_name(<ECLBASE>=A/<ECLBASE>)",
+            ["A/JOB0"],
+            id="The NOSIM job takes <ECLBASE> as args. Expect no infinite loop.",
+        ),
     ],
 )
 def test_forward_model_job(job, forward_model, expected_args):


### PR DESCRIPTION
While global substitutions are done until fixpoint, this makes no sense for private args, which we do only until fixpoint.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
