### PR TITLE
Change TransformationDirection.__str__ for mypy

### DIFF
--- a/src/ert/data/record/_transformation.py
+++ b/src/ert/data/record/_transformation.py
@@ -33,15 +33,15 @@ class TransformationDirection(Flag):
     """Transformation is able to transform in both directions."""
 
     def __str__(self) -> str:
-        if self == self.__class__.FROM_RECORD:
+        if self == TransformationDirection.FROM_RECORD:
             return "from_record"
-        elif self == self.__class__.TO_RECORD:
+        elif self == TransformationDirection.TO_RECORD:
             return "to_record"
-        elif self == self.__class__.BIDIRECTIONAL:
+        elif self == TransformationDirection.BIDIRECTIONAL:
             return "bidirectional"
-        elif self == self.__class__.NONE:
+        elif self == TransformationDirection.NONE:
             return "none"
-        raise ValueError
+        raise ValueError()
 
 
 def _prepare_location(root_path: Path, location: Path) -> None:


### PR DESCRIPTION
Changes the __str__ for TransformationDirection so that mypy is happy. The `__str__` was made so that overloading of TransformationDirection would preserve the behavior of `__str__` but it is not possible to extend an enumeration in any case.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
