### PR TITLE
Fix bug where base surface was copied to all reals

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/surface_config.py
+++ b/src/ert/_c_wrappers/enkf/config/surface_config.py
@@ -26,7 +26,6 @@ class SurfaceConfig(ParameterConfig):
     yflip: int
     forward_init_file: str
     output_file: Path
-    base_surface_path: str
 
     def load(self, run_path: Path, real_nr: int, ensemble: EnsembleAccessor):
         t = time.perf_counter()

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -359,7 +359,6 @@ class EnsembleConfig:
             forward_init=forward_init,
             forward_init_file=init_file,
             output_file=Path(out_file),
-            base_surface_path=base_surface,
         )
 
     @staticmethod

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -490,7 +490,18 @@ class LocalEnsembleAccessor(LocalEnsembleReader):
     ) -> None:
         output_path = self.mount_point / f"realization-{realization}"
         Path.mkdir(output_path, exist_ok=True)
-        surf = self.experiment.get_surface(key)
+        param_info = self.experiment.parameter_info[key]
+        surf = xtgeo.RegularSurface(
+            ncol=param_info["ncol"],
+            nrow=param_info["nrow"],
+            xinc=param_info["xinc"],
+            yinc=param_info["yinc"],
+            xori=param_info["xori"],
+            yori=param_info["yori"],
+            yflip=param_info["yflip"],
+            rotation=param_info["rotation"],
+            values=data,
+        )
         surf.to_file(output_path / f"{key}.irap", fformat="irap_ascii")
         self.update_realization_state(
             realization,

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -99,10 +99,7 @@ class LocalExperimentAccessor(LocalExperimentReader):
             if isinstance(parameter, GenKwConfig):
                 self.save_gen_kw_info(parameter.getKey(), parameter.get_priors())
             elif isinstance(parameter, SurfaceConfig):
-                self.save_surface_info(
-                    parameter.name,
-                    parameter.base_surface_path,
-                )
+                parameter_data[parameter.name] = parameter.to_dict()
             elif isinstance(parameter, Field):
                 parameter_data[parameter.name] = parameter.to_dict()
 
@@ -138,10 +135,6 @@ class LocalExperimentAccessor(LocalExperimentReader):
             name=name,
             prior_ensemble=prior_ensemble,
         )
-
-    def save_surface_info(self, name: str, base_surface: str) -> None:
-        surf = xtgeo.surface_from_file(base_surface, fformat="irap_ascii")
-        surf.to_file(self.mount_point / f"{name}.irap", fformat="irap_ascii")
 
     def save_gen_kw_info(
         self, name: str, parameter_transfer_functions: List["PriorDict"]


### PR DESCRIPTION
This commit replaces the save_surface_info function with the more standard to_dict method. Previously, the base surface was written to the /experiments directory, but it was never utilized. Now, we are storing sufficient info about the suface in parameters.json so that we can re-create the header or instantiate a xtgeo.RegularSurface.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
