### PR TITLE
Make ErtPluginManager a singleton

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -40,7 +40,7 @@ from ert.gui.tools.workflows import WorkflowsTool
 from ert.libres_facade import LibresFacade
 from ert.namespace import Namespace
 from ert.services import StorageService
-from ert.shared.plugins.plugin_manager import ErtPluginManager
+from ert.shared.plugins.plugin_manager import ert_plugin_manager
 from ert.storage import EnsembleAccessor, StorageReader, open_storage
 
 
@@ -221,7 +221,7 @@ def _setup_suggester(errors, warning_msgs, suggestions, ert_window=None):
 
     help_label = QLabel("Help:")
     help_buttons_layout.addWidget(help_label)
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     help_links = pm.get_help_links()
 
     for menu_label, link in help_links.items():

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
 
 from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertnotifier import ErtNotifier
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins import ert_plugin_manager
 
 
 class ErtMainWindow(QMainWindow):
@@ -80,7 +80,7 @@ class ErtMainWindow(QMainWindow):
         self.__view_menu = self.menuBar().addMenu("&View")
         self.__help_menu = self.menuBar().addMenu("&Help")
 
-        pm = ErtPluginManager()
+        pm = ert_plugin_manager()
         help_links = pm.get_help_links()
 
         for menu_label, link in help_links.items():

--- a/src/ert/shared/_doc_utils/ert_jobs.py
+++ b/src/ert/shared/_doc_utils/ert_jobs.py
@@ -5,7 +5,7 @@ from docutils import nodes
 from sphinx.util import nested_parse_with_titles
 from sphinx.util.docutils import SphinxDirective
 
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins import ert_plugin_manager
 
 
 class _ForwardModelDocumentation:
@@ -235,7 +235,7 @@ def _create_section_with_title(section_id, title):
 
 
 class ErtForwardModelDocumentation(_ErtDocumentation):
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     _JOBS = pm.get_documentation_for_jobs()
     _TITLE = "Forward models"
     _SECTION_ID = "ert-forward-models"
@@ -249,7 +249,7 @@ class ErtForwardModelDocumentation(_ErtDocumentation):
 
 
 class ErtWorkflowDocumentation(_ErtDocumentation):
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     _JOBS = pm.get_documentation_for_workflows()
     _TITLE = "Workflow jobs"
     _SECTION_ID = "ert-workflow-jobs"

--- a/src/ert/shared/plugins/__init__.py
+++ b/src/ert/shared/plugins/__init__.py
@@ -1,3 +1,3 @@
-from .plugin_manager import ErtPluginContext, ErtPluginManager
+from .plugin_manager import ErtPluginContext, ert_plugin_manager
 
-__all__ = ["ErtPluginContext", "ErtPluginManager"]
+__all__ = ["ErtPluginContext", "ert_plugin_manager"]

--- a/tests/unit_tests/all/plugins/test_export_misfit.py
+++ b/tests/unit_tests/all/plugins/test_export_misfit.py
@@ -5,7 +5,7 @@ from ert.exceptions import StorageError
 from ert.shared.hook_implementations.workflows.export_misfit_data import (
     ExportMisfitDataJob,
 )
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins import ert_plugin_manager
 
 
 def test_export_misfit(snake_oil_case_storage, snake_oil_default_storage, snapshot):
@@ -25,5 +25,5 @@ def test_export_misfit_no_responses_in_storage(poly_case, new_ensemble):
 
 
 def test_export_misfit_data_job_is_loaded():
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     assert "EXPORT_MISFIT_DATA" in pm.get_installable_workflow_jobs()

--- a/tests/unit_tests/all/plugins/test_export_runpath.py
+++ b/tests/unit_tests/all/plugins/test_export_runpath.py
@@ -6,7 +6,7 @@ import pytest
 from ert._c_wrappers.enkf import EnKFMain
 from ert._c_wrappers.enkf.runpaths import Runpaths
 from ert.shared.hook_implementations.workflows.export_runpath import ExportRunpathJob
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins import ert_plugin_manager
 from ert.storage import open_storage
 
 
@@ -91,5 +91,5 @@ def test_export_runpath_bad_arguments(writing_setup):
 
 
 def test_export_runpath_job_is_loaded():
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     assert "EXPORT_RUNPATH" in pm.get_installable_workflow_jobs().keys()

--- a/tests/unit_tests/all/plugins/test_parameter_disable.py
+++ b/tests/unit_tests/all/plugins/test_parameter_disable.py
@@ -6,7 +6,7 @@ from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.shared.hook_implementations.workflows.disable_parameters import (
     DisableParametersUpdate,
 )
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins import ert_plugin_manager
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_parse_comma_list(tmpdir, monkeypatch, input_string, expected):
 
 
 def test_disable_parameters_is_loaded():
-    pm = ErtPluginManager()
+    pm = ert_plugin_manager()
     assert "DISABLE_PARAMETERS" in pm.get_installable_workflow_jobs()
 
 

