### PR TITLE
Remove no longer used queue functions

### DIFF
--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -63,9 +63,6 @@ extern "C" PY_USED bool job_queue_node_kill_simple(job_queue_node_type *node,
 extern "C" void job_queue_node_free(job_queue_node_type *node);
 extern "C" job_status_type
 job_queue_node_get_status(const job_queue_node_type *node);
-PY_USED bool job_queue_node_update_status(job_queue_node_type *node,
-                                          job_queue_status_type *status,
-                                          queue_driver_type *driver);
 extern "C" PY_USED job_status_type job_queue_node_refresh_status(
     job_queue_node_type *node, queue_driver_type *driver);
 extern "C" int


### PR DESCRIPTION
Possible after 7192d0d0b43cdd7e45e27352249a033cff376d40

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] IRRELEVANT Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
