### PR TITLE
Improved error message on time mismatch in refcase

### DIFF
--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -1031,13 +1031,13 @@ void enkf_obs_load(Cwrap<enkf_obs_type> enkf_obs, const char *config_file,
     } catch (exc::out_of_range err) {
         if (enkf_obs->refcase) {
             throw exc::out_of_range(
-                "{}, the time map is set from the REFCASE keyword.\n Either "
-                "the REFCASE has a incorrect/missing date, or the observation "
+                "{} The time map is set from the REFCASE keyword.\n Either "
+                "the REFCASE has an incorrect/missing date, or the observation "
                 "is given an incorrect date.",
                 err.what());
         } else {
             throw exc::out_of_range(
-                "{}, the time map is set from the TIME_MAP keyword.\n Either "
+                "{} The time map is set from the TIME_MAP keyword.\n Either "
                 "the time map file has an incorrect/missing date, or the "
                 "observation is given an incorrect date.",
                 err.what());

--- a/src/clib/lib/enkf/obs_vector.cpp
+++ b/src/clib/lib/enkf/obs_vector.cpp
@@ -104,17 +104,18 @@ __conf_instance_get_restart_nr(const conf_instance_type *conf_instance,
                                  obs_key);
     obs_restart_nr = find_nearest_time_index(time_map, obs_time);
     if (obs_restart_nr < 0) {
-        std::string error =
-            fmt::format("Observation: {} failed to match time", obs_key);
+        std::string error = fmt::format(
+            "Observation {} does not have a matching time in the time map.",
+            obs_key);
         if (conf_instance_has_item(conf_instance, "DATE"))
             error += fmt::format(
-                ", corresponding to DATE={}",
+                " DATE={} is not in the time map.",
                 conf_instance_get_item_value_ref(conf_instance, "DATE"));
         else if (conf_instance_has_item(conf_instance, "DAYS"))
             error += fmt::format(
-                ", corresponding to DAYS={}",
+                " DAYS={} is not in the time map.",
                 conf_instance_get_item_value_ref(conf_instance, "DAYS"));
-        throw exc::out_of_range(error + " the date could be incorrect");
+        throw exc::out_of_range(error);
     }
     return obs_restart_nr;
 }

--- a/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
@@ -57,7 +57,7 @@ def run_sim(start_date):
             "2.0",
             pytest.raises(
                 ObservationConfigError,
-                match="FOPR_1 failed to match time, corresponding to DAYS=2",
+                match="FOPR_1 does not have a matching time in the time map. DAYS=2",
             ),
             id="Outside tolerance",
         ),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32731672/219573422-bb3e82d3-8393-4650-95c1-5c8c28f6c03f.png)
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
