### PR TITLE
Fix strange `gui` case name appearing for each run of EnsembleSmoother

### DIFF
--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -91,6 +91,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
     def getSimulationArguments(self):
         arguments = Arguments(
             mode="ensemble_smoother",
+            current_case=f"{self.notifier.current_case_name}_prior",
             target_case=self._target_case_model.getValue(),
             realizations=self._active_realizations_field.text(),
         )


### PR DESCRIPTION
Replace the `gui` name with current selected case name with a `_prior` suffix

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
