### PR TITLE
Make private arg log message happen only once

### DIFF
--- a/src/ert/_c_wrappers/job_queue/forward_model.py
+++ b/src/ert/_c_wrappers/job_queue/forward_model.py
@@ -62,11 +62,6 @@ class ForwardModel:
             if string is not None:
                 copy_private_args = SubstitutionList()
                 for key, val in job.private_args:
-                    if key in context:
-                        logger.info(
-                            f"Private arg '{key}':'{val}' chosen over"
-                            f" global '{context[key]}' in forward model {job.name}"
-                        )
                     copy_private_args.addItem(
                         key, context.substitute_real_iter(val, iens, itr)
                     )
@@ -102,6 +97,14 @@ class ForwardModel:
             if not result:
                 return None
             return result
+
+        for job in self.jobs:
+            for key, val in job.private_args:
+                if key in context:
+                    logger.info(
+                        f"Private arg '{key}':'{val}' chosen over"
+                        f" global '{context[key]}' in forward model {job.name}"
+                    )
 
         return {
             "DATA_ROOT": data_root,


### PR DESCRIPTION
**Issue**
Reduces the amount of logging messages for private arg over global arg

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
