### PR TITLE
Expose CSV_EXPORT as gui plugin again

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -1,7 +1,6 @@
 from os import path
-from threading import Timer
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QTimer
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
 
@@ -62,16 +61,19 @@ class CopyableLabel(QHBoxLayout):
             current_dir, "..", "resources", "gui", "img", "check.svg"
         )
         self.copy_button.setIcon(QIcon(icon_path))
+        self.restore_timer = QTimer(self)
+
+        def restore_text():
+            self.copy_button.setIcon(QIcon(icon_path))
+
+        self.restore_timer.timeout.connect(restore_text)
 
         def copy_text() -> None:
             text = unescape_string(self.label.text())
             QApplication.clipboard().setText(text)
             self.copy_button.setIcon(QIcon(icon_path_check))
 
-            def restore_text():
-                self.copy_button.setIcon(QIcon(icon_path))
-
-            Timer(1.0, restore_text).start()
+            self.restore_timer.start(1000)
 
         self.copy_button.clicked.connect(copy_text)
 

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -2,9 +2,14 @@ import os
 import re
 
 import pandas
+from qtpy.QtWidgets import QCheckBox
 
 from ert import LibresFacade
-from ert._c_wrappers.job_queue import ErtScript
+from ert._c_wrappers.job_queue import CancelPluginException, ErtPlugin
+from ert.gui.ertwidgets.customdialog import CustomDialog
+from ert.gui.ertwidgets.listeditbox import ListEditBox
+from ert.gui.ertwidgets.models.path_model import PathModel
+from ert.gui.ertwidgets.pathchooser import PathChooser
 
 
 def loadDesignMatrix(filename) -> pandas.DataFrame:
@@ -14,7 +19,7 @@ def loadDesignMatrix(filename) -> pandas.DataFrame:
     return dm
 
 
-class CSVExportJob(ErtScript):
+class CSVExportJob(ErtPlugin):
     """
     Export of summary, misfit, design matrix data and gen kw into a single CSV file.
 
@@ -39,9 +44,33 @@ class CSVExportJob(ErtScript):
     The script also looks for default values for output path and design matrix
     path to present in the GUI. These can be specified with DATA_KW keyword in
     the config file:
-        DATA_KW CSV_OUTPUT_PATH <some path>
-        DATA_KW DESIGN_MATRIX_PATH <some path>
+        DATA_KW <CSV_OUTPUT_PATH> {some path}
+        DATA_KW <DESIGN_MATRIX_PATH> {some path}
     """
+
+    INFER_HELP = (
+        "<html>"
+        "If this is checked the iteration number will be inferred from the name i.e.:"
+        "<ul>"
+        "<li>case_name -> iteration: 0</li>"
+        "<li>case_name_0 -> iteration: 0</li>"
+        "<li>case_name_2 -> iteration: 2</li>"
+        "<li>case_0, case_2, case_5 -> iterations: 0, 2, 5</li>"
+        "</ul>"
+        "Leave this unchecked to set iteration number to the order of the listed cases:"
+        "<ul><li>case_0, case_2, case_5 -> iterations: 0, 1, 2</li></ul>"
+        "<br/>"
+        "</html>"
+    )
+
+    def getName(self):
+        return "CSV Export"
+
+    def getDescription(self):
+        return (
+            "Export GenKW, design matrix, misfit data "
+            "and summary data into a single CSV file."
+        )
 
     def inferIterationNumber(self, case_name):
         pattern = re.compile("_([0-9]+$)")
@@ -129,6 +158,69 @@ class CSVExportJob(ErtScript):
             f"columns to {output_file}."
         )
         return export_info
