### PR TITLE
Ensure that migrating EXT_PARAM throws

### DIFF
--- a/src/clib/lib/block_fs_native/module.cpp
+++ b/src/clib/lib/block_fs_native/module.cpp
@@ -209,7 +209,6 @@ public:
 
                 case Kind::surface:
                 case Kind::gen_kw:
-                case Kind::ext_param:
                     // The count is given in the config and not available in the
                     // data file, but we can make an informed guess by looking
                     // at the size of the whole data section
@@ -219,6 +218,10 @@ public:
                 case Kind::field:
                     // The count is given in the config
                     break;
+
+                case Kind::ext_param:
+                    throw std::runtime_error(
+                        "Migrating EXT_PARAM is not supported");
 
                 default:
                     continue;

--- a/tests/unit_tests/storage/migration/test_block_fs_ext_param.py
+++ b/tests/unit_tests/storage/migration/test_block_fs_ext_param.py
@@ -1,0 +1,48 @@
+import logging
+
+import pytest
+
+import ert.storage
+import ert.storage.migration.block_fs as bf
+from ert._c_wrappers.enkf import ErtConfig
+from ert.storage.local_storage import local_storage_set_ert_config
+
+
+@pytest.fixture(scope="module")
+def enspath(block_storage_path):
+    return block_storage_path / "ext_param/storage"
+
+
+@pytest.fixture(scope="module")
+def ert_config(block_storage_path):
+    return ErtConfig.from_file(str(block_storage_path / "ext_param/config.ert"))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_ert_config(ert_config):
+    yield local_storage_set_ert_config(ert_config)
+    local_storage_set_ert_config(None)
+
+
+def test_migration_failure(storage, enspath, caplog, monkeypatch):
+    """Run migration but fail due to missing config data. Expected behaviour is
+    for the error to be logged but no exception be propagated.
+
+    """
+    monkeypatch.setattr(ert.storage, "open_storage", lambda: storage)
+
+    # Sanity check: no ensembles are created before migration
+    assert list(storage.ensembles) == []
+
+    with caplog.at_level(logging.WARNING, logger="ert.storage.migration.block_fs"):
+        bf._migrate_case_ignoring_exceptions(storage, enspath / "sim_fs")
+
+    # No ensembles were created due to failure
+    assert list(storage.ensembles) == []
+
+    # Warnings are in caplog
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "Exception occurred during migration of BlockFs case 'sim_fs': "
+        "Migrating EXT_PARAM is not supported"
+    )


### PR DESCRIPTION
We have decided not to support EXT_PARAM due to them being added to the EnsembleConfig at runtime, making it difficult to create a migration tool.