### PR TITLE
Make qt gui main window tests more stable / less brittle

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -46,6 +46,7 @@ class RunDialog(QDialog):
 
     def __init__(self, config_file, run_model, parent=None):
         QDialog.__init__(self, parent)
+        self.setAttribute(Qt.WA_DeleteOnClose)
         self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowTitle(f"Simulations - {config_file}")

--- a/src/ert/gui/tools/manage_cases/manage_cases_tool.py
+++ b/src/ert/gui/tools/manage_cases/manage_cases_tool.py
@@ -20,4 +20,5 @@ class ManageCasesTool(Tool):
         )
 
         dialog = ClosableDialog("Manage cases", case_management_widget, self.parent())
+        dialog.setObjectName("manage-cases")
         dialog.exec_()

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -3,7 +3,7 @@ import os.path
 import shutil
 import stat
 from textwrap import dedent
-from typing import List
+from typing import List, Tuple
 from unittest.mock import Mock
 
 import numpy as np
@@ -39,6 +39,16 @@ from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.services import Storage
 from ert.shared.models import EnsembleExperiment, MultipleDataAssimilation
+
+
+def find_cases_dialog_and_panel(
+    gui, qtbot: QtBot
+) -> Tuple[ClosableDialog, CaseInitializationConfigurationPanel]:
+    qtbot.waitUntil(lambda: gui.findChild(ClosableDialog, "manage-cases") is not None)
+    dialog = gui.findChild(ClosableDialog, "manage-cases")
+    cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
+    assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
+    return (dialog, cases_panel)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -110,8 +120,8 @@ def run_experiment(request, opened_main_window):
         # The Run dialog opens, click show details and wait until done appears
         # then click it
         def use_rundialog():
-            qtbot.waitUntil(lambda: isinstance(QApplication.activeWindow(), RunDialog))
-            run_dialog = QApplication.activeWindow()
+            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+            run_dialog = gui.findChild(RunDialog)
 
             qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
@@ -140,10 +150,7 @@ def ensemble_experiment_has_run(opened_main_window, run_experiment, request):
     qtbot = QtBot(request)
 
     def handle_dialog():
-        qtbot.waitUntil(lambda: gui.findChild(ClosableDialog) is not None)
-        dialog = gui.findChild(ClosableDialog)
-        cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
-        assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
+        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
 
         # Open the create new cases tab
         cases_panel.setCurrentIndex(0)
@@ -301,11 +308,7 @@ def test_that_the_manage_cases_tool_can_be_used(
 
     # Click on "Manage Cases"
     def handle_dialog():
-        qtbot.waitUntil(lambda: gui.findChild(ClosableDialog) is not None)
-        dialog = gui.findChild(ClosableDialog)
-        cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
-        assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
-
+        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
         # Open the create new cases tab
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
@@ -396,9 +399,7 @@ def test_that_the_manual_analysis_tool_works(
 
     # Open the manage cases dialog
     def handle_manage_dialog():
-        dialog = QApplication.activeWindow()
-        cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
-        assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
+        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
 
         # In the "create new case" tab, it should now contain "iter-1"
         cases_panel.setCurrentIndex(0)
@@ -455,8 +456,8 @@ def test_that_the_manual_analysis_tool_works(
     # The Run dialog opens, click show details and wait until done appears
     # then click it
     def use_rundialog():
-        qtbot.waitUntil(lambda: isinstance(QApplication.activeWindow(), RunDialog))
-        run_dialog = QApplication.activeWindow()
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
 
         qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 


### PR DESCRIPTION
**Issue**
Resolves #5045 


**Approach**
See commit messages

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
