### PR TITLE
Use new config parser by default

### DIFF
--- a/.github/workflows/check_old_parser.yml
+++ b/.github/workflows/check_old_parser.yml
@@ -1,4 +1,4 @@
-name: Test new parser
+name: Test old parser
 on:
  push:
    branches:
@@ -15,11 +15,11 @@ concurrency:
 env:
   ERT_SHOW_BACKTRACE: 1
   ECL_SKIP_SIGNAL: 1
-  USE_NEW_ERT_PARSER: "YES"
+  USE_OLD_ERT_PARSER: "YES"
 
 jobs:
   python-test-coverage-lark:
-    name: Test new Parser
+    name: Test old Parser
     timeout-minutes: 40
     runs-on: ubuntu-latest
     strategy:

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -35,10 +35,10 @@ from ._deprecation_migration_suggester import DeprecationMigrationSuggester
 
 logger = logging.getLogger(__name__)
 
-USE_NEW_PARSER_BY_DEFAULT = False
+USE_NEW_PARSER_BY_DEFAULT = True
 
-if "USE_NEW_ERT_PARSER" in os.environ and os.environ["USE_NEW_ERT_PARSER"] == "YES":
-    USE_NEW_PARSER_BY_DEFAULT = True
+if "USE_OLD_ERT_PARSER" in os.environ and os.environ["USE_OLD_ERT_PARSER"] == "YES":
+    USE_NEW_PARSER_BY_DEFAULT = False
 
 
 def site_config_location():


### PR DESCRIPTION
**Issue**
Resolves #5361

Old parser can be enabled through the environment variable `USE_OLD_PARSER=YES`

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
