### PR TITLE
Workflows with errors are no longer loaded, before they would give error when run

### DIFF
--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -488,9 +488,22 @@ class ErtConfig:
 
         for work in workflow_info:
             filename = os.path.basename(work[0]) if len(work) == 1 else work[1]
-            workflows[filename] = Workflow.from_file(
-                work[0], substitution_list, workflow_jobs
-            )
+            try:
+                existed = filename in workflows
+                workflows[filename] = Workflow.from_file(
+                    work[0], substitution_list, workflow_jobs
+                )
+                if existed:
+                    warnings.warn(
+                        f"Workflow {filename!r} was added twice",
+                        category=ConfigWarning,
+                    )
+            except ConfigValidationError as err:
+                warnings.warn(
+                    f"Encountered error(s) {err.errors!r} while"
+                    f" reading workflow {filename!r}. It will not be loaded.",
+                    category=ConfigWarning,
+                )
 
         for hook_name, mode_name in hook_workflow_info:
             if mode_name not in [runtime.name for runtime in HookRuntime.enums()]:

--- a/src/ert/_c_wrappers/job_queue/workflow.py
+++ b/src/ert/_c_wrappers/job_queue/workflow.py
@@ -4,7 +4,7 @@ import time
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from ert._c_wrappers.config import ConfigParser, ConfigValidationError
+from ert._c_wrappers.config import ConfigParser, ConfigValidationError, UnrecognizedEnum
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain
@@ -64,7 +64,9 @@ class Workflow:
         cmd_list = []
         parser = _workflow_parser(job_list)
         try:
-            content = parser.parse(to_compile)
+            content = parser.parse(
+                to_compile, unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_ERROR
+            )
         except ConfigValidationError as err:
             err.config_file = src_file
             raise err from None

--- a/test-data/snake_oil_structure/ert/bin/workflows/MAGIC_PRINT
+++ b/test-data/snake_oil_structure/ert/bin/workflows/MAGIC_PRINT
@@ -1,1 +1,1 @@
-MAGIC_PRINT  magic-list.txt  <ERTCASE>  __MAGIC__
+UBER_PRINT  magic-list.txt  <ERTCASE>  __MAGIC__


### PR DESCRIPTION
**Issue**
Resolves #4931 


**Approach**
Stop loading workflows with errors and show an appropriate ConfigWarning which shows in the GUI.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
