### PR TITLE
Stop flaky gui tests

### DIFF
--- a/.github/workflows/check_new_parser.yml
+++ b/.github/workflows/check_new_parser.yml
@@ -49,9 +49,10 @@ jobs:
       if: matrix.test-type == 'gui-tests'
       env:
         DISPLAY: ':99.0'
+      timeout-minutes: 10
       run: |
         ci/github/start_herbstluftwm.sh &
-        sleep 5
+        sleep 15
         pytest tests/ --cov=ert --hypothesis-profile=ci -m "requires_window_manager" --cov-report=xml:cov.xml
 
     - name: Test Integration

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
         DISPLAY: ':99.0'
       run: |
         ci/github/start_herbstluftwm.sh &
-        sleep 5
+        sleep 15
         pytest tests/ --cov=ert --hypothesis-profile=ci -m "requires_window_manager" --cov-report=xml:cov.xml
 
     - name: Test Integration

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -52,7 +52,7 @@ jobs:
         DISPLAY: ':99.0'
       run: |
         ci/github/start_herbstluftwm.sh &
-        sleep 5
+        sleep 15
         pytest tests -sv --hypothesis-profile=ci -m "requires_window_manager" --benchmark-disable
 
     - name: Unit Test


### PR DESCRIPTION
Increases the sleep time to 15 for the gui tests in order to stop tests from hanging.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
