### PR TITLE
Remove .DATA suffix from REFCASE path

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -179,6 +179,9 @@ class EnsembleConfig(BaseCClass):
         if refcase_file is None:
             return None
 
+        refcase_filepath = Path(refcase_file)
+        refcase_file = str(refcase_filepath.parent / refcase_filepath.stem)
+
         if not os.path.exists(refcase_file + ".UNSMRY"):
             raise ConfigValidationError(
                 f"Cannot find UNSMRY file for refcase provided! {refcase_file}.UNSMRY"


### PR DESCRIPTION
Retain backwards compatibility where REFCASE had `.DATA` suffix The suffix is removed regardless, but this allows us to validate presence of refcase .UNSMRY and .SMSPEC files.

**Issue**
Resolves #5244 


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
