### PR TITLE
Remove pinning on grpcio-tools

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ decorator
 ecl_data_io
 flake8
 flake8-bugbear
-grpcio-tools==1.41.0
+grpcio-tools
 hypothesis
 isort
 jsonpath_ng

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
     "ecl",
     "conan<2",
     "pybind11>=2.10.0",  # If this comes out of sync with the version installed by Conan please update the version in CMakeLists
-    "grpcio-tools==1.41.0",
+    "grpcio-tools",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ args = dict(
         "pandas",
         "pluggy",
         "prefect<2",
-        "protobuf<4",
+        "protobuf",
         "psutil",
         "pydantic >= 1.10.8",
         "PyQt5",


### PR DESCRIPTION
Pinning on grpcio-tools was related to pinning on protobuf which has been lifted.

Related to https://github.com/equinor/spinningjenny/issues/328
Related to https://github.com/OPM/ResInsight/pull/10422 