### PR TITLE
Fix errors in workflow referring to temporary file

### DIFF
--- a/src/ert/_c_wrappers/job_queue/workflow.py
+++ b/src/ert/_c_wrappers/job_queue/workflow.py
@@ -53,7 +53,9 @@ class Workflow:
     ):
         to_compile = src_file
         if not os.path.exists(src_file):
-            raise ConfigValidationError(f"Workflow file {src_file} does not exist")
+            raise ConfigValidationError(
+                f"Workflow file {src_file} does not exist", config_file=src_file
+            )
         if context is not None:
             tmpdir = mkdtemp("ert_workflow")
             to_compile = os.path.join(tmpdir, "ert-workflow")
@@ -61,7 +63,11 @@ class Workflow:
 
         cmd_list = []
         parser = _workflow_parser(job_list)
-        content = parser.parse(to_compile)
+        try:
+            content = parser.parse(to_compile)
+        except ConfigValidationError as err:
+            err.config_file = src_file
+            raise err from None
 
         for line in content:
             cmd_list.append(

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
@@ -52,6 +52,17 @@ def test_workflow_run():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_failing_workflow_run():
-    WorkflowCommon.createExternalDumpJob()
-    with pytest.raises(ValueError, match="does not exist"):
+    with pytest.raises(ConfigValidationError, match="does not exist") as err:
         _ = Workflow.from_file("undefined", None, {})
+    assert err.value.config_file == "undefined"
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_failure_in_parsing_workflow_gives_config_validation_error():
+    with open("workflow", "w", encoding="utf-8") as f:
+        f.write("DEFINE\n")
+    with pytest.raises(
+        ConfigValidationError, match="DEFINE must have two or more arguments"
+    ) as err:
+        _ = Workflow.from_file("workflow", None, {})
+    assert err.value.config_file == "workflow"


### PR DESCRIPTION
backports #4848


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
