### PR TITLE
Speed up slow test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,12 +45,12 @@ jobs:
     - name: Test Integration
       if: matrix.test-type == 'integration-tests'
       run: |
-        pytest tests/ --cov=ert -m "integration_test" --cov-report=xml:cov.xml
+        pytest tests/ -n4 --cov=ert -m "integration_test" --cov-report=xml:cov.xml
 
     - name: Test units
       if: matrix.test-type == 'unit-tests'
       run: |
-        pytest tests/ --cov=ert -m "not integration_test and not requires_window_manager" --cov-report=xml:cov.xml
+        pytest tests/ -n4 --cov=ert -m "not integration_test and not requires_window_manager" --cov-report=xml:cov.xml --dist loadgroup
 
     - name: Upload python coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/src/ert/parsing/file_context_token.py
+++ b/src/ert/parsing/file_context_token.py
@@ -78,5 +78,7 @@ class FileContextToken(Token):
         )
 
     def replace_value(self, old: str, new: str, count: int = -1) -> "FileContextToken":
-        replaced = self.value.replace(old, new, count)
-        return FileContextToken(self.update(value=replaced), filename=self.filename)
+        if old in self.value:
+            replaced = self.value.replace(old, new, count)
+            return FileContextToken(self.update(value=replaced), filename=self.filename)
+        return self

--- a/tests/test_config_parsing/test_enkf_obs_parsing.py
+++ b/tests/test_config_parsing/test_enkf_obs_parsing.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import ExitStack as does_not_raise
 from datetime import datetime
 from pathlib import Path
@@ -17,12 +18,12 @@ from .config_dict_generator import config_generators
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.filterwarnings("ignore::ert.parsing.ConfigWarning")
-@pytest.mark.usefixtures("set_site_config")
 @given(config_generators(use_eclbase=st.just(True)))
 def test_that_enkf_obs_keys_are_ordered(tmp_path_factory, config_generator):
-    filename = "config.ert"
-    with config_generator(tmp_path_factory, filename) as config_values:
-        ert_config = ErtConfig.from_file(filename)
+    with config_generator(tmp_path_factory) as config_values:
+        ert_config = ErtConfig.from_dict(
+            config_values.to_config_dict("test.ert", os.getcwd())
+        )
         observations = EnkfObs.from_ert_config(ert_config)
         for o in config_values.observations:
             assert observations.hasKey(o.name)

--- a/tests/test_config_parsing/test_ensemble_config.py
+++ b/tests/test_config_parsing/test_ensemble_config.py
@@ -1,17 +1,18 @@
+import os
+
 import pytest
 from hypothesis import assume, given
 
 from ert._c_wrappers.enkf import ErtConfig
 
-from .config_dict_generator import config_generators, to_config_file
+from .config_dict_generator import config_generators
 
 
 @given(config_generators())
 def test_ensemble_config_errors_on_unknown_function_in_field(
     tmp_path_factory, config_generator
 ):
-    filename = "config.ert"
-    with config_generator(tmp_path_factory, filename) as config_values:
+    with config_generator(tmp_path_factory) as config_values:
         assume(len(config_values.field) > 0)
 
         silly_function_name = "NORMALIZE_EGGS"
@@ -29,9 +30,10 @@ def test_ensemble_config_errors_on_unknown_function_in_field(
 
         config_values.field = mylist
 
-        to_config_file(filename, config_values)
         with pytest.raises(
             expected_exception=ValueError,
             match=f"FIELD INIT_TRANSFORM:{silly_function_name} is an invalid function",
         ):
-            ErtConfig.from_file(filename)
+            _ = ErtConfig.from_dict(
+                config_values.to_config_dict("test.ert", os.getcwd())
+            )

--- a/tests/test_config_parsing/test_forward_model.py
+++ b/tests/test_config_parsing/test_forward_model.py
@@ -10,14 +10,13 @@ from hypothesis import given
 from ert._c_wrappers.enkf import ErtConfig
 from ert.parsing import ConfigValidationError, ConfigWarning
 
-from .config_dict_generator import config_generators, to_config_file
+from .config_dict_generator import config_generators
 
 
 @given(config_generators())
 def test_ert_config_throws_on_missing_forward_model_job(
     tmp_path_factory, config_generator
 ):
-    filename = "config.ert"
     with config_generator(tmp_path_factory) as config_values:
         config_values.install_job = []
         config_values.install_job_directory = []
@@ -25,10 +24,10 @@ def test_ert_config_throws_on_missing_forward_model_job(
             ["this-is-not-the-job-you-are-looking-for", "<WAVE-HAND>=casually"]
         )
 
-        to_config_file(filename, config_values)
-
         with pytest.raises(expected_exception=ValueError, match="Could not find job"):
-            ErtConfig.from_file(filename)
+            _ = ErtConfig.from_dict(
+                config_values.to_config_dict("test.ert", os.getcwd())
+            )
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
Use `set_siteconfig` fixture to avoid parsing. This reduces the time taken by about half. Unfortunately, this still means that we parse the extjob configs so it is still not very fast.

Also sets up coverage to use xdist.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
