### PR TITLE
Make field parameter self contained in enkf_fs

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/field_config.py
+++ b/src/ert/_c_wrappers/enkf/config/field_config.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import math
-from typing import TYPE_CHECKING
-
-import numpy as np
 from cwrap import BaseCClass
 from ecl.grid import EclGrid
 
@@ -11,9 +7,6 @@ from ert._c_wrappers import ResPrototype
 from ert._c_wrappers.enkf.enums import EnkfFieldFileFormatEnum, EnkfTruncationType
 
 from .field_type_enum import FieldTypeEnum
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 
 class FieldConfig(BaseCClass):
@@ -114,52 +107,6 @@ class FieldConfig(BaseCClass):
 
     def free(self) -> None:
         self._free()
-
-    def truncate(self, data: npt.ArrayLike) -> npt.ArrayLike:
-        truncation_mode = self._get_truncation_mode()
-        if truncation_mode == EnkfTruncationType.TRUNCATE_MIN:
-            min_ = self.get_truncation_min()
-            vfunc = np.vectorize(lambda x: max(x, min_))
-            return vfunc(data)
-        if truncation_mode == EnkfTruncationType.TRUNCATE_MAX:
-            max_ = self.get_truncation_max()
-            vfunc = np.vectorize(lambda x: min(x, max_))
-            return vfunc(data)
-        if (
-            truncation_mode
-            == EnkfTruncationType.TRUNCATE_MAX | EnkfTruncationType.TRUNCATE_MIN
-        ):
-            min_ = self.get_truncation_min()
-            max_ = self.get_truncation_max()
-            vfunc = np.vectorize(lambda x: max(min(x, max_), min_))
-            return vfunc(data)
-
-        return data
-
-    def transform(self, transform_name: str, data: npt.ArrayLike) -> npt.ArrayLike:
-        if not transform_name:
-            return data
-
-        def f(x):
-            if transform_name in ("LN", "LOG"):
-                return math.log(x, math.e)
-            if transform_name == "LN0":
-                return math.log(x, math.e) + 0.000001
-            if transform_name == "LOG10":
-                return math.log(x, 10)
-            if transform_name == "EXP":
-                return math.exp(x)
-            if transform_name == "EXP0":
-                return math.exp(x) + 0.000001
-            if transform_name == "POW10":
-                return math.pow(x, 10)
-            if transform_name == "TRUNC_POW10":
-                return math.pow(max(x, 0.001), 10)
-            return x
-
-        vfunc = np.vectorize(f)
-
-        return vfunc(data)
 
     def __repr__(self) -> str:
         return self._create_repr(

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -15,7 +15,7 @@ import pandas as pd
 import xarray as xr
 import xtgeo
 
-from ert._c_wrappers.enkf.enums import RealizationStateEnum
+from ert._c_wrappers.enkf.enums import EnkfTruncationType, RealizationStateEnum
 from ert._c_wrappers.enkf.model_callbacks import LoadStatus
 from ert._c_wrappers.enkf.time_map import TimeMap
 from ert._clib import trans_func
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from ecl.summary import EclSum
     from xtgeo import RegularSurface
 
-    from ert._c_wrappers.enkf.config import FieldConfig
     from ert._c_wrappers.enkf.res_config import EnsembleConfig
     from ert._c_wrappers.enkf.run_arg import RunArg
 
@@ -289,6 +288,33 @@ class EnkfFs:
             result.append(surf.get_values1d(order="F"))
         return np.stack(result).T
 
+    def save_field_info(  # pylint: disable=too-many-arguments
+        self,
+        key: str,
+        grid_file: Optional[str],
+        transfer_out: str,
+        truncation_mode: EnkfTruncationType,
+        trunc_min: float,
+        trunc_max: float,
+        nx: int,
+        ny: int,
+        nz: int,
+    ) -> None:
+        self._storage.save_field_info(
+            key,
+            grid_file,
+            transfer_out,
+            truncation_mode,
+            trunc_min,
+            trunc_max,
+            nx,
+            ny,
+            nz,
+        )
+
+    def field_has_info(self, key: str) -> bool:
+        return self._storage.field_has_info(key)
+
     def save_field_data(
         self,
         parameter_name: str,
@@ -306,22 +332,18 @@ class EnkfFs:
         return self._storage.load_field(key, realizations)
 
     def export_field(
-        self, config_node: FieldConfig, realization: int, output_path: str, fformat: str
+        self, key: str, realization: int, output_path: Path, fformat: str
     ) -> None:
-        return self._storage.export_field(
-            config_node, realization, output_path, fformat
-        )
+        return self._storage.export_field(key, realization, output_path, fformat)
 
     def export_field_many(
         self,
-        config_node: FieldConfig,
+        key: str,
         realizations: List[int],
         output_path: str,
         fformat: str,
     ) -> None:
-        return self._storage.export_field_many(
-            config_node, realizations, output_path, fformat
-        )
+        return self._storage.export_field_many(key, realizations, output_path, fformat)
 
     def field_has_data(self, key: str, realization: int) -> bool:
         return self._storage.field_has_data(key, realization)

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -26,6 +26,7 @@ from ert._c_wrappers.enkf.model_config import ModelConfig
 from ert._c_wrappers.enkf.queue_config import QueueConfig
 from ert._c_wrappers.enkf.runpaths import Runpaths
 from ert._c_wrappers.util.substitution_list import SubstitutionList
+from ert.storage import _field_transform
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf.config import FieldConfig, GenKwConfig
@@ -159,31 +160,12 @@ def _generate_field_parameter_file(
     run_path: Path,
 ) -> None:
     key = config.get_key()
-    grid = config.get_grid()
-    x = config.get_nx()
-    y = config.get_ny()
-    z = config.get_nz()
-
-    data = fs.load_field(key, [realization])
-    transform_name = config.get_output_transform_name()
-    data_transformed = config.transform(transform_name, data)
-    data_truncated = config.truncate(data_transformed)
-
-    gp = xtgeo.GridProperty(
-        ncol=x,
-        nrow=y,
-        nlay=z,
-        values=data_truncated,
-        grid=grid,
-        name=key,
-    )
-
     target_path = Path(run_path) / target_file
     if os.path.islink(target_path):
         os.unlink(target_path)
 
     file_out = run_path.joinpath(target_file)
-    gp.to_file(file_out, fformat="grdecl")
+    fs.export_field(key, realization, file_out, "grdecl")
 
 
 def _generate_parameter_files(
@@ -502,7 +484,9 @@ class EnKFMain:
                     init_file = config_node.get_init_file_fmt()
                     if "%d" in init_file:
                         init_file = init_file % realization_nr
-                    grid = xtgeo.grid_from_file(self.ensembleConfig().grid_file)
+                    grid_file = self.ensembleConfig().grid_file
+                    assert grid_file is not None
+                    grid = xtgeo.grid_from_file(grid_file)
                     props = xtgeo.gridproperty_from_file(
                         init_file, name=parameter, grid=grid
                     )
@@ -510,8 +494,19 @@ class EnKFMain:
                     data = props.values1d.data
                     field_config = config_node.getFieldModelConfig()
                     trans = field_config.get_init_transform_name()
-                    data_transformed = field_config.transform(trans, data)
-
+                    data_transformed = _field_transform(data, trans)
+                    if not storage.field_has_info(parameter):
+                        storage.save_field_info(
+                            parameter,
+                            grid_file,
+                            field_config.get_output_transform_name(),
+                            field_config.get_truncation_mode(),
+                            field_config.get_truncation_min(),
+                            field_config.get_truncation_max(),
+                            field_config.get_nx(),
+                            field_config.get_ny(),
+                            field_config.get_nz(),
+                        )
                     storage.save_field_data(parameter, realization_nr, data_transformed)
 
             elif impl_type == ErtImplType.GEN_KW:

--- a/src/ert/_c_wrappers/enkf/enums/enkf_truncation_type.py
+++ b/src/ert/_c_wrappers/enkf/enums/enkf_truncation_type.py
@@ -3,9 +3,9 @@ from cwrap import BaseCEnum
 
 class EnkfTruncationType(BaseCEnum):
     TYPE_NAME = "enkf_truncation_type_enum"
-    TRUNCATE_NONE = None
-    TRUNCATE_MIN = None
-    TRUNCATE_MAX = None
+    TRUNCATE_NONE = 0
+    TRUNCATE_MIN = 1
+    TRUNCATE_MAX = 2
 
 
 EnkfTruncationType.addEnum("TRUNCATE_NONE", 0)

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -135,6 +135,19 @@ def _save_temporary_storage_to_disk(
                     key, realization, surface_config.base_surface_path, matrix[:, i]
                 )
         elif config_node.getImplementationType() == ErtImplType.FIELD:
+            if not target_fs.field_has_info(key):
+                field_config = config_node.getFieldModelConfig()
+                target_fs.save_field_info(
+                    key,
+                    ensemble_config.grid_file,
+                    field_config.get_output_transform_name(),
+                    field_config.get_truncation_mode(),
+                    field_config.get_truncation_min(),
+                    field_config.get_truncation_max(),
+                    field_config.get_nx(),
+                    field_config.get_ny(),
+                    field_config.get_nz(),
+                )
             for i, realization in enumerate(iens_active_index):
                 target_fs.save_field_data(key, realization, matrix[:, i])
         else:

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -111,7 +111,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         ext = config_node.get_enkf_outfile().rsplit(".")[-1]
         field_config_node = config_node.getFieldModelConfig()
         file_system.export_field_many(
-            field_config_node,
+            field_config_node.get_key(),
             list(range(0, self.get_ensemble_size())),
             filepath + "." + ext,
             "grdecl",

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -39,7 +39,7 @@ def test_field_export_many(snake_oil_field_example):
     fs = prior.sim_fs
 
     fs.export_field_many(
-        config_node.getFieldModelConfig(),
+        config_node.getFieldModelConfig().get_key(),
         [0, 2, 4],
         "export/with/path/PERMX_%d.grdecl",
         fformat="grdecl",
@@ -62,7 +62,7 @@ def test_field_export(snake_oil_field_example):
     fs = ert.storage_manager["default"]
 
     fs.export_field(
-        config_node.getFieldModelConfig(),
+        config_node.getFieldModelConfig().get_key(),
         0,
         "export/with/path/PERMX_0.grdecl",
         fformat="grdecl",
@@ -74,7 +74,7 @@ def test_field_export(snake_oil_field_example):
         KeyError, match="Unable to load FIELD for key: PERMX, realization: 1"
     ):
         fs.export_field(
-            config_node.getFieldModelConfig(),
+            config_node.getFieldModelConfig().get_key(),
             1,
             "export/with/path/PERMX_1.grdecl",
             fformat="grdecl",
@@ -85,7 +85,7 @@ def test_field_export(snake_oil_field_example):
         KeyError, match="Unable to load FIELD for key: PERMX, realization: 2"
     ):
         fs.export_field(
-            config_node.getFieldModelConfig(),
+            config_node.getFieldModelConfig().get_key(),
             2,
             "export/with/path/PERMX_2.grdecl",
             fformat="grdecl",
@@ -93,7 +93,7 @@ def test_field_export(snake_oil_field_example):
     assert not os.path.isfile("export/with/path/PERMX_2.grdecl")
 
     fs.export_field(
-        config_node.getFieldModelConfig(),
+        config_node.getFieldModelConfig().get_key(),
         3,
         "export/with/path/PERMX_3.grdecl",
         fformat="grdecl",
@@ -102,7 +102,7 @@ def test_field_export(snake_oil_field_example):
     assert os.path.getsize("export/with/path/PERMX_3.grdecl") > 0
 
     fs.export_field(
-        config_node.getFieldModelConfig(),
+        config_node.getFieldModelConfig().get_key(),
         4,
         "export/with/path/PERMX_4.grdecl",
         fformat="grdecl",


### PR DESCRIPTION
Store all info from field_config in enkf_fs such that one can read fields with not config

**Issue**


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
