### PR TITLE
Update current case when running run models

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -291,7 +291,7 @@ class EnKFMain:
     ) -> RunContext:
         """This creates a new case in storage
         and returns the run information for that case"""
-        return RunContext(
+        run_context = RunContext(
             sim_fs=self.storage_manager.add_case(case_name),
             path_format=self.getModelConfig().jobname_format_string,
             format_string=self.getModelConfig().runpath_format_string,
@@ -300,12 +300,15 @@ class EnKFMain:
             global_substitutions=dict(self.get_context()),
             iteration=iteration,
         )
+        self.switchFileSystem(case_name)
+        return run_context
 
     def load_ensemble_context(
         self, case_name, active_realizations, iteration
     ) -> RunContext:
         """This loads an existing case from storage
         and creates run information for that case"""
+        self.switchFileSystem(case_name)
         return RunContext(
             sim_fs=self.storage_manager[case_name],
             path_format=self.getModelConfig().jobname_format_string,

--- a/src/ert/shared/models/iterated_ensemble_smoother.py
+++ b/src/ert/shared/models/iterated_ensemble_smoother.py
@@ -72,7 +72,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.setPhaseName("Analyzing...", indeterminate=True)
 
         self.setPhaseName("Pre processing update...", indeterminate=True)
+        self.ert().switchFileSystem(prior_storage.case_name)
         self.ert().runWorkflows(HookRuntime.PRE_UPDATE)
+        self.ert().switchFileSystem(posterior_storage.case_name)
 
         try:
             self.facade.iterative_smoother_update(


### PR DESCRIPTION
**Issue**
Bug reported by user in https://equinor.slack.com/archives/CDPJULWR4/p1682686843179699
Seems like there are multiple reports of issues with the MISFIT_PREPROCESSOR  in the latest releases. Have gotten one which I haven't seen in the other threads (but could be that I missed it). It looks like this (where OBSX are whatever the observations are called):
The script 'MisfitPreprocessorJob' caused an error while running:
No response loaded for observation keys: ['OBS1, 'OBS2', 'OBS3']
The hooked workflow fails, but ERT still continues to the next iteration (I assume without the effect of the MISFIT_PREPROCESSOR). It appears to work fine in komodo 2022.12 , but not in current stable  (2023.04) and testing (2023.05).

**Approach**
Reimplement current_case


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
