### PR TITLE
Change Torque option TIMEOUT to QUEUE_QUERY_TIMEOUT

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1855,7 +1855,7 @@ bjobs.
         flakyness.
 
         ::
-                QUEUE_OPTION TORQUE TIMEOUT 126
+                QUEUE_OPTION TORQUE QUEUE_QUERY_TIMEOUT 126
 
 .. _configuring_the_slurm_queue:
 

--- a/src/clib/lib/include/ert/job_queue/torque_driver.hpp
+++ b/src/clib/lib/include/ert/job_queue/torque_driver.hpp
@@ -18,14 +18,14 @@
 #define TORQUE_JOB_PREFIX_KEY "JOB_PREFIX"
 #define TORQUE_SUBMIT_SLEEP "SUBMIT_SLEEP"
 #define TORQUE_DEBUG_OUTPUT "DEBUG_OUTPUT"
-#define TORQUE_TIMEOUT "TIMEOUT"
+#define TORQUE_QUEUE_QUERY_TIMEOUT "QUEUE_QUERY_TIMEOUT"
 
 #define TORQUE_DEFAULT_QSUB_CMD "qsub"
 #define TORQUE_DEFAULT_QSTAT_CMD "qstat_proxy.sh"
 #define TORQUE_DEFAULT_QSTAT_OPTIONS "-x"
 #define TORQUE_DEFAULT_QDEL_CMD "qdel"
 #define TORQUE_DEFAULT_SUBMIT_SLEEP "0"
-#define TORQUE_DEFAULT_TIMEOUT "62"
+#define TORQUE_DEFAULT_QUEUE_QUERY_TIMEOUT "62"
 
 typedef struct torque_driver_struct torque_driver_type;
 typedef struct torque_job_struct torque_job_type;

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -79,8 +79,8 @@ void *torque_driver_alloc() {
     torque_driver_set_option(torque_driver, TORQUE_NUM_NODES, "1");
     torque_driver_set_option(torque_driver, TORQUE_SUBMIT_SLEEP,
                              TORQUE_DEFAULT_SUBMIT_SLEEP);
-    torque_driver_set_option(torque_driver, TORQUE_TIMEOUT,
-                             TORQUE_DEFAULT_TIMEOUT);
+    torque_driver_set_option(torque_driver, TORQUE_QUEUE_QUERY_TIMEOUT,
+                             TORQUE_DEFAULT_QUEUE_QUERY_TIMEOUT);
 
     return torque_driver;
 }
