### PR TITLE
Use pathlib object for path joining

### DIFF
--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -21,16 +21,12 @@ from ._import_from_location import import_from_location
 
 ecl_config = import_from_location(
     "ecl_config",
-    os.path.join(
-        SOURCE_DIR, "src/ert/shared/share/ert/forward-models/res/script/ecl_config.py"
-    ),
+    SOURCE_DIR / "src/ert/shared/share/ert/forward-models/res/script/ecl_config.py",
 )
 
 ecl_run = import_from_location(
     "ecl_run",
-    os.path.join(
-        SOURCE_DIR, "src/ert/shared/share/ert/forward-models/res/script/ecl_run.py"
-    ),
+    SOURCE_DIR / "src/ert/shared/share/ert/forward-models/res/script/ecl_run.py",
 )
 
 

--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -506,15 +506,17 @@ def test_error_parse(init_ecl100_config, source_root):
     sim = econfig.sim("2014.2")
     erun = ecl_run.EclRun("SPE1.DATA", sim)
 
-    # NB: The ugly white space in the error0 literal is actually part of
-    #     the string we are matching; i.e. it must be retained.
-    error0 = """ @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):
- @           UNABLE TO OPEN INCLUDED FILE                                    
- @           /private/joaho/ERT/git/Gurbat/XXexample_grid_sim.GRDECL         
- @           SYSTEM ERROR CODE IS       29                                   """  # noqa
+    error0 = (
+        " @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):\n"
+        " @           UNABLE TO OPEN INCLUDED FILE                                    \n"  # noqa
+        " @           /private/joaho/ERT/git/Gurbat/XXexample_grid_sim.GRDECL         \n"  # noqa
+        " @           SYSTEM ERROR CODE IS       29                                   "
+    )
 
-    error1 = """ @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):
- @           INCLUDE FILES MISSING.                                          """  # noqa
+    error1 = (
+        " @--  ERROR  AT TIME        0.0   DAYS    ( 1-JAN-0):\n",
+        " @           INCLUDE FILES MISSING.                                          ",
+    )
 
     assert erun.parseErrors() == [error0, error1]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ import websockets.server
 from _ert_job_runner.client import Client
 
 
-def source_dir():
+def source_dir() -> Path:
     src = Path("@CMAKE_CURRENT_SOURCE_DIR@/../..")
     if src.is_dir():
         return src.relative_to(Path.cwd())
@@ -25,7 +25,7 @@ def source_dir():
     raise RuntimeError("Cannot find the source folder")
 
 
-SOURCE_DIR = source_dir()
+SOURCE_DIR: Path = source_dir()
 
 
 def wait_until(func, interval=0.5, timeout=30):


### PR DESCRIPTION
**Issue**
Resolves unecessary usage of os.path.join when one of the argument is already a pathlib.Path object.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
