### PR TITLE
Update case info tab after case is initialized

### DIFF
--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -70,6 +70,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         self.addInitializeFromScratchTab()
         self.addInitializeFromExistingTab()
         self.addShowCaseInfo()
+        self.currentChanged.connect(self.on_tab_changed)
 
     def addCreateNewCaseTab(self):
         panel = QWidget()
@@ -235,7 +236,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
 
         layout.addLayout(row1)
 
-        self._case_info_area = QTextEdit()
+        self._case_info_area = QTextEdit(objectName="html_text")
         self._case_info_area.setReadOnly(True)
         self._case_info_area.setMinimumHeight(300)
 
@@ -250,8 +251,6 @@ class CaseInitializationConfigurationPanel(QTabWidget):
 
         self.addTab(case_widget, "Case info")
 
-        self._showInfoForCase()
-
     def _showInfoForCase(self, case_name=None):
         if case_name is None:
             case_name = self.ert.storage_manager.current_case.case_name
@@ -265,3 +264,8 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         html += "</table>"
 
         self._case_info_area.setHtml(html)
+
+    @showWaitCursorWhileWaiting
+    def on_tab_changed(self, p_int):
+        if self.tabText(p_int) == "Case info":
+            self._showInfoForCase()

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QPushButton
+from qtpy.QtWidgets import QPushButton, QTextEdit
 
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert._clib.state_map import RealizationStateEnum
@@ -75,3 +75,26 @@ def test_that_case_tool_can_copy_case_state(qtbot):
     ).flatten()[
         0
     ] == pytest.approx(-0.8814227775506998)
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_case_tool_init_updates_the_case_info_tab(qtbot):
+    ert = EnKFMain(ErtConfig.from_file("poly.ert"))
+    tool = CaseInitializationConfigurationPanel(ert, MagicMock())
+    html_edit = tool.findChild(QTextEdit, name="html_text")
+
+    assert not html_edit.toPlainText()
+    # Change to the "case info" tab
+    tool.setCurrentIndex(3)
+    assert "STATE_UNDEFINED" in html_edit.toPlainText()
+
+    # Change to the "initialize from scratch" tab
+    tool.setCurrentIndex(1)
+    qtbot.mouseClick(
+        tool.findChild(QPushButton, name="initialize_from_scratch_button"),
+        Qt.LeftButton,
+    )
+
+    # Change to the "case info" tab
+    tool.setCurrentIndex(3)
+    assert "STATE_INITIALIZED" in html_edit.toPlainText()


### PR DESCRIPTION

**Issue**
Resolves #4864 


**Approach**
Update the case info list after initializing a case from scratch or from another existing case.



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
