### PR TITLE
Made the Runpath text in the GUI is selectable, and added a copy button

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -55,7 +55,7 @@ class CopyableLabel(QHBoxLayout):
         self.label = QLabel(f"<b>{escape_string(text)}</b>")
         self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self.copy_button = QPushButton("copy")
+        self.copy_button = QPushButton("")
         icon_path = path.join(current_dir, "..", "resources", "gui", "img", "copy.svg")
         self.copy_button.setIcon(QIcon(icon_path))
 
@@ -65,7 +65,7 @@ class CopyableLabel(QHBoxLayout):
             self.copy_button.setText("copied!")
 
             def restore_text():
-                self.copy_button.setText("copy")
+                self.copy_button.setText("")
 
             Timer(1.0, restore_text).start()
 

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -3,7 +3,7 @@ from threading import Timer
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
 
 from ert.gui.ertwidgets import addHelpToWidget
 
@@ -56,6 +56,10 @@ class CopyableLabel(QHBoxLayout):
         self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self.copy_button = QPushButton("")
+        self.copy_button.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        self.copy_button.setStyleSheet(
+            "QPushButton { padding: 8px; max-width: 150px; min-width: 30px; }"
+        )
         icon_path = path.join(current_dir, "..", "resources", "gui", "img", "copy.svg")
         self.copy_button.setIcon(QIcon(icon_path))
 

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -1,8 +1,14 @@
+from os import path
 from threading import Timer
 
-from ert.gui.ertwidgets import addHelpToWidget
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton
+
+from ert.gui.ertwidgets import addHelpToWidget
+
+# Get the absolute path of the directory that contains the current script
+current_dir = path.dirname(path.abspath(__file__))
 
 
 def escape_string(string):
@@ -50,6 +56,8 @@ class CopyableLabel(QHBoxLayout):
         self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self.copy_button = QPushButton("copy")
+        icon_path = path.join(current_dir, "..", "resources", "gui", "img", "copy.svg")
+        self.copy_button.setIcon(QIcon(icon_path))
 
         def copy_text() -> None:
             text = unescape_string(self.label.text())

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -1,0 +1,70 @@
+from threading import Timer
+
+from ert.gui.ertwidgets import addHelpToWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton
+
+
+def escape_string(string):
+    """
+    Designed to replace/escape invalid html characters for
+    correct display in Qt QWidgets
+
+    >>> escape_string("realization-<IENS>/iteration-<ITER>")
+    'realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;'
+
+    >>> escape_string("<some>&<thing>")
+    '&lt;some&gt;&amp;&lt;thing&gt;'
+    """
+    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def unescape_string(string):
+    """
+    Designed to transform an escaped string within a Qt widget
+    into an unescaped string.
+
+    >>> unescape_string("<b>realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;</b>")
+    'realization-<IENS>/iteration-<ITER>'
+
+    >>> unescape_string("<b>&lt;some&gt;&amp;&lt;thing&gt;</b>")
+    '<some>&<thing>'
+    """
+    return (
+        string.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("<b>", "")
+        .replace("</b>", "")
+    )
+
+
+class CopyableLabel(QHBoxLayout):
+    """CopyableLabel shows a string that is copyable via
+    selection or clicking of a copy button"""
+
+    def __init__(self, text, executeAddHelpToWidget=True) -> None:
+        super().__init__()
+
+        self.label = QLabel(f"<b>{escape_string(text)}</b>")
+        self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        self.copy_button = QPushButton("copy")
+
+        def copy_text() -> None:
+            text = unescape_string(self.label.text())
+            QApplication.clipboard().setText(text)
+            self.copy_button.setText("copied!")
+
+            def restore_text():
+                self.copy_button.setText("copy")
+
+            Timer(1.0, restore_text).start()
+
+        self.copy_button.clicked.connect(copy_text)
+
+        self.addWidget(self.label)
+        self.addWidget(self.copy_button)
+
+        if executeAddHelpToWidget:
+            addHelpToWidget(self.label, "")

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -6,6 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.ertmodel import get_runnable_realizations_mask
 from ert.gui.ertwidgets.models.init_iter_value import IterValueModel
@@ -14,7 +15,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import IntegerArgument, RangeStringArgument
 from ert.shared.models import EnsembleExperiment
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -35,9 +36,8 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
 
         self._case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", self._case_selector)
