### PR TITLE
Pass in lower-case fformat when saving grid to file

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -423,7 +423,7 @@ class LocalEnsembleReader:
 
         os.makedirs(Path(output_path).parent, exist_ok=True)
 
-        gp.to_file(output_path, fformat=fformat)
+        gp.to_file(output_path, fformat=fformat.lower())
 
     def export_field_many(
         self,


### PR DESCRIPTION
xtgeo accepts only lower, so grdecl but not GRDECL


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
