### PR TITLE
Bump the queue_query timeout in Torque driver

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1847,7 +1847,7 @@ bjobs.
         intermittently not respond and give error messages when submitting jobs
         or asking for job statuses. The timeout (in seconds) determines how long
         ERT will wait before it will give up. Applies to job submission (qsub)
-        and job status queries (qstat). Default is 62 seconds.
+        and job status queries (qstat). Default is 126 seconds.
 
         ERT will do exponential sleeps, starting at 2 seconds, and the provided
         timeout is a maximum. Let the timeout be sums of series like 2+4+8+16+32+64
@@ -1855,7 +1855,7 @@ bjobs.
         flakyness.
 
         ::
-                QUEUE_OPTION TORQUE QUEUE_QUERY_TIMEOUT 126
+                QUEUE_OPTION TORQUE QUEUE_QUERY_TIMEOUT 254
 
 .. _configuring_the_slurm_queue:
 

--- a/src/clib/lib/include/ert/job_queue/torque_driver.hpp
+++ b/src/clib/lib/include/ert/job_queue/torque_driver.hpp
@@ -25,7 +25,7 @@
 #define TORQUE_DEFAULT_QSTAT_OPTIONS "-x"
 #define TORQUE_DEFAULT_QDEL_CMD "qdel"
 #define TORQUE_DEFAULT_SUBMIT_SLEEP "0"
-#define TORQUE_DEFAULT_QUEUE_QUERY_TIMEOUT "62"
+#define TORQUE_DEFAULT_QUEUE_QUERY_TIMEOUT "126"
 
 typedef struct torque_driver_struct torque_driver_type;
 typedef struct torque_job_struct torque_job_type;


### PR DESCRIPTION
Adding 64 seconds .

62 seconds have been proven occasionally to be insufficient.

**Issue**
Possibly resolves flakyness whenever the PBS queue system in Azure has a bad moment.


**Approach**
Increase timeout

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
