### PR TITLE
Lower memory usage significantly when handling fields/grids

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -90,3 +90,12 @@ ignore_errors = True
 
 [mypy-ert.experiment_server.*]
 ignore_errors = True
+
+[mypy-ert.callbacks]
+ignore_errors = True
+
+[mypy-ecl_data_io.*]
+ignore_missing_imports = True
+
+[mypy-deprecation.*]
+ignore_missing_imports = True

--- a/src/clib/lib/include/ert/enkf/enkf_config_node.hpp
+++ b/src/clib/lib/include/ert/enkf/enkf_config_node.hpp
@@ -49,8 +49,6 @@ extern "C" enkf_config_node_type *
 enkf_config_node_alloc_GEN_DATA_everest(const char *key,
                                         const int_vector_type *report_steps);
 
-extern "C" enkf_config_node_type *
-enkf_config_node_alloc_field(const char *key, ecl_grid_type *ecl_grid);
 extern "C" const stringlist_type *
 enkf_config_node_get_obs_keys(const enkf_config_node_type *);
 extern "C" void enkf_config_node_free(enkf_config_node_type *);

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -425,7 +425,7 @@ class EnKFMain:
         logger.debug(f"sample_prior() time_used {(time.perf_counter() - t):.4f}s")
 
     def rng(self) -> np.random.Generator:
