### PR TITLE
Resolve timeout problems around running >= 200 realizations

### DIFF
--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -81,6 +81,10 @@ class Client:  # pylint: disable=too-many-instance-attributes
             self.url,
             ssl=self._ssl_context,
             extra_headers=self._extra_headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         )
 
     async def _send(self, msg: AnyStr) -> None:

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -12,24 +12,14 @@ import threading
 import time
 from collections import deque
 from threading import Semaphore
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Union
 
 from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
 from cwrap import BaseCClass
-from websockets.client import connect
+from websockets.client import WebSocketClientProtocol, connect
 from websockets.datastructures import Headers
-from websockets.exceptions import ConnectionClosedError
+from websockets.exceptions import ConnectionClosed
 
 import _ert_com_protocol
 from ert._c_wrappers import ResPrototype
@@ -231,14 +221,11 @@ class JobQueue(BaseCClass):
         self._free()
 
     def is_active(self) -> bool:
-        for job in self.job_list:
-            if job.thread_status in (
-                ThreadStatus.READY,
-                ThreadStatus.RUNNING,
-                ThreadStatus.STOPPING,
-            ):
-                return True
-        return False
+        return any(
+            job.thread_status
+            in (ThreadStatus.READY, ThreadStatus.RUNNING, ThreadStatus.STOPPING)
+            for job in self.job_list
+        )
 
     def fetch_next_waiting(self) -> Optional[JobQueueNode]:
         for job in self.job_list:
@@ -385,9 +372,7 @@ class JobQueue(BaseCClass):
     async def _publish_changes(
         ens_id: str,
         changes: Dict[int, str],
-        ws_uri: str,
-        ssl_context: Optional[Union[bool, ssl.SSLContext]],
-        headers: Mapping[str, str],
+        ee_connection: WebSocketClientProtocol,
     ) -> None:
         events = deque(
             [
@@ -395,50 +380,29 @@ class JobQueue(BaseCClass):
                 for real_id, status in changes.items()
             ]
         )
+        while events:
+            await asyncio.wait_for(ee_connection.send(to_json(events[0])), 60)
+            events.popleft()
 
