### PR TITLE
Initialize lark parser when module loads

### DIFF
--- a/src/ert/_c_wrappers/enkf/lark_parser.py
+++ b/src/ert/_c_wrappers/enkf/lark_parser.py
@@ -122,6 +122,8 @@ inst: "DEFINE" KW_NAME kw_val -> define
 instruction: inst COMMENT | COMMENT | inst NEWLINE | NEWLINE
 """  # noqa: E501
 
+parser = Lark(grammar, propagate_positions=True)
+
 logger = logging.getLogger(__name__)
 
 
@@ -507,7 +509,6 @@ def _parse_file(
     try:
         with open(file, encoding="utf-8") as f:
             content = f.read()
-        parser = Lark(grammar, propagate_positions=True)
         tree = parser.parse(content + "\n")
         return FileContextTransformer(file).transform(
             StringQuotationTransformer().transform(tree)


### PR DESCRIPTION
**Issue**
Resolves #5014


**Approach**
move the line that initilaizes the parser to module scope


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
