### PR TITLE
Disable CLI runs for some modes when no observations are present.

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -12,7 +12,7 @@ from typing import Any
 import filelock
 
 from ert._c_wrappers.enkf import EnKFMain, ResConfig
-from ert.cli import WORKFLOW_MODE
+from ert.cli import ENSEMBLE_EXPERIMENT_MODE, TEST_RUN_MODE, WORKFLOW_MODE
 from ert.cli.model_factory import create_model
 from ert.cli.monitor import Monitor
 from ert.cli.workflow import execute_workflow
@@ -44,6 +44,16 @@ def run_cli(args):
     os.chdir(res_config.config_path)
     ert = EnKFMain(res_config)
     facade = LibresFacade(ert)
+    if not facade.have_observations and args.mode not in [
+        ENSEMBLE_EXPERIMENT_MODE,
+        TEST_RUN_MODE,
+        WORKFLOW_MODE,
+    ]:
+        raise RuntimeError(
+            f"To run {args.mode}, observations are needed. \n"
+            f"Please add an observation file to {args.config}. Example: \n"
+            f"'OBS_CONFIG observation_file.txt'."
+        )
     ens_path = Path(res_config.ens_path)
     storage_lock = filelock.FileLock(ens_path / f"{ens_path.stem}.lock")
     try:


### PR DESCRIPTION
**Issue**
Resolves #4827 


**Approach**
Disabled modes: ITERATIVE_ENSEMBLE_SMOOTHER_MODE, ENSEMBLE_SMOOTHER_MODE, ES_MDA_MODE
when no observations are present



## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
