### PR TITLE
Change to a faster timeout for a timeout test

### DIFF
--- a/tests/unit_tests/services/test_base_service.py
+++ b/tests/unit_tests/services/test_base_service.py
@@ -129,6 +129,7 @@ sys.exit(2)
 """
 )
 def test_not_respond(server, caplog):
+    server._timeout = 1
     with pytest.raises(TimeoutError):
         with caplog.at_level(logging.CRITICAL):
             server.fetch_conn_info()


### PR DESCRIPTION
**Issue**
test_not_respond in test_base_service.py has a timeout of 10 seconds. No need to wait that long to test the timeout.


**Approach**
Changed timeout to a lower value


## Pre review checklist

- [ x ] Added appropriate release note label
- [ x ] PR title captures the intent of the changes, and is fitting for release notes.
- [ x ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ x ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
