### PR TITLE
Log full exception in batching dispatcher

### DIFF
--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import time
 import traceback
@@ -83,12 +84,10 @@ class BatchingDispatcher:
 
     async def join(self):
         self._running = False
-        try:
+        # if result is exception it should have been handled by
+        # done-handler, but also avoid killing the caller here
+        with contextlib.suppress(BaseException):
             await self._task
-        except BaseException:
-            # if result is exception it should have been handled by
-            # done-handler, but also avoid killing the caller here
-            pass
 
     def register_event_handler(self, event_types, function, batching=True):
         if not isinstance(event_types, set):

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+import traceback
 from collections import OrderedDict, defaultdict
 
 from ert.ensemble_evaluator import identifiers
@@ -25,7 +26,11 @@ class BatchingDispatcher:
         try:
             failure = self._task.exception()
             if failure is not None:
-                logger.warning(f"exception in batcher: {failure}")
+                logger.error(f"exception in batcher: {failure}")
+                trace_info = traceback.format_exception(
+                    type(failure), failure, failure.__traceback__
+                )
+                logger.error("".join(trace_info))
             else:
                 logger.debug("batcher finished normally")
                 return


### PR DESCRIPTION
    So far, only the first line or word (unsure) of an exception was logged
    that occured in the batching dispatcher, for instance during handling of
    events sent from the ensemble evaluator.
    
    We rectify this by logging the full stack trace, which should make
    debugging easier.

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT RELEVANT Updated documentation
- [X] OH YEAH - MANUALLY THOUGH Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
