### PR TITLE
Do not propagate websockets logs to ert file

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -102,7 +102,7 @@ loggers:
   websockets:
     level: INFO
     handlers: [eefile]
-    propagate: yes
+    propagate: no
   ert._c_wrappers:
     level: INFO
     propagate: yes


### PR DESCRIPTION
We have logs from the websockets library handled by the ee file handler (`ee-...`) - but we also propagate them to the "main" ert log file (`ert-...`). This is an unnecessary duplication of logs, and the websockets logs are more suitably located in the ee log file.


## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] DOES NOT APPLY Updated documentation
- [X] Ensured new behaviour is tested