### PR TITLE
Fix intercomponent communication instability when running many realizations (>=200)

### DIFF
--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -14,7 +14,10 @@ from websockets.exceptions import (
     InvalidURI,
 )
 
+logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class ClientConnectionError(Exception):
@@ -85,6 +88,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             ping_timeout=60,
             ping_interval=60,
             close_timeout=60,
+            logger=logger,
         )
 
     async def _send(self, msg: AnyStr) -> None:

--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -81,6 +81,10 @@ class Client:  # pylint: disable=too-many-instance-attributes
             self.url,
             ssl=self._ssl_context,
             extra_headers=self._extra_headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         )
 
     async def _send(self, msg: AnyStr) -> None:

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -576,7 +576,7 @@ def main() -> None:
     if args.verbose:
         root_logger = logging.getLogger()
         handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(logging.INFO)
+        handler.setLevel(logging.DEBUG)
         root_logger.addHandler(handler)
 
     FeatureToggling.update_from_args(args)

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -32,7 +32,10 @@ if TYPE_CHECKING:
     from ert._c_wrappers.enkf.run_arg import RunArg
 
 
+logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 LONG_RUNNING_FACTOR = 1.25
 

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -383,7 +383,15 @@ class JobQueue(BaseCClass):
             ]
         )
 
-        async for websocket in connect(ws_uri, ssl=ssl_context, extra_headers=headers):
+        async for websocket in connect(
+            ws_uri,
+            ssl=ssl_context,
+            extra_headers=headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
+        ):
             try:
                 while events:
                     await asyncio.wait_for(websocket.send(to_json(events[0])), 60)

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -383,36 +383,14 @@ class JobQueue(BaseCClass):
             ]
         )
 
-        retries = 0
-        while True:
+        async for websocket in connect(ws_uri, ssl=ssl_context, extra_headers=headers):
             try:
-                async with connect(
-                    ws_uri, ssl=ssl_context, extra_headers=headers
-                ) as websocket:
-                    while events:
-                        await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
-                        events.popleft()
-                    return
-            except (ConnectionClosedError, asyncio.TimeoutError) as e:
-                if retries >= 10:
-                    logger.exception(
-                        "Connection to websocket %s failed, unable to publish changes",
-                        ws_uri,
-                    )
-                    raise
-
-                # websockets for python > 3.6 comes with builtin backoff, implement a
-                # crude one here
-                retries += 1
-                backoff = max(3, min(60, 2**retries))
-                logger.info(
-                    "Connection to websocket %s was closed, retry in %d seconds.",
-                    ws_uri,
-                    backoff,
-                    exc_info=e,
-                )
-
-                await asyncio.sleep(backoff)
+                while events:
+                    await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
+                    events.popleft()
+                return
+            except ConnectionClosedError:
+                continue
 
     async def execute_queue_via_websockets(  # pylint: disable=too-many-arguments
         self,

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -141,6 +141,7 @@ class LegacyEnsemble(Ensemble):
         if not config:
             raise ValueError("no config for evaluator")
         self._config = config
+        logger.info("$$$ we are here. in evaluate.")
         get_event_loop().run_until_complete(
             wait_for_evaluator(
                 base_url=self._config.url,
@@ -148,6 +149,7 @@ class LegacyEnsemble(Ensemble):
                 cert=self._config.cert,
             )
         )
+        logger.info("$$$ evaluate: done waiting for evaluator")
 
         threading.Thread(target=self._evaluate, name="LegacyEnsemble").start()
 
@@ -161,6 +163,7 @@ class LegacyEnsemble(Ensemble):
         asyncio.set_event_loop(asyncio.new_event_loop())
 
         if self._config is None:
+            # TODO should event loop be closed?
             raise ValueError("no config")
 
         # The cloudevent_unary_send only accepts a cloud event, but in order to

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -40,27 +40,27 @@ class BatchingDispatcher:
 
     async def _work(self):
         t0 = time.time()
-        event_buffer = []
+        batch_of_events_for_processing = []
         for _ in range(self._max_batch):
             try:
-                event_buffer.append(self._buffer.popleft())
+                batch_of_events_for_processing.append(self._buffer.popleft())
             except IndexError:
                 break
         left_in_queue = len(self._buffer)
 
-        if len(event_buffer) == 0:
+        if len(batch_of_events_for_processing) == 0:
             logger.debug("no events to be processed in queue")
             return
 
         function_to_events_map = OrderedDict()
-        for f, event in event_buffer:
+        for f, event in batch_of_events_for_processing:
             if f not in function_to_events_map:
                 function_to_events_map[f] = []
             function_to_events_map[f].append(event)
 
         def done_logger(_):
             logger.debug(
-                f"processed {len(event_buffer)} events in "
+                f"processed {len(batch_of_events_for_processing)} events in "
                 f"{(time.time()-t0):.6f}s. "
                 f"{left_in_queue} left in queue"
             )

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -6,7 +6,10 @@ from collections import OrderedDict, defaultdict, deque
 
 from ert.ensemble_evaluator import identifiers
 
+logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class BatchingDispatcher:
@@ -51,6 +54,8 @@ class BatchingDispatcher:
         if len(batch_of_events_for_processing) == 0:
             logger.debug("no events to be processed in queue")
             return
+
+        logger.debug(f"about to process {len(batch_of_events_for_processing)} events")
 
         function_to_events_map = OrderedDict()
         for f, event in batch_of_events_for_processing:

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -48,6 +48,10 @@ class BatchingDispatcher:
                 break
         left_in_queue = len(self._buffer)
 
+        if len(event_buffer) == 0:
+            logger.debug("no events to be processed in queue")
+            return
+
         function_to_events_map = OrderedDict()
         for f, event in event_buffer:
             if f not in function_to_events_map:

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -289,6 +289,9 @@ class EnsembleEvaluator:
             process_request=self.process_request,
             max_queue=None,
             max_size=2**26,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         ):
             await self._done
             if self._dispatchers_connected is not None:

