### PR TITLE
Use np.loadtxt instead of open() to load gen_data

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_state.py
+++ b/src/ert/_c_wrappers/enkf/enkf_state.py
@@ -35,9 +35,7 @@ def _internalize_GEN_DATA(
                 errors.append(f"{key} report step {i} missing")
                 continue
 
-            with open(run_path / filename, "r", encoding="utf-8") as f:
-                data = [float(v.strip()) for v in f.readlines()]
-            all_data[f"{key}@{i}"] = np.array(data)
+            all_data[f"{key}@{i}"] = np.loadtxt(run_path / filename)
 
     run_arg.ensemble_storage.save_gen_data(all_data, run_arg.iens)
     if errors:


### PR DESCRIPTION
Is approx. twice as fast

ensemble_size = 500 | nr_responses = 100_000
Numpy: 9.5s
Python: 18.5s

More tests:

```text
# ensemble_size = 500 | nr_responses = 10_000
# Numpy: 1.369697093963623
# Python: 2.23101806640625

# ensemble_size = 500 | nr_responses = 1_000_000
# Numpy: 105.9092390537262
# Python: 200.49167895317078
```

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
