### PR TITLE
Fix a crash occurring when the run dialog was closed before the plot window

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -206,7 +206,7 @@ def _setup_main_window(
     window.addDock(
         "Configuration summary", SummaryPanel(ert), area=Qt.BottomDockWidgetArea
     )
-    window.addTool(PlotTool(config_file))
+    window.addTool(PlotTool(config_file, window))
     window.addTool(ExportTool(ert))
     window.addTool(WorkflowsTool(ert, notifier))
     window.addTool(ManageCasesTool(ert, notifier))

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -106,8 +106,7 @@ class RunDialog(QDialog):
 
         self.running_time = QLabel("")
 
-        self.plot_tool = PlotTool(config_file)
-        self.plot_tool.setParent(self)
+        self.plot_tool = PlotTool(config_file, self.parent())
         self.plot_button = QPushButton(self.plot_tool.getName())
         self.plot_button.clicked.connect(self.plot_tool.trigger)
         self.plot_button.setEnabled(ert is not None)

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -175,10 +175,7 @@ class SimulationPanel(QWidget):
                     abort = True
 
             if not abort:
-                dialog = RunDialog(
-                    self._config_file,
-                    model,
-                )
+                dialog = RunDialog(self._config_file, model, self.parent())
                 self.run_button.setDisabled(True)
                 self.run_button.setText("Simulation running...")
                 dialog.startSimulation()

--- a/src/ert/gui/tools/plot/plot_tool.py
+++ b/src/ert/gui/tools/plot/plot_tool.py
@@ -5,10 +5,11 @@ from .plot_window import PlotWindow
 
 
 class PlotTool(Tool):
-    def __init__(self, config_file):
+    def __init__(self, config_file, main_window):
         super().__init__("Create plot", "tools/plot", resourceIcon("timeline.svg"))
         self._config_file = config_file
+        self.main_window = main_window
 
     def trigger(self):
-        plot_window = PlotWindow(self._config_file, self.parent())
+        plot_window = PlotWindow(self._config_file, self.main_window)
         plot_window.show()


### PR DESCRIPTION


**Issue**
Resolves #4752


**Approach**
PlotWindow would get the RunDialog as parent when create plot was clicked from RunDialog. This lead to the memory being freed to early when RunDialog was closed before PlotWindow.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
