### PR TITLE
Mitigate partial coverage uploads from ci.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         files: cov.xml
 
   build-linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # We don't cancel on protected branches which codecov uses as a base
+  cancel-in-progress: ${{ ! github.ref_protected }}
 
 env:
   ERT_SHOW_BACKTRACE: 1

--- a/.github/workflows/check_new_parser.yml
+++ b/.github/workflows/check_new_parser.yml
@@ -70,4 +70,5 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         files: cov.xml

--- a/.github/workflows/check_new_parser.yml
+++ b/.github/workflows/check_new_parser.yml
@@ -9,7 +9,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # We don't cancel on protected branches which codecov uses as a base
+  cancel-in-progress: ${{ ! github.ref_protected }}
 
 env:
   ERT_SHOW_BACKTRACE: 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,4 +65,5 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         files: cov.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # We don't cancel on protected branches which codecov uses as a base
+  cancel-in-progress: ${{ ! github.ref_protected }}
 
 jobs:
   python-test-coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,6 @@ fixes:
     - "*/site-packages/::"
     - "/home/runner/work/ert/ert/::"
 comment:
-    # The code coverage is made up of 5 test runs so only after all coverage
+    # The code coverage is made up of 7 test runs so only after all coverage
     # reports have been uploaded will the comparison be sane
-    after_n_builds: 4
+    after_n_builds: 7


### PR DESCRIPTION
To stop partial uploads to codecov which makes the coverage report weird, we stop canceling on the main branch which codecov uses to compair against.

Also, we fail the coverage when the upload fails. This happens very rarely, but frequent enough (roughly once every other week). For PR's, most checks are optional except the cmake one, which is fairly fast to rerun.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
