### PR TITLE
Fix RunDialog unintentionally becoming modal

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -48,8 +48,6 @@ class RunDialog(QDialog):
         QDialog.__init__(self, parent)
         self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
-        self.setModal(True)
-        self.setWindowModality(Qt.WindowModal)
         self.setWindowTitle(f"Simulations - {config_file}")
 
         self._snapshot_model = SnapshotModel(self)

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -179,9 +179,13 @@ class SimulationPanel(QWidget):
                 self.run_button.setDisabled(True)
                 self.run_button.setText("Simulation running...")
                 dialog.startSimulation()
-                dialog.exec_()
-                self.run_button.setText("Start simulation")
-                self.run_button.setDisabled(False)
+                dialog.show()
+
+                def exit_handler():
+                    self.run_button.setText("Start simulation")
+                    self.run_button.setDisabled(False)
+
+                dialog.finished.connect(exit_handler)
 
                 self.notifier.emitErtChange()  # simulations may have added new cases
 


### PR DESCRIPTION
**Issue**
In 8a4eefe37df5876ebed7be8d159b1f13bd3f59e9 , RunDialog started blocking the main gui. It was designed to be modal, but because there was no connection to main_window it never blocked it. This changes the behavior so that it is modeless. This has the changed behavior that closing the main window while the RunDialog is open will now open the "kill jobs dialog". If the user chooses "no" then behavior is as before.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
