### PR TITLE
Set correct state on child ensemble when doing manual update

### DIFF
--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -2,6 +2,11 @@ import uuid
 
 from qtpy.QtWidgets import QMessageBox
 
+from ert._clib.state_map import (
+    STATE_LOAD_FAILURE,
+    STATE_PARENT_FAILURE,
+    STATE_UNDEFINED,
+)
 from ert.analysis import ErtAnalysisError, ESUpdate
 from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
@@ -17,7 +22,10 @@ def analyse(ert, target, source):
 
     target_fs = fs_manager.add_case(target)
     source_fs = fs_manager[source]
-
+    for iens in source_fs.getStateMap().realizationList(
+        STATE_LOAD_FAILURE | STATE_UNDEFINED
+    ):
+        target_fs.getStateMap()[iens] = STATE_PARENT_FAILURE
     es_update.smootherUpdate(source_fs, target_fs, uuid.uuid4())
 
 


### PR DESCRIPTION
This state was not properly set, meaning that all realizations were considered runable, which in turn meant that the prior was overwritten.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
