### PR TITLE
Use new parser for workflows

### DIFF
--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -644,7 +644,7 @@ class ErtConfig:
                     work[0],
                     substitution_list,
                     workflow_jobs,
-                    use_new_parser=USE_NEW_PARSER_BY_DEFAULT,
+                    use_new_parser=use_new_parser,
                 )
                 if existed:
                     warnings.warn(

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -644,6 +644,7 @@ class ErtConfig:
                     work[0],
                     substitution_list,
                     workflow_jobs,
+                    use_new_parser=USE_NEW_PARSER_BY_DEFAULT,
                 )
                 if existed:
                     warnings.warn(

--- a/src/ert/_c_wrappers/job_queue/workflow_job.py
+++ b/src/ert/_c_wrappers/job_queue/workflow_job.py
@@ -13,7 +13,7 @@ from ert.parsing import (
     ConfigValidationError,
     SchemaItemType,
     WorkflowJobKeys,
-    init_workflow_schema,
+    init_workflow_job_schema,
     lark_parse,
 )
 
@@ -44,7 +44,7 @@ _config_parser = _workflow_job_config_parser()
 
 
 def new_workflow_job_parser(file: str):
-    schema = init_workflow_schema()
+    schema = init_workflow_job_schema()
     return lark_parse(file, schema=schema)
 
 

--- a/src/ert/parsing/__init__.py
+++ b/src/ert/parsing/__init__.py
@@ -11,13 +11,15 @@ from .ext_job_schema import init_ext_job_schema
 from .lark_parser import parse as lark_parse
 from .types import ConfigDict
 from .workflow_job_keywords import WorkflowJobKeys
-from .workflow_job_schema import init_workflow_schema
+from .workflow_job_schema import init_workflow_job_schema
+from .workflow_schema import init_workflow_schema
 
 __all__ = [
     "lark_parse",
     "ConfigWarning",
     "ConfigValidationError",
     "WorkflowJobKeys",
+    "init_workflow_job_schema",
     "init_workflow_schema",
     "ConfigKeys",
     "SchemaItemType",

--- a/src/ert/parsing/config_schema_item.py
+++ b/src/ert/parsing/config_schema_item.py
@@ -9,6 +9,7 @@ from ert.parsing.context_values import (
     ContextBool,
     ContextFloat,
     ContextInt,
+    ContextList,
     ContextString,
     ContextValue,
 )
@@ -197,7 +198,9 @@ class SchemaItem(BaseModel):
     ) -> List[Union[T, ContextValue]]:
         errors: List[Union[ErrorInfo, ConfigValidationError]] = []
 
-        args_with_context: List[Union[T, ContextValue]] = []
+        args_with_context: ContextList[Union[T, ContextValue]] = ContextList(
+            token=keyword
+        )
         for i, x in enumerate(args):
             if isinstance(x, FileContextToken):
                 try:

--- a/src/ert/parsing/context_values.py
+++ b/src/ert/parsing/context_values.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Union
 
 from .file_context_token import FileContextToken
@@ -72,6 +73,15 @@ class ContextString(str):
         new_instance = ContextString(str(self), self.token, self.keyword_token)
         memo[id(self)] = new_instance
         return new_instance
+
+
+@dataclass
+class ContextList(list):
+    keyword_token: FileContextToken
+
+    def __init__(self, token: FileContextToken):
+        super().__init__()
+        self.keyword_token = token
 
 
 ContextValue = Union[ContextString, ContextFloat, ContextInt, ContextBool]

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -508,19 +508,23 @@ def parse(
     file: str,
     schema: SchemaItemDict,
     site_config: Optional[ConfigDict] = None,
+    pre_defines: Optional[Tuple[str, str]] = None,
 ) -> ConfigDict:
     filepath = os.path.normpath(os.path.abspath(file))
     tree = _parse_file(filepath)
     config_dir = os.path.dirname(filepath)
     config_file_name = os.path.basename(file)
     config_file_base = config_file_name.split(".")[0]
-    pre_defines = [
-        ["<CONFIG_PATH>", config_dir],
-        ["<CONFIG_FILE_BASE>", config_file_base],
-        ["<DATE>", datetime.date.today().isoformat()],
-        ["<CWD>", config_dir],
-        ["<CONFIG_FILE>", os.path.basename(file)],
-    ]
+
+    if not pre_defines:
+        pre_defines = [
+            ["<CONFIG_PATH>", config_dir],
+            ["<CONFIG_FILE_BASE>", config_file_base],
+            ["<DATE>", datetime.date.today().isoformat()],
+            ["<CWD>", config_dir],
+            ["<CONFIG_FILE>", os.path.basename(file)],
+        ]
+
     # need to copy pre_defines because _handle_includes will
     # add to this list
     _handle_includes(tree, pre_defines.copy(), filepath)

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -508,7 +508,7 @@ def parse(
     file: str,
     schema: SchemaItemDict,
     site_config: Optional[ConfigDict] = None,
-    pre_defines: Optional[Tuple[str, str]] = None,
+    pre_defines: Optional[List[Tuple[str, str]]] = None,
 ) -> ConfigDict:
     filepath = os.path.normpath(os.path.abspath(file))
     tree = _parse_file(filepath)

--- a/src/ert/parsing/workflow_job_schema.py
+++ b/src/ert/parsing/workflow_job_schema.py
@@ -96,7 +96,7 @@ class WorkflowJobSchemaDict(SchemaItemDict):
                 )
 
 
