### PR TITLE
Implement changes to allow upgrading websockets >11.0

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -289,6 +289,7 @@ class EnsembleEvaluator:
             process_request=self.process_request,
             max_queue=None,
             max_size=2**26,
+            open_timeout=10,
         ):
             await self._done
             if self._dispatchers_connected is not None:

--- a/src/ert/experiment_server/_server.py
+++ b/src/ert/experiment_server/_server.py
@@ -120,6 +120,7 @@ class ExperimentServer:
                 self._handler,
                 sock=self._config.get_socket(),
                 ssl=self._config.get_server_ssl_context(),
+                open_timeout=10,
             ):
                 logger.debug("Running experiment server")
                 await self._server_done

--- a/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -27,7 +27,7 @@ def _mock_ws(host, port, messages, delay_startup=0):
     async def _run_server():
         await asyncio.sleep(delay_startup)
         async with websockets.server.serve(
-            _handler, host, port, ping_timeout=1, ping_interval=1
+            _handler, host, port, ping_timeout=1, ping_interval=1, open_timeout=10
         ):
             await done
 

--- a/tests/unit_tests/ensemble_evaluator/test_sync_ws_duplexer.py
+++ b/tests/unit_tests/ensemble_evaluator/test_sync_ws_duplexer.py
@@ -36,6 +36,7 @@ def ws(event_loop: asyncio.AbstractEventLoop):
             websockets.server.serve(
                 handler,
                 **kwargs,
+                open_timeout=10,
             ),
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,7 @@ def _mock_ws(host, port, messages, delay_startup=0):
 
     async def _run_server():
         await asyncio.sleep(delay_startup)
-        async with websockets.server.serve(_handler, host, port):
+        async with websockets.server.serve(_handler, host, port, open_timeout=10):
             await done
 
     loop.run_until_complete(_run_server())


### PR DESCRIPTION
Resolves #5200 

**Approach**
- checked [change log for weksockets 11.0](https://websockets.readthedocs.io/en/stable/project/changelog.html)

**Backwards-incompatible changes**
## The Sans-I/O implementation was moved. ##

Aliases provide compatibility for all previously public APIs according to the [backwards-compatibility policy](https://websockets.readthedocs.io/en/stable/project/changelog.html#backwards-compatibility-policy).

- The connection module was renamed to protocol.

- The connection.Connection, server.ServerConnection, and client.ClientConnection classes were renamed to protocol.Protocol, server.ServerProtocol, and client.ClientProtocol.

**Conclusion: did not find any instances of those functions**

## Sans-I/O protocol constructors now use keyword-only arguments. ##

If you instantiate [ServerProtocol](https://websockets.readthedocs.io/en/stable/reference/sansio/server.html#websockets.server.ServerProtocol) or [ClientProtocol](https://websockets.readthedocs.io/en/stable/reference/sansio/client.html#websockets.client.ClientProtocol) directly, make sure you are using keyword arguments.

**Conclusion: did not find any instances of those functions**

## Closing a connection without an empty close frame is OK. ##

Receiving an empty close frame now results in [ConnectionClosedOK](https://websockets.readthedocs.io/en/stable/reference/exceptions.html#websockets.exceptions.ConnectionClosedOK) instead of [ConnectionClosedError](https://websockets.readthedocs.io/en/stable/reference/exceptions.html#websockets.exceptions.ConnectionClosedError).

As a consequence, calling WebSocket.close() without arguments in a browser isn’t reported as an error anymore.

**Conclusion: There is a couple of instances of close(), but I am not sure how this change would affect the behaviour.**

## [serve()](https://websockets.readthedocs.io/en/stable/reference/asyncio/server.html#websockets.server.serve) times out on the opening handshake after 10 seconds by default. ##

You can adjust the timeout with the open_timeout parameter. Set it to [None](https://docs.python.org/3/library/constants.html#None) to disable the timeout entirely.

**Conclusion: Fixed with open_timeout=10. Could not find the previous behaviour.**

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