-        async for websocket in connect(
-            ws_uri,
-            ssl=ssl_context,
-            extra_headers=headers,
+    async def _execution_loop_queue_via_websockets(
+        self,
+        ee_uri: str,
+        ens_id: str,
+        pool_sema: threading.BoundedSemaphore,
+        evaluators: List[Callable[..., Any]],
+        ee_ssl_context,
+        ee_headers,
+    ) -> None:
+        async for ee_connection in connect(
+            ee_uri,
+            ssl=ee_ssl_context,
+            extra_headers=ee_headers,
             open_timeout=60,
             ping_timeout=60,
             ping_interval=60,
             close_timeout=60,
         ):
             try:
-                while events:
-                    await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
-                    events.popleft()
-                return
-            except ConnectionClosedError:
-                continue
-
-    async def execute_queue_via_websockets(  # pylint: disable=too-many-arguments
-        self,
-        ws_uri: str,
-        ens_id: str,
-        pool_sema: threading.BoundedSemaphore,
-        evaluators: List[Callable[..., Any]],
-        cert: Optional[Union[str, bytes]] = None,
-        token: Optional[str] = None,
-    ) -> None:
-        if evaluators is None:
-            evaluators = []
-        ssl_context: Optional[Union[ssl.SSLContext, bool]]
-        if cert is not None:
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            ssl_context.load_verify_locations(cadata=cert)
-        else:
-            ssl_context = True if ws_uri.startswith("wss") else None
-        headers = Headers()
-        if token is not None:
-            headers["token"] = token
-
-        try:
-            await JobQueue._publish_changes(
-                ens_id, self._differ.snapshot(), ws_uri, ssl_context, headers
-            )
-            while True:
                 self.launch_jobs(pool_sema)
 
                 await asyncio.sleep(1)
@@ -446,19 +410,68 @@ class JobQueue(BaseCClass):
                 for func in evaluators:
                     func()
 
-                await JobQueue._publish_changes(
-                    ens_id,
-                    self.changes_after_transition(),
-                    ws_uri,
-                    ssl_context,
-                    headers,
-                )
+                changes = self.changes_after_transition()
+                # logically not necessary the way publish changes is implemented at the
+                # moment, but highly relevant before, and might be relevant in the
+                # future in case publish changes becomes expensive again
+                if len(changes) > 0:
+                    await JobQueue._publish_changes(
+                        ens_id,
+                        changes,
+                        ee_connection,
+                    )
 
                 if self.stopped:
                     raise asyncio.CancelledError
 
                 if not self.is_active():
                     break
+            except ConnectionClosed:
+                logger.warning(
+                    "job queue dropped connection to ensemble evaulator - "
+                    "going to try and reconnect"
+                )
+                continue
+
+    async def execute_queue_via_websockets(  # pylint: disable=too-many-arguments
+        self,
+        ee_uri: str,
+        ens_id: str,
+        pool_sema: threading.BoundedSemaphore,
+        evaluators: List[Callable[..., Any]],
+        ee_cert: Optional[Union[str, bytes]] = None,
+        ee_token: Optional[str] = None,
+    ) -> None:
+        if evaluators is None:
+            evaluators = []
+        ee_ssl_context: Optional[Union[ssl.SSLContext, bool]]
+        if ee_cert is not None:
+            ee_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ee_ssl_context.load_verify_locations(cadata=ee_cert)
+        else:
+            ee_ssl_context = True if ee_uri.startswith("wss") else None
+        ee_headers = Headers()
+        if ee_token is not None:
+            ee_headers["token"] = ee_token
+
+        try:
+            # initial publish
+            async with connect(
+                ee_uri,
+                ssl=ee_ssl_context,
+                extra_headers=ee_headers,
+                open_timeout=60,
+                ping_timeout=60,
+                ping_interval=60,
+                close_timeout=60,
+            ) as ee_connection:
+                await JobQueue._publish_changes(
+                    ens_id, self._differ.snapshot(), ee_connection
+                )
+            # loop
+            await self._execution_loop_queue_via_websockets(
+                ee_uri, ens_id, pool_sema, evaluators, ee_ssl_context, ee_headers
+            )
 
         except asyncio.CancelledError:
             logger.debug("queue cancelled, stopping jobs...")
@@ -477,9 +490,19 @@ class JobQueue(BaseCClass):
 
         self.assert_complete()
         self._differ.transition(self.job_list)
-        await JobQueue._publish_changes(
-            ens_id, self._differ.snapshot(), ws_uri, ssl_context, headers
-        )
+        # final publish
+        async with connect(
+            ee_uri,
+            ssl=ee_ssl_context,
+            extra_headers=ee_headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
+        ) as ee_connection:
+            await JobQueue._publish_changes(
+                ens_id, self._differ.snapshot(), ee_connection
+            )
 
     async def execute_queue_comms_via_bus(  # pylint: disable=too-many-arguments
         self,

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -396,36 +396,14 @@ class JobQueue(BaseCClass):
             ]
         )
 
-        retries = 0
-        while True:
+        async for websocket in connect(ws_uri, ssl=ssl_context, extra_headers=headers):
             try:
