### PR TITLE
Copying label confirmed with "check" icon instead of text

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -61,15 +61,18 @@ class CopyableLabel(QHBoxLayout):
             "QPushButton { padding: 8px; max-width: 150px; min-width: 30px; }"
         )
         icon_path = path.join(current_dir, "..", "resources", "gui", "img", "copy.svg")
+        icon_path_check = path.join(
+            current_dir, "..", "resources", "gui", "img", "check.svg"
+        )
         self.copy_button.setIcon(QIcon(icon_path))
 
         def copy_text() -> None:
             text = unescape_string(self.label.text())
             QApplication.clipboard().setText(text)
-            self.copy_button.setText("copied!")
+            self.copy_button.setIcon(QIcon(icon_path_check))
 
             def restore_text():
-                self.copy_button.setText("")
+                self.copy_button.setIcon(QIcon(icon_path))
 
             Timer(1.0, restore_text).start()
 


### PR DESCRIPTION
**Issue**
Resolves #4985


**Approach**
Use check icon instead of "copied!" text to confirm copy action
<img width="988" alt="Screenshot 2023-03-01 at 14 41 30" src="https://user-images.githubusercontent.com/11595637/222155459-1d44730f-781b-400b-a704-a536cd82eaa8.png">


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
