### PR TITLE
Fix gui error message from observations

### DIFF
--- a/src/clib/lib/enkf/enkf_obs.cpp
+++ b/src/clib/lib/enkf/enkf_obs.cpp
@@ -744,7 +744,9 @@ ERT_CLIB_SUBMODULE("enkf_obs", m) {
                        errors;
             }
             if (!conf_instance_validate(self))
-                return std::string("Error in observations configuration file");
+                return std::string(
+                    "The observations file failed to validate. "
+                    "See output in terminal for more information");
             return std::string("");
         });
     m.def("obs_time", [](Cwrap<enkf_obs_type> self) { return self->obs_time; });

--- a/src/ert/_c_wrappers/enkf/enkf_obs.py
+++ b/src/ert/_c_wrappers/enkf/enkf_obs.py
@@ -30,11 +30,11 @@ DEFAULT_TIME_DELTA = timedelta(seconds=30)
 
 class ObservationConfigError(ConfigValidationError):
     @classmethod
-    def _get_error_message(cls, info: ErrorInfo) -> str:
+    def get_value_error_message(cls, info: ErrorInfo) -> str:
         return (
             (
                 f"Parsing observations config file `{info.filename}` "
-                f"resulted in the errors: {info.message}"
+                f"resulted in the following errors: {info.message}"
             )
             if info.filename is not None
             else info.message
@@ -452,7 +452,7 @@ class EnkfObs(BaseCClass):
         conf_instance = _clib.enkf_obs.ConfInstance(config_file)
         errors = conf_instance.get_errors()
         if errors != "":
-            raise ValueError(f"{errors} in configuration file {config_file}")
+            raise ValueError(errors)
         self._handle_history_observation(conf_instance, std_cutoff, history)
         self._handle_summary_observation(conf_instance)
         self._handle_general_observation(conf_instance)

--- a/src/ert/parsing/config_errors.py
+++ b/src/ert/parsing/config_errors.py
@@ -22,9 +22,7 @@ class ConfigValidationError(ValueError):
         else:
             self.errors.append(ErrorInfo(message=errors, filename=config_file))
         super().__init__(
-            ";".join(
-                [self._get_old_style_error_message(error) for error in self.errors]
-            )
+            ";".join([self.get_value_error_message(error) for error in self.errors])
         )
 
     @classmethod
@@ -32,11 +30,15 @@ class ConfigValidationError(ValueError):
         return cls([info])
 
     @classmethod
-    def _get_old_style_error_message(cls, info: ErrorInfo) -> str:
+    def get_value_error_message(cls, info: ErrorInfo) -> str:
+        """
+        :returns: The error message as used by cls as a ValueError.
+        Can be overridden.
+        """
         return (
             (
                 f"Parsing config file `{info.filename}` "
-                f"resulted in the errors: {info.message}"
+                f"resulted in the following errors: {info.message}"
             )
             if info.filename is not None
             else info.message
@@ -54,10 +56,19 @@ class ConfigValidationError(ValueError):
         for filename, info_list in by_filename.items():
             for info in info_list:
                 messages.append(
-                    f"{filename}:"
-                    f"{info.line}:"
-                    f"{info.column}:{info.end_column}:"
-                    f"{info.message}"
+                    ":".join(
+                        [
+                            str(k)
+                            for k in [
+                                filename,
+                                info.line,
+                                info.column,
+                                info.end_column,
+                                info.message,
+                            ]
+                            if k is not None
+                        ]
+                    )
                 )
 
         return messages

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -26,7 +26,7 @@ def test_bad_user_config_file_error_message(tmp_path):
 
     rconfig = None
     with pytest.raises(
-        ConfigValidationError, match=r"Parsing.*resulted in the errors:"
+        ConfigValidationError, match=r"Parsing.*resulted in the following errors:"
     ):
         rconfig = ErtConfig.from_file(str(tmp_path / "test.ert"), use_new_parser=False)
 
@@ -1033,12 +1033,12 @@ def test_that_multiple_errors_are_shown_for_forward_model():
 
     expected_nice_messages_list = [
         (
-            "test.ert:None:None:None:"
+            "test.ert:"
             "Could not find job 'does_not_exist' "
             "in list of installed jobs: []"
         ),
         (
-            "test.ert:None:None:None:"
+            "test.ert:"
             "Could not find job 'does_not_exist2' "
             "in list of installed jobs: []"
         ),


### PR DESCRIPTION
The error message used to look like this: 
![image](https://github.com/equinor/ert/assets/32731672/ee6d14a7-7fcc-41ba-9f4f-31b0d6abfdeb)

Now it looks like this:

![image](https://github.com/equinor/ert/assets/32731672/04a95ee9-c07b-4b87-afca-c9532bbd90b3)



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