-                async with connect(
-                    ws_uri, ssl=ssl_context, extra_headers=headers
-                ) as websocket:
-                    while events:
-                        await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
-                        events.popleft()
-                    return
-            except (ConnectionClosedError, asyncio.TimeoutError) as e:
-                if retries >= 10:
-                    logger.exception(
-                        "Connection to websocket %s failed, unable to publish changes",
-                        ws_uri,
-                    )
-                    raise
-
-                # websockets for python > 3.6 comes with builtin backoff, implement a
-                # crude one here
-                retries += 1
-                backoff = max(3, min(60, 2**retries))
-                logger.info(
-                    "Connection to websocket %s was closed, retry in %d seconds.",
-                    ws_uri,
-                    backoff,
-                    exc_info=e,
-                )
-
-                await asyncio.sleep(backoff)
+                while events:
+                    await asyncio.wait_for(websocket.send(to_json(events[0])), 60)
+                    events.popleft()
+                return
+            except ConnectionClosedError:
+                continue
 
     async def execute_queue_via_websockets(  # pylint: disable=too-many-arguments
         self,

--- a/src/ert/_c_wrappers/job_queue/queue.py
+++ b/src/ert/_c_wrappers/job_queue/queue.py
@@ -396,7 +396,15 @@ class JobQueue(BaseCClass):
             ]
         )
 
-        async for websocket in connect(ws_uri, ssl=ssl_context, extra_headers=headers):
+        async for websocket in connect(
+            ws_uri,
+            ssl=ssl_context,
+            extra_headers=headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
+        ):
             try:
                 while events:
                     await asyncio.wait_for(websocket.send(to_json(events[0])), 60)

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -300,8 +300,8 @@ class LegacyEnsemble(Ensemble):
                     self.id_,
                     sema,
                     queue_evaluators,  # type: ignore
-                    cert=self._config.cert,
-                    token=self._config.token,
+                    ee_cert=self._config.cert,
+                    ee_token=self._config.token,
                 )
 
         except asyncio.CancelledError:

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -43,16 +43,26 @@ class BatchingDispatcher:
             self._buffer[: self._max_batch],
             self._buffer[self._max_batch :],
         )
+        left_in_queue = len(self._buffer)
+
         function_to_events_map = OrderedDict()
         for f, event in event_buffer:
             if f not in function_to_events_map:
                 function_to_events_map[f] = []
             function_to_events_map[f].append(event)
