### PR TITLE
Make run path label copiable in the gui

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -1,0 +1,69 @@
+from qtpy.QtCore import Signal, Qt
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QPushButton, QApplication
+from threading import Timer
+from ert.gui.ertwidgets import addHelpToWidget
+
+
+def escape_string(string):
+    """
+    Designed to replace/escape invalid html characters for
+    correct display in Qt QWidgets
+
+    >>> escape_string("realization-<IENS>/iteration-<ITER>")
+    'realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;'
+
+    >>> escape_string("<some>&<thing>")
+    '&lt;some&gt;&amp;&lt;thing&gt;'
+    """
+    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def unescape_string(string):
+    """
+    Designed to transform an escaped string within a Qt widget
+    into an unescaped string.
+
+    >>> unescape_string("<b>realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;</b>")
+    'realization-<IENS>/iteration-<ITER>'
+
+    >>> unescape_string("<b>&lt;some&gt;&amp;&lt;thing&gt;</b>")
+    '<some>&<thing>'
+    """
+    return (
+        string.replace("&amp", "&;")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("<b>", "")
+        .replace("</b>", "")
+    )
+
+
+class CopyableLabel(QHBoxLayout):
+    """CopyableLabel shows a string that is copyable via
+    selection or clicking of a copy button"""
+
+    def __init__(self, text, executeAddHelpToWidget=True) -> None:
+        super().__init__()
+
+        self.label = QLabel(f"<b>{escape_string(text)}</b>")
+        self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        self.copy_button = QPushButton("copy")
+
+        def copy_text() -> None:
+            text = unescape_string(self.label.text())
+            QApplication.clipboard().setText(text)
+            self.copy_button.setText("copied!")
+
+            def restore_text():
+                self.copy_button.setText("copy")
+
+            Timer(1.0, restore_text).start()
+
+        self.copy_button.clicked.connect(copy_text)
+
+        self.addWidget(self.label)
+        self.addWidget(self.copy_button)
+
+        if executeAddHelpToWidget:
+            addHelpToWidget(self.label, "")

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -32,7 +32,7 @@ def unescape_string(string):
     '<some>&<thing>'
     """
     return (
-        string.replace("&amp", "&;")
+        string.replace("&amp;", "&")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("<b>", "")

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -1,6 +1,8 @@
-from qtpy.QtCore import Signal, Qt
-from qtpy.QtWidgets import QHBoxLayout, QLabel, QPushButton, QApplication
 from threading import Timer
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton
+
 from ert.gui.ertwidgets import addHelpToWidget
 
 

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -6,6 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.ertmodel import get_runnable_realizations_mask
 from ert.gui.ertwidgets.models.init_iter_value import IterValueModel
@@ -14,7 +15,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import IntegerArgument, RangeStringArgument
 from ert.shared.models import EnsembleExperiment
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -26,18 +27,17 @@ class Arguments:
 
 class EnsembleExperimentPanel(SimulationConfigPanel):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier):
+        super().__init__(EnsembleExperiment)
         self.ert = ert
         self.facade = LibresFacade(ert)
-        super().__init__(EnsembleExperiment)
         self.setObjectName("Ensemble_experiment_panel")
 
         layout = QFormLayout()
 
         self._case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", self._case_selector)
-        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=self.facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -6,6 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit, addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.ertmodel import get_runnable_realizations_mask
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -14,7 +15,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import ProperNameArgument, RangeStringArgument
 from ert.shared.models import EnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -34,9 +35,8 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         self._case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", self._case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
         addHelpToWidget(

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -4,6 +4,7 @@ from qtpy.QtWidgets import QFormLayout, QLabel, QSpinBox
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit, CaseSelector, addHelpToWidget
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert.gui.ertwidgets.stringbox import StringBox
@@ -14,7 +15,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import IteratedEnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -36,10 +37,8 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
-
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=self.facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -10,6 +10,7 @@ from ert.gui.ertwidgets import (
     CaseSelector,
     addHelpToWidget,
 )
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.init_iter_value import IterValueModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -24,7 +25,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import MultipleDataAssimilation
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -45,9 +46,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
         addHelpToWidget(

--- a/src/ert/gui/simulation/simulation_config_panel.py
+++ b/src/ert/gui/simulation/simulation_config_panel.py
@@ -1,20 +1,7 @@
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget
-
-
-def escape_string(string):
-    """
-    Designed to replace/escape invalid html characters for
-    correct display in Qt QWidgets
-
-    >>> escape_string("realization-<IENS>/iteration-<ITER>")
-    'realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;'
-
-    >>> escape_string("<some>&<thing>")
-    '&lt;some&gt;&amp;&lt;thing&gt;'
-    """
-    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
+from qtpy.QtCore import Signal, Qt
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton, QApplication
+from threading import Timer
+from ert.gui.ertwidgets import addHelpToWidget
 
 class SimulationConfigPanel(QWidget):
     simulationConfigurationChanged = Signal()

--- a/src/ert/gui/simulation/simulation_config_panel.py
+++ b/src/ert/gui/simulation/simulation_config_panel.py
@@ -1,7 +1,6 @@
-from qtpy.QtCore import Signal, Qt
-from qtpy.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton, QApplication
-from threading import Timer
-from ert.gui.ertwidgets import addHelpToWidget
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QWidget
+
 
 class SimulationConfigPanel(QWidget):
     simulationConfigurationChanged = Signal()

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from qtpy.QtWidgets import QFormLayout
 
 from ert.gui.ertwidgets.caseselector import CaseSelector
-from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
+from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.libres_facade import LibresFacade
 from ert.shared.models import SingleTestRun
 

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 
-from qtpy.QtWidgets import QFormLayout, QLabel
+from qtpy.QtWidgets import QFormLayout
 
-from ert.gui.ertwidgets import addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.libres_facade import LibresFacade
 from ert.shared.models import SingleTestRun
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -18,18 +18,17 @@ class Arguments:
 
 class SingleTestRunPanel(SimulationConfigPanel):
     def __init__(self, ert, notifier):
+        super().__init__(SingleTestRun)
         self.ert = ert
         facade = LibresFacade(ert)
-        SimulationConfigPanel.__init__(self, SingleTestRun)
         self.setObjectName("Single_test_run_panel")
         layout = QFormLayout()
 
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         self._active_realizations_model = ActiveRealizationsModel(facade)
 

--- a/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
+++ b/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
@@ -1,7 +1,8 @@
 import pytest
-from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QWidget
+
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 
 
 @pytest.fixture(

--- a/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
+++ b/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
@@ -1,0 +1,25 @@
+import pytest
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
+
+
+@pytest.fixture(
+    params=[("<b>hehehehe</b>", "hehehehe"), ("<b>foooo-<ITER></b>", "foooo-<ITER>")]
+)
+def label_testcase(request):
+    return request.param
+
+
+def test_copy_clickbtn(qtbot, tmpdir, monkeypatch, label_testcase):
+    label_markup, label = label_testcase
+    copyable_label = CopyableLabel(label_markup)
+    wrapper_widget = QWidget()
+    wrapper_widget.setLayout(copyable_label)
+
+    qtbot.addWidget(wrapper_widget)
+    qtbot.waitExposed(wrapper_widget)
+
+    qtbot.mouseClick(copyable_label.copy_button, Qt.MouseButton.LeftButton)
+
+    assert QApplication.clipboard().text() == label


### PR DESCRIPTION
**Issue**
Resolves #4641 


**Approach**
![image](https://user-images.githubusercontent.com/32731672/220901211-0a23662e-f2bd-411f-a69b-14291fc5d819.png)


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
