### PR TITLE
Fix creation of paths in subfolders for outfile in GEN_KW, backport to 4.2

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -196,7 +196,7 @@ static void add_gen_kw_keyword(config_parser_type *config_parser) {
     auto item = config_add_schema_item(config_parser, GEN_KW_KEY, false);
     config_schema_item_set_argc_minmax(item, 4, 6);
     config_schema_item_iset_type(item, 1, CONFIG_EXISTING_PATH);
-    config_schema_item_iset_type(item, 2, CONFIG_PATH);
+    config_schema_item_iset_type(item, 2, CONFIG_STRING);
     config_schema_item_iset_type(item, 3, CONFIG_EXISTING_PATH);
 }
 

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -258,7 +258,7 @@ class EnsembleConfig(BaseCClass):
         if isinstance(gen_kw, dict):
             name = gen_kw.get(ConfigKeys.NAME)
             tmpl_path = _get_abs_path(gen_kw.get(ConfigKeys.TEMPLATE))
-            out_file = _get_filename(gen_kw.get(ConfigKeys.OUT_FILE))
+            out_file = gen_kw.get(ConfigKeys.OUT_FILE)
             param_file_path = _get_abs_path(gen_kw.get(ConfigKeys.PARAMETER_FILE))
             forward_init = gen_kw.get(ConfigKeys.FORWARD_INIT)
             init_files = _get_abs_path(gen_kw.get(ConfigKeys.INIT_FILES))
@@ -266,7 +266,7 @@ class EnsembleConfig(BaseCClass):
             options = _option_dict(gen_kw, 4)
             name = gen_kw[0]
             tmpl_path = _get_abs_path(gen_kw[1])
-            out_file = _get_filename(_get_abs_path(gen_kw[2]))
+            out_file = gen_kw[2]
             param_file_path = _get_abs_path(gen_kw[3])
             forward_init = _str_to_bool(options.get(ConfigKeys.FORWARD_INIT, "FALSE"))
             init_files = _get_abs_path(options.get(ConfigKeys.INIT_FILES))

--- a/tests/unit_tests/c_wrappers/test_integration_config.py
+++ b/tests/unit_tests/c_wrappers/test_integration_config.py
@@ -1,12 +1,16 @@
 import json
 import os
+from argparse import ArgumentParser
 from pathlib import Path
 
 import pytest
 
+from ert.__main__ import ert_parser
 from ert._c_wrappers.enkf import RunContext
 from ert._c_wrappers.enkf.enkf_main import EnKFMain
 from ert._c_wrappers.enkf.res_config import ResConfig
+from ert.cli import TEST_RUN_MODE
+from ert.cli.main import run_cli
 
 
 def _create_runpath(enkf_main: EnKFMain) -> RunContext:
@@ -87,3 +91,55 @@ def test_environment_var_list(tmpdir):
 
         assert global_update_path["FOURTH"] == "TheFourthValue"
         assert config.env_vars.updatelist["FOURTH"] == "TheFourthValue"
+
+
+def replace_string_in_file(file: str, from_string: str, to_string: str):
+    with open(file, encoding="utf-8") as f:
+        content = f.read()
+
+    with open(file, mode="w", encoding="utf-8") as f:
+        f.write(content.replace(from_string, to_string))
+
+
+def test_that_outfile_from_gen_kw_template_creates_relative_path(copy_case):
+    copy_case("poly_example")
+
+    replace_string_in_file("poly.ert", "coeffs.json", "somepath/coeffs.json")
+    replace_string_in_file("poly_eval.py", "coeffs.json", "somepath/coeffs.json")
+
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            TEST_RUN_MODE,
+            "poly.ert",
+            "--port-range",
+            "1024-65535",
+        ],
+    )
+    run_cli(parsed)
+
+    assert os.path.exists("poly_out/realization-0/iter-0/somepath/coeffs.json")
+
+
+# This test was added to show current behaviour for Ert.
+# If absolute paths should be possible to be used like this is up for debate.
+def test_that_outfile_from_gen_kw_template_accepts_absolute_path(copy_case):
+    copy_case("poly_example")
+
+    replace_string_in_file("poly.ert", "coeffs.json", "/tmp/somepath/coeffs.json")
+    replace_string_in_file("poly_eval.py", "coeffs.json", "tmp/somepath/coeffs.json")
+
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            TEST_RUN_MODE,
+            "poly.ert",
+            "--port-range",
+            "1024-65535",
+        ],
+    )
+    run_cli(parsed)
+
+    assert os.path.exists("poly_out/realization-0/iter-0/tmp/somepath/coeffs.json")


### PR DESCRIPTION
**Issue**
Resolves #4773 


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
