### PR TITLE
Solve warning from ecl

### DIFF
--- a/tests/unit_tests/storage/test_local_ensemble.py
+++ b/tests/unit_tests/storage/test_local_ensemble.py
@@ -1,6 +1,6 @@
 import numpy
 import xtgeo
-from ecl.grid import EclGrid
+from ecl.grid import EclGridGenerator
 
 from ert.storage import open_storage
 
@@ -43,7 +43,7 @@ def test_save_field_ecl(tmp_path):
         assert ensemble_dir.exists()
 
         mask = [True] * 3 + [False] * 16 + [True]
-        grid = EclGrid.create_rectangular((4, 5, 1), (1, 1, 1), actnum=mask)
+        grid = EclGridGenerator.create_rectangular((4, 5, 1), (1, 1, 1), actnum=mask)
         grid.save_GRID(f"{experiment.mount_point}/grid.GRID")
 
         data = [1.2, 1.1, 4.3, 3.1]


### PR DESCRIPTION
DeprecationWarning: EclGrid.createRectangular is deprecated. Please use the similar method: EclGridGenerator.createRectangular.

**Issue**
Resolves 
`DeprecationWarning: EclGrid.createRectangular is deprecated. Please use the similar method: EclGridGenerator.createRectangular.`

**Approach**
Do as suggested by the warning


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
