### PR TITLE
Separate out EnkfObs from EnKFMain

### DIFF
--- a/src/ert/_c_wrappers/enkf/__init__.py
+++ b/src/ert/_c_wrappers/enkf/__init__.py
@@ -11,8 +11,8 @@ from .config import (
     SummaryConfig,
 )
 from .config_keys import ConfigKeys
-from .enkf_main import EnKFMain, ObservationConfigError
-from .enkf_obs import EnkfObs
+from .enkf_main import EnKFMain
+from .enkf_obs import EnkfObs, ObservationConfigError
 from .ensemble_config import EnsembleConfig
 from .enums import (
     ActiveMode,

--- a/tests/test_config_parsing/test_num_cpu.py
+++ b/tests/test_config_parsing/test_num_cpu.py
@@ -33,7 +33,7 @@ def test_num_cpu_from_config_preferred():
         ConfigKeys.RUNPATH_FILE: os.path.join(os.getcwd(), "runpath.file"),
     }
     ert_config = ErtConfig.from_dict(config_dict)
-    enkf_main: EnKFMain = EnKFMain(ert_config)
+    enkf_main = EnKFMain(ert_config)
     assert ert_config.preferred_num_cpu() == config_num_cpu
     assert enkf_main.get_num_cpu() == config_num_cpu
 
@@ -56,6 +56,6 @@ PARALLEL
         ConfigKeys.RUNPATH_FILE: os.path.join(os.getcwd(), "runpath.file"),
     }
     ert_config = ErtConfig.from_dict(config_dict)
-    enkf_main: EnKFMain = EnKFMain(ert_config)
+    enkf_main = EnKFMain(ert_config)
     assert enkf_main.resConfig().preferred_num_cpu() == data_file_num_cpu
     assert enkf_main.get_num_cpu() == data_file_num_cpu

--- a/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
+++ b/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
@@ -572,8 +572,8 @@ if __name__ == "__main__":
         )
 
         run_cli(parsed)
-        ert = EnKFMain(ErtConfig.from_file("config.ert"))
-        with open_storage(ert.resConfig().ens_path) as storage:
+        facade = LibresFacade.from_config_file("config.ert")
+        with open_storage(facade.enspath) as storage:
             prior = storage.get_ensemble_by_name("prior")
             posterior = storage.get_ensemble_by_name("smoother_update")
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_load_forward_model.py
@@ -51,9 +51,7 @@ def test_load_inconsistent_time_map_summary(caplog):
                 continue
             print(line, end="")
 
-    ert_config = ErtConfig.from_file("snake_oil.ert")
-    ert = EnKFMain(ert_config)
-    facade = LibresFacade(ert)
+    facade = LibresFacade.from_config_file("snake_oil.ert")
     realisation_number = 0
     storage = open_storage(facade.enspath, mode="w")
     ensemble = storage.get_ensemble_by_name("default_0")
@@ -94,15 +92,13 @@ def test_load_forward_model(snake_oil_default_storage):
                 continue
             print(line, end="")
 
-    ert_config = ErtConfig.from_file("snake_oil.ert")
-    ert = EnKFMain(ert_config)
-    facade = LibresFacade(ert)
+    facade = LibresFacade.from_config_file("snake_oil.ert")
     realisation_number = 0
 
     realizations = [False] * facade.get_ensemble_size()
     realizations[realisation_number] = True
 
-    with open_storage(ert_config.ens_path, mode="w") as storage:
+    with open_storage(facade.enspath, mode="w") as storage:
         # 'load_from_forward_model' requires the ensemble to be writeable...
         default = storage.get_ensemble_by_name("default_0")
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import ExitStack as does_not_raise
 from datetime import datetime
 from textwrap import dedent
@@ -6,13 +5,8 @@ from textwrap import dedent
 import pytest
 from ecl.summary import EclSum
 
-from ert._c_wrappers.enkf import (
-    ActiveList,
-    EnKFMain,
-    ErtConfig,
-    ObservationConfigError,
-    SummaryObservation,
-)
+from ert import LibresFacade
+from ert._c_wrappers.enkf import ActiveList, ObservationConfigError, SummaryObservation
 
 
 def test_create():
@@ -98,8 +92,6 @@ def test_that_loading_summary_obs_with_days_is_within_tolerance(
         # We create a reference case
         run_sim(datetime(2014, 9, 10))
 
-        ert_config = ErtConfig.from_file("config.ert")
-        os.chdir(ert_config.config_path)
         with expectation:
-            ert = EnKFMain(ert_config)
-            assert ert.getObservations().hasKey("FOPR_1")
+            facade = LibresFacade.from_config_file("config.ert")
+            assert facade.get_observations().hasKey("FOPR_1")

--- a/tests/unit_tests/data/test_integration_data.py
+++ b/tests/unit_tests/data/test_integration_data.py
@@ -6,7 +6,6 @@ import time
 import numpy as np
 import pytest
 
-from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.data import MeasuredData, loader
 from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
@@ -74,12 +73,9 @@ def test_summary_obs_runtime(create_measured_data):
     with obs_file.open(mode="a") as fin:
         fin.write(create_summary_observation())
 
-    ert_config = ErtConfig.from_file("snake_oil.ert")
-    ert = EnKFMain(ert_config)
+    facade = LibresFacade.from_config_file("snake_oil.ert")
 
-    facade = LibresFacade(ert)
-
-    storage = open_storage(ert_config.ens_path)
+    storage = open_storage(facade.enspath)
     ensemble = storage.get_ensemble_by_name("default_0")
     start_time = time.time()
     foprh = MeasuredData(
@@ -117,11 +113,8 @@ def test_summary_obs_last_entry(formatted_date):
             "};\n"
         )
 
-    ert_config = ErtConfig.from_file("snake_oil.ert")
-    ert = EnKFMain(ert_config)
-
-    facade = LibresFacade(ert)
-    storage = open_storage(ert_config.ens_path)
+    facade = LibresFacade.from_config_file("snake_oil.ert")
+    storage = open_storage(facade.enspath)
     ensemble = storage.get_ensemble_by_name("default_0")
 
     foprh = MeasuredData(facade, ensemble, ["LAST_DATE"])
@@ -138,11 +131,8 @@ def test_gen_obs_runtime(snapshot, create_measured_data):
     with obs_file.open(mode="a") as fin:
         fin.write(create_general_observation())
 
-    ert_config = ErtConfig.from_file("snake_oil.ert")
-    ert = EnKFMain(ert_config)
-
-    facade = LibresFacade(ert)
-    storage = open_storage(ert_config.ens_path)
+    facade = LibresFacade.from_config_file("snake_oil.ert")
+    storage = open_storage(facade.enspath)
     ensemble = storage.get_ensemble_by_name("default_0")
 
     df = MeasuredData(


### PR DESCRIPTION
As a first step in creating tests for the observations parsing, we need to separate out the parsing from `EnKFMain.__init__`


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
