### PR TITLE
Ignore B028 in annotations

### DIFF
--- a/.github/workflows/annotate_python.yml
+++ b/.github/workflows/annotate_python.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "changed_files=$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' |  xargs ls -d 2>/dev/null | grep -E '.py$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       - run: echo ::add-matcher::.github/flake8-matcher.json
       - name: run flake8
-        run: flake8 --exit-zero ${{steps.find_changed_files.outputs.changed_files}}
+        run: flake8 --exit-zero --ignore B028 ${{steps.find_changed_files.outputs.changed_files}}
         if: steps.find_changed_files.outputs.changed_files != ''
       - run: echo ::add-matcher::.github/mypy-matcher.json
       - name: generate grpc typing stubs


### PR DESCRIPTION
These errors are:

> B028: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user. 

These are unhelpful as we have legitemate reasons to not add stacklevel to warnings

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
