### PR TITLE
Fix bug in es-mda where returned variable could potentially be unbound

### DIFF
--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -160,7 +160,7 @@ class MultipleDataAssimilation(BaseRunModel):
 
         self.setPhase(iteration_count + 1, "Simulations completed.")
 
-        return posterior_context
+        return prior_context
 
     def _count_active_realizations(self, run_context: "RunContext") -> int:
         return sum(run_context.mask)


### PR DESCRIPTION
Posterior context could potentially be unbound, so return the prior context instead. The last thing that happens in the loop is to set prior_context = posterior_context, so the result should be the same.

**Issue**
Resolves #4754


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
