### PR TITLE
CaseSelector keeps track of global current_case

### DIFF
--- a/src/ert/gui/ertwidgets/caselist.py
+++ b/src/ert/gui/ertwidgets/caselist.py
@@ -101,11 +101,11 @@ class CaseList(QWidget):
         )
         new_case_name = dialog.showAndTell()
         if not new_case_name == "":
-            self.storage.create_ensemble(
-                self.storage.create_experiment(),
+            ensemble = self.storage.create_experiment().create_ensemble(
                 name=new_case_name,
                 ensemble_size=self.facade.get_ensemble_size(),
             )
+            self.notifier.set_current_case(ensemble)
             self.notifier.ertChanged.emit()
 
     def removeItem(self):

--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -1,76 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Optional
+
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import addHelpToWidget
-from ert.libres_facade import LibresFacade
-from ert.storage import StorageAccessor
+
+if TYPE_CHECKING:
+    from ert.storage import EnsembleReader
 
 
 class CaseSelector(QComboBox):
     def __init__(
         self,
-        facade: LibresFacade,
         notifier: ErtNotifier,
         update_ert: bool = True,
         show_only_initialized: bool = False,
         ignore_current: bool = False,
         help_link: str = "init/current_case_selection",
     ):
-        self.facade = facade
+        super().__init__()
         self.notifier = notifier
-        QComboBox.__init__(self)
-        self._update_ert = update_ert  # If true current case of ert will be change
-        self._show_only_initialized = (
-            show_only_initialized  # only show initialized cases
-        )
-        self._ignore_current = (
-            ignore_current  # ignore the currently selected case if it changes
-        )
+
+        # If true current case of ert will be change
+        self._update_ert = update_ert
+        # only show initialized cases
+        self._show_only_initialized = show_only_initialized
+        # ignore the currently selected case if it changes
+        self._ignore_current = ignore_current
 
         addHelpToWidget(self, help_link)
         self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
-        self.currentIndexChanged[int].connect(self.on_current_index_changed)
+        if update_ert:
+            # Update ERT when this combo box is changed
+            self.currentIndexChanged[int].connect(self._on_current_index_changed)
+
+            # Update this combo box when ERT is changed
+            notifier.current_case_changed.connect(self._on_global_current_case_changed)
+
         notifier.ertChanged.connect(self.populate)
         notifier.storage_changed.connect(self.populate)
 
         if notifier._storage is not None:
             self.populate()
 
-    @property
-    def storage(self) -> StorageAccessor:
-        return self.notifier.storage
-
-    def on_current_index_changed(self, index: int) -> None:
-        if self._update_ert:
-            assert (
-                0 <= index < self.count()
-            ), f"Should not happen! Index out of range: 0 <= {index} < {self.count()}"
-
-            self.notifier.set_current_case(self.itemData(index))
-
     def populate(self):
-        block = self.signalsBlocked()
-        self.blockSignals(True)
-
-        if self._show_only_initialized:
-            case_list = (x for x in self.storage.ensembles if x.is_initalized)
-        else:
-            case_list = self.storage.ensembles
-
-        case_list = sorted(case_list, key=lambda x: x.started_at, reverse=True)
+        block = self.blockSignals(True)
 
         self.clear()
 
-        for case in case_list:
+        for case in self._case_list():
             self.addItem(case.name, userData=case)
 
-        current_index = 0
-        current_case = self.notifier.current_case
-        if current_case in case_list:
-            current_index = case_list.index(current_case)
-
-        if current_index != self.currentIndex() and not self._ignore_current:
-            self.setCurrentIndex(current_index)
+        if not self._ignore_current:
+            current_index = self.findData(
+                self.notifier.current_case, Qt.ItemDataRole.UserRole
+            )
+            self.setCurrentIndex(max(current_index, 0))
 
         self.blockSignals(block)
+
+    def _case_list(self) -> Iterable[EnsembleReader]:
+        if self._show_only_initialized:
+            case_list = (x for x in self.notifier.storage.ensembles if x.is_initalized)
+        else:
+            case_list = self.notifier.storage.ensembles
+        return sorted(case_list, key=lambda x: x.started_at, reverse=True)
+
+    def _on_current_index_changed(self, index: int) -> None:
+        self.notifier.set_current_case(self.itemData(index))
+
+    def _on_global_current_case_changed(self, data: Optional[EnsembleReader]) -> None:
+        self.setCurrentIndex(max(self.findData(data, Qt.ItemDataRole.UserRole), 0))

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -36,7 +36,7 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
 
         layout = QFormLayout()
 
-        self._case_selector = CaseSelector(self.facade, notifier)
+        self._case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", self._case_selector)
         runpath_label = CopyableLabel(text=self.facade.run_path)
         layout.addRow("Runpath:", runpath_label)

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -36,7 +36,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
 
         self.setObjectName("ensemble_smoother_panel")
 
-        self._case_selector = CaseSelector(facade, notifier)
+        self._case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", self._case_selector)
 
         runpath_label = CopyableLabel(text=facade.run_path)

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -35,7 +35,7 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
 
         layout = QFormLayout()
 
-        case_selector = CaseSelector(self.facade, notifier)
+        case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
 
         runpath_label = CopyableLabel(text=self.facade.run_path)

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -45,7 +45,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
 
         layout = QFormLayout()
 
-        case_selector = CaseSelector(facade, notifier)
+        case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
 
         runpath_label = CopyableLabel(text=facade.run_path)

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -182,6 +182,7 @@ class SimulationPanel(QWidget):
                 def exit_handler():
                     self.run_button.setText("Start simulation")
                     self.run_button.setDisabled(False)
+                    self.notifier.emitErtChange()
 
                 dialog.finished.connect(exit_handler)
 

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -26,7 +26,7 @@ class SingleTestRunPanel(SimulationConfigPanel):
         self.setObjectName("Single_test_run_panel")
         layout = QFormLayout()
 
-        case_selector = CaseSelector(facade, notifier)
+        case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
 
         runpath_label = CopyableLabel(text=facade.run_path)

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -34,10 +34,7 @@ class LoadResultsPanel(QWidget):
 
         layout.addRow("Load data from current run path: ", run_path_text)
 
-        case_selector = CaseSelector(
-            self._facade,
-            self._notifier,
-        )
+        case_selector = CaseSelector(self._notifier)
         layout.addRow("Load into case:", case_selector)
 
         self._active_realizations_model = ActiveRealizationsModel(self._facade)

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -93,7 +93,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         panel.setObjectName("initialize_from_scratch_panel")
         layout = QVBoxLayout()
 
-        target_case = CaseSelector(LibresFacade(self.ert), self.notifier)
+        target_case = CaseSelector(self.notifier)
         row = createRow(QLabel("Target case:"), target_case)
         layout.addLayout(row)
 
@@ -132,12 +132,11 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         widget.setObjectName("intialize_from_existing_panel")
         layout = QVBoxLayout()
 
-        target_case = CaseSelector(LibresFacade(self.ert), self.notifier)
+        target_case = CaseSelector(self.notifier)
         row = createRow(QLabel("Target case:"), target_case)
         layout.addLayout(row)
 
         source_case = CaseSelector(
-            LibresFacade(self.ert),
             self.notifier,
             update_ert=False,
             show_only_initialized=True,
@@ -219,7 +218,6 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         layout = QVBoxLayout()
 
         case_selector = CaseSelector(
-            LibresFacade(self.ert),
             self.notifier,
             update_ert=False,
             help_link="init/selected_case_info",

--- a/src/ert/gui/tools/run_analysis/run_analysis_panel.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_panel.py
@@ -18,9 +18,7 @@ class RunAnalysisPanel(QWidget):
             help_link="config/analysis/analysis_module",
         )
         self.target_case_text = QLineEdit()
-        self.source_case_selector = CaseSelector(
-            LibresFacade(self.ert), notifier, update_ert=False
-        )
+        self.source_case_selector = CaseSelector(notifier, update_ert=False)
 
         layout = QFormLayout()
         layout.addRow("Analysis", self.analysis_module)

--- a/tests/unit_tests/gui/ertwidgets/test_caseselector.py
+++ b/tests/unit_tests/gui/ertwidgets/test_caseselector.py
@@ -1,0 +1,77 @@
+import pytest
+
+from ert._c_wrappers.enkf.ert_config import ErtConfig
+from ert.gui.ertnotifier import ErtNotifier
+from ert.gui.ertwidgets.caseselector import CaseSelector
+
+
+@pytest.fixture
+def notifier():
+    return ErtNotifier(ErtConfig())
+
+
+def test_empty(qtbot, notifier):
+    widget = CaseSelector(notifier)
+    qtbot.addWidget(widget)
+
+    assert widget.count() == 0
+
+
+def test_current_case(qtbot, notifier, storage):
+    ensemble = storage.create_experiment().create_ensemble(
+        name="default", ensemble_size=1
+    )
+
+    # Adding a storage after widget creation populates it
+    widget = CaseSelector(notifier)
+    qtbot.addWidget(widget)
+    assert widget.count() == 0
+
+    notifier.set_storage(storage)
+    notifier.set_current_case(ensemble)
+    assert widget.count() == 1
+    assert widget.currentData() == ensemble
+
+    # Creating CaseSelector after storage has been created populates it
+    widget = CaseSelector(notifier)
+    qtbot.addWidget(widget)
+    assert widget.count() == 1
+    assert widget.currentData() == ensemble
+
+
+def test_changing_case(qtbot, notifier, storage):
+    ensemble_a = storage.create_experiment().create_ensemble(
+        name="default_a", ensemble_size=1
+    )
+    ensemble_b = storage.create_experiment().create_ensemble(
+        name="default_b", ensemble_size=1
+    )
+
+    notifier.set_storage(storage)
+    notifier.set_current_case(ensemble_a)
+    widget_a = CaseSelector(notifier)
+    widget_b = CaseSelector(notifier)
+    qtbot.addWidget(widget_a)
+    qtbot.addWidget(widget_b)
+
+    assert widget_a.count() == 2
+    assert widget_b.count() == 2
+
+    # First ensemble is selected in both
+    assert widget_a.currentData() == ensemble_a
+    assert widget_b.currentData() == ensemble_a
+
+    # Second ensemble is selected via signal, changing both widgets'
+    # selections
+    notifier.set_current_case(ensemble_b)
+    assert widget_a.currentData() == ensemble_b
+    assert widget_b.currentData() == ensemble_b
+
+    # Changing back to first ensemble via widget sets the global current_case
+    qtbot.keyClicks(
+        widget_a,
+        widget_a.itemText(widget_a.findData(ensemble_a)),
+    )
+    assert notifier.current_case == ensemble_a
+    assert widget_a.currentData() == ensemble_a
+    assert widget_b.currentData() == ensemble_a

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -65,6 +65,11 @@ def opened_main_window(source_root, tmpdir_factory, request):
         ), open_storage(poly_case.ert_config.ens_path, mode="w") as storage:
             gui = _setup_main_window(poly_case, args_mock, GUILogHandler())
             gui.notifier.set_storage(storage)
+            gui.notifier.set_current_case(
+                storage.create_experiment().create_ensemble(
+                    name="default", ensemble_size=poly_case.getEnsembleSize()
+                )
+            )
             yield gui, poly_case.getEnsembleSize()
 
 
@@ -180,6 +185,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
         combo_box.setCurrentIndex(i)
         case_names.append(combo_box.currentText())
     assert sorted(case_names) == [
+        "default",
         "default_0",
         "default_0",
         "default_1",
@@ -223,7 +229,13 @@ def test_that_the_plot_window_contains_the_expected_elements(
         combo_boxes: List[QComboBox] = case_selection.findChildren(
             QComboBox
         )  # type: ignore
-    assert len(case_selection.findChildren(QComboBox)) == len(case_names)
+    assert {x.currentText() for x in case_selection.findChildren(QComboBox)} == {
+        "default",
+        "default_0",
+        "default_1",
+        "default_2",
+        "default_3",
+    }
 
     # Cycle through showing all the tabs and plot each data key
 
@@ -265,7 +277,7 @@ def test_that_the_manage_cases_tool_can_be_used(
         assert isinstance(case_list, CaseList)
 
         # The case list should contain the expected cases
-        assert case_list._list.count() == 5
+        assert case_list._list.count() == 6
 
         # Click add case and name it "new_case"
         def handle_add_dialog():
@@ -278,7 +290,7 @@ def test_that_the_manage_cases_tool_can_be_used(
         qtbot.mouseClick(create_widget.addButton, Qt.LeftButton)
 
         # The list should now contain "new_case"
-        assert case_list._list.count() == 6
+        assert case_list._list.count() == 7
 
         # Go to the "initialize from scratch" panel
         cases_panel.setCurrentIndex(1)


### PR DESCRIPTION
Previously, each CaseSelector would only set its currently selected case
when `ertChanged` happens, usually only after simulations have
run (although this didn't always happen either.) Because ErtNotifier has
slightly more fine-grained signals, we can listed for
`current_case_changed` specifically and update the ComboBox' current
index.

Note how each CaseSelector listens to the global current_case, as well
as emits it, there is a potential for an infinite loop where each
CaseSelector responds to the change in the global variable by setting
it, which causes it to respond to the change etcetera. This, however,
does not happen because `setCurrentIndex` does not emit a signal if the
new index is already the current index. In theory we make a few too many
calls to this signal but in practice it is fine and is probably worth
the code cleanliness.

This commit also adds a `ertChanged` signal emission when the simulation
runner dialog is closed. Finer-grained controls are still required by
this makes it so that the CaseSelector boxes are updated more correctly.