### PR TITLE
Fix false positive in environment variables change

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,12 @@ def class_source_root(request, source_root):
 
 @pytest.fixture(autouse=True)
 def env_save():
-    exceptions = ["PYTEST_CURRENT_TEST", "KMP_DUPLICATE_LIB_OK", "KMP_INIT_AT_FORK"]
+    exceptions = [
+        "PYTEST_CURRENT_TEST",
+        "KMP_DUPLICATE_LIB_OK",
+        "KMP_INIT_AT_FORK",
+        "QT_API",
+    ]
     environment_pre = [
         (key, val) for key, val in os.environ.items() if key not in exceptions
     ]


### PR DESCRIPTION
It seems like pytest-qt sets an environment variable, which leads our internal test that checks whether the environment was changed to fail.

We add the variable in question to the list of exceptions in that check.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
