### PR TITLE
Add timestamps to torque debug log statements

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -334,17 +334,16 @@ stringlist_type *torque_driver_alloc_cmd(torque_driver_type *driver,
 
 static void torque_debug(const torque_driver_type *driver, const char *fmt,
                          ...) {
-    if (driver->debug_stream) {
-        {
-            va_list ap;
-            va_start(ap, fmt);
-            vfprintf(driver->debug_stream, fmt, ap);
-            va_end(ap);
-        }
-        fprintf(driver->debug_stream, "\n");
-        fsync(fileno(driver->debug_stream));
-        fflush(driver->debug_stream);
+    if (!driver->debug_stream) {
+        return;
     }
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(driver->debug_stream, fmt, ap);
+    va_end(ap);
+    fprintf(driver->debug_stream, "\n");
+    fsync(fileno(driver->debug_stream));
+    fflush(driver->debug_stream);
 }
 
 static int torque_job_parse_qsub_stdout(const torque_driver_type *driver,


### PR DESCRIPTION
Co-authored-by: chatgpt4

**Issue**
Resolves missing timestamps in torque debug log

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
