### PR TITLE
Rename SUGGESTION label to DEPRECATION also update colour to yellow.

### DIFF
--- a/src/ert/gui/ertwidgets/suggestor_message.py
+++ b/src/ert/gui/ertwidgets/suggestor_message.py
@@ -36,15 +36,15 @@ class SuggestorMessage(QWidget):
 
     @classmethod
     def error_msg(cls, text):
-        color = "#ff2f00"
+        color = "#ff0000"
         return SuggestorMessage("ERROR", color, text)
 
     @classmethod
     def warning_msg(cls, text):
-        color = "#ff8000"
+        color = "#ff6a00"
         return SuggestorMessage("WARNING", color, text)
 
     @classmethod
-    def suggestion_msg(cls, text):
-        color = "#3b8dd4"
-        return SuggestorMessage("SUGGESTION", color, text)
+    def deprecation_msg(cls, text):
+        color = "#faf339"
+        return SuggestorMessage("DEPRECATION", color, text)

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -152,7 +152,7 @@ def _setup_suggester(errors, warning_msgs, suggestions, ert_window=None):
         suggest_layout.addWidget(SuggestorMessage.warning_msg(msg))
     for msg in suggestions:
         text += msg + "\n"
-        suggest_layout.addWidget(SuggestorMessage.suggestion_msg(msg))
+        suggest_layout.addWidget(SuggestorMessage.deprecation_msg(msg))
 
     suggest_layout.addStretch()
     suggest_msgs.setLayout(suggest_layout)


### PR DESCRIPTION
**Issue**

Rename the SUGGESTION label to DEPRECATION also update the colour to yellow.

Update the colours for ERROR and  WARNING also to make the red more red and the orange more orange. 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
