### PR TITLE
Skip flaky performance test on mac

### DIFF
--- a/tests/unit_tests/data/test_integration_data.py
+++ b/tests/unit_tests/data/test_integration_data.py
@@ -1,5 +1,6 @@
 import pathlib
 import shutil
+import sys
 import time
 
 import numpy as np
@@ -34,6 +35,9 @@ def test_summary_obs(facade_snake_oil):
     ] == np.datetime64("2011-12-21")
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Performance of mac is unreliable"
+)
 @pytest.mark.usefixtures("copy_snake_oil_case_storage")
 @pytest.mark.integration_test
 def test_summary_obs_runtime():


### PR DESCRIPTION
Skips performance test that consistently fails on github mac runners.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
