### PR TITLE
Fix __all__ not being a list of strings

### DIFF
--- a/src/ert/_c_wrappers/__init__.py
+++ b/src/ert/_c_wrappers/__init__.py
@@ -10,11 +10,11 @@ warnings.filterwarnings(action="always", category=DeprecationWarning, module=r"r
 
 from cwrap import Prototype  # noqa: E402 module level import not at top of file
 
-__all__ = [ecl, Prototype]
+__all__ = ["ecl", "Prototype"]
 try:
     from ._version import version as __version__
 
-    __all__ += [__version__]
+    __all__ += ["__version__"]
 except ImportError:
     pass
 

--- a/src/ert/_c_wrappers/job_queue/__init__.py
+++ b/src/ert/_c_wrappers/job_queue/__init__.py
@@ -42,9 +42,7 @@ import os
 
 from cwrap import Prototype
 
-import ert._c_wrappers
-
-__all__ = [Prototype, ert._c_wrappers]
+import ert._c_wrappers  # noqa
 
 
 def setenv(var, value):
@@ -82,6 +80,7 @@ from .workflow_job import WorkflowJob  # noqa
 from .workflow_runner import WorkflowRunner  # noqa
 
 __all__ = [
+    "Prototype",
     "JobStatusType",
     "RunStatusType",
     "ThreadStatus",

--- a/src/ert/_c_wrappers/util/__init__.py
+++ b/src/ert/_c_wrappers/util/__init__.py
@@ -1,8 +1,8 @@
 from cwrap import Prototype
 
-import ert._c_wrappers
+import ert._c_wrappers  # noqa
 
 from .path_format import PathFormat
 from .substitution_list import SubstitutionList
 
-__all__ = [Prototype, ert._c_wrappers, PathFormat, SubstitutionList]
+__all__ = ["Prototype", "PathFormat", "SubstitutionList"]

--- a/src/ert/gui/tools/__init__.py
+++ b/src/ert/gui/tools/__init__.py
@@ -1,3 +1,3 @@
 from .tool import Tool
 
-__all__ = [Tool]
+__all__ = ["Tool"]

--- a/src/ert/gui/tools/export/__init__.py
+++ b/src/ert/gui/tools/export/__init__.py
@@ -1,4 +1,4 @@
 from .export_panel import ExportPanel
 from .export_tool import ExportTool
 
-__all__ = [ExportPanel, ExportTool]
+__all__ = ["ExportPanel", "ExportTool"]

--- a/src/ert/gui/tools/file/__init__.py
+++ b/src/ert/gui/tools/file/__init__.py
@@ -1,4 +1,4 @@
 from .file_dialog import FileDialog
 from .file_update_worker import FileUpdateWorker
 
-__all__ = [FileDialog, FileUpdateWorker]
+__all__ = ["FileDialog", "FileUpdateWorker"]

--- a/src/ert/gui/tools/manage_cases/__init__.py
+++ b/src/ert/gui/tools/manage_cases/__init__.py
@@ -1,3 +1,3 @@
 from .manage_cases_tool import ManageCasesTool
 
-__all__ = [ManageCasesTool]
+__all__ = ["ManageCasesTool"]

--- a/src/ert/gui/tools/plot/widgets/__init__.py
+++ b/src/ert/gui/tools/plot/widgets/__init__.py
@@ -1,3 +1,3 @@
 from ert.gui.tools.plot.widgets.copy_style_to_dialog import CopyStyleToDialog
 
-__all__ = [CopyStyleToDialog]
+__all__ = ["CopyStyleToDialog"]

--- a/src/ert/gui/tools/run_analysis/__init__.py
+++ b/src/ert/gui/tools/run_analysis/__init__.py
@@ -1,4 +1,4 @@
 from .run_analysis_panel import RunAnalysisPanel
 from .run_analysis_tool import RunAnalysisTool
 
-__all__ = [RunAnalysisPanel, RunAnalysisTool]
+__all__ = ["RunAnalysisPanel", "RunAnalysisTool"]

--- a/src/ert/gui/tools/workflows/__init__.py
+++ b/src/ert/gui/tools/workflows/__init__.py
@@ -1,4 +1,4 @@
 from .run_workflow_widget import RunWorkflowWidget
 from .workflows_tool import WorkflowsTool
 
-__all__ = [RunWorkflowWidget, WorkflowsTool]
+__all__ = ["RunWorkflowWidget", "WorkflowsTool"]

--- a/src/ert/shared/ide/keywords/data/__init__.py
+++ b/src/ert/shared/ide/keywords/data/__init__.py
@@ -1,3 +1,3 @@
 from .validation_status import ValidationStatus
 
-__all__ = [ValidationStatus]
+__all__ = ["ValidationStatus"]


### PR DESCRIPTION
The module global variable should be string of the exported names: https://peps.python.org/pep-0008/

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
