### PR TITLE
Fix ES-MDA CLI parser missing current_case

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -419,6 +419,13 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         ES_MDA_MODE, description=es_mda_description, help=es_mda_description
     )
     es_mda_parser.add_argument(
+        "--current-case",
+        type=valid_name,
+        default="default",
+        help="Name of the case where the results for the simulation "
+        "using the prior parameters will be stored.",
+    )
+    es_mda_parser.add_argument(
         "--target-case",
         type=valid_name_format,
         help="The es_mda creates multiple cases for the different "


### PR DESCRIPTION
Resolves: #5096 

The CLI is a mess and I am not sure whether this should even be used. This functionality means that not adding any options would default target case to `default_%d`.

See: https://github.com/equinor/ert/blob/d66e7d2f8a87b2a7bc77d8af9fe888a22a880b5f/src/ert/cli/model_factory.py#L173

Tested by going into `poly_example` and doing `ert es_mda poly.ert`, noting that no options were required and everything is happy.