### PR TITLE
Require parameters when using smoother simulation modes

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -13,7 +13,14 @@ from typing import Any
 import filelock
 
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
-from ert.cli import ENSEMBLE_EXPERIMENT_MODE, TEST_RUN_MODE, WORKFLOW_MODE
+from ert.cli import (
+    ENSEMBLE_EXPERIMENT_MODE,
+    ENSEMBLE_SMOOTHER_MODE,
+    ES_MDA_MODE,
+    ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
+    TEST_RUN_MODE,
+    WORKFLOW_MODE,
+)
 from ert.cli.model_factory import create_model
 from ert.cli.monitor import Monitor
 from ert.cli.workflow import execute_workflow
@@ -68,11 +75,22 @@ def run_cli(args):
         TEST_RUN_MODE,
         WORKFLOW_MODE,
     ]:
-        raise RuntimeError(
+        raise ErtCliError(
             f"To run {args.mode}, observations are needed. \n"
             f"Please add an observation file to {args.config}. Example: \n"
             f"'OBS_CONFIG observation_file.txt'."
         )
+
+    if not facade.have_smoother_parameters and args.mode in [
+        ENSEMBLE_SMOOTHER_MODE,
+        ES_MDA_MODE,
+        ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
+    ]:
+        raise ErtCliError(
+            f"To run {args.mode}, GEN_KW, FIELD or SURFACE parameters are needed. \n"
+            f"Please add to file {args.config}"
+        )
+
     ens_path = Path(ert_config.ens_path)
     storage_lock = filelock.FileLock(ens_path / f"{ens_path.stem}.lock")
     try:

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -84,16 +84,20 @@ class SimulationPanel(QWidget):
         """ :type: OrderedDict[BaseRunModel,SimulationConfigPanel]"""
         self.addSimulationConfigPanel(SingleTestRunPanel(ert, notifier), True)
         self.addSimulationConfigPanel(EnsembleExperimentPanel(ert, notifier), True)
+
+        simulation_mode_valid = (
+            self.facade.have_smoother_parameters and self.facade.have_observations
+        )
+
         self.addSimulationConfigPanel(
-            EnsembleSmootherPanel(ert, notifier), self.facade.have_observations
+            EnsembleSmootherPanel(ert, notifier), simulation_mode_valid
         )
         self.addSimulationConfigPanel(
-            MultipleDataAssimilationPanel(self.facade, notifier),
-            self.facade.have_observations,
+            MultipleDataAssimilationPanel(self.facade, notifier), simulation_mode_valid
         )
         self.addSimulationConfigPanel(
             IteratedEnsembleSmootherPanel(self.facade, notifier),
-            self.facade.have_observations,
+            simulation_mode_valid,
         )
 
         self.setLayout(layout)
@@ -109,7 +113,7 @@ class SimulationPanel(QWidget):
             item_count = self._simulation_mode_combo.count() - 1
             sim_item = self._simulation_mode_combo.model().item(item_count)
             sim_item.setEnabled(False)
-            sim_item.setToolTip("Disabled due to no observations")
+            sim_item.setToolTip("Both observations and parameters must be defined")
             sim_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxWarning))
 
         panel.simulationConfigurationChanged.connect(self.validationStatusChanged)

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -86,6 +86,11 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     def number_of_iterations(self) -> int:
         return self._enkf_main.analysisConfig().num_iterations
 
