### PR TITLE
For several config errors, show more simultaneously in the "Some problems detected" window 

### DIFF
--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -75,9 +75,7 @@ class ConfigValidationError(ValueError):
 class CombinedConfigError(ConfigValidationError):
     def __init__(
         self,
-        errors: Optional[
-            List[Union[ConfigValidationError, "CombinedConfigError"]]
-        ] = None,
+        errors: Optional[List[ConfigValidationError]] = None,
     ):
         self.errors = []
 
@@ -90,7 +88,7 @@ class CombinedConfigError(ConfigValidationError):
     def is_empty(self):
         return len(self.errors) == 0
 
-    def add_error(self, error: Union[ConfigValidationError, "CombinedConfigError"]):
+    def add_error(self, error: ConfigValidationError):
         if isinstance(error, CombinedConfigError):
             self.errors.append(*error.errors)
         else:

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -90,14 +90,14 @@ class CombinedConfigError(ConfigValidationError):
 
     def add_error(self, error: ConfigValidationError):
         if isinstance(error, CombinedConfigError):
-            self.errors.append(*error.errors)
+            self.errors += error.errors
         else:
             self.errors.append(error)
 
     def get_error_messages(self):
         all_messages = []
         for e in self.errors:
-            all_messages.append(*e.get_error_messages())
+            all_messages += e.get_error_messages()
 
         return all_messages
 

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -90,6 +90,9 @@ class CombinedConfigError(ConfigValidationError):
 
     def add_error(self, error: ConfigValidationError):
         if isinstance(error, CombinedConfigError):
+            if error == self:
+                raise ValueError("Cannot add a combined configuration error to itself")
+
             self.errors += error.errors
         else:
             self.errors.append(error)

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -16,15 +16,14 @@ if TYPE_CHECKING:
 
 class ObservationConfigError(ConfigValidationError):
     def __init__(self, errors: str, config_file: Optional[str] = None) -> None:
-        self.config_file = config_file
-        self.errors = errors
         super().__init__(
-            (
-                f"Parsing observations config file `{self.config_file}` "
-                f"resulted in the errors: {self.errors}"
+            errors=(
+                f"Parsing observations config file `{config_file}` "
+                f"resulted in the errors: {errors}"
             )
-            if self.config_file
-            else f"{self.errors}"
+            if config_file
+            else f"{errors}",
+            config_file=config_file,
         )
 
 

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -595,7 +595,9 @@ class ErtConfig:
                 )
 
         for hook_name, mode_name in hook_workflow_info:
-            if mode_name not in [runtime.name for runtime in HookRuntime.enums()]:
+            try:
+                run_mode = HookRuntime.from_string(mode_name)
+            except ValueError:
                 combined_error.add_error(
                     ConfigValidationError(
                         errors=f"Run mode {mode_name!r} not supported for Hook "
@@ -604,7 +606,9 @@ class ErtConfig:
                 )
                 continue
 
-            if hook_name not in workflows:
+            try:
+                workflow = workflows[hook_name]
+            except KeyError:
                 combined_error.add_error(
                     ConfigValidationError(
                         errors=f"Cannot setup hook for non-existing jo"
@@ -613,9 +617,7 @@ class ErtConfig:
                 )
                 continue
 
-            hooked_workflows[HookRuntime.from_string(mode_name)].append(
-                workflows[hook_name]
-            )
+            hooked_workflows[run_mode].append(workflow)
 
         if not combined_error.is_empty():
             raise combined_error

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -394,6 +394,7 @@ class ErtConfig:
                             config_file=config_file,
                         )
                     )
+                    continue
 
             try:
                 job.validate_args(substitution_list)

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -612,8 +612,8 @@ class ErtConfig:
             except KeyError:
                 combined_error.add_error(
                     ConfigValidationError(
-                        errors=f"Cannot setup hook for non-existing jo"
-                        f"b name {hook_name!r}"
+                        errors=f"Cannot setup hook for non-existing workflow named "
+                        f"{hook_name!r}"
                     )
                 )
                 continue

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -261,11 +261,11 @@ class ErtConfig:
     def _validate_queue_option_max_running(cls, config_path, config_dict):
         combined_error = CombinedConfigError()
 
-        for _, option_name, *values in config_dict.get("QUEUE_OPTION", []):
+        for queue_name, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             if option_name == "MAX_RUNNING" and int(*values) < 0:
                 combined_error.add_error(
                     ConfigValidationError(
-                        errors=f"QUEUE_OPTION MAX_RUNNING is negative: "
+                        errors=f"QUEUE_OPTION {queue_name} MAX_RUNNING is negative: "
                         f"{str(*values)!r}",
                     )
                 )

