### PR TITLE
Split up gui tests

### DIFF
--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -29,7 +29,7 @@ class Server(uvicorn.Server):
 
     async def startup(self, sockets: Optional[List[socket.socket]] = None) -> None:
         """Overridden startup that also sends connection information"""
-        await super().startup(sockets)  # type: ignore
+        await super().startup(sockets)
         if not self.started:
             return
         write_to_pipe(self.connection_info)

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -1,10 +1,20 @@
 import copy
+import fileinput
+import os.path
+import shutil
+import stat
 import time
 from datetime import datetime as dt
+from textwrap import dedent
+from typing import Tuple
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QComboBox, QMessageBox, QWidget
 
+from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.ensemble_evaluator.identifiers import CURRENT_MEMORY_USAGE, MAX_MEMORY_USAGE
 from ert.ensemble_evaluator.snapshot import (
     Job,
@@ -20,6 +30,183 @@ from ert.ensemble_evaluator.state import (
     REALIZATION_STATE_UNKNOWN,
     STEP_STATE_UNKNOWN,
 )
+from ert.gui.ertwidgets.caselist import AddRemoveWidget, CaseList
+from ert.gui.ertwidgets.closabledialog import ClosableDialog
+from ert.gui.ertwidgets.validateddialog import ValidatedDialog
+from ert.gui.main import GUILogHandler, _setup_main_window
+from ert.gui.simulation.run_dialog import RunDialog
+from ert.gui.simulation.simulation_panel import SimulationPanel
+from ert.gui.simulation.view import RealizationWidget
+from ert.gui.tools.manage_cases.case_init_configuration import (
+    CaseInitializationConfigurationPanel,
+)
+from ert.services import Storage
+from ert.shared.models import EnsembleExperiment, MultipleDataAssimilation
+
+
+def find_cases_dialog_and_panel(
+    gui, qtbot: QtBot
+) -> Tuple[ClosableDialog, CaseInitializationConfigurationPanel]:
+    qtbot.waitUntil(lambda: gui.findChild(ClosableDialog, "manage-cases") is not None)
+    dialog = gui.findChild(ClosableDialog, "manage-cases")
+    cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
+    assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
+    return (dialog, cases_panel)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.fixture(scope="module")
+def opened_main_window(source_root, tmpdir_factory):
+    with pytest.MonkeyPatch.context() as mp:
+        tmp_path = tmpdir_factory.mktemp("test-data")
+        shutil.copytree(
+            os.path.join(source_root, "test-data", "poly_example"),
+            tmp_path / "test_data",
+        )
+        mp.chdir(tmp_path / "test_data")
+        with fileinput.input("poly.ert", inplace=True) as fin:
+            for line in fin:
+                if "NUM_REALIZATIONS" in line:
+                    # Decrease the number of realizations to speed up the test,
+                    # if there is flakyness, this can be increased.
+                    print("NUM_REALIZATIONS 20", end="\n")
+                else:
+                    print(line, end="")
+            poly_case = EnKFMain(ErtConfig.from_file("poly.ert"))
+        args_mock = Mock()
+        args_mock.config = "poly.ert"
+
+        with Storage.init_service(
+            ert_config=args_mock.config,
+            project=os.path.abspath(poly_case.ert_config.ens_path),
+        ):
+            gui = _setup_main_window(poly_case, args_mock, GUILogHandler())
+            yield gui
+            gui.close()
+
+
+@pytest.mark.usefixtures("use_tmpdir, opened_main_window")
+@pytest.fixture(scope="module")
+def esmda_has_run(run_experiment):
+    # Runs a default ES-MDA run
+    run_experiment(MultipleDataAssimilation)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.fixture(scope="module")
+def run_experiment(request, opened_main_window):
+    def func(experiment_mode):
+        qtbot = QtBot(request)
+        gui = opened_main_window
+        try:
+            shutil.rmtree("poly_out")
+        except FileNotFoundError:
+            pass
+        # Select correct experiment in the simulation panel
+        simulation_panel = gui.findChild(SimulationPanel)
+        assert isinstance(simulation_panel, SimulationPanel)
+        simulation_mode_combo = simulation_panel.findChild(QComboBox)
+        assert isinstance(simulation_mode_combo, QComboBox)
+        simulation_mode_combo.setCurrentText(experiment_mode.name())
+
+        # Click start simulation and agree to the message
+        start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+
+        def handle_dialog():
+            message_box = gui.findChild(QMessageBox)
+            qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+        QTimer.singleShot(500, handle_dialog)
+
+        # The Run dialog opens, click show details and wait until done appears
+        # then click it
+        def use_rundialog():
+            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+            run_dialog = gui.findChild(RunDialog)
+
+            qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+
+            qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+            qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+
+            # Assert that the number of boxes in the detailed view is
+            # equal to the number of realizations
+            realization_widget = run_dialog._tab_widget.currentWidget()
+            assert isinstance(realization_widget, RealizationWidget)
+            list_model = realization_widget._real_view.model()
+            assert list_model.rowCount() == simulation_panel.ert.getEnsembleSize()
+
+            qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+        QTimer.singleShot(1000, use_rundialog)
+        qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+    return func
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.fixture(scope="module")
+def ensemble_experiment_has_run(opened_main_window, run_experiment, request):
+    gui = opened_main_window
+    qtbot = QtBot(request)
+
+    def handle_dialog():
+        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
+
+        # Open the create new cases tab
+        cases_panel.setCurrentIndex(0)
+        current_tab = cases_panel.currentWidget()
+        assert current_tab.objectName() == "create_new_case_tab"
+        create_widget = current_tab.findChild(AddRemoveWidget)
+        case_list = current_tab.findChild(CaseList)
+        assert isinstance(case_list, CaseList)
+
+        # Click add case and name it "iter-0"
+        def handle_add_dialog():
+            qtbot.waitUntil(lambda: current_tab.findChild(ValidatedDialog) is not None)
+            dialog = gui.findChild(ValidatedDialog)
+            dialog.param_name.setText("iter-0")
+            qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
+
+        QTimer.singleShot(1000, handle_add_dialog)
+        qtbot.mouseClick(create_widget.addButton, Qt.LeftButton)
+
+        dialog.close()
+
+    QTimer.singleShot(1000, handle_dialog)
+    manage_tool = gui.tools["Manage cases"]
+    manage_tool.trigger()
+
+    with open("poly_eval.py", "w", encoding="utf-8") as f:
+        f.write(
+            dedent(
+                """#!/usr/bin/env python
+import numpy as np
+import sys
+import json
+
+def _load_coeffs(filename):
+    with open(filename, encoding="utf-8") as f:
+        return json.load(f)
+
+def _evaluate(coeffs, x):
+    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+
+if __name__ == "__main__":
+    if np.random.random(1) > 0.5:
+        sys.exit(1)
+    coeffs = _load_coeffs("coeffs.json")
+    output = [_evaluate(coeffs, x) for x in range(10)]
+    with open("poly_0.out", "w", encoding="utf-8") as f:
+        f.write("\\n".join(map(str, output)))
+        """
+            )
+        )
+    os.chmod(
+        "poly_eval.py",
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    )
+    run_experiment(EnsembleExperiment)
 
 
 @pytest.fixture()

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -1,0 +1,136 @@
+import shutil
+
+import numpy as np
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QApplication, QComboBox, QMessageBox, QPushButton, QWidget
+
+from ert.gui.ertwidgets.caselist import CaseList
+from ert.gui.simulation.ensemble_experiment_panel import EnsembleExperimentPanel
+from ert.gui.simulation.run_dialog import RunDialog
+from ert.gui.simulation.simulation_panel import SimulationPanel
+from ert.shared.models import EnsembleExperiment
+
+from .conftest import find_cases_dialog_and_panel
+
+
+def test_that_the_manual_analysis_tool_works(
+    ensemble_experiment_has_run, opened_main_window, qtbot, run_experiment
+):
+    """This runs a full manual update workflow, first running ensemble experiment
+    where some of the realizations fail, then doing an update before running an
+    ensemble experiment again to calculate the forecast of the update.
+    """
+    gui = opened_main_window
+    analysis_tool = gui.tools["Run analysis"]
+
+    # Open the "Run analysis" tool in the main window after ensemble experiment has run
+    def handle_analysis_dialog():
+        dialog = analysis_tool._dialog
+
+        # Set target case to "iter-1"
+        run_panel = analysis_tool._run_widget
+        run_panel.target_case_text.setText("iter-1")
+
+        # Source case is "iter-0"
+        case_selector = run_panel.source_case_selector
+        assert case_selector.currentText() == "iter-0"
+
+        # Click on "Run" and click ok on the message box
+        def handle_dialog():
+            messagebox = QApplication.activeWindow()
+            assert isinstance(messagebox, QMessageBox)
+            ok_button = messagebox.button(QMessageBox.Ok)
+            qtbot.mouseClick(ok_button, Qt.LeftButton)
+
+        QTimer.singleShot(1000, handle_dialog)
+        qtbot.mouseClick(
+            dialog.findChild(QPushButton, name="Run"),
+            Qt.LeftButton,
+        )
+
+    QTimer.singleShot(2000, handle_analysis_dialog)
+    analysis_tool.trigger()
+
+    # Open the manage cases dialog
+    def handle_manage_dialog():
+        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
+
+        # In the "create new case" tab, it should now contain "iter-1"
+        cases_panel.setCurrentIndex(0)
+        current_tab = cases_panel.currentWidget()
+        assert current_tab.objectName() == "create_new_case_tab"
+        case_list = current_tab.findChild(CaseList)
+        assert isinstance(case_list, CaseList)
+        assert len(case_list._list.findItems("iter-1", Qt.MatchFlag.MatchExactly)) == 1
+        dialog.close()
+
+    QTimer.singleShot(1000, handle_manage_dialog)
+    manage_tool = gui.tools["Manage cases"]
+    manage_tool.trigger()
+
+    # Select correct experiment in the simulation panel
+    simulation_panel = gui.findChild(SimulationPanel)
+    simulation_mode_combo = simulation_panel.findChild(QComboBox)
+    simulation_settings = simulation_panel.findChild(EnsembleExperimentPanel)
+    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+    shutil.rmtree("poly_out")
+
+    current_select = 0
+    simulation_settings._case_selector.setCurrentIndex(current_select)
+    while simulation_settings._case_selector.currentText() != "iter-0":
+        current_select += 1
+        simulation_settings._case_selector.setCurrentIndex(current_select)
+
+    active_reals_string_len = len(
+        simulation_panel.getSimulationArguments().realizations
+    )
+    current_select = 0
+    simulation_settings._case_selector.setCurrentIndex(current_select)
+    while simulation_settings._case_selector.currentText() != "iter-1":
+        current_select += 1
+        simulation_settings._case_selector.setCurrentIndex(current_select)
+
+    # We have selected the updated case and because some realizations failed in the
+    # parent ensemble we expect the active realizations string to be longer as it
+    # needs to account for the missing realizations.
+    assert (
+        len(simulation_panel.getSimulationArguments().realizations)
+        > active_reals_string_len
+    )
+
+    # Click start simulation and agree to the message
+    start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+
+    def handle_dialog():
+        message_box = gui.findChild(QMessageBox)
+        qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+    QTimer.singleShot(500, handle_dialog)
+
+    # The Run dialog opens, click show details and wait until done appears
+    # then click it
+    def use_rundialog():
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
+
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+    QTimer.singleShot(1000, use_rundialog)
+    qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+    facade = simulation_panel.facade
+    df_prior = facade.load_all_gen_kw_data("iter-0")
+    df_posterior = facade.load_all_gen_kw_data("iter-1")
+
+    # We expect that ERT's update step lowers the
+    # generalized variance for the parameters.
+    assert (
+        0
+        < np.linalg.det(df_posterior.cov().to_numpy())
+        < np.linalg.det(df_prior.cov().to_numpy())
+    )

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -1,17 +1,9 @@
-import fileinput
-import os.path
-import shutil
-import stat
-from textwrap import dedent
-from typing import List, Tuple
-from unittest.mock import Mock
+import os
+from typing import List
 
-import numpy as np
 import pytest
-from pytestqt.qtbot import QtBot
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import (
-    QApplication,
     QComboBox,
     QMessageBox,
     QPushButton,
@@ -20,193 +12,18 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.gui.ertwidgets.analysismodulevariablespanel import AnalysisModuleVariablesPanel
 from ert.gui.ertwidgets.caselist import AddRemoveWidget, CaseList
 from ert.gui.ertwidgets.caseselector import CaseSelector
-from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.pathchooser import PathChooser
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
-from ert.gui.main import GUILogHandler, _setup_main_window
-from ert.gui.simulation.ensemble_experiment_panel import EnsembleExperimentPanel
-from ert.gui.simulation.run_dialog import RunDialog
-from ert.gui.simulation.simulation_panel import SimulationPanel
-from ert.gui.simulation.view import RealizationWidget
-from ert.gui.tools.manage_cases.case_init_configuration import (
-    CaseInitializationConfigurationPanel,
-)
 from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
-from ert.services import Storage
-from ert.shared.models import EnsembleExperiment, MultipleDataAssimilation
 
-
-def find_cases_dialog_and_panel(
-    gui, qtbot: QtBot
-) -> Tuple[ClosableDialog, CaseInitializationConfigurationPanel]:
-    qtbot.waitUntil(lambda: gui.findChild(ClosableDialog, "manage-cases") is not None)
-    dialog = gui.findChild(ClosableDialog, "manage-cases")
-    cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
-    assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
-    return (dialog, cases_panel)
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@pytest.fixture(scope="module")
-def opened_main_window(source_root, tmpdir_factory):
-    with pytest.MonkeyPatch.context() as mp:
-        tmp_path = tmpdir_factory.mktemp("test-data")
-        shutil.copytree(
-            os.path.join(source_root, "test-data", "poly_example"),
-            tmp_path / "test_data",
-        )
-        mp.chdir(tmp_path / "test_data")
-        with fileinput.input("poly.ert", inplace=True) as fin:
-            for line in fin:
-                if "NUM_REALIZATIONS" in line:
-                    # Decrease the number of realizations to speed up the test,
-                    # if there is flakyness, this can be increased.
-                    print("NUM_REALIZATIONS 20", end="\n")
-                else:
-                    print(line, end="")
-            poly_case = EnKFMain(ErtConfig.from_file("poly.ert"))
-        args_mock = Mock()
-        args_mock.config = "poly.ert"
-
-        with Storage.init_service(
-            ert_config=args_mock.config,
-            project=os.path.abspath(poly_case.ert_config.ens_path),
-        ):
-            gui = _setup_main_window(poly_case, args_mock, GUILogHandler())
-            yield gui
-            gui.close()
-
-
-@pytest.mark.usefixtures("use_tmpdir, opened_main_window")
-@pytest.fixture(scope="module")
-def esmda_has_run(run_experiment):
-    # Runs a default ES-MDA run
-    run_experiment(MultipleDataAssimilation)
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@pytest.fixture(scope="module")
-def run_experiment(request, opened_main_window):
-    def func(experiment_mode):
-        qtbot = QtBot(request)
-        gui = opened_main_window
-        try:
-            shutil.rmtree("poly_out")
-        except FileNotFoundError:
-            pass
-        # Select correct experiment in the simulation panel
-        simulation_panel = gui.findChild(SimulationPanel)
-        assert isinstance(simulation_panel, SimulationPanel)
-        simulation_mode_combo = simulation_panel.findChild(QComboBox)
-        assert isinstance(simulation_mode_combo, QComboBox)
-        simulation_mode_combo.setCurrentText(experiment_mode.name())
-
-        # Click start simulation and agree to the message
-        start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
-
-        def handle_dialog():
-            message_box = gui.findChild(QMessageBox)
-            qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
-
-        QTimer.singleShot(500, handle_dialog)
-
-        # The Run dialog opens, click show details and wait until done appears
-        # then click it
-        def use_rundialog():
-            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-            run_dialog = gui.findChild(RunDialog)
-
-            qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-
-            qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
-            qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-
-            # Assert that the number of boxes in the detailed view is
-            # equal to the number of realizations
-            realization_widget = run_dialog._tab_widget.currentWidget()
-            assert isinstance(realization_widget, RealizationWidget)
-            list_model = realization_widget._real_view.model()
-            assert list_model.rowCount() == simulation_panel.ert.getEnsembleSize()
-
-            qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-
-        QTimer.singleShot(1000, use_rundialog)
-        qtbot.mouseClick(start_simulation, Qt.LeftButton)
-
-    return func
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@pytest.fixture(scope="module")
-def ensemble_experiment_has_run(opened_main_window, run_experiment, request):
-    gui = opened_main_window
-    qtbot = QtBot(request)
-
-    def handle_dialog():
-        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
-
-        # Open the create new cases tab
-        cases_panel.setCurrentIndex(0)
-        current_tab = cases_panel.currentWidget()
-        assert current_tab.objectName() == "create_new_case_tab"
-        create_widget = current_tab.findChild(AddRemoveWidget)
-        case_list = current_tab.findChild(CaseList)
-        assert isinstance(case_list, CaseList)
-
-        # Click add case and name it "iter-0"
-        def handle_add_dialog():
-            qtbot.waitUntil(lambda: current_tab.findChild(ValidatedDialog) is not None)
-            dialog = gui.findChild(ValidatedDialog)
-            dialog.param_name.setText("iter-0")
-            qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
-
-        QTimer.singleShot(1000, handle_add_dialog)
-        qtbot.mouseClick(create_widget.addButton, Qt.LeftButton)
-
-        dialog.close()
-
-    QTimer.singleShot(1000, handle_dialog)
-    manage_tool = gui.tools["Manage cases"]
-    manage_tool.trigger()
-
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """#!/usr/bin/env python
-import numpy as np
-import sys
-import json
-
-def _load_coeffs(filename):
-    with open(filename, encoding="utf-8") as f:
-        return json.load(f)
-
-def _evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
-
-if __name__ == "__main__":
-    if np.random.random(1) > 0.5:
-        sys.exit(1)
-    coeffs = _load_coeffs("coeffs.json")
-    output = [_evaluate(coeffs, x) for x in range(10)]
-    with open("poly_0.out", "w", encoding="utf-8") as f:
-        f.write("\\n".join(map(str, output)))
-        """
-            )
-        )
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
-    )
-    run_experiment(EnsembleExperiment)
+from .conftest import find_cases_dialog_and_panel
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -358,129 +175,6 @@ def test_that_the_manage_cases_tool_can_be_used(
     QTimer.singleShot(1000, handle_dialog)
     manage_tool = gui.tools["Manage cases"]
     manage_tool.trigger()
-
-
-def test_that_the_manual_analysis_tool_works(
-    ensemble_experiment_has_run, opened_main_window, qtbot, run_experiment
-):
-    """This runs a full manual update workflow, first running ensemble experiment
-    where some of the realizations fail, then doing an update before running an
-    ensemble experiment again to calculate the forecast of the update.
-    """
-    gui = opened_main_window
-    analysis_tool = gui.tools["Run analysis"]
-
-    # Open the "Run analysis" tool in the main window after ensemble experiment has run
-    def handle_analysis_dialog():
-        dialog = analysis_tool._dialog
-
-        # Set target case to "iter-1"
-        run_panel = analysis_tool._run_widget
-        run_panel.target_case_text.setText("iter-1")
-
-        # Source case is "iter-0"
-        case_selector = run_panel.source_case_selector
-        assert case_selector.currentText() == "iter-0"
-
-        # Click on "Run" and click ok on the message box
-        def handle_dialog():
-            messagebox = QApplication.activeWindow()
-            assert isinstance(messagebox, QMessageBox)
-            ok_button = messagebox.button(QMessageBox.Ok)
-            qtbot.mouseClick(ok_button, Qt.LeftButton)
-
-        QTimer.singleShot(1000, handle_dialog)
-        qtbot.mouseClick(
-            dialog.findChild(QPushButton, name="Run"),
-            Qt.LeftButton,
-        )
-
-    QTimer.singleShot(2000, handle_analysis_dialog)
-    analysis_tool.trigger()
-
-    # Open the manage cases dialog
-    def handle_manage_dialog():
-        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
-
-        # In the "create new case" tab, it should now contain "iter-1"
-        cases_panel.setCurrentIndex(0)
-        current_tab = cases_panel.currentWidget()
-        assert current_tab.objectName() == "create_new_case_tab"
-        case_list = current_tab.findChild(CaseList)
-        assert isinstance(case_list, CaseList)
-        assert len(case_list._list.findItems("iter-1", Qt.MatchFlag.MatchExactly)) == 1
-        dialog.close()
-
-    QTimer.singleShot(1000, handle_manage_dialog)
-    manage_tool = gui.tools["Manage cases"]
-    manage_tool.trigger()
-
-    # Select correct experiment in the simulation panel
-    simulation_panel = gui.findChild(SimulationPanel)
-    simulation_mode_combo = simulation_panel.findChild(QComboBox)
-    simulation_settings = simulation_panel.findChild(EnsembleExperimentPanel)
-    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
-    shutil.rmtree("poly_out")
-
-    current_select = 0
-    simulation_settings._case_selector.setCurrentIndex(current_select)
-    while simulation_settings._case_selector.currentText() != "iter-0":
-        current_select += 1
-        simulation_settings._case_selector.setCurrentIndex(current_select)
-
-    active_reals_string_len = len(
-        simulation_panel.getSimulationArguments().realizations
-    )
-    current_select = 0
-    simulation_settings._case_selector.setCurrentIndex(current_select)
-    while simulation_settings._case_selector.currentText() != "iter-1":
-        current_select += 1
-        simulation_settings._case_selector.setCurrentIndex(current_select)
-
-    # We have selected the updated case and because some realizations failed in the
-    # parent ensemble we expect the active realizations string to be longer as it
-    # needs to account for the missing realizations.
-    assert (
-        len(simulation_panel.getSimulationArguments().realizations)
-        > active_reals_string_len
-    )
-
-    # Click start simulation and agree to the message
-    start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
-
-    def handle_dialog():
-        message_box = gui.findChild(QMessageBox)
-        qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
-
-    QTimer.singleShot(500, handle_dialog)
-
-    # The Run dialog opens, click show details and wait until done appears
-    # then click it
-    def use_rundialog():
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
-        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-
-        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-
-    QTimer.singleShot(1000, use_rundialog)
-    qtbot.mouseClick(start_simulation, Qt.LeftButton)
-
-    facade = simulation_panel.facade
-    df_prior = facade.load_all_gen_kw_data("iter-0")
-    df_posterior = facade.load_all_gen_kw_data("iter-1")
-
-    # We expect that ERT's update step lowers the
-    # generalized variance for the parameters.
-    assert (
-        0
-        < np.linalg.det(df_posterior.cov().to_numpy())
-        < np.linalg.det(df_prior.cov().to_numpy())
-    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
Because one test is running es-mda and the other
an ensemble experiment with failing realizations
the results could be hard to track. Split it into
two files.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
