### PR TITLE
Fix closing the RunDialog with a file open takes down the entire application

### DIFF
--- a/src/ert/gui/tools/file/file_dialog.py
+++ b/src/ert/gui/tools/file/file_dialog.py
@@ -24,6 +24,7 @@ class FileDialog(QDialog):
             f"{job_name} # {job_number} "
             f"Realization: {realization} Iteration: {iteration}"
         )
+        self.setObjectName(file_name)
 
         try:
             # pylint: disable=consider-using-with

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -1,9 +1,13 @@
-from unittest.mock import patch
+import os
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QMessageBox, QToolButton
 
+from ert._c_wrappers.enkf import EnKFMain, ErtConfig
 from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
 from ert.ensemble_evaluator.event import (
@@ -12,7 +16,11 @@ from ert.ensemble_evaluator.event import (
     SnapshotUpdateEvent,
 )
 from ert.ensemble_evaluator.snapshot import PartialSnapshot, SnapshotBuilder
+from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.gui.simulation.run_dialog import RunDialog
+from ert.gui.simulation.view.realization import RealizationWidget
+from ert.gui.tools.file import FileDialog
+from ert.services import StorageService
 
 
 def test_success(runmodel, qtbot, mock_tracker):
@@ -40,7 +48,7 @@ def test_kill_simulations(runmodel, qtbot, mock_tracker):
         tracker.return_value = mock_tracker([EndEvent(failed=False, failed_msg="")])
         widget.startSimulation()
 
-    with qtbot.waitExposed(widget, timeout=30000):
+    with qtbot.waitSignal(widget.rejected, timeout=30000):
 
         def handle_dialog():
             message_box = [
@@ -324,3 +332,67 @@ def test_run_dialog(events, tab_widget_count, runmodel, qtbot, mock_tracker):
             lambda: widget._tab_widget.count() == tab_widget_count, timeout=5000
         )
         qtbot.waitUntil(widget.done_button.isVisible, timeout=5000)
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
+    qtbot, storage, source_root
+):
+    """
+    This is a regression test for a crash happening when
+    closing the RunDialog with a file open.
+    """
+
+    config_file = Path("poly.ert")
+    args_mock = Mock()
+    args_mock.config = str(config_file)
+
+    ert_config = ErtConfig.from_file(str(config_file))
+    enkf_main = EnKFMain(ert_config)
+    with StorageService.init_service(
+        ert_config=str(config_file),
+        project=os.path.abspath(ert_config.ens_path),
+    ):
+        gui = _setup_main_window(enkf_main, args_mock, GUILogHandler())
+        gui.notifier.set_storage(storage)
+        qtbot.addWidget(gui)
+        start_simulation = gui.findChild(QToolButton, name="start_simulation")
+
+        def handle_dialog():
+            message_box = gui.findChild(QMessageBox)
+            qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
+
+        QTimer.singleShot(500, handle_dialog)
+        qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+        job_view = run_dialog._job_view
+        qtbot.waitUntil(job_view.isVisible, timeout=20000)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
+
+        realization_widget = run_dialog.findChild(RealizationWidget)
+
+        click_pos = realization_widget._real_view.rectForIndex(
+            realization_widget._real_list_model.index(0, 0)
+        ).center()
+
+        with qtbot.waitSignal(realization_widget.currentChanged, timeout=30000):
+            qtbot.mouseClick(
+                realization_widget._real_view.viewport(),
+                Qt.LeftButton,
+                pos=click_pos,
+            )
+        click_pos = job_view.visualRect(run_dialog._job_model.index(0, 4)).center()
+        qtbot.mouseClick(job_view.viewport(), Qt.LeftButton, pos=click_pos)
+
+        qtbot.waitUntil(run_dialog.findChild(FileDialog).isVisible, timeout=3000)
+
+        with qtbot.waitSignal(run_dialog.accepted, timeout=30000):
+            run_dialog.close()  # Close the run dialog by pressing 'x' close button
+
+        # Ensure that once the run dialog is closed
+        # another simulation can be started
+        assert start_simulation.isEnabled()
+        gui.close()


### PR DESCRIPTION
**Issue**
Resolves #5079 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
