### PR TITLE
Only load parameters from forward init for iteration 0

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -26,7 +26,7 @@ def forward_model_ok(
 ) -> Tuple[LoadStatus, str]:
     try:  # pylint: disable=R1702
         result = (LoadStatus.LOAD_SUCCESSFUL, "")
-        if ens_conf.have_forward_init():
+        if ens_conf.have_forward_init() and run_arg.itr == 0:
             forward_init_config_nodes = ens_conf.check_forward_init_nodes()
             error_msg = ""
             for config_node in forward_init_config_nodes:


### PR DESCRIPTION
We should only load parameters from the runpath for the first iteration. After that, ert should be in charge of the parameters

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
