### PR TITLE
Mute test output from job_runner_performance

### DIFF
--- a/tests/performance_tests/test_job_runner_performance.py
+++ b/tests/performance_tests/test_job_runner_performance.py
@@ -21,5 +21,6 @@ def test_job_runner_startup_overhead():
                 "-m",
                 "_ert_job_runner.job_dispatch",
                 "-h",
-            )
+            ),
+            stdout=subprocess.DEVNULL,
         )


### PR DESCRIPTION
Redirecting stdout to devnull removes  ca 100 lines of output while running tests

**Issue**
Resolves hard-to-read-test-output

**Approach**
Redirect repeated output to /dev/null.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
