### PR TITLE
Make default jobname <CONFIG_FILE>-<IENS>

### DIFF
--- a/docs/getting_started/configuration/poly_new/guide.rst
+++ b/docs/getting_started/configuration/poly_new/guide.rst
@@ -25,9 +25,8 @@ Then create a file ``poly.ert`` inside the folder with the following content:
     .. literalinclude:: minimal/poly.ert
 
 :ref:`JOBNAME <jobname>`
-    Specifies the name for each simulation. The ``%d``
-    will be replaced with the simulation number, so that the jobs will be
-    called ``poly_0``, ``poly_1``, etc.
+    Specifies the name for each simulation. If not defined it will default to
+    ``<CONFIG_FILE>-<IENS>``
 :ref:`NUM_REALIZATIONS <num_realizations>`
     We have to specify how many simulations we want to run.
 :ref:`QUEUE_SYSTEM <QUEUE_SYSTEM>`

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -49,7 +49,7 @@ Keyword name                                                            Required
 :ref:`ITER_CASE <iter_Case>`                                            NO                                      IES%d                           Case name format - iterated ensemble smoother
 :ref:`ITER_COUNT <iter_count>`                                          NO                                      4                               Number of iterations - iterated ensemble smoother
 :ref:`ITER_RETRY_COUNT <iter_retry_count>`                              NO                                      4                               Number of retries for a iteration - iterated ensemble smoother
-:ref:`JOBNAME <jobname>`                                                NO                                                                      Name used for simulation files.
+:ref:`JOBNAME <jobname>`                                                NO                                      <CONFIG_FILE>-<IENS>            Name used for simulation files.
 :ref:`JOB_SCRIPT <job_script>`                                          NO                                                                      Python script managing the forward model
 :ref:`LOAD_WORKFLOW <load_workflow>`                                    NO                                                                      Load a workflow into ERT
 :ref:`LOAD_WORKFLOW_JOB <load_workflow_job>`                            NO                                                                      Load a workflow job into ERT
@@ -193,13 +193,13 @@ Commonly used keywords
                 ECLBASE eclipse/model/MY_VERY_OWN_OIL_FIELD-<IENS>
 
         If not supplied, ECLBASE will default to JOBNAME, and if JOBNAME is not set,
-        it will default to "ECLBASE<IENS>".
+        it will default to "<CONFIG_FILE>-<IENS>".
 
 .. _jobname:
 .. topic::  JOBNAME
 
         Sets the name of the job submitted to the queue system. Will default to
-        ECLBASE If that is set, otherwise it defaults to "JOB<IENS>". If JOBNAME
+        ECLBASE If that is set, otherwise it defaults to "<CONFIG_FILE>-<IENS>". If JOBNAME
         is set, and not ECLBASE, it will also be used as the value for ECLBASE.
 
 .. _grid:

--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -36,7 +36,7 @@ class ModelConfig:
             else self.DEFAULT_HISTORY_SOURCE
         )
         self.jobname_format_string = (
-            replace_runpath_format(jobname_format_string) or "JOB<IENS>"
+            replace_runpath_format(jobname_format_string) or "<CONFIG_FILE>-<IENS>"
         )
         self.eclbase_format_string = (
             replace_runpath_format(eclbase_format_string) or "ECLBASE<IENS>"

--- a/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_model_config.py
@@ -23,6 +23,11 @@ from ert.parsing import ConfigValidationError
             "JOBNAME<IENS>",
             id="JOBNAME is used when no ECLBASE is present",
         ),
+        pytest.param(
+            {},
+            "<CONFIG_FILE>-<IENS>",
+            id="JOBNAME defaults to <CONFIG_FILE>-<IENS>",
+        ),
     ],
 )
 def test_model_config_jobname_and_eclbase(extra_config, expected):


### PR DESCRIPTION
**Issue**
Resolves #5403


**Approach**
Make default jobname <CONFIG_FILE>-<IENS>


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
