### PR TITLE
Fix missing empty line in RST file

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1820,8 +1820,8 @@ bjobs.
 
                 QUEUE_OPTION TORQUE DEBUG_OUTPUT torque_log.txt
 
-.. _torque_timeout:
-.. topic:: TIMEOUT
+.. _torque_queue_query_timeout:
+.. topic:: QUEUE_QUERY_TIMEOUT
 
         The driver allows the backend Torque system to be flaky, i.e. it may
         intermittently not respond and give error messages when submitting jobs
@@ -1835,12 +1835,13 @@ bjobs.
         flakyness.
 
         ::
+
                 QUEUE_OPTION TORQUE QUEUE_QUERY_TIMEOUT 254
 
 .. _configuring_the_slurm_queue:
 
 Configuring the SLURM queue
---------------------------------------
+---------------------------
 
         The slurm queue managing tool has a very fine grained control. In ERT only the options that
         are the most necessary have been added.


### PR DESCRIPTION
The missing empty line made the sphinx-rendering go wrong for this section.

Also adjust other rst-technicalities nearby.

**Issue**
Resolves visual bug:
![image](https://github.com/equinor/ert/assets/306834/5b0418d6-8f6b-414b-9f45-8157fe550764)



**Approach**
Add missing line

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
