### PR TITLE
Fix run_workflow_widget

### DIFF
--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -32,7 +32,7 @@ class RunWorkflowWidget(QWidget):
         addHelpToWidget(self._workflow_combo, "run/workflow")
 
         self._workflow_combo.addItems(
-            sorted(ert.getWorkflowList().getWorkflowNames(), key=str.lower)
+            sorted(ert.resConfig().workflows.keys(), key=str.lower)
         )
 
         layout.addWidget(QLabel("Select workflow:"), 0, Qt.AlignVCenter)
@@ -102,9 +102,7 @@ class RunWorkflowWidget(QWidget):
 
     def getCurrentWorkflowName(self):
         index = self._workflow_combo.currentIndex()
-        return sorted(self.ert.getWorkflowList().getWorkflowNames(), key=str.lower)[
-            index
-        ]
+        return (sorted(self.ert.resConfig().workflows.keys(), key=str.lower))[index]
 
     def startWorkflow(self):
         self._running_workflow_dialog = WorkflowDialog(
@@ -116,9 +114,7 @@ class RunWorkflowWidget(QWidget):
         workflow_thread.daemon = True
         workflow_thread.run = self.runWorkflow
 
-        workflow_list = self.ert.getWorkflowList()
-
-        workflow = workflow_list[self.getCurrentWorkflowName()]
+        workflow = self.ert.resConfig().workflows[self.getCurrentWorkflowName()]
         self._workflow_runner = WorkflowRunner(workflow, self.ert)
         self._workflow_runner.run()
 


### PR DESCRIPTION
run_workflow_widget broke due to the removal of workflow_list.

Changes the tests to not use a mock, but instead use a minimal config.

**Issue**
Resolves #4727 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
