### PR TITLE
Remove duplicate installation from documentation

### DIFF
--- a/docs/getting_started/setup.rst
+++ b/docs/getting_started/setup.rst
@@ -11,5 +11,8 @@ Then you can test the installation by running::
 
 If you get a message explaining how to use ERT, you are ready.
 
-If you don't have access to komodo, you might have another means of using it in your
-organisation. If not, you have to `build and install <https://github.com/equinor/ert>`_ it yourself.
+If not, you can install ert from PyPi into your own environment::
+
+    $ pip install ert
+
+If you want to build and install the latest development version, please see the `ERT Github page <https://github.com/equinor/ert>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,11 +35,6 @@ with model updates and uncertainty estimation. You can read more about the theor
 
    theory/index
 
-.. toctree::
-   :hidden:
-   :caption: Installation
-
-   installation/index
 
 .. This is commented out until the api is ready for public use
    .. toctree::

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,5 +1,0 @@
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   installation_guide

--- a/docs/installation/installation_guide.rst
+++ b/docs/installation/installation_guide.rst
@@ -1,8 +1,0 @@
-Installation guide (todo)
-=========================
-
-See installation guide on `Github <https://github.com/equinor/ert>`_.
-
-.. todo::
-   Detailed explanation how to install (link to github?)
-


### PR DESCRIPTION
**Issue**
Documentation has an installation guide marked with TODO. Setup already has a brief installation guide. This is probably leftover from when installing ERT was a longer process.

**Approach**
Remove the installation guide and update the setup page slightly.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
