### PR TITLE
Move config errors and warnings to one file

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -14,7 +14,7 @@ import yaml
 from ecl import set_abort_handler
 
 import ert.shared
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import ErtConfig
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,

--- a/src/ert/_c_wrappers/analysis/analysis_module.py
+++ b/src/ert/_c_wrappers/analysis/analysis_module.py
@@ -2,10 +2,9 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Type, TypedDict, Union
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 
 logger = logging.getLogger(__name__)
-
 
 if TYPE_CHECKING:
 
@@ -132,7 +131,9 @@ class AnalysisModule:
     def handle_special_key_set(self, var_name, value):
         if var_name in self.DEPRECATED_KEYS:
             logger.warning(
-                f"The {var_name} key have been removed" f"use the INVERSION key instead"
+                f"The {var_name} key have been removed"
+                f"use the INVERSION key "
+                f"instead"
             )
         elif var_name == "INVERSION":
             inversion_str_map = {

--- a/src/ert/_c_wrappers/analysis/analysis_module.py
+++ b/src/ert/_c_wrappers/analysis/analysis_module.py
@@ -131,9 +131,7 @@ class AnalysisModule:
     def handle_special_key_set(self, var_name, value):
         if var_name in self.DEPRECATED_KEYS:
             logger.warning(
-                f"The {var_name} key have been removed"
-                f"use the INVERSION key "
-                f"instead"
+                f"The {var_name} key has been removed" f"use the INVERSION key instead"
             )
         elif var_name == "INVERSION":
             inversion_str_map = {

--- a/src/ert/_c_wrappers/config/__init__.py
+++ b/src/ert/_c_wrappers/config/__init__.py
@@ -1,5 +1,6 @@
 from .config_content import ConfigContent, ContentItem, ContentNode
-from .config_parser import ConfigParser, ConfigValidationError, ConfigWarning
+from .config_errors import CombinedConfigError, ConfigValidationError, ConfigWarning
+from .config_parser import ConfigParser
 from .config_path_elm import ConfigPathElm
 from .content_type_enum import ContentTypeEnum
 from .schema_item import SchemaItem
@@ -16,4 +17,5 @@ __all__ = [
     "ConfigParser",
     "ConfigValidationError",
     "ConfigWarning",
+    "CombinedConfigError",
 ]

--- a/src/ert/_c_wrappers/config/config_errors.py
+++ b/src/ert/_c_wrappers/config/config_errors.py
@@ -75,36 +75,40 @@ class CombinedConfigError(ConfigValidationError):
             List[Union[ConfigValidationError, "CombinedConfigError"]]
         ] = None,
     ):
-        self.errors = []
+        self.errors_list = []
 
         for err in errors or []:
             self.add_error(err)
 
+    @property
+    def errors(self):
+        return self.errors_list
+
     def __str__(self):
-        return ", ".join(str(x) for x in self.errors)
+        return ", ".join(str(x) for x in self.errors_list)
 
     def is_empty(self):
-        return len(self.errors) == 0
+        return len(self.errors_list) == 0
 
     def add_error(self, error: Union[ConfigValidationError, "CombinedConfigError"]):
         if isinstance(error, CombinedConfigError):
-            self.errors.append(*error.errors)
+            self.errors_list.append(*error.errors_list)
         else:
-            self.errors.append(error)
+            self.errors_list.append(error)
 
     def get_error_messages(self):
         all_messages = []
-        for e in self.errors:
+        for e in self.errors_list:
             all_messages.append(*e.get_error_messages())
 
         return all_messages
 
     def find_matching_error(self, match: str) -> Optional[ConfigValidationError]:
-        return next(x for x in self.errors if match in str(x))
+        return next(x for x in self.errors_list if match in str(x))
 
     @property
     def config_file(self):
-        return self.errors[0].location.filename
+        return self.errors_list[0].location.filename
 
 
 class ObservationConfigError(ConfigValidationError):

