### PR TITLE
Fix a bug where job_name did not get substituted with DEFINEs

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -264,7 +264,10 @@ class ResConfig:
             + self.substitution_list.get("<CONFIG_FILE>", "")
         )
         jobs = []
-        for job_name, args in config_dict.get(ConfigKeys.FORWARD_MODEL, []):
+        for unsubstituted_job_name, args in config_dict.get(
+            ConfigKeys.FORWARD_MODEL, []
+        ):
+            job_name = self.substitution_list.substitute(unsubstituted_job_name)
             try:
                 job = copy.deepcopy(self.installed_jobs[job_name])
             except KeyError as err:


### PR DESCRIPTION
Resolves an issue where user reported that substitutions did not happen in job names:
![user-image](https://user-images.githubusercontent.com/32731672/217224447-81d5806a-f30f-46f3-b824-e84becbf8939.png)

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
