### PR TITLE
Remove stray string in comment

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -21,7 +21,7 @@ start_tests () {
     export ECL_SKIP_SIGNAL=ON
 
     # The existence of a running xvfb process will produce
-    # a lock filgit ree for the default server and kill the run
+    # a lock file for the default server and kill the run
     # Allow xvfb to find a new server
     pushd ${CI_TEST_ROOT}/tests
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \


### PR DESCRIPTION
String looks to be erroneously injected in a04409c053da9af8b237ef1f67bcd581e7eb84a9

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
