### PR TITLE
Fix bug where a single gen_data point was not loaded

### DIFF
--- a/src/ert/_c_wrappers/enkf/enkf_state.py
+++ b/src/ert/_c_wrappers/enkf/enkf_state.py
@@ -34,7 +34,7 @@ def _internalize_GEN_DATA(
                 errors.append(f"{key} report step {report_step} missing")
                 continue
 
-            data = np.loadtxt(run_path / filename)
+            data = np.loadtxt(run_path / filename, ndmin=1)
             active_information_file = run_path / (filename + "_active")
             if active_information_file.exists():
                 index_list = np.flatnonzero(np.loadtxt(active_information_file))


### PR DESCRIPTION
A single value to np.loadtxt is by default given dimension 0

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
