### PR TITLE
Remove outdated documentation about numerical schemes

### DIFF
--- a/docs/theory/ensemble_based_methods.rst
+++ b/docs/theory/ensemble_based_methods.rst
@@ -329,48 +329,6 @@ The pseudo algorithm for ES:
 5) Run the forward model :math:`Y_a = g(X_a)` to obtain the posterior simulated responses
 
 
-Numerical schemes
-------------------
-
-There are several numerical schemes, i.e. methods to estimate the Kalman gain matrix
-
-.. math::
-   \bar{C}_{xy}(\bar{C}_{xy}^{f}\bar{C}_{xx}^{-1}\bar{C}_{xy}+\bar{C}_{dd})^{-1}
-
-implemented in ERT.
-
-
-STD EnKF
-~~~~~~~~
-
-The recommended scheme.
-
-
-SQRT EnKF
-~~~~~~~~~
-
-
-
-NULL ENKF
-~~~~~~~~~
-
-
-
-FWD STEP EnKF
-~~~~~~~~~~~~~
-
-
-
-CV ENKF
-~~~~~~~~
-
-
-
-BOOTSTRAP ENKF
-~~~~~~~~~~~~~~
-
-
-
 Ensemble smoother - multiple data assimilation (ES MDA)
 -------------------------------------------------------
 


### PR DESCRIPTION
There is only one way to calculate kalman gain now.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
