### PR TITLE
Make tests pass on NixOS

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -81,14 +81,14 @@ static auto logger = ert::get_logger("job_queue.lsf_driver");
   to source schell specific input files prior to executing your
   job. This can be achieved with the LSF_LOGIN_SHELL option:
 
-     lsf_driver_set_option( driver , LSF_LOGIN_SHELL , "/bin/csh" );
+     lsf_driver_set_option( driver , LSF_LOGIN_SHELL , "csh" );
 
 */
 
 #define MAX_ERROR_COUNT 100
 #define SUBMIT_ERROR_SLEEP 2
 #define BJOBS_REFRESH_TIME "10"
-#define DEFAULT_RSH_CMD "/usr/bin/ssh"
+#define DEFAULT_RSH_CMD "ssh"
 #define DEFAULT_BSUB_CMD "bsub"
 #define DEFAULT_BJOBS_CMD "bjobs"
 #define DEFAULT_BKILL_CMD "bkill"

--- a/src/clib/old_tests/job_queue/test_job_list.cpp
+++ b/src/clib/old_tests/job_queue/test_job_list.cpp
@@ -20,7 +20,7 @@ void call_iget_job(void *arg) {
 void test_add_job() {
     job_list_type *list = job_list_alloc();
     job_queue_node_type *node = job_queue_node_alloc(
-        "name", "/tmp", "/bin/ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
+        "name", "/tmp", "ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
     job_list_add_job(list, node);
     test_assert_int_equal(job_list_get_size(list), 1);
     test_assert_int_equal(job_queue_node_get_queue_index(node), 0);

--- a/src/clib/old_tests/job_queue/test_job_lsf.cpp
+++ b/src/clib/old_tests/job_queue/test_job_lsf.cpp
@@ -66,7 +66,7 @@ void test_cmd(void) {
     lsf_driver_type *driver = (lsf_driver_type *)lsf_driver_alloc();
     {
         stringlist_type *cmd =
-            lsf_driver_alloc_cmd(driver, "out", "job", "/bin/echo", 1, 0, NULL);
+            lsf_driver_alloc_cmd(driver, "out", "job", "echo", 1, 0, NULL);
         test_assert_false(lsf_driver_has_project_code(driver));
         test_assert_false(stringlist_contains(cmd, "-P"));
         stringlist_free(cmd);
@@ -75,7 +75,7 @@ void test_cmd(void) {
     lsf_driver_set_option(driver, LSF_PROJECT_CODE, project_code);
     {
         stringlist_type *cmd =
-            lsf_driver_alloc_cmd(driver, "out", "job", "/bin/echo", 1, 0, NULL);
+            lsf_driver_alloc_cmd(driver, "out", "job", "echo", 1, 0, NULL);
         int P_index = stringlist_find_first(cmd, "-P");
         test_assert_true(lsf_driver_has_project_code(driver));
         test_assert_true(P_index >= 0);

--- a/src/clib/old_tests/job_queue/test_job_mock_slurm.cpp
+++ b/src/clib/old_tests/job_queue/test_job_mock_slurm.cpp
@@ -68,7 +68,7 @@ void install_script(queue_driver_type *driver, const char *option,
 }
 
 void make_slurm_commands(queue_driver_type *driver) {
-    std::string sbatch = R"(#!/bin/bash
+    std::string sbatch = R"(#!/usr/bin/env bash
 
 if [ $2 = "--job-name=0" ]; then
    exit 1
@@ -91,12 +91,12 @@ if [ $2 = "--job-name=4" ]; then
 fi
 )";
 
-    std::string scancel = R"(#!/bin/bash
+    std::string scancel = R"(#!/usr/bin/env bash
 
 exit 0
 )";
 
-    std::string scontrol = R"(#!/bin/bash
+    std::string scontrol = R"(#!/usr/bin/env bash
 if [ $3 = "1" ]; then
 cat <<EOF
    UserId=user(777) GroupId=group(888) MCS_label=N/A
@@ -163,7 +163,7 @@ fi
 
 )";
 
-    std::string squeue = R"(#!/bin/bash
+    std::string squeue = R"(#!/usr/bin/env bash
 echo "2 PENDING"
 echo "3 RUNNING"
 )";

--- a/src/clib/old_tests/job_queue/test_job_node.cpp
+++ b/src/clib/old_tests/job_queue/test_job_node.cpp
@@ -5,7 +5,7 @@
 
 void test_create() {
     job_queue_node_type *node = job_queue_node_alloc(
-        "name", "/tmp", "/bin/ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
+        "name", "/tmp", "ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
     job_queue_node_free(node);
 }
 
@@ -16,14 +16,14 @@ void call_get_queue_index(void *arg) {
 
 void test_queue_index() {
     job_queue_node_type *node = job_queue_node_alloc(
-        "name", "/tmp", "/bin/ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
+        "name", "/tmp", "ls", 0, stringlist_alloc_new(), 1, NULL, NULL);
     test_assert_util_abort("job_queue_node_get_queue_index",
                            call_get_queue_index, node);
 }
 
 void test_path_does_not_exist() {
     job_queue_node_type *node =
-        job_queue_node_alloc("name", "does-not-exist", "/bin/ls", 0,
+        job_queue_node_alloc("name", "does-not-exist", "ls", 0,
                              stringlist_alloc_new(), 1, NULL, NULL);
     test_assert_NULL(node);
 }

--- a/tests/unit_tests/c_wrappers/job_runner/test_file_reporter.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_file_reporter.py
@@ -38,7 +38,7 @@ def test_report_with_successful_start_message_argument(reporter):
                 "stdout": "/stdout.0",
                 "stderr": "/stderr.0",
                 "argList": ["--foo", "1", "--bar", "2"],
-                "executable": "/bin/bash",
+                "executable": "/bin/sh",
             },
             0,
         )
@@ -51,7 +51,7 @@ def test_report_with_successful_start_message_argument(reporter):
         assert "job1" in f.readline(), "STATUS file missing job1"
     with open(LOG_file, "r", encoding="utf-8") as f:
         assert (
-            "Calling: /bin/bash --foo 1 --bar 2" in f.readline()
+            "Calling: /bin/sh --foo 1 --bar 2" in f.readline()
         ), """JOB_LOG file missing executable and arguments"""
 
     with open(STATUS_json, "r", encoding="utf-8") as f:

--- a/tests/unit_tests/c_wrappers/job_runner/test_job.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_job.py
@@ -38,7 +38,7 @@ def test_run_fails_using_exit_bash_builtin():
     job = Job(
         {
             "name": "exit 1",
-            "executable": "/bin/bash",
+            "executable": "/bin/sh",
             "stdout": "exit_out",
             "stderr": "exit_err",
             "argList": ["-c", 'echo "failed with 1" 1>&2 ; exit 1'],
@@ -149,7 +149,7 @@ def test_makedirs(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     job = Job(
         {
-            "executable": "/usr/bin/true",
+            "executable": "true",
             "stdout": "a/file",
             "stderr": "b/c/file",
         },

--- a/tests/unit_tests/c_wrappers/job_runner/test_jobmanager.py
+++ b/tests/unit_tests/c_wrappers/job_runner/test_jobmanager.py
@@ -81,7 +81,7 @@ def test_missing_joblist_json():
 def test_run_output_rename():
     job = {
         "name": "TEST_JOB",
-        "executable": "/bin/mkdir",
+        "executable": "mkdir",
         "stdout": "out",
         "stderr": "err",
     }
@@ -102,7 +102,7 @@ def test_run_multiple_ok():
     for job_index in dir_list:
         job = {
             "name": "MKDIR",
-            "executable": "/bin/mkdir",
+            "executable": "mkdir",
             "stdout": f"mkdir_out.{job_index}",
             "stderr": f"mkdir_err.{job_index}",
             "argList": ["-p", "-v", job_index],
@@ -130,7 +130,7 @@ def test_run_multiple_fail_only_runs_one():
     for index in range(1, 6):
         job = {
             "name": "exit",
-            "executable": "/bin/bash",
+            "executable": "/bin/sh",
             "stdout": "exit_out",
             "stderr": "exit_err",
             # produces something on stderr, and exits with

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -899,7 +899,7 @@ def test_that_job_definition_file_with_unexecutable_script_gives_validation_erro
     with open(job_name, "w", encoding="utf-8") as fh:
         fh.write(f"EXECUTABLE {job_script_file}\n")
     with open(job_script_file, "w", encoding="utf-8") as fh:
-        fh.write("#!/bin/bash\n")
+        fh.write("#!/bin/sh\n")
     with open(test_config_file_name, "w", encoding="utf-8") as fh:
         fh.write(test_config_contents)
     with pytest.raises(

--- a/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
@@ -223,7 +223,7 @@ def test_that_torque_driver_passes_options_to_qstat(
     _deploy_script("qsub", MOCK_QSUB)
     _deploy_script(
         "qstat",
-        "#!/bin/bash\n"
+        "#!/bin/sh\n"
         + create_qstat_f_output(state="E", bash=True)
         + "\n"
         + "echo $@ > qstat_options",

--- a/tests/unit_tests/services/test_base_service.py
+++ b/tests/unit_tests/services/test_base_service.py
@@ -45,7 +45,7 @@ def server_script(monkeypatch, tmp_path: Path, request):
     script = (
         dedent(
             """\
-    #!/usr/bin/python3
+    #!/usr/bin/env python3
     import os
     import sys
     import time

--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -220,7 +220,7 @@ def test_running_flow_given_env_config_can_still_read_parent_env(monkeypatch):
 
     # create a script that prints env vars ENV1 and ENV2 to a file
     with open("mocked_flow", "w", encoding="utf-8") as f:
-        f.write("#!/bin/bash\n")
+        f.write("#!/bin/sh\n")
         f.write("echo $ENV1 > out.txt\n")
         f.write("echo $ENV2 >> out.txt\n")
     executable = os.path.join(os.getcwd(), "mocked_flow")
@@ -269,7 +269,7 @@ def test_running_flow_given_no_env_config_can_still_read_parent_env(monkeypatch)
 
     # create a script that prints env vars ENV1 and ENV2 to a file
     with open("flow", "w", encoding="utf-8") as f:
-        f.write("#!/bin/bash\n")
+        f.write("#!/bin/sh\n")
         f.write("echo $ENV1 > out.txt\n")
         f.write("echo $ENV2 >> out.txt\n")
     executable = os.path.join(os.getcwd(), "flow")
@@ -321,7 +321,7 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
 
     # create a script that prints env vars ENV1 and ENV2 to a file
     with open("flow", "w", encoding="utf-8") as filehandle:
-        filehandle.write("#!/bin/bash\n")
+        filehandle.write("#!/bin/sh\n")
         filehandle.write("echo $ENV1 > out.txt\n")
         filehandle.write("echo $ENV2 >> out.txt\n")
     executable = os.path.join(os.getcwd(), "flow")

--- a/tests/unit_tests/shared/share/test_rms.py
+++ b/tests/unit_tests/shared/share/test_rms.py
@@ -391,7 +391,7 @@ def test_run_wrapper(monkeypatch, source_root):
     shutil.copy(os.path.join(source_root, "tests/unit_tests/shared/share/rms"), "bin")
 
     with open(wrapper_file_name, "w", encoding="utf-8") as f:
-        f.write("#!/bin/bash\n")
+        f.write("#!/usr/bin/env bash\n")
         f.write("exec ${@:1}")
     st = os.stat(wrapper_file_name)
     os.chmod(wrapper_file_name, st.st_mode | stat.S_IEXEC)

--- a/tests/unit_tests/shared/share/test_subprocess.py
+++ b/tests/unit_tests/shared/share/test_subprocess.py
@@ -53,7 +53,7 @@ def test_await_process_tee():
     with open("a", "wb") as a_fh, open("b", "wb") as b_fh:
         # pylint: disable=consider-using-with
         # ecl_run.await_process_tee() ensures the process is terminated
-        process = Popen(["/bin/cat", "original"], stdout=PIPE)
+        process = Popen(["cat", "original"], stdout=PIPE)
         ecl_run.await_process_tee(process, a_fh, b_fh)
 
     with open("a", "rb") as f:
@@ -76,7 +76,7 @@ def test_await_process_finished_tee():
     with open("a", "wb") as a_fh, open("b", "wb") as b_fh:
         # pylint: disable=consider-using-with
         # ecl_run.await_process_tee() ensures the process is terminated
-        process = Popen(["/bin/cat", "original"], stdout=PIPE)
+        process = Popen(["cat", "original"], stdout=PIPE)
         process.wait()
         ecl_run.await_process_tee(process, a_fh, b_fh)
 


### PR DESCRIPTION
NixOS is an "alternative" Linux distribution which does not use the standard Linux filesystem hierarchy. The directories `/bin` and `/usr/bin` _only_ have `sh` and `env` respectively. For example, `/bin/bash` does not exist on NixOS.

To have the test suite pass, we replace all absolute paths to eg. `bash` with `/usr/bin/env` versions.