### PR TITLE
Backport to v4.5: Fix possible error source in qstat-proxy script

### DIFF
--- a/src/ert/_c_wrappers/job_queue/qstat_proxy.sh
+++ b/src/ert/_c_wrappers/job_queue/qstat_proxy.sh
@@ -82,7 +82,7 @@ if [ $proxyage_seconds -gt $CACHE_TIMEOUT ]; then
     flock --nonblock \
         --conflict-exit-code 0 \
         $proxyfile \
-        --command "$QSTAT $QSTAT_OPTIONS > $proxyfile.tmp; mv $proxyfile.tmp $proxyfile"
+        --command "$QSTAT $QSTAT_OPTIONS > $proxyfile.tmp && mv $proxyfile.tmp $proxyfile"
 fi
 
 # The file is potentially updated:


### PR DESCRIPTION
The qstat proxy script calls the qstat backend, and records the result in a file used as a caching proxy for the backend.

When it updates that cache file by calling the backend, it stores the result in a temp file first, and then moves that temp file to the actual cache file location (for race conditions reasons).

This moving of the temp file happens regardless of the return code of the qstat backend. We mitigate here by only moving if the call to the backend was successful.