### PR TITLE
Provide feedback if not valid weights provided for ES_MDA

### DIFF
--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -44,6 +44,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         SimulationConfigPanel.__init__(self, MultipleDataAssimilation)
 
         layout = QFormLayout()
+        self.setObjectName("ES_MDA_panel")
 
         runpath_label = CopyableLabel(text=facade.run_path)
         layout.addRow("Runpath:", runpath_label)
@@ -64,6 +65,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout.addRow("Target case format:", self._target_case_format_field)
 
         self.weights = MultipleDataAssimilation.default_weights
+        self.weights_valid = True
         self._createInputForWeights(layout)
 
         self._analysis_module_edit = AnalysisModuleEdit(
@@ -137,6 +139,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout.addRow("Normalized weights:", normalized_weights_widget)
 
         def updateVisualizationOfNormalizedWeights():
+            self.weights_valid = False
+
             if self._relative_iteration_weights_box.isValid():
                 weights = MultipleDataAssimilation.parseWeights(
                     relative_iteration_weights_model.getValue()
@@ -145,6 +149,11 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
                 normalized_weights_model.setValue(
                     ", ".join(f"{x:.2f}" for x in normalized_weights)
                 )
+
+                if not weights:
+                    normalized_weights_model.setValue("The weights are invalid!")
+                else:
+                    self.weights_valid = True
             else:
                 normalized_weights_model.setValue("The weights are invalid!")
 
@@ -159,6 +168,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
             self._target_case_format_field.isValid()
             and self._active_realizations_field.isValid()
             and self._relative_iteration_weights_box.isValid()
+            and self.weights_valid
         )
 
     def getSimulationArguments(self):
@@ -173,6 +183,4 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         )
 
     def setWeights(self, weights):
-        str_weights = str(weights)
-        print(f"Weights changed: {str_weights}")
-        self.weights = str_weights
+        self.weights = str(weights)

--- a/src/ert/shared/models/multiple_data_assimilation.py
+++ b/src/ert/shared/models/multiple_data_assimilation.py
@@ -43,6 +43,10 @@ class MultipleDataAssimilation(BaseRunModel):
             self._simulation_arguments["active_realizations"].count(True)
         )
         weights = self.parseWeights(self._simulation_arguments["weights"])
+
+        if not weights:
+            raise ErtRunError("Cannot perform ES_MDA with no weights provided!")
+
         iteration_count = len(weights)
 
         self.setAnalysisModule(self._simulation_arguments["analysis_module"])

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -479,3 +479,32 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
         match=f"To run {mode}, GEN_KW, FIELD or SURFACE parameters are needed.",
     ):
         run_cli(parsed)
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
+    args = Mock()
+    args.config = "poly.ert"
+    parser = ArgumentParser(prog="test_main")
+
+    ert_args = [
+        "es_mda",
+        "poly.ert",
+        "--port-range",
+        "1024-65535",
+        "--target-case",
+        "testcase-%d",
+        "--weights",
+        "0",
+    ]
+
+    parsed = ert_parser(
+        parser,
+        ert_args,
+    )
+
+    with pytest.raises(
+        ErtCliError,
+        match="Cannot perform ES_MDA with no weights provided!",
+    ):
+        run_cli(parsed)


### PR DESCRIPTION
**Issue**
Resolves #5022

**Approach**
Raise exception if simulation executed with no valid weights provided.
Show status string 'Weights are invalid' whenever no valid weights
are provided for ES_MDA.
Disable Run simulation button when no valid weights for ES_MDA.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