-        "Will return the random number generator used for updates."
+        """Will return the random number generator used for updates."""
         return self._shared_rng
 
     def createRunPath(self, run_context: RunContext) -> None:

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -173,7 +173,7 @@ def _save_temporary_storage_to_disk(
                 target_fs.save_surface_data(key, realization, matrix[:, i])
         elif isinstance(config_node, Field):
             for i, realization in enumerate(iens_active_index):
-                target_fs.save_field(key, realization, matrix[:, i], unmasked=True)
+                target_fs.save_field(key, realization, matrix[:, i])
         else:
             raise NotImplementedError(
                 f"{ensemble_config.getNode(key).getImplementationType()}"

--- a/src/ert/storage/field_utils/__init__.py
+++ b/src/ert/storage/field_utils/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from ert.storage.field_utils.field_utils import (
+    Shape,
+    get_mask,
+    get_masked_field,
+    get_shape,
+    read_field,
+    read_mask,
+    save_field,
+)
+
+__all__ = [
+    "get_mask",
+    "read_mask",
+    "get_masked_field",
+    "get_shape",
+    "save_field",
+    "read_field",
+    "Shape",
+]

--- a/src/ert/storage/field_utils/field_utils.py
+++ b/src/ert/storage/field_utils/field_utils.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional, Tuple, Union
+
+import ecl_data_io
+import numpy as np
+from xtgeo.grid3d._gridprop_import_roff import import_roff
+
+from ert.storage.field_utils.grdecl_io import (
+    export_grdecl,
+    import_bgrdecl,
+    read_grdecl_3d_property,
+)
+from ert.storage.field_utils.roff_io import export_roff
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+_PathLike = Union[str, "os.PathLike[str]"]
+
+
+class Shape(NamedTuple):
+    nx: int
+    ny: int
+    nz: int
+
+
+def get_mask(
+    grid_path: Optional[_PathLike],
+    shape: Optional[Shape] = None,
+) -> Tuple[npt.NDArray[np.bool_], Shape]:
+    if grid_path is not None:
+        mask, shape = read_mask(grid_path, shape)
+        if mask is None:
+            return np.zeros(shape, dtype=bool), shape
+        else:
+            return mask, shape
+    elif shape is not None:
+        return np.zeros(shape, dtype=bool), shape
+
+    raise ValueError("Could not load mask with no grid file or shape specified")
+
+
+# pylint: disable=R0912
+def read_mask(
+    grid_path: _PathLike,
+    shape: Optional[Shape] = None,
+) -> Tuple[Optional[npt.NDArray[np.bool_]], Shape]:
+    actnum = None
+    actnum_coords: List[Tuple[int, int, int]] = []
+    with open(grid_path, "rb") as f:
+        for entry in ecl_data_io.lazy_read(f):
+            if actnum is not None and shape is not None:
+                break
+
+            keyword = str(entry.read_keyword()).strip()
+            if actnum is None:
+                if keyword == "COORDS":
+                    coord_array = entry.read_array()
+                    if coord_array[4]:
+                        actnum_coords.append(
+                            (coord_array[0], coord_array[1], coord_array[2])
+                        )
+                if keyword == "ACTNUM":
+                    actnum = entry.read_array()
+            if shape is None:
+                if keyword == "GRIDHEAD":
+                    arr = entry.read_array()
+                    shape = Shape(*(int(val) for val in arr[1:4]))
+                elif keyword == "DIMENS":
+                    arr = entry.read_array()
+                    shape = Shape(*(int(val) for val in arr[0:3]))
+
+    # Could possibly read shape from actnum_coords if they were read.
+    if shape is None:
+        raise ValueError(f"Could not load shape from {grid_path}")
+
+    if actnum is None:
+        if actnum_coords and len(actnum_coords) != np.prod(shape):
+            actnum = np.ones(shape, dtype=bool)
+            for coord in actnum_coords:
+                actnum[coord[0] - 1, coord[1] - 1, coord[2] - 1] = False
+    else:
+        actnum = np.ascontiguousarray(np.logical_not(actnum.reshape(shape, order="F")))
+
+    return actnum, shape
+
+
+def get_masked_field(
+    field_path: _PathLike,
+    field_name: str,
+    grid_path: _PathLike,
+    shape: Optional[Shape] = None,
+) -> Optional[npt.NDArray[np.double]]:
+    mask, shape = get_mask(grid_path, shape)
+    return read_field(field_path, field_name, mask, shape)
+
+
+def get_shape(
+    grid_path: _PathLike,
+) -> Optional[Shape]:
+    shape = None
+    with open(grid_path, "rb") as f:
+        for entry in ecl_data_io.lazy_read(f):
+            keyword = str(entry.read_keyword()).strip()
+            if keyword == "GRIDHEAD":
+                arr = entry.read_array()
+                shape = Shape(*(int(val) for val in arr[1:4]))
+            elif keyword == "DIMENS":
+                arr = entry.read_array()
+                shape = Shape(*(int(val) for val in arr[0:3]))
+
+    return shape
+
+
+# pylint: disable=too-many-arguments
+def save_field(
+    data: npt.NDArray[np.double],
+    field_name: str,
+    grid_path: Optional[_PathLike],
+    shape: Shape,
+    output_path: _PathLike,
+    fformat: str,
+) -> None:
+    data_with_mask = _mask_data(data, grid_path, shape)
+    _save_field(data_with_mask, field_name, output_path, fformat)
+
+
+def read_field(
+    field_path: _PathLike,
+    field_name: str,
+    mask: npt.NDArray[np.bool_],
+    shape: Shape,
+) -> np.ma.MaskedArray[Any, np.dtype[np.double]]:
+    path = Path(field_path)
+    ext = path.suffix
+    if ext == ".roff":
+
+        @dataclass
+        class _Path:
+            _file: str
+
+        results = import_roff(_Path(str(field_path)), field_name)
+        values = results["values"]
+    elif ext == ".grdecl":
+        values = read_grdecl_3d_property(path, field_name, shape, dtype=np.double)
+    elif ext == ".bgrdecl":
+        values = import_bgrdecl(field_path, field_name, shape)
+    else:
+        raise ValueError(f'Could not read {field_path}. Unrecognized suffix "{ext}"')
+
+    return np.ma.MaskedArray(data=values, mask=mask, fill_value=np.nan)  # type: ignore
+
+
+def _save_field(
+    field: np.ma.MaskedArray[Any, np.dtype[np.double]],
+    field_name: str,
+    output_path: _PathLike,
+    file_format: str,
+) -> None:
+    path = Path(output_path)
+    os.makedirs(path.parent, exist_ok=True)
+    if file_format in ["roff_binary", "roff_ascii", "roff"]:
+        export_roff(field, output_path, field_name, True)
+    elif file_format == "grdecl":
+        export_grdecl(field, output_path, field_name)
+    elif file_format == "bgrdecl":
+        export_grdecl(field, output_path, field_name, binary=True)
+    else:
+        raise ValueError(f"Cannot export, invalid file format: {file_format}")
+
+
+def _mask_data(
+    data: npt.NDArray[np.double],
+    grid_path: Optional[_PathLike],
+    shape: Optional[Shape],
+) -> np.ma.MaskedArray[Any, np.dtype[np.double]]:
+    actnum, shape = get_mask(grid_path, shape)
+    return np.ma.MaskedArray(data=data, mask=actnum, fill_value=np.nan)  # type: ignore

--- a/src/ert/storage/field_utils/grdecl_io.py
+++ b/src/ert/storage/field_utils/grdecl_io.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, List, Optional, TextIO, Tuple, Union
+
+import ecl_data_io
+import numpy as np
+import numpy.typing as npt
+
+
+def split_line_no_string(line: str) -> Iterator[str]:
+    for w in line.split():
+        if w.startswith("--"):
+            return
+        yield w
+
+
+def until_space(string: str) -> str:
+    """
+    returns the given string until the first space.
+    Similar to string.split(max_split=1)[0] except
+    initial spaces are not ignored:
+    >>> until_space(" hello")
+    ''
+    >>> until_space("hello world")
+    'hello'
+
+    """
+    result = ""
+    for w in string:
+        if w.isspace():
+            return result
+        result += w
+    return result
+
+
+def interpret_token(val: str) -> list[str]:
+    """
+    Interpret a eclipse token, tries to interpret the
+    value in the following order:
+    * string literal
+    * keyword
+    * repreated keyword
+    * number
+
+    If the token cannot be matched, we default to returning
+    the uninterpreted token.
+
+    >>> interpret_token("3")
+    ['3']
+    >>> interpret_token("1.0")
+    ['1.0']
+    >>> interpret_token("'hello'")
+    ['hello']
+    >>> interpret_token("PORO")
+    ['PORO']
+    >>> interpret_token("3PORO")
+    ['3PORO']
+    >>> interpret_token("3*PORO")
+    ['PORO', 'PORO', 'PORO']
+    >>> interpret_token("3*'PORO '")
+    ['PORO ', 'PORO ', 'PORO ']
+    >>> interpret_token("3'PORO '")
+    ["3'PORO '"]
+
+    """
+    if val[0] == "'" and val[-1] == "'":
+        # A string literal
+        return [val[1:-1]]
+    if val[0].isalpha():
+        # A keyword
+        return [val]
+    if "*" in val:
+        multiplicand, value = val.split("*")
+        return interpret_token(value) * int(multiplicand)
+    return [val]
+
+
+IGNORE_ALL = None
+
+
+@contextmanager
+def open_grdecl(
+    grdecl_file: Union[str, os.PathLike[str]],
+    keywords: list[str],
+) -> Iterator[Iterator[Tuple[str, str]]]:
+    """Generates tuples of keyword and values in records of a grdecl file.
+
+    The format of the file must be that of the GRID section of a eclipse input
+    DATA file.
+
+    The records looked for must be "simple" ie.  start with the keyword, be
+    followed by single word values and ended by a slash ('/').
+
+    .. code-block:: none
+
+        KEYWORD
+        value value value /
+
+    reading the above file with :code:`open_grdecl("filename.grdecl",
+    keywords="KEYWORD")` will generate :code:`[("KEYWORD", ["value", "value",
+    "value"])]`
+
+    open_grdecl does not follow includes, obey skips, parse MESSAGE commands or
+    make exception for groups and subrecords.
+
+    Raises:
+        ValueError: when end of file is reached without terminating a keyword,
+            or the file contains an unrecognized (or ignored) keyword.
+
+    Args:
+        grdecl_file (str): file path
+        keywords (List[str]): Which keywords to look for, these are expected to
+        be at the start of a line in the file  and the respective values
+        following on subsequent lines separated by whitespace. Reading of a
+        keyword is completed by a final '\'. See example above.
+    """
+
+    def read_grdecl(grdecl_stream: TextIO) -> Iterator[Tuple[str, str]]:
+        words: List[str] = []
+        keyword = None
+        nonlocal keywords
+        keywords = [until_space(keyword) for keyword in keywords]
+
+        line_no = 1
+        line = grdecl_stream.readline()
+
+        while line:
+            if line is None:
+                break
+
+            if keyword is None:
+                snubbed = line[0 : min(8, len(until_space(line)))]
+                simple_matched_keywords = [kw for kw in keywords if kw == snubbed]
+                if simple_matched_keywords:
+                    keyword = simple_matched_keywords[0]
+            else:
+                for word in split_line_no_string(line):
+                    if word == "/":
+                        yield (keyword, words)
+                        keyword = None
+                        words = []
+                        break
+                    words += interpret_token(word)
+            line = grdecl_stream.readline()
+            line_no += 1
+
+        if keyword is not None:
+            raise ValueError(f"Reached end of stream while reading {keyword}")
+
+    with open(grdecl_file, "r", encoding="utf-8") as stream:
+        yield read_grdecl(stream)
+
+
+def read_grdecl_3d_property(
+    filename: Union[str, os.PathLike[str]],
+    keyword: str,
+    dimensions: Tuple[int, int, int],
+    dtype: npt.DTypeLike = float,
+) -> npt.NDArray[np.double]:
+    """
+    Read a 3d grid property from a grdecl file, see open_grdecl for description
+    of format.
+
+    Args:
+        filename (pathlib.Path or str): File in grdecl format.
+        keyword (str): The keyword of the property in the file
+        dimensions ((int,int,int)): Triple of the size of grid.
+        dtype (data-type, optional): The datatype to be read, ie., float.
+
+    Raises:
+        xtgeo.KeywordNotFoundError: If keyword is not found in the file.
+
+    Returns:
+        numpy array with given dimensions and data type read
+        from the grdecl file.
+    """
+    result = None
+
+    with open_grdecl(filename, keywords=[keyword]) as kw_generator:
+        try:
+            _, result = next(kw_generator)
+        except StopIteration as si:
+            raise ValueError(
+                f"Cannot import {keyword}, not present in file {filename}?"
+            ) from si
+
+    # The values are stored in F order in the grdecl file
+    f_order_values = np.asarray(result, dtype=dtype)
+    return np.ascontiguousarray(f_order_values.reshape(dimensions, order="F"))
+
+
+def import_bgrdecl(
+    file_path: Union[str, os.PathLike[str]],
+    field_name: str,
+    dimensions: Tuple[int, int, int],
+) -> Optional[npt.NDArray[np.double]]:
+    field_name = field_name.strip()
+    with open(file_path, "rb") as f:
+        for entry in ecl_data_io.lazy_read(f):
+            keyword = str(entry.read_keyword()).strip()
+            if keyword == field_name:
+                values = entry.read_array()
+                if np.issubdtype(values.dtype, np.integer):
+                    values = values.astype(np.int32)
+                else:
+                    values = values.astype(np.float64)
+                return values.reshape(dimensions, order="F")  # type: ignore
+    return None
+
+
+# pylint: disable=too-many-arguments
+def export_grdecl(
+    values: Union[np.ma.MaskedArray[Any, np.dtype[np.double]], npt.NDArray[np.double]],
+    file_path: Union[str, os.PathLike[str]],
+    param_name: str,
+    binary: bool = False,
+    discrete: bool = False,
+    dtype: npt.DTypeLike = None,
+    fmt: Optional[str] = None,
+) -> None:
+    """Export ascii or binary GRDECL"""
+    values = values.flatten(order="F")
+    if np.ma.isMaskedArray(values):  # type: ignore
+        values = values.filled(np.nan)  # type: ignore
+
+    if binary:
+        with open(file_path, "wb") as fh:
+            if dtype is not None:
+                ecl_data_io.write(fh, [(param_name.ljust(8), values.astype(dtype))])
+            elif discrete:
+                ecl_data_io.write(fh, [(param_name.ljust(8), values.astype(np.int32))])
+            else:
+                ecl_data_io.write(
+                    fh, [(param_name.ljust(8), values.astype(np.float32))]
+                )
+
+    else:
+        with open(file_path, "w", encoding="utf-8") as fh:
+            fh.write(param_name + "\n")
+            for i, v in enumerate(values):
+                fh.write(" ")
+                if fmt:
+                    fh.write(fmt % v)
+                elif discrete:
+                    fh.write(str(v))
+                else:
+                    fh.write(f"{v:3e}")
+                if i % 6 == 5:
+                    fh.write("\n")
+
+            fh.write(" /\n")

--- a/src/ert/storage/field_utils/roff_io.py
+++ b/src/ert/storage/field_utils/roff_io.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import warnings
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, BinaryIO, TextIO, Union
+
+import numpy as np
+import roffio  # type: ignore
+
+if TYPE_CHECKING:
+    from os import PathLike
+
+_PathLike = Union[str, "PathLike[str]"]
+
+
+def export_roff(
+    data: np.ma.MaskedArray[Any, np.dtype[np.double]],
+    filelike: Union[TextIO, BinaryIO, _PathLike],
+    parameter_name: str,
+    binary: bool = True,
+) -> None:
+    dimensions = data.shape
+    data = np.flip(data, -1).ravel()  # type: ignore
+    data = data.filled(np.nan)  # type: ignore
+
+    data_ = OrderedDict(
+        {
+            "filedata": {"filetype": "parameter"},
+            "dimensions": {
+                "nX": dimensions[0],
+                "nY": dimensions[1],
+                "nZ": dimensions[2],
+            },
+            "parameter": {"name": parameter_name},
+        }
+    )
+    data_["parameter"]["data"] = data
+    roff_format = roffio.Format.BINARY if binary else roffio.Format.ASCII
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", r"casting array")
+        roffio.write(filelike, data_, roff_format=roff_format)

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
 import xtgeo
-from ecl.grid import EclGrid
 
 from ert._c_wrappers.enkf.config.field_config import Field
 from ert._c_wrappers.enkf.config.gen_kw_config import GenKwConfig, PriorDict
@@ -36,8 +35,12 @@ class LocalExperimentReader:
         return self._id
 
     @property
-    def grid(self) -> Optional[Union[xtgeo.Grid, EclGrid]]:
-        return self._load_grid()
+    def grid_path(self) -> Optional[str]:
+        if (self._path / "grid.EGRID").exists():
+            return str(self._path / "grid.EGRID")
+        if (self._path / "grid.GRID").exists():
+            return str(self._path / "grid.GRID")
+        return None
 
     @property
     def mount_point(self) -> Path:
@@ -64,13 +67,6 @@ class LocalExperimentReader:
         with open(path, encoding="utf-8", mode="r") as f:
             info = json.load(f)
         return info
-
-    def _load_grid(self) -> Optional[Union[xtgeo.Grid, EclGrid]]:
-        if (self._path / "grid.EGRID").exists():
-            return xtgeo.grid_from_file(self._path / "grid.EGRID")
-        if (self._path / "grid.GRID").exists():
-            return EclGrid(str(self._path / "grid.GRID"))
-        return None
 
     def load_gen_kw_priors(self) -> Dict[str, List[PriorDict]]:
         with open(self.mount_point / "gen-kw-priors.json", "r", encoding="utf-8") as f:

--- a/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
+++ b/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
@@ -98,7 +98,9 @@ def test_unknown_file_extension(storage, tmpdir):
         ert, ensemble = create_runpath(storage, "config.ert")
         load_from_forward_model(ert, ensemble)
 
-        with pytest.raises(ValueError, match="Cannot export, invalid fformat: wrong"):
+        with pytest.raises(
+            ValueError, match="Cannot export, invalid file format: wrong"
+        ):
             create_runpath(storage, "config.ert", ensemble=ensemble, iteration=1)
 
 
@@ -744,9 +746,9 @@ if __name__ == "__main__":
 @pytest.mark.parametrize(
     "actnum",
     [
-        [True] * 16,
-        [True] * 8 + [False] * 8,
-        [False] * 8 + [True] * 8,
+        [True] * 24,
+        [True] * 12 + [False] * 12,
+        [False] * 12 + [True] * 12,
     ],
 )
 def test_inactive_grdecl_ecl(tmpdir, storage, actnum):
@@ -764,7 +766,7 @@ def test_inactive_grdecl_ecl(tmpdir, storage, actnum):
             float(i) if mask else missing_value for (i, mask) in enumerate(actnum)
         ]
 
-        grid = EclGrid.create_rectangular((4, 4, 1), (1, 1, 1), actnum=actnum)
+        grid = EclGrid.create_rectangular((4, 3, 2), (1, 1, 1), actnum=actnum)
         grid.save_GRID("MY_GRID.GRID")
 
         expect_param = EclKW("MY_PARAM", grid.get_global_size(), EclDataType.ECL_FLOAT)
@@ -791,9 +793,9 @@ def test_inactive_grdecl_ecl(tmpdir, storage, actnum):
 @pytest.mark.parametrize(
     "actnum",
     [
-        [True] * 16,
-        [True] * 8 + [False] * 8,
-        [False] * 8 + [True] * 8,
+        [True] * 24,
+        [True] * 12 + [False] * 12,
+        [False] * 12 + [True] * 12,
     ],
 )
 def test_inactive_grdecl_xtgeo(tmpdir, storage, actnum):
@@ -811,7 +813,7 @@ def test_inactive_grdecl_xtgeo(tmpdir, storage, actnum):
             float(i) if mask else missing_value for (i, mask) in enumerate(actnum)
         ]
 
