### PR TITLE
Do not add _prior suffix to ES runs

### DIFF
--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -91,7 +91,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
     def getSimulationArguments(self):
         arguments = Arguments(
             mode="ensemble_smoother",
-            current_case=f"{self.notifier.current_case_name}_prior",
+            current_case=self.notifier.current_case_name,
             target_case=self._target_case_model.getValue(),
             realizations=self._active_realizations_field.text(),
         )


### PR DESCRIPTION
In ERT 4, running ES with default settings will create the ensembles `default` and `default_smoother_update`. Creating with user set `current_case` and `target_case` will create three ensembles, where there is an empty `default` ensemble together with the two non-empty set by the user.

This preserves this behaviour in ERT 5.