### PR TITLE
Better error message for invalid QUEUE_SYSTEM provided

### DIFF
--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Union
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.job_queue import Driver, JobQueue, QueueDriverEnum
 
 
@@ -18,6 +19,15 @@ class QueueConfig:
     @classmethod
     def from_dict(cls, config_dict):
         queue_system = config_dict.get("QUEUE_SYSTEM", "LOCAL")
+
+        valid_queue_systems = ["LSF", "LOCAL", "TORQUE", "SLURM"]
+
+        if queue_system not in valid_queue_systems:
+            raise ConfigValidationError(
+                f"Invalid QUEUE_SYSTEM provided: {queue_system!r}. Valid choices for "
+                f"QUEUE_SYSTEM are {valid_queue_systems!r}"
+            )
+
         queue_system = QueueDriverEnum.from_string(f"{queue_system}_DRIVER")
         job_script = config_dict.get("JOB_SCRIPT", shutil.which("job_dispatch.py"))
         job_script = job_script or "job_dispatch.py"

--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -20,7 +20,11 @@ class QueueConfig:
     def from_dict(cls, config_dict):
         queue_system = config_dict.get("QUEUE_SYSTEM", "LOCAL")
 
-        valid_queue_systems = ["LSF", "LOCAL", "TORQUE", "SLURM"]
+        valid_queue_systems = []
+
+        for driver_names in QueueDriverEnum.enums():
+            if driver_names.name not in str(QueueDriverEnum.NULL_DRIVER):
+                valid_queue_systems.append(driver_names.name[: -len("_DRIVER")])
 
         if queue_system not in valid_queue_systems:
             raise ConfigValidationError(

--- a/tests/test_config_parsing/test_queue_config.py
+++ b/tests/test_config_parsing/test_queue_config.py
@@ -2,6 +2,7 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
+from ert._c_wrappers.config.config_parser import ConfigValidationError
 from ert._c_wrappers.enkf import ErtConfig
 
 
@@ -16,3 +17,18 @@ def test_queue_config_default_max_running_is_unlimited(num_real):
         ErtConfig.from_file(filename).queue_config.create_job_queue().get_max_running()
         == 0
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
+@given(st.integers(min_value=1, max_value=300))
+def test_queue_config_invalid_queue_system_provided(num_real):
+    filename = "config.ert"
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f"NUM_REALIZATIONS {num_real}\nQUEUE_SYSTEM VOID\n")
+
+    with pytest.raises(
+        expected_exception=ConfigValidationError,
+        match="Invalid QUEUE_SYSTEM provided: 'VOID'",
+    ):
+        ErtConfig.from_file(filename).queue_config.create_job_queue()


### PR DESCRIPTION
**Issue**
Resolves #4884 



**Approach**
Validate QUEUE_SYSTEM is valid before casting to Enum

Option:
Extract valid QUEUE_SYSTEM values from Enum, but omit NULL_DRIVER, and remove suffix _DRIVER from strings.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
