### PR TITLE
Add log statement for new forward model behavior

### DIFF
--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -62,6 +62,11 @@ class ForwardModel:
             if string is not None:
                 copy_private_args = SubstitutionList()
                 for key, val in job.private_args:
+                    if key in context:
+                        logger.info(
+                            f"Private arg '{key}':'{val}' chosen over"
+                            f" global '{context[key]}' in forward model {job.name}"
+                        )
                     copy_private_args.addItem(
                         key, context.substitute_real_iter(val, iens, itr)
                     )

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_sim_model.py
@@ -1,3 +1,4 @@
+import logging
 from textwrap import dedent
 from typing import List
 
@@ -240,3 +241,36 @@ def test_simulation_job(job, forward_model, expected_args):
     assert len(forward_model.jobs) == 1
     assert job_data["argList"] == expected_args
     assert valid_args(forward_model_job.arg_types, job_data["argList"])
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_private_over_global_args_gives_logging_message(caplog):
+    caplog.set_level(logging.INFO)
+    with open("job_file", "w", encoding="utf-8") as fout:
+        fout.write(
+            dedent(
+                """
+            EXECUTABLE echo
+            ARGLIST <ARG>
+            ARG_TYPE 0 STRING
+            """
+            )
+        )
+
+    with open("config_file.ert", "w", encoding="utf-8") as fout:
+        # Write a minimal config file
+        fout.write("NUM_REALIZATIONS 1\n")
+        fout.write("DEFINE <ARG> A\n")
+        fout.write("INSTALL_JOB job_name job_file\n")
+        fout.write("FORWARD_MODEL job_name(<ARG>=B)")
+
+    res_config = ResConfig("config_file.ert")
+    ert = EnKFMain(res_config)
+
+    forward_model = ert.resConfig().forward_model
+    job_data = forward_model.get_job_data(
+        "", "", 0, 0, ert.get_context(), res_config.env_vars
+    )["jobList"][0]
+    assert len(forward_model.jobs) == 1
+    assert job_data["argList"] == ["B"]
+    assert "Private arg '<ARG>':'B' chosen over global 'A'" in caplog.text


### PR DESCRIPTION
Adding a log statement to monitor possible breaking changes from global to private arguments in forward model.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
