### PR TITLE
Add a missing popd in testkomodo.sh

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -40,6 +40,7 @@ EOF
             cat realization-0/iter-0/FLOW.stdout.0 || true
             cat logs/ert-log* || true
         )
+    popd
 }
 
 start_tests () {


### PR DESCRIPTION
The introduction of the OPM test added a new pushd which was not paired with a popd.

The consequence was that the github action workflow file no longer was able to locate ci/run_ert_ctests.sh (which for now fails silently).

**Issue**
Resolves 

```
+ [[ -s ci/run_ert_ctests.sh ]]
+ echo 'ci/run_ert_ctests.sh not available: ctests not running.'

```
in https://github.com/equinor/komodo-releases/actions/runs/5384406340/jobs/9773011256

**Approach**
👀 🧠 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