-        grid = xtgeo.create_box_grid(dimension=(4, 4, 1))
+        grid = xtgeo.create_box_grid(dimension=(2, 3, 4))
         mask = grid.get_actnum()
         mask.values = [int(mask) for mask in actnum]
         grid.set_actnum(mask)
@@ -824,7 +826,7 @@ def test_inactive_grdecl_xtgeo(tmpdir, storage, actnum):
             nlay=grid.nlay,
             name="MY_PARAM",
             grid=grid,
-            values=np.arange(16),
+            values=np.arange(24),
         )
         prop.to_file(f"my_param_0.{fformat}", fformat=fformat)
 
@@ -845,9 +847,9 @@ def test_inactive_grdecl_xtgeo(tmpdir, storage, actnum):
 @pytest.mark.parametrize(
     "actnum",
     [
-        [True] * 16,
-        [True] * 8 + [False] * 8,
-        [False] * 8 + [True] * 8,
+        [True] * 24,
+        [True] * 12 + [False] * 12,
+        [False] * 12 + [True] * 12,
     ],
 )
 def test_inactive_roff_xtgeo(tmpdir, storage, actnum):
@@ -865,7 +867,7 @@ def test_inactive_roff_xtgeo(tmpdir, storage, actnum):
             float(i) if mask else missing_value for (i, mask) in enumerate(actnum)
         ]
 
