### PR TITLE
Fix total progress bar exceeding 100 percent progress

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator_tracker.py
+++ b/src/ert/ensemble_evaluator/evaluator_tracker.py
@@ -193,7 +193,12 @@ class EvaluatorTracker:
                 ]:
                     done_reals += 1
             real_progress = float(done_reals) / len(all_reals)
-            return (current_iter + real_progress) / self._model.phaseCount()
+
+            return (
+                (current_iter + real_progress) / self._model.phaseCount()
+                if self._model.phaseCount() != 1
+                else real_progress
+            )
 
     def _clear_work_queue(self) -> None:
         try:

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -349,6 +349,7 @@ class RunDialog(QDialog):
                 self._snapshot_model._add_snapshot(event.snapshot, event.iteration)
             self._progress_view.setIndeterminate(event.indeterminate)
             progress = int(event.progress * 100)
+            self.validate_percentage_range(progress)
             self._total_progress_bar.setValue(progress)
             self._total_progress_label.setText(
                 _TOTAL_PROGRESS_TEMPLATE.format(
@@ -363,12 +364,18 @@ class RunDialog(QDialog):
                 )
             self._progress_view.setIndeterminate(event.indeterminate)
             progress = int(event.progress * 100)
+            self.validate_percentage_range(progress)
             self._total_progress_bar.setValue(progress)
             self._total_progress_label.setText(
                 _TOTAL_PROGRESS_TEMPLATE.format(
                     total_progress=progress, phase_name=event.phase_name
                 )
             )
+
+    def validate_percentage_range(self, progress: int):
+        if progress not in range(0, 101):
+            logger = logging.getLogger(__name__)
+            logger.warning(f"Total progress bar exceeds [0-100] range: {progress}")
 
     def restart_failed_realizations(self):
         msg = QMessageBox(self)


### PR DESCRIPTION
**Issue**
Resolves #4327

The progress bar would wrongly calculate the progress when encountering ensemble_experiments (which always are one phase) for other iterations than zero.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
