### PR TITLE
Wrap UnexpectedCharacters error as ObservationConfigError

### DIFF
--- a/src/ert/parsing/new_observations_parser.py
+++ b/src/ert/parsing/new_observations_parser.py
@@ -114,7 +114,7 @@ def _parse_content(
         allowed_chars = e.allowed
         message = (
             f"Observation parsing failed: Did not expect character: {unexpected_char}. "
-            f"Expected one of {allowed_chars}"
+            f"Expected one of {allowed_chars}."
         )
 
         raise ObservationConfigError.from_info(

--- a/src/ert/parsing/new_observations_parser.py
+++ b/src/ert/parsing/new_observations_parser.py
@@ -112,8 +112,10 @@ def _parse_content(
     except UnexpectedCharacters as e:
         unexpected_char = e.char
         allowed_chars = e.allowed
+        unexpected_line = content.splitlines()[e.line - 1]
         message = (
-            f"Observation parsing failed: Did not expect character: {unexpected_char}. "
+            f"Observation parsing failed: Did not expect character: {unexpected_char}"
+            f" (on line {e.line}: {unexpected_line}). "
             f"Expected one of {allowed_chars}."
         )
 

--- a/tests/test_config_parsing/test_new_observations_parser.py
+++ b/tests/test_config_parsing/test_new_observations_parser.py
@@ -1,4 +1,10 @@
-from ert.parsing.new_observations_parser import ObservationType, _parse_content
+import pytest
+
+from ert.parsing.new_observations_parser import (
+    ObservationConfigError,
+    ObservationType,
+    _parse_content,
+)
 
 
 def test_parse():
@@ -68,3 +74,44 @@ def test_parse():
             ),
         ]
     )
+
+
+def test_parse_include_outside_raises_obsconf_error():
+    with pytest.raises(
+        ObservationConfigError,
+        match="Observation parsing failed: Did not expect character",
+    ):
+        _parse_content(
+            """
+            include a;
+        HISTORY_OBSERVATION FOPR;
+
+        SUMMARY_OBSERVATION WOPR_OP1_9
+        {
+            VALUE   = 0.1;
+            ERROR   = 0.05;
+            DATE    = 2010-03-31;  -- (RESTART = 9)
+            KEY     = WOPR:OP1;
+        };
+
+        GENERAL_OBSERVATION WPR_DIFF_1 {
+           DATA       = SNAKE_OIL_WPR_DIFF;
+           INDEX_LIST = 400,800,1200,1800;
+           DATE       = 2015-06-13;  -- (RESTART = 199)
+           OBS_FILE   = wpr_diff_obs.txt;
+        };
+
+        HISTORY_OBSERVATION  FOPR
+        {
+           ERROR      = 0.1;
+
+           SEGMENT SEG
+           {
+              START = 1;
+              STOP  = 0;
+              ERROR = -1;
+           };
+        };
+    """,
+            "",
+        )

--- a/tests/test_config_parsing/test_new_observations_parser.py
+++ b/tests/test_config_parsing/test_new_observations_parser.py
@@ -76,42 +76,9 @@ def test_parse():
     )
 
 
-def test_parse_include_outside_raises_obsconf_error():
+def test_that_unexpected_character_gives_observation_config_error():
     with pytest.raises(
         ObservationConfigError,
-        match="Observation parsing failed: Did not expect character",
+        match="Observation parsing failed: Did not expect character: i",
     ):
-        _parse_content(
-            """
-            include a;
-        HISTORY_OBSERVATION FOPR;
-
-        SUMMARY_OBSERVATION WOPR_OP1_9
-        {
-            VALUE   = 0.1;
-            ERROR   = 0.05;
-            DATE    = 2010-03-31;  -- (RESTART = 9)
-            KEY     = WOPR:OP1;
-        };
-
-        GENERAL_OBSERVATION WPR_DIFF_1 {
-           DATA       = SNAKE_OIL_WPR_DIFF;
-           INDEX_LIST = 400,800,1200,1800;
-           DATE       = 2015-06-13;  -- (RESTART = 199)
-           OBS_FILE   = wpr_diff_obs.txt;
-        };
-
-        HISTORY_OBSERVATION  FOPR
-        {
-           ERROR      = 0.1;
-
-           SEGMENT SEG
-           {
-              START = 1;
-              STOP  = 0;
-              ERROR = -1;
-           };
-        };
-    """,
-            "",
-        )
+        _parse_content(content="include a;", filename="")

--- a/tests/test_config_parsing/test_new_observations_parser.py
+++ b/tests/test_config_parsing/test_new_observations_parser.py
@@ -79,6 +79,6 @@ def test_parse():
 def test_that_unexpected_character_gives_observation_config_error():
     with pytest.raises(
         ObservationConfigError,
-        match="Observation parsing failed: Did not expect character: i",
+        match=".*i.*line 1.*include a;",
     ):
         _parse_content(content="include a;", filename="")


### PR DESCRIPTION
**Issue**
Resolves #5716 (partially)


**Approach**
Wraps UnexpectedCharacters error as localized ObservationConfigError, but does not handle the bigger issue of gathering/exposing these for linting, when linting ert config files pointing to faulty observations files. Made issue for that @ #5729 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
