### PR TITLE
Fix bug introduced in e379e40

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -629,17 +629,17 @@ torque_driver_get_qstat_status(torque_driver_type *driver,
             // can therefore assume that qstat results about Unknown Job Id are
             // failures (these have nonzero output length, but return value != 0)
             // that should trigger retries.
-            if (std::error_code ec; fs::file_size(tmp_std_file, ec) > 0 && ec &&
-                                    return_value == 0) {
+            if (std::error_code ec; fs::file_size(tmp_std_file, ec) > 0 &&
+                                    !ec && return_value == 0) {
                 qstat_succeeded = true;
             }
 
             if (!qstat_succeeded) {
                 if (slept_time + retry_interval <= driver->timeout) {
-                    torque_debug(
-                        driver,
-                        "qstat failed for job %s, retrying in %d seconds",
-                        jobnr_char, retry_interval);
+                    torque_debug(driver,
+                                 "qstat failed for job %s with exit code "
+                                 "%d, retrying in %d seconds",
+                                 jobnr_char, return_value, retry_interval);
                     sleep(retry_interval);
                     slept_time += retry_interval;
                     retry_interval *= 2;


### PR DESCRIPTION
std::error_code is true when there is an error, not the other way around

**Issue**
Resolves #5548 


**Approach**
Read documentation and figure out how ec evaluates to bools.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