-def init_workflow_schema() -> SchemaItemDict:
+def init_workflow_job_schema() -> SchemaItemDict:
     schema = WorkflowJobSchemaDict()
     for item in [
         executable_keyword(),

--- a/src/ert/parsing/workflow_keywords.py
+++ b/src/ert/parsing/workflow_keywords.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class WorkflowKeys(str, Enum):
+    DEFINE = "DEFINE"

--- a/src/ert/parsing/workflow_schema.py
+++ b/src/ert/parsing/workflow_schema.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict
+
+from .config_schema_item import SchemaItem
+from .schema_dict import SchemaItemDict
+from .workflow_keywords import WorkflowKeys
+
+
+def define_keyword() -> SchemaItem:
+    return SchemaItem(
+        kw=WorkflowKeys.DEFINE,
+        required_set=False,
+        argc_min=2,
+        argc_max=2,
+        multi_occurrence=True,
+        substitute_from=2,
+        join_after=1,
+    )
+
+
+class WorkflowSchemaDict(SchemaItemDict):
+    def check_required(self, config_dict: Dict[str, Any], filename: str):
+        pass
+
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, kw: str):
+        if kw == "DEFINE":
+            return define_keyword()
+        # Since workflow keywords are arbitrary, we create
+        # a schema item on the fly when
+        # it is requested by the lark parser via
+        # [kw]
+        return SchemaItem(kw=kw, argc_min=-1, argc_max=-1, multi_occurrence=True)
+
+
+def init_workflow_schema() -> SchemaItemDict:
+    schema = WorkflowSchemaDict()
+    return schema

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
@@ -131,3 +131,27 @@ def test_that_multiple_workflow_jobs_with_redefines_are_ordered_correctly():
     commands = [(name, args[0]) for (name, args) in wf.cmd_list]
 
     assert commands == [("foo", "1"), ("bar", "1"), ("foo", "3"), ("baz", "3")]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_unknown_jobs_gives_error():
+    with open("workflow", "w", encoding="utf-8") as f:
+        f.write(
+            "\n".join(
+                [
+                    "boo <A>",
+                    "kingboo <A>",
+                ]
+            )
+        )
+
+    with pytest.raises(
+        ConfigValidationError, match="Job with name: kingboo is not recognized"
+    ):
+        Workflow.from_file(
+            src_file="workflow",
+            context=None,
+            job_dict={
+                "boo": "boo",
+            },
+        )

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_workflow.py
@@ -1,4 +1,5 @@
 import pytest
+from hypothesis import given, strategies
 
 from ert._c_wrappers.job_queue import Workflow, WorkflowJob, WorkflowRunner
 from ert._c_wrappers.util.substitution_list import SubstitutionList
@@ -16,7 +17,9 @@ def test_workflow():
     with pytest.raises(ConfigValidationError, match="Could not open config_file"):
         _ = WorkflowJob.from_file("knock_job", name="KNOCK")
 
-    workflow = Workflow.from_file("dump_workflow", None, {"DUMP": dump_job})
+    workflow = Workflow.from_file(
+        "dump_workflow", None, {"DUMP": dump_job}, use_new_parser=False
+    )
 
     assert len(workflow) == 2
 
@@ -62,7 +65,69 @@ def test_that_failure_in_parsing_workflow_gives_config_validation_error():
     with open("workflow", "w", encoding="utf-8") as f:
         f.write("DEFINE\n")
     with pytest.raises(
-        ConfigValidationError, match="DEFINE must have two or more arguments"
+        ConfigValidationError, match="DEFINE must have .* arguments"
     ) as err:
         _ = Workflow.from_file("workflow", None, {})
-    assert err.value.errors[0].filename == "workflow"
+    assert "workflow" in err.value.errors[0].filename
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@given(
+    strategies.lists(
+        strategies.sampled_from(
+            [
+                "foo",
+                "bar",
+                "baz",
+            ]
+        ),
+        min_size=1,
+        max_size=20,
+    )
+)
+def test_that_multiple_workflow_jobs_are_ordered_correctly(order):
+    with open("workflow", "w", encoding="utf-8") as f:
+        f.write("\n".join(order))
+
+    wf = Workflow.from_file(
+        src_file="workflow",
+        context=None,
+        job_dict={
+            "foo": "foo",
+            "bar": "bar",
+            "baz": "baz",
+        },
+    )
+
+    assert [x[0] for x in wf.cmd_list] == order
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_multiple_workflow_jobs_with_redefines_are_ordered_correctly():
+    with open("workflow", "w", encoding="utf-8") as f:
+        f.write(
+            "\n".join(
+                [
+                    "DEFINE <A> 1",
+                    "foo <A>",
+                    "bar <A>",
+                    "DEFINE <A> 3",
+                    "foo <A>",
+                    "baz <A>",
+                ]
+            )
+        )
+
+    wf = Workflow.from_file(
+        src_file="workflow",
+        context=None,
+        job_dict={
+            "foo": "foo",
+            "bar": "bar",
+            "baz": "baz",
+        },
+    )
+
+    commands = [(name, args[0]) for (name, args) in wf.cmd_list]
+
+    assert commands == [("foo", "1"), ("bar", "1"), ("foo", "3"), ("baz", "3")]


### PR DESCRIPTION
**Issue**
Resolves #5475 


**Approach**
Use new parser for workflows
* Lark parser has to create arbitrary schema items as keywords can be anything but `DEFINE`, thus it is necessary to override `__getitem__` in `WorkflowSchemaDict`.
* The order of jobs in a workflow matters, so we use the line number of the keyword to order them after being parsed by the lark parser. Lark parser parses them into a dict keyed by the job name, with one arglist (possibly empty) per occurrence. It is therefore necessary to attach the context to the arglist parsed in by lark, and this is done the config schema item.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
