### PR TITLE
Avoid Pandas deprecation warning on frame.append

### DIFF
--- a/src/ert/data/loader.py
+++ b/src/ert/data/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Optional, Protocol, Sequence
+from typing import TYPE_CHECKING, Callable, List, Optional, Protocol, Sequence
 
 import pandas as pd
 
@@ -118,11 +118,10 @@ def _load_general_response(
             for key in facade.all_data_type_keys()
             if facade.is_gen_data_key(key) and data_key in key
         ]
-        data = pd.DataFrame()
-
+        gen_data_list: List[pd.DataFrame] = []
         for time_step in time_steps:
-            gen_data = facade.load_gen_data(ensemble, data_key, time_step).T
-            data = data.append(gen_data)
+            gen_data_list.append(facade.load_gen_data(ensemble, data_key, time_step).T)
+        data = pd.concat(gen_data_list)
     except KeyError as err:
         raise ResponseError(
             f"No response loaded for observation key: {obs_key}"


### PR DESCRIPTION
This warning is now removed:

loader.py:125: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
    data = data.append(gen_data)

The merging of dataframes has also been postponed until all data has been collected, which might give a small speed increase.

**Issue**
Resolves noise in test logs


**Approach**
Refactor slightly and use pd.concat instead.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
