### PR TITLE
Revert "Disregard the exit code from qstat"

### DIFF
--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
@@ -372,18 +372,6 @@ def test_no_such_job_id(tmpdir, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")
-def test_proxy_fails_if_backend_fails():
-    with pytest.raises(subprocess.CalledProcessError), testpath.MockCommand(
-        "qstat", python=MOCKED_QSTAT_BACKEND_FAILS
-    ):
-        subprocess.run(
-            [PROXYSCRIPT, "15399", PROXYFILE_FOR_TESTS],
-            check=True,
-            capture_output=False,
-        )
-
-
-@pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")
 def test_no_argument(tmpdir, monkeypatch):
     """qstat with no arguments lists all jobs. So should the proxy."""
     monkeypatch.chdir(tmpdir)

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -135,10 +135,6 @@ exit 1
 """
 )
 
-# A qstat command that has no output but return code 0 on first invocation
-# and nonzero output and return code 0 on second invocation:
-LYING_QSTAT = FLAKY_QSTAT.replace("exit 1", "exit 0")
-
 
 def _deploy_script(scriptname: Path, scripttext: str):
     script = Path(scriptname)
@@ -179,7 +175,6 @@ def _build_jobqueuenode(dummy_config: JobConfig, job_id=0):
         pytest.param(FLAKY_QSUB, MOCK_QSTAT, id="flaky_qsub"),
         pytest.param(MOCK_QSUB, FLAKY_QSTAT, id="flaky_qstat"),
         pytest.param(FLAKY_QSUB, FLAKY_QSTAT, id="all_flaky"),
-        pytest.param(MOCK_QSUB, LYING_QSTAT, id="lying_qstat"),
     ],
 )
 def test_run_torque_job(


### PR DESCRIPTION
This reverts commit 7f6cfb2427752b4443e5e846f85f94255a11fb83.

The commit failed passing the hm-tutorial tests, yielding multiple JOB_QUEUE_STATUS_FAILURE messages.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
