### PR TITLE
Make private args be substituted only once

### DIFF
--- a/src/clib/lib/config/config_content.cpp
+++ b/src/clib/lib/config/config_content.cpp
@@ -267,7 +267,7 @@ config_content_iget_stringlist_ref(const config_content_type *content,
 void config_content_add_define(config_content_type *content, const char *key,
                                const char *value) {
     char *filtered_value =
-        subst_list_alloc_filtered_string(content->define_list, value);
+        subst_list_alloc_filtered_string(content->define_list, value, 1000);
     subst_list_append_copy(content->define_list, key, filtered_value);
     free(filtered_value);
 }

--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -129,7 +129,7 @@ static config_content_node_type *config_content_item_set_arg__(
             for (iarg = 0; iarg < argc; iarg++) {
 
                 char *filtered_copy = subst_list_alloc_filtered_string(
-                    define_list, stringlist_iget(token_list, iarg + 1));
+                    define_list, stringlist_iget(token_list, iarg + 1), 1000);
                 stringlist_iset_owned_ref(token_list, iarg + 1, filtered_copy);
             }
         }

--- a/src/clib/lib/include/ert/res_util/subst_list.hpp
+++ b/src/clib/lib/include/ert/res_util/subst_list.hpp
@@ -19,7 +19,7 @@ void subst_list_append_owned_ref(subst_list_type *, const char *, const char *);
 extern "C" bool subst_list_filter_file(const subst_list_type *, const char *,
                                        const char *);
 extern "C" char *subst_list_alloc_filtered_string(const subst_list_type *,
-                                                  const char *);
+                                                  const char *, const int);
 extern "C" int subst_list_get_size(const subst_list_type *);
 extern "C" const char *subst_list_get_value(const subst_list_type *subst_list,
                                             const char *key);

--- a/src/clib/lib/res_util/subst_list.cpp
+++ b/src/clib/lib/res_util/subst_list.cpp
@@ -357,17 +357,20 @@ subst_list_update_string(const subst_list_type *subst_list, char **string) {
    operation has been performed.
 */
 char *subst_list_alloc_filtered_string(const subst_list_type *subst_list,
-                                       const char *string) {
+                                       const char *string,
+                                       const int max_iterations) {
     char *filtered_string = util_alloc_string_copy(string);
     if (subst_list) {
         std::vector<std::string> matches = {"<ANY>"};
-        const int max_iterations = 1000;
-        int iterations = 1;
+        int iterations = 0;
         while (matches.size() > 0 && iterations++ < max_iterations) {
             matches = subst_list_update_string(subst_list, &filtered_string);
         }
 
-        if (iterations >= max_iterations) {
+        // For max_iterations = 1, matches.size() > 0
+        // means that any substitution happened and does not indicate
+        // that there is an infinite loop.
+        if (matches.size() > 0 && max_iterations > 1) {
             logger->warning(fmt::format(
                 "Reached max iterations while trying to resolve defines in "
                 "'{}', it matched to '{}' and resulted in '{}'",

--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -1,16 +1,13 @@
-import copy
 import json
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import Any, Dict, List
 
 from ert._c_wrappers.job_queue import EnvironmentVarlist, ExtJob
+from ert._c_wrappers.util.substitution_list import SubstitutionList
 from ert._clib import job_kw
-
-if TYPE_CHECKING:
-    from ert._c_wrappers.util.substitution_list import SubstitutionList
 
 logger = logging.getLogger(__name__)
 
@@ -57,23 +54,12 @@ class ForwardModel:
     ) -> Dict[str, Any]:
         def substitute(job, string):
             if string is not None:
-                copy_private_args = copy.deepcopy(job.private_args)
-                # We need to still be able to handle that the user has
-                # written e.g. FORWARD_MODEL JOB(<ITER>=<ITER>). The
-                # way this argument passing works is at odds with expected
-                # behavior, and is a known bug/problem.
-
-                if (
-                    "<ITER>" not in copy_private_args
-                    or copy_private_args["<ITER>"] == "<ITER>"
-                ):
-                    copy_private_args.addItem("<ITER>", str(itr))
-                if (
-                    "<IENS>" not in copy_private_args
-                    or copy_private_args["<IENS>"] == "<IENS>"
-                ):
-                    copy_private_args.addItem("<IENS>", str(iens))
-                string = copy_private_args.substitute(string)
+                copy_private_args = SubstitutionList()
+                for key, val in job.private_args:
+                    copy_private_args.addItem(
+                        key, context.substitute_real_iter(val, iens, itr)
+                    )
+                string = copy_private_args.substitute(string, 1)
                 return context.substitute_real_iter(string, iens, itr)
             else:
                 return string

--- a/src/ert/_c_wrappers/util/substitution_list.py
+++ b/src/ert/_c_wrappers/util/substitution_list.py
@@ -18,7 +18,7 @@ class SubstitutionList(BaseCClass):
     _has_key = ResPrototype("bool subst_list_has_key(subst_list, char*)")
     _append_copy = ResPrototype("void subst_list_append_copy(subst_list, char*, char*)")
     _alloc_filtered_string = ResPrototype(
-        "char* subst_list_alloc_filtered_string(subst_list, char*)"
+        "char* subst_list_alloc_filtered_string(subst_list, char*, int)"
     )
     _add_from_string = ResPrototype(
         "void subst_list_add_from_string(subst_list, char*)"
@@ -112,8 +112,8 @@ class SubstitutionList(BaseCClass):
 
         return None  # Should never happen!
 
-    def substitute(self, to_substitute: str) -> str:
-        return self._alloc_filtered_string(to_substitute)
+    def substitute(self, to_substitute: str, max_iterations: int = 1000) -> str:
+        return self._alloc_filtered_string(to_substitute, max_iterations)
 
     def substitute_real_iter(
         self, to_substitute: str, realization: int, iteration: int

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -112,6 +112,17 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             ["0"],
             id="This style of args works without infinite substitution loop.",
         ),
+        pytest.param(
+            dedent(
+                """
+            EXECUTABLE echo
+            ARGLIST <ECLBASE>
+            """
+            ),
+            "FORWARD_MODEL job_name(<ECLBASE>=A/<ECLBASE>)",
+            ["A/JOB0"],
+            id="The NOSIM job takes <ECLBASE> as args. Expect no infinite loop.",
+        ),
     ],
 )
 def test_forward_model_job(job, forward_model, expected_args):


### PR DESCRIPTION
backports #4760 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
