### PR TITLE
Use !r for formatting of values in config errors

### DIFF
--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -165,7 +165,7 @@ def parse_signature_job(signature: str) -> Tuple[str, Optional[str]]:
     close_paren = signature.find(")")
     if close_paren == -1:
         raise ConfigValidationError(
-            errors=[f"Missing ) in FORWARD_MODEL job description {signature}"]
+            errors=[f"Missing ) in FORWARD_MODEL job description {signature!r}"]
         )
     if close_paren < len(signature) - 1:
         logger.warning(

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -60,7 +60,7 @@ class AnalysisConfig:
                 self._modules[dst_name] = new_module
             else:
                 raise ConfigValidationError(
-                    f"Trying to copy module {src_name} which does not exist"
+                    f"Trying to copy module {src_name!r} which does not exist"
                 )
 
     def _set_modules_var_list(self):

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -413,7 +413,7 @@ class EnsembleConfig(BaseCClass):
         key = config_node.getKey()
         if key in self:
             raise ConfigValidationError(
-                f"Enkf config node with key {key} already present in ensemble config"
+                f"Enkf config node with key {key!r} already present in ensemble config"
             )
         self._add_node(config_node)
         config_node.convertToCReference(self)

--- a/src/ert/_c_wrappers/enkf/res_config.py
+++ b/src/ert/_c_wrappers/enkf/res_config.py
@@ -180,7 +180,7 @@ class ResConfig:
                 raise ConfigValidationError(
                     config_file=config_path,
                     errors=[
-                        f"QUEUE_OPTION MAX_RUNNING is negative: {str(*values)}",
+                        f"QUEUE_OPTION MAX_RUNNING is negative: {str(*values)!r}",
                     ],
                 )
 
@@ -273,8 +273,8 @@ class ResConfig:
             except KeyError as err:
                 raise ConfigValidationError(
                     errors=(
-                        f"Could not find job `{job_name}` in list of installed jobs: "
-                        f"{list(self.installed_jobs.keys())}"
+                        f"Could not find job {job_name!r} in list of installed jobs: "
+                        f"{list(self.installed_jobs.keys())!r}"
                     ),
                     config_file=config_file,
                 ) from err
@@ -284,7 +284,7 @@ class ResConfig:
                     job.private_args.add_from_string(args)
                 except ValueError as err:
                     raise ConfigValidationError(
-                        errors=f"{err}: FORWARD_MODEL {job_name} ({args})\n",
+                        errors=f"{err}: 'FORWARD_MODEL {job_name}({args})'\n",
                         config_file=config_file,
                     ) from err
 
@@ -300,7 +300,7 @@ class ResConfig:
                 job = copy.deepcopy(self.installed_jobs[job_description[0]])
             except KeyError as err:
                 raise ConfigValidationError(
-                    f"Could not find job `{job_description[0]}` "
+                    f"Could not find job {job_description[0]!r} "
                     "in list of installed jobs.",
                     config_file=config_file,
                 ) from err
@@ -474,12 +474,14 @@ class ResConfig:
         for hook_name, mode_name in hook_workflow_info:
             if mode_name not in [runtime.name for runtime in HookRuntime.enums()]:
                 raise ConfigValidationError(
-                    errors=[f"Run mode {mode_name} not supported for Hook Workflow"]
+                    errors=[f"Run mode {mode_name!r} not supported for Hook Workflow"]
                 )
 
             if hook_name not in self.workflows:
                 raise ConfigValidationError(
-                    errors=[f"Cannot setup hook for non-existing job name {hook_name}"]
+                    errors=[
+                        f"Cannot setup hook for non-existing job name {hook_name!r}"
+                    ]
                 )
 
             self.hooked_workflows[HookRuntime.from_string(mode_name)].append(
@@ -501,7 +503,7 @@ class ResConfig:
         for job_path in config_dict.get(ConfigKeys.INSTALL_JOB_DIRECTORY, []):
             if not os.path.isdir(job_path):
                 raise ConfigValidationError(
-                    f"Unable to locate job directory {job_path}"
+                    f"Unable to locate job directory {job_path!r}"
                 )
 
             files = os.listdir(job_path)

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -71,22 +71,24 @@ class ExtJob:
         if resolved is None:
             raise ConfigValidationError(
                 config_file=config_file_location,
-                errors=[f"Could not find executable {executable} for job {name}"],
+                errors=[f"Could not find executable {executable!r} for job {name!r}"],
             )
 
         if not os.access(resolved, os.X_OK):  # is not executable
             raise ConfigValidationError(
                 config_file=config_file_location,
                 errors=[
-                    f"ExtJob {name} with executable"
-                    f" {resolved} does not have execute permissions"
+                    f"ExtJob {name!r} with executable"
+                    f" {resolved!r} does not have execute permissions"
                 ],
             )
 
         if os.path.isdir(resolved):
             raise ConfigValidationError(
                 config_file=config_file_location,
-                errors=[f"ExtJob {name} has executable set to directory {resolved}"],
+                errors=[
+                    f"ExtJob {name!r} has executable set to directory {resolved!r}"
+                ],
             )
 
         return resolved
@@ -181,7 +183,7 @@ class ExtJob:
         except IOError as err:
             raise ConfigValidationError(
                 config_file=config_file,
-                errors=f"Could not open job config file {config_file}",
+                errors=f"Could not open job config file {config_file!r}",
             ) from err
 
         logger.info(

--- a/src/ert/_c_wrappers/job_queue/workflow_job.py
+++ b/src/ert/_c_wrappers/job_queue/workflow_job.py
@@ -90,7 +90,7 @@ class WorkflowJob:
                 optional_get("FUNCTION"),
             )
         else:
-            raise ConfigValidationError(f"Could not open config_file:{config_file}")
+            raise ConfigValidationError(f"Could not open config_file:{config_file!r}")
 
     def isPlugin(self) -> bool:
         if self.script is not None:

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -524,7 +524,7 @@ def test_that_unknown_job_gives_config_validation_error():
     with open(test_config_file_name, "w", encoding="utf-8") as fh:
         fh.write(test_config_contents)
 
-    with pytest.raises(ConfigValidationError, match="Could not find job `NO_SUCH_JOB`"):
+    with pytest.raises(ConfigValidationError, match="Could not find job 'NO_SUCH_JOB'"):
         _ = ResConfig(user_config_file=test_config_file_name)
 
 
@@ -559,7 +559,7 @@ def test_that_unknown_hooked_job_gives_config_validation_error():
 
     with pytest.raises(
         ConfigValidationError,
-        match="Cannot setup hook for non-existing job name NO_SUCH_JOB",
+        match="Cannot setup hook for non-existing job name 'NO_SUCH_JOB'",
     ):
         _ = ResConfig(user_config_file=test_config_file_name)
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -218,7 +218,7 @@ def test_ensemble_config_duplicate_node_names(setup_case):
             ]
         ],
     }
-    error_match = f"key {duplicate_name} already present in ensemble config"
+    error_match = f"key {duplicate_name!r} already present in ensemble config"
 
     with pytest.raises(ConfigValidationError, match=error_match):
         EnsembleConfig.from_dict(config_dict=config_dict)

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
@@ -11,7 +11,7 @@ from ert._c_wrappers.job_queue.ext_job import ExtJob
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_forward_model_raises_on_missing():
     with pytest.raises(
-        ConfigValidationError, match="Could not open job config file CONFIG_FILE"
+        ConfigValidationError, match="Could not open job config file 'CONFIG_FILE'"
     ):
         _ = ExtJob.from_config_file("CONFIG_FILE")
 


### PR DESCRIPTION
Use !r to format config validation errors to make it more clear what parts of the message are values.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
