### PR TITLE
Fix an issue where __del__ raises

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -120,9 +120,6 @@ class LocalStorageReader:
     def _experiment_path(self, experiment_id: UUID) -> Path:
         return self.path / "experiments" / str(experiment_id)
 
-    def __del__(self) -> None:
-        self.close()
-
     def __enter__(self) -> Self:
         return self
 


### PR DESCRIPTION
LocalStorage.__del__ could raise NoSuchAttribute
self._experiment. Currently closing in __del__ is not necessary so it is removed.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
