### PR TITLE
Create hypothesis strategy for observations parsing

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -166,7 +166,7 @@ class EnsembleConfig(BaseCClass):
             "load_case": refcase_file,
             "join_string": ":",
             "include_restart": True,
-            "lazy_load": True,
+            "lazy_load": False,
             "file_options": 0,
         }
         return EclSum(**refcase_load_args)

--- a/tests/test_config_parsing/egrid_generator.py
+++ b/tests/test_config_parsing/egrid_generator.py
@@ -14,7 +14,7 @@ class Units(Enum):
     CM = auto()
     FEET = auto()
 
-    def to_egrid(self):
+    def to_ecl(self):
         return self.name.ljust(8)
 
 
@@ -30,7 +30,7 @@ class GridRelative(Enum):
     MAP = auto()
     ORIGIN = auto()
 
-    def to_grdecl(self) -> str:
+    def to_ecl(self) -> str:
         if self == GridRelative.MAP:
             return "MAP".ljust(8)
         else:
@@ -53,14 +53,14 @@ class GrdeclKeyword:
     ...     field1: A
     ...     field2: B
 
-    will have a to_grdecl method that will be similar to
+    will have a to_ecl method that will be similar to
 
-    >>> def to_egrid(self):
-    ...     return [self.field1.to_egrid(), self.field2.to_egrid]
+    >>> def to_ecl(self):
+    ...     return [self.field1.to_ecl(), self.field2.to_ecl]
     """
 
-    def to_egrid(self) -> List[Any]:
-        return [value.to_egrid() for value in astuple(self)]
+    def to_ecl(self) -> List[Any]:
+        return [value.to_ecl() for value in astuple(self)]
 
 
 @dataclass
@@ -88,7 +88,7 @@ class CoordinateType(Enum):
     CARTESIAN = auto()
     CYLINDRICAL = auto()
 
-    def to_egrid(self) -> int:
+    def to_ecl(self) -> int:
         if self == CoordinateType.CARTESIAN:
             return 0
         else:
@@ -163,7 +163,7 @@ class Filehead:
     rock_model: RockModel
     grid_format: GridFormat
 
-    def to_egrid(self) -> np.ndarray:
+    def to_ecl(self) -> np.ndarray:
         """
         Returns:
             List of values, as layed out after the FILEHEAD keyword for
@@ -200,7 +200,7 @@ class GridHead:
     lgr_start: Tuple[int, int, int]
     lgr_end: Tuple[int, int, int]
 
-    def to_egrid(self) -> np.ndarray:
+    def to_ecl(self) -> np.ndarray:
         # The data is expected to consist of
         # 100 integers, but only a subset is used.
         result = np.zeros((100,), dtype=np.int32)
@@ -211,7 +211,7 @@ class GridHead:
         result[4] = self.grid_reference_number
         result[24] = self.numres
         result[25] = self.nseg
-        result[26] = self.coordinate_type.to_egrid()
+        result[26] = self.coordinate_type.to_ecl()
         result[[27, 28, 29]] = np.array(self.lgr_start)
         result[[30, 31, 32]] = np.array(self.lgr_end)
         return result
@@ -240,9 +240,9 @@ class GlobalGrid:
             and np.array_equal(self.zcorn, other.zcorn)
         )
 
-    def to_egrid(self) -> List[Tuple[str, Any]]:
+    def to_ecl(self) -> List[Tuple[str, Any]]:
         result = [
-            ("GRIDHEAD", self.grid_head.to_egrid()),
+            ("GRIDHEAD", self.grid_head.to_ecl()),
             ("COORD   ", self.coord.astype(np.float32)),
             ("ZCORN   ", self.zcorn.astype(np.float32)),
         ]
