### PR TITLE
Backport: Only resample parameters if necessary

### DIFF
--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11 ecl
+        python3 -m pip install "conan<2" pybind11 ecl
 
     - name: Create compile commands for clib
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install dependencies from PyPI
       run: |
-        python3 -m pip install conan pybind11 ecl
+        python3 -m pip install "conan<2" pybind11 ecl
         echo "PIP_PKGS_PATH=$(python3 -m pip show conan | grep Location | cut -d ' ' -f 2 | sed -e 's@/lib/.*site-packages$@/bin@')" >> "$GITHUB_ENV"
 
     - name: Build ert clib

--- a/ci/jenkins/test_libres_jenkins.sh
+++ b/ci/jenkins/test_libres_jenkins.sh
@@ -45,7 +45,7 @@ enable_environment () {
 
 setup () {
 	/opt/rh/rh-python38/root/usr/bin/python -m venv ${ERT_SOURCE_ROOT}/venv
-	${ERT_SOURCE_ROOT}/venv/bin/pip install -U pip wheel setuptools cmake pybind11 conan ecl
+	${ERT_SOURCE_ROOT}/venv/bin/pip install -U pip wheel setuptools cmake pybind11 "conan<2" ecl
 }
 
 build_ert_clib () {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "cmake",
     "ninja",
     "ecl",
-    "conan",
+    "conan<2",
     "pybind11>=2.10.0",  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
     "grpcio-tools==1.41.0",
 ]

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -143,7 +143,7 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
       "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
   file(
     DOWNLOAD
-    "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
+    "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
     "${CMAKE_BINARY_DIR}/conan.cmake")
 endif()
 

--- a/src/ert/_c_wrappers/enkf/enkf_fs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_fs.py
@@ -15,6 +15,7 @@ from ert._c_wrappers.enkf.res_config import EnsembleConfig
 from ert._c_wrappers.enkf.summary_key_set import SummaryKeySet
 from ert._c_wrappers.enkf.time_map import TimeMap
 from ert._clib import update
+from ert._clib.state_map import RealizationStateEnum
 
 if TYPE_CHECKING:
     from ecl.summary import EclSum
@@ -22,7 +23,6 @@ if TYPE_CHECKING:
 
     from ert._c_wrappers.enkf import RunArg
     from ert._c_wrappers.enkf.state_map import StateMap
-    from ert._clib.state_map import RealizationStateEnum
 
 
 class EnkfFs(BaseCClass):
@@ -76,6 +76,12 @@ class EnkfFs(BaseCClass):
             self._ensemble_config.parameters,
             self._ensemble_size,
         )
+
+    def realizations_initialized(self, realizations: List[int]):
+        initialized_realisations = self.realizationList(
+            RealizationStateEnum.STATE_INITIALIZED
+        )
+        return all(real in initialized_realisations for real in realizations)
 
     @classmethod
     def createFileSystem(

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -386,12 +386,17 @@ class EnKFMain:
                 gen_kw_node = enkf_node.asGenKw()
                 keys = [val[0] for val in gen_kw_node.items()]
                 if config_node.get_init_file_fmt():
+                    logging.info(
+                        f"Reading from init file {config_node.get_init_file_fmt()}"
+                        + f" for {parameter}"
+                    )
                     parameter_values = gen_kw_node.values_from_files(
                         active_realizations,
                         config_node.get_init_file_fmt(),
                         keys,
                     )
                 else:
+                    logging.info(f"Sampling parameter {parameter}")
                     parameter_values = gen_kw_node.sample_values(
                         parameter,
                         keys,

--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -115,7 +115,9 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(0, "Running simulations...", indeterminate=False)
 
         self.setPhaseName("Pre processing...", indeterminate=True)
-        if not prior_context.sim_fs.is_initalized:
+        if not prior_context.sim_fs.realizations_initialized(
+            prior_context.active_realizations
+        ):
             self.ert().sample_prior(
                 prior_context.sim_fs,
                 prior_context.active_realizations,


### PR DESCRIPTION
In the scenario that a sampling has already occured, we reuse the sampling when running the ensemble experiment. A possible scenario is that a user runs an ensemble experiment, manual analysis and then wants to run ensemble experiment on the target case for the manual analysis.

This will also hinder a user to run multiple ensemble experiments with the same setup and get resampling. Doing this was not possible before either though.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
