### PR TITLE
Extend summary config to avoid observations adding response configuration

### DIFF
--- a/src/ert/_c_wrappers/enkf/config/response_config.py
+++ b/src/ert/_c_wrappers/enkf/config/response_config.py
@@ -1,20 +1,10 @@
 import dataclasses
 from abc import ABC
-from typing import List
-
-from sortedcontainers import SortedList
 
 
 @dataclasses.dataclass
 class ResponseConfig(ABC):
     name: str
-    _observation_list: SortedList = SortedList()
 
     def getKey(self):
         return self.name
-
-    def update_observation_keys(self, observations: List[str]):
-        self._observation_list = SortedList(observations)
-
-    def get_observation_keys(self) -> List[str]:
-        return self._observation_list

--- a/src/ert/_c_wrappers/enkf/config/summary_config.py
+++ b/src/ert/_c_wrappers/enkf/config/summary_config.py
@@ -1,8 +1,27 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from ert._c_wrappers.enkf.config.response_config import ResponseConfig
+
+if TYPE_CHECKING:
+    from typing import List, Optional
+
+    from ecl.summary import EclSum
 
 
 @dataclass
 class SummaryConfig(ResponseConfig):
-    ...
+    input_file: str
+    keys: List[str]
+    refcase: Optional[EclSum] = None
+
+    def __eq__(self, other):
+        if (
+            self.input_file != other.input_file
+            or self.keys != other.keys
+            or self.refcase.case != other.refcase.case
+        ):
+            return False
+        return True

