### PR TITLE
Create .fs_version in storage

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -167,6 +167,13 @@ class LocalStorageAccessor(LocalStorageReader):
 
         self.path.mkdir(parents=True, exist_ok=True)
 
+        # ERT 4 checks that this file exists and if it exists tells the user
+        # that their ERT storage is incompatible
+        try:
+            (self.path / ".fs_version").symlink_to("index.json")
+        except FileExistsError:
+            pass
+
         self._lock = FileLock(self.path / "storage.lock")
         try:
             self._lock.acquire(timeout=self.LOCK_TIMEOUT)


### PR DESCRIPTION
This file is used by newer versions of ERT 4 to determine whether there should be an error when loading.

Resolves: #5600 

Tested by running `ert gui` on `poly_example`, then checking out ERT 4.5.6 and running `ert gui` again, noting that the output is.
```
(venv) zohar@nixbox ~/D/E/F/e/t/poly_example ((4.5.6))> ert gui poly.ert
ERT crashed unexpectedly with "Trying to load storage created by a newer file system version: Current version: 0, found on disk: 1".
See logfile(s) for details:
   /var/home/zohar/Develop/Equinor/FMU/ert/test-data/poly_example/logs/ert-log-2023-06-20T1058.txt
```