### PR TITLE
Add test for flow reservoir simulator on a DATA deck with PARALLEL

### DIFF
--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -196,6 +196,20 @@ def test_flow(init_flow_config, source_root):
         ecl_run.run(flow_config, ["SPE1.DATA", "--version=no/such/version"])
 
 
+@flow_installed
+def test_flow_with_mpi(init_flow_config, source_root):
+    """This only tests that ERT will be able to start flow on a data deck with
+    the PARALLEL keyword present. It does not assert anything regarding whether
+    MPI-parallelization will get into play."""
+    shutil.copy(
+        source_root / "test-data/eclipse/SPE1_PARALLEL.DATA", "SPE1_PARALLEL.DATA"
+    )
+    flow_config = ecl_config.FlowConfig()
+    sim = flow_config.sim()
+    flow_run = ecl_run.EclRun("SPE1_PARALLEL.DATA", sim)
+    flow_run.runEclipse()
+
+
 @pytest.mark.usefixtures("use_tmpdir")
 def test_running_flow_given_env_config_can_still_read_parent_env(monkeypatch):
     version = "1111.11"


### PR DESCRIPTION
**Issue**
Resolves #5517 

**Approach**
Add a test that asserts that flow will not crash in case the PARALLEL keyword is present in the deck.

(the real fix is in https://github.com/equinor/ert-configurations/pull/73 )

This test will only be run during komodo integration testing, where the ert-configuration package configures how flow should act on this test.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