-        grid = xtgeo.create_box_grid(dimension=(4, 4, 1))
+        grid = xtgeo.create_box_grid(dimension=(4, 2, 3))
         mask = grid.get_actnum()
         mask.values = [int(mask) for mask in actnum]
         grid.set_actnum(mask)
@@ -877,7 +879,7 @@ def test_inactive_roff_xtgeo(tmpdir, storage, actnum):
             nrow=grid.nrow,
             nlay=grid.nlay,
             name="MY_PARAM",
-            values=np.arange(16),
+            values=np.arange(24),
         )
         prop.to_file(f"my_param_0.{fformat}", fformat=fformat)
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 import pytest
-from ecl.grid.ecl_grid import EclGrid
 from ecl.summary import EclSum
 
 from ert._c_wrappers.enkf import ConfigKeys, EnsembleConfig, ErtConfig
@@ -45,24 +44,6 @@ _________________________________________     _____    ____________________
         EnsembleConfig.from_dict(config_dict=config_dict)
 
 
-@pytest.mark.usefixtures("use_tmpdir")
-def test_ensemble_config_fails_on_non_sensical_grid_file():
-    grid_file = "BRICKWALL"
-    # NB: this is just silly ASCII content, not even close to a correct GRID file
-    grid_file_content = """
-_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
-___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|__
-_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
-___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|__
-_|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|___|
-"""
-    with open(grid_file, "w+", encoding="utf-8") as grid_file_handler:
-        grid_file_handler.write(grid_file_content)
-    with pytest.raises(expected_exception=ValueError, match=grid_file):
-        config_dict = {ConfigKeys.GRID: grid_file}
-        EnsembleConfig.from_dict(config_dict=config_dict)
-
-
 def test_ensemble_config_construct_refcase_and_grid(setup_case):
     setup_case("configuration_tests", "ensemble_config.ert")
     grid_file = "grid/CASE.EGRID"
