### PR TITLE
Introduce random sleep when sending events from reporter

### DIFF
--- a/src/_ert_job_runner/reporting/event.py
+++ b/src/_ert_job_runner/reporting/event.py
@@ -1,7 +1,9 @@
 import datetime
 import logging
 import queue
+import random
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict
 
@@ -81,6 +83,7 @@ class Event(Reporter):
 
     def _event_publisher(self):
         logger.debug("Publishing event.")
+        time_sleep_seconds = 0.5
         with Client(
             url=self._evaluator_url,
             token=self._token,
@@ -104,6 +107,9 @@ class Event(Reporter):
                 try:
                     client.send(to_json(event).decode())
                     event = None
+                    # sleep between (0.25, 0.75) seconds to slow down
+                    # reporting from ultra fast jobs
+                    time.sleep(time_sleep_seconds + random.random() / 2.0 - 0.25)
                 except ClientConnectionError as exception:
                     # Possible intermittent failure, we retry sending the event
                     logger.debug(str(exception))

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -55,18 +55,13 @@ class BatchingDispatcher:
                 function_to_events_map[f] = []
             function_to_events_map[f].append(event)
 
-        def done_logger(_):
-            logger.debug(
-                f"processed {len(batch_of_events_for_processing)} events in "
-                f"{(time.time()-t0):.6f}s. "
-                f"{left_in_queue} left in queue"
-            )
-
-        events_handling = asyncio.gather(
-            *[f(events) for f, events in function_to_events_map.items()]
+        for f, events in function_to_events_map.items():
+            await f(events)
+        logger.debug(
+            f"processed {len(batch_of_events_for_processing)} events in "
+            f"{(time.time()-t0):.6f}s. "
+            f"{left_in_queue} left in queue"
         )
-        events_handling.add_done_callback(done_logger)
-        await events_handling
 
     async def _job(self):
         while self._running:


### PR DESCRIPTION
**Issue**
Ultra fast jobs can quickly clog the ensemble evaluator by reporting to many events.


**Approach**
Introduce random time.sleep , when sending events. Additionally, make sure that the events in `BatchingDispatcher` are processed in the correct order.


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
