### PR TITLE
Pin conan<2 and conan-cmake=0.18.1

### DIFF
--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11 ecl
+        python3 -m pip install "conan<2" pybind11 ecl
 
     - name: Create compile commands for clib
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11 ecl
+        python3 -m pip install "conan<2" pybind11 ecl
         echo "PIP_PKGS_PATH=$(python3 -m pip show conan | grep Location | cut -d ' ' -f 2 | sed -e 's@/lib/.*site-packages$@/bin@')" >> "$GITHUB_ENV"
 
     - name: Build ert clib

--- a/ci/jenkins/test_libres_jenkins.sh
+++ b/ci/jenkins/test_libres_jenkins.sh
@@ -45,7 +45,7 @@ enable_environment () {
 
 setup () {
 	/opt/rh/rh-python38/root/usr/bin/python -m venv ${ERT_SOURCE_ROOT}/venv
-	${ERT_SOURCE_ROOT}/venv/bin/pip install -U pip wheel setuptools cmake pybind11 conan ecl
+	${ERT_SOURCE_ROOT}/venv/bin/pip install -U pip wheel setuptools cmake pybind11 "conan<2" ecl
 }
 
 build_ert_clib () {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "cmake",
     "ninja",
     "ecl",
-    "conan",
+    "conan<2",
     "pybind11>=2.10.0",  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
     "grpcio-tools==1.41.0",
 ]

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -143,7 +143,7 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
       "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
   file(
     DOWNLOAD
-    "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
+    "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
     "${CMAKE_BINARY_DIR}/conan.cmake")
 endif()
 


### PR DESCRIPTION
conan-cmake is not compatible with conan version 2
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
