### PR TITLE
Fix flake8-bugbear's B007 on unused loop control variables

### DIFF
--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -76,10 +76,10 @@ class Monitor:
 
     def _print_job_errors(self):
         failed_jobs = {}
-        for snapshot_id, snapshot in self._snapshots.items():
-            for real_id, real in snapshot.reals.items():
-                for step_id, step in real.steps.items():
-                    for job_id, job in step.jobs.items():
+        for snapshot in self._snapshots.values():
+            for real in snapshot.reals.values():
+                for step in real.steps.values():
+                    for job in step.jobs.values():
                         if job.status == JOB_STATE_FAILURE:
                             result = failed_jobs.get(job.error, 0)
                             failed_jobs[job.error] = result + 1

--- a/src/ert/gui/plottery/plots/ccsp.py
+++ b/src/ert/gui/plottery/plots/ccsp.py
@@ -41,7 +41,7 @@ def plotCrossCaseStatistics(figure, plot_context, case_to_data_map, _observation
         "p67": {},
         "p90": {},
     }
-    for case_index, (case, data) in enumerate(case_to_data_map.items()):
+    for case_index, data in enumerate(case_to_data_map.values()):
         case_indexes.append(case_index)
         std_dev_factor = config.getStandardDeviationFactor()
 

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -155,7 +155,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 iteration=current_iter,
             )
             update_success = False
-            for iteration in range(analysis_config.num_retries_per_iter):
+            for _iteration in range(analysis_config.num_retries_per_iter):
                 self.analyzeStep(
                     prior_context.sim_fs,
                     posterior_context.sim_fs,

--- a/src/ert/shared/share/ert/forward-models/res/script/rms.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/rms.py
@@ -113,7 +113,7 @@ class RMSRun:
     def init_seed(self, iens):
         if "RMS_SEED" in os.environ:
             seed = int(os.getenv("RMS_SEED"))
-            for x in range(iens):
+            for _ in range(iens):
                 seed *= RMSRun._seed_factor
         else:
             single_seed_file = os.path.join(self.run_path, RMSRun._single_seed_file)

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -147,7 +147,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
             cases = ["default"]
 
         data_frame = pandas.DataFrame()
-        for index, case in enumerate(cases):
+        for case in cases:
             case = case.strip()
             case_frame = pandas.DataFrame()
 

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -228,7 +228,7 @@ def test_tracking(
         assert tracker._progress() == progress
 
         assert len(snapshots) == num_iters
-        for iter_, snapshot in snapshots.items():
+        for snapshot in snapshots.values():
             successful_reals = list(
                 filter(
                     lambda item: item[1].status == REALIZATION_STATE_FINISHED,


### PR DESCRIPTION
**Issue**
Resolves flake8-bugbear B007 which says:
> B007: Loop control variable not used within the loop body. If this is intended, start the name with an underscore.


**Approach**
Rewrite.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