--- a/src/ert/_c_wrappers/job_queue/workflow.py
+++ b/src/ert/_c_wrappers/job_queue/workflow.py
@@ -5,6 +5,7 @@ from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ert._c_wrappers.config import ConfigParser, ConfigValidationError, UnrecognizedEnum
+from ert._c_wrappers.config.config_parser import CombinedConfigError
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain
@@ -68,6 +69,9 @@ class Workflow:
             content = parser.parse(
                 to_compile, unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_ERROR
             )
+        except CombinedConfigError as err:
+            err.config_file = src_file
+            raise err from None
         except ConfigValidationError as err:
             err.config_file = src_file
             raise err from None

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -129,7 +129,7 @@ def _start_initial_gui_window(
         ]
 
     except ConfigValidationError as error:
-        error_messages.append(str(error))
+        error_messages += error.get_error_messages()
         logger.info("Error in config file shown in gui: '%s'", str(error))
         return (
             _setup_suggester(

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -174,7 +174,7 @@ def test_that_queue_config_content_negative_value_invalid():
         fh.write(test_config_contents)
     with pytest.raises(
         expected_exception=ConfigValidationError,
-        match="QUEUE_OPTION MAX_RUNNING is negative",
+        match="QUEUE_OPTION LOCAL MAX_RUNNING is negative",
     ):
         ErtConfig.from_file(test_config_file_name)
 
@@ -190,7 +190,7 @@ def test_that_queue_config_dict_negative_value_invalid(
 
     with pytest.raises(
         expected_exception=ConfigValidationError,
-        match="QUEUE_OPTION MAX_RUNNING is negative",
+        match="QUEUE_OPTION LSF MAX_RUNNING is negative",
     ):
         ErtConfig.from_dict(config_dict)
 

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -60,10 +60,6 @@ def test_add_combined_config_error_to_itself_raises_error():
         combined_error.add_error(combined_error)
 
 
-def test_add_config_error_to_combined_config_error():
-    pass
-
-
 def test_bad_user_config_file_error_message(tmp_path):
     (tmp_path / "test.ert").write_text("NUM_REL 10\n")
 

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -12,6 +12,7 @@ from hypothesis import assume, given
 from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import ErtConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
+from ert._c_wrappers.util import SubstitutionList
 
 from .config_dict_generator import config_generators
 
@@ -370,7 +371,22 @@ def test_that_unknown_hooked_job_gives_config_validation_error():
         ConfigValidationError,
         match="Cannot setup hook for non-existing job name 'NO_SUCH_JOB'",
     ):
-        _ = ErtConfig.from_file(test_config_file_name)
+        ErtConfig.from_file(test_config_file_name)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_unknown_run_mode_gives_config_validation_error():
+    content_dict = {
+        "HOOK_WORKFLOW": [["MAKE_DIRECTORY", "PRE_SIMULATIONnn"]],
+    }
+
+    substitution_list = SubstitutionList.from_dict({})
+
+    with pytest.raises(
+        ConfigValidationError,
+        match="Run mode .* not supported for Hook Workflow",
+    ):
+        _ = ErtConfig._workflows_from_dict(content_dict, substitution_list)
 
 
 @pytest.mark.usefixtures("set_site_config")

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -407,7 +407,7 @@ def test_that_unknown_hooked_job_gives_config_validation_error():
 
     with pytest.raises(
         ConfigValidationError,
-        match="Cannot setup hook for non-existing job name 'NO_SUCH_JOB'",
+        match=r".* non-existing workflow .* 'NO_SUCH_JOB'",
     ):
         ErtConfig.from_file(test_config_file_name)
 


### PR DESCRIPTION
**Issue**
Previously targeted towards 5099

![image](https://user-images.githubusercontent.com/32731672/227515082-406d693b-7f1a-44e7-b82c-dcb0130cdf7e.png)


**Approach**
Base idea: Each ConfigValidationError can store information about several error, and most errors should be pinpointed to a text segment in the config file.

Motivation & planned future usage:
Validation errors are caught inside a try-except, and combined so that there is a "top-level" error with all the future error information. This still lets us have local control over error handling and smoothly transition into a consolidated error handling for the ert config parsing.

First step: Introduce `errors_list` field to ConfigValidationError, which can be made use of gradually.

Example usage (with errors)
```python
errors: [ConfigValidationError] = []
for items in some_list:
   if item.fail(): 
      errors.append(
         ConfigValidationError(info=ErrorInfo(line, end_line, column, end_column, message="",data={})
      )
...
# ...gathering up more errors

raise ConfigValidationError.combined(errors)
```

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
