### PR TITLE
Clean up typing of callbacks

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import Callable, List, Tuple
 
-from ert._c_wrappers.enkf import SummaryConfig
+from ert._c_wrappers.enkf import EnsembleConfig, RunArg, SummaryConfig
 from ert._c_wrappers.enkf.config.parameter_config import ParameterConfig
 from ert._c_wrappers.enkf.enums import RealizationStateEnum
 
 from .load_status import LoadResult, LoadStatus
 
-if TYPE_CHECKING:
-    from ert._c_wrappers.enkf import EnsembleConfig, RunArg
+CallbackArgs = Tuple[RunArg, EnsembleConfig]
+Callback = Callable[[RunArg, EnsembleConfig], LoadResult]
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def forward_model_ok(
     return final_result
 
 
-def forward_model_exit(run_arg: RunArg, *_: Tuple[Any]) -> LoadResult:
+def forward_model_exit(run_arg: RunArg, _: EnsembleConfig) -> LoadResult:
     run_arg.ensemble_storage.state_map[
         run_arg.iens
     ] = RealizationStateEnum.STATE_LOAD_FAILURE

--- a/src/ert/ensemble_evaluator/_builder/_step.py
+++ b/src/ert/ensemble_evaluator/_builder/_step.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
 
 from ._function_task import FunctionTask
 from ._io_ import IO, DummyIO, DummyIOBuilder, InputBuilder, IOBuilder, OutputBuilder
@@ -12,8 +14,7 @@ from ._unix_task import UnixTask
 SOURCE_TEMPLATE_STEP = "/step/{step_id}"
 if TYPE_CHECKING:
     from ert._c_wrappers.enkf import RunArg
-
-callback = Callable[[List[Any]], Union[bool, Tuple[Any, str]]]
+    from ert.callbacks import Callback, CallbackArgs
 
 
 class Step(Stage):
@@ -82,9 +83,9 @@ class LegacyStep(Step):  # pylint: disable=too-many-instance-attributes
         ee_url: str,
         source: str,
         max_runtime: Optional[int],
-        callback_arguments: Optional[Sequence[Any]],
-        done_callback: callback,
-        exit_callback: callback,
+        callback_arguments: CallbackArgs,
+        done_callback: Callback,
+        exit_callback: Callback,
         num_cpu: Optional[int],
         run_path: Path,
         job_script: str,
@@ -114,9 +115,9 @@ class StepBuilder(StageBuilder):  # pylint: disable=too-many-instance-attributes
 
         # legacy parts
         self._max_runtime: Optional[int] = None
-        self._callback_arguments: Optional[Sequence[Any]] = None
-        self._done_callback: Optional[callback] = None
-        self._exit_callback: Optional[callback] = None
+        self._callback_arguments: Optional[CallbackArgs] = None
+        self._done_callback: Optional[Callback] = None
+        self._exit_callback: Optional[Callback] = None
         self._num_cpu: Optional[int] = None
         self._run_path: Optional[Path] = None
         self._job_script: Optional[str] = None
@@ -160,17 +161,15 @@ class StepBuilder(StageBuilder):  # pylint: disable=too-many-instance-attributes
             self._max_runtime = max_runtime
         return self
 
-    def set_callback_arguments(
-        self, callback_arguments: Sequence[Any]
-    ) -> "StepBuilder":
+    def set_callback_arguments(self, callback_arguments: CallbackArgs) -> "StepBuilder":
         self._callback_arguments = callback_arguments
         return self
 
-    def set_done_callback(self, done_callback: callback) -> "StepBuilder":
+    def set_done_callback(self, done_callback: Callback) -> "StepBuilder":
         self._done_callback = done_callback
         return self
 
-    def set_exit_callback(self, exit_callback: callback) -> "StepBuilder":
+    def set_exit_callback(self, exit_callback: Callback) -> "StepBuilder":
         self._exit_callback = exit_callback
         return self
 

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -383,9 +383,9 @@ class BaseRunModel:
                         self.ert().resConfig().ensemble_config,
                     )
                 ).set_done_callback(
-                    lambda x: forward_model_ok(*x)
+                    forward_model_ok
                 ).set_exit_callback(
-                    lambda x: forward_model_exit(*x)
+                    forward_model_exit
                 ).set_num_cpu(
                     self.ert().get_num_cpu()
                 ).set_run_path(

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -14,21 +14,9 @@ from ert.shared.runpaths import Runpaths
 from .forward_model_status import ForwardModelStatus
 
 if TYPE_CHECKING:
-    from ert._c_wrappers.enkf import EnKFMain, ErtConfig, RunArg
+    from ert._c_wrappers.enkf import EnKFMain, RunArg
     from ert._c_wrappers.job_queue import JobQueue, JobStatusType
-    from ert.load_status import LoadResult
     from ert.storage import EnsembleAccessor
-
-
-def done_callback(args: Tuple["RunArg", "ErtConfig"]) -> LoadResult:
-    return forward_model_ok(
-        args[0],
-        args[1].ensemble_config,
-    )
-
-
-def exit_callback(args: Tuple["RunArg", Any]) -> None:
-    forward_model_exit(args[0])
 
 
 def _run_forward_model(
@@ -50,8 +38,8 @@ def _run_forward_model(
             run_arg,
             ert.resConfig(),
             max_runtime,
-            done_callback,
-            exit_callback,
+            forward_model_ok,
+            forward_model_exit,
             ert.get_num_cpu(),
         )
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager.py
@@ -32,14 +32,14 @@ class Config(TypedDict):
     exit_callback: Callable
 
 
-def dummy_ok_callback(args):
-    print(f"success {args[1]}")
-    (Path(args[1]) / "OK").write_text("success", encoding="utf-8")
+def dummy_ok_callback(runarg, path):
+    print(f"success {runarg}, {path}")
+    (Path(path) / "OK").write_text("success", encoding="utf-8")
     return (LoadStatus.LOAD_SUCCESSFUL, "")
 
 
-def dummy_exit_callback(args):
-    print(f"failure {args}")
+def dummy_exit_callback(runarg, path):
+    print(f"failure {runarg} {path}")
     Path("ERROR").write_text("failure", encoding="utf-8")
 
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -50,12 +50,12 @@ class JobConfig(TypedDict):
     exit_callback: Callable
 
 
-def dummy_ok_callback(args):
-    (Path(args[1]) / "OK").write_text("success", encoding="utf-8")
+def dummy_ok_callback(runargs, path):
+    (Path(path) / "OK").write_text("success", encoding="utf-8")
     return (LoadStatus.LOAD_SUCCESSFUL, "")
 
 
-def dummy_exit_callback(_args):
+def dummy_exit_callback(*_args):
     Path("ERROR").write_text("failure", encoding="utf-8")
 
 

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -128,12 +128,12 @@ def make_ensemble_builder(queue_config):
                     .set_job_script("job_dispatch.py")
                     .set_max_runtime(10000)
                     .set_run_arg(Mock(iens=iens))
-                    .set_done_callback(lambda _: (LoadStatus.LOAD_SUCCESSFUL, ""))
-                    .set_exit_callback(lambda _: True)
+                    .set_done_callback(lambda _, _b: (LoadStatus.LOAD_SUCCESSFUL, ""))
+                    .set_exit_callback(lambda _, _b: (LoadStatus.LOAD_FAILURE, ""))
                     # the first callback_argument is expected to be a run_arg
                     # from the run_arg, the queue wants to access the iens prop
-                    .set_callback_arguments([RunArg(iens)])
-                    .set_run_path(str(run_path))
+                    .set_callback_arguments((RunArg(iens), None))
+                    .set_run_path(run_path)
                     .set_num_cpu(1)
                     .set_name("dummy step")
                     .set_dummy_io()


### PR DESCRIPTION
Cleans up the typing of callbacks.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
