### PR TITLE
Change current working directory to config path

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -37,7 +37,13 @@ class ErtTimeoutError(Exception):
 
 
 def run_cli(args, _=None):
+    ert_dir = os.path.abspath(os.path.dirname(args.config))
+    os.chdir(ert_dir)
+    # Changing current working directory means we need to update
+    # the config file to be the base name of the original config
+    args.config = os.path.basename(args.config)
     ert_config = ErtConfig.from_file(args.config)
+
     try:
         with warnings.catch_warnings(record=True) as silenced_warnings:
             warnings.simplefilter("always")
@@ -73,7 +79,6 @@ def run_cli(args, _=None):
     for suggestion in ErtConfig.make_suggestion_list(args.config):
         print(f"Warning: {suggestion}")
 
-    os.chdir(ert_config.config_path)
     ert = EnKFMain(ert_config)
     facade = LibresFacade(ert)
     if not facade.have_observations and args.mode not in [

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -119,13 +119,14 @@ def _start_initial_gui_window(
     with warnings.catch_warnings(record=True) as all_warnings:
         try:
             _check_locale()
-            ert_config = ErtConfig.from_file(args.config)
-            suggestions += ErtConfig.make_suggestion_list(args.config)
-            _log_difference_with_old_parser(args, ert_config)
-            os.chdir(ert_config.config_path)
+            ert_dir = os.path.abspath(os.path.dirname(args.config))
+            os.chdir(ert_dir)
             # Changing current working directory means we need to update
             # the config file to be the base name of the original config
             args.config = os.path.basename(args.config)
+            ert_config = ErtConfig.from_file(args.config)
+            suggestions += ErtConfig.make_suggestion_list(args.config)
+            _log_difference_with_old_parser(args, ert_config)
             ert = EnKFMain(ert_config)
         except ConfigValidationError as error:
             config_warnings = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,11 @@ def copy_poly_case(copy_case):
 
 
 @pytest.fixture()
+def copy_snake_oil_surface(copy_case):
+    copy_case("snake_oil_field")
+
+
+@pytest.fixture()
 def copy_snake_oil_case(copy_case):
     copy_case("snake_oil")
 

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -408,3 +408,19 @@ def test_that_es_mda_is_disabled_when_weights_are_invalid(qtbot):
         es_mda_panel._relative_iteration_weights_box.setText("1")
 
         assert run_sim_button.isEnabled()
+
+
+@pytest.mark.usefixtures("copy_snake_oil_surface")
+def test_that_ert_changes_to_config_directory(qtbot):
+    """
+    This is a regression test that verifies that ert changes directories
+    to the config dir (where .ert is).
+    Failure to do so would in this case result in SURFACE keyword not
+    finding the INIT_FILE provided (surface/small.irap)
+    """
+    args = Mock()
+    os.chdir("..")
+    args.config = "test_data/snake_oil_surface.ert"
+    with add_gui_log_handler() as log_handler:
+        gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
+        assert gui.windowTitle() == "ERT - snake_oil_surface.ert"


### PR DESCRIPTION
**Issue**
Resolves #5070 

When executing an ert-file, the results should be the same whether you execute;

```
ert gui snake_oil_surface.ert
ert gui test-data/snake_oil_field/snake_oil_surface.ert
```

**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
