### PR TITLE
Fix flaky failure of gui tests

### DIFF
--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -209,13 +209,13 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot):
     args_mock = Mock()
     args_mock.config = str(config_file)
 
+    ert_config = ErtConfig.from_file(str(config_file))
+    enkf_main = EnKFMain(ert_config)
     with Storage.init_service(
-        res_config=args_mock.config,
-        project="storage",
+        res_config=str(config_file),
+        project=os.path.abspath(ert_config.ens_path),
     ):
-        gui = _setup_main_window(
-            EnKFMain(ErtConfig.from_file(str(config_file))), args_mock, GUILogHandler()
-        )
+        gui = _setup_main_window(enkf_main, args_mock, GUILogHandler())
         qtbot.addWidget(gui)
 
         start_simulation = gui.findChild(QToolButton, name="start_simulation")

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -52,7 +52,7 @@ def opened_main_window(source_root, tmpdir_factory, request):
 
         with Storage.init_service(
             res_config=args_mock.config,
-            project="storage",
+            project=os.path.abspath(poly_case.res_config.ens_path),
         ):
             gui = _setup_main_window(poly_case, args_mock, GUILogHandler())
             yield gui


### PR DESCRIPTION
gui tests would intermittently fail due to missing enspath when starting storage.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
