### PR TITLE
Add help buttons to suggester UI

### DIFF
--- a/src/ert/gui/about_dialog.py
+++ b/src/ert/gui/about_dialog.py
@@ -84,6 +84,7 @@ class AboutDialog(QDialog):
         button_layout = QHBoxLayout()
 
         close_button = QPushButton("Close")
+        close_button.setObjectName("close_button")
         close_button.clicked.connect(self.accept)
 
         button_layout.addStretch()

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -9,6 +9,7 @@ import filelock
 from PyQt5.QtWidgets import (
     QFrame,
     QHBoxLayout,
+    QLabel,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
@@ -162,18 +163,20 @@ def _setup_suggester(errors, warning_msgs, suggestions, ert_window=None):
     container_layout = QVBoxLayout()
 
     help_button_frame = QFrame()
-    help_button_frame.setFrameStyle(QFrame.StyledPanel)
     help_buttons_layout = QHBoxLayout()
     help_button_frame.setLayout(help_buttons_layout)
 
     button_size = QSize(-1, -1)
     helpbuttons = []
 
+    help_label = QLabel("Help:")
+    help_buttons_layout.addWidget(help_label)
     pm = ErtPluginManager()
     help_links = pm.get_help_links()
 
     for menu_label, link in help_links.items():
         button = QPushButton(menu_label)
+        button.setObjectName(menu_label)
         button.clicked.connect(
             functools.partial(_clicked_help_button, menu_label, link)
         )
@@ -181,6 +184,7 @@ def _setup_suggester(errors, warning_msgs, suggestions, ert_window=None):
         help_buttons_layout.addWidget(button)
 
     about_button = QPushButton("About")
+    about_button.setObjectName("about_button")
     helpbuttons.append(about_button)
     help_buttons_layout.addWidget(about_button)
 


### PR DESCRIPTION
**Issue**
Resolves #4811 


**Approach**
Adds the same help links as buttons in the suggester UI.
Note that the amount of available buttons depend on from where you run Ert. Within the Equinor domain more links/buttons will be added.

Added stretch/spacer to force buttons leftwards.
All help menu buttons have the same size.
Added stretch/spacer to split the Copy and Run/Exit buttons in the lower parts of the UI.

Logs button presses to allow tracking usage.

Version 2023-03-01:
![help_buttons_label](https://user-images.githubusercontent.com/114403625/222170916-3dfec8c5-91eb-4c9f-966e-74b4b629b203.png)

Old version:
![help_menu_buttons](https://user-images.githubusercontent.com/114403625/220612999-79319686-7d17-46dc-9791-bc6c7a88e270.PNG)


Trigger by adding to config:
```
RUNPATH poly_out/realization-%d/iter-%d
```

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
