### PR TITLE
Show Error in suggestor when unsupported non-UTF-8 characters found

### DIFF
--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -87,6 +87,24 @@ class ConfigParser(BaseCClass):
         else:
             raise KeyError(f"Config parser does not have item:{keyword}")
 
+    @staticmethod
+    def check_non_utf_chars(config_file):
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                f.read()
+        except UnicodeDecodeError as e:
+            error_words = str(e).split(" ")
+            hex_str = error_words[error_words.index("byte") + 1]
+            try:
+                unknown_char = chr(int(hex_str, 16))
+            except ValueError:
+                unknown_char = f"hex:{hex_str}"
+            raise ConfigValidationError(
+                f"Unsupported non UTF-8 character {unknown_char!r} "
+                f"found in config file: {config_file!r}",
+                config_file=config_file,
+            )
+
     def parse(
         self,
         config_file,
@@ -108,6 +126,7 @@ class ConfigParser(BaseCClass):
             raise IOError(f"File: {config_file} does not exists")
         if not os.access(config_file, os.R_OK):
             raise IOError(f"We do not have read permissions for file: {config_file}")
+        self.check_non_utf_chars(config_file)
         config_content = self._parse(
             config_file,
             comment_string,

--- a/src/ert/_c_wrappers/enkf/lark_parser.py
+++ b/src/ert/_c_wrappers/enkf/lark_parser.py
@@ -532,6 +532,18 @@ def _parse_file(
                 f"The parser said: {msg!r}"
             )
         raise ConfigValidationError(msg, config_file=file)
+    except UnicodeDecodeError as e:
+        error_words = str(e).split(" ")
+        hex_str = error_words[error_words.index("byte") + 1]
+        try:
+            unknown_char = chr(int(hex_str, 16))
+        except ValueError:
+            unknown_char = f"hex:{hex_str}"
+        raise ConfigValidationError(
+            f"Unsupported non UTF-8 character {unknown_char!r} "
+            f"found in config file: {file!r}",
+            config_file=file,
+        )
 
 
 def parse(

--- a/src/ert/data/loader.py
+++ b/src/ert/data/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Protocol, Sequence
 
 import pandas as pd
 
@@ -117,11 +117,10 @@ def _load_general_response(
             for key in facade.all_data_type_keys()
             if facade.is_gen_data_key(key) and data_key in key
         ]
-        data = pd.DataFrame()
-
+        gen_data_list: List[pd.DataFrame] = []
         for time_step in time_steps:
-            gen_data = facade.load_gen_data(case_name, data_key, time_step).T
-            data = data.append(gen_data)
+            gen_data_list.append(facade.load_gen_data(case_name, data_key, time_step).T)
+        data = pd.concat(gen_data_list)
     except ValueError as err:
         raise ResponseError(
             f"No response loaded for observation key: {obs_key}"


### PR DESCRIPTION
Show Error in suggestor when unsupported non-UTF-8 characters are present in the config file.

Backport bugfix:
https://github.com/equinor/ert/pull/5036

Part of Backporting to version-4.5 task
https://github.com/equinor/ert/issues/5177

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
