### PR TITLE
ctest helper script for komodo-releases

### DIFF
--- a/ci/run_ert_ctests.sh
+++ b/ci/run_ert_ctests.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 set -x
-# This script is designed to be able to run in stages in the Jenkins pipline
+# This script is designed to be run by a self-hosted Github action runner
+# from komodo-releases.
 #
 # You can also run it locally. Note that only the committed code is tested,
 # not changes in your working directory.
 #
 # If you want to run the whole build in one go:
-#   sh testjenkins.sh build_and_test
+#   bash run_ert_ctests.sh build_and_test
 #
 # If you want to run the build in separate stages:
-#   sh testjenkins.sh setup
-#   sh testjenkins.sh build_elc
+#   sh run_ert_ctests.sh setup
+#   sh run_ert_ctests.sh build_ert_clib
 #   etc...
 #
-# By default it will try to build everything inside a folder 'jenkinsbuild'
-# You can override this with the env variable WORKING_DIR e.g.:
-#   WORKING_DIR=$(mktemp -d) sh testjenkins.sh build_and_test
+# By default it will try to build everything inside a folder 'build'
 #
-# After https://github.com/equinor/ert/issues/1634 the ERT_SOURCE_ROOT needs to
-# point at the ert source root (where .git is).
+# Current working directory must contain a checked out ert repository
+#
+# When running manually you might have to delete the folder _skbuild
 
 build_and_test () {
 	setup
@@ -36,7 +36,6 @@ enable_environment () {
 	cmake --version
 
 	export ERT_SHOW_BACKTRACE=Y
-	export RMS_SITE_CONFIG=/prog/res/komodo/bleeding-py38-rhel7/root/lib/python3.8/site-packages/ert_configurations/resources/rms_config.yml
 
 	# Conan v1 bundles its own certs due to legacy reasons, so we point it
 	# to the system's certs instead.

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -21,7 +21,7 @@ start_tests () {
     export ECL_SKIP_SIGNAL=ON
 
     # The existence of a running xvfb process will produce
-    # a lock filgit ree for the default server and kill the run
+    # a lock file for the default server and kill the run
     # Allow xvfb to find a new server
     pushd ${CI_TEST_ROOT}/tests
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \


### PR DESCRIPTION
Moved test_libres_jenkins.sh up one level as this is to run differently from komodo-releases after Jenkins shutdown.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
