### PR TITLE
Remove print statement from make_poly_example

### DIFF
--- a/tests/performance_tests/performance_utils.py
+++ b/tests/performance_tests/performance_utils.py
@@ -89,7 +89,6 @@ def make_poly_example(folder, source, **kwargs):
 
     if use_ecl_data_io:
         keywords = [f"PSUM{s}" for s in range(summary_count)]
-        print(keywords)
         write_summary_spec(str(folder) + "/refcase/REFCASE.SMSPEC", keywords)
         write_summary_data(
             str(folder) + "/refcase/REFCASE.UNSMRY",


### PR DESCRIPTION
Fills up the terminal window when running pytest with -sv.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
