### PR TITLE
Reuse plugin manager rather than create new

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -39,11 +39,11 @@ from ert.shared.ide.keywords.definitions import (
     RangeStringArgument,
 )
 from ert.shared.models.multiple_data_assimilation import MultipleDataAssimilation
-from ert.shared.plugins.plugin_manager import ErtPluginContext
+from ert.shared.plugins.plugin_manager import ErtPluginContext, ErtPluginManager
 from ert.shared.storage.command import add_parser_options as ert_api_add_parser_options
 
 
-def run_ert_storage(args: Namespace) -> None:
+def run_ert_storage(args: Namespace, _: Optional[ErtPluginManager] = None) -> None:
     kwargs = {"ert_config": args.config, "verbose": True}
 
     if args.database_url is not None:
@@ -53,7 +53,7 @@ def run_ert_storage(args: Namespace) -> None:
         server.wait()
 
 
-def run_webviz_ert(args: Namespace) -> None:
+def run_webviz_ert(args: Namespace, _: Optional[ErtPluginManager] = None) -> None:
     try:
         # pylint: disable=unused-import,import-outside-toplevel
         import webviz_ert  # type: ignore  # noqa
@@ -202,11 +202,11 @@ def range_limited_int(user_input: str) -> int:
     raise ArgumentTypeError("Range must be in range 1 - 99")
 
 
-def run_gui_wrapper(args: Namespace) -> None:
+def run_gui_wrapper(args: Namespace, ert_plugin_manager: ErtPluginManager) -> None:
     # pylint: disable=import-outside-toplevel
     from ert.gui.main import run_gui
 
-    run_gui(args)
+    run_gui(args, ert_plugin_manager)
 
 
 # pylint: disable=too-many-statements
@@ -577,7 +577,7 @@ def main() -> None:
                     raise NotImplementedError(
                         f"experiment-server can only run '{ENSEMBLE_EXPERIMENT_MODE}'"
                     )
-            args.func(args)
+            args.func(args, context.plugin_manager)
     except (ErtCliError, ErtTimeoutError) as err:
         logger.exception(str(err))
         sys.exit(str(err))

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -36,7 +36,7 @@ class ErtTimeoutError(Exception):
     pass
 
 
-def run_cli(args):
+def run_cli(args, _=None):
     ert_config = ErtConfig.from_file(args.config)
     try:
         with warnings.catch_warnings(record=True) as silenced_warnings:

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -1,5 +1,6 @@
 import functools
 import webbrowser
+from typing import Optional
 
 from qtpy.QtCore import QSettings, Qt, Signal
 from qtpy.QtWidgets import (
@@ -19,7 +20,7 @@ from ert.shared.plugins import ErtPluginManager
 class ErtMainWindow(QMainWindow):
     close_signal = Signal()
 
-    def __init__(self, config_file):
+    def __init__(self, config_file, plugin_manager: Optional[ErtPluginManager] = None):
         QMainWindow.__init__(self)
         self.notifier = ErtNotifier(config_file)
         self.tools = {}
@@ -27,6 +28,7 @@ class ErtMainWindow(QMainWindow):
         self.resize(300, 700)
         self.setWindowTitle(f"ERT - {config_file}")
 
+        self.plugin_manager = plugin_manager
         self.__main_widget = None
 
         self.central_widget = QWidget()
@@ -80,8 +82,7 @@ class ErtMainWindow(QMainWindow):
         self.__view_menu = self.menuBar().addMenu("&View")
         self.__help_menu = self.menuBar().addMenu("&Help")
 
-        pm = ErtPluginManager()
-        help_links = pm.get_help_links()
+        help_links = self.plugin_manager.get_help_links() if self.plugin_manager else {}
 
         for menu_label, link in help_links.items():
             help_link_item = self.__help_menu.addAction(menu_label)

--- a/src/ert/namespace.py
+++ b/src/ert/namespace.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from typing import Callable
+from typing import Callable, Optional
+
+from ert.shared.plugins.plugin_manager import ErtPluginManager
 
 
 class Namespace(argparse.Namespace):
@@ -15,4 +17,4 @@ class Namespace(argparse.Namespace):
     verbose: bool
     experimental_mode: bool
     logdir: str
-    func: Callable[[Namespace], None]
+    func: Callable[[Namespace, Optional[ErtPluginManager]], None]

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -16,6 +16,7 @@ from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.services import StorageService
+from ert.shared.plugins.plugin_manager import ErtPluginManager
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -300,7 +301,9 @@ def test_help_buttons_in_suggester_dialog(tmp_path, qtbot):
     args = Mock()
     args.config = str(config_file)
     with add_gui_log_handler() as log_handler:
-        gui, _, _ = ert.gui.main._start_initial_gui_window(args, log_handler)
+        gui, _, _ = ert.gui.main._start_initial_gui_window(
+            args, log_handler, ErtPluginManager()
+        )
         assert gui.windowTitle() == "Some problems detected"
 
         about_button = gui.findChild(QWidget, name="about_button")


### PR DESCRIPTION
initializing the plugin manager is a heavy operation and so should just be done once.



**Approach**
The first attempt, which was a bit cleaner, was to use a singleton for ErtPluginManager. However, ert.shared.plugins is used by all plugins and changing its API is breaking. Therefore, the change here is made by passing the ErtPluginManager to the main functions.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
