### PR TITLE
Improve error handling around executables in configuration

### DIFF
--- a/src/clib/lib/config/config_schema_item.cpp
+++ b/src/clib/lib/config/config_schema_item.cpp
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <fmt/format.h>
+
 #include <ert/res_util/res_env.hpp>
 #include <ert/util/hash.hpp>
 #include <ert/util/parser.hpp>
@@ -403,7 +405,9 @@ bool config_schema_item_validate_set(const config_schema_item_type *item,
                             if (util_is_executable(relocated))
                                 stringlist_iset_copy(token_list, iarg,
                                                      relocated);
-
+                            else
+                                error_list.push_back(fmt::format(
+                                    "File not executable:{}", value));
                             free(relocated);
                             break;
                         }

--- a/src/clib/lib/res_util/res_env.cpp
+++ b/src/clib/lib/res_util/res_env.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -9,6 +10,8 @@
 #include <ert/res_util/string.hpp>
 #include <ert/util/buffer.hpp>
 #include <ert/util/util.hpp>
+
+namespace fs = std::filesystem;
 
 void res_env_unsetenv(const char *variable) { unsetenv(variable); }
 
@@ -66,6 +69,11 @@ char *res_env_alloc_PATH_executable(const char *executable) {
         int ipath = 0;
 
         for (auto path : path_list) {
+            try {
+                auto dir_iter = fs::directory_iterator(fs::path(path));
+            } catch (fs::filesystem_error &err) {
+                continue;
+            }
             char *current_attempt =
                 util_alloc_filename(path.c_str(), executable, NULL);
 

--- a/src/ert/_c_wrappers/enkf/lark_parser.py
+++ b/src/ert/_c_wrappers/enkf/lark_parser.py
@@ -279,6 +279,16 @@ class _TreeToDictTransformer:
                             f"Could not find executable {val.value!r}",
                             config_file=val.filename,
                         )
+                if not os.access(path, os.X_OK):
+                    context = (
+                        f"{val.value!r} which was resolved to {path!r}"
+                        if val.value != path
+                        else f"{val.value!r}"
+                    )
+                    raise ConfigValidationError(
+                        f"File not executable: {context}",
+                        config_file=val.filename,
+                    )
                 return path
             return str(val)
 

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -1097,3 +1097,21 @@ def test_that_boolean_values_can_be_any_case(val, expected):
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert ert_config.analysis_config.get_stop_long_running() == expected
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_not_executable_job_script_fails_gracefully():
+    """Given a non executable job script, we should fail gracefully"""
+
+    config_file_name = "config.ert"
+    script_name = "not-executable-script.py"
+    touch(script_name)
+    config_file_contents = dedent(
+        f"""NUM_REALIZATIONS 1
+         JOB_SCRIPT {script_name}
+         """
+    )
+    with open(config_file_name, mode="w", encoding="utf-8") as fh:
+        fh.write(config_file_contents)
+    with pytest.raises(ConfigValidationError, match=f"not executable.*{script_name}"):
+        ErtConfig.from_file(config_file_name)

--- a/tests/test_config_parsing/test_res_config.py
+++ b/tests/test_config_parsing/test_res_config.py
@@ -1115,3 +1115,33 @@ def test_not_executable_job_script_fails_gracefully():
         fh.write(config_file_contents)
     with pytest.raises(ConfigValidationError, match=f"not executable.*{script_name}"):
         ErtConfig.from_file(config_file_name)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_not_executable_job_script_somewhere_in_PATH_fails_gracefully(monkeypatch):
+    """Given a non executable job script referred to by relative path (in this case:
+    just the filename) in the config file, where the relative path is not relative to
+    the location of the config file / current directory, but rather some location
+    specified by the env var PATH, we should fail gracefully"""
+
+    config_file_name = "config.ert"
+    script_name = "not-executable-script.py"
+    path_location = os.path.join(os.getcwd(), "bin")
+    os.mkdir(path_location)
+    touch(os.path.join(path_location, script_name))
+    os.chmod(path_location, 0x0)
+    monkeypatch.setenv("PATH", path_location, ":")
+    config_file_contents = dedent(
+        f"""NUM_REALIZATIONS 1
+         JOB_SCRIPT {script_name}
+         """
+    )
+    with open(config_file_name, mode="w", encoding="utf-8") as fh:
+        fh.write(config_file_contents)
+    with pytest.raises(
+        ConfigValidationError,
+        match="Could not find executable|Executable.*does not exist",
+    ):
+        ErtConfig.from_file(config_file_name)
+
+    os.chmod(path_location, 0x775)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from ert._c_wrappers.config import ConfigParser, ContentTypeEnum
@@ -66,7 +67,7 @@ SINGLE_OCCURRENCE_KEY_TYPES = {
     ConfigKeys.ITER_COUNT: "int",
     ConfigKeys.ITER_RETRY_COUNT: "int",
     ConfigKeys.JOBNAME: "str",
-    ConfigKeys.JOB_SCRIPT: "file_path",
+    ConfigKeys.JOB_SCRIPT: "executable_file_path",
     ConfigKeys.LICENSE_PATH: "file_path",
     ConfigKeys.MAX_RUNTIME: "int",
     ConfigKeys.MAX_SUBMIT: "int",
@@ -91,13 +92,17 @@ def test_config_content_as_dict_single_value_keys(tmpdir):
         conf = ConfigParser()
         existing_file_1 = "test_1.t"
         existing_file_2 = "test_2.t"
+        executable_existing_file = "script.py"
         Path(existing_file_2).write_text("something", encoding="utf-8")
         Path(existing_file_1).write_text("not important", encoding="utf-8")
+        Path(executable_existing_file).write_text("import gravity", encoding="utf-8")
+        os.chmod(executable_existing_file, 0x755)
         init_user_config_parser(conf)
         type_value_map = {
             "str": "abc",
             "path": tmpdir,
             "file_path": existing_file_1,
+            "executable_file_path": executable_existing_file,
             "bool": "TRUE",
             "float": 4.2,
             "int": 2,


### PR DESCRIPTION
**Issue**
Resolves #4960
Related to #4945


**Approach**
See commits

NB: we log a warning when there are directories in the PATH that are not accessible / do not exist. this might create noise for users. please take this under consideration during review. testing locally, for me (ouch my setup), running `ert gui poly.ert` with added line `JOBSCRIPT less` produces

```
Could not search PATH dir /snap/dotnet-sdk/current for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/snap/dotnet-sdk/current]
2023-03-06 15:51:51,305 [WARNING] res.job_queue: Could not search PATH dir /home/val/adb-fastboot/platform-tools for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/home/val/adb-fastboot/platform-tools]
2023-03-06 15:51:51,305 [WARNING] res.job_queue: Could not search PATH dir /home/val/code/go/bin for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/home/val/code/go/bin]
2023-03-06 15:51:51,305 [WARNING] res.job_queue: Could not search PATH dir /snap/dotnet-sdk/current for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/snap/dotnet-sdk/current]
2023-03-06 15:51:51,305 [WARNING] res.job_queue: Could not search PATH dir /home/val/adb-fastboot/platform-tools for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/home/val/adb-fastboot/platform-tools]
2023-03-06 15:51:51,305 [WARNING] res.job_queue: Could not search PATH dir /home/val/code/go/bin for executable less - filesystem error: directory iterator cannot open directory: No such file or directory [/home/val/code/go/bin]
```

which is quite a bit of noise...

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
