### PR TITLE
Fix bug where inversion type could not be set via GUI

### DIFF
--- a/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
+++ b/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
@@ -65,6 +65,7 @@ class AnalysisModuleVariablesPanel(QWidget):
                     spinner = self.createSpinBox(
                         variable_name,
                         variable_value,
+                        variable_type,
                         analysis_module_variables_model,
                     )
 
@@ -145,6 +146,7 @@ class AnalysisModuleVariablesPanel(QWidget):
         self,
         variable_name,
         variable_value,
+        variable_type,
         analysis_module_variables_model,
     ):
         spinner = QSpinBox()
@@ -161,6 +163,10 @@ class AnalysisModuleVariablesPanel(QWidget):
         spinner.setObjectName(variable_name)
         if variable_value is not None:
             spinner.setValue(variable_value)
+            spinner.valueChanged.connect(
+                partial(self.valueChanged, variable_name, variable_type, spinner)
+            )
+
         return spinner
 
     def createCheckBox(self, variable_name, variable_value, variable_type):

--- a/src/ert/gui/ertwidgets/closabledialog.py
+++ b/src/ert/gui/ertwidgets/closabledialog.py
@@ -5,7 +5,6 @@ from qtpy.QtWidgets import QDialog, QHBoxLayout, QLayout, QPushButton, QVBoxLayo
 class ClosableDialog(QDialog):
     def __init__(self, title, widget, parent=None):
         QDialog.__init__(self, parent)
-
         self.setWindowTitle(title)
         self.setModal(True)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -31,6 +31,8 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         facade = LibresFacade(ert)
         layout = QFormLayout()
 
+        self.setObjectName("ensemble_smoother_panel")
+
         self._case_selector = CaseSelector(facade, notifier)
         layout.addRow("Current case:", self._case_selector)
 
@@ -56,6 +58,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
             module_name="STD_ENKF",
             help_link="config/analysis/analysis_module",
         )
+        self._analysis_module_edit.setObjectName("ensemble_smoother_edit")
         layout.addRow("Analysis module:", self._analysis_module_edit)
 
         active_realizations_model = ActiveRealizationsModel(facade)

--- a/tests/unit_tests/gui/ertwidgets/test_analysismodulevariablespanel.py
+++ b/tests/unit_tests/gui/ertwidgets/test_analysismodulevariablespanel.py
@@ -21,5 +21,6 @@ def test_createSpinBox(qtbot):
                 variable_dialog.createSpinBox(
                     variable_name,
                     variable_value,
+                    int,
                     analysis_module_variables_model,
                 )


### PR DESCRIPTION
**Issue**
Resolves #4954 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