--- a/src/ert/_c_wrappers/enkf/enkf_main.py
+++ b/src/ert/_c_wrappers/enkf/enkf_main.py
@@ -146,7 +146,6 @@ class EnKFMain:
         self._ensemble_size = self.ert_config.model_config.num_realizations
         self._runpaths = Runpaths(
             jobname_format=self.getModelConfig().jobname_format_string,
-            eclbase_format=self.getModelConfig().eclbase_format_string,
             runpath_format=self.getModelConfig().runpath_format_string,
             filename=self.getModelConfig().runpath_file,
             substitute=self.get_context().substitute_real_iter,

--- a/src/ert/_c_wrappers/enkf/ert_run_context.py
+++ b/src/ert/_c_wrappers/enkf/ert_run_context.py
@@ -27,12 +27,9 @@ class RunContext:
         job_names = self.runpaths.get_jobnames(
             list(range(len(self.initial_mask))), self.iteration
         )
-        eclbases = self.runpaths.get_eclbases(
-            list(range(len(self.initial_mask))), self.iteration
-        )
 
-        for iens, (run_path, job_name, active, eclbase) in enumerate(
-            zip(paths, job_names, self.initial_mask, eclbases)
+        for iens, (run_path, job_name, active) in enumerate(
+            zip(paths, job_names, self.initial_mask)
         ):
             self.run_args.append(
                 RunArg(
@@ -42,7 +39,6 @@ class RunContext:
                     self.iteration,
                     run_path,
                     job_name,
-                    eclbase,
                     active,
                 )
             )

--- a/src/ert/_c_wrappers/enkf/observations/obs_vector.py
+++ b/src/ert/_c_wrappers/enkf/observations/obs_vector.py
@@ -55,12 +55,11 @@ class ObsVector:
                 n: "SummaryObservation" = self.observations[time_step]
                 observations.append(n.value)
                 errors.append(n.std)
-            data_key = self.data_key
             time_axis = [obs.obs_time[i] for i in active_steps]
             return "summary", xr.Dataset(
                 {
                     "observations": (["name", "time"], [observations]),
                     "std": (["name", "time"], [errors]),
                 },
-                coords={"time": time_axis, "name": [data_key]},
+                coords={"time": time_axis, "name": [self.observation_key]},
             )

--- a/src/ert/_c_wrappers/enkf/run_arg.py
+++ b/src/ert/_c_wrappers/enkf/run_arg.py
@@ -16,7 +16,6 @@ class RunArg:
     itr: int
     runpath: str
     job_name: str
-    eclbase: str
     active: bool = True
     # Below here is legacy related to Everest
     queue_index: Optional[int] = None

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -202,7 +202,11 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         return observation.observation_type.name
 
     def get_data_key_for_obs_key(self, observation_key: str) -> str:
-        return self._enkf_main.getObservations()[observation_key].data_key
+        obs = self._enkf_main.getObservations()[observation_key]
+        if obs.observation_type == EnkfObservationImplementationType.SUMMARY_OBS:
+            return list(obs.observations.values())[0].summary_key  # type: ignore
+        else:
+            return obs.data_key
 
     def get_matching_wildcards(self) -> Callable[[str], List[str]]:
         return self._enkf_main.getObservations().getMatchingKeys
@@ -259,10 +263,10 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
             else:
                 return []
         elif key in self.get_summary_keys():
-            return [
-                str(k)
-                for k in self._enkf_main.ensembleConfig().get_node_observation_keys(key)
-            ]
+            obs = self.get_observations().getTypedKeylist(
+                EnkfObservationImplementationType.SUMMARY_OBS
+            )
+            return [i for i in obs if self.get_observations()[i].observation_key == key]
         else:
             return []
 

--- a/src/ert/shared/runpaths.py
+++ b/src/ert/shared/runpaths.py
@@ -10,8 +10,6 @@ class Runpaths:
     is one job name for each of the runpaths.
 
     :param jobname_format: The format of the job name, e.g., "job_<IENS>"
-    :param eclbase_format: The format for the ECLIPSE simulation file.
-        e.g., NAME-<IENS>
     :param runpath_format: The format of the runpath, e.g.
         "/path/<case>/ensemble-<IENS>/iteration-<ITER>"
     :param filename: The filename of the runpath list file. Defaults to
@@ -31,13 +29,11 @@ class Runpaths:
     def __init__(
         self,
         jobname_format: str,
-        eclbase_format: str,
         runpath_format: str,
         filename: str = ".ert_runpath_list",
         substitute: Callable[[str, int, int], str] = lambda x, *_: x,
     ):
         self._jobname_format = jobname_format
-        self._eclbase_format = eclbase_format
         self.runpath_list_filename = Path(filename)
         self._runpath_format = str(Path(runpath_format).resolve())
         self._substitute = substitute
@@ -51,12 +47,6 @@ class Runpaths:
     def get_jobnames(self, realizations: List[int], iteration: int) -> List[str]:
         return [
             self._substitute(self._jobname_format, realization, iteration)
-            for realization in realizations
-        ]
-
-    def get_eclbases(self, realizations: List[int], iteration: int) -> List[str]:
-        return [
-            self._substitute(self._eclbase_format, realization, iteration)
             for realization in realizations
         ]
 

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -113,7 +113,6 @@ class SimulationContext:
             sim_fs=sim_fs,
             runpaths=Runpaths(
                 jobname_format=ert.getModelConfig().jobname_format_string,
-                eclbase_format=ert.getModelConfig().eclbase_format_string,
                 runpath_format=ert.getModelConfig().runpath_format_string,
                 filename=ert.getModelConfig().runpath_file,
                 substitute=global_substitutions.substitute_real_iter,

--- a/tests/test_config_parsing/config_dict_generator.py
+++ b/tests/test_config_parsing/config_dict_generator.py
@@ -391,8 +391,8 @@ def composite_keys(smspec: Smspec) -> st.SearchStrategy[str]:
 
 
 @st.composite
-def ert_config_values(draw):
-    use_eclbase = draw(st.booleans())
+def ert_config_values(draw, use_eclbase=st.booleans()):
+    use_eclbase = draw(use_eclbase)
     queue_system = draw(queue_systems)
     install_jobs = draw(small_list(random_ext_job_names(words, file_names)))
     forward_model = draw(small_list(job(install_jobs))) if install_jobs else []
@@ -576,8 +576,8 @@ def _observation_dates(
 
 
 @st.composite
-def config_generators(draw):
-    config_values = draw(ert_config_values())
+def config_generators(draw, use_eclbase=st.booleans()):
+    config_values = draw(ert_config_values(use_eclbase=use_eclbase))
 
     should_exist_files = [job_path for _, job_path in config_values.install_job]
     should_exist_files.extend(

--- a/tests/test_config_parsing/test_enkf_obs_parsing.py
+++ b/tests/test_config_parsing/test_enkf_obs_parsing.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import pytest
 from ecl.summary import EclSum
 from hypothesis import given
+from hypothesis import strategies as st
 
 from ert._c_wrappers.enkf import EnkfObs, ErtConfig, ObservationConfigError
 from ert.parsing import ConfigValidationError, ConfigWarning
@@ -17,7 +18,7 @@ from .config_dict_generator import config_generators
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.filterwarnings("ignore::ert.parsing.ConfigWarning")
 @pytest.mark.usefixtures("set_site_config")
-@given(config_generators())
+@given(config_generators(use_eclbase=st.just(True)))
 def test_that_enkf_obs_keys_are_ordered(tmp_path_factory, config_generator):
     filename = "config.ert"
     with config_generator(tmp_path_factory, filename) as config_values:
@@ -57,7 +58,7 @@ def test_that_having_no_refcase_but_history_observations_causes_exception(tmpdir
     with tmpdir.as_cwd():
         config = dedent(
             """
-        JOBNAME my_name%d
+        ECLBASE my_name%d
         NUM_REALIZATIONS 10
         OBS_CONFIG observations
         TIME_MAP time_map.txt

--- a/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
+++ b/tests/unit_tests/c_wrappers/integration/test_field_parameter.py
@@ -976,7 +976,7 @@ def test_config_node_meta_information(storage, tmpdir):
         assert ensemble_config["KW_NAME"].output_file == "kw.txt"
 
         # summary
-        assert isinstance(ensemble_config["WOPR:MY_WELL"], SummaryConfig)
+        assert isinstance(ensemble_config["summary"], SummaryConfig)
 
         # field
         assert ensemble_config["MY_PARAM2"].forward_init is True

--- a/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_data_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/config/test_gen_data_config.py
@@ -44,14 +44,8 @@ def test_gen_data_eq_config():
     alt3 = GenDataConfig(name="ALT1", report_steps=[3])
     alt4 = GenDataConfig(name="ALT4", report_steps=[3])
     alt5 = GenDataConfig(name="ALT4", report_steps=[4])
-    alt6 = GenDataConfig(name="ALT4", report_steps=[4])
-
-    obs_list = ["DEF", "ABC", "GHI"]
-    alt6.update_observation_keys(obs_list)
-    assert alt6.get_observation_keys() == sorted(obs_list)
 
     assert alt1 == alt2  # name and ordered steps ok
     assert alt1 != alt3  # amount steps differ
     assert alt3 != alt4  # name differ
     assert alt4 != alt5  # steps differ
-    assert alt5 != alt6  # obs list differ

--- a/tests/unit_tests/c_wrappers/res/enkf/config/test_summary_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/config/test_summary_config.py
@@ -5,9 +5,5 @@ from ert._c_wrappers.enkf import SummaryConfig
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_summary_config():
-    summary_config = SummaryConfig(name="ALT1")
+    summary_config = SummaryConfig(name="ALT1", input_file="ECLBASE", keys=[])
     assert summary_config.getKey() == "ALT1"
-    obs_list = ["ABC", "GHI", "DEF"]
-    assert not summary_config.get_observation_keys()
-    summary_config.update_observation_keys(obs_list)
-    assert summary_config.get_observation_keys() == sorted(obs_list)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_main.py
@@ -54,9 +54,6 @@ def test_create_run_context(monkeypatch, enkf_main, prior_ensemble, config_dict)
     assert [real.job_name for real in run_context] == [
         f"name{i}" for i in range(ensemble_size)
     ]
-    assert [real.eclbase for real in run_context] == [
-        f"name{i}" for i in range(ensemble_size)
-    ]
 
     substitutions = enkf_main.get_context()
     assert "<RUNPATH>" in substitutions
@@ -84,9 +81,6 @@ def test_create_run_context_separate_base_and_name(
     ]
     assert [real.job_name for real in run_context] == [
         f"name{i}" for i in range(ensemble_size)
-    ]
-    assert [real.eclbase for real in run_context] == [
-        f"base{i}" for i in range(ensemble_size)
     ]
 
     substitutions = enkf_main.get_context()

--- a/tests/unit_tests/c_wrappers/res/enkf/test_enkf_obs.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_enkf_obs.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 import pytest
 from ecl.summary import EclSum
 
-from ert._c_wrappers.enkf import EnkfObs, ErtConfig, ObsVector, SummaryConfig
+from ert._c_wrappers.enkf import EnkfObs, ErtConfig, ObsVector
 from ert._c_wrappers.enkf.enums import EnkfObservationImplementationType
 from ert._c_wrappers.enkf.observations.summary_observation import SummaryObservation
 from ert.parsing import ConfigWarning
@@ -52,7 +52,7 @@ def test_that_correct_key_observation_is_loaded(extra_config, expected):
     config_text = dedent(
         """
         NUM_REALIZATIONS 1
-        JOBNAME my_case%d
+        ECLBASE my_case%d
         REFCASE MY_REFCASE
         OBS_CONFIG observations_config
         """
@@ -81,7 +81,7 @@ def test_date_parsing_in_observations(datestring, errors):
     config_text = dedent(
         """
         NUM_REALIZATIONS 1
-        JOBNAME my_case%d
+        ECLBASE my_case%d
         REFCASE MY_REFCASE
         OBS_CONFIG observations_config
         """
@@ -109,11 +109,10 @@ def test_observations(setup_case):
     count = 10
     summary_key = "test_key"
     observation_key = "test_obs_key"
-    summary_observation_node = SummaryConfig(summary_key)
     observation_vector = ObsVector(
         EnkfObservationImplementationType.SUMMARY_OBS,
         observation_key,
-        summary_observation_node.getKey(),
+        "summary",
         {},
     )
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ert_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ert_config.py
@@ -238,7 +238,7 @@ def test_extensive_config(setup_case):
 
     ensemble_config = ert_config.ensemble_config
     assert set(
-        snake_oil_structure_config["SUMMARY"]
+        ["summary"]
         + snake_oil_structure_config["GEN_KW"]
         + snake_oil_structure_config["GEN_DATA"]
     ) == set(ensemble_config.keys)

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ert_run_context.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ert_run_context.py
@@ -19,7 +19,6 @@ def test_create(storage):
         Runpaths(
             "path/to/sim%d",
             "job%d",
-            "eclbase%d",
             Path("runpath_file_name"),
         ),
         mask,
@@ -41,7 +40,6 @@ def test_create(storage):
         Runpaths(
             "path/to/sim%d",
             "job%d",
-            "eclbase%d",
             Path("runpath_file_name"),
         ),
         mask,

--- a/tests/unit_tests/c_wrappers/res/enkf/test_runpaths.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_runpaths.py
@@ -60,7 +60,6 @@ def test_runpath_file(tmp_path, job_format, runpath_format, expected_contents):
     context = SubstitutionList()
     runpaths = Runpaths(
         job_format,
-        job_format,
         runpath_format,
         runpath_file,
         context.substitute_real_iter,
@@ -77,7 +76,6 @@ def test_runpath_file_writer_substitution(tmp_path):
     context.addItem("<casename>", "my_case")
     runpaths = Runpaths(
         "<casename>_job",
-        "<casename>",
         "/path/<casename>/ensemble-<IENS>/iteration<ITER>",
         runpath_file,
         context.substitute_real_iter,
@@ -128,7 +126,6 @@ def test_write_snakeoil_runpath_file(snake_oil_case, storage, itr):
     run_context = RunContext(
         sim_fs=prior_ensemble,
         runpaths=Runpaths(
-            jobname_fmt,
             jobname_fmt,
             runpath_fmt,
             "a_file_name",


### PR DESCRIPTION
We are now saving summary data as a single "node" named "summary", so instead of hard coding that everywhere that should be known by the config. Also also add a summary config node if we have ECLBASE which means that the 
observations wil no longer be responsible for adding additional nodes.

The conceptual change here is that the observation vectors are not responsible of adding response configurations, and the summary response has a fixed name. Also responses are not aware that they are being observed, the observations checks that there exists a corresponding response.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
