### PR TITLE
Reformat lint cli message

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -199,22 +199,22 @@ class EnkfObs(BaseCClass):
             except IndexError as err:
                 if config.ensemble_config.refcase is not None:
                     raise ObservationConfigError(
-                        f"{err} The time map is set from the REFCASE keyword.\n Either "
+                        f"{err} The time map is set from the REFCASE keyword. Either "
                         "the REFCASE has an incorrect/missing date, or the observation "
                         "is given an incorrect date.",
                         config_file=config.model_config.obs_config_file,
                     ) from err
                 raise ObservationConfigError(
                     f"{err} The time map is set from the TIME_MAP"
-                    "keyword.\n Either the time map file has an"
-                    "incorrect/missing date, or the  observation is given an"
+                    "keyword. Either the time map file has an"
+                    "incorrect/missing date, or the observation is given an"
                     "incorrect date.",
                     config_file=config.model_config.obs_config_file,
                 ) from err
 
             except ValueError as err:
                 raise ObservationConfigError(
-                    str(err),
+                    str(err).replace("\n", " ").replace("  ", " "),
                     config_file=config.model_config.obs_config_file,
                 ) from err
         return ret

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -389,7 +389,7 @@ class EnsembleConfig(BaseCClass):
         elif not Path(base_surface).exists():
             errors.append(f"BASE_SURFACE:{base_surface} not found")
         if errors:
-            errors = "\n".join(errors)
+            errors = ". ".join(errors)
             raise ConfigValidationError(
                 f"SURFACE {name} incorrectly configured: {errors}"
             )

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -389,7 +389,7 @@ class EnsembleConfig(BaseCClass):
         elif not Path(base_surface).exists():
             errors.append(f"BASE_SURFACE:{base_surface} not found")
         if errors:
-            errors = ". ".join(errors)
+            errors = ";".join(errors)
             raise ConfigValidationError(
                 f"SURFACE {name} incorrectly configured: {errors}"
             )

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -427,7 +427,7 @@ class ErtConfig:
                 except ValueError as err:
                     errors.append(
                         ConfigValidationError(
-                            errors=f"{err}: 'FORWARD_MODEL {job_name}({args})'\n",
+                            errors=f"{err}: 'FORWARD_MODEL {job_name}({args})'",
                             config_file=config_file,
                         )
                     )

--- a/src/ert/parsing/config_errors.py
+++ b/src/ert/parsing/config_errors.py
@@ -50,17 +50,17 @@ class ConfigValidationError(ValueError):
         for error in self.errors:
             by_filename[error.filename].append(error)
 
-        nice_messages = []
+        messages = []
         for filename, info_list in by_filename.items():
             for info in info_list:
