### PR TITLE
Get ensemble by name instead of UUID

### DIFF
--- a/src/ert/shared/models/ensemble_experiment.py
+++ b/src/ert/shared/models/ensemble_experiment.py
@@ -110,10 +110,10 @@ class EnsembleExperiment(BaseRunModel):
         evaluator_server_config: EvaluatorServerConfig,
     ) -> RunContext:
         current_case = self._simulation_arguments["current_case"]
-        if isinstance(current_case, UUID):
-            ensemble = self._storage.get_ensemble(current_case)
+        try:
+            ensemble = self._storage.get_ensemble_by_name(current_case)
             assert isinstance(ensemble, EnsembleAccessor)
-        else:
+        except KeyError:
             ensemble = self._storage.create_ensemble(
                 self._experiment_id,
                 name=current_case,

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -347,14 +347,14 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
         storage = open_storage(ert.ert_config.ens_path, mode="w")
         experiment_id = storage.create_experiment()
         ensemble = storage.create_ensemble(
-            experiment_id, name="default", ensemble_size=ert.getEnsembleSize()
+            experiment_id, name="iter-0", ensemble_size=ert.getEnsembleSize()
         )
         prior_ensemble_id = ensemble.id
         prior_context = ert.ensemble_context(ensemble, prior_mask, 0)
         ert.sample_prior(prior_context.sim_fs, prior_context.active_realizations)
         facade = LibresFacade(ert)
         prior_values = facade.load_all_gen_kw_data(
-            storage.get_ensemble_by_name("default")
+            storage.get_ensemble_by_name("iter-0")
         )
         storage.close()
 
@@ -364,7 +364,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
             [
                 ENSEMBLE_EXPERIMENT_MODE,
                 "poly_example/poly.ert",
-                f"--current-case=UUID={prior_ensemble_id}",
+                "--current-case=iter-0",
                 "--port-range",
                 "1024-65535",
                 "--realizations",


### PR DESCRIPTION
This reverts the behavior of `ensemble_experiment`back to `main`

Related to: #4637


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
