### PR TITLE
Improve config testing via hypothesis

### DIFF
--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -378,8 +378,7 @@ static void handle_summary_observation(enkf_obs_type *enkf_obs,
             break;
 
         obs_vector_load_from_SUMMARY_OBSERVATION(obs_vector, sum_obs_conf,
-                                                 enkf_obs->obs_time,
-                                                 enkf_obs->ensemble_config);
+                                                 enkf_obs->obs_time);
         enkf_obs_add_obs_vector(enkf_obs, obs_vector);
     }
 }

--- a/src/clib/lib/enkf/obs_vector.cpp
+++ b/src/clib/lib/enkf/obs_vector.cpp
@@ -281,8 +281,7 @@ int obs_vector_get_next_active_step(const obs_vector_type *obs_vector,
 */
 void obs_vector_load_from_SUMMARY_OBSERVATION(
     obs_vector_type *obs_vector, const conf_instance_type *conf_instance,
-    const std::vector<time_t> &obs_time,
-    ensemble_config_type *ensemble_config) {
+    const std::vector<time_t> &obs_time) {
     if (!conf_instance_is_of_class(conf_instance, "SUMMARY_OBSERVATION"))
         util_abort("%s: internal error. expected \"SUMMARY_OBSERVATION\" "
                    "instance, got \"%s\".\n",

--- a/src/clib/lib/include/ert/enkf/obs_vector.hpp
+++ b/src/clib/lib/include/ert/enkf/obs_vector.hpp
@@ -49,7 +49,7 @@ obs_vector_alloc_from_GENERAL_OBSERVATION(const conf_instance_type *,
                                           enkf_config_node_type *);
 void obs_vector_load_from_SUMMARY_OBSERVATION(
     obs_vector_type *obs_vector, const conf_instance_type *,
-    const std::vector<time_t> &obs_time, ensemble_config_type *);
+    const std::vector<time_t> &obs_time);
 bool obs_vector_load_from_HISTORY_OBSERVATION(
     obs_vector_type *obs_vector, const conf_instance_type *,
     const std::vector<time_t> &obs_time, const history_source_type history,

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -195,16 +195,16 @@ class AnalysisConfig:
     def __repr__(self):
         return (
             "AnalysisConfig("
-            f"alpha={self._alpha}"
-            f"std_cutoff={self._std_cutoff}"
-            f"stop_long_running={self._stop_long_running}"
-            f"global_std_scaling={self._global_std_scaling}"
-            f"max_runtime={self._max_runtime}"
-            f"min_realization={self._min_realization}"
-            f"update_log_path={self._update_log_path}"
-            f"analysis_iter_config={self._analysis_iter_config}"
-            f"analysis_copy={self._analysis_copy}"
-            f"analysis_set_var={self._analysis_set_var}"
+            f"alpha={self._alpha}, "
+            f"std_cutoff={self._std_cutoff}, "
+            f"stop_long_running={self._stop_long_running}, "
+            f"global_std_scaling={self._global_std_scaling}, "
+            f"max_runtime={self._max_runtime}, "
+            f"min_realization={self._min_realization}, "
+            f"update_log_path={self._update_log_path}, "
+            f"analysis_iter_config={self._analysis_iter_config}, "
+            f"analysis_copy={self._analysis_copy}, "
+            f"analysis_set_var={self._analysis_set_var}, "
             f"analysis_select={self._active_module})"
         )
 

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -58,6 +58,10 @@ class EnkfObs(BaseCClass):
         refcase: Optional["EclSum"],
         ensemble_config: "EnsembleConfig",
     ):
+        # The c object holds on to ensemble_config, so we
+        # need to hold onto a reference to it here so it does not
+        # get destructed
+        self._ensemble_config = ensemble_config
         c_ptr = _clib.enkf_obs.alloc(
             int(history_type), time_map, refcase, ensemble_config
         )

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -3,20 +3,22 @@ import datetime
 import os
 import os.path
 import stat
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Any, List, Literal, Tuple, Union
 
 import hypothesis.strategies as st
 from hypothesis import assume, note
 from py import path as py_path
+from pydantic import PositiveInt
 
 from ert._c_wrappers.enkf import ConfigKeys
 from ert._c_wrappers.enkf.config.enkf_config_node import FIELD_FUNCTION_NAMES
 from ert._c_wrappers.job_queue import QueueDriverEnum
 
-from .egrid_generator import egrids
-from .observations_generator import observations
-from .summary_generator import summaries
+from .egrid_generator import EGrid, egrids
+from .observations_generator import Observation, observations
+from .summary_generator import Smspec, Unsmry, summaries
 
 words = st.text(
     min_size=4, max_size=8, alphabet=st.characters(min_codepoint=65, max_codepoint=90)
@@ -30,6 +32,10 @@ def touch(filename):
 
 file_names = words
 format_file_names = st.builds(lambda file_name: file_name + "-%d", file_names)
+
+
+def small_list(*arg, max_size=5, **kw_args):
+    return st.lists(*arg, **kw_args, max_size=max_size)
 
 
 @st.composite
@@ -211,132 +217,229 @@ def random_ext_job_names(draw, some_words, some_file_names):
     )
 
 
-def defines(config_dict, config_files, cwd):
-    """
-    We combine default defines that are magically populated in the config
-    content path using the predefined keyword mechanism with random key values.
-    When initializing from dict, unlike when reading from file, defines are not
-    resolved so we must make sure a define key is not present in any file names
-    etc. Therefore all file_names are upper case and define keys are prefixed
-    with the lower case 'key'.
-    """
-    config_file_name = os.path.basename(config_files)
-    return [
-        ("<CONFIG_PATH>", cwd),
-        ("<CONFIG_FILE_BASE>", config_file_name.split(".")[0]),
-        ("<DATE>", datetime.date.today().isoformat()),
-        ("<CWD>", cwd),
-        ("<CONFIG_FILE>", config_file_name),
-        ("<RUNPATH_FILE>", os.path.join(cwd, config_dict[ConfigKeys.RUNPATH_FILE])),
-        ("<NUM_CPU>", str(config_dict[ConfigKeys.NUM_CPU])),
-    ]
+@dataclass
+class ErtConfigValues:
+    num_realizations: PositiveInt
+    eclbase: str
+    runpath_file: str
+    run_template: List[str]
+    enkf_alpha: float
+    iter_case: str
+    iter_count: PositiveInt
+    iter_retry_count: PositiveInt
+    update_log_path: str
+    std_cutoff: float
+    max_runtime: PositiveInt
+    min_realizations: PositiveInt
+    define: List[Tuple[str, str]]
+    forward_model: List[List[str]]
+    simulation_job: List[List[str]]
+    stop_long_running: bool
+    data_kw_key: List[Tuple[str, str]]
+    data_file: str
+    grid_file: str
+    job_script: str
+    jobname: str
+    runpath: str
+    enspath: str
+    time_map: str
+    obs_config: str
+    history_source: Literal["REFCASE_SIMULATED", "REFCASE_HISTORY"]
+    refcase: str
+    gen_kw_export_name: str
+    field: List[Tuple[str, ...]]
+    gen_data: List[Tuple[str, ...]]
+    max_submit: PositiveInt
+    num_cpu: PositiveInt
+    queue_system: Literal["LSF", "LOCAL", "TORQUE", "SLURM"]
+    queue_option: List[Union[Tuple[str, str], Tuple[str, str, str]]]
+    analysis_copy: List[Tuple[str, str]]
+    analysis_set_var: List[Tuple[str, str, Any]]
+    analysis_select: str
+    install_job: List[Tuple[str, str]]
+    install_job_directory: List[str]
+    license_path: str
+    random_seed: str
+    setenv: List[Tuple[str, str]]
+    observations: List[Observation]
+    refcase_summaries: Tuple[Smspec, Unsmry]
+    egrid: EGrid
+
+    def to_config_dict(self, config_file, cwd, all_defines=True):
+        return {
+            ConfigKeys.FORWARD_MODEL: self.forward_model,
+            ConfigKeys.SIMULATION_JOB: self.simulation_job,
+            ConfigKeys.NUM_REALIZATIONS: self.num_realizations,
+            ConfigKeys.ECLBASE: self.eclbase,
+            ConfigKeys.RUNPATH_FILE: self.runpath_file,
+            ConfigKeys.RUN_TEMPLATE: self.run_template,
+            ConfigKeys.ALPHA_KEY: self.enkf_alpha,
+            ConfigKeys.ITER_CASE: self.iter_case,
+            ConfigKeys.ITER_COUNT: self.iter_count,
+            ConfigKeys.ITER_RETRY_COUNT: self.iter_retry_count,
+            ConfigKeys.UPDATE_LOG_PATH: self.update_log_path,
+            ConfigKeys.STD_CUTOFF_KEY: self.std_cutoff,
+            ConfigKeys.MAX_RUNTIME: self.max_runtime,
+            ConfigKeys.MIN_REALIZATIONS: self.min_realizations,
+            ConfigKeys.DEFINE_KEY: self.all_defines(config_file, cwd)
+            if all_defines
+            else self.define,
+            ConfigKeys.STOP_LONG_RUNNING: self.stop_long_running,
+            ConfigKeys.DATA_KW_KEY: self.data_kw_key,
+            ConfigKeys.DATA_FILE: self.data_file,
+            ConfigKeys.GRID: self.grid_file,
+            ConfigKeys.JOB_SCRIPT: self.job_script,
+            ConfigKeys.JOBNAME: self.jobname,
+            ConfigKeys.RUNPATH: self.runpath,
+            ConfigKeys.ENSPATH: self.enspath,
+            ConfigKeys.TIME_MAP: self.time_map,
+            ConfigKeys.OBS_CONFIG: self.obs_config,
+            ConfigKeys.HISTORY_SOURCE: self.history_source,
+            ConfigKeys.REFCASE: self.refcase,
+            ConfigKeys.GEN_KW_EXPORT_NAME: self.gen_kw_export_name,
+            ConfigKeys.FIELD_KEY: self.field,
+            ConfigKeys.GEN_DATA: self.gen_data,
+            ConfigKeys.MAX_SUBMIT: self.max_submit,
+            ConfigKeys.NUM_CPU: self.num_cpu,
+            ConfigKeys.QUEUE_SYSTEM: self.queue_system,
+            ConfigKeys.QUEUE_OPTION: self.queue_option,
+            ConfigKeys.ANALYSIS_COPY: self.analysis_copy,
+            ConfigKeys.ANALYSIS_SET_VAR: self.analysis_set_var,
+            ConfigKeys.ANALYSIS_SELECT: self.analysis_select,
+            ConfigKeys.INSTALL_JOB: self.install_job,
+            ConfigKeys.INSTALL_JOB_DIRECTORY: self.install_job_directory,
+            ConfigKeys.LICENSE_PATH: self.license_path,
+            ConfigKeys.RANDOM_SEED: self.random_seed,
+            ConfigKeys.SETENV: self.setenv,
+        }
+
+    def all_defines(self, config_file, cwd):
+        """
+        We combine default defines that are magically populated in the config
+        content path using the predefined keyword mechanism with random key values.
+        When initializing from dict, unlike when reading from file, defines are not
+        resolved so we must make sure a define key is not present in any file names
+        etc. Therefore all file_names are upper case and define keys are prefixed
+        with the lower case 'key'.
+        """
+        config_file_name = os.path.basename(config_file)
+        result = [
+            ("<CONFIG_PATH>", cwd),
+            ("<CONFIG_FILE_BASE>", config_file_name.split(".")[0]),
+            ("<DATE>", datetime.date.today().isoformat()),
+            ("<CWD>", cwd),
+            ("<CONFIG_FILE>", config_file_name),
+        ]
+        result.extend(self.define)
+        result.extend(
+            [
+                ("<RUNPATH_FILE>", self.runpath_file),
+                ("<NUM_CPU>", str(self.num_cpu)),
+            ]
+        )
+        return result
 
 
-def small_list(*arg, max_size=5, **kw_args):
-    return st.lists(*arg, **kw_args, max_size=max_size)
-
-
-def generate_config(draw):
+@st.composite
+def ert_config_values(draw):
     queue_system = draw(queue_systems)
-    config_dict = draw(
-        st.fixed_dictionaries(
-            {
-                ConfigKeys.NUM_REALIZATIONS: positives,
-                ConfigKeys.ECLBASE: st.just(draw(words) + "%d"),
-                ConfigKeys.RUNPATH_FILE: st.just(draw(file_names) + "runpath"),
-                ConfigKeys.RUN_TEMPLATE: small_list(
-                    st.builds(lambda fil: [fil + ".templ", fil], file_names)
-                ),
-                ConfigKeys.ALPHA_KEY: small_floats,
-                ConfigKeys.ITER_CASE: words,
-                ConfigKeys.ITER_COUNT: positives,
-                ConfigKeys.ITER_RETRY_COUNT: positives,
-                ConfigKeys.UPDATE_LOG_PATH: directory_names(),
-                ConfigKeys.STD_CUTOFF_KEY: small_floats,
-                ConfigKeys.MAX_RUNTIME: positives,
-                ConfigKeys.MIN_REALIZATIONS: positives,
-                ConfigKeys.DEFINE_KEY: small_list(
-                    st.tuples(st.just(f"<key-{draw(words)}>"), words)
-                ),
-                ConfigKeys.STOP_LONG_RUNNING: st.booleans(),
-                ConfigKeys.DATA_KW_KEY: small_list(
-                    st.tuples(st.just(f"<{draw(words)}>"), words)
-                ),
-                ConfigKeys.DATA_FILE: st.just(draw(file_names) + ".DATA"),
-                ConfigKeys.GRID: st.just(draw(words) + ".EGRID"),
-                ConfigKeys.JOB_SCRIPT: st.just(draw(file_names) + "job_script"),
-                ConfigKeys.JOBNAME: st.just("JOBNAME-" + draw(words)),
-                ConfigKeys.RUNPATH: st.just("runpath-" + draw(format_file_names)),
-                ConfigKeys.ENSPATH: st.just(draw(words) + ".enspath"),
-                ConfigKeys.TIME_MAP: st.just(draw(file_names) + ".timemap"),
-                ConfigKeys.OBS_CONFIG: st.just("obs-config-" + draw(file_names)),
-                ConfigKeys.HISTORY_SOURCE: st.just("REFCASE_SIMULATED"),
-                ConfigKeys.REFCASE: st.just("refcase/" + draw(file_names)),
-                ConfigKeys.GEN_KW_EXPORT_NAME: st.just(
-                    "gen-kw-export-name-" + draw(file_names)
-                ),
-                ConfigKeys.FIELD_KEY: small_list(
-                    st.tuples(
-                        st.just("FIELD-" + draw(words)),
-                        st.just("PARAMETER"),
-                        file_names,
-                        st.just(f"FORWARD_INIT:{draw(st.booleans())}"),
-                        st.just(f"INIT_TRANSFORM:{draw(transforms)}"),
-                        st.just(f"OUTPUT_TRANSFORM:{draw(transforms)}"),
-                        st.just(f"MIN:{draw(small_floats)}"),
-                        st.just(f"MAX:{draw(small_floats)}"),
-                        st.just(f"INIT_FILES:{draw(file_names)}"),
-                    ),
-                    unique_by=lambda element: element[0],
-                ),
-                ConfigKeys.GEN_DATA: small_list(
-                    st.tuples(
-                        st.just(f"GEN_DATA-{draw(words)}"),
-                        st.just(f"{ConfigKeys.RESULT_FILE}:{draw(format_file_names)}"),
-                        st.just(f"{ConfigKeys.INPUT_FORMAT}:ASCII"),
-                        st.just(f"{ConfigKeys.REPORT_STEPS}:{draw(report_steps())}"),
-                    ),
-                    unique_by=lambda tup: tup[0],
-                ),
-                ConfigKeys.MAX_SUBMIT: positives,
-                ConfigKeys.NUM_CPU: positives,
-                ConfigKeys.QUEUE_SYSTEM: st.just(queue_system),
-                ConfigKeys.QUEUE_OPTION: small_list(
-                    queue_options(st.just(queue_system))
-                ),
-                ConfigKeys.ANALYSIS_COPY: small_list(
-                    st.tuples(
-                        st.just("STD_ENKF"),
-                        words,
-                    )
-                ),
-                ConfigKeys.ANALYSIS_SET_VAR: small_list(
-                    st.tuples(
-                        st.just("STD_ENKF"),
-                        st.just("ENKF_NCOMP"),
-                        st.integers(),
-                    )
-                ),
-                ConfigKeys.ANALYSIS_SELECT: st.just("STD_ENKF"),
-                ConfigKeys.INSTALL_JOB: small_list(
-                    random_ext_job_names(words, file_names)
-                ),
-                ConfigKeys.INSTALL_JOB_DIRECTORY: small_list(directory_names()),
-                ConfigKeys.LICENSE_PATH: directory_names(),
-                ConfigKeys.RANDOM_SEED: words,
-                ConfigKeys.SETENV: small_list(st.tuples(words, words)),
-            }
+    install_jobs = draw(small_list(random_ext_job_names(words, file_names)))
+    forward_model = draw(small_list(job(install_jobs))) if install_jobs else []
+    simulation_job = draw(small_list(sim_job(install_jobs))) if install_jobs else []
+    gen_data = draw(
+        small_list(
+            st.tuples(
+                st.builds(lambda x: f"GEN_DATA-{x}", words),
+                st.builds(lambda x: f"{ConfigKeys.RESULT_FILE}:{x}", format_file_names),
+                st.just(f"{ConfigKeys.INPUT_FORMAT}:ASCII"),
+                st.builds(lambda x: f"{ConfigKeys.REPORT_STEPS}:{x}", report_steps()),
+            ),
+            unique_by=lambda tup: tup[0],
         )
     )
-
-    installed_jobs = config_dict[ConfigKeys.INSTALL_JOB]
-    config_dict[ConfigKeys.FORWARD_MODEL] = (
-        draw(small_list(job(installed_jobs))) if installed_jobs else []
+    obs = draw(observations([g[0] for g in gen_data]))
+    dates = _observation_dates(obs, datetime.datetime.strptime("1999-1-1", "%Y-%m-%d"))
+    refcase_summaries = draw(summaries(dates=st.just(dates)))
+    return draw(
+        st.builds(
+            ErtConfigValues,
+            forward_model=st.just(forward_model),
+            simulation_job=st.just(simulation_job),
+            num_realizations=positives,
+            eclbase=st.just(draw(words) + "%d"),
+            runpath_file=st.just(draw(file_names) + "runpath"),
+            run_template=small_list(
+                st.builds(lambda fil: [fil + ".templ", fil], file_names)
+            ),
+            enkf_alpha=small_floats,
+            iter_case=words,
+            iter_count=positives,
+            iter_retry_count=positives,
+            update_log_path=directory_names(),
+            std_cutoff=small_floats,
+            max_runtime=positives,
+            min_realizations=positives,
+            define=small_list(
+                st.tuples(st.builds(lambda x: f"<key-{x}>", words), words)
+            ),
+            stop_long_running=st.booleans(),
+            data_kw_key=small_list(
+                st.tuples(st.builds(lambda x: f"<{x}>", words), words)
+            ),
+            data_file=st.just(draw(file_names) + ".DATA"),
+            grid_file=st.just(draw(words) + ".EGRID"),
+            job_script=st.just(draw(file_names) + "job_script"),
+            jobname=st.just("JOBNAME-" + draw(words)),
+            runpath=st.just("runpath-" + draw(format_file_names)),
+            enspath=st.just(draw(words) + ".enspath"),
+            time_map=st.just(draw(file_names) + ".timemap"),
+            obs_config=st.just("obs-config-" + draw(file_names)),
+            history_source=st.just("REFCASE_SIMULATED"),
+            refcase=st.just("refcase/" + draw(file_names)),
+            gen_kw_export_name=st.just("gen-kw-export-name-" + draw(file_names)),
+            field=small_list(
+                st.tuples(
+                    st.builds(lambda w: "FIELD-" + w, words),
+                    st.just("PARAMETER"),
+                    file_names,
+                    st.builds(lambda x: f"FORWARD_INIT:{x}", st.booleans()),
+                    st.builds(lambda x: f"INIT_TRANSFORM:{x}", transforms),
+                    st.builds(lambda x: f"OUTPUT_TRANSFORM:{x}", transforms),
+                    st.builds(lambda x: f"MIN:{x}", small_floats),
+                    st.builds(lambda x: f"MAX:{x}", small_floats),
+                    st.builds(lambda x: f"INIT_FILES:{x}", file_names),
+                ),
+                unique_by=lambda element: element[0],
+            ),
+            gen_data=st.just(gen_data),
+            max_submit=positives,
+            num_cpu=positives,
+            queue_system=st.just(queue_system),
+            queue_option=small_list(queue_options(st.just(queue_system))),
+            analysis_copy=small_list(
+                st.tuples(
+                    st.sampled_from(["STD_ENKF", "IES_ENKF"]),
+                    words,
+                )
+            ),
+            analysis_set_var=small_list(
+                st.tuples(
+                    st.just("STD_ENKF"),
+                    st.just("ENKF_NCOMP"),
+                    st.integers(),
+                )
+            ),
+            analysis_select=st.sampled_from(["STD_ENKF", "IES_ENKF"]),
+            install_job=st.just(install_jobs),
+            install_job_directory=small_list(directory_names()),
+            license_path=directory_names(),
+            random_seed=words,
+            setenv=small_list(st.tuples(words, words)),
+            observations=st.just(obs),
+            refcase_summaries=st.just(refcase_summaries),
+            egrid=egrids,
+        )
     )
-    config_dict[ConfigKeys.SIMULATION_JOB] = (
-        draw(small_list(sim_job(installed_jobs))) if installed_jobs else []
-    )
-    return config_dict
 
 
 def job(installed_jobs):
@@ -379,53 +482,37 @@ def _observation_dates(
 
 @st.composite
 def config_generators(draw):
-    config_dict = generate_config(draw)
-    egrid = draw(egrids)
-    obs = draw(observations([g[0] for g in config_dict.get(ConfigKeys.GEN_DATA, [])]))
+    config_values = draw(ert_config_values())
 
-    should_exist_files = [
-        job_path for _, job_path in config_dict[ConfigKeys.INSTALL_JOB]
-    ]
+    should_exist_files = [job_path for _, job_path in config_values.install_job]
     should_exist_files.extend(
         [
-            config_dict[ConfigKeys.DATA_FILE],
-            config_dict[ConfigKeys.JOB_SCRIPT],
-            config_dict[ConfigKeys.TIME_MAP],
-            config_dict[ConfigKeys.OBS_CONFIG],
+            config_values.data_file,
+            config_values.job_script,
+            config_values.time_map,
+            config_values.obs_config,
         ]
     )
+    obs = config_values.observations
     for o in obs:
         if hasattr(o, "obs_file") and o.obs_file is not None:
             should_exist_files.append(o.obs_file)
         if hasattr(o, "index_file") and o.index_file is not None:
             should_exist_files.append(o.index_file)
 
-    dates = _observation_dates(obs, datetime.datetime.strptime("1999-1-1", "%Y-%m-%d"))
-
-    ref_smspec, ref_unsmry = draw(summaries(dates=st.just(dates)))
-
-    should_exist_files.extend(
-        [src for src, target in config_dict[ConfigKeys.RUN_TEMPLATE]]
-    )
-
-    should_be_executable_files = [config_dict[ConfigKeys.JOB_SCRIPT]]
-
-    should_exist_directories = config_dict[ConfigKeys.INSTALL_JOB_DIRECTORY]
+    should_exist_files.extend([src for src, _ in config_values.run_template])
+    should_be_executable_files = [config_values.job_script]
+    should_exist_directories = config_values.install_job_directory
 
     def generate_job_config(job_path):
         return job_path, draw(file_names) + ".exe"
 
     should_exist_job_configs = [
-        generate_job_config(job_path)
-        for _, job_path in config_dict[ConfigKeys.INSTALL_JOB]
+        generate_job_config(job_path) for _, job_path in config_values.install_job
     ] + [
         generate_job_config(job_dir + "/" + draw(file_names))
-        for job_dir in config_dict[ConfigKeys.INSTALL_JOB_DIRECTORY]
+        for job_dir in config_values.install_job_directory
     ]
-
-    should_exist_refcase = (
-        config_dict[ConfigKeys.REFCASE] if ConfigKeys.REFCASE in config_dict else None
-    )
 
     # Context manager is returned from the generator and given to test function
     # Run this function to get dict, and as a side effect all required files
@@ -437,10 +524,22 @@ def config_generators(draw):
         tmp = py_path.local(tmp_path_factory.mktemp("config_dict"))
         note(f"Using tmp dir: {str(tmp)}")
         with tmp.as_cwd():
-            config_dict[ConfigKeys.JOB_SCRIPT] = os.path.abspath(
-                config_dict[ConfigKeys.JOB_SCRIPT]
-            )
-
+            config_values.run_template = [
+                [os.path.join(tmp, src), target]
+                for src, target in config_values.run_template
+            ]
+            for key in [
+                "runpath",
+                "runpath_file",
+                "enspath",
+                "time_map",
+                "obs_config",
+                "data_file",
+                "job_script",
+            ]:
+                setattr(
+                    config_values, key, os.path.join(tmp, getattr(config_values, key))
+                )
             for dirname in should_exist_directories:
                 if not os.path.isdir(dirname):
                     os.mkdir(dirname)
@@ -449,7 +548,7 @@ def config_generators(draw):
                 if not os.path.isfile(filename):
                     touch(filename)
 
-            with open(config_dict[ConfigKeys.OBS_CONFIG], "w", encoding="utf-8") as fh:
+            with open(config_values.obs_config, "w", encoding="utf-8") as fh:
                 for o in obs:
                     fh.write(str(o))
                     fh.write("\n")
@@ -472,56 +571,29 @@ def config_generators(draw):
                     encoding="utf-8",
                 )
 
-            if should_exist_refcase is not None:
-                summary_basename = os.path.splitext(
-                    os.path.basename(should_exist_refcase)
-                )[0]
-                with contextlib.suppress(FileExistsError):
-                    os.mkdir("./refcase")
-                ref_smspec.to_file(f"./refcase/{summary_basename}.SMSPEC")
-                ref_unsmry.to_file(f"./refcase/{summary_basename}.UNSMRY")
+            summary_basename = os.path.splitext(
+                os.path.basename(config_values.refcase)
+            )[0]
+            with contextlib.suppress(FileExistsError):
+                os.mkdir("./refcase")
+            ref_smspec, ref_unsmry = config_values.refcase_summaries
+            ref_smspec.to_file(f"./refcase/{summary_basename}.SMSPEC")
+            ref_unsmry.to_file(f"./refcase/{summary_basename}.UNSMRY")
 
-            egrid.to_file(config_dict[ConfigKeys.GRID])
-
-            # Make all paths absolute, as that should be the result after parsing
-            cwd = os.getcwd()
-            keys_that_should_be_absolute = [
-                ConfigKeys.RUNPATH,
-                ConfigKeys.RUNPATH_FILE,
-                ConfigKeys.ENSPATH,
-                ConfigKeys.TIME_MAP,
-                ConfigKeys.OBS_CONFIG,
-                ConfigKeys.DATA_FILE,
-            ]
-            for key in keys_that_should_be_absolute:
-                config_dict[key] = os.path.join(cwd, config_dict[key])
-
-            def make_run_template_abs(template):
-                src, target = template
-                return [os.path.join(cwd, src), target]
-
-            config_dict[ConfigKeys.RUN_TEMPLATE] = list(
-                map(
-                    make_run_template_abs,
-                    config_dict.get(ConfigKeys.RUN_TEMPLATE, []),
-                )
-            )
+            config_values.egrid.to_file(config_values.grid_file)
 
             if config_file_name is not None:
-                to_config_file(config_file_name, config_dict)
-                assume(config_dict[ConfigKeys.DATA_FILE] != config_file_name)
-                assume(config_dict[ConfigKeys.RUNPATH_FILE] != config_file_name)
+                to_config_file(config_file_name, config_values)
+                assume(config_values.data_file != config_file_name)
+                assume(config_values.runpath_file != config_file_name)
 
-            yield config_dict
+            yield config_values
 
     return generate_files_and_dict
 
 
-def to_config_file(filename, config_dict):  # pylint: disable=too-many-branches
-    predefines = defines(config_dict, filename, os.getcwd())
-    predefines.extend(config_dict[ConfigKeys.DEFINE_KEY])
-    config_dict[ConfigKeys.DEFINE_KEY] = predefines
-
+def to_config_file(filename, config_values):  # pylint: disable=too-many-branches
+    config_dict = config_values.to_config_dict(filename, os.getcwd(), all_defines=False)
     with open(file=filename, mode="w+", encoding="utf-8") as config:
         config.write(
             f"{ConfigKeys.RUNPATH_FILE} {config_dict[ConfigKeys.RUNPATH_FILE]}\n"

--- a/tests/test_config_parsing/observations_generator.py
+++ b/tests/test_config_parsing/observations_generator.py
@@ -39,7 +39,7 @@ class Observation(ABC):
             elif isinstance(val, Observation):
                 result += str(val)
             elif isinstance(val, list):
-                result += f"{f.name.upper()} = {','.join([str(v) for v in val])}; "
+                result += f"{' '.join([str(v) for v in val])}"
             else:
                 assert False
         result += " };"

--- a/tests/test_config_parsing/observations_generator.py
+++ b/tests/test_config_parsing/observations_generator.py
@@ -189,7 +189,11 @@ def observations(ensemble_keys):
             st.one_of(
                 summary_observations(),
                 general_observations(st.sampled_from(ensemble_keys)),
-                st.builds(HistoryObservation, name=names),
+                st.builds(
+                    HistoryObservation,
+                    segment=st.lists(st.builds(Segment, name=names), max_size=2),
+                    name=names,
+                ),
             ),
             min_size=1,
             max_size=5,
@@ -198,7 +202,11 @@ def observations(ensemble_keys):
         return st.lists(
             st.one_of(
                 summary_observations(),
-                st.builds(HistoryObservation, name=names),
+                st.builds(
+                    HistoryObservation,
+                    segment=st.lists(st.builds(Segment, name=names), max_size=2),
+                    name=names,
+                ),
             ),
             min_size=1,
             max_size=5,

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,7 +1,7 @@
 import pytest
 from hypothesis import assume, given
 
-from ert._c_wrappers.enkf import ConfigKeys, ErtConfig
+from ert._c_wrappers.enkf import ErtConfig
 
 from .config_dict_generator import config_generators, to_config_file
 
@@ -11,14 +11,11 @@ def test_ensemble_config_errors_on_unknown_function_in_field(
     tmp_path_factory, config_generator
 ):
     filename = "config.ert"
-    with config_generator(tmp_path_factory, filename) as config_dict:
-        assume(
-            ConfigKeys.FIELD_KEY in config_dict
-            and len(config_dict[ConfigKeys.FIELD_KEY]) > 0
-        )
+    with config_generator(tmp_path_factory, filename) as config_values:
+        assume(len(config_values.field) > 0)
 
         silly_function_name = "NORMALIZE_EGGS"
-        fieldlist = list(config_dict[ConfigKeys.FIELD_KEY][0])
+        fieldlist = list(config_values.field[0])
         alteredfieldlist = []
 
         for val in fieldlist:
@@ -30,9 +27,9 @@ def test_ensemble_config_errors_on_unknown_function_in_field(
         mylist = []
         mylist.append(tuple(alteredfieldlist))
 
-        config_dict[ConfigKeys.FIELD_KEY] = mylist
+        config_values.field = mylist
 
-        to_config_file(filename, config_dict)
+        to_config_file(filename, config_values)
         with pytest.raises(
             expected_exception=ValueError,
             match=f"FIELD INIT_TRANSFORM:{silly_function_name} is an invalid function",

--- a/tests/test_config_parsing/test_forward_model.py
+++ b/tests/test_config_parsing/test_forward_model.py
@@ -11,7 +11,6 @@ from hypothesis import given
 
 from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import ErtConfig
-from ert._c_wrappers.enkf.config_keys import ConfigKeys
 
 from .config_dict_generator import config_generators, to_config_file
 
@@ -21,19 +20,17 @@ def test_ert_config_throws_on_missing_forward_model_job(
     tmp_path_factory, config_generator
 ):
     filename = "config.ert"
-    with config_generator(tmp_path_factory) as config_dict:
-        config_dict.pop(ConfigKeys.INSTALL_JOB)
-        config_dict.pop(ConfigKeys.INSTALL_JOB_DIRECTORY)
-        config_dict[ConfigKeys.FORWARD_MODEL].append(
+    with config_generator(tmp_path_factory) as config_values:
+        config_values.install_job = []
+        config_values.install_job_directory = []
+        config_values.forward_model.append(
             ["this-is-not-the-job-you-are-looking-for", "<WAVE-HAND>=casually"]
         )
 
-        to_config_file(filename, config_dict)
+        to_config_file(filename, config_values)
 
         with pytest.raises(expected_exception=ValueError, match="Could not find job"):
             ErtConfig.from_file(filename)
-        with pytest.raises(expected_exception=ValueError, match="Could not find job"):
-            ErtConfig.from_dict(config_dict)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/test_config_parsing/test_substitution_list.py
+++ b/tests/test_config_parsing/test_substitution_list.py
@@ -1,3 +1,5 @@
+import os
+
 from hypothesis import assume, given
 
 from ert._c_wrappers.enkf import ConfigKeys, ErtConfig
@@ -9,16 +11,17 @@ from .config_dict_generator import config_generators
 def test_different_defines_give_different_subst_lists(
     tmp_path_factory, config_generator1, config_generator2
 ):
-    with config_generator1(tmp_path_factory) as config_dict1:
-        ert_config1 = ErtConfig.from_dict(config_dict1)
-        with config_generator2(tmp_path_factory) as config_dict2:
-            assume(
-                config_dict1[ConfigKeys.DEFINE_KEY]
-                != config_dict2[ConfigKeys.DEFINE_KEY]
-            )
+    with config_generator1(tmp_path_factory) as config_values1:
+        ert_config1 = ErtConfig.from_dict(
+            config_values1.to_config_dict("test.ert", os.getcwd())
+        )
+        with config_generator2(tmp_path_factory) as config_values2:
+            assume(config_values1.define != config_values2.define)
             assert (
                 ert_config1.substitution_list
-                != ErtConfig.from_dict(config_dict2).substitution_list
+                != ErtConfig.from_dict(
+                    config_values2.to_config_dict("test.ert", os.getcwd())
+                ).substitution_list
             )
 
 


### PR DESCRIPTION
In preparation for further testing of EnkfObs.load, we need access to all the values that went into ert config setup from the tests.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
