### PR TITLE
Improve exception handling around init/loading of enkf nodes

### DIFF
--- a/src/clib/lib/enkf/field.cpp
+++ b/src/clib/lib/enkf/field.cpp
@@ -847,10 +847,9 @@ static bool field_fload_custom__(field_type *field, const char *filename,
 
     field_file_format_type file_type = field_config_guess_file_type(filename);
     if (file_type == UNDEFINED_FORMAT) {
-        std::string error_meessage =
-            fmt::format("could not automagically infer type "
-                        "for file: %s\n",
-                        filename);
+        std::string error_meessage = fmt::format("could not infer type "
+                                                 "for file: %s\n",
+                                                 filename);
         throw std::runtime_error(error_meessage);
     }
 

--- a/src/clib/lib/enkf/gen_kw_config.cpp
+++ b/src/clib/lib/enkf/gen_kw_config.cpp
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <numeric>
 
 #include <stdlib.h>
 #include <string.h>
@@ -105,9 +106,13 @@ void gen_kw_config_set_parameter_file(gen_kw_config_type *config,
             config_parse(parser, parameter_file, "--", NULL, NULL, NULL,
                          CONFIG_UNRECOGNIZED_ADD, false);
         if (!content->valid) {
-            logger->warning(
+            auto header = fmt::format(
                 "encountered errors while parsing GEN_KW parameter file {}",
                 parameter_file);
+            auto errors =
+                std::reduce(content->parse_errors.begin(),
+                            content->parse_errors.end(), std::string("\n"));
+            logger->warning("{}\n{}", header, errors);
         }
         for (auto parse_error : content->parse_errors) {
             logger->warning(parse_error);

--- a/src/clib/lib/enkf/gen_kw_config.cpp
+++ b/src/clib/lib/enkf/gen_kw_config.cpp
@@ -8,6 +8,7 @@
 #include <ert/util/vector.h>
 
 #include <ert/config/config_parser.hpp>
+#include <ert/logging.hpp>
 
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/enkf_defaults.hpp>
@@ -17,6 +18,7 @@
 #include <ert/enkf/trans_func.hpp>
 
 namespace fs = std::filesystem;
+static auto logger = ert::get_logger("gen_kw_config");
 
 typedef struct {
     char *name;
@@ -102,6 +104,14 @@ void gen_kw_config_set_parameter_file(gen_kw_config_type *config,
         config_content_type *content =
             config_parse(parser, parameter_file, "--", NULL, NULL, NULL,
                          CONFIG_UNRECOGNIZED_ADD, false);
+        if (!content->valid) {
+            logger->warning(
+                "encountered errors while parsing GEN_KW parameter file {}",
+                parameter_file);
+        }
+        for (auto parse_error : content->parse_errors) {
+            logger->warning(parse_error);
+        }
         for (int item_index = 0; item_index < config_content_get_size(content);
              item_index++) {
             const config_content_node_type *node =

--- a/src/ert/_c_wrappers/enkf/data/enkf_node.py
+++ b/src/ert/_c_wrappers/enkf/data/enkf_node.py
@@ -107,10 +107,10 @@ class EnkfNode(BaseCClass):
     def name(self) -> str:
         return self._get_name()
 
-    def load(self, fs: EnkfFs, node_id: NodeId):
+    def load(self, fs: EnkfFs, node_id: NodeId) -> None:
         if not self.tryLoad(fs, node_id):
-            raise Exception(
-                f"Could not load node: {self.name()} iens: {node_id.iens} "
+            raise RuntimeError(
+                f"Could not load node: {self.name()!r}, iens: {node_id.iens} "
                 f"report: {node_id.report_step}"
             )
 

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -1,3 +1,4 @@
+import os
 from typing import Iterator, List, Optional, Union
 
 from cwrap import BaseCClass
@@ -116,6 +117,11 @@ class EnkfObs(BaseCClass):
         self._free()
 
     def load(self, config_file, std_cutoff):
+        if not os.access(config_file, os.R_OK):
+            raise RuntimeError(
+                "Do not have permission to open observation "
+                f"config file {config_file!r}"
+            )
         _clib.enkf_obs.load(self, config_file, std_cutoff)
 
     @property

--- a/src/ert/ensemble_evaluator/_wait_for_evaluator.py
+++ b/src/ert/ensemble_evaluator/_wait_for_evaluator.py
@@ -8,6 +8,8 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
+WAIT_FOR_EVALUATOR_TIMEOUT = 60
+
 
 def get_ssl_context(cert: Optional[Union[str, bytes]]) -> Optional[ssl.SSLContext]:
     if cert is None:
@@ -41,9 +43,11 @@ async def wait_for_evaluator(  # pylint: disable=too-many-arguments
     token: Optional[str] = None,
     cert: Optional[Union[str, bytes]] = None,
     healthcheck_endpoint: str = "/healthcheck",
-    timeout: float = 60,
+    timeout: Optional[float] = None,
     connection_timeout: float = 2,
 ) -> None:
+    if timeout is None:
+        timeout = WAIT_FOR_EVALUATOR_TIMEOUT
     healthcheck_url = base_url + healthcheck_endpoint
     start = time.time()
     sleep_time = 0.2

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -86,6 +86,28 @@ def test_field_init_file_not_readable(copy_case):
         assert "failed to open" in str(err)
 
 
+def test_surface_init_fails_during_forward_model_callback(copy_case):
+    copy_case("snake_oil_field")
+    config_file_name = "snake_oil_surface.ert"
+    with open(config_file_name, mode="r+", encoding="utf-8") as config_file_handler:
+        content_lines = config_file_handler.read().splitlines()
+        index_line_with_surface_top = [
+            index
+            for index, line in enumerate(content_lines)
+            if line.startswith("SURFACE TOP")
+        ][0]
+        line_with_surface_top = content_lines[index_line_with_surface_top]
+        breaking_line_with_surface_top = line_with_surface_top + " FORWARD_INIT:True"
+        content_lines[index_line_with_surface_top] = breaking_line_with_surface_top
+        config_file_handler.seek(0)
+        config_file_handler.write("\n".join(content_lines))
+
+    try:
+        run_ert_test_run(config_file_name)
+    except ErtCliError as err:
+        assert "Failed to initialize node" in str(err)
+
+
 def run_ert_test_run(config_file: str) -> None:
     parser = ArgumentParser(prog="test_run")
     parsed = ert_parser(

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 
 import pytest
 
+from ert import ensemble_evaluator
 from ert.__main__ import ert_parser
 from ert._c_wrappers.enkf import NodeId
 from ert._c_wrappers.enkf.config import FieldTypeEnum
@@ -66,7 +67,10 @@ def test_field_export_many(snake_oil_field_example):
     assert os.path.isfile("export/with/path/PERMX_4.grdecl")
 
 
-def test_field_init_file_not_readable(copy_case):
+def test_field_init_file_not_readable(copy_case, monkeypatch):
+    monkeypatch.setattr(
+        ensemble_evaluator._wait_for_evaluator, "WAIT_FOR_EVALUATOR_TIMEOUT", 5
+    )
     copy_case("snake_oil_field")
     config_file_name = "snake_oil_field.ert"
     field_file_rel_path = "fields/permx0.grdecl"

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -446,17 +446,9 @@ def test_field_init_file_not_readable(copy_case, monkeypatch):
     config_file_name = "snake_oil_field.ert"
     field_file_rel_path = "fields/permx0.grdecl"
     os.chmod(field_file_rel_path, 0x0)
-    parser = ArgumentParser(prog="test_field_init_segfault")
-    parsed = ert_parser(
-        parser,
-        [
-            TEST_RUN_MODE,
-            config_file_name,
-        ],
-    )
 
     try:
-        run_cli(parsed)
+        run_ert_test_run(config_file_name)
     except ErtCliError as err:
         assert "failed to open" in str(err)
 

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -522,8 +522,8 @@ def test_unopenable_observation_config_fails_gracefully(copy_case):
         run_ert_test_run(config_file_name)
     except RuntimeError as err:
         assert (
-            f"Failed to open observation config file {observation_config_abs_path!r}"
-            in str(err)
+            "Do not have permission to open observation config file "
+            f"{observation_config_abs_path!r}" in str(err)
         )
 
 

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import fileinput
+import logging
 import os
 import shutil
 import threading
@@ -473,6 +474,33 @@ def test_surface_init_fails_during_forward_model_callback(copy_case):
         run_ert_test_run(config_file_name)
     except ErtCliError as err:
         assert "Failed to initialize node" in str(err)
+
+
+def test_config_parser_fails_gracefully_on_unreadable_config_file(copy_case, caplog):
+    """we cannot test on the config file directly, as the argument parser already check
+    if the file is readable. so we use the GEN_KW parameter file which is also parsed
+    using our config parser."""
+
+    copy_case("snake_oil_field")
+    config_file_name = "snake_oil_surface.ert"
+
+    with open(config_file_name, mode="r", encoding="utf-8") as config_file_handler:
+        content_lines = config_file_handler.read().splitlines()
+
+    index_line_with_gen_kw = [
+        index for index, line in enumerate(content_lines) if line.startswith("GEN_KW")
+    ][0]
+    gen_kw_parameter_file = content_lines[index_line_with_gen_kw].split(" ")[4]
+    os.chmod(gen_kw_parameter_file, 0x0)
+    gen_kw_parameter_file_abs_path = os.path.join(os.getcwd(), gen_kw_parameter_file)
+    caplog.set_level(logging.WARNING)
+
+    ErtConfig.from_file(config_file_name)
+
+    assert (
+        f"could not open file `{gen_kw_parameter_file_abs_path}` for parsing"
+        in caplog.text
+    )
 
 
 def test_unopenable_observation_config_fails_gracefully(copy_case):


### PR DESCRIPTION
**Issue**
Resolves #4900

**OBS**
we're using a kind of integration test approach. it takes like 2 minutes to run one of the tests, which is quite long. i've tried looking at this before, but it seems like we might not be able to do much about it because of how we set up different components of ert in threads, and their communication with each other.


**Approach**
See commit messages.


## Pre review checklist

- [X] Added appropriate release note label
- [X] SKIPPED! PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] IRRELEVANT Updated documentation
- [X] Ensured new behaviour is tested