### PR TITLE
Fix DeprecationWarning regarding implicit conversion to integers for job keyword type

### DIFF
--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -422,7 +422,9 @@ class ResConfig:
                     "max_running_minutes": job.max_running_minutes,
                     "max_running": job.max_running,
                     "min_arg": job.min_arg,
-                    "arg_types": [job_kw.kw_from_type(typ) for typ in job.arg_types],
+                    "arg_types": [
+                        job_kw.kw_from_type(int(typ)) for typ in job.arg_types
+                    ],
                     "max_arg": job.max_arg,
                 }
                 for idx, job in enumerate(forward_model_list)


### PR DESCRIPTION
**Issue**
Resolves #4687 


**Approach**
Force int conversion


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