@@ -76,7 +57,6 @@ def test_ensemble_config_construct_refcase_and_grid(setup_case):
     )
 
     assert isinstance(ec, EnsembleConfig)
-    assert isinstance(ec.grid, EclGrid)
     assert isinstance(ec.refcase, EclSum)
 
     assert ec._grid_file == os.path.realpath(grid_file)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_field_export.py
@@ -1,17 +1,14 @@
 import os
 
 import pytest
-from ecl.grid import EclGrid
 
 
 def test_field_basics(snake_oil_field_example):
     ert = snake_oil_field_example
     ens_config = ert.ensembleConfig()
     fc = ens_config["PERMX"]
-    grid = EclGrid(fc.grid_file)
 
     assert (fc.nx, fc.ny, fc.nz) == (10, 10, 5)
-    assert (grid.nx, grid.ny, grid.nz) == (10, 10, 5)
     assert fc.truncation_min is None
     assert fc.truncation_max is None
     assert fc.input_transformation is None

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -589,7 +589,7 @@ def test_field_init_file_not_readable(copy_case, monkeypatch):
     try:
         run_ert_test_run(config_file_name)
     except ErtCliError as err:
-        assert "Failed to open init file for parameter PERMX" in str(err)
+        assert "Permission denied:" in str(err)
 
 
 def test_surface_init_fails_during_forward_model_callback(copy_case):