@@ -278,8 +278,8 @@ class EGrid:
             file_format (ecl_data_io.Format): The format of the file.
         """
         contents = []
-        contents.append(("FILEHEAD", self.file_head.to_egrid()))
-        contents += self.global_grid.to_egrid()
+        contents.append(("FILEHEAD", self.file_head.to_ecl()))
+        contents += self.global_grid.to_ecl()
         eclio.write(filelike, contents)
 
 

--- a/tests/test_config_parsing/observations_generator.py
+++ b/tests/test_config_parsing/observations_generator.py
@@ -1,0 +1,201 @@
+import datetime
+from abc import ABC, abstractproperty
+from dataclasses import dataclass, field, fields
+from enum import Enum, auto
+from typing import List, Optional
+
+import hypothesis.strategies as st
+from pydantic import PositiveFloat
+
+
+class ErrorMode(Enum):
+    REL = auto()
+    ABS = auto()
+    RELMIN = auto()
+
+
+@dataclass
+class Observation(ABC):
+    name: str
+    error: PositiveFloat
+
+    @abstractproperty
+    def class_name(self):
+        pass
+
+    def __str__(self):
+        result = f"{self.class_name} {self.name}"
+        result += " { "
+        for f in fields(self):
+            if f.name == "name":
+                continue
+            val = getattr(self, f.name)
+            if val is None or val == []:
+                continue
+            if isinstance(val, Enum):
+                result += f"{f.name.upper()} = {val.name}; "
+            elif isinstance(val, (float, str, int)):
+                result += f"{f.name.upper()} = {val}; "
+            elif isinstance(val, Observation):
+                result += str(val)
+            elif isinstance(val, list):
+                result += f"{f.name.upper()} = {','.join([str(v) for v in val])}; "
+            else:
+                assert False
+        result += " };"
+        return result
+
+
+@dataclass
+class Segment(Observation):
+    start: int
+    stop: int
+    error_min: PositiveFloat
+
+    @property
+    def class_name(self):
+        return "SEGMENT"
+
+
+@dataclass
+class HistoryObservation(Observation):
+    error_mode: ErrorMode
+    segment: List[Segment] = field(default_factory=list)
+
+    @property
+    def class_name(self):
+        return "HISTORY_OBSERVATION"
+
+    def get_date(self, start):
+        return start
+
+
+@dataclass
+class SummaryObservation(Observation):
+    value: float
+    key: str
+    error_min: PositiveFloat
+    error_mode: ErrorMode
+    days: Optional[float] = None
+    hours: Optional[float] = None
+    restart: Optional[int] = None
+    date: Optional[str] = None
+
+    @property
+    def class_name(self):
+        return "SUMMARY_OBSERVATION"
+
+    def get_date(self, start):
+        if self.date is not None:
+            return datetime.datetime.strptime(self.date, "%Y-%m-%d")
+        delta = datetime.timedelta(days=0)
+        if self.days is not None:
+            delta += datetime.timedelta(days=self.days)
+        if self.hours is not None:
+            delta += datetime.timedelta(hours=self.hours)
+        return start + delta
+
+
+@dataclass
+class GeneralObservation(Observation):
+    data: str
+    date: Optional[str] = None
+    days: Optional[float] = None
+    hours: Optional[float] = None
+    restart: Optional[int] = None
+    obs_file: Optional[str] = None
+    value: Optional[float] = None
+    index_list: Optional[List[int]] = None
+
+    def get_date(self, start):
+        if self.date is not None:
+            return datetime.datetime.strptime(self.date, "%Y-%m-%d")
+        delta = datetime.timedelta(0)
+        if self.days is not None:
+            delta += datetime.timedelta(days=self.days)
+        if self.hours is not None:
+            delta += datetime.timedelta(hours=self.hours)
+        return start + delta
+
+    @property
+    def class_name(self):
+        return "GENERAL_OBSERVATION"
+
+
+names = st.text(
+    min_size=1, max_size=8, alphabet=st.characters(min_codepoint=65, max_codepoint=90)
+)
+
+
+@st.composite
+def general_observations(draw, ensemble_keys):
+    kws = {}
+    kws["data"] = draw(ensemble_keys)
+    kws["name"] = draw(names)
+    kws["error"] = draw(st.floats(min_value=0.0))
+    val_type = draw(st.sampled_from(["value", "obs_file"]))
+    time_type = draw(st.sampled_from(["date", "days", "restart", "hours"]))
+    if val_type == "value":
+        kws["value"] = draw(st.floats())
+    if val_type == "obs_file":
+        kws["obs_file"] = draw(names)
+        kws["error"] = None
+    if time_type == "date":
+        kws["date"] = (
+            f"{draw(st.integers(min_value=1999, max_value=2037))}"
+            f"-{draw(st.integers(min_value=1, max_value=12))}"
+            f"-{draw(st.integers(min_value=1, max_value=30))}"
+        )
+    if time_type in ["days", "hours"]:
+        kws[time_type] = draw(st.floats(min_value=1.0, max_value=10000))
+    if time_type == "restart":
+        kws[time_type] = draw(st.integers(min_value=1, max_value=10))
+    return GeneralObservation(**kws)
+
+
+positive_floats = st.floats(min_value=0.1, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def summary_observations(draw):
+    kws = {}
+    kws["name"] = draw(names)
+    kws["key"] = draw(names)
+    kws["error"] = draw(positive_floats)
+    kws["error_min"] = draw(positive_floats)
+    kws["error_mode"] = draw(st.sampled_from(ErrorMode))
+    kws["value"] = draw(positive_floats)
+    time_type = draw(st.sampled_from(["date", "days", "restart", "hours"]))
+    if time_type == "date":
+        kws["date"] = (
+            f"{draw(st.integers(min_value=1999, max_value=2037))}"
+            f"-{draw(st.integers(min_value=1, max_value=12))}"
+            f"-{draw(st.integers(min_value=2, max_value=30))}"
+        )
+    if time_type in ["days", "hours"]:
+        kws[time_type] = draw(st.floats(min_value=1, max_value=10000))
+    if time_type == "restart":
+        kws[time_type] = draw(st.integers(min_value=1, max_value=10))
+    return SummaryObservation(**kws)
+
+
+def observations(ensemble_keys):
+    if ensemble_keys:
+        return st.lists(
+            st.one_of(
+                summary_observations(),
+                general_observations(st.sampled_from(ensemble_keys)),
+                st.builds(HistoryObservation, name=names),
+            ),
+            min_size=1,
+            max_size=5,
+        )
+    else:
+        return st.lists(
+            st.one_of(
+                summary_observations(),
+                st.builds(HistoryObservation, name=names),
+            ),
+            min_size=1,
+            max_size=5,
+        )

--- a/tests/test_config_parsing/summary_generator.py
+++ b/tests/test_config_parsing/summary_generator.py
@@ -1,0 +1,309 @@
+"""
+Implements a hypothesis strategy for unified summary files
+(.SMSPEC and .UNSMRY) without any optional fields.
+See https://opm-project.org/?page_id=955
+"""
+from dataclasses import astuple, dataclass
+from datetime import datetime
+from enum import Enum, unique
+from typing import Any, List, Tuple
+
+import ecl_data_io
+import hypothesis.strategies as st
+import numpy as np
+from pydantic import PositiveInt, conint
+
+from .egrid_generator import GrdeclKeyword
+
+
+@st.composite
+def summary_variables(draw):
+    """
+    Generator for summary variable mnemonic, See
+    section 11.2.1 in opm flow reference manual 2022-10.
+    """
+    first_character = draw(st.sampled_from("ABFGRWCS"))
+    if first_character == "A":
+        second_character = draw(st.sampled_from("ALN"))
+        third_character = draw(st.sampled_from("QL"))
+        fourth_character = draw(st.sampled_from("RT"))
+        return first_character + second_character + third_character + fourth_character
+
+    kind = draw(st.sampled_from([1, 2, 3, 4]))
+    if kind == 1:
+        return draw(
+            st.sampled_from(
+                ["BAPI", "BOSAT", "BPR", "FAQR", "FPR", "FWCT", "WBHP", "WWCT"]
+            )
+        )
+    elif kind == 2:
+        direction = draw(st.sampled_from("IJK"))
+        return (
+            draw(st.sampled_from(["FLOO", "VELG", "VELO", "FLOW", "VELW"])) + direction
+        )
+    elif kind == 3:
+        dimension = draw(st.sampled_from("XYZRT"))
+        direction = draw(st.sampled_from(" -"))
+        return draw(st.sampled_from(["GKR", "OKR", "WKR"])) + dimension + direction
+    else:
+        second_character = draw(st.sampled_from("OWGVLPT"))
+        third_character = draw(st.sampled_from("PIF"))
+        fourth_character = draw(st.sampled_from("RT"))
+        return first_character + second_character + third_character + fourth_character
+
+
+unit_names = st.sampled_from(
+    ["SM3/DAY", "BARSA", "SM3/SM3", "FRACTION", "DAYS", "YEARS", "SM3", "SECONDS"]
+)
+
+names = st.text(
+    min_size=8, max_size=8, alphabet=st.characters(min_codepoint=65, max_codepoint=90)
+)
+
+
+@unique
+class UnitSystem(Enum):
+    METRIC = 1
+    FIELD = 2
+    LAB = 3
+
+    def to_ecl(self):
+        return self.value
+
+
+@unique
+class Simulator(Enum):
+    ECLIPSE_100 = 100
+    ECLIPSE_300 = 300
+    ECLIPSE_300_THERMAL = 500
+    INTERSECT = 700
+    FRONTSIM = 800
+
+    def to_ecl(self):
+        return self.value
+
+
+@dataclass
+class SmspecIntehead(GrdeclKeyword):
+    unit: UnitSystem
+    simulator: Simulator
+
+
+@dataclass
+class Date:
+    day: conint(ge=1, le=31)  # type: ignore
+    month: conint(ge=1, le=12)  # type: ignore
+    year: conint(gt=1901, lt=2038)  # type: ignore
+    hour: conint(ge=0, lt=24)  # type: ignore
+    minutes: conint(ge=0, lt=60)  # type: ignore
+    micro_seconds: conint(ge=0, lt=60000000)  # type: ignore
+
+    def to_ecl(self):
+        return astuple(self)
+
+
+@dataclass
+class Smspec:
+    intehead: SmspecIntehead
+    restart: str
+    num_keywords: PositiveInt
+    nx: PositiveInt
+    ny: PositiveInt
+    nz: PositiveInt
+    restarted_from_step: PositiveInt
+    keywords: List[str]
+    well_names: List[str]
+    region_numbers: List[str]
+    units: List[str]
+    start_date: Date
+
+    def to_ecl(self) -> List[Tuple[str, Any]]:
+        # The restart field contains 9 strings of length 8 which
+        # should contain the name of the file restarted from.
+        # If shorter than 72 characters (most likely), the rest
+        # are spaces. (opm manual table F.44, keyword name RESTART)
+        restart = self.restart.ljust(72, " ")
+        restart_list = [restart[i * 8 : i * 8 + 8] for i in range(9)]
+        return [
+            ("INTEHEAD", self.intehead.to_ecl()),
+            ("RESTART ", restart_list),
+            (
+                "DIMENS  ",
+                np.array(
+                    [
+                        self.num_keywords,
+                        self.nx,
+                        self.ny,
+                        self.nz,
+                        0,
+                        self.restarted_from_step,
+                    ],
+                    dtype=np.int32,
+                ),
+            ),
+            ("KEYWORDS", self.keywords),
+            ("WGNAMES ", self.well_names),
+            ("NUMS    ", self.region_numbers),
+            ("UNITS   ", self.units),
+            ("STARTDAT", self.start_date.to_ecl()),
+        ]
+
+    def to_file(
+        self, filelike, file_format: ecl_data_io.Format = ecl_data_io.Format.UNFORMATTED
+    ):
+        ecl_data_io.write(filelike, self.to_ecl(), file_format)
+
+
+positives = st.integers(min_value=1, max_value=10000)
+small_ints = st.integers(min_value=1, max_value=10)
+
+
+@st.composite
+def smspecs(
+    draw,
+    num_keywords,
+    start_date,
+):
+    """
+    Strategy for smspec that ensures that the TIME parameter, as required by
+    ert, is in the parameters list.
+    """
+    n = draw(num_keywords)
+    nx = draw(small_ints)
+    ny = draw(small_ints)
+    nz = draw(small_ints)
+    keywords = ["TIME    "] + draw(
+        st.lists(summary_variables(), min_size=n - 1, max_size=n - 1)
+    )
+    units = ["DAYS    "] + draw(st.lists(unit_names, min_size=n - 1, max_size=n - 1))
+    well_names = [":+:+:+:+"] + draw(st.lists(names, min_size=n - 1, max_size=n - 1))
+    region_numbers = [-32676] + draw(
+        st.lists(
+            st.integers(min_value=0, max_value=nx * ny * nz),
+            min_size=n - 1,
+            max_size=n - 1,
+        )
+    )
+    return draw(
+        st.builds(
+            Smspec,
+            nx=st.just(nx),
+            ny=st.just(ny),
+            nz=st.just(nz),
+            # restarted_from_step is hardcoded to 0 because
+            # of a bug in enkf_obs where it assumes that
+            # ecl_sum_get_first_report_step is always 1
+            restarted_from_step=st.just(0),
+            num_keywords=st.just(n),
+            restart=names,
+            keywords=st.just(keywords),
+            well_names=st.just(well_names),
+            region_numbers=st.just(region_numbers),
+            units=st.just(units),
+            start_date=start_date,
+        )
+    )
+
+
+@dataclass
+class SummaryMiniStep:
+    mini_step: int
+    params: List[float]
+
+    def to_ecl(self):
+        return [
+            ("MINISTEP", [self.mini_step]),
+            ("PARAMS  ", np.array(self.params, dtype=np.float32)),
+        ]
+
+
+@dataclass
+class SummaryStep:
+    seqnum: int
+    ministeps: List[SummaryMiniStep]
+
+    def to_ecl(self):
+        return [("SEQHDR  ", [self.seqnum])] + [
+            i for ms in self.ministeps for i in ms.to_ecl()
+        ]
+
+
+@dataclass
+class Unsmry:
+    steps: List[SummaryStep]
+
+    def to_ecl(self):
+        return [i for step in self.steps for i in step.to_ecl()]
+
+    def to_file(
+        self, filelike, file_format: ecl_data_io.Format = ecl_data_io.Format.UNFORMATTED
+    ):
+        ecl_data_io.write(filelike, self.to_ecl(), file_format)
+
+
+positive_floats = st.floats(min_value=0.1, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def unsmrys(
+    draw,
+    num_params,
+    report_steps,
+    mini_steps,
+    days,
+):
+    """
+    Simplified strategy for unsmrys that will generate a summary file
+    with one ministep per report step.
+    """
+    n = num_params - 1
+    rs = sorted(draw(report_steps))
+    ms = sorted(draw(mini_steps), reverse=True)
+    ds = sorted(draw(days), reverse=True)
+    steps = []
+    for r in rs:
+        minis = [
+            SummaryMiniStep(
+                ms.pop(),
+                [ds.pop()] + draw(st.lists(positive_floats, min_size=n, max_size=n)),
+            )
+        ]
+        steps.append(SummaryStep(r, minis))
+    return Unsmry(steps)
+
+
+@st.composite
+def summaries(draw, dates):
+    """
+    Strategy for tuples of Smspec and Unsrmy that have the given
+    dates as report steps.
+    """
+    num_params = draw(small_ints)
+    ds = sorted(draw(dates))
+    fd: datetime = ds[0]
+    smspec = draw(
+        smspecs(
+            num_keywords=st.just(num_params),
+            start_date=st.just(
+                Date(
+                    year=fd.year,
+                    month=fd.month,
+                    day=fd.day,
+                    hour=fd.hour,
+                    minutes=fd.minute,
+                    micro_seconds=fd.second * 10**6 + fd.microsecond,
+                )
+            ),
+        )
+    )
+    time_diffs = [d - fd for d in ds]
+    time_diff_floats = [diff.total_seconds() / (3600 * 24) for diff in time_diffs]
+    unsmry = draw(
+        unsmrys(
+            num_params,
+            report_steps=st.just(list(range(1, len(ds) + 1))),
+            mini_steps=st.just(list(range(len(ds) + 1))),
+            days=st.just(time_diff_floats),
+        )
+    )
+    return smspec, unsmry

--- a/tests/test_config_parsing/test_enkf_obs_parsing.py
+++ b/tests/test_config_parsing/test_enkf_obs_parsing.py
@@ -1,0 +1,17 @@
+import pytest
+from hypothesis import given
+
+from ert._c_wrappers.enkf import EnkfObs, ErtConfig
+
+from .config_dict_generator import config_generators
+
+
+@pytest.mark.usefixtures("set_site_config")
+@given(config_generators())
+def test_that_creating_enkf_obs_from_generated_values_does_not_produce_errors(
+    tmp_path_factory, config_generator
+):
+    filename = "config.ert"
+    with config_generator(tmp_path_factory, filename):
+        observations = EnkfObs.from_ert_config(ErtConfig.from_file(filename))
+        assert observations.error == ""


### PR DESCRIPTION
This PR extends the configuration hypothesis strategy to generate observation data. In order to do that, we also need to randomly generate summary data for the refcase, in order for enkf_obs to set the correct time map.

The next step is to refactor the generator so that the tests have access to the generated values, not just the config dict and written files. Then fields in ert_config and enkf_obs can be tested to include the correct values.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
