### PR TITLE
Show Error in suggestor when non-UTF-8 found in DATA file

### DIFF
--- a/src/ert/_c_wrappers/config/config_parser.py
+++ b/src/ert/_c_wrappers/config/config_parser.py
@@ -88,9 +88,9 @@ class ConfigParser(BaseCClass):
             raise KeyError(f"Config parser does not have item:{keyword}")
 
     @staticmethod
-    def check_non_utf_chars(config_file):
+    def check_non_utf_chars(file_path):
         try:
-            with open(config_file, "r", encoding="utf-8") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 f.read()
         except UnicodeDecodeError as e:
             error_words = str(e).split(" ")
@@ -101,8 +101,8 @@ class ConfigParser(BaseCClass):
                 unknown_char = f"hex:{hex_str}"
             raise ConfigValidationError(
                 f"Unsupported non UTF-8 character {unknown_char!r} "
-                f"found in config file: {config_file!r}",
-                config_file=config_file,
+                f"found in file: {file_path!r}",
+                config_file=file_path,
             )
 
     def parse(

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -272,6 +272,7 @@ class ErtConfig:
             target_file = (
                 config_dict[ConfigKeys.ECLBASE].replace("%d", "<IENS>") + ".DATA"
             )
+            ConfigParser.check_non_utf_chars(source_file)
             templates.append([source_file, target_file])
 
         for template in config_dict.get(ConfigKeys.RUN_TEMPLATE, []):

--- a/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_config_content_as_dict.py
@@ -150,6 +150,6 @@ def test_check_non_utf_characters(tmpdir):
         with pytest.raises(
             ConfigValidationError,
             match="Unsupported non UTF-8 character "
-            f"'ÿ' found in config file: {config_file!r}",
+            f"'ÿ' found in file: {config_file!r}",
         ):
             ConfigParser.check_non_utf_chars(config_file)


### PR DESCRIPTION
:warning: Merge after https://github.com/equinor/ert/pull/5194

Show Error in suggestor when unsupported non-UTF-8 characters are present in the DATA file

Backport bugfix:
https://github.com/equinor/ert/pull/5072

Part of Backporting to version-4.5 task
https://github.com/equinor/ert/issues/5177

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
