### PR TITLE
Fix flaky gui tests

### DIFF
--- a/src/ert/gui/ertwidgets/analysismoduleedit.py
+++ b/src/ert/gui/ertwidgets/analysismoduleedit.py
@@ -1,6 +1,7 @@
+from typing import Literal
+
 from qtpy.QtCore import QMargins, Qt
 from qtpy.QtWidgets import QHBoxLayout, QToolButton, QWidget
-from typing_extensions import Literal
 
 from ert.gui.ertwidgets import ClosableDialog, addHelpToWidget, resourceIcon
 from ert.gui.ertwidgets.analysismodulevariablespanel import AnalysisModuleVariablesPanel

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -157,29 +157,26 @@ def run_experiment(request, opened_main_window):
             qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
 
         QTimer.singleShot(500, handle_dialog)
+        qtbot.mouseClick(start_simulation, Qt.LeftButton)
 
         # The Run dialog opens, click show details and wait until done appears
         # then click it
-        def use_rundialog():
-            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-            run_dialog = gui.findChild(RunDialog)
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
 
-            qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
-            qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
-            qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
-            # Assert that the number of boxes in the detailed view is
-            # equal to the number of realizations
-            realization_widget = run_dialog._tab_widget.currentWidget()
-            assert isinstance(realization_widget, RealizationWidget)
-            list_model = realization_widget._real_view.model()
-            assert list_model.rowCount() == simulation_panel.ert.getEnsembleSize()
+        # Assert that the number of boxes in the detailed view is
+        # equal to the number of realizations
+        realization_widget = run_dialog._tab_widget.currentWidget()
+        assert isinstance(realization_widget, RealizationWidget)
+        list_model = realization_widget._real_view.model()
+        assert list_model.rowCount() == simulation_panel.ert.getEnsembleSize()
 
-            qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-
-        qtbot.mouseClick(start_simulation, Qt.LeftButton)
-        use_rundialog()
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
     return func
 

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -112,22 +112,15 @@ def test_that_the_manual_analysis_tool_works(
         qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
 
     QTimer.singleShot(500, handle_dialog)
-
+    qtbot.mouseClick(start_simulation, Qt.LeftButton)
     # The Run dialog opens, click show details and wait until done appears
     # then click it
-    def use_rundialog():
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
-        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-
-        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-
-    QTimer.singleShot(1000, use_rundialog)
-    qtbot.mouseClick(start_simulation, Qt.LeftButton)
+    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+    qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+    qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+    qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
     facade = simulation_panel.facade
     storage = gui.notifier.storage

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -274,31 +274,28 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
             qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
 
         QTimer.singleShot(500, handle_dialog)
-
-        def use_rundialog():
-            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-
-            # Ensure that once the run dialog is opened
-            # another simulation cannot be started
-            assert not start_simulation.isEnabled()
-
-            run_dialog = gui.findChild(RunDialog)
-            assert isinstance(run_dialog, RunDialog)
-
-            # The user expects to be able to open e.g. the even viewer
-            # while the run dialog is open
-            assert not run_dialog.isModal()
-
-            qtbot.mouseClick(run_dialog.plot_button, Qt.LeftButton)
-            qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
-            qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-
-            # Ensure that once the run dialog is closed
-            # another simulation can be started
-            assert start_simulation.isEnabled()
-
-        QTimer.singleShot(1000, use_rundialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+
+        # Ensure that once the run dialog is opened
+        # another simulation cannot be started
+        assert not start_simulation.isEnabled()
+
+        run_dialog = gui.findChild(RunDialog)
+        assert isinstance(run_dialog, RunDialog)
+
+        # The user expects to be able to open e.g. the even viewer
+        # while the run dialog is open
+        assert not run_dialog.isModal()
+
+        qtbot.mouseClick(run_dialog.plot_button, Qt.LeftButton)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+        # Ensure that once the run dialog is closed
+        # another simulation can be started
+        assert start_simulation.isEnabled()
 
         qtbot.waitUntil(lambda: gui.findChild(PlotWindow) is not None)
 


### PR DESCRIPTION
Resolves several issues which led to flaky gui tests


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
