### PR TITLE
Adjust corner case min_realizations for ensemble_experiment

### DIFF
--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -193,6 +193,9 @@ class AnalysisConfig:
     def set_num_iterations(self, num_iterations: int):
         self._analysis_iter_config.iter_count = num_iterations
 
+    def set_min_realizations(self, min_realizations: int):
+        self._min_realization = min_realizations
+
     def __repr__(self):
         return (
             "AnalysisConfig("


### PR DESCRIPTION
In the corner case where the user have;
NUM_REALIZATIONS 100
MIN_REALIZATIONS 50
and specify only to execute active_realizations 0-9 We update the MIN_REALIZATIONS to match active_realizations.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
