### PR TITLE
Delete unnecessary test of gen_data_config

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/gen_data_config.py
+++ b/src/ert/_c_wrappers/enkf/config/gen_data_config.py
@@ -71,10 +71,7 @@ class GenDataConfig(BaseCClass):
         self._free()
 
     def __repr__(self):
-        return (
-            f"GenDataConfig(name = {self.name()}, "
-            f"initial_size = {self.get_initial_size()}) {self._ad_str()}"
-        )
+        return f"GenDataConfig(key={self.name()}, input_format={self.getInputFormat()})"
 
     def hasReportStep(self, report_step) -> bool:
         return self._has_report_step(report_step)

--- a/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_data_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_data_config.py
@@ -1,5 +1,0 @@
-from ert._c_wrappers.enkf.config import GenDataConfig
-
-
-def test_create():
-    GenDataConfig("KEY")


### PR DESCRIPTION
Fix __repr__ of GenDataConfig to match constructor.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
