### PR TITLE
Fix stop_long_running_keyword not being recognized

### DIFF
--- a/src/clib/lib/config/config_keywords.cpp
+++ b/src/clib/lib/config/config_keywords.cpp
@@ -274,6 +274,7 @@ ERT_CLIB_SUBMODULE("config_keywords", m) {
             add_string_keyword(config_parser, UPDATE_LOG_PATH_KEY);
             add_string_keyword(config_parser, MIN_REALIZATIONS_KEY);
             add_int_keyword(config_parser, MAX_RUNTIME_KEY);
+            add_stop_long_running_keyword(config_parser);
             add_string_keyword(config_parser, ANALYSIS_SELECT_KEY);
             add_analysis_copy_keyword(config_parser);
             add_analysis_set_var_keyword(config_parser);

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -257,6 +257,7 @@ def generate_config(draw):
                 ConfigKeys.DEFINE_KEY: small_list(
                     st.tuples(st.just(f"<key-{draw(words)}>"), words)
                 ),
+                ConfigKeys.STOP_LONG_RUNNING: st.booleans(),
                 ConfigKeys.DATA_KW_KEY: small_list(
                     st.tuples(st.just(f"<{draw(words)}>"), words)
                 ),


### PR DESCRIPTION
backports #4998 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
