### PR TITLE
Explicitly use mixed format when converting to dates, avoiding warning

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -158,7 +158,7 @@ class PlotApi:
             df = pd.read_parquet(stream)
 
             try:
-                df.columns = pd.to_datetime(df.columns)
+                df.columns = pd.to_datetime(df.columns, format="mixed")
             except (ParserError, ValueError):
                 df.columns = [int(s) for s in df.columns]
 


### PR DESCRIPTION
Using mixed parsing seems safest for now. In the poly-case, a warning will be emitted (because inferral of the format does not work when everything is non-dates) unless this option is set

**Issue**
Resolves #5416 


**Approach**
Set the option

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
