### PR TITLE
Retry codecov uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,11 @@ jobs:
     - name: Upload c coverage to Codecov
       uses: codecov/codecov-action@v3
       if: matrix.os == 'ubuntu-latest'
+      # codecov upload endpoint fails intermittently, but works
+      # fine when retried
+      max_attempts: 3
+      retry_on: error
+      retry_wait_seconds: 10
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/check_old_parser.yml
+++ b/.github/workflows/check_old_parser.yml
@@ -59,6 +59,11 @@ jobs:
 
     - name: Upload python coverage to Codecov
       uses: codecov/codecov-action@v3
+      # codecov upload endpoint fails intermittently, but works
+      # fine when retried
+      max_attempts: 3
+      retry_on: error
+      retry_wait_seconds: 10
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,6 +54,11 @@ jobs:
 
     - name: Upload python coverage to Codecov
       uses: codecov/codecov-action@v3
+      # codecov upload endpoint fails intermittently, but works
+      # fine when retried
+      max_attempts: 3
+      retry_on: error
+      retry_wait_seconds: 10
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
Sometimes the codecov upload fails, but works fine when the action is rerun. Add a retry policy that simply retries the upload if it fails.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