+    def get_surface_parameters(self) -> List[str]:
+        return list(
+            self._enkf_main.ensembleConfig().getKeylistFromImplType(ErtImplType.SURFACE)
+        )
+
     def get_field_parameters(self) -> List[str]:
         return list(
             self._enkf_main.ensembleConfig().getKeylistFromImplType(ErtImplType.FIELD)
@@ -155,6 +160,14 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
 
     def get_number_of_iterations(self) -> int:
         return self._enkf_main.analysisConfig().num_iterations
+
+    @property
+    def have_smoother_parameters(self) -> bool:
+        return bool(
+            self.get_surface_parameters()
+            or self.get_gen_kw()
+            or self.get_field_parameters()
+        )
 
     @property
     def have_observations(self) -> bool:

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import shutil
-from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
@@ -10,15 +9,8 @@ from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QComboBox, QMessageBox, QToolButton, QWidget
 
 import ert.gui
-from ert.__main__ import ert_parser
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.gui.about_dialog import AboutDialog
-from ert.cli import (
-    ENSEMBLE_SMOOTHER_MODE,
-    ES_MDA_MODE,
-    ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
-)
-from ert.cli.main import ErtCliError, run_cli
 from ert.gui.main import GUILogHandler, _setup_main_window, run_gui
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer import add_gui_log_handler
@@ -195,7 +187,6 @@ def test_that_the_ui_show_warnings_when_there_are_no_observations(qapp, tmp_path
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_the_ui_show_warnings_when_parameters_are_missing(qapp, tmp_path):
-
     with open("poly.ert", "r", encoding="utf-8") as fin:
         with open("poly-no-gen-kw.ert", "w", encoding="utf-8") as fout:
             for line in fin:
@@ -216,50 +207,6 @@ def test_that_the_ui_show_warnings_when_parameters_are_missing(qapp, tmp_path):
             assert not combo_box.model().item(i).isEnabled()
 
         assert gui.windowTitle() == "ERT - poly-no-gen-kw.ert"
-
-
-@pytest.mark.parametrize(
-    "mode",
-    [
-        pytest.param(ENSEMBLE_SMOOTHER_MODE),
-        pytest.param(ITERATIVE_ENSEMBLE_SMOOTHER_MODE),
-        pytest.param(ES_MDA_MODE),
-    ],
-)
-@pytest.mark.usefixtures("copy_poly_case")
-def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
-
-    with open("poly.ert", "r", encoding="utf-8") as fin:
-        with open("poly-no-gen-kw.ert", "w", encoding="utf-8") as fout:
-            for line in fin:
-                if "GEN_KW" not in line:
-                    fout.write(line)
-
-    args = Mock()
-    args.config = "poly-no-gen-kw.ert"
-    parser = ArgumentParser(prog="test_main")
-
-    ert_args = [
-        mode,
-        "poly-no-gen-kw.ert",
-        "--port-range",
-        "1024-65535",
-        "--target-case",
-    ]
-
-    testcase = "testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d"
-    ert_args.append(testcase)
-
-    parsed = ert_parser(
-        parser,
-        ert_args,
-    )
-
-    with pytest.raises(
-        ErtCliError,
-        match=f"To run {mode}, GEN_KW, FIELD or SURFACE parameters are needed.",
-    ):
-        run_cli(parsed)
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
**Issue**
Resolves #4828 


~~Will add tests if the proposed solution is acceptable~~

Where can i move the CLI test?

Current implementation:
![disabled_parameters_smoother_sim](https://user-images.githubusercontent.com/114403625/222464106-cedf2b32-4528-4fb3-b885-9c0354100f17.PNG)

```diff
diff --git a/test-data/poly_example/poly.ert b/test-data/poly_example/poly.ert
index e57a8ead0..0f56bf779 100644
--- a/test-data/poly_example/poly.ert
+++ b/test-data/poly_example/poly.ert
@@ -11,7 +11,7 @@ TIME_MAP time_map
 NUM_REALIZATIONS 100
 MIN_REALIZATIONS 1

-GEN_KW COEFFS coeff.tmpl coeffs.json coeff_priors
+--GEN_KW COEFFS coeff.tmpl coeffs.json coeff_priors
 GEN_DATA POLY_RES RESULT_FILE:poly_%d.out REPORT_STEPS:0 INPUT_FORMAT:ASCII

 INSTALL_JOB poly_eval POLY_EVAL
```

**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
