### PR TITLE
Change weights via method instead of GUI during test

### DIFF
--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -379,7 +379,7 @@ def test_that_run_workflow_component_enabled_when_workflows(qapp, tmp_path):
 
 
 @pytest.mark.usefixtures("copy_poly_case")
-def test_that_es_mda_disabled_when_invalid_weights(qtbot):
+def test_that_es_mda_is_disabled_when_weights_are_invalid(qtbot):
     args = Mock()
     args.config = "poly.ert"
     with add_gui_log_handler() as log_handler:
@@ -402,16 +402,10 @@ def test_that_es_mda_disabled_when_invalid_weights(qtbot):
         assert run_sim_button
         assert run_sim_button.isEnabled()
 
-        qtbot.keyClick(
-            es_mda_panel._relative_iteration_weights_box,
-            Qt.Key_Home,
-            modifier=Qt.ShiftModifier,
-        )
-        qtbot.keyClick(es_mda_panel._relative_iteration_weights_box, Qt.Key_Backspace)
-        qtbot.keyClicks(es_mda_panel._relative_iteration_weights_box, "0")
+        es_mda_panel._relative_iteration_weights_box.setText("0")
 
         assert not run_sim_button.isEnabled()
 
-        qtbot.keyClick(es_mda_panel._relative_iteration_weights_box, Qt.Key_Backspace)
-        qtbot.keyClicks(es_mda_panel._relative_iteration_weights_box, "1")
+        es_mda_panel._relative_iteration_weights_box.setText("1")
+
         assert run_sim_button.isEnabled()


### PR DESCRIPTION
Test has been flaky locally on mac and this seems to resolve it.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