@@ -227,7 +227,7 @@ bool torque_driver_set_option(void *__driver, const char *option_key,
             torque_driver_set_debug_output(driver, value);
         else if (strcmp(TORQUE_SUBMIT_SLEEP, option_key) == 0)
             option_set = torque_driver_set_submit_sleep(driver, value);
-        else if (strcmp(TORQUE_TIMEOUT, option_key) == 0)
+        else if (strcmp(TORQUE_QUEUE_QUERY_TIMEOUT, option_key) == 0)
             option_set = torque_driver_set_timeout(driver, value);
         else
             option_set = false;
@@ -259,7 +259,7 @@ const void *torque_driver_get_option(const void *__driver,
             return driver->cluster_label;
         else if (strcmp(TORQUE_JOB_PREFIX_KEY, option_key) == 0)
             return driver->job_prefix;
-        else if (strcmp(TORQUE_TIMEOUT, option_key) == 0)
+        else if (strcmp(TORQUE_QUEUE_QUERY_TIMEOUT, option_key) == 0)
             return driver->timeout_char;
         else {
             util_abort("%s: option_id:%s not recognized for TORQUE driver \n",
@@ -280,7 +280,7 @@ void torque_driver_init_option_list(stringlist_type *option_list) {
     stringlist_append_copy(option_list, TORQUE_KEEP_QSUB_OUTPUT);
     stringlist_append_copy(option_list, TORQUE_CLUSTER_LABEL);
     stringlist_append_copy(option_list, TORQUE_JOB_PREFIX_KEY);
-    stringlist_append_copy(option_list, TORQUE_TIMEOUT);
+    stringlist_append_copy(option_list, TORQUE_QUEUE_QUERY_TIMEOUT);
 }
 
 torque_job_type *torque_job_alloc() {

--- a/src/clib/old_tests/job_queue/test_job_torque.cpp
+++ b/src/clib/old_tests/job_queue/test_job_torque.cpp
@@ -26,7 +26,7 @@ void setoption_setalloptions_optionsset() {
     test_option(driver, TORQUE_KEEP_QSUB_OUTPUT, "0");
     test_option(driver, TORQUE_CLUSTER_LABEL, "thecluster");
     test_option(driver, TORQUE_JOB_PREFIX_KEY, "coolJob");
-    test_option(driver, TORQUE_TIMEOUT, "128");
+    test_option(driver, TORQUE_QUEUE_QUERY_TIMEOUT, "128");
 
     test_assert_int_equal(0, torque_driver_get_submit_sleep(driver));
     test_assert_NULL(torque_driver_get_debug_stream(driver));
@@ -35,7 +35,8 @@ void setoption_setalloptions_optionsset() {
         torque_driver_set_option(driver, TORQUE_SUBMIT_SLEEP, "0.25"));
     test_assert_int_equal(250000, torque_driver_get_submit_sleep(driver));
 
-    test_assert_true(torque_driver_set_option(driver, TORQUE_TIMEOUT, "5"));
+    test_assert_true(
+        torque_driver_set_option(driver, TORQUE_QUEUE_QUERY_TIMEOUT, "5"));
     test_assert_int_equal(5, torque_driver_get_timeout(driver));
 
     char tmp_path[] = "/tmp/torque_debug_XXXXXX";
@@ -68,7 +69,7 @@ void setoption_setalloptions_optionsset() {
     torque_driver_set_option(driver, TORQUE_NUM_CPUS_PER_NODE, NULL);
     torque_driver_set_option(driver, TORQUE_NUM_NODES, NULL);
     torque_driver_set_option(driver, TORQUE_KEEP_QSUB_OUTPUT, NULL);
-    torque_driver_set_option(driver, TORQUE_TIMEOUT, NULL);
+    torque_driver_set_option(driver, TORQUE_QUEUE_QUERY_TIMEOUT, NULL);
     test_assert_string_equal((const char *)torque_driver_get_option(
                                  driver, TORQUE_NUM_CPUS_PER_NODE),
                              "42");
@@ -77,8 +78,9 @@ void setoption_setalloptions_optionsset() {
     test_assert_string_equal(
         (const char *)torque_driver_get_option(driver, TORQUE_KEEP_QSUB_OUTPUT),
         "0");
-    test_assert_string_equal(
-        (const char *)torque_driver_get_option(driver, TORQUE_TIMEOUT), "5");
+    test_assert_string_equal((const char *)torque_driver_get_option(
+                                 driver, TORQUE_QUEUE_QUERY_TIMEOUT),
+                             "5");
 
     torque_driver_free(driver);
 }
@@ -105,7 +107,8 @@ void setoption_set_typed_options_wrong_format_returns_false() {
         torque_driver_set_option(driver, TORQUE_KEEP_QSUB_OUTPUT, "1.1"));
     test_assert_false(
         torque_driver_set_option(driver, TORQUE_SUBMIT_SLEEP, "X45"));
-    test_assert_false(torque_driver_set_option(driver, TORQUE_TIMEOUT, "X45"));
+    test_assert_false(
+        torque_driver_set_option(driver, TORQUE_QUEUE_QUERY_TIMEOUT, "X45"));
 }
 
 void getoption_nooptionsset_defaultoptionsreturned() {


### PR DESCRIPTION
The term TIMEOUT is overloaded, and something more specific is needed to distuingish this particular timeout from other timeouts. This particular timeout is specific for Torque only, and should not be confused with similar timeouts in other drivers.

This change is breaking, as ert configs using the previous option name will not have the intended effect. But usage of this option outside of developer testing should be marginal enough to not categorize this as a breaking change causing version bump.


**Issue**
Problem exposed in #5216 


**Approach**
Rename

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