--- a/src/ert/_c_wrappers/config/config_errors.py
+++ b/src/ert/_c_wrappers/config/config_errors.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+
+class ExtJobInvalidArgsException(BaseException):
+    pass
+
+
+class ConfigWarning(UserWarning):
+    pass
+
+
+@dataclass()
+class Location:
+    filename: str
+    start_pos: Optional[int] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    end_line: Optional[int] = None
+    end_column: Optional[int] = None
+    end_pos: Optional[int] = None
+
+
+class ConfigValidationError(ValueError):
+    def __init__(
+        self,
+        errors: str,
+        config_file: Optional[str] = None,
+        location: Optional[Union[str, Location]] = None,
+    ) -> None:
+        if config_file:
+            self.location = Location(config_file)
+        elif location is not None:
+            if isinstance(location, Location):
+                self.location = location
+            else:
+                self.location = Location(location)
+        else:
+            self.location = Location(filename="")
+
+        self.errors = errors
+
+        super().__init__(
+            (
+                f"Parsing config file `{self.config_file}` "
+                f"resulted in the errors: {self.errors}"
+            )
+            if self.config_file
+            else f"{self.errors}"
+        )
+
+    def replace(self, old_text: str, new_text: str):
+        return ConfigValidationError(
+            errors=self.errors.replace(old_text, new_text),
+            config_file=self.config_file,
+            location=self.location,
+        )
+
+    @property
+    def config_file(self):
+        return self.location.filename
+
+    @config_file.setter
+    def config_file(self, config_file):
+        self.location.filename = config_file
+
+    def get_error_messages(self):
+        return [self.errors]
+
+
+class CombinedConfigError(ConfigValidationError):
+    def __init__(
+        self,
+        errors: Optional[
+            List[Union[ConfigValidationError, "CombinedConfigError"]]
+        ] = None,
+    ):
+        self.errors = []
+
+        for err in errors or []:
+            self.add_error(err)
+
+    def __str__(self):
+        return ", ".join(str(x) for x in self.errors)
+
+    def is_empty(self):
+        return len(self.errors) == 0
+
+    def add_error(self, error: Union[ConfigValidationError, "CombinedConfigError"]):
+        if isinstance(error, CombinedConfigError):
+            self.errors.append(*error.errors)
+        else:
+            self.errors.append(error)
+
+    def get_error_messages(self):
+        all_messages = []
+        for e in self.errors:
+            all_messages.append(*e.get_error_messages())
+
+        return all_messages
+
+    def find_matching_error(self, match: str) -> Optional[ConfigValidationError]:
+        return next(x for x in self.errors if match in str(x))
+
+    @property
+    def config_file(self):
+        return self.errors[0].location.filename
+
+
+class ObservationConfigError(ConfigValidationError):
+    def __init__(self, errors: str, config_file: Optional[str] = None) -> None:
+        super().__init__(
+            errors=(
+                f"Parsing observations config file `{config_file}` "
+                f"resulted in the errors: {errors}"
+            )
+            if config_file
+            else f"{errors}",
+            config_file=config_file,
+        )

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -1,114 +1,12 @@
 import os.path
-from dataclasses import dataclass
-from typing import List, Optional, Union
 
 from cwrap import BaseCClass
 from ecl.util.util import StringHash
 
 from ert._c_wrappers import ResPrototype
+from ert._c_wrappers.config import CombinedConfigError, ConfigValidationError
 from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.unrecognized_enum import UnrecognizedEnum
-
-
-@dataclass()
-class Location:
-    filename: str
-    start_pos: Optional[int] = None
-    line: Optional[int] = None
-    column: Optional[int] = None
-    end_line: Optional[int] = None
-    end_column: Optional[int] = None
-    end_pos: Optional[int] = None
-
-
-class ConfigWarning(UserWarning):
-    pass
-
-
-class ConfigValidationError(ValueError):
-    def __init__(
-        self,
-        errors: str,
-        config_file: Optional[str] = None,
-        location: Optional[Union[str, Location]] = None,
-    ) -> None:
-        if config_file:
-            self.location = Location(config_file)
-        elif location is not None:
-            if isinstance(location, Location):
-                self.location = location
-            else:
-                self.location = Location(location)
-        else:
-            self.location = Location(filename="")
-
-        self.errors = errors
-
-        super().__init__(
-            (
-                f"Parsing config file `{self.config_file}` "
-                f"resulted in the errors: {self.errors}"
-            )
-            if self.config_file
-            else f"{self.errors}"
-        )
-
-    def replace(self, old_text: str, new_text: str):
-        return ConfigValidationError(
-            errors=self.errors.replace(old_text, new_text),
-            config_file=self.config_file,
-            location=self.location,
-        )
-
-    @property
-    def config_file(self):
-        return self.location.filename
-
-    @config_file.setter
-    def config_file(self, config_file):
-        self.location.filename = config_file
-
-    def get_error_messages(self):
-        return [self.errors]
-
-
-class CombinedConfigError(ConfigValidationError):
-    def __init__(
-        self,
-        errors: Optional[
-            List[Union[ConfigValidationError, "CombinedConfigError"]]
-        ] = None,
-    ):
-        self.errors = []
-
-        for err in errors or []:
-            self.add_error(err)
-
-    def __str__(self):
-        return ", ".join(str(x) for x in self.errors)
-
-    def is_empty(self):
-        return len(self.errors) == 0
-
-    def add_error(self, error: Union[ConfigValidationError, "CombinedConfigError"]):
-        if isinstance(error, CombinedConfigError):
-            self.errors.append(*error.errors)
-        else:
-            self.errors.append(error)
-
-    def get_error_messages(self):
-        all_messages = []
-        for e in self.errors:
-            all_messages.append(*e.get_error_messages())
-
-        return all_messages
-
-    def find_matching_error(self, match: str) -> Optional[ConfigValidationError]:
-        return next(x for x in self.errors if match in str(x))
-
-    @property
-    def config_file(self):
-        return self.errors[0].location.filename
 
 
 class ConfigParser(BaseCClass):

