### PR TITLE
Only resample parameters if necessary

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -15,6 +15,7 @@ from ert._c_wrappers.enkf.ert_config import EnsembleConfig
 from ert._c_wrappers.enkf.summary_key_set import SummaryKeySet
 from ert._c_wrappers.enkf.time_map import TimeMap
 from ert._clib import update
+from ert._clib.state_map import RealizationStateEnum
 
 if TYPE_CHECKING:
     from ecl.summary import EclSum
@@ -22,7 +23,6 @@ if TYPE_CHECKING:
 
     from ert._c_wrappers.enkf import RunArg
     from ert._c_wrappers.enkf.state_map import StateMap
-    from ert._clib.state_map import RealizationStateEnum
 
 
 class EnkfFs(BaseCClass):
@@ -76,6 +76,12 @@ class EnkfFs(BaseCClass):
             self._ensemble_config.parameters,
             self._ensemble_size,
         )
+
+    def realizations_initialized(self, realizations: List[int]):
+        initialized_realisations = self.realizationList(
+            RealizationStateEnum.STATE_INITIALIZED
+        )
+        return all(real in initialized_realisations for real in realizations)
 
     @classmethod
     def createFileSystem(

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -386,12 +386,17 @@ class EnKFMain:
                 gen_kw_node = enkf_node.asGenKw()
                 keys = [val[0] for val in gen_kw_node.items()]
                 if config_node.get_init_file_fmt():
+                    logging.info(
+                        f"Reading from init file {config_node.get_init_file_fmt()}"
+                        + f" for {parameter}"
+                    )
                     parameter_values = gen_kw_node.values_from_files(
                         active_realizations,
                         config_node.get_init_file_fmt(),
                         keys,
                     )
                 else:
+                    logging.info(f"Sampling parameter {parameter}")
                     parameter_values = gen_kw_node.sample_values(
                         parameter,
                         keys,

--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -115,7 +115,9 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(0, "Running simulations...", indeterminate=False)
 
         self.setPhaseName("Pre processing...", indeterminate=True)
-        if not prior_context.sim_fs.is_initalized:
+        if not prior_context.sim_fs.realizations_initialized(
+            prior_context.active_realizations
+        ):
             self.ert().sample_prior(
                 prior_context.sim_fs,
                 prior_context.active_realizations,

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -377,8 +377,28 @@ def test_bad_config_error_message(tmp_path):
 
 
 @pytest.mark.integration_test
+@pytest.mark.parametrize(
+    "prior_mask,reals_rerun_option,should_resample",
+    [
+        pytest.param(
+            None, "0-4", False, id="All realisations first, subset second run"
+        ),
+        pytest.param(
+            [False, True, True, True, True],
+            "2-3",
+            False,
+            id="Subset of realisation first run, subs-subset second run",
+        ),
+        pytest.param(
+            [True] * 3,
+            "0-5",
+            True,
+            id="Subset of realisation first, superset in second run - must resample",
+        ),
+    ],
+)
 def test_that_prior_is_not_overwritten_in_ensemble_experiment(
-    tmpdir, source_root, capsys
+    prior_mask, reals_rerun_option, should_resample, tmpdir, source_root, capsys
 ):
     shutil.copytree(
         os.path.join(source_root, "test-data", "poly_example"),
@@ -387,9 +407,8 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
 
     with tmpdir.as_cwd():
         ert = EnKFMain(ErtConfig.from_file("poly_example/poly.ert"))
-        prior_context = ert.load_ensemble_context(
-            "default", [True] * ert.getEnsembleSize(), 0
-        )
+        prior_mask = prior_mask or [True] * ert.getEnsembleSize()
+        prior_context = ert.load_ensemble_context("default", prior_mask, 0)
         ert.sample_prior(prior_context.sim_fs, prior_context.active_realizations)
         facade = LibresFacade(ert)
         prior_values = facade.load_all_gen_kw_data("default")
@@ -403,7 +422,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
                 "--port-range",
                 "1024-65535",
                 "--realizations",
-                "0-4",
+                reals_rerun_option,
             ],
         )
 
@@ -411,4 +430,9 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
         run_cli(parsed)
         post_facade = LibresFacade.from_config_file("poly.ert")
         parameter_values = post_facade.load_all_gen_kw_data("default")
-        pd.testing.assert_frame_equal(parameter_values, prior_values)
+
+        if should_resample:
+            with pytest.raises(AssertionError):
+                pd.testing.assert_frame_equal(parameter_values, prior_values)
+        else:
+            pd.testing.assert_frame_equal(parameter_values, prior_values)


### PR DESCRIPTION
**Issue**
Resolves #4863


**Approach**
In the scenario that a sampling has already occured, we reuse the sampling when running the ensemble experiment. A possible scenario is that a user runs an ensemble experiment, manual analysis and then wants to run ensemble experiment on the target case for the manual analysis.

This will also hinder a user to run multiple ensemble experiments with the same setup and get resampling. Doing this was not possible before either though.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