-        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=self.facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -6,6 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit, addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.ertmodel import get_runnable_realizations_mask
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -14,7 +15,7 @@ from ert.libres_facade import LibresFacade
 from ert.shared.ide.keywords.definitions import ProperNameArgument, RangeStringArgument
 from ert.shared.models import EnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -34,9 +35,8 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         self._case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", self._case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
         addHelpToWidget(

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -4,6 +4,7 @@ from qtpy.QtWidgets import QFormLayout, QLabel, QSpinBox
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit, CaseSelector, addHelpToWidget
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert.gui.ertwidgets.stringbox import StringBox
@@ -14,7 +15,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import IteratedEnsembleSmoother
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -36,10 +37,8 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         case_selector = CaseSelector(self.facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(self.facade.run_path)}</b>")
-
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=self.facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -10,6 +10,7 @@ from ert.gui.ertwidgets import (
     CaseSelector,
     addHelpToWidget,
 )
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.init_iter_value import IterValueModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -24,7 +25,7 @@ from ert.shared.ide.keywords.definitions import (
 )
 from ert.shared.models import MultipleDataAssimilation
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -45,9 +46,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
         addHelpToWidget(

--- a/src/ert/gui/simulation/simulation_config_panel.py
+++ b/src/ert/gui/simulation/simulation_config_panel.py
@@ -2,20 +2,6 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget
 
 
-def escape_string(string):
-    """
-    Designed to replace/escape invalid html characters for
-    correct display in Qt QWidgets
-
-    >>> escape_string("realization-<IENS>/iteration-<ITER>")
-    'realization-&lt;IENS&gt;/iteration-&lt;ITER&gt;'
-
-    >>> escape_string("<some>&<thing>")
-    '&lt;some&gt;&amp;&lt;thing&gt;'
-    """
-    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
 class SimulationConfigPanel(QWidget):
     simulationConfigurationChanged = Signal()
 

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
 
+from qtpy.QtWidgets import QFormLayout
+
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.libres_facade import LibresFacade
 from ert.shared.models import SingleTestRun
-from qtpy.QtWidgets import QFormLayout
 
 from .simulation_config_panel import SimulationConfigPanel
 

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -1,14 +1,13 @@
 from dataclasses import dataclass
 
-from qtpy.QtWidgets import QFormLayout, QLabel
-
-from ert.gui.ertwidgets import addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.libres_facade import LibresFacade
 from ert.shared.models import SingleTestRun
+from qtpy.QtWidgets import QFormLayout
 
-from .simulation_config_panel import SimulationConfigPanel, escape_string
+from .simulation_config_panel import SimulationConfigPanel
 
 
 @dataclass
@@ -27,9 +26,8 @@ class SingleTestRunPanel(SimulationConfigPanel):
         case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", case_selector)
 
-        run_path_label = QLabel(f"<b>{escape_string(facade.run_path)}</b>")
-        addHelpToWidget(run_path_label, "config/simulation/runpath")
-        layout.addRow("Runpath:", run_path_label)
+        runpath_label = CopyableLabel(text=facade.run_path)
+        layout.addRow("Runpath:", runpath_label)
 
         self._active_realizations_model = ActiveRealizationsModel(facade)
 

--- a/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
+++ b/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
@@ -1,0 +1,26 @@
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
+
+from ert.gui.ertwidgets.copyablelabel import CopyableLabel
+
+
+@pytest.fixture(
+    params=[("<b>hehehehe</b>", "hehehehe"), ("<b>foooo-<ITER></b>", "foooo-<ITER>")]
+)
+def label_testcase(request):
+    return request.param
+
+
+def test_copy_clickbtn(qtbot, tmpdir, monkeypatch, label_testcase):
+    label_markup, label = label_testcase
+    copyable_label = CopyableLabel(label_markup)
+    wrapper_widget = QWidget()
+    wrapper_widget.setLayout(copyable_label)
+
+    qtbot.addWidget(wrapper_widget)
+    qtbot.waitExposed(wrapper_widget)
+
+    qtbot.mouseClick(copyable_label.copy_button, Qt.MouseButton.LeftButton)
+
+    assert QApplication.clipboard().text() == label


### PR DESCRIPTION
**Issue**
Resolves #4641 


**Approach**
<img width="1263" alt="Screenshot 2023-02-27 at 09 17 35" src="https://user-images.githubusercontent.com/11595637/221510309-18169c7c-cf2e-4a8c-8a3c-3d25cdeae6ae.png">


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
