### PR TITLE
Remove define_args from ExtJob

### DIFF
--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -355,7 +355,6 @@ class ErtConfig:
                         config_file=config_file,
                     ) from err
 
-                job.define_args = substitution_list
             try:
                 job.validate_args(substitution_list)
             except ExtJobInvalidArgsException as err:
@@ -371,7 +370,6 @@ class ErtConfig:
                     config_file=config_file,
                 ) from err
             job.arglist = job_description[1:]
-            job.define_args = substitution_list
             jobs.append(job)
 
         return jobs

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -41,7 +41,6 @@ class ExtJob:
     exec_env: Dict[str, str] = field(default_factory=dict)
     default_mapping: Dict[str, str] = field(default_factory=dict)
     private_args: SubstitutionList = field(default_factory=SubstitutionList)
-    define_args: SubstitutionList = field(default_factory=SubstitutionList)
     help_text: str = ""
 
     @staticmethod


### PR DESCRIPTION

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
