### PR TITLE
Fix an issue with flakiness in gui test

### DIFF
--- a/tests/unit_tests/gui/plottery/test_plotting_of_snake_oil.py
+++ b/tests/unit_tests/gui/plottery/test_plotting_of_snake_oil.py
@@ -64,7 +64,7 @@ def test_that_all_snake_oil_visualisations_matches_snapshot(
                                 selected_key["dimensionality"]
                                 == tab._plotter.dimensionality
                             )
-                            return tab._figure
+                            return tab._figure.figure
                         else:
                             assert (
                                 selected_key["dimensionality"]


### PR DESCRIPTION
Due to tab._figure.figure being a FigureCanvasQTAgg it may be deleted before mpl_image_compare gets to save it.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
