### PR TITLE
Reduce time-out in esmda_has_run so it quits earlier

### DIFF
--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -134,7 +134,7 @@ def esmda_has_run(opened_main_window, request):
 
         qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=2000000)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=120000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
         # Assert that the number of boxes in the detailed view is


### PR DESCRIPTION
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
