### PR TITLE
Fix use of non imported ResConfig, and use LibresFacade.from_config_file instead

### DIFF
--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -409,7 +409,6 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
 
         FeatureToggling.update_from_args(parsed)
         run_cli(parsed)
-        post_ert = EnKFMain(ResConfig("poly.ert"))
-        post_facade = LibresFacade(post_ert)
+        post_facade = LibresFacade.from_config_file("poly.ert")
         parameter_values = post_facade.load_all_gen_kw_data("default")
         pd.testing.assert_frame_equal(parameter_values, prior_values)


### PR DESCRIPTION
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