--- a/tests/unit_tests/storage/test_field_utils.py
+++ b/tests/unit_tests/storage/test_field_utils.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+import xtgeo
+
+from ert.storage import field_utils
+
+
+@pytest.mark.parametrize(
+    "shape, mask",
+    [
+        (
+            (2, 3, 4),
+            np.random.choice(a=[False, True], size=(2, 3, 4), p=[0.3, 0.7]),
+        ),
+        (
+            (4, 3, 2),
+            np.random.choice(a=[False, True], size=(4, 3, 2), p=[0.3, 0.7]),
+        ),
+        (
+            (3, 2, 4),
+            np.random.choice(a=[False, True], size=(3, 2, 4), p=[0.3, 0.7]),
+        ),
+        (
+            (20, 33, 44),
+            np.random.choice(a=[False, True], size=(20, 33, 44), p=[0.3, 0.7]),
+        ),
+    ],
+)
+def test_read_bgrdecl(tmpdir, shape, mask):
+    with tmpdir.as_cwd():
+        field_path = "test.bgrdecl"
+        grid_path = "test.egrid"
+        field_name = "MY_PARAM"
+        values = np.random.standard_normal(mask.shape)
+
+        grid = xtgeo.create_box_grid(dimension=shape)
+        grid_mask = grid.get_actnum()
+        grid_mask.values = [int(not num) for num in mask.flatten()]
+        grid.set_actnum(grid_mask)
+        grid.to_file(grid_path, "egrid")
+
+        prop = xtgeo.GridProperty(
+            ncol=shape[0],
+            nrow=shape[1],
+            nlay=shape[2],
+            name=field_name,
+            grid=grid,
+            values=values.flatten(),
+        )
+        prop.to_file(field_path, fformat="bgrdecl")
+
+        data = np.ma.MaskedArray(values, mask, fill_value=np.nan)
+        masked_field = field_utils.get_masked_field(field_path, field_name, grid_path)
+        assert np.ma.allclose(masked_field, data, masked_equal=True)

