### PR TITLE
Guard against div-by-zero when min_required_realizations is zero

### DIFF
--- a/src/ert/_c_wrappers/job_queue/job_queue_node.py
+++ b/src/ert/_c_wrappers/job_queue/job_queue_node.py
@@ -87,6 +87,7 @@ class JobQueueNode(BaseCClass):
         self._end_time: Optional[float] = None
         self._timed_out = False
         self._status_msg = ""
+        self._job_name = job_name
         c_ptr = self._alloc(
             job_name,
             run_path,
@@ -109,6 +110,13 @@ class JobQueueNode(BaseCClass):
 
     def free(self) -> None:
         self._free()
+
+    def __str__(self) -> str:
+        return (
+            f"JobNode: Name:{self._job_name}, Status: {self.status}, "
+            f"Timed_out: {self.timed_out}, "
+            f"Submit_attempt: {self.submit_attempt}"
+        )
 
     @property
     def timed_out(self) -> bool:

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -133,6 +133,14 @@ class JobQueue(BaseCClass):
             f"num_waiting={nwait}, num_pending={npend}"
         )
 
+    def __str__(self) -> str:
+        isrun = "running" if self.isRunning else "not running"
+        return (
+            f"JobQueue running: {isrun}, num_running={self.num_running}, "
+            f"num_complete={self.num_complete}, num_waiting={self.num_waiting}, "
+            f"num_pending={self.num_pending}"
+        )
+
     def __init__(self, driver: "Driver", max_submit: int = 2, size: int = 0):
         """
         Short doc...
@@ -604,10 +612,17 @@ class JobQueue(BaseCClass):
         ]
         finished_realizations = len(completed_jobs)
 
-        if (
-            finished_realizations < minimum_required_realizations
-            or not finished_realizations
-        ):
+        if not finished_realizations:
+            job_nodes_status = ""
+            for job in self.job_list:
+                job_nodes_status += str(job)
+            logger.error(
+                f"Attempted to stop finished jobs when none was found in queue"
+                f"{str(self)}, {job_nodes_status}"
+            )
+            return
+
+        if finished_realizations < minimum_required_realizations:
             return
 
         average_runtime = (

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -599,17 +599,19 @@ class JobQueue(BaseCClass):
         stage.run_arg.set_queue_index(self.add_job(job, iens))
 
     def stop_long_running_jobs(self, minimum_required_realizations: int) -> None:
-        finished_realizations = self.count_status(
-            JobStatusType.JOB_QUEUE_DONE,  # type: ignore
-        )
-        if finished_realizations < minimum_required_realizations:
-            return
-
         completed_jobs = [
             job for job in self.job_list if job.status == JobStatusType.JOB_QUEUE_DONE
         ]
-        average_runtime = sum(job.runtime for job in completed_jobs) / len(
-            completed_jobs
+        finished_realizations = len(completed_jobs)
+
+        if (
+            finished_realizations < minimum_required_realizations
+            or not finished_realizations
+        ):
+            return
+
+        average_runtime = (
+            sum(job.runtime for job in completed_jobs) / finished_realizations
         )
 
         for job in self.job_list:


### PR DESCRIPTION
Guard against div-by-zero when min_realizations is zero
Log queue and job node status when zero jobs
**Issue**
Resolves #5546 


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
