### PR TITLE
Add mailmap to disambiguate emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,110 @@
+Alin G. Chitu <alin.chitu@tno.nl> Alin Chitu <alin.chitu@tno.nl>
+Alin G. Chitu <alin.chitu@tno.nl> <agchitu@users.noreply.github.com>
+Andrea Brambilla <abramb@statoil.com> Andrea <andrea.bram@gmail.com>
+Andrea Brambilla <abramb@statoil.com> Andrea Brambilla (IT SI SIB) <abramb@be-lx922957.be.statoil.no>
+Andrea Brambilla <abramb@statoil.com> Andrea Brambilla (IT SI SIB) <abramb@equinor.com>
+Andrea Brambilla <abramb@statoil.com> Andrea Brambilla <andrea.bram@gmail.com>
+Andrea Brambilla <abramb@statoil.com> andreabrambilla <abramb@equinor.com>
+Andrea Brambilla <abramb@statoil.com> andreabrambilla <andrea.bram@gmail.com>
+Andrea Brambilla <abramb@statoil.com> abramb <abramb@ac-c02xw0rjjgh8.client.statoil.net>
+Andreas Eknes Lie <andrli@equinor.com> <114403625+andreas-el@users.noreply.github.com>
+Andreas Lauser <Andreas.Lauser@iws.uni-stuttgart.de> <and@poware.org>
+Anna Kvashchuk <akvas@equinor.com> <kvashchuka@users.noreply.github.com>
+Anna Kvashchuk <akvas@equinor.com> anna.kvashchuk <kvashchuk.anna@gmail.com>
+Anna Kvashchuk <akvas@equinor.com> kvashchuka <kvashchuk.anna@gmail.com>
+Ariel Almendral Vazquez <ariel@nr.no> <ariel@login1.nr.no>
+Arne Morten Kvarving <arne.morten.kvarving@sintef.no> <akva@localhost.localdomain>
+Berent Å. S. Lunde <lundeberent@gmail.com>
+Bjarne Geir Herland <bjarne.herland@gmail.com>
+Bård Skaflestad <Bard.Skaflestad@sintef.no> <skaflestad@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Chandan Gowda <41890434+chandansgowda@users.noreply.github.com>
+Christine Fløysand <chflo@statoil.com>
+Dan Sava <dan.sava42@gmail.com>
+Eivind Jahren <ejah@equinor.com> <eivind.jahren@gmail.com>
+Eivind Jahren <ejah@equinor.com> <eivind.jahren@webstep.no>
+Eivind Jahren <ejah@equinor.com> <eja@equinor.com>
+Eivind Smoergrav <eism@statoil.com> <eism@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Feda Curic <fcur@equinor.com> <feda.curic>
+Feda Curic <fcur@equinor.com> <feda.curic@gmail.com>
+Feda Curic <fcur@equinor.com> <feda.curic@gmail.com>
+Feda Curic <fcur@equinor.com> <fedacuric@Fedas-MBP.home>
+Fredrik Gundersen <fgun@statoil.com>
+Fredrik Gundersen <fgun@statoil.com> Fredrik Gundersen (ITV DIS VCD) <fgun@be-linapp15.be.statoil.no>
+Fredrik Gundersen <fgun@statoil.com> <fredrik.gundersen@mac.com>
+Fredrik Gundersen <fgun@statoil.com> <iLoop2@users.noreply.github.com>
+Fredrik Gundersen <fgun@statoil.com> iLoop2 <fredrik.gundersen@mac.com>
+Fredrik Gundersen <fgun@statoil.com> iLoop2 <iLoop2@users.noreply.github.com>
+Frode Aarstad <frodeaarstad@gmail.com>
+Geir Evensen <geev@norceresearch.no> <geve@iris.no>
+Geir Evensen <geev@norceresearch.no> geirev <geir.evensen@gmail.com>
+Håvard Berland <havb@equinor.com>
+Håvard Berland <havb@equinor.com> <berland@pvv.ntnu.no>
+Håvard Berland <havb@equinor.com> Havard Berland <havb@equinor.com>
+Håvard Berland <havb@equinor.com> Havard Berland <havb@statoil.com>
+Håvard Berland <havb@equinor.com> havb <havb@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Helena Nandi Formentin <hnfo@equinor.com> hnformentin <helena.formentin@gmail.com>
+Inge Myrseth <myrseth@nr.no> Inge Myrseth <inge.myrseth@nr.no>
+Inge Myrseth <myrseth@nr.no> Inge Myrseth (MADI CRR NGR) <inmyr@tr-lx553324.tr.statoil.no>
+Inge Myrseth <myrseth@nr.no> inmyr <inmyr@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Inge Myrseth <myrseth@nr.no> myrseth <myrseth@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Jean-Paul Balabanian <jpb@statoil.com> Jean-Paul <jepebe@users.noreply.github.com>
+Jean-Paul Balabanian <jpb@statoil.com> <jepebe@users.noreply.github.com>
+Jean-Paul Balabanian <jpb@statoil.com> jeanpaul <jepebe@users.noreply.github.com>
+Jean-Paul Balabanian <jpb@statoil.com> jepebe <GitHubMongo78>
+Jean-Paul Balabanian <jpb@statoil.com> jepebe <GitHubMongo80>
+Jean-Paul Balabanian <jpb@statoil.com> jepebe <jepebe@users.noreply.github.co>
+Jean-Paul Balabanian <jpb@statoil.com> jpb <jepebe@users.noreply.github.com>
+Jean-Paul Balabanian <jpb@statoil.com> jpb <jpb@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Jean-Paul Balabanian <jpb@statoil.com> jpb@statoil.com <jpb@lt-811217.client.statoil.net>
+Jean-Paul Balabanian <jpb@statoil.com> jpb@statoil.com <jpb@pc155997.client.statoil.net>
+Jehan-h20220012 <112852631+Jehan-h20220012@users.noreply.github.com>
+Joakim Hove <joakim.hove@gmail.com> joaho <joaho@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Jon Holba <jholba@equinor.com> <jon.holba@gmail.com>
+Jonas Grønås Drange <jond@equinor.com>
+Jonas Grønås Drange <jond@equinor.com> <jonas@drange.net>
+Jonas Grønås Drange <jond@equinor.com> <53553193+jondequinor@users.noreply.github.com>
+Julius Parulek <jparu@equinor.com> xjules <jparu@equinor.com>
+Julius Parulek <jparu@equinor.com> xjules <parulek@gmail.com>
+Julius Parulek <jparu@equinor.com> <parulek@gmail.com>
+Kjell W. Kongsvik <kwko@statoil.com> Kjell Kongsvik <kjell.kongsvik@gmail.com>
+Kristian Flikka <kristian.flikka@gmail.com> flikka <kristian.flikka@gmail.com>
+Kurt R. Petvipusit <racp@statoil.com>
+Kurt R. Petvipusit <racp@statoil.com> KurtPetvipusit <KurtPetvipusit@users.noreply.github.com>
+Lars Petter Øren Hauge <lpha@equinor.com> <lpha@statoil.com>
+Lars Petter Øren Hauge <lpha@equinor.com> <larsenhauge@gmail.com>
+Lars Petter Øren Hauge <lpha@equinor.com> <larsenhauge@gmail.com>
+Lars Petter Øren Hauge <lpha@equinor.com> lars petter <larsenhauge@gmail.com>
+Magne Sjaastad <magne.sjaastad@ceetron.com> magne <magne@localhost>
+Maren Wessel-Berg <maren@wez.no> marenwb <maren@wez.no>
+Markus Fanebust Dregi <mfane@statoil.com> Markus Dregi <markusdregi@gmail.com>
+Markus Fanebust Dregi <mfane@statoil.com> Markus Sortland Dregi <markusdregi@gmail.com>
+Matthew Owoyemi Iwajomo (MADI CRR NGR) <moiw@be-linapp08.be.statoil.no> <moiw@be-linapp17.be.statoil.no>
+Matthew Owoyemi Iwajomo (MADI CRR NGR) <moiw@be-linapp08.be.statoil.no> <moiw@be-tawapp02.be.statoil.no>
+Matthew Owoyemi Iwajomo (MADI CRR NGR) <moiw@be-linapp08.be.statoil.no> <moiw@be-tawapp04.be.statoil.no>
+Morten Bendiksen <morten.bendiksen@gmail.com>
+Oddvar Lia (ST MSU GEO) <olia@equinor.com> olia <olia@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
+Oddvar Lia (ST MSU GEO) <olia@equinor.com> oddvarlia <77153131+oddvarlia@users.noreply.github.com>
+Per Røe <Per.Roe@nr.no> perroe <per.roe@nr.no>
+Peter Verveer <pieter.verveer@tno.nl>
+Pål Grønås Drange <pgdr@statoil.com> <PGDR@statoil.com>
+Pål Grønås Drange <pgdr@statoil.com> <pgdr@users.noreply.github.com>
+Sharlon Regales <sharlon.regales@tno.nl> sregales-TNO <82570369+sregales-TNO@users.noreply.github.com>
+Sondre Sortland <sonso@equinor.com> <sondreso@users.noreply.github.com>
+Steinar Foss <steinar@unicus.no> Steinar Foss (GBS IT SI) <stefos@be-linrgsn087.be.statoil.no>
+Steinar Foss <steinar@unicus.no> stefoss23 <steinar@unicus.no>
+Thorvald Johannessen <thorvjo@statoil.com> <thorvaldj@users.noreply.github.com>
+Valentin Krasontovitsch <vkra@equinor.com> <valentin.krasontovitsch@webstep.no>
+Yngve S. Kristiansen <yngve-sk@users.noreply.github.com>
+Zohar Malamant <zom@equinor.com> <ZOM@equinor.com>
+Åsmund Birkeland <musiv@equinor.com>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Rognerud Birkeland (IT SI SIB) <musiv@be-linrgsn224.be.statoil.no>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Rognerud Birkeland (IT SI SIB) <musiv@be-lx128372.be.statoil.no>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Rognerud Birkeland (IT SI SIB) <musiv@lt-lx941322.client.statoil.net>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Rognerud Birkeland <aasmund.birkeland@gmail.com>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Birkeland <aasmund.birkeland@gmail.com>
+Åsmund Birkeland <musiv@equinor.com> Åsmund Birkeland <asmundbirkeland@Asmunds-MacBook-Pro.local>
+Øystein Olai Heggen <ooh@equinor.com> <ooh@statoil.com>
+Øystein Olai Heggen <ooh@equinor.com> <oystein.heggen@gmail.com>
+Øyvind Eide <oyveid@equinor.com> Øyvind Eide (IT SI SIB) <oyveid@be-lx128374.be.statoil.no>
+Øyvind Eide <oyveid@equinor.com> <44577479+oyvindeide@users.noreply.github.com>
+Øyvind Eide <oyveid@equinor.com> <eide.oyvind87@gmail.com>


### PR DESCRIPTION
The mailmap is only used to identify entries with different name/email which are actually the same. Preference is given to use

Full Name <shortname@equinor.com>

if available. If not available, then the most recent used version with a github account is used.


Note: the mailmap syntax is not intuitive, see https://blog.developer.atlassian.com/aliasing-authors-in-git/ for guidance.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