--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Optional
+from dataclasses import dataclass
+from typing import List, Optional, Union
 
 from cwrap import BaseCClass
 from ecl.util.util import StringHash
@@ -9,14 +10,40 @@ from ert._c_wrappers.config.config_content import ConfigContent
 from ert._c_wrappers.config.unrecognized_enum import UnrecognizedEnum
 
 
+@dataclass()
+class Location:
+    filename: str
+    start_pos: Optional[int] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    end_line: Optional[int] = None
+    end_column: Optional[int] = None
+    end_pos: Optional[int] = None
+
+
 class ConfigWarning(UserWarning):
     pass
 
 
 class ConfigValidationError(ValueError):
-    def __init__(self, errors: str, config_file: Optional[str] = None) -> None:
-        self.config_file = config_file
+    def __init__(
+        self,
+        errors: str,
+        config_file: Optional[str] = None,
+        location: Optional[Union[str, Location]] = None,
+    ) -> None:
+        if config_file:
+            self.location = Location(config_file)
+        elif location is not None:
+            if isinstance(location, Location):
+                self.location = location
+            else:
+                self.location = Location(location)
+        else:
+            self.location = Location(filename="")
+
         self.errors = errors
+
         super().__init__(
             (
                 f"Parsing config file `{self.config_file}` "
@@ -25,6 +52,63 @@ class ConfigValidationError(ValueError):
             if self.config_file
             else f"{self.errors}"
         )
+
+    def replace(self, old_text: str, new_text: str):
+        return ConfigValidationError(
+            errors=self.errors.replace(old_text, new_text),
+            config_file=self.config_file,
+            location=self.location,
+        )
+
+    @property
+    def config_file(self):
+        return self.location.filename
+
+    @config_file.setter
+    def config_file(self, config_file):
+        self.location.filename = config_file
+
+    def get_error_messages(self):
+        return [self.errors]
+
+
+class CombinedConfigError(ConfigValidationError):
+    def __init__(
+        self,
+        errors: Optional[
+            List[Union[ConfigValidationError, "CombinedConfigError"]]
+        ] = None,
+    ):
+        self.errors = []
+
+        for err in errors or []:
+            self.add_error(err)
+
+    def __str__(self):
+        return ", ".join(str(x) for x in self.errors)
+
+    def is_empty(self):
+        return len(self.errors) == 0
+
+    def add_error(self, error: Union[ConfigValidationError, "CombinedConfigError"]):
+        if isinstance(error, CombinedConfigError):
+            self.errors.append(*error.errors)
+        else:
+            self.errors.append(error)
+
+    def get_error_messages(self):
+        all_messages = []
+        for e in self.errors:
+            all_messages.append(*e.get_error_messages())
+
+        return all_messages
+
+    def find_matching_error(self, match: str) -> Optional[ConfigValidationError]:
+        return next(x for x in self.errors if match in str(x))
+
+    @property
+    def config_file(self):
+        return self.errors[0].location.filename
 
 
 class ConfigParser(BaseCClass):
@@ -140,8 +224,11 @@ class ConfigParser(BaseCClass):
         config_content.setParser(self)
 
         if validate and not config_content.isValid():
-            raise ConfigValidationError(
-                config_file=config_file, errors=config_content.getErrors()
+            raise CombinedConfigError(
+                errors=[
+                    ConfigValidationError(errors=x, config_file=config_file)
+                    for x in config_content.getErrors()
+                ],
             )
 
         return config_content

--- a/src/ert/_c_wrappers/enkf/__init__.py
+++ b/src/ert/_c_wrappers/enkf/__init__.py
@@ -12,7 +12,7 @@ from .config import (
 )
 from .config_keys import ConfigKeys
 from .enkf_main import EnKFMain
-from .enkf_obs import EnkfObs, ObservationConfigError
+from .enkf_obs import EnkfObs
 from .ensemble_config import EnsembleConfig
 from .enums import (
     ActiveMode,
@@ -71,5 +71,4 @@ __all__ = [
     "RunArg",
     "RunContext",
     "EnKFMain",
-    "ObservationConfigError",
 ]

--- a/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
+++ b/src/ert/_c_wrappers/enkf/_config_content_as_dict.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from ert._c_wrappers.config import ConfigContent
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigContent, ConfigValidationError
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 
 logger = logging.getLogger(__name__)

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -4,7 +4,7 @@ from os.path import realpath
 from typing import Dict, List, Optional
 
 from ert._c_wrappers.analysis import AnalysisMode, AnalysisModule
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf.analysis_iter_config import AnalysisIterConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 

--- a/src/ert/_c_wrappers/enkf/config/enkf_config_node.py
+++ b/src/ert/_c_wrappers/enkf/config/enkf_config_node.py
@@ -7,7 +7,7 @@ from ecl.grid import EclGrid
 from ecl.util.util import IntVector, StringList
 
 from ert._c_wrappers import ResPrototype
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert._c_wrappers.enkf.enums import (
     EnkfTruncationType,
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
-
 
 FIELD_FUNCTION_NAMES: Final = [
     "LN",
@@ -338,8 +337,8 @@ class EnkfConfigNode(BaseCClass):
         if base_surface_file is None:
             valid = False
             msg = (
-                msg
-                + f"Missing {ConfigKeys.BASE_SURFACE_KEY}:/path/to/base_surface_file\n"
+                msg + f"Missing "
+                f"{ConfigKeys.BASE_SURFACE_KEY}:/path/to/base_surface_file\n"
             )
         elif not os.path.exists(os.path.realpath(base_surface_file)):
             msg += (

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -6,25 +6,12 @@ from ecl.util.util import CTime, StringList
 
 from ert import _clib
 from ert._c_wrappers import ResPrototype
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config.config_errors import ObservationConfigError
 from ert._c_wrappers.enkf.enums import EnkfObservationImplementationType
 from ert._c_wrappers.enkf.observations import ObsVector
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import ErtConfig
-
-
-class ObservationConfigError(ConfigValidationError):
-    def __init__(self, errors: str, config_file: Optional[str] = None) -> None:
-        super().__init__(
-            errors=(
-                f"Parsing observations config file `{config_file}` "
-                f"resulted in the errors: {errors}"
-            )
-            if config_file
-            else f"{errors}",
-            config_file=config_file,
-        )
 
 
 class EnkfObs(BaseCClass):

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -16,15 +16,14 @@ if TYPE_CHECKING:
 
 class ObservationConfigError(ConfigValidationError):
     def __init__(self, errors: str, config_file: Optional[str] = None) -> None:
-        self.config_file = config_file
-        self.errors = errors
         super().__init__(
-            (
-                f"Parsing observations config file `{self.config_file}` "
-                f"resulted in the errors: {self.errors}"
+            errors=(
+                f"Parsing observations config file `{config_file}` "
+                f"resulted in the errors: {errors}"
             )
-            if self.config_file
-            else f"{self.errors}"
+            if config_file
+            else f"{errors}",
+            config_file=config_file,
         )
 
 

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -13,7 +13,7 @@ from ecl.util.util import StringList
 
 from ert import _clib
 from ert._c_wrappers import ResPrototype
-from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
+from ert._c_wrappers.config import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.config.rangestring import rangestring_to_list
 from ert._c_wrappers.enkf.config import EnkfConfigNode
 from ert._c_wrappers.enkf.config_keys import ConfigKeys

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -11,7 +11,11 @@ from typing import Any, ClassVar, Dict, List, Mapping
 import pkg_resources
 
 from ert._c_wrappers.config import ConfigParser
-from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
+from ert._c_wrappers.config.config_parser import (
+    CombinedConfigError,
+    ConfigValidationError,
+    ConfigWarning,
+)
 from ert._c_wrappers.enkf.analysis_config import AnalysisConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert._c_wrappers.enkf.ensemble_config import EnsembleConfig
@@ -84,10 +88,12 @@ class ErtConfig:
         user_config_dict = ErtConfig.read_user_config(
             user_config_file, use_new_parser=use_new_parser
         )
+
         config_dir = os.path.abspath(os.path.dirname(user_config_file))
         ErtConfig._log_config_file(user_config_file)
         ErtConfig._log_config_dict(user_config_dict)
         ErtConfig.apply_config_content_defaults(user_config_dict, config_dir)
+
         return ErtConfig.from_dict(user_config_dict)
 
     @classmethod
@@ -253,13 +259,19 @@ class ErtConfig:
 
     @classmethod
     def _validate_queue_option_max_running(cls, config_path, config_dict):
+        combined_error = CombinedConfigError()
+
         for _, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             if option_name == "MAX_RUNNING" and int(*values) < 0:
-                raise ConfigValidationError(
-                    errors=[
-                        f"QUEUE_OPTION MAX_RUNNING is negative: {str(*values)!r}",
-                    ],
+                combined_error.add_error(
+                    ConfigValidationError(
+                        errors=f"QUEUE_OPTION MAX_RUNNING is negative: "
+                        f"{str(*values)!r}",
+                    )
                 )
+
+        if not combined_error.is_empty():
+            raise combined_error
 
     @classmethod
     def _read_templates(cls, config_dict):
@@ -289,55 +301,80 @@ class ErtConfig:
                 category=ConfigWarning,
             )
 
+        combined_error = CombinedConfigError()
+
         if ConfigKeys.SUMMARY in config_dict and ConfigKeys.ECLBASE not in config_dict:
-            raise ConfigValidationError(
-                "When using SUMMARY keyword, the config must also specify ECLBASE",
-                config_file=config_file,
+            combined_error.add_error(
+                ConfigValidationError(
+                    "When using SUMMARY keyword, the config must also specify ECLBASE",
+                    config_file=config_file,
+                )
             )
-        cls._validate_queue_option_max_running(config_file, config_dict)
+
+        try:
+            cls._validate_queue_option_max_running(config_file, config_dict)
+        except ConfigValidationError as err:
+            combined_error.add_error(err)
+
+        if not combined_error.is_empty():
+            raise combined_error
 
     @classmethod
     def _validate_ensemble_config(cls, ensemble_config, config_path):
+        combined_error = CombinedConfigError()
+
         for key in ensemble_config.getKeylistFromImplType(ErtImplType.GEN_KW):
             if ensemble_config.getNode(key).getUseForwardInit():
-                raise ConfigValidationError(
-                    config_file=config_path,
-                    errors=[
-                        "Loading GEN_KW from files created by the forward model "
-                        "is not supported."
-                    ],
+                combined_error.add_error(
+                    ConfigValidationError(
+                        config_file=config_path,
+                        errors="Loading GEN_KW from files created by the forward "
+                        "model "
+                        "is not supported.",
+                    )
                 )
             if (
                 ensemble_config.getNode(key).get_init_file_fmt() is not None
                 and "%" not in ensemble_config.getNode(key).get_init_file_fmt()
             ):
-                raise ConfigValidationError(
-                    config_file=config_path,
-                    errors=["Loading GEN_KW from files requires %d in file format"],
+                combined_error.add_error(
+                    ConfigValidationError(
+                        config_file=config_path,
+                        errors="Loading GEN_KW from files requires %d in file format",
+                    )
                 )
+
+        if not combined_error.is_empty():
+            raise combined_error
 
     @classmethod
     def read_forward_model(
         cls, installed_jobs, substitution_list, config_dict, config_file
     ):
         jobs = []
-        for job in config_dict.get(ConfigKeys.FORWARD_MODEL, []):
-            if len(job) > 1:
-                unsubstituted_job_name, args = job
+        combined_error = CombinedConfigError()
+
+        for job_as_list in config_dict.get(ConfigKeys.FORWARD_MODEL, []):
+            if len(job_as_list) > 1:
+                unsubstituted_job_name, args = job_as_list
             else:
-                unsubstituted_job_name = job[0]
+                unsubstituted_job_name = job_as_list[0]
                 args = []
             job_name = substitution_list.substitute(unsubstituted_job_name)
             try:
                 job = copy.deepcopy(installed_jobs[job_name])
-            except KeyError as err:
-                raise ConfigValidationError(
-                    errors=(
-                        f"Could not find job {job_name!r} in list of installed jobs: "
-                        f"{list(installed_jobs.keys())!r}"
-                    ),
-                    config_file=config_file,
-                ) from err
+            except KeyError:
+                combined_error.add_error(
+                    ConfigValidationError(
+                        errors=(
+                            f"Could not find job {job_name!r} in list of installed "
+                            f"jobs: "
+                            f"{list(installed_jobs.keys())!r}"
+                        ),
+                        config_file=config_file,
+                    )
+                )
+                continue
             if args:
                 job.private_args = SubstitutionList()
                 try:
@@ -351,27 +388,36 @@ class ErtConfig:
                         for key, val in args:
                             job.private_args.addItem(key, val)
                 except ValueError as err:
-                    raise ConfigValidationError(
-                        errors=f"{err}: 'FORWARD_MODEL {job_name}({args})'\n",
-                        config_file=config_file,
-                    ) from err
+                    combined_error.add_error(
+                        ConfigValidationError(
+                            errors=f"{err}: 'FORWARD_MODEL {job_name}({args})'\n",
+                            config_file=config_file,
+                        )
+                    )
 
             try:
                 job.validate_args(substitution_list)
             except ExtJobInvalidArgsException as err:
                 logger.warning(str(err))
             jobs.append(job)
-        for job_description in config_dict.get(ConfigKeys.SIMULATION_JOB, []):
+        for job_as_list in config_dict.get(ConfigKeys.SIMULATION_JOB, []):
             try:
-                job = copy.deepcopy(installed_jobs[job_description[0]])
-            except KeyError as err:
-                raise ConfigValidationError(
-                    f"Could not find job {job_description[0]!r} "
-                    "in list of installed jobs.",
-                    config_file=config_file,
-                ) from err
-            job.arglist = job_description[1:]
+                name, *args = job_as_list
+                job = copy.deepcopy(installed_jobs[name])
+            except KeyError:
+                combined_error.add_error(
+                    ConfigValidationError(
+                        f"Could not find job {name!r} " "in list of installed jobs.",
+                        config_file=config_file,
+                    )
+                )
+                continue
+
+            job.arglist = args
             jobs.append(job)
+
+        if not combined_error.is_empty():
+            raise combined_error
 
         return jobs
 
@@ -493,6 +539,8 @@ class ErtConfig:
         workflows = {}
         hooked_workflows = defaultdict(list)
 
+        combined_error = CombinedConfigError()
+
         for workflow_job in workflow_job_info:
             try:
                 new_job = WorkflowJob.fromFile(
@@ -548,25 +596,35 @@ class ErtConfig:
 
         for hook_name, mode_name in hook_workflow_info:
             if mode_name not in [runtime.name for runtime in HookRuntime.enums()]:
-                raise ConfigValidationError(
-                    errors=[f"Run mode {mode_name!r} not supported for Hook Workflow"]
+                combined_error.add_error(
+                    ConfigValidationError(
+                        errors=f"Run mode {mode_name!r} not supported for Hook "
+                        f"Workflow"
+                    )
                 )
 
             if hook_name not in workflows:
-                raise ConfigValidationError(
-                    errors=[
-                        f"Cannot setup hook for non-existing job name {hook_name!r}"
-                    ]
+                combined_error.add_error(
+                    ConfigValidationError(
+                        errors=f"Cannot setup hook for non-existing jo"
+                        f"b name {hook_name!r}"
+                    )
                 )
+                continue
 
             hooked_workflows[HookRuntime.from_string(mode_name)].append(
                 workflows[hook_name]
             )
+
+        if not combined_error.is_empty():
+            raise combined_error
+
         return workflow_jobs, workflows, hooked_workflows
 
     @classmethod
     def _installed_jobs_from_dict(cls, config_dict):
         jobs = {}
+        combined_error = CombinedConfigError()
         for job in config_dict.get(ConfigKeys.INSTALL_JOB, []):
             name = job[0]
             job_config_file = os.path.abspath(job[1])
@@ -584,9 +642,12 @@ class ErtConfig:
 
         for job_path in config_dict.get(ConfigKeys.INSTALL_JOB_DIRECTORY, []):
             if not os.path.isdir(job_path):
-                raise ConfigValidationError(
-                    f"Unable to locate job directory {job_path!r}"
+                combined_error.add_error(
+                    ConfigValidationError(
+                        f"Unable to locate job directory {job_path!r}"
+                    )
                 )
+                continue
 
             files = os.listdir(job_path)
 
@@ -614,6 +675,9 @@ class ErtConfig:
                         category=ConfigWarning,
                     )
                 jobs[name] = new_job
+
+        if not combined_error.is_empty():
+            raise combined_error
 
         return jobs
 

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -329,8 +329,7 @@ class ErtConfig:
                     ConfigValidationError(
                         config_file=config_path,
                         errors="Loading GEN_KW from files created by the forward "
-                        "model "
-                        "is not supported.",
+                        "model is not supported.",
                     )
                 )
             if (

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -10,9 +10,9 @@ from typing import Any, ClassVar, Dict, List, Mapping
 
 import pkg_resources
 
-from ert._c_wrappers.config import ConfigParser
-from ert._c_wrappers.config.config_parser import (
+from ert._c_wrappers.config import (
     CombinedConfigError,
+    ConfigParser,
     ConfigValidationError,
     ConfigWarning,
 )

--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Union
 
-from ..config import ConfigValidationError
-from ..job_queue import Driver, JobQueue, QueueDriverEnum
+from ert._c_wrappers.config import ConfigValidationError
+from ert._c_wrappers.job_queue import Driver, JobQueue, QueueDriverEnum
 
 
 @dataclass

--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Union
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError
-from ert._c_wrappers.job_queue import Driver, JobQueue, QueueDriverEnum
+from ..config import ConfigValidationError
+from ..job_queue import Driver, JobQueue, QueueDriverEnum
 
 
 @dataclass

--- a/src/ert/_c_wrappers/job_queue/__init__.py
+++ b/src/ert/_c_wrappers/job_queue/__init__.py
@@ -44,6 +44,8 @@ from cwrap import Prototype
 
 import ert._c_wrappers  # noqa
 
+from ..config.config_errors import ExtJobInvalidArgsException
+
 
 def setenv(var, value):
     if not os.getenv(var):
@@ -62,7 +64,7 @@ if LSF_HOME:
 from .driver import Driver, LocalDriver, LSFDriver, QueueDriverEnum  # noqa
 from .ert_plugin import CancelPluginException, ErtPlugin  # noqa
 from .ert_script import ErtScript  # noqa
-from .ext_job import ExtJob, ExtJobInvalidArgsException  # noqa
+from .ext_job import ExtJob  # noqa
 from .external_ert_script import ExternalErtScript  # noqa
 from .function_ert_script import FunctionErtScript  # noqa
 from .job import Job  # noqa

--- a/src/ert/_c_wrappers/job_queue/ext_job.py
+++ b/src/ert/_c_wrappers/job_queue/ext_job.py
@@ -8,18 +8,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from ert._c_wrappers.config import ConfigParser, ConfigValidationError, ContentTypeEnum
-from ert._c_wrappers.config.config_parser import CombinedConfigError
+from ert._c_wrappers.config import (
+    CombinedConfigError,
+    ConfigParser,
+    ConfigValidationError,
+    ContentTypeEnum,
+)
+from ert._c_wrappers.config.config_errors import ExtJobInvalidArgsException
 from ert._c_wrappers.util import SubstitutionList
 from ert._clib.job_kw import type_from_kw
 
 _SUBSTITUTED_AT_EXECUTION_TIME: List[str] = ["<ITER>", "<IENS>"]
 
 logger = logging.getLogger(__name__)
-
-
-class ExtJobInvalidArgsException(BaseException):
-    pass
 
 
 @dataclass

--- a/src/ert/_c_wrappers/job_queue/workflow.py
+++ b/src/ert/_c_wrappers/job_queue/workflow.py
@@ -5,6 +5,7 @@ from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ert._c_wrappers.config import ConfigParser, ConfigValidationError, UnrecognizedEnum
+from ert._c_wrappers.config.config_parser import CombinedConfigError
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain
@@ -68,6 +69,8 @@ class Workflow:
             content = parser.parse(
                 to_compile, unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_ERROR
             )
+        except CombinedConfigError as err:
+            raise err from None
         except ConfigValidationError as err:
             err.config_file = src_file
             raise err from None

--- a/src/ert/_c_wrappers/job_queue/workflow.py
+++ b/src/ert/_c_wrappers/job_queue/workflow.py
@@ -4,8 +4,12 @@ import time
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from ert._c_wrappers.config import ConfigParser, ConfigValidationError, UnrecognizedEnum
-from ert._c_wrappers.config.config_parser import CombinedConfigError
+from ert._c_wrappers.config import (
+    CombinedConfigError,
+    ConfigParser,
+    ConfigValidationError,
+    UnrecognizedEnum,
+)
 
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import EnKFMain

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -18,8 +18,7 @@ from PyQt5.QtWidgets import (
 from qtpy.QtCore import QLocale, QSize, Qt
 from qtpy.QtWidgets import QApplication
 
-from ert._c_wrappers.config import ConfigWarning
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertwidgets import SuggestorMessage, SummaryPanel, resourceIcon

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -129,7 +129,7 @@ def _start_initial_gui_window(
         ]
 
     except ConfigValidationError as error:
-        error_messages.append(str(error))
+        error_messages.append(*error.get_error_messages())
         logger.info("Error in config file shown in gui: '%s'", str(error))
         return (
             _setup_suggester(
@@ -276,6 +276,7 @@ def _setup_suggester(
     suggest_layout = QVBoxLayout()
     buttons_layout = QHBoxLayout()
 
+    print(errors)
     text = ""
     for msg in errors:
         text += msg + "\n"

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import pytest
 from hypothesis import assume, given
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
+from ert._c_wrappers.config import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import ErtConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 
@@ -448,7 +448,8 @@ def test_that_failing_to_load_ert_script_with_errors_fails_gracefully(load_state
     does not work with the current versions of plugins installed in the system,
     but could have worked with an older or newer version of the packages installed.
 
-    Therefore the user should be warned about workflow jobs that have issues, and not be
+    Therefore the user should be warned about workflow jobs that have issues,
+    and not be
     able to run those later.
     """
     test_config_file_name = "test.ert"

--- a/tests/test_config_parsing/test_forward_model.py
+++ b/tests/test_config_parsing/test_forward_model.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import pytest
 from hypothesis import given
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
+from ert._c_wrappers.config import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import ErtConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 

--- a/tests/unit_tests/c_wrappers/res/analysis/test_analysis_module.py
+++ b/tests/unit_tests/c_wrappers/res/analysis/test_analysis_module.py
@@ -9,7 +9,7 @@ from ert._c_wrappers.analysis.analysis_module import (
     DEFAULT_IES_MIN_STEPLENGTH,
     get_mode_variables,
 )
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 
 
 def test_analysis_module_default_values():

--- a/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_analysis_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import AnalysisConfig, ConfigKeys
 
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -5,13 +5,13 @@ from textwrap import dedent
 import pytest
 from ecl.summary import EclSum
 
+from ert._c_wrappers.config.config_errors import ObservationConfigError
 from ert._c_wrappers.enkf import (
     AnalysisConfig,
     EnKFMain,
     EnsembleConfig,
     ErtConfig,
     ModelConfig,
-    ObservationConfigError,
 )
 
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_summary_observation.py
@@ -6,7 +6,8 @@ import pytest
 from ecl.summary import EclSum
 
 from ert import LibresFacade
-from ert._c_wrappers.enkf import ActiveList, ObservationConfigError, SummaryObservation
+from ert._c_wrappers.config.config_errors import ObservationConfigError
+from ert._c_wrappers.enkf import ActiveList, SummaryObservation
 
 
 def test_create():

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_function_ert_script.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_function_ert_script.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.job_queue import WorkflowJob
 
 from .workflow_common import WorkflowCommon

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -15,7 +15,7 @@ import pytest
 import ert.shared
 from ert import LibresFacade, ensemble_evaluator
 from ert.__main__ import ert_parser
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config import ConfigValidationError
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,


### PR DESCRIPTION
**Issue**
Resolves #5123 


**Approach**
Currently the error classes are sitting in the old config parsing file `config_parser.py` and `enkf_obs.py`, this PR moves them all to a separate file that contains all the logic of configuration errors.


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
