### PR TITLE
Fix logging messages that failed with telemetry

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -434,7 +434,6 @@ class EnKFMain:
         (Path(self.res_config.ens_path) / "current_case").write_text(case_name)
 
     def createRunPath(self, run_context: RunContext) -> None:
-        first_time = True
         for iens, run_arg in enumerate(run_context):
             if run_context.is_active(iens):
                 os.makedirs(
@@ -483,12 +482,6 @@ class EnKFMain:
                     )
 
                     json.dump(forward_model_output, fptr)
-
-                    if first_time:
-                        first_time = False
-                        logger.info(
-                            "Content of first jobs.json", extra=forward_model_output
-                        )
 
         run_context.runpaths.write_runpath_list(
             [run_context.iteration], run_context.active_realizations

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -36,7 +36,7 @@ def run_cli(args):
     # the root-logger.
     logger = logging.getLogger(__name__)
     for job in res_config.forward_model_list:
-        logger.info("Config contains forward model job %s", job)
+        logger.info("Config contains forward model job %s", job.name)
 
     for suggestion in ErtConfig.make_suggestion_list(args.config):
         print(f"Warning: {suggestion}")

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -88,11 +88,11 @@ def _start_initial_gui_window(args, log_handler):
         ]
     except ConfigValidationError as error:
         messages.append(str(error))
-        logger.info("Error in config file shown in gui: '%s'", error)
+        logger.info("Error in config file shown in gui: '%s'", str(error))
         return _setup_suggester(messages), None
 
     for job in res_config.forward_model_list:
-        logger.info("Config contains forward model job %s", job)
+        logger.info("Config contains forward model job %s", job.name)
     for wm in warning_messages:
         if wm.category != ConfigWarning:
             logger.warning(wm.message)


### PR DESCRIPTION
Fixes log messages that caused telemetry to crash.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
