### PR TITLE
Add flake8-bugbear to CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ cmake-format
 decorator
 ecl_data_io
 flake8
+flake8-bugbear
 grpcio-tools==1.41.0
 hypothesis
 isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,16 @@ per-file-ignores =
      src/ert/experiment_server/_server.py: E501
      # Ignore all protobuf v2 files
     *_pb2.py: E
-# We ignore only things that black takes (better) care of:
 ignore =
+    # whitespace before ':'; solved by black:
     E203
+    # line break before binary operator, solved by black:
     W503
+    # The minimal set of ignores that makes flake8 pass when flake8-bugbear is installed:
+    B008
+    B009
+    B014
+    B017
+    B019
+    B028
 max-line-length = 88


### PR DESCRIPTION
Ignoring error for now

**Issue**
Resolves need for CI infrastructure to solve warnings emitted by flake8-bugbear


**Approach**
Add to dev-requirements and add needed exceptions.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
