### PR TITLE
Avoid trusting zero exit code from qstat (backport to version-5.0)

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -616,18 +616,30 @@ torque_driver_get_qstat_status(torque_driver_type *driver,
            every second for every realization, thus the initial sleep time
            is 2 seconds. */
         int return_value = -1;
+        bool qstat_succeeded = false;
         int retry_interval = 2; /* seconds */
         int slept_time = 0;
-        while ((return_value != 0) && (slept_time <= driver->timeout)) {
+        while ((!qstat_succeeded) && (slept_time <= driver->timeout)) {
             return_value =
                 util_spawn_blocking(driver->qstat_cmd, argv.size(), argv.data(),
                                     tmp_std_file, tmp_err_file);
-            if (return_value != 0) {
+            // A non-zero return value is trusted, but a zero return-value
+            // is not trusted unless the output has nonzero length.
+            // ERT never calls qstat unless it has already submitted something, and
+            // can therefore assume that qstat results about Unknown Job Id are
+            // failures (these have nonzero output length, but return value != 0)
+            // that should trigger retries.
+            if (std::error_code ec; fs::file_size(tmp_std_file, ec) > 0 &&
+                                    !ec && return_value == 0) {
+                qstat_succeeded = true;
+            }
+
+            if (!qstat_succeeded) {
                 if (slept_time + retry_interval <= driver->timeout) {
-                    torque_debug(
-                        driver,
-                        "qstat failed for job %s, retrying in %d seconds",
-                        jobnr_char, retry_interval);
+                    torque_debug(driver,
+                                 "qstat failed for job %s with exit code "
+                                 "%d, retrying in %d seconds",
+                                 jobnr_char, return_value, retry_interval);
                     sleep(retry_interval);
                     slept_time += retry_interval;
                     retry_interval *= 2;

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
@@ -372,6 +372,19 @@ def test_no_such_job_id(tmpdir, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")
+def test_proxy_fails_if_backend_fails(tmpdir, monkeypatch):
+    monkeypatch.chdir(tmpdir)
+    with pytest.raises(subprocess.CalledProcessError), testpath.MockCommand(
+        "qstat", python=MOCKED_QSTAT_BACKEND_FAILS
+    ):
+        subprocess.run(
+            [PROXYSCRIPT, "15399", PROXYFILE_FOR_TESTS],
+            check=True,
+            capture_output=False,
+        )
+
+
+@pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")
 def test_no_argument(tmpdir, monkeypatch):
     """qstat with no arguments lists all jobs. So should the proxy."""
     monkeypatch.chdir(tmpdir)

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -135,6 +135,10 @@ exit 1
 """
 )
 
+# A qstat command that has no output but return code 0 on first invocation
+# and nonzero output and return code 0 on second invocation:
+LYING_QSTAT = FLAKY_QSTAT.replace("exit 1", "exit 0")
+
 
 def _deploy_script(scriptname: Path, scripttext: str):
     script = Path(scriptname)
@@ -175,6 +179,7 @@ def _build_jobqueuenode(dummy_config: JobConfig, job_id=0):
         pytest.param(FLAKY_QSUB, MOCK_QSTAT, id="flaky_qsub"),
         pytest.param(MOCK_QSUB, FLAKY_QSTAT, id="flaky_qstat"),
         pytest.param(FLAKY_QSUB, FLAKY_QSTAT, id="all_flaky"),
+        pytest.param(MOCK_QSUB, LYING_QSTAT, id="lying_qstat"),
     ],
 )
 def test_run_torque_job(


### PR DESCRIPTION
Experience shows that a zero exit code from qstat (or qstat_proxy) is sometimes zero also in case of failures. So to trust a zero exit code, we also require that the output file has length more than zero.

Failure codes from qstat is trusted as before.

This relies on:
 * ERT never asks the queue system for status unless it has actually submitted something
 * ERT only asks for status for jobs it has submitted, and when a job is finished, it is still reported by the queue system (accomplished by the -x default option).

This PR also adds a test verifying that the qstat_proxy would forward a nonzero exit code.
