### PR TITLE
Evaluate min_realizations for ensemble_experiment

### DIFF
--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -189,6 +189,9 @@ class AnalysisConfig:
     def set_num_iterations(self, num_iterations: int):
         self._analysis_iter_config.iter_count = num_iterations
 
+    def set_min_realizations(self, min_realizations: int):
+        self._min_realization = min_realizations
+
     def __ne__(self, other):
         return not self == other
 

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -13,7 +13,7 @@ import pytest
 import ert.shared
 from ert import LibresFacade
 from ert.__main__ import ert_parser
-from ert._c_wrappers.config.config_parser import ConfigValidationError
+from ert._c_wrappers.config.config_parser import ConfigValidationError, ConfigWarning
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
@@ -528,7 +528,6 @@ def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
         pytest.param(ENSEMBLE_SMOOTHER_MODE),
         pytest.param(ITERATIVE_ENSEMBLE_SMOOTHER_MODE),
         pytest.param(ES_MDA_MODE),
-        pytest.param(ENSEMBLE_EXPERIMENT_MODE),
     ],
 )
 @pytest.mark.usefixtures("copy_poly_case")
@@ -557,12 +556,10 @@ def test_that_the_model_raises_exception_if_active_less_than_minimum_realization
         "1024-65535",
         "--realizations",
         "0-19",
+        "--target-case",
     ]
 
-    if mode is not ENSEMBLE_EXPERIMENT_MODE:
-        ert_args.append("--target-case")
-        testcase = "testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d"
-        ert_args.append(testcase)
+    ert_args.append("testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d")
 
     parsed = ert_parser(
         parser,
@@ -572,5 +569,46 @@ def test_that_the_model_raises_exception_if_active_less_than_minimum_realization
     with pytest.raises(
         ErtCliError,
         match="Number of active realizations",
+    ):
+        run_cli(parsed)
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_the_model_warns_when_active_realizations_less_min_realizations():
+    """
+    Verify that the run model checks that active realizations is equal or higher than
+    NUM_REALIZATIONS when running ensemble_experiment.
+    A warning is issued when NUM_REALIZATIONS is higher than active_realizations.
+    """
+    with open("poly.ert", "r", encoding="utf-8") as fin, open(
+        "poly_lower_active_reals.ert", "w", encoding="utf-8"
+    ) as fout:
+        for line in fin:
+            if "MIN_REALIZATIONS" in line:
+                fout.write("MIN_REALIZATIONS 100")
+            else:
+                fout.write(line)
+
+    args = Mock()
+    args.config = "poly_lower_active_reals.ert"
+    parser = ArgumentParser(prog="test_main")
+
+    ert_args = [
+        "ensemble_experiment",
+        "poly_lower_active_reals.ert",
+        "--port-range",
+        "1024-65535",
+        "--realizations",
+        "0-4",
+    ]
+
+    parsed = ert_parser(
+        parser,
+        ert_args,
+    )
+
+    with pytest.warns(
+        ConfigWarning,
+        match="Due to active_realizations 5 is lower than MIN_REALIZATIONS",
     ):
         run_cli(parsed)


### PR DESCRIPTION
Adjust corner case min_realizations for ensemble_experiment

In the corner case where the user have;
NUM_REALIZATIONS 100
MIN_REALIZATIONS 50
and specify only to execute active_realizations 0-9 We update the MIN_REALIZATIONS to match active_realizations.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
