### PR TITLE
Increase timeout on job runner startup overhead

### DIFF
--- a/tests/performance_tests/test_forward_model_script_overhead.py
+++ b/tests/performance_tests/test_forward_model_script_overhead.py
@@ -11,7 +11,7 @@ forward_models_path = os.path.join(
 )
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(
     sys.platform.startswith("darwin"), reason="Performance can be flaky"
 )


### PR DESCRIPTION
This test is failing on azure. We were instructed to adjust our expectations, so we increase the timeout to see if we can get the test to pass.

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] Updated documentation
- [X] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
