### PR TITLE
Fix warning and errors not showing up together in the suggestor window

### DIFF
--- a/src/ert/data/loader.py
+++ b/src/ert/data/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Protocol, Sequence
 
 import pandas as pd
 
@@ -117,11 +117,10 @@ def _load_general_response(
             for key in facade.all_data_type_keys()
             if facade.is_gen_data_key(key) and data_key in key
         ]
-        data = pd.DataFrame()
-
+        gen_data_list: List[pd.DataFrame] = []
         for time_step in time_steps:
-            gen_data = facade.load_gen_data(case_name, data_key, time_step).T
-            data = data.append(gen_data)
+            gen_data_list.append(facade.load_gen_data(case_name, data_key, time_step).T)
+        data = pd.concat(gen_data_list)
     except ValueError as err:
         raise ResponseError(
             f"No response loaded for observation key: {obs_key}"

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QComboBox, QMessageBox, QToolButton, QWidget
 import ert.gui
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.gui.about_dialog import AboutDialog
+from ert.gui.ertwidgets import SuggestorMessage
 from ert.gui.main import GUILogHandler, _setup_main_window, run_gui
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer import add_gui_log_handler
@@ -145,6 +146,25 @@ def test_that_errors_are_shown_in_the_suggester_window_when_present(qapp, tmp_pa
     with add_gui_log_handler() as log_handler:
         gui, _ = ert.gui.main._start_initial_gui_window(args, log_handler)
         assert gui.windowTitle() == "Some problems detected"
+
+
+def test_that_both_errors_are_warnings_are_shown(qapp, tmp_path):
+    config_file = tmp_path / "config.ert"
+    config_file.write_text(
+        "NUM_REALIZATIONS 1\n"
+        "JOBNAME something\n"
+        "ECLBASE something\n"
+        "FORWARD_MODEL not_installed\n"
+    )
+
+    args = Mock()
+    args.config = str(config_file)
+    with add_gui_log_handler() as log_handler:
+        gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "Some problems detected"
+        suggestions = gui.findChildren(SuggestorMessage)
+        shown_messages = [elem.type_lbl.text() for elem in suggestions]
+        assert shown_messages == ["ERROR", "WARNING"]
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
Fix warning and errors not showing up together in the suggestor window

Backport bugfix:
https://github.com/equinor/ert/pull/5165

Part of Backporting to version-4.5 task
https://github.com/equinor/ert/issues/5177

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
