### PR TITLE
Change BaseRunModel to throw an exception with stacktrace

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -140,5 +140,4 @@ def run_cli(args: Namespace, _: Any = None) -> None:
     thread.join()
     storage.close()
 
-    if model.hasRunFailed():
-        raise ErtCliError(model.getFailMessage())
+    model.reraise_exception(ErtCliError)

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -8,7 +8,7 @@ from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizations
 from ert.gui.ertwidgets.models.valuemodel import ValueModel
 from ert.gui.ertwidgets.stringbox import StringBox
 from ert.libres_facade import LibresFacade
-from ert.run_models.base_run_model import _LogAggregration, captured_logs
+from ert.run_models.base_run_model import captured_logs
 from ert.validation import IntegerArgument, RangeStringArgument
 
 
@@ -81,8 +81,8 @@ class LoadResultsPanel(QWidget):
                 ),
             )
             return False
-        logs: _LogAggregration = _LogAggregration()
-        with captured_logs() as logs:
+        messages = []
+        with captured_logs(messages):
             loaded = self._facade.load_from_forward_model(
                 selected_case, realizations, iteration
             )
@@ -93,10 +93,10 @@ class LoadResultsPanel(QWidget):
             )
         elif loaded > 0:
             msg = ErtMessageBox(
-                f"Successfully loaded {loaded} realizations", "\n".join(logs.messages)
+                f"Successfully loaded {loaded} realizations", "\n".join(messages)
             )
             msg.exec_()
         else:
-            msg = ErtMessageBox("No realizations loaded", "\n".join(logs.messages))
+            msg = ErtMessageBox("No realizations loaded", "\n".join(messages))
             msg.exec_()
         return loaded

--- a/tests/unit_tests/shared/test_log_capture.py
+++ b/tests/unit_tests/shared/test_log_capture.py
@@ -19,12 +19,13 @@ logger = logging.getLogger(__name__)
 )
 def test_default_log_capture(log_level, expect_propagation, caplog):
     with caplog.at_level(logging.INFO):
-        with captured_logs() as logs:
+        messages = []
+        with captured_logs(messages):
             log_level("This is not actually an error")
         if expect_propagation:
-            assert "This is not actually an error" in logs.messages
+            assert "This is not actually an error" in messages
         else:
-            assert "This is not actually an error" not in logs.messages
+            assert "This is not actually an error" not in messages
 
 
 @pytest.mark.parametrize(
@@ -49,9 +50,10 @@ def test_default_log_capture(log_level, expect_propagation, caplog):
 )
 def test_custom_log_capture(log_level, log_func, corresponding_level, caplog):
     with caplog.at_level(logging.DEBUG):
-        with captured_logs(level=log_level) as logs:
+        messages = []
+        with captured_logs(messages, level=log_level):
             log_func("This is a message")
-        if corresponding_level >= logs.level:
-            assert "This is a message" in logs.messages
+        if corresponding_level >= log_level:
+            assert "This is a message" in messages
         else:
-            assert "This is a message" not in logs.messages
+            assert "This is a message" not in messages


### PR DESCRIPTION
Previously, if an exception occurred during ensemble evaluation, ERT would throw an exception but with no stack trace. Instead, we save the exception instead of just the message.