### PR TITLE
Show error in suggester dialog when GEN_DATA RESULT_FILE is missing or malformed

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -237,6 +237,10 @@ class EnsembleConfig(BaseCClass):
         options = _option_dict(gen_data, 1)
         name = gen_data[0]
         res_file = options.get(ConfigKeys.RESULT_FILE)
+        if res_file is None:
+            raise ConfigValidationError(
+                f"Missing or unsupported RESULT_FILE for GEN_DATA key {name!r}"
+            )
         input_format_str = options.get(ConfigKeys.INPUT_FORMAT)
         if input_format_str != "ASCII":
             warnings.warn(


### PR DESCRIPTION
**Issue**
Resolves #4947 


**Approach**
Raise ConfigValidationError when GEN_DATA RESULT_FILE missing or malformed. 
The error will end up in the suggestor dialog and displayed in the GUI for the user to see

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
