### PR TITLE
Silence warnings from lark parser

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -7,6 +7,7 @@ import os
 import sys
 import threading
 import uuid
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +41,14 @@ class ErtTimeoutError(Exception):
 def run_cli(args):
     ert_config = ErtConfig.from_file(args.config)
     try:
-        ert_config_new = ErtConfig.from_file(args.config, use_new_parser=True)
+        with warnings.catch_warnings(record=True) as silenced_warnings:
+            warnings.simplefilter("always")
+
+            ert_config_new = ErtConfig.from_file(args.config, use_new_parser=True)
+
+            for w in silenced_warnings:
+                logging.info(f"Parser warning: {w.message}")
+
         if ert_config != ert_config_new:
             fields = dataclasses.fields(ert_config)
             difference = [

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -99,7 +99,16 @@ def _start_initial_gui_window(args, log_handler):
             suggestions += ErtConfig.make_suggestion_list(args.config)
             ert_config = ErtConfig.from_file(args.config)
             try:
-                ert_config_new = ErtConfig.from_file(args.config, use_new_parser=True)
+                with warnings.catch_warnings(record=True) as silenced_warnings:
+                    warnings.simplefilter("always")
+
+                    ert_config_new = ErtConfig.from_file(
+                        args.config, use_new_parser=True
+                    )
+
+                    for w in silenced_warnings:
+                        logging.info(f"Parser warning: {w.message}")
+
                 if ert_config != ert_config_new:
                     fields = dataclasses.fields(ert_config)
                     difference = [


### PR DESCRIPTION
The new parser provides duplicate warnings currently, and we catch these and report them only to the logger system.

**Issue**
Resolves #5020 


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