-                nice_messages.append(
+                messages.append(
                     f"{filename}:"
                     f"{info.line}:"
                     f"{info.column}:{info.end_column}:"
                     f"{info.message}"
                 )
 
-        return nice_messages
+        return messages
 
     @classmethod
     def from_collected(

--- a/src/ert/parsing/config_errors.py
+++ b/src/ert/parsing/config_errors.py
@@ -42,10 +42,10 @@ class ConfigValidationError(ValueError):
             else info.message
         )
 
-    def get_cli_message(self) -> List[str]:
+    def get_cli_message(self) -> str:
         return "\n".join(self.get_error_messages())
 
-    def get_error_messages(self) -> str:
+    def get_error_messages(self) -> List[str]:
         by_filename = defaultdict(list)
         for error in self.errors:
             by_filename[error.filename].append(error)

--- a/src/ert/parsing/config_keywords.py
+++ b/src/ert/parsing/config_keywords.py
@@ -256,7 +256,7 @@ class SchemaItem(BaseModel):
             if val_type == SchemaType.CONFIG_EXISTING_PATH and not os.path.exists(
                 str(path)
             ):
-                err = f'Cannot find file or directory "{token.value}. "'
+                err = f'Cannot find file or directory "{token.value}". '
                 if path != token:
                     err += f"The configured value was {path!r} "
                 raise ConfigValidationError.from_info(

--- a/src/ert/parsing/config_keywords.py
+++ b/src/ert/parsing/config_keywords.py
@@ -256,7 +256,7 @@ class SchemaItem(BaseModel):
             if val_type == SchemaType.CONFIG_EXISTING_PATH and not os.path.exists(
                 str(path)
             ):
-                err = f'Cannot find file or directory "{token.value}" \n'
+                err = f'Cannot find file or directory "{token.value}. "'
                 if path != token:
                     err += f"The configured value was {path!r} "
                 raise ConfigValidationError.from_info(

--- a/src/ert/parsing/error_info.py
+++ b/src/ert/parsing/error_info.py
@@ -20,6 +20,9 @@ class ErrorInfo:
     end_pos: Optional[int] = None
     originates_from: Optional[MaybeWithContext] = None
 
+    def __post_init__(self):
+        assert "\n" not in self.message, "newlines are not allowed in error messages."
+
     @classmethod
     def _take(cls, context: MaybeWithContext, attr: str):
         if isinstance(context, FileContextToken):

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -322,7 +322,13 @@ def _parse_file(
             )
         raise IOError(f"{error_context_string} file: {str(file)} not found")
     except UnexpectedCharacters as e:
-        raise ConfigValidationError(str(e), config_file=str(file)) from e
+        unexpected_char = e.char
+        allowed_chars = e.allowed
+        message = (
+            f'Did not expect character: {unexpected_char}. '
+            f'Expected one of {allowed_chars}'
+        )
+        raise ConfigValidationError(message, config_file=file)
     except UnicodeDecodeError as e:
         error_words = str(e).split(" ")
         hex_str = error_words[error_words.index("byte") + 1]

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -325,8 +325,8 @@ def _parse_file(
         unexpected_char = e.char
         allowed_chars = e.allowed
         message = (
-            f'Did not expect character: {unexpected_char}. '
-            f'Expected one of {allowed_chars}'
+            f"Did not expect character: {unexpected_char}. "
+            f"Expected one of {allowed_chars}"
         )
         raise ConfigValidationError(message, config_file=file)
     except UnicodeDecodeError as e:

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -291,7 +291,7 @@ def test_that_loading_non_existant_workflow_gives_validation_error():
         fh.write(test_config_contents)
     with pytest.raises(
         expected_exception=ConfigValidationError,
-        match='Cannot find file or directory "does_not_exist" ',
+        match='Cannot find file or directory "does_not_exist"',
     ):
         ErtConfig.from_file(test_config_file_name)
 

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -12,7 +12,6 @@ from hypothesis import assume, given
 from ert._c_wrappers.enkf import ErtConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert.parsing import ConfigValidationError, ConfigWarning
-from ert.parsing.error_info import ErrorInfo
 
 from .config_dict_generator import config_generators
 
@@ -1017,7 +1016,7 @@ def test_that_defines_in_included_files_has_immediate_effect():
 
 
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
-def test_that_multiple_errors_is_shown_for_forward_model():
+def test_that_multiple_errors_are_shown_for_forward_model():
     test_config_file_name = "test.ert"
     test_config_contents = dedent(
         """
@@ -1032,57 +1031,23 @@ def test_that_multiple_errors_is_shown_for_forward_model():
     with pytest.raises(ConfigValidationError) as err:
         _ = ErtConfig.from_file(test_config_file_name)
 
-    expected_cli_message = (
-        "Parsing config file `test.ert` "
-        "resulted in the errors: \n"
-        "  * Could not find job 'does_not_exist' in list of "
-        "installed jobs: [] at line None, column None-None\n"
-        "  * Could not find job 'does_not_exist2' in list of "
-        "installed jobs: [] at line None, column None-None"
-    )
+    expected_nice_messages_list = [
+        (
+            "test.ert:None:None:None:"
+            "Could not find job 'does_not_exist' "
+            "in list of installed jobs: []"
+        ),
+        (
+            "test.ert:None:None:None:"
+            "Could not find job 'does_not_exist2' "
+            "in list of installed jobs: []"
+        ),
+    ]
+
+    expected_nice_message = "\n".join(expected_nice_messages_list)
 
     cli_message = err.value.get_cli_message()
     error_messages_list = err.value.get_error_messages()
 
-    assert expected_cli_message == cli_message
-
-    expected_messages_list = [
-        "Parsing config file `test.ert` resulted in the errors: Could not find job "
-        "'does_not_exist' in list of installed jobs: []",
-        "Parsing config file `test.ert` resulted in the errors: Could not find job "
-        "'does_not_exist2' in list of installed jobs: []",
-    ]
-
-    assert error_messages_list == expected_messages_list
-
-
-@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
-def test_that_multiline_errors_are_indented_properly():
-    dummy_info = ErrorInfo(
-        message='Cannot find file or directory "coeffs.tmpl" \n'
-        "The configured value was '/test-data/poly_example/coeffs.tmpl' ",
-        filename="/test-data/poly_example/poly.ert",
-        start_pos=230,
-        line=14,
-        column=15,
-        end_line=14,
-        end_column=26,
-        end_pos=241,
-        originates_from="coeffs.tmpl",
-    )
-
-    dummy_error = ConfigValidationError([dummy_info, dummy_info])
-
-    cli_message = dummy_error.get_cli_message()
-    expected_cli_message = (
-        "Parsing config file `/test-data/poly_example/poly.ert`"
-        " resulted in the errors: \n"
-        '  * Cannot find file or directory "coeffs.tmpl" \n'
-        "    The configured value was '/test-data/poly_example/coeffs.tmpl'"
-        "  at line 14, column 15-26\n"
-        '  * Cannot find file or directory "coeffs.tmpl" \n'
-        "    The configured value was '/test-data/poly_example/coeffs.tmpl'"
-        "  at line 14, column 15-26"
-    )
-
-    assert cli_message == expected_cli_message
+    assert expected_nice_message == cli_message
+    assert error_messages_list == expected_nice_messages_list

--- a/tests/test_config_parsing/test_forward_model.py
+++ b/tests/test_config_parsing/test_forward_model.py
@@ -353,7 +353,7 @@ def test_that_positional_forward_model_args_gives_config_validation_error():
     test_config_contents = dedent(
         """
         NUM_REALIZATIONS  1
-        FORWARD_MODEL RMS(<IENS>)
+        FORWARD_MODEL RMS <IENS>
         """
     )
     with open(test_config_file_name, "w", encoding="utf-8") as fh:

--- a/tests/test_config_parsing/test_forward_model.py
+++ b/tests/test_config_parsing/test_forward_model.py
@@ -360,7 +360,10 @@ def test_that_positional_forward_model_args_gives_config_validation_error():
         fh.write(test_config_contents)
 
     with pytest.raises(ConfigValidationError, match="FORWARD_MODEL RMS"):
-        _ = ErtConfig.from_file(test_config_file_name)
+        _ = ErtConfig.from_file(test_config_file_name, use_new_parser=True)
+
+    with pytest.raises(ConfigValidationError, match="Could not find job 'RMS<IENS>'"):
+        _ = ErtConfig.from_file(test_config_file_name, use_new_parser=False)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -173,7 +173,7 @@ def test_that_missing_obs_file_raises_exception(tmpdir):
 
         with pytest.raises(
             expected_exception=ObservationConfigError,
-            match="did not resolve to a valid path:\n OBS_FILE",
+            match="did not resolve to a valid path: OBS_FILE",
         ):
             EnKFMain(ert_config)
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -240,7 +240,7 @@ def test_surface_bad_init_values(setup_case):
         f" BASE_SURFACE:{base_surface}"
     )
     error = (
-        "Must give file name with %d with FORWARD_INIT:FALSE\n"
+        "Must give file name with %d with FORWARD_INIT:FALSE. "
         f"BASE_SURFACE:{base_surface} not found"
     )
     with pytest.raises(ConfigValidationError, match=error):

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -240,7 +240,7 @@ def test_surface_bad_init_values(setup_case):
         f" BASE_SURFACE:{base_surface}"
     )
     error = (
-        "Must give file name with %d with FORWARD_INIT:FALSE. "
+        "Must give file name with %d with FORWARD_INIT:FALSE;"
         f"BASE_SURFACE:{base_surface} not found"
     )
     with pytest.raises(ConfigValidationError, match=error):


### PR DESCRIPTION
**Issue**
Resolves #5300

Partially fixes #5319 (adding error info & localization to the errors in that method should be a separate PR)


**Approach**
* Format CLI message in standard linting format
* Remove newlines from errors
* Unexpected characters message without newlines

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
