### PR TITLE
Include performance testing of GUI snapshot

### DIFF
--- a/tests/performance_tests/test_snapshot.py
+++ b/tests/performance_tests/test_snapshot.py
@@ -15,6 +15,14 @@ from ert.ensemble_evaluator.snapshot import (
     Step,
 )
 
+from ..unit_tests.gui.conftest import (  # noqa  # pylint: disable=unused-import
+    active_realizations,
+    large_snapshot,
+    mock_tracker,
+    runmodel,
+)
+from ..unit_tests.gui.simulation.test_run_dialog import test_large_snapshot
+
 
 @pytest.mark.parametrize(
     "ensemble_size, forward_models, memory_reports",
@@ -33,6 +41,25 @@ def test_snapshot_handling_of_forward_model_events(
         ensemble_size,
         forward_models,
         memory_reports,
+    )
+
+
+def test_gui_snapshot(
+    benchmark,
+    runmodel,  # noqa
+    large_snapshot,  # noqa
+    qtbot,
+    mock_tracker,  # noqa
+):
+    # pylint: disable=redefined-outer-name
+    infinite_timeout = 100000
+    benchmark(
+        test_large_snapshot,
+        runmodel,
+        large_snapshot,
+        qtbot,
+        mock_tracker,
+        timeout_per_iter=infinite_timeout,
     )
 
 

--- a/tests/performance_tests/test_snapshot.py
+++ b/tests/performance_tests/test_snapshot.py
@@ -16,7 +16,7 @@ from ert.ensemble_evaluator.snapshot import (
 )
 
 from ..unit_tests.gui.conftest import (  # noqa  # pylint: disable=unused-import
-    active_realizations,
+    active_realizations_fixture,
     large_snapshot,
     mock_tracker,
     runmodel,

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -66,7 +66,9 @@ def test_kill_simulations(runmodel, qtbot: QtBot, mock_tracker):
         widget.killJobs()
 
 
-def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
+def test_large_snapshot(
+    runmodel, large_snapshot, qtbot: QtBot, mock_tracker, timeout_per_iter=5000
+):
     widget = RunDialog("poly.ert", runmodel)
     widget.show()
     qtbot.addWidget(widget)
@@ -95,12 +97,15 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
         )
         widget.startSimulation()
 
-    with qtbot.waitExposed(widget, timeout=30000):
+    with qtbot.waitExposed(widget, timeout=timeout_per_iter * 6):
         qtbot.waitUntil(
-            lambda: widget._total_progress_bar.value() == 100, timeout=15000
+            lambda: widget._total_progress_bar.value() == 100,
+            timeout=timeout_per_iter * 3,
         )
         qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
-        qtbot.waitUntil(lambda: widget._tab_widget.count() == 2, timeout=5000)
+        qtbot.waitUntil(
+            lambda: widget._tab_widget.count() == 2, timeout=timeout_per_iter
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is to establish a baseline before the snapshot code (both in ensemble_evaluator and in the gui portion) is refactored.

**Issue**
Relates to #5273 

**Approach**
Add to performance tests something that includes handling the snapshot events in the gui. If the ensemble evaluator code is refactored without the GUI following along with a refactor, this might impact the GUI performance significantly.

This benchmark wraps an existing function which includes a timeout. If the timeout is exceeded, this benchmark will fail.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
