### PR TITLE
Use numpy vectorised funcs in TRANSFORM_FUNCTIONS

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/field_config.py
+++ b/src/ert/_c_wrappers/enkf/config/field_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import math
 import os
 import time
 from dataclasses import dataclass
@@ -83,18 +82,16 @@ class Field(ParameterConfig):
 
 
 # pylint: disable=unnecessary-lambda
-_TRANSFORM_FUNCTIONS = {
-    "LN": lambda x: math.log(x, math.e),
-    "LOG": lambda x: math.log(x, math.e),
-    "LN0": lambda x: math.log(x + 0.000001, math.e),
-    "LOG10": lambda x: math.log(x, 10),
-    "EXP": lambda x: math.exp(x),
-    "EXP0": lambda x: math.exp(x) - 0.000001,
-    "POW10": lambda x: math.log(x, math.e),
-    "TRUNC_POW10": lambda x: math.pow(max(x, 0.001), 10),
+TRANSFORM_FUNCTIONS = {
+    "LN": np.log,
+    "LOG": np.log,
+    "LN0": lambda v: np.log(v + 0.000001),
+    "LOG10": np.log10,
+    "EXP": np.exp,
+    "EXP0": lambda v: np.exp(v) - 0.000001,
+    "POW10": lambda v: np.power(10.0, v),
+    "TRUNC_POW10": lambda v: np.maximum(np.power(10, v), 0.001),
 }
-
-TRANSFORM_FUNCTIONS = {k: np.vectorize(v) for k, v in _TRANSFORM_FUNCTIONS.items()}
 
 
 def field_transform(data: npt.ArrayLike, transform_name: str) -> npt.ArrayLike:


### PR DESCRIPTION
I did some simple microbenchmarks comparing the current implementation, numpy vectorised operations and numba with both JIT (just-in-time; compile-when-python-is-started) and AOT (ahead-of-time; compile-into-a-python-module-then-start) modes. I used `/usr/bin/time` for timing and the test was performed on a massive randomised numpy array.

The current implementation did by far the worst, nearly an order of magnitude worse than numpy. Numpy and numba AOT were about equivalent. This can be explained that `LN0` is fairly trivial. Numba JIT performed worse, owing due to its increased startup time (compiling the code first), but still did better than `math`.

I did no testing on memory use. I think in this area numba AOT can perform better than numpy because we can do everything in-place using a simple for-loop.