--- a/tests/unit_tests/storage/test_local_ensemble.py
+++ b/tests/unit_tests/storage/test_local_ensemble.py
@@ -12,9 +12,9 @@ def test_save_field_xtgeo(tmp_path):
         ensemble_dir = tmp_path / "ensembles" / str(ensemble.id)
         assert ensemble_dir.exists()
 
-        grid = xtgeo.create_box_grid(dimension=(4, 4, 1))
+        grid = xtgeo.create_box_grid(dimension=(4, 5, 1))
         mask = grid.get_actnum()
-        mask.values = [True] * 3 + [False] * 12 + [True]
+        mask.values = [True] * 3 + [False] * 16 + [True]
         grid.set_actnum(mask)
         grid.to_file(f"{experiment.mount_point}/grid.EGRID", "egrid")
 
@@ -23,14 +23,15 @@ def test_save_field_xtgeo(tmp_path):
             parameter_name="MY_PARAM",
             realization=1,
             data=data,
-            unmasked=True,
         )
 
         saved_file = ensemble_dir / "realization-1" / "MY_PARAM.npy"
         assert saved_file.exists()
 
         loaded_data = numpy.load(saved_file)
-        expected_data = data[:-1] + [numpy.nan] * 12 + [data[3]]
+        expected_data = data[:-1] + [numpy.nan] * 16 + [data[3]]
+        expected_data = numpy.asarray(expected_data)
+        expected_data = expected_data.reshape(4, 5, 1)
         numpy.testing.assert_array_equal(loaded_data, expected_data)
 
 
