### PR TITLE
Add keywords replaced with QUEUE_OPTION to suggester

### DIFF
--- a/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
+++ b/src/ert/_c_wrappers/enkf/_deprecation_migration_suggester.py
@@ -31,7 +31,13 @@ class DeprecationMigrationSuggester:
         "LOG_LEVEL",
         "ENKF_RERUN",
     ]
-    RSH_KEYWORDS = ["RSH_HOST", "RHS_COMMAND"]
+    RSH_KEYWORDS = ["RSH_HOST", "RSH_COMMAND", "MAX_RUNNING_RSH"]
+    USE_QUEUE_OPTION = [
+        "LSF_SERVER",
+        "LSF_QUEUE",
+        "MAX_RUNNING_LSF",
+        "MAX_RUNNING_LOCAL",
+    ]
 
     def _add_deprecated_keywords_to_parser(self):
         for kw in self.REPLACE_WITH_GEN_KW:
@@ -39,6 +45,8 @@ class DeprecationMigrationSuggester:
         for kw in self.JUST_REMOVE_KEYWORDS:
             self._parser.add(kw)
         for kw in self.RSH_KEYWORDS:
+            self._parser.add(kw)
+        for kw in self.USE_QUEUE_OPTION:
             self._parser.add(kw)
         self._parser.add("PLOT_SETTINGS")
         self._parser.add("HAVANA_FAULT")
@@ -99,9 +107,18 @@ class DeprecationMigrationSuggester:
             add_suggestion(
                 kw,
                 f"The {kw} was used for the deprecated and removed "
-                "support for RHS queues. It no longer has any effect "
+                "support for RSH queues. It no longer has any effect "
                 "and can safely be removed from the config file.",
             )
+        for kw in self.USE_QUEUE_OPTION:
+            add_suggestion(
+                kw,
+                f"The {kw} keyword has been removed. For most cases this option "
+                "should be set in the site config, and as a regular user you can "
+                "simply remove this from your config. If you need to set these "
+                "options it is now done via the QUEUE_OPTION keyword.",
+            )
+
         add_suggestion(
             "HAVANA_FAULT",
             "Direct interoperability with havana was removed from ert in 2009."

--- a/tests/test_config_parsing/test_suggester.py
+++ b/tests/test_config_parsing/test_suggester.py
@@ -49,7 +49,16 @@ def test_that_suggester_gives_rsh_migrations(suggester, tmp_path, kw):
     suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
 
     assert len(suggestions) == 1
-    assert "deprecated and removed support for RHS queues." in suggestions[0]
+    assert "deprecated and removed support for RSH queues." in suggestions[0]
+
+
+@pytest.mark.parametrize("kw", DeprecationMigrationSuggester.USE_QUEUE_OPTION)
+def test_that_suggester_gives_queue_option_migrations(suggester, tmp_path, kw):
+    (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
+    suggestions = suggester.suggest_migrations(str(tmp_path / "config.ert"))
+
+    assert len(suggestions) == 1
+    assert f"The {kw} keyword has been removed. For most cases " in suggestions[0]
 
 
 def test_that_suggester_gives_refcase_list_migration(suggester, tmp_path):


### PR DESCRIPTION
LSF_SERVER, LSF_QUEUE, MAX_RUNNING_LSF, MAX_RUNNING_LOCAL get a message to replace with QUEUE_OPTION

MAX_RUNNING_RSH
get a message that RHS has been removed

**Issue**
Resolves #4756 

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
