### PR TITLE
Make intent more clear on testing in pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,6 @@ _Short description of the approach_
 - [ ] PR title captures the intent of the changes, and is fitting for release notes.
 - [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
 - [ ] Updated documentation
-- [ ] Ensured new behaviour is tested
+- [ ] Tested the changes manually
 
 Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).


### PR DESCRIPTION
This changes from 'Ensure new behaviour is tested' to 'Tested manually', in order to make it clear that the checkbox here is not related to the automated tests

**Issue**
Resolves unclear intention in pull request template


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
