### PR TITLE
Fix strange `gui` case name appearing for each run of EnsembleSmoother

### DIFF
--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -91,7 +91,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
     def getSimulationArguments(self):
         arguments = Arguments(
             mode="ensemble_smoother",
-            current_case="gui",
+            current_case=f"{self.notifier.current_case_name}_prior",
             target_case=self._target_case_model.getValue(),
             realizations=self._active_realizations_field.text(),
         )


### PR DESCRIPTION
**Issue**
Resolves #5141


**Approach**
Replace the `gui` name with current selected case name with a `_prior` suffix. So if a user runs EnsembleSmoother with the current case set for the `default` case. after the smoother runs two new cases are created: 

1. `default_prior`
2. `default_smoother_update`

![image](https://user-images.githubusercontent.com/4508053/231440869-e0623858-47d3-4171-a2e4-aedef42184d1.png)


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
