### PR TITLE
Make get_machine_name predictive for multiple PTR

### DIFF
--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -33,11 +33,13 @@ def get_machine_name():
         # We need the ip-address to perform a reverse lookup to deal with
         # differences in how the clusters are getting their fqdn's
         ip_addr = socket.gethostbyname(hostname)
-        rev_name = reversename.from_address(ip_addr)
-        resolved_host = str(resolver.resolve(rev_name, "PTR")[0])
-        if resolved_host[-1] == ".":
-            resolved_host = resolved_host[:-1]
-        return resolved_host
+        reverse_name = reversename.from_address(ip_addr)
+        resolved_hosts = [
+            str(ptr_record).rstrip(".")
+            for ptr_record in resolver.resolve(reverse_name, "PTR")
+        ]
+        resolved_hosts.sort()
+        return resolved_hosts[0]
     except (resolver.NXDOMAIN, exception.Timeout):
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name


### PR DESCRIPTION
**Issue**
Resolves #4888

**Approach**
Sort the hostnames from reverse DNS lookup

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
