### PR TITLE
Backport fix for 5202 (flaky gui test) to 4.5

### DIFF
--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -138,8 +138,8 @@ def run_experiment(request, opened_main_window):
 
             qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
-        QTimer.singleShot(1000, use_rundialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)
+        use_rundialog()
 
     return func
 


### PR DESCRIPTION
It seems like the way the test fixture was set up, the test using the fixture started running before the fixture was finished. I think that since this is a module scope fixture, used by several tests, depending on when the test ran we had failures.

Fixes #5202