### PR TITLE
Simplify backoff for queue websockets client

### DIFF
--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -389,7 +389,7 @@ class JobQueue(BaseCClass):
                     await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
                     events.popleft()
                 return
-            except (ConnectionClosedError) as e:
+            except ConnectionClosedError:
                 continue
 
     async def execute_queue_via_websockets(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
The websockets client in our queue system implements a manual backoff, which is no longer necessary with python >= 3.8

Related to #5273 

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT RELEVANT Updated documentation
- [X] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
