### PR TITLE
Verify that refcase is found for history observations

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ert import _clib
 from ert._c_wrappers.analysis.configuration import UpdateConfiguration
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import EnkfFs
 from ert._c_wrappers.enkf.analysis_config import AnalysisConfig
 from ert._c_wrappers.enkf.data import EnkfNode
@@ -166,10 +167,14 @@ class EnKFMain:
                     f"{config.model_config.obs_config_file}"
                     f": {self._observations.error}"
                 )
-            self._observations.load(
-                config.model_config.obs_config_file,
-                config.analysis_config.get_std_cutoff(),
-            )
+            try:
+                self._observations.load(
+                    config.model_config.obs_config_file,
+                    config.analysis_config.get_std_cutoff(),
+                )
+            except ValueError as err:
+                raise ConfigValidationError(err)
+
         self._ensemble_size = self.res_config.model_config.num_realizations
         self._runpaths = Runpaths(
             self.resConfig().preferred_job_fmt(),

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import pytest
 from ecl.summary import EclSum
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import (
     AnalysisConfig,
     EnkfFs,
@@ -212,6 +213,32 @@ def test_empty_observations_file_cause_exception(tmpdir):
         with pytest.raises(
             expected_exception=ValueError,
             match="Empty observations file.*",
+        ):
+            EnKFMain(res_config)
+
+
+def test_no_refcase_but_history_observations_cause_exception(tmpdir):
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        JOBNAME my_name%d
+        NUM_REALIZATIONS 10
+        OBS_CONFIG observations
+        TIME_MAP time_map.txt
+        """
+        )
+        with open("config.ert", "w", encoding="utf-8") as fh:
+            fh.writelines(config)
+        with open("observations", "w", encoding="utf-8") as fo:
+            fo.writelines("HISTORY_OBSERVATION FOPR;")
+        with open("time_map.txt", "w", encoding="utf-8") as fo:
+            fo.writelines("2023-02-01")
+
+        res_config = ResConfig("config.ert")
+
+        with pytest.raises(
+            expected_exception=ConfigValidationError,
+            match="REFCASE is required for HISTORY_OBSERVATION",
         ):
             EnKFMain(res_config)
 


### PR DESCRIPTION
**Issue**
Resolves #4758 

We need to discuss what makes sense here.
This kind of error should optimally be raised to the UI.

https://fmu-docs.equinor.com/docs/ert/reference/configuration/keywords.html#obs-config


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
