### PR TITLE
Pin websockets less than version 11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ args = dict(
         "scipy<1.9.2",
         "sqlalchemy",
         "uvicorn >= 0.17.0",
-        "websockets >= 9.0.1",
+        "websockets >= 9.0.1, <11.0",
         "httpx",
         "tables",
     ],


### PR DESCRIPTION
Experimentserver is currently relying on using timeout features that was changed in the newest 11.0 release of websockets. Pin version to retain functionality while the issue is resolved.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
