### PR TITLE
Stop substituting in FORWARD_MODEL argument names version-4.2 backport

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -56,6 +56,7 @@ static void add_run_template_keyword(config_parser_type *config_parser) {
 static void add_forward_model_keyword(config_parser_type *config_parser) {
     auto item = config_add_schema_item(config_parser, FORWARD_MODEL_KEY, false);
     config_schema_item_set_argc_minmax(item, 1, CONFIG_DEFAULT_ARG_MAX);
+    config_schema_item_disable_substitutions(item);
 }
 
 static void add_simulation_job_keyword(config_parser_type *config_parser) {

--- a/src/clib/lib/config/config_parser.cpp
+++ b/src/clib/lib/config/config_parser.cpp
@@ -124,7 +124,8 @@ static config_content_node_type *config_content_item_set_arg__(
             config_content_item_get_schema(item);
 
         /* Filtering based on DEFINE statements */
-        if (subst_list_get_size(define_list) > 0) {
+        if (subst_list_get_size(define_list) > 0 &&
+            config_schema_item_substitutions_enabled(schema_item)) {
             int iarg;
             for (iarg = 0; iarg < argc; iarg++) {
 

--- a/src/clib/lib/config/config_schema_item.cpp
+++ b/src/clib/lib/config/config_schema_item.cpp
@@ -85,6 +85,7 @@ struct config_schema_item_struct {
     bool expand_envvar;
     bool deprecated;
     char *deprecate_msg;
+    bool do_substitutions;
 };
 
 static void validate_set_default_type(validate_type *validate,
@@ -208,6 +209,7 @@ config_schema_item_type *config_schema_item_alloc(const char *kw,
                                 //     item,
                                 //     false);
     item->validate = validate_alloc();
+    item->do_substitutions = true;
     return item;
 }
 
@@ -506,6 +508,15 @@ void config_schema_item_set_argc_minmax(config_schema_item_type *item,
 void config_schema_item_iset_type(config_schema_item_type *item, int index,
                                   config_item_types type) {
     validate_iset_type(item->validate, index, type);
+}
+
+void config_schema_item_disable_substitutions(config_schema_item_type *item) {
+    item->do_substitutions = false;
+}
+
+bool config_schema_item_substitutions_enabled(
+    const config_schema_item_type *item) {
+    return item->do_substitutions;
 }
 
 void config_schema_item_set_default_type(config_schema_item_type *item,

--- a/src/clib/lib/include/ert/config/config_schema_item.hpp
+++ b/src/clib/lib/include/ert/config/config_schema_item.hpp
@@ -58,6 +58,9 @@ void config_schema_item_set_common_selection_set(config_schema_item_type *item,
 void config_schema_item_set_indexed_selection_set(config_schema_item_type *item,
                                                   int index,
                                                   const stringlist_type *argv);
+void config_schema_item_disable_substitutions(config_schema_item_type *item);
+bool config_schema_item_substitutions_enabled(
+    const config_schema_item_type *item);
 extern "C" void
 config_schema_item_add_indexed_alternative(config_schema_item_type *item,
                                            int index, const char *value);

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -32,6 +32,22 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             dedent(
                 """
             EXECUTABLE echo
+            ARGLIST <ARGUMENTA>
+            """
+            ),
+            dedent(
+                """
+            DEFINE <ARGUMENTA> foo
+            FORWARD_MODEL job_name
+            """
+            ),
+            ["foo"],
+            id="Global arguments are used inside job definition",
+        ),
+        pytest.param(
+            dedent(
+                """
+            EXECUTABLE echo
             ARGLIST <ARGUMENT>
             """
             ),
@@ -47,18 +63,16 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             ARGLIST <ARGUMENTA> <ARGUMENTB> <ARGUMENTC>
                 """
             ),
-            dedent(
-                """
-            DEFINE <TO_BE_DEFINED> <ARGUMENTB>
-            FORWARD_MODEL job_name(<ARGUMENTA>=configured_argumentA, <TO_BE_DEFINED>=configured_argumentB)
-            """  # noqa E501
-            ),
+            "DEFINE <TO_BE_DEFINED> <ARGUMENTB>\n"
+            "FORWARD_MODEL job_name(<ARGUMENTA>=configured_argumentA,"
+            " <TO_BE_DEFINED>=configured_argumentB)",
             [
                 "configured_argumentA",
-                "configured_argumentB",
+                "<ARGUMENTB>",
                 "<ARGUMENTC>",
             ],
-            id="Using DEFINE, substituting arg name, default argument C",
+            id="Keywords in argument list are not substituted, "
+            "so argument B gets no value",
         ),
         pytest.param(
             dedent(
@@ -74,8 +88,8 @@ def valid_args(arg_types, arg_list: List[str], runtime: bool = False):
             FORWARD_MODEL job_name(<ARGUMENTB>=configured_argumentB)
             """
             ),
-            ["DEFAULT_ARGA_VALUE", "DEFINED_ARGUMENTB_VALUE", "<ARGUMENTC>"],
-            id="Resolved argument given by DEFINE, even though user specified value",
+            ["DEFAULT_ARGA_VALUE", "configured_argumentB", "<ARGUMENTC>"],
+            id="Resolved argument given by argument list, not overridden by global",
         ),
         pytest.param(
             dedent(


### PR DESCRIPTION
**Issue**
Backport #4634 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
