### PR TITLE
Initialize ert_config before creating suggestions

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -83,8 +83,8 @@ def _start_initial_gui_window(args, log_handler):
     try:
         with warnings.catch_warnings(record=True) as warning_messages:
             _check_locale()
-            suggestions += ErtConfig.make_suggestion_list(args.config)
             ert_config = ErtConfig.from_file(args.config)
+            suggestions += ErtConfig.make_suggestion_list(args.config)
         os.chdir(ert_config.config_path)
         # Changing current working directory means we need to update the config file to
         # be the base name of the original config


### PR DESCRIPTION
This will validate the config file before attempting to create a list of suggestions


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
