### PR TITLE
Declare qsub jobs as not rerunnable

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -297,6 +297,8 @@ stringlist_type *torque_driver_alloc_cmd(torque_driver_type *driver,
     stringlist_type *argv = stringlist_alloc_new();
 
     if (driver->keep_qsub_output) {
+        // Retain both standard output and standard error streams on the
+        // execution host:
         stringlist_append_copy(argv, "-k");
         stringlist_append_copy(argv, "oe");
     }
@@ -326,6 +328,10 @@ stringlist_type *torque_driver_alloc_cmd(torque_driver_type *driver,
         stringlist_append_copy(argv, "-N");
         stringlist_append_copy(argv, job_name);
     }
+
+    // Declare the job as not rerunnable
+    stringlist_append_copy(argv, "-r");
+    stringlist_append_copy(argv, "n");
 
     stringlist_append_copy(argv, submit_script);
 


### PR DESCRIPTION
Reruns need to be controlled by ERT. Whether jobs can be rerun depends on the forward models in use.

**Issue**
Resolves #


**Approach**
Add hardcoded option to `qsub`.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