-        logger.debug(
-            f"processed {len(event_buffer)} events in {(time.time()-t0):.6f}s. {len(self._buffer)} left in queue"  # noqa: E501
+
+        def done_logger(_):
+            logger.debug(
+                f"processed {len(event_buffer)} events in "
+                f"{(time.time()-t0):.6f}s. "
+                f"{left_in_queue} left in queue"
+            )
+
+        events_handling = asyncio.gather(
+            *[f(events) for f, events in function_to_events_map.items()]
         )
-        for f, events in function_to_events_map.items():
-            await f(events)
+        events_handling.add_done_callback(done_logger)
+        await events_handling
 
     async def _job(self):
         while self._running:

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -38,6 +38,10 @@ class BatchingDispatcher:
         asyncio.gather(*[f([]) for f, _ in funcs])
 
     async def _work(self):
+        if len(self._buffer) == 0:
+            logger.debug("no events to be processed in queue")
+            return
+
         t0 = time.time()
         event_buffer, self._buffer = (
             self._buffer[: self._max_batch],

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -43,21 +43,21 @@ class BatchingDispatcher:
             return
 
         t0 = time.time()
-        event_buffer, self._buffer = (
+        batch_of_events_for_processing, self._buffer = (
             self._buffer[: self._max_batch],
             self._buffer[self._max_batch :],
         )
         left_in_queue = len(self._buffer)
 
         function_to_events_map = OrderedDict()
-        for f, event in event_buffer:
+        for f, event in batch_of_events_for_processing:
             if f not in function_to_events_map:
                 function_to_events_map[f] = []
             function_to_events_map[f].append(event)
 
         def done_logger(_):
             logger.debug(
-                f"processed {len(event_buffer)} events in "
+                f"processed {len(batch_of_events_for_processing)} events in "
                 f"{(time.time()-t0):.6f}s. "
                 f"{left_in_queue} left in queue"
             )

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -289,6 +289,9 @@ class EnsembleEvaluator:
             process_request=self.process_request,
             max_queue=None,
             max_size=2**26,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         ):
             await self._done
             if self._dispatchers_connected is not None:

--- a/src/ert/ensemble_evaluator/sync_ws_duplexer.py
+++ b/src/ert/ensemble_evaluator/sync_ws_duplexer.py
@@ -71,6 +71,10 @@ class SyncWebsocketDuplexer:
             extra_headers=self._extra_headers,
             max_size=2**26,
             max_queue=500,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
         )
 
         await wait_for_evaluator(

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -106,6 +106,9 @@ loggers:
   ert._c_wrappers:
     level: INFO
     propagate: yes
+  ert._c_wrappers.job_queue:
+    level: DEBUG
+    propagate: yes
   ert.analysis:
     level: DEBUG
     propagate: yes
@@ -115,7 +118,7 @@ loggers:
   ert._c_wrappers.enkf.enkf_main:
     level: DEBUG
     propagate: yes
-    
+
 
 root:
   level: DEBUG

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import stat
 import time
@@ -6,10 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import BoundedSemaphore
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
-from websockets.exceptions import ConnectionClosedError
+from unittest.mock import MagicMock, patch
 
 from ert._c_wrappers.job_queue import (
     Driver,
@@ -291,44 +287,6 @@ def test_add_dispatch_info_cert_none(tmpdir, monkeypatch):
 
         assert content["ee_cert_path"] is None
         assert not (runpath / cert_file).exists()
-
-
-@pytest.mark.timeout(20)
-@pytest.mark.asyncio
-async def test_retry_on_closed_connection(tmpdir, monkeypatch):
-    monkeypatch.chdir(tmpdir)
-    job_queue = create_local_queue(SIMPLE_SCRIPT, max_submit=1)
-    pool_sema = BoundedSemaphore(value=10)
-
-    with patch("ert._c_wrappers.job_queue.queue.connect") as queue_connection:
-        websocket_mock = AsyncMock()
-        queue_connection.side_effect = [
-            ConnectionClosedError(1006, "expected close"),
-            websocket_mock,
-        ]
-
-        # the queue ate both the exception, and the websocket_mock, trying to
-        # consume a third item from the mock causes an (expected) exception
-        with pytest.raises(RuntimeError, match="coroutine raised StopIteration"):
-            await job_queue.execute_queue_via_websockets(
-                ws_uri="ws://example.org",
-                ens_id="",
-                pool_sema=pool_sema,
-                evaluators=[],
-            )
-
-        # one fails, the next is a mock, the third is a StopIteration
-        assert (
-            queue_connection.call_count == 3
-        ), "unexpected number of connect calls {f.call_count}"
-
-        # there will be many send calls in here, but the main point it tried
-        assert len(websocket_mock.mock_calls) > 0, "the websocket was never called"
-
-    # job_queue cannot go out of scope before queue has completed
-    await job_queue.stop_jobs_async()
-    while job_queue.isRunning:
-        await asyncio.sleep(0.1)
 
 
 class MockedJob:


### PR DESCRIPTION
**Issue**
Resolves #5273


**Approach**
The failing symptoms occur in components communicating over websockets, in particular the ensemble evaluator as a server and the job queue, gui/cli, and job dispatch scripts as clients.

There are several improvements around the communication between those components.
The main (suspected) fix is backing of the so-called `JobQueueNode` busy business, by letting it sleep for a longer amount of time instead of one second between each querying of the queue system.
Rationale behind this is that the `JobQueueNode` keeps track of the state of a whole realization, with coarse resolution (not considering forward models). For long running realizations (>= 1h) it is quite unnecessary to query the state every second, as it does not change as long as the realization is running.
Given that each `JobQueueNode` runs in its own thread, @berland had the idea that this might starve components running in other threads for resources, which was somewhat confirmed by looking at timing logs (how long did some processing take) and their respective timestamps.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT RELEVANT - Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
