### PR TITLE
Raise error on faulty result file and missing report steps

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -247,7 +247,7 @@ class EnsembleConfig:
         report_steps = rangestring_to_list(options.get(ConfigKeys.REPORT_STEPS, ""))
 
         if os.path.isabs(res_file) or "%d" not in res_file:
-            result_file_context = next(
+            result_file_context: ContextValue = next(
                 x for x in gen_data if x.startswith("RESULT_FILE:")
             )
             raise ConfigValidationError.from_info(

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -19,6 +19,7 @@ from ert.config.response_config import ResponseConfig
 from ert.config.summary_config import SummaryConfig
 from ert.config.surface_config import SurfaceConfig
 from ert.parsing import ConfigValidationError, ConfigWarning, ErrorInfo
+from ert.parsing.context_values import ContextList, ContextValue
 from ert.storage.field_utils.field_utils import Shape, get_shape
 from ert.validation import rangestring_to_list
 
@@ -233,7 +234,7 @@ class EnsembleConfig:
             self.addNode(self.get_field_node(field, grid_file, dims))
 
     @staticmethod
-    def gen_data_node(gen_data: List[str]) -> Optional[GenDataConfig]:
+    def gen_data_node(gen_data: ContextList[ContextValue]) -> Optional[GenDataConfig]:
         options = _option_dict(gen_data, 1)
         name = gen_data[0]
         res_file = options.get(ConfigKeys.RESULT_FILE)
@@ -246,21 +247,29 @@ class EnsembleConfig:
         report_steps = rangestring_to_list(options.get(ConfigKeys.REPORT_STEPS, ""))
 
         if os.path.isabs(res_file) or "%d" not in res_file:
-            logger.error(
-                f"The RESULT_FILE:{res_file} setting for {name} is invalid - "
-                "must have an embedded %d - and be a relative path"
+            result_file_context = next(
+                x for x in gen_data if x.startswith("RESULT_FILE:")
             )
-        elif not report_steps:
-            logger.error(
-                "The GEN_DATA keywords must have a REPORT_STEPS:xxxx defined"
-                "Several report steps separated with ',' and ranges with '-'"
-                "can be listed"
+            raise ConfigValidationError.from_info(
+                ErrorInfo(
+                    filename=result_file_context.token.filename,
+                    message=f"The RESULT_FILE:{res_file} setting for {name} is "
+                    f"invalid - must have an embedded %d - and be a relative path",
+                ).set_context(result_file_context)
             )
-        else:
-            gdc = GenDataConfig(
-                name=name, input_file=res_file, report_steps=report_steps
+
+        if not report_steps:
+            raise ConfigValidationError.from_info(
+                ErrorInfo(
+                    filename=gen_data.keyword_token.filename,
+                    message="The GEN_DATA keywords must have a REPORT_STEPS:xxxx"
+                    " defined. Several report steps separated with ',' "
+                    "and ranges with '-' can be listed",
+                ).set_context_keyword(gen_data.keyword_token)
             )
-            return gdc
+
+        gdc = GenDataConfig(name=name, input_file=res_file, report_steps=report_steps)
+        return gdc
 
     @staticmethod
     def get_surface_node(surface: List[str]) -> SurfaceConfig:

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -254,7 +254,7 @@ class EnsembleConfig:
                 ErrorInfo(
                     filename=result_file_context.token.filename,
                     message=f"The RESULT_FILE:{res_file} setting for {name} is "
-                    f"invalid - must have an embedded %d - and be a relative path",
+                    f"invalid - must have an embedded %d and be a relative path",
                 ).set_context(result_file_context)
             )
 
@@ -262,7 +262,7 @@ class EnsembleConfig:
             raise ConfigValidationError.from_info(
                 ErrorInfo(
                     filename=gen_data.keyword_token.filename,
-                    message="The GEN_DATA keywords must have a REPORT_STEPS:xxxx"
+                    message="The GEN_DATA keywords must have REPORT_STEPS:xxxx"
                     " defined. Several report steps separated with ',' "
                     "and ranges with '-' can be listed",
                 ).set_context_keyword(gen_data.keyword_token)

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -362,7 +362,8 @@ def _handle_includes(
                         filename=config_file,
                     ).set_context(error_context)
                 )
-                continue
+
+                args = args[0:1]
 
             file_to_include = _substitute_token(defines, args[0])
 

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -7,7 +7,6 @@ import xtgeo
 from ecl.summary import EclSum
 
 from ert._c_wrappers.enkf import ConfigKeys, EnsembleConfig, ErtConfig
-from ert.config.gen_data_config import GenDataConfig
 from ert.parsing import ConfigValidationError, ConfigWarning
 
 
@@ -118,36 +117,6 @@ def test_that_files_for_refcase_exists(existing_suffix, expected_suffix):
                 ConfigKeys.REFCASE: refcase_file,
             },
         )
-
-
-@pytest.mark.parametrize(
-    "gen_data_str, expected",
-    [
-        pytest.param(
-            "GDK RESULT_FILE:Results INPUT_FORMAT:ASCII REPORT_STEPS:10",
-            None,
-            id="RESULT_FILE missing %d in file name",
-        ),
-        pytest.param(
-            "GDK RESULT_FILE:Results%d INPUT_FORMAT:ASCII",
-            None,
-            id="REPORT_STEPS missing",
-        ),
-        pytest.param(
-            "GDK RESULT_FILE:Results%d INPUT_FORMAT:ASCII REPORT_STEPS:10,20,30",
-            "Valid",
-            id="Valid case",
-        ),
-    ],
-)
-def test_gen_data_node(gen_data_str, expected):
-    node = EnsembleConfig.gen_data_node(gen_data_str.split(" "))
-    if expected is None:
-        assert node == expected
-    else:
-        assert node is not None
-        assert isinstance(node, GenDataConfig)
-        assert node.report_steps == [10, 20, 30]
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
**Issue**
Resolves #5712 


**Approach**
Raise localized error upon faulty `RESULT_FILE` without `%d`, or missing `REPORT_STEPS` of `GEN_DATA` entry.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