--- a/src/ert/ensemble_evaluator/monitor.py
+++ b/src/ert/ensemble_evaluator/monitor.py
@@ -17,7 +17,10 @@ if TYPE_CHECKING:
     from .ensemble_evaluator import EvaluatorConnectionInfo
 
 
+logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class Monitor:

--- a/src/ert/ensemble_evaluator/sync_ws_duplexer.py
+++ b/src/ert/ensemble_evaluator/sync_ws_duplexer.py
@@ -71,6 +71,10 @@ class SyncWebsocketDuplexer:
             extra_headers=self._extra_headers,
             max_size=2**26,
             max_queue=500,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         )
 
         await wait_for_evaluator(

--- a/src/ert/ensemble_evaluator/sync_ws_duplexer.py
+++ b/src/ert/ensemble_evaluator/sync_ws_duplexer.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import ssl
 import threading
@@ -12,6 +13,11 @@ from websockets.client import WebSocketClientProtocol  # type: ignore
 from websockets.datastructures import Headers
 
 from ._wait_for_evaluator import wait_for_evaluator
+
+logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class SyncWebsocketDuplexer:
@@ -59,8 +65,10 @@ class SyncWebsocketDuplexer:
         while not self._connection.done():
             time.sleep(0.1)
         try:
+            logger.debug("trying to connect...")
             self._connection.result()
         except Exception:
+            logger.debug("didn't work!")
             self.stop()
             raise
 
@@ -75,6 +83,7 @@ class SyncWebsocketDuplexer:
             ping_timeout=60,
             ping_interval=60,
             close_timeout=60,
+            logger=logger,
         )
 
         await wait_for_evaluator(


### PR DESCRIPTION
**Issue**
Related to #5273, might solve it

NB: one left issue is that the proposed pattern in queue.py will continue to try to reconnect basically forever (OBS: maybe not if the socket gets closed, and there is nobody listening on the port anymore!) - this should perhaps be adjusted, which is sadly non-trivial based on how the loop is set up (where to catch the exception to count reconnects, how to recover from possible partial data submission, ...)

**Approach**
We traced the symptoms back to the websockets server and client.
We increase timeouts, and change the websockets connection usage in the job queue.
We also dramatically increase loggin - *NB* that particular last commit can be dropped or modified at reviewer's discretion.


## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT RELEVANT Updated documentation
- [ ] STILL WORKING ON IT - Ensured new behaviour is tested