### PR TITLE
Simplify snapshot update for fm events

### DIFF
--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -269,9 +269,9 @@ class PartialSnapshot:
             return self
         if real_id not in self._data.reals:
             jobs = pmap({"jobs": pmap({job_id: _job_to_pmap(job)})})
-            steps = pmap({"steps": pmap({step_id: jobs})})
+            steps = pmap({step_id: jobs})
             new_reals = self._data.reals.set(real_id, pmap({"steps": steps}))
-            self._data.set("reals", new_reals)
+            self._data = self._data.set("reals", new_reals)
             return self
         if "jobs" not in self._data.reals[real_id].steps[step_id]:  # no jobs yet
             jobs = pmap({job_id: _job_to_pmap(job)})

--- a/tests/unit_tests/ensemble_evaluator/test_snapshot.py
+++ b/tests/unit_tests/ensemble_evaluator/test_snapshot.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from cloudevents.http.event import CloudEvent
@@ -14,6 +14,337 @@ from ert.ensemble_evaluator.snapshot import (
     _get_real_id,
     _get_step_id,
 )
+
+STEP = "0"
+
+
+def fm_job_start_event(
+    realization: int, forward_model: int, start_time: datetime
+) -> CloudEvent:
+    return CloudEvent(
+        attributes={
+            "specversion": "1.0",
+            "id": "eventid",
+            "source": (
+                f"/ert/ensemble/ensemble-id/real/{realization}"
+                f"/step/{STEP}/job/{forward_model}/index/{forward_model}"
+            ),
+            "type": ids.EVTYPE_FM_JOB_START,
+            "datacontenttype": "application/json",
+            "time": start_time.isoformat(),
+        },
+        data={
+            "stdout": (
+                f"scratch/realization-{realization}/iter-{forward_model}"
+                f"/job_name.stdout.{forward_model}"
+            ),
+            "stderr": (
+                f"scratch/realization-{realization}/iter-{forward_model}"
+                f"/job_name.stderr.{forward_model}"
+            ),
+        },
+    )
+
+
+def fm_job_running_event(
+    realization: int,
+    forward_model: int,
+    timestamp: datetime,
+    current_memory_usage: int,
+    max_memory_usage: int,
+) -> CloudEvent:
+    return CloudEvent(
+        attributes={
+            "specversion": "1.0",
+            "id": "eventid",
+            "source": (
+                f"/ert/ensemble/ensemble-id/real/{realization}"
+                f"/step/{STEP}/job/{forward_model}/index/{forward_model}"
+            ),
+            "type": ids.EVTYPE_FM_JOB_RUNNING,
+            "datacontenttype": "application/json",
+            "time": timestamp.isoformat(),
+        },
+        data={
+            "max_memory_usage": max_memory_usage,
+            "current_memory_usage": current_memory_usage,
+        },
+    )
+
+
+def fm_job_done_event(
+    realization: int,
+    forward_model: int,
+    timestamp: datetime,
+) -> CloudEvent:
+    return CloudEvent(
+        attributes={
+            "specversion": "1.0",
+            "id": "eventid",
+            "source": (
+                f"/ert/ensemble/ensemble-id/real/{realization}"
+                f"/step/{STEP}/job/{forward_model}/index/{forward_model}"
+            ),
+            "type": ids.EVTYPE_FM_JOB_SUCCESS,
+            "datacontenttype": "application/json",
+            "time": timestamp.isoformat(),
+        },
+        data=None,
+    )
+
+
+def fm_job_failed_event(
+    realization: int, forward_model: int, timestamp: datetime, err_msg: str
+) -> Job:
+    return CloudEvent(
+        attributes={
+            "type": ids.EVTYPE_FM_JOB_FAILURE,
+            "specversion": "1.0",
+            "id": "eventid",
+            "source": (
+                f"/ert/ensemble/ensemble-id/real/{realization}"
+                f"/step/{STEP}/job/{forward_model}/index/{forward_model}"
+            ),
+            "datacontenttype": "application/json",
+            "time": timestamp.isoformat(),
+        },
+        data={
+            "error_msg": err_msg,
+        },
+    )
+
+
+def apply_and_verify_start_event(
+    snapshot: PartialSnapshot,
+    realization: int,
+    forward_model: int,
+    start_time: datetime,
+) -> Job:
+    start_event_fm = fm_job_start_event(realization, forward_model, start_time)
+    fm = f"{forward_model}"
+    real = f"{realization}"
+
+    if "reals" in snapshot.data() and real in snapshot.data().reals:
+        assert fm not in snapshot.data().reals[real].steps[STEP].jobs
+
+    snapshot.from_cloudevent(start_event_fm)
+
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    fm_start = snapshot.data().reals[real].steps[STEP].jobs[fm]
+    assert fm_start.index == fm
+    assert fm_start.stdout == start_event_fm.data["stdout"]
+    assert fm_start.stderr == start_event_fm.data["stderr"]
+    assert fm_start.status == "Pending"
+    assert fm_start.start_time == start_time
+
+    return fm_start
+
+
+def apply_and_verify_running_event(
+    snapshot: PartialSnapshot,
+    realization: int,
+    forward_model: int,
+    timestamp: datetime,
+    current_mem_usage: int,
+    max_mem_usage: int,
+) -> Job:
+    running_event = fm_job_running_event(
+        realization, forward_model, timestamp, current_mem_usage, max_mem_usage
+    )
+    fm = f"{forward_model}"
+    real = f"{realization}"
+
+    # job should be there from before
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    previous_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    snapshot.from_cloudevent(running_event)
+
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    updated_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    # updated stuff
+    assert updated_fm.status == "Running"
+    assert updated_fm.data.current_memory_usage == current_mem_usage
+    if (
+        "data" in previous_fm
+        and "max_memory_usage" in previous_fm.data
+        and previous_fm.data.max_memory_usage < max_mem_usage
+    ) or ("data" not in previous_fm or "max_memory_usage" not in previous_fm.data):
+        assert updated_fm.data.max_memory_usage == max_mem_usage
+    else:
+        assert updated_fm.data.max_memory_usage == max_mem_usage
+
+    # unchanged stuff
+    assert updated_fm.index == previous_fm.index
+    assert updated_fm.stdout == previous_fm.stdout
+    assert updated_fm.stderr == previous_fm.stderr
+    assert updated_fm.start_time == previous_fm.start_time
+
+    return updated_fm
+
+
+def apply_and_verify_done_event(
+    snapshot: PartialSnapshot,
+    realization: int,
+    forward_model: int,
+    timestamp: datetime,
+) -> Job:
+    done_event = fm_job_done_event(realization, forward_model, timestamp)
+    fm = f"{forward_model}"
+    real = f"{realization}"
+
+    # job should be there from before
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    previous_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    snapshot.from_cloudevent(done_event)
+
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    updated_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    # updated stuff
+    assert updated_fm.status == "Finished"
+    assert updated_fm.end_time == timestamp
+
+    # unchanged stuff
+    assert updated_fm.data.current_memory_usage == previous_fm.data.current_memory_usage
+    assert updated_fm.data.max_memory_usage == previous_fm.data.max_memory_usage
+    assert updated_fm.index == previous_fm.index
+    assert updated_fm.stdout == previous_fm.stdout
+    assert updated_fm.stderr == previous_fm.stderr
+    assert updated_fm.start_time == previous_fm.start_time
+
+    return updated_fm
+
+
+def apply_and_verify_failed_event(
+    snapshot: PartialSnapshot,
+    realization: int,
+    forward_model: int,
+    timestamp: datetime,
+    err_msg: str,
+) -> Job:
+    failed_event = fm_job_failed_event(realization, forward_model, timestamp, err_msg)
+    fm = f"{forward_model}"
+    real = f"{realization}"
+
+    # job should be there from before
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    previous_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    snapshot.from_cloudevent(failed_event)
+
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    updated_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    # updated stuff
+    assert updated_fm.status == "Failed"
+    assert updated_fm.end_time == timestamp
+    assert updated_fm.error == err_msg
+
+    # unchanged stuff
+    assert updated_fm.data.current_memory_usage == previous_fm.data.current_memory_usage
+    assert updated_fm.data.max_memory_usage == previous_fm.data.max_memory_usage
+    assert updated_fm.index == previous_fm.index
+    assert updated_fm.stdout == previous_fm.stdout
+    assert updated_fm.stderr == previous_fm.stderr
+    assert updated_fm.start_time == previous_fm.start_time
+
+    return updated_fm
+
+
+def verify_fm_unchanged(
+    snapshot: PartialSnapshot, realization: int, expected_forward_model: Job
+):
+    real = f"{realization}"
+    fm = expected_forward_model.index
+
+    assert fm in snapshot.data().reals[real].steps[STEP].jobs
+    actual_fm = snapshot.data().reals[real].steps[STEP].jobs[fm]
+
+    assert expected_forward_model == actual_fm
+
+
+def test_snapshot_from_cloudevent_for_fm_events(snapshot: Snapshot):
+    mutating_snapshot = PartialSnapshot(snapshot)
+
+    # START FM 0
+
+    start_time_stamp = datetime.fromisoformat("1995-06-13")
+    realization = 0
+    forward_model_0 = 0
+    forward_model_1 = 1
+
+    start_fm0 = apply_and_verify_start_event(
+        mutating_snapshot, realization, forward_model_0, start_time_stamp
+    )
+
+    # START FM 1
+
+    start_fm1 = apply_and_verify_start_event(
+        mutating_snapshot, realization, forward_model_1, start_time_stamp
+    )
+
+    verify_fm_unchanged(mutating_snapshot, realization, start_fm0)
+
+    # FM 0 RUNNING
+
+    fm0_running = apply_and_verify_running_event(
+        mutating_snapshot,
+        realization,
+        forward_model_0,
+        start_time_stamp + timedelta(seconds=1),
+        5000,
+        5000,
+    )
+
+    verify_fm_unchanged(mutating_snapshot, realization, start_fm1)
+
+    # FM 1 RUNNING
+    fm1_running = apply_and_verify_running_event(
+        mutating_snapshot,
+        realization,
+        forward_model_1,
+        start_time_stamp + timedelta(seconds=2),
+        2000,
+        3000,
+    )
+
+    verify_fm_unchanged(mutating_snapshot, realization, fm0_running)
+
+    # FM 0 RUNNING UPDATE
+
+    apply_and_verify_running_event(
+        mutating_snapshot,
+        realization,
+        forward_model_0,
+        start_time_stamp + timedelta(seconds=1),
+        8000,
+        8000,
+    )
+    verify_fm_unchanged(mutating_snapshot, realization, fm1_running)
+
+    # FM 0 DONE
+
+    fm0_done = apply_and_verify_done_event(
+        mutating_snapshot,
+        realization,
+        forward_model_0,
+        start_time_stamp + timedelta(seconds=3),
+    )
+    verify_fm_unchanged(mutating_snapshot, realization, fm1_running)
+
+    # FM 1 FAILED
+
+    apply_and_verify_failed_event(
+        mutating_snapshot,
+        realization,
+        forward_model_1,
+        start_time_stamp + timedelta(seconds=5),
+        "we failed",
+    )
+    verify_fm_unchanged(mutating_snapshot, realization, fm0_done)
 
 
 def test_snapshot_merge(snapshot: Snapshot):


### PR DESCRIPTION
**Issue**
Related to #5273 

**Approach**
we reimplement the update job function to avoid using recursive update for bulk of events (those about forward models)

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
