### PR TITLE
Make config warning the only category shown in GUI

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -77,12 +77,10 @@ def run_gui(args: Namespace):
 def _log_difference_with_new_parser(args, ert_config):
     try:
         with warnings.catch_warnings(record=True) as silenced_warnings:
-            warnings.simplefilter("always")
-
             ert_config_new = ErtConfig.from_file(args.config, use_new_parser=True)
 
             for w in silenced_warnings:
-                logging.info(f"Parser warning: {w.message}")
+                logging.info(f"New Parser warning: {w.message}")
 
         if ert_config != ert_config_new:
             fields = dataclasses.fields(ert_config)

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -183,13 +183,13 @@ def _check_locale():
     current_locale = QLocale()
     decimal_point = str(current_locale.decimalPoint())
     if decimal_point != ".":
-        msg = f"""
-** WARNING: You are using a locale with decimalpoint: '{decimal_point}' - the ert application is
-written with the assumption that '.' is  used as decimalpoint, and chances
-are that something will break if you continue with this locale. It is highly
-recommended that you set the decimalpoint to '.' using one of the environment
-variables 'LANG', LC_ALL', or 'LC_NUMERIC' to either the 'C' locale or
-alternatively a locale which uses '.' as decimalpoint.\n"""  # noqa
+        msg = f"""You are using a locale with decimalpoint: '{decimal_point}'
+the ert application is written with the assumption that '.' is  used as
+decimalpoint, and chances are that something will break if you continue with
+this locale. It is highly recommended that you set the decimalpoint to '.'
+using one of the environment variables 'LANG', LC_ALL', or 'LC_NUMERIC' to
+either the 'C' locale or alternatively a locale which uses '.' as
+decimalpoint.\n"""  # noqa
         warnings.warn(msg, category=ConfigWarning)
 
 


### PR DESCRIPTION
We used to only show ConfigWarning in the GUI. Likely it is a good idea to not show all categories of warnings in the GUI as  dependencies may raise warnings that make no sense to the user. If we want to have a more general category of warning than `ConfigWarning` (say `ErtWarning`) that is supposed to end up in the GUI, then we should create that.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
