### PR TITLE
Double the timeout due to the Azure slow performance

### DIFF
--- a/tests/performance_tests/test_job_runner_performance.py
+++ b/tests/performance_tests/test_job_runner_performance.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 
-@pytest.mark.timeout(4)
+@pytest.mark.timeout(8)
 @pytest.mark.skipif(
     sys.platform.startswith("darwin"), reason="Performance can be flaky"
 )


### PR DESCRIPTION
**Issue**
Might resolve https://github.com/equinor/komodo-releases/issues/3189.
This test always fail on Azure. Both when sourcing komodo from Managed Lustre or ANF.


**Approach**
Double the timeout


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
