### PR TITLE
Only set config dict entry to None if not multi occurrence

### DIFF
--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -196,16 +196,16 @@ def _tree_to_dict(
     cwd = os.path.dirname(os.path.abspath(config_file))
 
     for node in tree.children:
+        args: List[FileContextToken]
+        kw: FileContextToken
+        kw, *args = node  # type: ignore
+        if kw not in schema:
+            warnings.warn(f"Unknown keyword {kw!r}", category=ConfigWarning)
+            continue
+
+        constraints = schema[kw]
+
         try:
-            args: List[FileContextToken]
-            kw: FileContextToken
-            kw, *args = node  # type: ignore
-
-            if kw not in schema:
-                warnings.warn(f"Unknown keyword {kw!r}", category=ConfigWarning)
-                continue
-            constraints = schema[kw]
-
             args = constraints.join_args(args)
             args = _substitute_args(args, constraints, defines)
             value_list = constraints.apply_constraints(args, kw, cwd)
@@ -227,7 +227,9 @@ def _tree_to_dict(
             else:
                 config_dict[kw] = value_list
         except ConfigValidationError as e:
-            config_dict[kw] = None
+            if not constraints.multi_occurrence:
+                config_dict[kw] = None
+
             errors.append(e)
 
     try:

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -1136,3 +1136,24 @@ def test_parsing_workflow_with_multiple_args():
     ert_config = ErtConfig.from_file("config.ert")
 
     assert ert_config is not None
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_missing_arglist_does_not_affect_subsequent_calls():
+    """
+    Check that the summary without arglist causes a ConfigValidationError and
+    not an error from appending to None parsed from SUMMARY w/o arglist
+    """
+    with open("config.ert", mode="w", encoding="utf-8") as fh:
+        fh.write(
+            dedent(
+                """
+                NUM_REALIZATIONS 1
+                SUMMARY
+                SUMMARY B 2
+                """
+            )
+        )
+
+    with pytest.raises(ConfigValidationError, match="must have at least"):
+        _ = lark_parse("config.ert", schema=init_user_config_schema())


### PR DESCRIPTION
**Issue**
Resolves #5711 


**Approach**
Unspecified arglists for multi-occurrence keywords will no longer set the dict entry to `None`, which will not create an error obscuring the underlying `ConfigValidationError` about missing arguments

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
