### PR TITLE
Add error collection to handle_includes

### DIFF
--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -324,7 +324,8 @@ def _handle_includes(
                 errors.append(
                     ErrorInfo(
                         message="Keyword:INCLUDE must have exactly one argument "
-                        f"at ({current_included_file.filename} line {superfluous.line})",
+                        f"at ({current_included_file.filename} "
+                        f"line {superfluous.line})",
                         filename=config_file,
                     ).set_context(error_context)
                 )

--- a/tests/test_config_parsing/test_parser_error_collection.py
+++ b/tests/test_config_parsing/test_parser_error_collection.py
@@ -345,7 +345,7 @@ def test_summary_without_eclbase():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_include_non_existing_file_is_located(tmpdir):
+def test_that_include_non_existing_file_errors_with_location(tmpdir):
     assert_that_config_leads_to_error(
         config_file_contents=dedent(
             """
@@ -364,7 +364,7 @@ def test_include_non_existing_file_is_located(tmpdir):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_include_with_too_many_args_error_is_located(tmpdir):
+def test_that_include_with_too_many_args_errors_with_location(tmpdir):
     assert_that_config_leads_to_error(
         config_file_contents=dedent(
             """
@@ -382,7 +382,7 @@ def test_that_include_with_too_many_args_error_is_located(tmpdir):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_include_with_too_many_args_error_is_located_indirect(tmpdir):
+def test_include_with_too_many_args_error_is_located_indirect(tmpdir):
     assert_that_config_leads_to_error(
         config_file_contents=dedent(
             """


### PR DESCRIPTION
And some more logic to properly detect and display cycles

**Issue**
Resolves #5314


**Approach**
Added some more detailed include handling to lark parser to properly detect imports. One consideration here is that ert files are linted once at a time, so when finding errors in other files, they must still be located to their origins in the currently active .ert file.


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
