### PR TITLE
Increase sleeptime in qstat concurrency test

### DIFF
--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ert_qstat_proxy.py
@@ -263,7 +263,7 @@ def test_many_concurrent_qstat_invocations(tmpdir, monkeypatch):
     """
     starttime = time.time()
     invocations = 400
-    sleeptime = 0.02  # seconds. Lower number increase probability of race conditions.
+    sleeptime = 0.03  # seconds. Lower number increase probability of race conditions.
     # (the mocked qstat backend sleeps for 0.5 seconds to facilitate races)
     cache_timeout = 2  # This is CACHE_TIMEOUT in the shell script
     assert invocations * sleeptime > cache_timeout  # Ensure race conditions can happen


### PR DESCRIPTION
This test has been observed flaky, giving the error message that 'first invocation should not fail' when run with pytest -n <alot>. That error is maybe due to the machine being heavy loaded and the Linux scheduler actually letting the second invocation finish first. If that is the case, this sleeptime increase might help the flakyness

**Issue**
Might resolve flakyness

**Approach**
🧠 and guesswork.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
