### PR TITLE
Enable new parser DEFINE key to allow multiple arguments

### DIFF
--- a/src/ert/_c_wrappers/enkf/config_keywords.py
+++ b/src/ert/_c_wrappers/enkf/config_keywords.py
@@ -371,6 +371,7 @@ def define_keyword():
         argc_max=2,
         multi_occurrence=True,
         substitute_from=2,
+        join_after=1,
     )
 
 

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -518,6 +518,31 @@ def test_that_define_statements_with_less_than_one_argument_raises_error():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+def test_that_define_statements_with_more_than_one_argument():
+    test_config_file_name = "test.ert"
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS  1
+        DEFINE <TEST1> 111 222 333
+        DEFINE <TEST2> <TEST1> 444 555
+        """
+    )
+    with open(test_config_file_name, "w", encoding="utf-8") as fh:
+        fh.write(test_config_contents)
+
+    ert_config = ErtConfig.from_file(test_config_file_name, use_new_parser=False)
+    assert ert_config.substitution_list.get("<TEST1>") == "111 222 333"
+    assert ert_config.substitution_list.get("<TEST2>") == "111 222 333 444 555"
+    new_parser_ert_config = ErtConfig.from_file(
+        test_config_file_name, use_new_parser=True
+    )
+    assert new_parser_ert_config.substitution_list.get("<TEST1>") == "111 222 333"
+    assert (
+        new_parser_ert_config.substitution_list.get("<TEST2>") == "111 222 333 444 555"
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_giving_non_int_values_give_config_validation_error():
     test_config_file_name = "test.ert"
     test_config_contents = dedent(


### PR DESCRIPTION
**Issue**
Resolves #5143



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