@@ -41,8 +42,8 @@ def test_save_field_ecl(tmp_path):
         ensemble_dir = tmp_path / "ensembles" / str(ensemble.id)
         assert ensemble_dir.exists()
 
-        mask = [True] * 3 + [False] * 12 + [True]
-        grid = EclGrid.create_rectangular((4, 4, 1), (1, 1, 1), actnum=mask)
+        mask = [True] * 3 + [False] * 16 + [True]
+        grid = EclGrid.create_rectangular((4, 5, 1), (1, 1, 1), actnum=mask)
         grid.save_GRID(f"{experiment.mount_point}/grid.GRID")
 
         data = [1.2, 1.1, 4.3, 3.1]
@@ -50,12 +51,13 @@ def test_save_field_ecl(tmp_path):
             parameter_name="MY_PARAM",
             realization=1,
             data=data,
-            unmasked=True,
         )
 
         saved_file = ensemble_dir / "realization-1" / "MY_PARAM.npy"
         assert saved_file.exists()
 
         loaded_data = numpy.load(saved_file)
-        expected_data = data[:-1] + [numpy.nan] * 12 + [data[3]]
+        expected_data = data[:-1] + [numpy.nan] * 16 + [data[3]]
+        expected_data = numpy.asarray(expected_data)
+        expected_data = expected_data.reshape(4, 5, 1, order="F")
         numpy.testing.assert_array_equal(loaded_data, expected_data)


### PR DESCRIPTION
**Issue**
A very large amount of memory is used for loading grids/fields
#5164 

**Approach**
Used memray to pinpoint the issue.
Removed grid that was kept in field config node.
Replaced libecl and xtgeo with ecl_data_io for reading grids.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