--- a/tests/unit_tests/all/plugins/test_plugin_context.py
+++ b/tests/unit_tests/all/plugins/test_plugin_context.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 from ert.shared.plugins import ErtPluginContext
+from ert.shared.plugins.plugin_manager import _ErtPluginManager
 from tests.unit_tests.all.plugins import dummy_plugins
 
 env_vars = [
@@ -16,10 +17,16 @@ env_vars = [
 ]
 
 
+def plugin_context(plugins):
+    ctx = ErtPluginContext()
+    ctx.plugin_manager = _ErtPluginManager(plugins)
+    return ctx
+
+
 def test_no_plugins(monkeypatch):
     # pylint: disable=pointless-statement
     monkeypatch.delenv("ERT_SITE_CONFIG", raising=False)
-    with ErtPluginContext(plugins=[]) as c:
+    with plugin_context(plugins=[]) as c:
         with pytest.raises(KeyError):
             os.environ["ECL100_SITE_CONFIG"]
         with pytest.raises(KeyError):
@@ -46,7 +53,7 @@ def test_with_plugins(monkeypatch):
     # We are comparing two function calls, both of which generate a tmpdir,
     # this makes sure that the same tmpdir is called on both occasions.
     monkeypatch.setattr(tempfile, "mkdtemp", Mock(return_value=tempfile.mkdtemp()))
-    with ErtPluginContext(plugins=[dummy_plugins]) as c:
+    with plugin_context(plugins=[dummy_plugins]) as c:
         with pytest.raises(KeyError):
             os.environ["ECL100_SITE_CONFIG"]
         with pytest.raises(KeyError):
@@ -71,7 +78,7 @@ def test_already_set(monkeypatch):
     for var in env_vars:
         monkeypatch.setenv(var, "TEST")
 
-    with ErtPluginContext(plugins=[dummy_plugins]):
+    with plugin_context(plugins=[dummy_plugins]):
         for var in env_vars:
             assert os.environ[var] == "TEST"
 

--- a/tests/unit_tests/all/plugins/test_plugin_manager.py
+++ b/tests/unit_tests/all/plugins/test_plugin_manager.py
@@ -3,12 +3,12 @@ import tempfile
 from unittest.mock import Mock
 
 import ert.shared.hook_implementations
-from ert.shared.plugins import ErtPluginManager
+from ert.shared.plugins.plugin_manager import _ErtPluginManager
 from tests.unit_tests.all.plugins import dummy_plugins
 
 
 def test_no_plugins():
-    pm = ErtPluginManager(plugins=[ert.shared.hook_implementations])
+    pm = _ErtPluginManager(plugins=[ert.shared.hook_implementations])
     assert pm.get_help_links() == {"GitHub page": "https://github.com/equinor/ert"}
     assert pm.get_flow_config_path() is None
     assert pm.get_ecl100_config_path() is None
@@ -27,7 +27,7 @@ def test_no_plugins():
 
 
 def test_with_plugins():
-    pm = ErtPluginManager(plugins=[ert.shared.hook_implementations, dummy_plugins])
+    pm = _ErtPluginManager(plugins=[ert.shared.hook_implementations, dummy_plugins])
     assert pm.get_help_links() == {
         "GitHub page": "https://github.com/equinor/ert",
         "test": "test",
@@ -55,7 +55,7 @@ def test_with_plugins():
 
 
 def test_job_documentation():
-    pm = ErtPluginManager(plugins=[dummy_plugins])
+    pm = _ErtPluginManager(plugins=[dummy_plugins])
     expected = {
         "job1": {
             "config_file": "/dummy/path/job1",
@@ -82,13 +82,13 @@ def test_workflows_merge(monkeypatch, tmpdir):
     }
     tempfile_mock = Mock(return_value=tmpdir)
     monkeypatch.setattr(tempfile, "mkdtemp", tempfile_mock)
-    pm = ErtPluginManager(plugins=[dummy_plugins])
+    pm = _ErtPluginManager(plugins=[dummy_plugins])
     result = pm.get_installable_workflow_jobs()
     assert result == expected_result
 
 
 def test_workflows_merge_duplicate(caplog):
-    pm = ErtPluginManager(plugins=[dummy_plugins])
+    pm = _ErtPluginManager(plugins=[dummy_plugins])
 
     dict_1 = {"some_job": "/a/path"}
     dict_2 = {"some_job": "/a/path"}
@@ -106,7 +106,7 @@ def test_workflows_merge_duplicate(caplog):
 
 def test_add_logging_handle(tmpdir):
     with tmpdir.as_cwd():
-        pm = ErtPluginManager(plugins=[dummy_plugins])
+        pm = _ErtPluginManager(plugins=[dummy_plugins])
         pm.add_logging_handle_to_root(logging.getLogger())
         logging.critical("I should write this to spam.log")
         with open("spam.log", encoding="utf-8") as fin:


### PR DESCRIPTION
This is to avoid loading plugins more than once which is a slow operation

Generally, ErtPluginManager should be consider private to ert, but is used in an semeio test and exposed through ert.compat. 
Here are the PR's removing that usage:
- https://github.com/equinor/semeio/pull/502
- https://github.com/equinor/ert-compat/pull/6

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
