### PR TITLE
Make experiment server websockets>=11.0 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ args = dict(
         "scipy<1.9.2",
         "sqlalchemy",
         "uvicorn >= 0.17.0",
-        "websockets >= 9.0.1, <11.0",
+        "websockets",
         "httpx",
         "tables",
         "xarray",


### PR DESCRIPTION
- We need to call `dispatcher.send` within the same connection establish context since connection is now being closed automatically when existing the contextmanager.
- ~~We need to provide at least one awaitable after creating the server task, since connect itself has await-able when specifying `open_timeout` parameter in client.connect function but currently it looks to be ignored (?) in Python 3.8 https://github.com/python-websockets/websockets/blob/1bf73423044dedc325435d261a39473337f5ddcf/src/websockets/legacy/client.py#L646~~
Seems like using `async for x in connect(x...): ` solves the problem.

**Issue**
Resolves #5199 


**Approach**
Remove dispatcher factory and provide `await asyncio.sleep()`


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
