### PR TITLE
Move enkf_obs_load into python

### DIFF
--- a/src/clib/lib/config/conf.cpp
+++ b/src/clib/lib/config/conf.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 #include <vector>
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include <ert/logging.hpp>
 #include <ert/util/path_stack.hpp>

--- a/src/clib/lib/config/conf.cpp
+++ b/src/clib/lib/config/conf.cpp
@@ -110,7 +110,7 @@ conf_item_spec_type *conf_item_spec_alloc(const char *name, bool required_set,
     conf_item_spec->dt = dt;
     conf_item_spec->default_value = NULL;
     conf_item_spec->help = NULL;
-    conf_item_spec_set_help(conf_item_spec, help);
+    conf_item_spec->help = util_realloc_string_copy(conf_item_spec->help, help);
 
     conf_item_spec->restriction = new std::set<std::string>();
     return conf_item_spec;
@@ -398,11 +398,6 @@ void conf_item_spec_set_default_value(conf_item_spec_type *conf_item_spec,
         conf_item_spec->default_value = util_alloc_string_copy(default_value);
     else
         conf_item_spec->default_value = NULL;
-}
-
-void conf_item_spec_set_help(conf_item_spec_type *conf_item_spec,
-                             const char *help) {
-    conf_item_spec->help = util_realloc_string_copy(conf_item_spec->help, help);
 }
 
 bool conf_class_has_item_spec(const conf_class_type *conf_class,

--- a/src/clib/lib/config/conf.cpp
+++ b/src/clib/lib/config/conf.cpp
@@ -372,18 +372,12 @@ void conf_item_spec_set_default_value(
 
 bool conf_class_has_item_spec(std::shared_ptr<conf_class_type> conf_class,
                               const char *item_name) {
-    if (!conf_class->item_specs.count(item_name))
-        return false;
-    else
-        return true;
+    return conf_class->item_specs.count(item_name);
 }
 
 bool conf_class_has_sub_class(std::shared_ptr<conf_class_type> conf_class,
                               const char *sub_class_name) {
-    if (!conf_class->sub_classes.count(sub_class_name))
-        return false;
-    else
-        return true;
+    return conf_class->sub_classes.count(sub_class_name);
 }
 
 std::shared_ptr<conf_class_type>
@@ -402,18 +396,12 @@ conf_instance_get_name_ref(std::shared_ptr<conf_instance_type> conf_instance) {
 
 bool conf_instance_is_of_class(
     std::shared_ptr<conf_instance_type> conf_instance, const char *class_name) {
-    if (strcmp(conf_instance->conf_class->class_name, class_name) == 0)
-        return true;
-    else
-        return false;
+    return strcmp(conf_instance->conf_class->class_name, class_name) == 0;
 }
 
 bool conf_instance_has_item(std::shared_ptr<conf_instance_type> conf_instance,
                             std::string item_name) {
-    if (!conf_instance->items.count(item_name))
-        return false;
-    else
-        return true;
+    return conf_instance->items.count(item_name);
 }
 
 std::shared_ptr<conf_instance_type> conf_instance_get_sub_instance_ref(

--- a/src/clib/lib/config/conf.cpp
+++ b/src/clib/lib/config/conf.cpp
@@ -86,60 +86,6 @@ conf_instance_alloc_default(const conf_class_type *conf_class,
     return conf_instance;
 }
 
-static void
-conf_instance_copy_items(conf_instance_type *conf_instance_target,
-                         const conf_instance_type *conf_instance_source) {
-    int num_items = hash_get_size(conf_instance_source->items);
-    char **item_keys = hash_alloc_keylist(conf_instance_source->items);
-
-    for (int item_nr = 0; item_nr < num_items; item_nr++) {
-        const char *item_name = item_keys[item_nr];
-        const conf_item_type *conf_item = (const conf_item_type *)hash_get(
-            conf_instance_source->items, item_name);
-        conf_item_type *conf_item_copy = conf_item_copyc(conf_item);
-        conf_instance_insert_owned_item(conf_instance_target, conf_item_copy);
-    }
-
-    util_free_stringlist(item_keys, num_items);
-}
-
-static void conf_instance_copy_sub_instances(
-    conf_instance_type *conf_instance_target,
-    const conf_instance_type *conf_instance_source) {
-    int num_sub_instances = hash_get_size(conf_instance_source->sub_instances);
-    char **sub_instance_keys =
-        hash_alloc_keylist(conf_instance_source->sub_instances);
-
-    for (int sub_nr = 0; sub_nr < num_sub_instances; sub_nr++) {
-        const char *sub_name = sub_instance_keys[sub_nr];
-        const conf_instance_type *sub_conf_instance =
-            (const conf_instance_type *)hash_get(
-                conf_instance_source->sub_instances, sub_name);
-        conf_instance_type *sub_conf_instance_copy =
-            conf_instance_copyc(sub_conf_instance);
-        conf_instance_insert_owned_sub_instance(conf_instance_target,
-                                                sub_conf_instance_copy);
-    }
-
-    util_free_stringlist(sub_instance_keys, num_sub_instances);
-}
-
-conf_instance_type *
-conf_instance_copyc(const conf_instance_type *conf_instance) {
-    conf_instance_type *conf_instance_copy =
-        (conf_instance_type *)util_malloc(sizeof *conf_instance_copy);
-
-    conf_instance_copy->conf_class = conf_instance->conf_class;
-    conf_instance_copy->name = util_alloc_string_copy(conf_instance->name);
-    conf_instance_copy->sub_instances = hash_alloc();
-    conf_instance_copy->items = hash_alloc();
-
-    conf_instance_copy_items(conf_instance_copy, conf_instance);
-    conf_instance_copy_sub_instances(conf_instance_copy, conf_instance);
-
-    return conf_instance_copy;
-}
-
 void conf_instance_free(conf_instance_type *conf_instance) {
     free(conf_instance->name);
     hash_free(conf_instance->sub_instances);
@@ -197,10 +143,6 @@ conf_item_type *conf_item_alloc(const conf_item_spec_type *conf_item_spec,
         conf_item->value = util_alloc_string_copy(value);
 
     return conf_item;
-}
-
-conf_item_type *conf_item_copyc(const conf_item_type *conf_item) {
-    return conf_item_alloc(conf_item->conf_item_spec, conf_item->value);
 }
 
 void conf_item_free(conf_item_type *conf_item) {

--- a/src/clib/lib/config/conf.cpp
+++ b/src/clib/lib/config/conf.cpp
@@ -1,16 +1,12 @@
 #include <filesystem>
 #include <iostream>
-#include <set>
-#include <string>
 #include <vector>
 
 #include <assert.h>
 #include <string.h>
 
 #include <ert/logging.hpp>
-#include <ert/util/hash.hpp>
 #include <ert/util/path_stack.hpp>
-#include <ert/util/vector.hpp>
 
 #include <ert/config/conf.hpp>
 #include <ert/config/conf_util.hpp>
@@ -18,61 +14,6 @@
 namespace fs = std::filesystem;
 
 static auto logger = ert::get_logger("config");
-
-struct conf_class_struct {
-    /** Can be NULL */
-    const conf_class_type *super_class;
-    char *class_name;
-    /** Can be NULL if not given */
-    char *help;
-    bool require_instance;
-    bool singleton;
-
-    /** conf_class_types */
-    hash_type *sub_classes;
-    /** conf_item_spec_types */
-    hash_type *item_specs;
-    /** item_mutex_types */
-    vector_type *item_mutexes;
-};
-
-struct conf_instance_struct {
-    const conf_class_type *conf_class;
-    char *name;
-
-    /** conf_instance_types */
-    hash_type *sub_instances;
-    /** conf_item_types */
-    hash_type *items;
-};
-
-struct conf_item_spec_struct {
-    /** NULL if not inserted into a class */
-    const conf_class_type *super_class;
-    char *name;
-    /** Require the item to take a valid value */
-    bool required_set;
-    /** Can be NULL if not given */
-    char *default_value;
-    /** Data type. See conf_data */
-    dt_enum dt;
-    std::set<std::string> *restriction;
-    /** Can be NULL if not given */
-    char *help;
-};
-
-struct conf_item_struct {
-    const conf_item_spec_type *conf_item_spec;
-    char *value;
-};
-
-struct conf_item_mutex_struct {
-    const conf_class_type *super_class;
-    bool require_one;
-    /** if inverse == true the 'mutex' implements: if A then ALSO B, C and D */
-    bool inverse;
-    hash_type *item_spec_refs;
-};
 
 conf_class_type *conf_class_alloc_empty(const char *class_name,
                                         bool require_instance, bool singleton,

--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -249,7 +249,7 @@ int enkf_obs_get_size(const enkf_obs_type *obs) {
    Adding inverse observation keys to the enkf_nodes; can be called
    several times.
 */
-static void enkf_obs_update_keys(enkf_obs_type *enkf_obs) {
+static void enkf_obs_update_keys(Cwrap<enkf_obs_type> enkf_obs) {
     /* First clear all existing observation keys. */
     for (auto &config_pair : enkf_obs->ensemble_config->config_nodes) {
         enkf_config_node_type *config_node = config_pair.second;
@@ -279,9 +279,11 @@ static void enkf_obs_update_keys(enkf_obs_type *enkf_obs) {
 }
 
 /** Handle HISTORY_OBSERVATION instances. */
-static void handle_history_observation(enkf_obs_type *enkf_obs,
-                                       conf_instance_type *enkf_conf,
-                                       size_t num_reports, double std_cutoff) {
+static void
+handle_history_observation(Cwrap<enkf_obs_type> enkf_obs,
+                           std::shared_ptr<conf_instance_type> enkf_conf,
+                           double std_cutoff) {
+    auto num_reports = enkf_obs->obs_time.size();
     stringlist_type *hist_obs_keys =
         conf_instance_alloc_list_of_sub_instances_of_class_by_name(
             enkf_conf, "HISTORY_OBSERVATION");
@@ -304,7 +306,7 @@ static void handle_history_observation(enkf_obs_type *enkf_obs,
                     obs_key);
             break;
         }
-        const conf_instance_type *hist_obs_conf =
+        auto hist_obs_conf =
             conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
 
         enkf_config_node_type *config_node = ensemble_config_add_summary(
@@ -343,9 +345,10 @@ static void handle_history_observation(enkf_obs_type *enkf_obs,
 }
 
 /** Handle SUMMARY_OBSERVATION instances. */
-static void handle_summary_observation(enkf_obs_type *enkf_obs,
-                                       conf_instance_type *enkf_conf,
-                                       size_t num_reports) {
+static void
+handle_summary_observation(Cwrap<enkf_obs_type> enkf_obs,
+                           std::shared_ptr<conf_instance_type> enkf_conf) {
+    auto num_reports = enkf_obs->obs_time.size();
     const std::unique_ptr<stringlist_type, void (*)(stringlist_type *)>
         sum_obs_keys(conf_instance_alloc_list_of_sub_instances_of_class_by_name(
                          enkf_conf, "SUMMARY_OBSERVATION"),
@@ -355,7 +358,7 @@ static void handle_summary_observation(enkf_obs_type *enkf_obs,
 
     for (int i = 0; i < num_sum_obs; i++) {
         const char *obs_key = stringlist_iget(sum_obs_keys.get(), i);
-        const conf_instance_type *sum_obs_conf =
+        auto sum_obs_conf =
             conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
         const char *sum_key =
             conf_instance_get_item_value_ref(sum_obs_conf, "KEY");
@@ -389,8 +392,9 @@ static void handle_summary_observation(enkf_obs_type *enkf_obs,
 }
 
 /** Handle GENERAL_OBSERVATION instances. */
-static void handle_general_observation(enkf_obs_type *enkf_obs,
-                                       conf_instance_type *enkf_conf) {
+static void
+handle_general_observation(Cwrap<enkf_obs_type> enkf_obs,
+                           std::shared_ptr<conf_instance_type> enkf_conf) {
     stringlist_type *obs_keys =
         conf_instance_alloc_list_of_sub_instances_of_class_by_name(
             enkf_conf, "GENERAL_OBSERVATION");
@@ -399,7 +403,7 @@ static void handle_general_observation(enkf_obs_type *enkf_obs,
 
     for (int i = 0; i < num_obs; i++) {
         const char *obs_key = stringlist_iget(obs_keys, i);
-        const conf_instance_type *gen_obs_conf =
+        auto gen_obs_conf =
             conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
 
         const char *state_kw =
@@ -423,12 +427,12 @@ static void handle_general_observation(enkf_obs_type *enkf_obs,
     stringlist_free(obs_keys);
 }
 
-conf_class_type *enkf_obs_get_obs_conf_class(void) {
+std::shared_ptr<conf_class_type> enkf_obs_get_obs_conf_class() {
     const char *enkf_conf_help =
         "An instance of the class ENKF_CONFIG shall contain neccessary "
         "infomation to run the enkf.";
-    conf_class_type *enkf_conf_class =
-        conf_class_alloc_empty("ENKF_CONFIG", true, false, enkf_conf_help);
+    auto enkf_conf_class =
+        make_conf_class("ENKF_CONFIG", true, false, enkf_conf_help);
     conf_class_set_help(enkf_conf_class, enkf_conf_help);
 
     /* Create and insert HISTORY_OBSERVATION class. */
@@ -442,20 +446,20 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "instance "
             "with name GOPR:P4 conditions on GOPR for group P4.";
 
-        conf_class_type *history_observation_class =
-            conf_class_alloc_empty("HISTORY_OBSERVATION", false, false,
-                                   help_class_history_observation);
+        auto history_observation_class =
+            make_conf_class("HISTORY_OBSERVATION", false, false,
+                            help_class_history_observation);
 
-        conf_item_spec_type *item_spec_error_mode =
-            conf_item_spec_alloc("ERROR_MODE", true, DT_STR,
-                                 "The string ERROR_MODE gives the error "
-                                 "mode for the observation.");
+        auto item_spec_error_mode =
+            make_conf_item_spec("ERROR_MODE", true, DT_STR,
+                                "The string ERROR_MODE gives the error "
+                                "mode for the observation.");
         conf_item_spec_add_restriction(item_spec_error_mode, "REL");
         conf_item_spec_add_restriction(item_spec_error_mode, "ABS");
         conf_item_spec_add_restriction(item_spec_error_mode, "RELMIN");
         conf_item_spec_set_default_value(item_spec_error_mode, "RELMIN");
 
-        conf_item_spec_type *item_spec_error = conf_item_spec_alloc(
+        auto item_spec_error = make_conf_item_spec(
             "ERROR", true, DT_POSFLOAT,
             "The positive floating number ERROR gives the standard "
             "deviation "
@@ -463,38 +467,37 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "observations.");
         conf_item_spec_set_default_value(item_spec_error, "0.10");
 
-        conf_item_spec_type *item_spec_error_min =
-            conf_item_spec_alloc("ERROR_MIN", true, DT_POSFLOAT,
-                                 "The positive floating point number "
-                                 "ERROR_MIN gives the minimum "
-                                 "value for the standard deviation of the "
-                                 "observation when RELMIN "
-                                 "is used.");
+        auto item_spec_error_min =
+            make_conf_item_spec("ERROR_MIN", true, DT_POSFLOAT,
+                                "The positive floating point number "
+                                "ERROR_MIN gives the minimum "
+                                "value for the standard deviation of the "
+                                "observation when RELMIN "
+                                "is used.");
         conf_item_spec_set_default_value(item_spec_error_min, "0.10");
 
-        conf_class_insert_owned_item_spec(history_observation_class,
-                                          item_spec_error_mode);
-        conf_class_insert_owned_item_spec(history_observation_class,
-                                          item_spec_error);
-        conf_class_insert_owned_item_spec(history_observation_class,
-                                          item_spec_error_min);
+        conf_class_insert_item_spec(history_observation_class,
+                                    item_spec_error_mode);
+        conf_class_insert_item_spec(history_observation_class, item_spec_error);
+        conf_class_insert_item_spec(history_observation_class,
+                                    item_spec_error_min);
 
         /* Sub class segment. */
         {
             const char *help_class_segment =
                 "The class SEGMENT is used to fine tune the error model.";
-            conf_class_type *segment_class = conf_class_alloc_empty(
-                "SEGMENT", false, false, help_class_segment);
+            auto segment_class =
+                make_conf_class("SEGMENT", false, false, help_class_segment);
 
-            conf_item_spec_type *item_spec_start_segment = conf_item_spec_alloc(
+            auto item_spec_start_segment = make_conf_item_spec(
                 "START", true, DT_INT, "The first restart in the segment.");
-            conf_item_spec_type *item_spec_stop_segment = conf_item_spec_alloc(
+            auto item_spec_stop_segment = make_conf_item_spec(
                 "STOP", true, DT_INT, "The last restart in the segment.");
 
-            conf_item_spec_type *item_spec_error_mode_segment =
-                conf_item_spec_alloc("ERROR_MODE", true, DT_STR,
-                                     "The string ERROR_MODE gives the error "
-                                     "mode for the observation.");
+            auto item_spec_error_mode_segment =
+                make_conf_item_spec("ERROR_MODE", true, DT_STR,
+                                    "The string ERROR_MODE gives the error "
+                                    "mode for the observation.");
             conf_item_spec_add_restriction(item_spec_error_mode_segment, "REL");
             conf_item_spec_add_restriction(item_spec_error_mode_segment, "ABS");
             conf_item_spec_add_restriction(item_spec_error_mode_segment,
@@ -502,7 +505,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             conf_item_spec_set_default_value(item_spec_error_mode_segment,
                                              "RELMIN");
 
-            conf_item_spec_type *item_spec_error_segment = conf_item_spec_alloc(
+            auto item_spec_error_segment = make_conf_item_spec(
                 "ERROR", true, DT_POSFLOAT,
                 "The positive floating number ERROR gives the standard "
                 "deviation (ABS) or the relative uncertainty "
@@ -510,33 +513,28 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
                 "the observations.");
             conf_item_spec_set_default_value(item_spec_error_segment, "0.10");
 
-            conf_item_spec_type *item_spec_error_min_segment =
-                conf_item_spec_alloc(
-                    "ERROR_MIN", true, DT_POSFLOAT,
-                    "The positive floating point number ERROR_MIN gives "
-                    "the "
-                    "minimum value for the standard deviation of the "
-                    "observation when RELMIN is used.");
+            auto item_spec_error_min_segment = make_conf_item_spec(
+                "ERROR_MIN", true, DT_POSFLOAT,
+                "The positive floating point number ERROR_MIN gives "
+                "the "
+                "minimum value for the standard deviation of the "
+                "observation when RELMIN is used.");
             conf_item_spec_set_default_value(item_spec_error_min_segment,
                                              "0.10");
 
-            conf_class_insert_owned_item_spec(segment_class,
-                                              item_spec_start_segment);
-            conf_class_insert_owned_item_spec(segment_class,
-                                              item_spec_stop_segment);
-            conf_class_insert_owned_item_spec(segment_class,
-                                              item_spec_error_mode_segment);
-            conf_class_insert_owned_item_spec(segment_class,
-                                              item_spec_error_segment);
-            conf_class_insert_owned_item_spec(segment_class,
-                                              item_spec_error_min_segment);
+            conf_class_insert_item_spec(segment_class, item_spec_start_segment);
+            conf_class_insert_item_spec(segment_class, item_spec_stop_segment);
+            conf_class_insert_item_spec(segment_class,
+                                        item_spec_error_mode_segment);
+            conf_class_insert_item_spec(segment_class, item_spec_error_segment);
+            conf_class_insert_item_spec(segment_class,
+                                        item_spec_error_min_segment);
 
-            conf_class_insert_owned_sub_class(history_observation_class,
-                                              segment_class);
+            conf_class_insert_sub_class(history_observation_class,
+                                        segment_class);
         }
 
-        conf_class_insert_owned_sub_class(enkf_conf_class,
-                                          history_observation_class);
+        conf_class_insert_sub_class(enkf_conf_class, history_observation_class);
     }
 
     /* Create and insert SUMMARY_OBSERVATION class. */
@@ -545,44 +543,44 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "The class SUMMARY_OBSERVATION can be used to condition on any "
             "observation whos simulated value is written to the summary "
             "file.";
-        conf_class_type *summary_observation_class =
-            conf_class_alloc_empty("SUMMARY_OBSERVATION", false, false,
-                                   help_class_summary_observation);
+        auto summary_observation_class =
+            make_conf_class("SUMMARY_OBSERVATION", false, false,
+                            help_class_summary_observation);
 
         const char *help_item_spec_value =
             "The floating point number VALUE gives the observed value.";
-        conf_item_spec_type *item_spec_value =
-            conf_item_spec_alloc("VALUE", true, DT_FLOAT, help_item_spec_value);
+        auto item_spec_value =
+            make_conf_item_spec("VALUE", true, DT_FLOAT, help_item_spec_value);
 
         const char *help_item_spec_error =
             "The positive floating point number ERROR is the standard "
             "deviation of the observed value.";
-        conf_item_spec_type *item_spec_error = conf_item_spec_alloc(
-            "ERROR", true, DT_POSFLOAT, help_item_spec_error);
+        auto item_spec_error = make_conf_item_spec("ERROR", true, DT_POSFLOAT,
+                                                   help_item_spec_error);
 
         const char *help_item_spec_date =
             "The DATE item gives the observation time as the date date it "
             "occured. Format is YYYY-MM-DD.";
-        conf_item_spec_type *item_spec_date =
-            conf_item_spec_alloc("DATE", false, DT_DATE, help_item_spec_date);
+        auto item_spec_date =
+            make_conf_item_spec("DATE", false, DT_DATE, help_item_spec_date);
 
         const char *help_item_spec_days =
             "The DAYS item gives the observation time as days after "
             "simulation "
             "start.";
-        conf_item_spec_type *item_spec_days = conf_item_spec_alloc(
-            "DAYS", false, DT_POSFLOAT, help_item_spec_days);
+        auto item_spec_days = make_conf_item_spec("DAYS", false, DT_POSFLOAT,
+                                                  help_item_spec_days);
 
         const char *help_item_spec_hours =
             "The HOURS item gives the observation time as hours after "
             "simulation start.";
-        conf_item_spec_type *item_spec_hours = conf_item_spec_alloc(
-            "HOURS", false, DT_POSFLOAT, help_item_spec_hours);
+        auto item_spec_hours = make_conf_item_spec("HOURS", false, DT_POSFLOAT,
+                                                   help_item_spec_hours);
 
         const char *help_item_spec_restart =
             "The RESTART item gives the observation time as the ECLIPSE "
             "restart nr.";
-        conf_item_spec_type *item_spec_restart = conf_item_spec_alloc(
+        auto item_spec_restart = make_conf_item_spec(
             "RESTART", false, DT_POSINT, help_item_spec_restart);
 
         const char *help_item_spec_sumkey =
@@ -590,20 +588,20 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "in "
             "the summary file. It has the same format as the summary.x "
             "program, e.g. WOPR:P4";
-        conf_item_spec_type *item_spec_sumkey =
-            conf_item_spec_alloc("KEY", true, DT_STR, help_item_spec_sumkey);
+        auto item_spec_sumkey =
+            make_conf_item_spec("KEY", true, DT_STR, help_item_spec_sumkey);
 
-        conf_item_spec_type *item_spec_error_min =
-            conf_item_spec_alloc("ERROR_MIN", true, DT_POSFLOAT,
-                                 "The positive floating point number "
-                                 "ERROR_MIN gives the minimum "
-                                 "value for the standard deviation of the "
-                                 "observation when RELMIN "
-                                 "is used.");
-        conf_item_spec_type *item_spec_error_mode =
-            conf_item_spec_alloc("ERROR_MODE", true, DT_STR,
-                                 "The string ERROR_MODE gives the error "
-                                 "mode for the observation.");
+        auto item_spec_error_min =
+            make_conf_item_spec("ERROR_MIN", true, DT_POSFLOAT,
+                                "The positive floating point number "
+                                "ERROR_MIN gives the minimum "
+                                "value for the standard deviation of the "
+                                "observation when RELMIN "
+                                "is used.");
+        auto item_spec_error_mode =
+            make_conf_item_spec("ERROR_MODE", true, DT_STR,
+                                "The string ERROR_MODE gives the error "
+                                "mode for the observation.");
 
         conf_item_spec_add_restriction(item_spec_error_mode, "REL");
         conf_item_spec_add_restriction(item_spec_error_mode, "ABS");
@@ -611,27 +609,22 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
         conf_item_spec_set_default_value(item_spec_error_mode, "ABS");
         conf_item_spec_set_default_value(item_spec_error_min, "0.10");
 
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_value);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_error);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_date);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_days);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_hours);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_restart);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_sumkey);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_error_mode);
-        conf_class_insert_owned_item_spec(summary_observation_class,
-                                          item_spec_error_min);
+        conf_class_insert_item_spec(summary_observation_class, item_spec_value);
+        conf_class_insert_item_spec(summary_observation_class, item_spec_error);
+        conf_class_insert_item_spec(summary_observation_class, item_spec_date);
+        conf_class_insert_item_spec(summary_observation_class, item_spec_days);
+        conf_class_insert_item_spec(summary_observation_class, item_spec_hours);
+        conf_class_insert_item_spec(summary_observation_class,
+                                    item_spec_restart);
+        conf_class_insert_item_spec(summary_observation_class,
+                                    item_spec_sumkey);
+        conf_class_insert_item_spec(summary_observation_class,
+                                    item_spec_error_mode);
+        conf_class_insert_item_spec(summary_observation_class,
+                                    item_spec_error_min);
 
         /* Create a mutex on DATE, DAYS and RESTART. */
-        conf_item_mutex_type *time_mutex =
+        auto time_mutex =
             conf_class_new_item_mutex(summary_observation_class, true, false);
 
         conf_item_mutex_add_item_spec(time_mutex, item_spec_date);
@@ -640,8 +633,7 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
         conf_item_mutex_add_item_spec(time_mutex, item_spec_restart);
         conf_item_mutex_add_item_spec(time_mutex, item_spec_days);
 
-        conf_class_insert_owned_sub_class(enkf_conf_class,
-                                          summary_observation_class);
+        conf_class_insert_sub_class(enkf_conf_class, summary_observation_class);
     }
 
     /* Create and insert class for general observations. */
@@ -662,30 +654,30 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
             "The HOURS item gives the observation time as hours after "
             "simulation start.";
 
-        conf_class_type *gen_obs_class =
-            conf_class_alloc_empty("GENERAL_OBSERVATION", false, false,
-                                   "The class general_observation is used "
-                                   "for general observations");
+        auto gen_obs_class =
+            make_conf_class("GENERAL_OBSERVATION", false, false,
+                            "The class general_observation is used "
+                            "for general observations");
 
-        conf_item_spec_type *item_spec_field =
-            conf_item_spec_alloc("DATA", true, DT_STR, help_item_spec_field);
-        conf_item_spec_type *item_spec_date =
-            conf_item_spec_alloc("DATE", false, DT_DATE, help_item_spec_date);
-        conf_item_spec_type *item_spec_days = conf_item_spec_alloc(
-            "DAYS", false, DT_POSFLOAT, help_item_spec_days);
-        conf_item_spec_type *item_spec_hours = conf_item_spec_alloc(
-            "HOURS", false, DT_POSFLOAT, help_item_spec_hours);
-        conf_item_spec_type *item_spec_restart = conf_item_spec_alloc(
-            "RESTART", false, DT_INT, help_item_spec_restart);
+        auto item_spec_field =
+            make_conf_item_spec("DATA", true, DT_STR, help_item_spec_field);
+        auto item_spec_date =
+            make_conf_item_spec("DATE", false, DT_DATE, help_item_spec_date);
+        auto item_spec_days = make_conf_item_spec("DAYS", false, DT_POSFLOAT,
+                                                  help_item_spec_days);
+        auto item_spec_hours = make_conf_item_spec("HOURS", false, DT_POSFLOAT,
+                                                   help_item_spec_hours);
+        auto item_spec_restart = make_conf_item_spec("RESTART", false, DT_INT,
+                                                     help_item_spec_restart);
 
-        conf_class_insert_owned_item_spec(gen_obs_class, item_spec_field);
-        conf_class_insert_owned_item_spec(gen_obs_class, item_spec_date);
-        conf_class_insert_owned_item_spec(gen_obs_class, item_spec_days);
-        conf_class_insert_owned_item_spec(gen_obs_class, item_spec_hours);
-        conf_class_insert_owned_item_spec(gen_obs_class, item_spec_restart);
+        conf_class_insert_item_spec(gen_obs_class, item_spec_field);
+        conf_class_insert_item_spec(gen_obs_class, item_spec_date);
+        conf_class_insert_item_spec(gen_obs_class, item_spec_days);
+        conf_class_insert_item_spec(gen_obs_class, item_spec_hours);
+        conf_class_insert_item_spec(gen_obs_class, item_spec_restart);
         /* Create a mutex on DATE, DAYS and RESTART. */
         {
-            conf_item_mutex_type *time_mutex =
+            auto time_mutex =
                 conf_class_new_item_mutex(gen_obs_class, true, false);
 
             conf_item_mutex_add_item_spec(time_mutex, item_spec_date);
@@ -695,22 +687,21 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
         }
 
         {
-            conf_item_spec_type *item_spec_obs_file = conf_item_spec_alloc(
+            auto item_spec_obs_file = make_conf_item_spec(
                 "OBS_FILE", false, DT_FILE,
                 "The name of an (ascii) file with observation values.");
-            conf_item_spec_type *item_spec_value = conf_item_spec_alloc(
+            auto item_spec_value = make_conf_item_spec(
                 "VALUE", false, DT_FLOAT, "One scalar observation value.");
-            conf_item_spec_type *item_spec_error = conf_item_spec_alloc(
+            auto item_spec_error = make_conf_item_spec(
                 "ERROR", false, DT_FLOAT, "One scalar observation error.");
-            conf_item_mutex_type *value_mutex =
+            auto value_mutex =
                 conf_class_new_item_mutex(gen_obs_class, true, false);
-            conf_item_mutex_type *value_error_mutex =
+            auto value_error_mutex =
                 conf_class_new_item_mutex(gen_obs_class, false, true);
 
-            conf_class_insert_owned_item_spec(gen_obs_class,
-                                              item_spec_obs_file);
-            conf_class_insert_owned_item_spec(gen_obs_class, item_spec_value);
-            conf_class_insert_owned_item_spec(gen_obs_class, item_spec_error);
+            conf_class_insert_item_spec(gen_obs_class, item_spec_obs_file);
+            conf_class_insert_item_spec(gen_obs_class, item_spec_value);
+            conf_class_insert_item_spec(gen_obs_class, item_spec_error);
 
             /* If the observation is in terms of VALUE - we must also have ERROR.
          The conf system does not (currently ??) enforce this dependency. */
@@ -728,28 +719,26 @@ conf_class_type *enkf_obs_get_obs_conf_class(void) {
        INDEX_LIST or INDEX_FILE keywords.
     */
         {
-            conf_item_spec_type *item_spec_index_list =
-                conf_item_spec_alloc("INDEX_LIST", false, DT_STR,
-                                     "A list of indicies - possibly with "
-                                     "ranges which should be "
-                                     "observed in the target field.");
-            conf_item_spec_type *item_spec_index_file =
-                conf_item_spec_alloc("INDEX_FILE", false, DT_FILE,
-                                     "An ASCII file containing a list of "
-                                     "indices which should be "
-                                     "observed in the target field.");
-            conf_item_mutex_type *index_mutex =
+            auto item_spec_index_list =
+                make_conf_item_spec("INDEX_LIST", false, DT_STR,
+                                    "A list of indicies - possibly with "
+                                    "ranges which should be "
+                                    "observed in the target field.");
+            auto item_spec_index_file =
+                make_conf_item_spec("INDEX_FILE", false, DT_FILE,
+                                    "An ASCII file containing a list of "
+                                    "indices which should be "
+                                    "observed in the target field.");
+            auto index_mutex =
                 conf_class_new_item_mutex(gen_obs_class, false, false);
 
-            conf_class_insert_owned_item_spec(gen_obs_class,
-                                              item_spec_index_list);
-            conf_class_insert_owned_item_spec(gen_obs_class,
-                                              item_spec_index_file);
+            conf_class_insert_item_spec(gen_obs_class, item_spec_index_list);
+            conf_class_insert_item_spec(gen_obs_class, item_spec_index_file);
             conf_item_mutex_add_item_spec(index_mutex, item_spec_index_list);
             conf_item_mutex_add_item_spec(index_mutex, item_spec_index_file);
         }
 
-        conf_class_insert_owned_sub_class(enkf_conf_class, gen_obs_class);
+        conf_class_insert_sub_class(enkf_conf_class, gen_obs_class);
     }
 
     return enkf_conf_class;
@@ -866,66 +855,40 @@ py::handle pybind_alloc(int history_,
         enkf_obs_alloc(history, external_time_map, refcase, ensemble_config);
     return PyLong_FromVoidPtr(ptr);
 }
-/**
- This function will load an observation configuration from the
-   observation file @config_file.
-
-   If called several times during one invocation the function will
-   start by clearing the current content.
-*/
-void enkf_obs_load(Cwrap<enkf_obs_type> enkf_obs, const char *config_file,
-                   double std_cutoff) {
-
-    const std::unique_ptr<conf_class_type, void (*)(conf_class_type *)>
-        enkf_conf_class(enkf_obs_get_obs_conf_class(), conf_class_free);
-    const std::unique_ptr<conf_instance_type, void (*)(conf_instance_type *)>
-        enkf_conf(conf_instance_alloc_from_file(enkf_conf_class.get(),
-                                                "enkf_conf", config_file),
-                  conf_instance_free);
-
-    const char *errors = conf_instance_get_path_error(enkf_conf.get());
-    if (errors) {
-        throw exc::invalid_argument{
-            "The following keywords in your configuration did not resolve to a "
-            "valid path:\n {}",
-            errors};
-    }
-
-    if (!conf_instance_validate(enkf_conf.get()))
-        throw exc::runtime_error("Error in configuration file: {}",
-                                 config_file);
-
-    handle_history_observation(enkf_obs, enkf_conf.get(),
-                               enkf_obs->obs_time.size(), std_cutoff);
-    try {
-        handle_summary_observation(enkf_obs, enkf_conf.get(),
-                                   enkf_obs->obs_time.size());
-        handle_general_observation(enkf_obs, enkf_conf.get());
-    } catch (exc::out_of_range err) {
-        if (enkf_obs->refcase) {
-            throw exc::out_of_range(
-                "{} The time map is set from the REFCASE keyword.\n Either "
-                "the REFCASE has an incorrect/missing date, or the observation "
-                "is given an incorrect date.",
-                err.what());
-        } else {
-            throw exc::out_of_range(
-                "{} The time map is set from the TIME_MAP keyword.\n Either "
-                "the time map file has an incorrect/missing date, or the "
-                "observation is given an incorrect date.",
-                err.what());
-        }
-    }
-
-    enkf_obs_update_keys(enkf_obs);
-}
 
 } // namespace
 
 ERT_CLIB_SUBMODULE("enkf_obs", m) {
     using namespace py::literals;
 
+    py::class_<conf_instance_type, std::shared_ptr<conf_instance_type>>(
+        m, "ConfInstance")
+        .def(py::init([](std::string config_file) {
+                 auto enkf_conf_class = enkf_obs_get_obs_conf_class();
+                 auto enkf_conf = conf_instance_alloc_from_file(
+                     enkf_conf_class, "enkf_conf", config_file.c_str());
+                 return enkf_conf;
+             }),
+             "config_file"_a)
+        .def("get_errors", [](std::shared_ptr<conf_instance_type> self) {
+            auto errors = conf_instance_get_path_error(self);
+            if (errors) {
+                return std::string(
+                           "The following keywords in your configuration did "
+                           "not resolve to a valid path:\n ") +
+                       errors;
+            }
+            if (!conf_instance_validate(self))
+                return std::string("Error in observations configuration file");
+            return std::string("");
+        });
     m.def("alloc", pybind_alloc, "history"_a, "time_map"_a, "refcase"_a,
           "ensemble_config"_a);
-    m.def("load", enkf_obs_load, "obs"_a, "config_file"_a, "std_cutoff"_a);
+    m.def("handle_history_observation", handle_history_observation,
+          py::arg("self"), py::arg("conf_instance"), py::arg("std_cutoff"));
+    m.def("handle_summary_observation", handle_summary_observation,
+          py::arg("self"), py::arg("conf_instance"));
+    m.def("handle_general_observation", handle_general_observation,
+          py::arg("self"), py::arg("conf_instance"));
+    m.def("update_keys", enkf_obs_update_keys, py::arg("self"));
 }

--- a/src/clib/lib/enkf/obs_vector.cpp
+++ b/src/clib/lib/enkf/obs_vector.cpp
@@ -65,10 +65,9 @@ static int find_nearest_time_index(std::vector<time_t> time_map,
     return nearest_index;
 }
 
-static int
-__conf_instance_get_restart_nr(const conf_instance_type *conf_instance,
-                               const char *obs_key,
-                               const std::vector<time_t> &time_map) {
+static int __conf_instance_get_restart_nr(
+    std::shared_ptr<conf_instance_type> conf_instance, const char *obs_key,
+    const std::vector<time_t> &time_map) {
     int obs_restart_nr = -1;
 
     if (conf_instance_has_item(conf_instance, "RESTART")) {
@@ -280,7 +279,8 @@ int obs_vector_get_next_active_step(const obs_vector_type *obs_vector,
    hash table.
 */
 void obs_vector_load_from_SUMMARY_OBSERVATION(
-    obs_vector_type *obs_vector, const conf_instance_type *conf_instance,
+    obs_vector_type *obs_vector,
+    std::shared_ptr<conf_instance_type> conf_instance,
     const std::vector<time_t> &obs_time) {
     if (!conf_instance_is_of_class(conf_instance, "SUMMARY_OBSERVATION"))
         util_abort("%s: internal error. expected \"SUMMARY_OBSERVATION\" "
@@ -327,7 +327,7 @@ void obs_vector_load_from_SUMMARY_OBSERVATION(
 }
 
 obs_vector_type *obs_vector_alloc_from_GENERAL_OBSERVATION(
-    const conf_instance_type *conf_instance,
+    std::shared_ptr<conf_instance_type> conf_instance,
     const std::vector<time_t> &obs_time, enkf_config_node_type *config_node) {
     if (!conf_instance_is_of_class(conf_instance, "GENERAL_OBSERVATION"))
         util_abort("%s: internal error. expected \"GENERAL_OBSERVATION\" "
@@ -469,7 +469,8 @@ static bool read_history_from_ecl_summary(const history_source_type history,
 // Should check the refcase for key - if it is != NULL.
 
 bool obs_vector_load_from_HISTORY_OBSERVATION(
-    obs_vector_type *obs_vector, const conf_instance_type *conf_instance,
+    obs_vector_type *obs_vector,
+    std::shared_ptr<conf_instance_type> conf_instance,
     const std::vector<time_t> &obs_time, const history_source_type history,
     double std_cutoff, const ecl_sum_type *refcase) {
 
@@ -531,9 +532,8 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(
                      segment_nr++) {
                     const char *segment_name =
                         stringlist_iget(segment_keys, segment_nr);
-                    const conf_instance_type *segment_conf =
-                        conf_instance_get_sub_instance_ref(conf_instance,
-                                                           segment_name);
+                    auto segment_conf = conf_instance_get_sub_instance_ref(
+                        conf_instance, segment_name);
 
                     int start =
                         conf_instance_get_item_value_int(segment_conf, "START");

--- a/src/clib/lib/enkf/obs_vector.cpp
+++ b/src/clib/lib/enkf/obs_vector.cpp
@@ -521,19 +521,18 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(
 
             // Handle SEGMENTs which can be used to customize the observation error. */
             {
-                stringlist_type *segment_keys =
+                std::vector<std::string> segment_keys =
                     conf_instance_alloc_list_of_sub_instances_of_class_by_name(
                         conf_instance, "SEGMENT");
-                stringlist_sort(segment_keys, NULL);
+                std::sort(segment_keys.begin(), segment_keys.end());
 
-                int num_segments = stringlist_get_size(segment_keys);
+                int num_segments = segment_keys.size();
 
                 for (int segment_nr = 0; segment_nr < num_segments;
                      segment_nr++) {
-                    const char *segment_name =
-                        stringlist_iget(segment_keys, segment_nr);
+                    std::string segment_name = segment_keys[segment_nr];
                     auto segment_conf = conf_instance_get_sub_instance_ref(
-                        conf_instance, segment_name);
+                        conf_instance, segment_name.c_str());
 
                     int start =
                         conf_instance_get_item_value_int(segment_conf, "START");
@@ -595,7 +594,6 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(
                             "%s: Internal error. Unknown error mode \"%s\"\n",
                             __func__, error_mode);
                 }
-                stringlist_free(segment_keys);
             }
 
             /*

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -217,9 +217,6 @@ void conf_item_spec_add_restriction(conf_item_spec_type *conf_item_spec,
 void conf_item_spec_set_default_value(conf_item_spec_type *conf_item_spec,
                                       const char *default_value);
 
-void conf_item_spec_set_help(conf_item_spec_type *conf_item_spec,
-                             const char *help);
-
 /** A C C E S S O R S */
 
 bool conf_class_has_item_spec(const conf_class_type *conf_class,

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -91,11 +91,11 @@
 
 #include <ert/config/conf_data.hpp>
 
-typedef struct conf_class_struct conf_class_type;
-typedef struct conf_instance_struct conf_instance_type;
-typedef struct conf_item_spec_struct conf_item_spec_type;
-typedef struct conf_item_struct conf_item_type;
-typedef struct conf_item_mutex_struct conf_item_mutex_type;
+using conf_class_type = struct conf_class_struct;
+using conf_instance_type = struct conf_instance_struct;
+using conf_item_spec_type = struct conf_item_spec_struct;
+using conf_item_type = struct conf_item_struct;
+using conf_item_mutex_type = struct conf_item_mutex_struct;
 
 struct conf_class_struct {
     /** Can be NULL */

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -82,14 +82,15 @@
  */
 
 #include <cstdbool>
-#include <set>
-#include <string>
-
-#include <ert/util/hash.hpp>
-#include <ert/util/stringlist.hpp>
-#include <ert/util/vector.hpp>
 
 #include <ert/config/conf_data.hpp>
+#include <ert/util/hash.hpp>
+#include <ert/util/vector.hpp>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
 
 using conf_class_type = struct conf_class_struct;
 using conf_instance_type = struct conf_instance_struct;
@@ -99,34 +100,29 @@ using conf_item_mutex_type = struct conf_item_mutex_struct;
 
 struct conf_class_struct {
     /** Can be NULL */
-    const conf_class_type *super_class;
+    std::shared_ptr<conf_class_type> super_class;
     char *class_name;
     /** Can be NULL if not given */
     char *help;
     bool require_instance;
     bool singleton;
 
-    /** conf_class_types */
-    hash_type *sub_classes;
-    /** conf_item_spec_types */
-    hash_type *item_specs;
-    /** item_mutex_types */
-    vector_type *item_mutexes;
+    std::map<std::string, std::shared_ptr<conf_class_type>> sub_classes;
+    std::map<std::string, std::shared_ptr<conf_item_spec_type>> item_specs;
+    std::vector<std::shared_ptr<conf_item_mutex_type>> item_mutexes;
 };
 
 struct conf_instance_struct {
-    const conf_class_type *conf_class;
+    std::shared_ptr<conf_class_type> conf_class;
     char *name;
 
-    /** conf_instance_types */
-    hash_type *sub_instances;
-    /** conf_item_types */
-    hash_type *items;
+    std::map<std::string, std::shared_ptr<conf_instance_type>> sub_instances;
+    std::map<std::string, std::shared_ptr<conf_item_type>> items;
 };
 
 struct conf_item_spec_struct {
     /** NULL if not inserted into a class */
-    const conf_class_type *super_class;
+    std::shared_ptr<conf_class_type> super_class;
     char *name;
     /** Require the item to take a valid value */
     bool required_set;
@@ -140,113 +136,100 @@ struct conf_item_spec_struct {
 };
 
 struct conf_item_struct {
-    const conf_item_spec_type *conf_item_spec;
+    std::shared_ptr<conf_item_spec_type> conf_item_spec;
     char *value;
 };
 
 struct conf_item_mutex_struct {
-    const conf_class_type *super_class;
+    std::shared_ptr<conf_class_type> super_class;
     bool require_one;
     /** if inverse == true the 'mutex' implements: if A then ALSO B, C and D */
     bool inverse;
-    hash_type *item_spec_refs;
+    std::map<std::string, std::shared_ptr<conf_item_spec_type>> item_spec_refs;
 };
 
 /** D E F A U L T   A L L O C / F R E E    F U N C T I O N S */
 
-conf_class_type *conf_class_alloc_empty(const char *class_name,
-                                        bool require_instance, bool singleton,
-                                        const char *help);
-
-void conf_class_free(conf_class_type *conf_class);
-
-void conf_class_free__(void *conf_class);
-
-void conf_instance_free(conf_instance_type *conf_instance);
-
-void conf_instance_free__(void *conf_instance);
-
-conf_item_spec_type *conf_item_spec_alloc(const char *name, bool required_set,
-                                          dt_enum dt, const char *help);
-
-void conf_item_spec_free(conf_item_spec_type *conf_item_spec);
-
-void conf_item_spec_free__(void *conf_item_spec);
-
-conf_item_type *conf_item_alloc(const conf_item_spec_type *conf_item_spec,
-                                const char *value);
-
-void conf_item_free(conf_item_type *conf_item);
-
-void conf_item_free__(void *conf_item);
-
-void conf_item_mutex_free(conf_item_mutex_type *conf_item_mutex);
-
-void conf_item_mutex_free__(void *conf_item_mutex);
-
+std::shared_ptr<conf_class_type> make_conf_class(const char *class_name,
+                                                 bool require_instance,
+                                                 bool singleton,
+                                                 const char *help);
+std::shared_ptr<conf_item_spec_type> make_conf_item_spec(const char *name,
+                                                         bool required_set,
+                                                         dt_enum dt,
+                                                         const char *help);
 /** M A N I P U L A T O R S ,   I N S E R T I O N */
 
-void conf_class_insert_owned_sub_class(conf_class_type *conf_class,
-                                       conf_class_type *sub_conf_class);
+void conf_class_insert_sub_class(
+    std::shared_ptr<conf_class_type> conf_class,
+    std::shared_ptr<conf_class_type> sub_conf_class);
 
-void conf_class_insert_owned_item_spec(conf_class_type *conf_class,
-                                       conf_item_spec_type *item_spec);
+void conf_class_insert_item_spec(
+    std::shared_ptr<conf_class_type> conf_class,
+    std::shared_ptr<conf_item_spec_type> item_spec);
 
-void conf_instance_insert_owned_sub_instance(
-    conf_instance_type *conf_instance, conf_instance_type *sub_conf_instance);
+void conf_instance_insert_sub_instance(
+    std::shared_ptr<conf_instance_type> conf_instance,
+    std::shared_ptr<conf_instance_type> sub_conf_instance);
 
 void conf_instance_insert_item(conf_instance_type *conf_instance,
                                const char *item_name, const char *value);
 
-conf_item_mutex_type *conf_class_new_item_mutex(conf_class_type *conf_class,
-                                                bool require_one, bool inverse);
+std::shared_ptr<conf_item_mutex_type>
+conf_class_new_item_mutex(std::shared_ptr<conf_class_type> conf_class,
+                          bool require_one, bool inverse);
 
-void conf_item_mutex_add_item_spec(conf_item_mutex_type *conf_item_mutex,
-                                   const conf_item_spec_type *conf_item_spec);
+void conf_item_mutex_add_item_spec(
+    std::shared_ptr<conf_item_mutex_type> conf_item_mutex,
+    std::shared_ptr<conf_item_spec_type> conf_item_spec);
 
 /** M A N I P U L A T O R S ,   C L A S S   A N D   I T E M   S P E C I F I C A T I O N */
 
-void conf_class_set_help(conf_class_type *conf_class, const char *help);
+void conf_class_set_help(std::shared_ptr<conf_class_type> conf_class,
+                         const char *help);
 
-void conf_item_spec_add_restriction(conf_item_spec_type *conf_item_spec,
-                                    const char *restriction);
+void conf_item_spec_add_restriction(
+    std::shared_ptr<conf_item_spec_type> conf_item_spec,
+    const char *restriction);
 
-void conf_item_spec_set_default_value(conf_item_spec_type *conf_item_spec,
-                                      const char *default_value);
+void conf_item_spec_set_default_value(
+    std::shared_ptr<conf_item_spec_type> conf_item_spec,
+    const char *default_value);
 
 /** A C C E S S O R S */
 
-bool conf_class_has_item_spec(const conf_class_type *conf_class,
+bool conf_class_has_item_spec(std::shared_ptr<conf_class_type> conf_class,
                               const char *item_name);
 
-bool conf_class_has_sub_class(const conf_class_type *conf_class,
+bool conf_class_has_sub_class(std::shared_ptr<conf_class_type> conf_class,
                               const char *sub_class_name);
 
-const conf_class_type *
-conf_class_get_sub_class_ref(const conf_class_type *conf_class,
+std::shared_ptr<conf_class_type>
+conf_class_get_sub_class_ref(std::shared_ptr<conf_class_type> conf_class,
                              const char *sub_class_name);
 
-const char *conf_instance_get_name_ref(const conf_instance_type *conf_instance);
+const char *
+conf_instance_get_name_ref(std::shared_ptr<conf_instance_type> conf_instance);
 
-bool conf_instance_is_of_class(const conf_instance_type *conf_instance,
-                               const char *class_name);
+bool conf_instance_is_of_class(
+    std::shared_ptr<conf_instance_type> conf_instance, const char *class_name);
 
-bool conf_instance_has_item(const conf_instance_type *conf_instance,
-                            const char *item_name);
+bool conf_instance_has_item(std::shared_ptr<conf_instance_type> conf_instance,
+                            std::string item_name);
 
-const conf_instance_type *
-conf_instance_get_sub_instance_ref(const conf_instance_type *conf_instance,
-                                   const char *sub_instance_name);
+std::shared_ptr<conf_instance_type> conf_instance_get_sub_instance_ref(
+    std::shared_ptr<conf_instance_type> conf_instance,
+    const char *sub_instance_name);
 
 stringlist_type *conf_instance_alloc_list_of_sub_instances_of_class_by_name(
-    const conf_instance_type *conf_instance, const char *sub_class_name);
+    std::shared_ptr<conf_instance_type> conf_instance,
+    const char *sub_class_name);
 
-const char *
-conf_instance_get_class_name_ref(const conf_instance_type *conf_instance);
+const char *conf_instance_get_class_name_ref(
+    std::shared_ptr<conf_instance_type> conf_instance);
 
-const char *
-conf_instance_get_item_value_ref(const conf_instance_type *conf_instance,
-                                 const char *item_name);
+const char *conf_instance_get_item_value_ref(
+    std::shared_ptr<conf_instance_type> conf_instance, std::string item_name);
 
 /** If the dt supports it, these functions will parse the item
     value to the requested types.
@@ -255,27 +238,25 @@ conf_instance_get_item_value_ref(const conf_instance_type *conf_instance,
     If the dt does not support it, or the conf_instance
     does not have the item, the functions will abort your program.
 */
-int conf_instance_get_item_value_int(const conf_instance_type *conf_instance,
-                                     const char *item_name);
+int conf_instance_get_item_value_int(
+    std::shared_ptr<conf_instance_type> conf_instance, std::string item_name);
+double conf_instance_get_item_value_double(
+    std::shared_ptr<conf_instance_type> conf_instance, std::string item_name);
 
-double
-conf_instance_get_item_value_double(const conf_instance_type *conf_instance,
-                                    const char *item_name);
+time_t conf_instance_get_item_value_time_t(
+    std::shared_ptr<conf_instance_type> conf_instance, std::string item_name);
 
-time_t
-conf_instance_get_item_value_time_t(const conf_instance_type *conf_instance,
-                                    const char *item_name);
-
-char *conf_instance_get_path_error(const conf_instance_type *conf_instance);
+char *
+conf_instance_get_path_error(std::shared_ptr<conf_instance_type> conf_instance);
 
 /** V A L I D A T O R S */
 
-bool conf_instance_validate(const conf_instance_type *conf_instance);
+bool conf_instance_validate(std::shared_ptr<conf_instance_type> conf_instance);
 
 /** A L L O C   F R O M   F I L E */
 
-conf_instance_type *
-conf_instance_alloc_from_file(const conf_class_type *conf_class,
+std::shared_ptr<conf_instance_type>
+conf_instance_alloc_from_file(std::shared_ptr<conf_class_type> conf_class,
                               const char *name, const char *file_name);
 
 #endif

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -81,8 +81,8 @@
  *
  */
 
+#include <cstdbool>
 #include <set>
-#include <stdbool.h>
 #include <string>
 
 #include <ert/util/hash.hpp>

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -221,7 +221,8 @@ std::shared_ptr<conf_instance_type> conf_instance_get_sub_instance_ref(
     std::shared_ptr<conf_instance_type> conf_instance,
     const char *sub_instance_name);
 
-stringlist_type *conf_instance_alloc_list_of_sub_instances_of_class_by_name(
+std::vector<std::string>
+conf_instance_alloc_list_of_sub_instances_of_class_by_name(
     std::shared_ptr<conf_instance_type> conf_instance,
     const char *sub_class_name);
 

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -162,9 +162,6 @@ void conf_class_free(conf_class_type *conf_class);
 
 void conf_class_free__(void *conf_class);
 
-conf_instance_type *
-conf_instance_copyc(const conf_instance_type *conf_instance);
-
 void conf_instance_free(conf_instance_type *conf_instance);
 
 void conf_instance_free__(void *conf_instance);
@@ -178,8 +175,6 @@ void conf_item_spec_free__(void *conf_item_spec);
 
 conf_item_type *conf_item_alloc(const conf_item_spec_type *conf_item_spec,
                                 const char *value);
-
-conf_item_type *conf_item_copyc(const conf_item_type *conf_item);
 
 void conf_item_free(conf_item_type *conf_item);
 

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -81,9 +81,13 @@
  *
  */
 
+#include <set>
 #include <stdbool.h>
+#include <string>
 
+#include <ert/util/hash.hpp>
 #include <ert/util/stringlist.hpp>
+#include <ert/util/vector.hpp>
 
 #include <ert/config/conf_data.hpp>
 
@@ -92,6 +96,61 @@ typedef struct conf_instance_struct conf_instance_type;
 typedef struct conf_item_spec_struct conf_item_spec_type;
 typedef struct conf_item_struct conf_item_type;
 typedef struct conf_item_mutex_struct conf_item_mutex_type;
+
+struct conf_class_struct {
+    /** Can be NULL */
+    const conf_class_type *super_class;
+    char *class_name;
+    /** Can be NULL if not given */
+    char *help;
+    bool require_instance;
+    bool singleton;
+
+    /** conf_class_types */
+    hash_type *sub_classes;
+    /** conf_item_spec_types */
+    hash_type *item_specs;
+    /** item_mutex_types */
+    vector_type *item_mutexes;
+};
+
+struct conf_instance_struct {
+    const conf_class_type *conf_class;
+    char *name;
+
+    /** conf_instance_types */
+    hash_type *sub_instances;
+    /** conf_item_types */
+    hash_type *items;
+};
+
+struct conf_item_spec_struct {
+    /** NULL if not inserted into a class */
+    const conf_class_type *super_class;
+    char *name;
+    /** Require the item to take a valid value */
+    bool required_set;
+    /** Can be NULL if not given */
+    char *default_value;
+    /** Data type. See conf_data */
+    dt_enum dt;
+    std::set<std::string> *restriction;
+    /** Can be NULL if not given */
+    char *help;
+};
+
+struct conf_item_struct {
+    const conf_item_spec_type *conf_item_spec;
+    char *value;
+};
+
+struct conf_item_mutex_struct {
+    const conf_class_type *super_class;
+    bool require_one;
+    /** if inverse == true the 'mutex' implements: if A then ALSO B, C and D */
+    bool inverse;
+    hash_type *item_spec_refs;
+};
 
 /** D E F A U L T   A L L O C / F R E E    F U N C T I O N S */
 

--- a/src/clib/lib/include/ert/config/conf.hpp
+++ b/src/clib/lib/include/ert/config/conf.hpp
@@ -195,9 +195,6 @@ void conf_class_insert_owned_item_spec(conf_class_type *conf_class,
 void conf_instance_insert_owned_sub_instance(
     conf_instance_type *conf_instance, conf_instance_type *sub_conf_instance);
 
-void conf_instance_insert_owned_item(conf_instance_type *conf_instance,
-                                     conf_item_type *conf_item);
-
 void conf_instance_insert_item(conf_instance_type *conf_instance,
                                const char *item_name, const char *value);
 
@@ -225,10 +222,6 @@ bool conf_class_has_item_spec(const conf_class_type *conf_class,
 bool conf_class_has_sub_class(const conf_class_type *conf_class,
                               const char *sub_class_name);
 
-const conf_item_spec_type *
-conf_class_get_item_spec_ref(const conf_class_type *conf_class,
-                             const char *item_name);
-
 const conf_class_type *
 conf_class_get_sub_class_ref(const conf_class_type *conf_class,
                              const char *sub_class_name);
@@ -244,9 +237,6 @@ bool conf_instance_has_item(const conf_instance_type *conf_instance,
 const conf_instance_type *
 conf_instance_get_sub_instance_ref(const conf_instance_type *conf_instance,
                                    const char *sub_instance_name);
-
-stringlist_type *conf_instance_alloc_list_of_sub_instances_of_class(
-    const conf_instance_type *conf_instance, const conf_class_type *conf_class);
 
 stringlist_type *conf_instance_alloc_list_of_sub_instances_of_class_by_name(
     const conf_instance_type *conf_instance, const char *sub_class_name);

--- a/src/clib/lib/include/ert/enkf/enkf_obs.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_obs.hpp
@@ -47,6 +47,6 @@ enkf_obs_alloc_matching_keylist(const enkf_obs_type *enkf_obs,
                                 const char *input_string);
 extern "C" time_t enkf_obs_iget_obs_time(const enkf_obs_type *enkf_obs,
                                          int report_step);
-conf_class_type *enkf_obs_get_obs_conf_class();
+std::shared_ptr<conf_class_type> enkf_obs_get_obs_conf_class();
 
 #endif

--- a/src/clib/lib/include/ert/enkf/obs_vector.hpp
+++ b/src/clib/lib/include/ert/enkf/obs_vector.hpp
@@ -44,16 +44,17 @@ void obs_vector_user_get(const obs_vector_type *obs_vector,
 extern "C" int obs_vector_get_next_active_step(const obs_vector_type *, int);
 extern "C" void *obs_vector_iget_node(const obs_vector_type *, int);
 obs_vector_type *
-obs_vector_alloc_from_GENERAL_OBSERVATION(const conf_instance_type *,
+obs_vector_alloc_from_GENERAL_OBSERVATION(std::shared_ptr<conf_instance_type>,
                                           const std::vector<time_t> &obs_time,
                                           enkf_config_node_type *);
 void obs_vector_load_from_SUMMARY_OBSERVATION(
-    obs_vector_type *obs_vector, const conf_instance_type *,
+    obs_vector_type *obs_vector, std::shared_ptr<conf_instance_type>,
     const std::vector<time_t> &obs_time);
 bool obs_vector_load_from_HISTORY_OBSERVATION(
-    obs_vector_type *obs_vector, const conf_instance_type *,
+    obs_vector_type *obs_vector,
+    std::shared_ptr<conf_instance_type> conf_instance,
     const std::vector<time_t> &obs_time, const history_source_type history,
-    double std_cutoff, const ecl_sum_type *);
+    double std_cutoff, const ecl_sum_type *refcase);
 extern "C" obs_vector_type *obs_vector_alloc(obs_impl_type obs_type,
                                              const char *obs_key,
                                              enkf_config_node_type *config_node,

--- a/src/clib/old_tests/enkf/test_enkf_obs_invalid_path.cpp
+++ b/src/clib/old_tests/enkf/test_enkf_obs_invalid_path.cpp
@@ -24,13 +24,11 @@ void test_invalid_path() {
         fclose(stream);
     }
 
-    conf_class_type *enkf_conf_class = enkf_obs_get_obs_conf_class();
-    conf_instance_type *enkf_conf = conf_instance_alloc_from_file(
-        enkf_conf_class, "enkf_conf", "obs_path/conf.txt");
+    auto enkf_conf_class = enkf_obs_get_obs_conf_class();
+    auto enkf_conf = conf_instance_alloc_from_file(enkf_conf_class, "enkf_conf",
+                                                   "obs_path/conf.txt");
     test_assert_true(conf_instance_get_path_error(enkf_conf));
     test_assert_false(conf_instance_validate(enkf_conf));
-
-    conf_instance_free(enkf_conf);
 }
 
 void test_valid_path() {
@@ -51,14 +49,12 @@ void test_valid_path() {
         fclose(stream);
     }
 
-    conf_class_type *enkf_conf_class = enkf_obs_get_obs_conf_class();
-    conf_instance_type *enkf_conf = conf_instance_alloc_from_file(
-        enkf_conf_class, "enkf_conf", "obs_path/conf.txt");
+    auto enkf_conf_class = enkf_obs_get_obs_conf_class();
+    auto enkf_conf = conf_instance_alloc_from_file(enkf_conf_class, "enkf_conf",
+                                                   "obs_path/conf.txt");
 
     test_assert_false(conf_instance_get_path_error(enkf_conf));
     test_assert_true(conf_instance_validate(enkf_conf));
-
-    conf_instance_free(enkf_conf);
 }
 
 int main(int argc, char **argv) {

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -149,7 +149,14 @@ class EnkfObs(BaseCClass):
                 "Do not have permission to open observation "
                 f"config file {config_file!r}"
             )
-        _clib.enkf_obs.load(self, config_file, std_cutoff)
+        conf_instance = _clib.enkf_obs.ConfInstance(config_file)
+        errors = conf_instance.get_errors()
+        if errors != "":
+            raise ValueError(f"{errors} in configuration file {config_file}")
+        _clib.enkf_obs.handle_history_observation(self, conf_instance, std_cutoff)
+        _clib.enkf_obs.handle_summary_observation(self, conf_instance)
+        _clib.enkf_obs.handle_general_observation(self, conf_instance)
+        _clib.enkf_obs.update_keys(self)
 
     @property
     def error(self) -> str:
@@ -188,7 +195,23 @@ class EnkfObs(BaseCClass):
                     config.model_config.obs_config_file,
                     config.analysis_config.get_std_cutoff(),
                 )
-            except (ValueError, IndexError) as err:
+            except IndexError as err:
+                if config.ensemble_config.refcase is not None:
+                    raise ObservationConfigError(
+                        f"{err} The time map is set from the REFCASE keyword.\n Either "
+                        "the REFCASE has an incorrect/missing date, or the observation "
+                        "is given an incorrect date.",
+                        config_file=config.model_config.obs_config_file,
+                    ) from err
+                raise ObservationConfigError(
+                    f"{err} The time map is set from the TIME_MAP"
+                    "keyword.\n Either the time map file has an"
+                    "incorrect/missing date, or the  observation is given an"
+                    "incorrect date.",
+                    config_file=config.model_config.obs_config_file,
+                ) from err
+
+            except ValueError as err:
                 raise ObservationConfigError(
                     str(err),
                     config_file=config.model_config.obs_config_file,


### PR DESCRIPTION
In order to test error handling in enkf_obs, conf.hpp/cpp is converted to use smart pointers and standard library containers. This is to have better compatibility with pybind and cpp error handling.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
