### PR TITLE
Improve documentation for disable_monitoring

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -473,7 +473,9 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         cli_parser.add_argument(
             "--disable-monitoring",
             action="store_true",
-            help="Disable monitoring.",
+            help="Monitoring will continuously print the status of the realisations"
+            + " classified into Waiting, Pending, Running, Failed, Finished"
+            + " and Unknown.",
             default=False,
         )
         cli_parser.add_argument(


### PR DESCRIPTION
## Context
Follow the discussion in https://github.com/equinor/komodo-releases/pull/3490#discussion_r1142082379_
```
It will disable the "Monitor"  (that displays in ASCII repeatedly the number of realizations in each state (pending/running/finished, etc). 

The command line argument is used here:
https://github.com/equinor/ert/blob/12ab4f8d2a7907171866986ceae7449d02abc9a5/src/ert/cli/main.py#L148
where we can read that the `Monitor` outputs this monitoring ascii always, but with this argument it is written directly to /dev/null.
```            

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [ ] (not applicable) Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
