### PR TITLE
Fix flaky block_storage test

### DIFF
--- a/src/ert/storage/migration/block_fs.py
+++ b/src/ert/storage/migration/block_fs.py
@@ -39,7 +39,7 @@ def migrate(path: Path) -> None:
 
     statuses: List[bool] = []
     with LocalStorageAccessor(path, ignore_migration_check=True) as storage:
-        for casedir in block_storage_path.iterdir():
+        for casedir in sorted(block_storage_path.iterdir()):
             if (casedir / "ert_fstab").is_file():
                 statuses.append(_migrate_case_ignoring_exceptions(storage, casedir))
     failures = len(statuses) - sum(statuses)

--- a/tests/unit_tests/storage/migration/test_block_fs_snake_oil.py
+++ b/tests/unit_tests/storage/migration/test_block_fs_snake_oil.py
@@ -162,7 +162,6 @@ def test_migration_failure(storage, enspath, ens_config, caplog, monkeypatch):
     )
 
 
-@pytest.mark.xfail(reason="Test is flaky")
 @pytest.mark.parametrize("should_fail", [False, True])
 def test_full_migration_logging(
     tmp_path, enspath, caplog, monkeypatch, should_fail, ens_config


### PR DESCRIPTION
**Issue**
A unit test for migrations is flaky.
This was due to directories being sorted in varying orders.


**Approach**
Sort directories when doing migrations.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested