### PR TITLE
Revert "Reduce the amount of test runners"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y valgrind
-
+    
     - uses: actions/cache@v3
       with:
         path: ~/.conan/
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
     uses: ./.github/workflows/build-wheels-linux.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
     uses: ./.github/workflows/build-wheels-macos.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -102,10 +102,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         os: [ ubuntu-latest ]
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         exclude:
+          - os: ubuntu-latest
+            python-version: '3.9'
+            test-type: 'gui-test'
           - os: ubuntu-latest
             python-version: '3.10'
             test-type: 'gui-test'
@@ -120,12 +123,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         os: [ macos-latest ]
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         exclude:
           - os: macos-latest
+            python-version: '3.9'
+          - os: macos-latest
             test-type: 'gui-test'
+          - os: macos-latest
+            python-version: '3.10'
     uses: ./.github/workflows/test_ert.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
This reverts commit 8ae8ef813810153afe15a94651d0a8df1c0e3dcd.

The reason is that it also stopped uploading of wheels for e.g. python 3.9



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
