### PR TITLE
Print debug info when torque job fails

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -774,6 +774,10 @@ job_status_type torque_driver_parse_status(const char *qstat_file,
     }
 
     if (exit_status != 0) {
+        fprintf(stderr,
+                "** Warning: Exit code %d from queue system on job: "
+                "%s, job_state: %s\n",
+                exit_status, jobnr_char, job_state.c_str());
         status = JOB_QUEUE_EXIT;
     }
 


### PR DESCRIPTION
This information is needed to debug some incidents when the queue system reports a job as failed but when there are no other traces of failure in the runpath.

This information might be better redirected to the torque_debug function, but the driver instance is not available in this function.

**Issue**
Aids debugging of https://github.com/equinor/scout/issues/800


**Approach**
fprintf


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
