### PR TITLE
Filter away expected warnings from running tests

### DIFF
--- a/tests/test_config_parsing/test_enkf_obs_parsing.py
+++ b/tests/test_config_parsing/test_enkf_obs_parsing.py
@@ -13,6 +13,9 @@ from ert.parsing import ConfigValidationError, ConfigWarning
 from .config_dict_generator import config_generators
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings("ignore::ert.parsing.ConfigWarning")
 @pytest.mark.usefixtures("set_site_config")
 @given(config_generators())
 def test_that_enkf_obs_keys_are_ordered(tmp_path_factory, config_generator):
@@ -565,6 +568,7 @@ def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
         assert observations[2].getNode(1).getStandardDeviation() == 10000
 
 
+@pytest.mark.filterwarnings("ignore::ert.parsing.ConfigWarning")
 def test_that_std_cutoff_is_applied(tmpdir):
     with tmpdir.as_cwd():
         config = dedent(

--- a/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
@@ -4,6 +4,7 @@ from ert._c_wrappers.enkf import ErtConfig
 from ert.parsing import ConfigValidationError
 
 
+@pytest.mark.filterwarnings("ignore::ert.parsing.config_errors.ConfigWarning")
 @pytest.mark.parametrize(
     "extra_config, expected",
     [

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -395,6 +395,7 @@ def test_experiment_server_ensemble_experiment(tmpdir, source_root, capsys):
     FeatureToggling.reset()
 
 
+@pytest.mark.filterwarnings("ignore::ert.parsing.config_errors.ConfigWarning")
 def test_bad_config_error_message(tmp_path):
     (tmp_path / "test.ert").write_text("NUM_REL 10\n")
     parser = ArgumentParser(prog="test_main")

--- a/tests/unit_tests/data/test_integration_data.py
+++ b/tests/unit_tests/data/test_integration_data.py
@@ -97,6 +97,7 @@ def test_summary_obs_runtime(create_measured_data):
     assert summary_obs_time < 10 * history_obs_time
 
 
+@pytest.mark.filterwarnings("ignore::ert.parsing.ConfigWarning")
 @pytest.mark.usefixtures("copy_snake_oil_case_storage")
 @pytest.mark.parametrize("formatted_date", ["2015-06-23", "23/06/2015"])
 def test_summary_obs_last_entry(formatted_date):


### PR DESCRIPTION
**Issue**
Resolves a subset of the warnings seen when running the test suite. The warnings muted by this PR are expected from these parts of the test suite.


**Approach**
`@pytest.mark.filterwarnings()
`
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
