### PR TITLE
Use config dict to lookup/set default defines

### DIFF
--- a/src/ert/_c_wrappers/enkf/queue_config.py
+++ b/src/ert/_c_wrappers/enkf/queue_config.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple, Union
 
 from ert._c_wrappers.job_queue import Driver, JobQueue, QueueDriverEnum
 from ert.parsing import ConfigValidationError
+from ert.parsing.error_info import ErrorInfo
 
 
 @dataclass
@@ -19,7 +20,29 @@ class QueueConfig:
     )
 
     @classmethod
-    def from_dict(cls, config_dict) -> QueueConfig:
+    def _validate_config_dict(cls, config_dict):
+        config_path = config_dict.get_define("<CONFIG_FILE>")
+        errors = []
+        for _, option_name, *values in config_dict.get("QUEUE_OPTION", []):
+            if option_name == "MAX_RUNNING":
+                err_msg = "QUEUE_OPTION MAX_RUNNING is"
+                try:
+                    int_val = int(*values)
+                    if int_val < 0:
+                        errors.append(
+                            ErrorInfo(
+                                filename=config_path,
+                                message=f"{err_msg} negative: {str(*values)!r}",
+                            ).set_context_list(values)
+                        )
+                except ValueError:
+                    errors.append(
+                        ErrorInfo(
+                            filename=config_path,
+                            message=f"{err_msg} not an integer: {str(*values)!r}",
+                        ).set_context_list(values)
+                    )
+
         queue_system = config_dict.get("QUEUE_SYSTEM", "LOCAL")
 
         valid_queue_systems = []
@@ -29,22 +52,37 @@ class QueueConfig:
                 valid_queue_systems.append(driver_names.name[: -len("_DRIVER")])
 
         if queue_system not in valid_queue_systems:
-            raise ConfigValidationError(
-                f"Invalid QUEUE_SYSTEM provided: {queue_system!r}. Valid choices for "
-                f"QUEUE_SYSTEM are {valid_queue_systems!r}"
+            errors.append(
+                ErrorInfo(
+                    message=f"Invalid QUEUE_SYSTEM provided: {queue_system!r}. Valid "
+                    f"choices for QUEUE_SYSTEM are {valid_queue_systems!r}",
+                    filename=config_path,
+                ).set_context(queue_system)
             )
 
+        return errors
+
+    @classmethod
+    def from_dict(cls, config_dict) -> QueueConfig:
+        errors = cls._validate_config_dict(config_dict)
+
+        if len(errors) > 0:
+            raise ConfigValidationError.from_collected(errors)
+
+        queue_system = config_dict.get("QUEUE_SYSTEM", "LOCAL")
         queue_system = QueueDriverEnum.from_string(f"{queue_system}_DRIVER")
         job_script = config_dict.get("JOB_SCRIPT", shutil.which("job_dispatch.py"))
         job_script = job_script or "job_dispatch.py"
         max_submit = config_dict.get("MAX_SUBMIT", 2)
         queue_options = defaultdict(list)
+
         for driver, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             queue_driver_type = QueueDriverEnum.from_string(driver + "_DRIVER")
             if values:
                 queue_options[queue_driver_type].append((option_name, values[0]))
             else:
                 queue_options[queue_driver_type].append(option_name)
+
         return QueueConfig(job_script, max_submit, queue_system, queue_options)
 
     def create_driver(self) -> Driver:


### PR DESCRIPTION
**Issue**
Resolves #5426


**Approach**
Use config dict to handle default values from <CONFIG_PATH> and <CONFIG_FILE>, also makes it possible to move validation of queue config to queue_config.py without having to pass the config_path parameter of the previous validation fn

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
