### PR TITLE
Increase sleep in job queue node threads

### DIFF
--- a/src/ert/_c_wrappers/job_queue/job_queue_node.py
+++ b/src/ert/_c_wrappers/job_queue/job_queue_node.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import time
 from threading import Lock, Semaphore, Thread
 from typing import TYPE_CHECKING, Optional
@@ -185,13 +186,26 @@ class JobQueueNode(BaseCClass):
 
         current_status = self.refresh_status(driver)
 
+        initial_sleep_seconds = 1
+        time_sleep_seconds = initial_sleep_seconds
+        max_sleep_seconds = 30
+        use_random_sleep_offset = False
         while self.is_running(current_status):
             if (
                 self._start_time is None
                 and current_status == JobStatusType.JOB_QUEUE_RUNNING
             ):
                 self._start_time = time.time()
-            time.sleep(1)
+            if (
+                self._start_time is not None
+                and time_sleep_seconds != max_sleep_seconds
+                and time.time() - self._start_time > 30
+            ):
+                time_sleep_seconds = max_sleep_seconds
+                use_random_sleep_offset = True
+            time.sleep(
+                time_sleep_seconds + use_random_sleep_offset * random.randint(-5, 5)
+            )
             if self._max_runtime is not None and self.runtime >= self._max_runtime:
                 self._kill(driver)
                 # We sometimes end up in a state where we are not able to kill it,


### PR DESCRIPTION
Cherry-picked Valentin's progressive time.sleep in job_queue.
The job queue node monitors the job running on a a single compute node, which is responsible for running all forward models for one realization, and runs in its own thread.

It queries the queue system regularly, in between sleeps.

We suspect that an increase of realizations, which leads to an increase of threads, starves other threads for resources, for instance the thread of the ensemble evaluator server, which in turn leads to timeouts in connections the server holds.

We increase the sleep duration (after an initial start-up phase) and add a random offset to stagger execution of the job threads.

**Issue**
Links to #5273 


**Approach**
Do a progressive and random sleep times after 30 seconds of running _job_monitor. This is a pure ad-hoc solution, which needs to be tested first.


## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
