### PR TITLE
Ensure cwd is unchanged when running tests in CI

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -26,4 +26,5 @@ start_tests () {
     pushd ${CI_TEST_ROOT}/tests
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m \
     pytest -m "not requires_window_manager" --hypothesis-profile=ci
+    popd
 }


### PR DESCRIPTION
The workflow (in komodo-releases) calling this script now has code after this tests that makes assumptions on cwd being unchanged.

**Issue**
Resolves failure in CI.

## Pre review checklist

- [x] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
