### PR TITLE
Replace button selection in gui tests

### DIFF
--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -223,7 +223,7 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot):
 
         def handle_dialog():
             message_box = gui.findChild(QMessageBox)
-            qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+            qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
 
         QTimer.singleShot(500, handle_dialog)
 


### PR DESCRIPTION
Replaces selecting the first button with selecting the yes button in test_that_run_dialog_can_be_closed_after_used_to_open_plots.
 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
