### PR TITLE
Fix new parser not striping empty spaces form forward model arguments if present.

### DIFF
--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -46,7 +46,7 @@ UNQUOTED: CHAR+
 
 CHAR_NO_EQ: /[+.\*a-zæøåA-ZÆØÅ10-9_%:\<\>\/-]/
 UNQUOTED_NO_EQ: /(?!([ ]))/ CHAR_NO_EQ+
-STR_NO_EQ_COM_PARN: /(?!([ ]))[^=,)(]+/
+STR_NO_EQ_COM_PARN: /[^=,)( ]+/
 
 CHAR_KW: /[a-zæøåA-ZÆØÅ10-9_:-]/
 UNQUOTED_KW: CHAR_KW+


### PR DESCRIPTION
Issue introduced in previous commit https://github.com/equinor/ert/commit/a3a212fdf1973bb76c864a5219d536591eed826f


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
