### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -55,7 +55,7 @@ Keyword name                                                            Required
 :ref:`LOAD_WORKFLOW_JOB <load_workflow_job>`                            NO                                                                      Load a workflow job into ERT
 :ref:`LICENSE_PATH <license_path>`                                      NO                                                                      A path where ert-licenses to e.g. RMS are stored
 :ref:`MAX_RUNTIME <max_runtime>`                                        NO                                      0                               Set the maximum runtime in seconds for a realization (0 means no runtime limit)
-:ref:`MAX_SUBMIT <max_submit>`                                          NO                                      2                               How many times should the queue system retry a simulation
+:ref:`MAX_SUBMIT <max_submit>`                                          NO                                      2                               How many times the queue system should retry a simulation
 :ref:`MIN_REALIZATIONS <min_realizations>`                              NO                                      0                               Set the number of minimum realizations that has to succeed in order for the run to continue (0 means identical to NUM_REALIZATIONS - all must pass).
 :ref:`NUM_CPU <num_cpu>`                                                NO                                      1                               Set the number of CPUs. Intepretation varies depending on context
 :ref:`NUM_REALIZATIONS <num_realizations>`                              YES                                                                     Set the number of reservoir realizations to use
@@ -1369,7 +1369,7 @@ to load, select and modify the analysis modules are documented here.
 .. _max_submit:
 .. topic:: MAX_SUBMIT
 
-        How many times should the queue system retry a simulation.
+        How many times the queue system should retry a simulation.
                 Default is 2.
 
 

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -121,7 +121,7 @@ class JobQueue(BaseCClass):
     def __init__(self, driver, max_submit=2, size=0):
         """
         Short doc...
-        The @max_submit argument says how many times the job be submitted
+        The @max_submit argument says how many times the job should be submitted
         (including a failure)
               max_submit = 2: means that we can submit job once more
         The @size argument is used to say how many jobs the queue will

--- a/test-data/snake_oil_structure/ert/model/user_config.ert
+++ b/test-data/snake_oil_structure/ert/model/user_config.ert
@@ -45,7 +45,7 @@ QUEUE_OPTION LSF LSF_RESOURCE select[x86_64Linux] same[type:model] -- arbitrary 
 QUEUE_OPTION LSF LSF_SERVER   simulacrum  -- name of server
 QUEUE_OPTION LSF LSF_QUEUE    mr  -- name of queue, mr=multiple realizations
 
-MAX_SUBMIT                    13  -- How many times should the queue system
+MAX_SUBMIT                    13  -- How many times the queue system should
                                   -- retry a simulation.  Default == 2.  Use
                                   -- 1 when debugging)
 


### PR DESCRIPTION
## Pre review checklist

- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
