### PR TITLE
Revert "Explicitly use mixed format when converting to dates, avoiding warning"

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -158,7 +158,7 @@ class PlotApi:
             df = pd.read_parquet(stream)
 
             try:
-                df.columns = pd.to_datetime(df.columns, format="mixed")
+                df.columns = pd.to_datetime(df.columns)
             except (ParserError, ValueError):
                 df.columns = [int(s) for s in df.columns]
 


### PR DESCRIPTION
Reverts equinor/ert#5417

The warning comes with Pandas 2.0.1, not with Pandas 1.5.3. 

#5417 fixed the warning in Pandas 2.0.1, but errors hard in Pandas 1.5.3.