+
+    def getArguments(self, parent=None):
+        description = "The CSV export requires some information before it starts:"
+        dialog = CustomDialog("CSV Export", description, parent)
+
+        default_csv_output_path = self.get_context_value(
+            "<CSV_OUTPUT_PATH>", default="output.csv"
+        )
+        output_path_model = PathModel(default_csv_output_path)
+        output_path_chooser = PathChooser(output_path_model)
+
+        design_matrix_default = self.get_context_value(
+            "<DESIGN_MATRIX_PATH>", default=""
+        )
+        design_matrix_path_model = PathModel(
+            design_matrix_default, is_required=False, must_exist=True
+        )
+        design_matrix_path_chooser = PathChooser(design_matrix_path_model)
+
+        list_edit = ListEditBox(self.getAllCaseList())
+
+        infer_iteration_check = QCheckBox()
+        infer_iteration_check.setChecked(True)
+        infer_iteration_check.setToolTip(CSVExportJob.INFER_HELP)
+
+        drop_const_columns_check = QCheckBox()
+        drop_const_columns_check.setChecked(False)
+        drop_const_columns_check.setToolTip(
+            "If checked, exclude columns whose value is the same for every entry"
+        )
+
+        dialog.addLabeledOption("Output file path", output_path_chooser)
+        dialog.addLabeledOption("Design matrix path", design_matrix_path_chooser)
+        dialog.addLabeledOption("List of cases to export", list_edit)
+        dialog.addLabeledOption("Infer iteration number", infer_iteration_check)
+        dialog.addLabeledOption("Drop constant columns", drop_const_columns_check)
+
+        dialog.addButtons()
+
+        success = dialog.showAndTell()
+
+        if success:
+            design_matrix_path = design_matrix_path_model.getPath()
+            if design_matrix_path.strip() == "":
+                design_matrix_path = None
+
+            case_list = ",".join(list_edit.getItems())
+
+            return [
+                output_path_model.getPath(),
+                case_list,
+                design_matrix_path,
+                infer_iteration_check.isChecked(),
+                drop_const_columns_check.isChecked(),
+            ]
+
+        raise CancelPluginException("User cancelled!")
+
+    def get_context_value(self, name, default):
+        context = self.ert().get_context()
+        if name in context:
+            return context[name]
+        return default
 
     def getAllCaseList(self):
         fs_manager = self.ert().storage_manager

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -71,6 +71,7 @@ def opened_main_window(source_root, tmpdir_factory, request):
         ):
             gui = _setup_main_window(poly_case, args_mock, GUILogHandler())
             yield gui
+            gui.close()
 
 
 @pytest.mark.usefixtures("use_tmpdir, opened_main_window")
@@ -86,7 +87,6 @@ def run_experiment(request, opened_main_window):
     def func(experiment_mode):
         qtbot = QtBot(request)
         gui = opened_main_window
-        qtbot.addWidget(gui)
         try:
             shutil.rmtree("poly_out")
         except FileNotFoundError:
@@ -484,7 +484,6 @@ def test_that_the_manual_analysis_tool_works(
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_inversion_type_can_be_set_from_gui(qtbot, opened_main_window):
     gui = opened_main_window
-    qtbot.addWidget(gui)
 
     sim_mode = gui.findChild(QWidget, name="Simulation_mode")
     qtbot.keyClick(sim_mode, Qt.Key_Down)

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -43,11 +43,9 @@ from ert.shared.models import EnsembleExperiment, MultipleDataAssimilation
 
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.fixture(scope="module")
-def opened_main_window(source_root, tmpdir_factory, request):
+def opened_main_window(source_root, tmpdir_factory):
     with pytest.MonkeyPatch.context() as mp:
         tmp_path = tmpdir_factory.mktemp("test-data")
-
-        request.addfinalizer(lambda: shutil.rmtree(tmp_path))
         shutil.copytree(
             os.path.join(source_root, "test-data", "poly_example"),
             tmp_path / "test_data",


### PR DESCRIPTION
In 8ef5e3148904eaa8ec89e8481334551ed28d704e CSV_EXPORT was removed as it hadn't functioned correctly for a long time, and was believed not used. By user request. It is now back.

This commit fixes the broken issue with get_context_value and adds a test for the plugin tool.

Fixes #5049 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
