### PR TITLE
Disable flaky test for migration logging

### DIFF
--- a/tests/unit_tests/storage/migration/test_block_fs_snake_oil.py
+++ b/tests/unit_tests/storage/migration/test_block_fs_snake_oil.py
@@ -162,6 +162,7 @@ def test_migration_failure(storage, enspath, ens_config, caplog, monkeypatch):
     )
 
 
+@pytest.mark.xfail(reason="Test is flaky")
 @pytest.mark.parametrize("should_fail", [False, True])
 def test_full_migration_logging(
     tmp_path, enspath, caplog, monkeypatch, should_fail, ens_config


### PR DESCRIPTION
**Issue**
a unit test for migration tool is flaky


**Approach**
disable it until we fix it

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
