### PR TITLE
Backport bugfixes configparsing

### DIFF
--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -22,6 +22,7 @@ from ert._c_wrappers.enkf.config.summary_config import SummaryConfig
 from ert._c_wrappers.enkf.config.surface_config import SurfaceConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert.parsing import ConfigValidationError, ConfigWarning, ErrorInfo
+from ert.parsing.context_values import ContextList, ContextValue
 from ert.storage.field_utils.field_utils import Shape, get_shape
 
 logger = logging.getLogger(__name__)
@@ -241,7 +242,7 @@ class EnsembleConfig:
             self.addNode(self.get_field_node(field, grid_file, dims))
 
     @staticmethod
-    def gen_data_node(gen_data: List[str]) -> Optional[GenDataConfig]:
+    def gen_data_node(gen_data: ContextList[ContextValue]) -> Optional[GenDataConfig]:
         options = _option_dict(gen_data, 1)
         name = gen_data[0]
         res_file = options.get(ConfigKeys.RESULT_FILE)
@@ -254,21 +255,29 @@ class EnsembleConfig:
         report_steps = rangestring_to_list(options.get(ConfigKeys.REPORT_STEPS, ""))
 
         if os.path.isabs(res_file) or "%d" not in res_file:
-            logger.error(
-                f"The RESULT_FILE:{res_file} setting for {name} is invalid - "
-                "must have an embedded %d - and be a relative path"
+            result_file_context: ContextValue = next(
+                x for x in gen_data if x.startswith("RESULT_FILE:")
             )
-        elif not report_steps:
-            logger.error(
-                "The GEN_DATA keywords must have a REPORT_STEPS:xxxx defined"
-                "Several report steps separated with ',' and ranges with '-'"
-                "can be listed"
+            raise ConfigValidationError.from_info(
+                ErrorInfo(
+                    filename=result_file_context.token.filename,
+                    message=f"The RESULT_FILE:{res_file} setting for {name} is "
+                    f"invalid - must have an embedded %d and be a relative path",
+                ).set_context(result_file_context)
             )
-        else:
-            gdc = GenDataConfig(
-                name=name, input_file=res_file, report_steps=report_steps
+
+        if not report_steps:
+            raise ConfigValidationError.from_info(
+                ErrorInfo(
+                    filename=gen_data.keyword_token.filename,
+                    message="The GEN_DATA keywords must have REPORT_STEPS:xxxx"
+                    " defined. Several report steps separated with ',' "
+                    "and ranges with '-' can be listed",
+                ).set_context_keyword(gen_data.keyword_token)
             )
-            return gdc
+
+        gdc = GenDataConfig(name=name, input_file=res_file, report_steps=report_steps)
+        return gdc
 
     @staticmethod
     def get_surface_node(surface: List[str]) -> SurfaceConfig:

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -22,7 +22,6 @@ from ert._c_wrappers.enkf.config.summary_config import SummaryConfig
 from ert._c_wrappers.enkf.config.surface_config import SurfaceConfig
 from ert._c_wrappers.enkf.config_keys import ConfigKeys
 from ert.parsing import ConfigValidationError, ConfigWarning, ErrorInfo
-from ert.parsing.context_values import ContextList, ContextValue
 from ert.storage.field_utils.field_utils import Shape, get_shape
 
 logger = logging.getLogger(__name__)
@@ -242,7 +241,7 @@ class EnsembleConfig:
             self.addNode(self.get_field_node(field, grid_file, dims))
 
     @staticmethod
-    def gen_data_node(gen_data: ContextList[ContextValue]) -> Optional[GenDataConfig]:
+    def gen_data_node(gen_data: List[str]) -> Optional[GenDataConfig]:
         options = _option_dict(gen_data, 1)
         name = gen_data[0]
         res_file = options.get(ConfigKeys.RESULT_FILE)
@@ -255,25 +254,17 @@ class EnsembleConfig:
         report_steps = rangestring_to_list(options.get(ConfigKeys.REPORT_STEPS, ""))
 
         if os.path.isabs(res_file) or "%d" not in res_file:
-            result_file_context: ContextValue = next(
-                x for x in gen_data if x.startswith("RESULT_FILE:")
-            )
-            raise ConfigValidationError.from_info(
-                ErrorInfo(
-                    filename=result_file_context.token.filename,
-                    message=f"The RESULT_FILE:{res_file} setting for {name} is "
-                    f"invalid - must have an embedded %d and be a relative path",
-                ).set_context(result_file_context)
+            raise ConfigValidationError(
+                f"The RESULT_FILE:{res_file} setting for {name} is "
+                f"invalid - must have an embedded %d and be a relative path"
             )
 
         if not report_steps:
-            raise ConfigValidationError.from_info(
-                ErrorInfo(
-                    filename=gen_data.keyword_token.filename,
-                    message="The GEN_DATA keywords must have REPORT_STEPS:xxxx"
-                    " defined. Several report steps separated with ',' "
-                    "and ranges with '-' can be listed",
-                ).set_context_keyword(gen_data.keyword_token)
+            raise ConfigValidationError(
+                "The GEN_DATA keywords must have "
+                "REPORT_STEPS:xxxx defined. Several "
+                "report steps separated with ',' "
+                "and ranges with '-' can be listed"
             )
 
         gdc = GenDataConfig(name=name, input_file=res_file, report_steps=report_steps)

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -364,7 +364,8 @@ def _handle_includes(
                         filename=config_file,
                     ).set_context(error_context)
                 )
-                continue
+
+                args = args[0:1]
 
             file_to_include = _substitute_token(defines, args[0])
 

--- a/src/ert/parsing/lark_parser.py
+++ b/src/ert/parsing/lark_parser.py
@@ -196,16 +196,16 @@ def _tree_to_dict(
     cwd = os.path.dirname(os.path.abspath(config_file))
 
     for node in tree.children:
+        args: List[FileContextToken]
+        kw: FileContextToken
+        kw, *args = node  # type: ignore
+        if kw not in schema:
+            warnings.warn(f"Unknown keyword {kw!r}", category=ConfigWarning)
+            continue
+
+        constraints = schema[kw]
+
         try:
-            args: List[FileContextToken]
-            kw: FileContextToken
-            kw, *args = node  # type: ignore
-
-            if kw not in schema:
-                warnings.warn(f"Unknown keyword {kw!r}", category=ConfigWarning)
-                continue
-            constraints = schema[kw]
-
             args = constraints.join_args(args)
             args = _substitute_args(args, constraints, defines)
             value_list = constraints.apply_constraints(args, kw, cwd)
@@ -227,7 +227,9 @@ def _tree_to_dict(
             else:
                 config_dict[kw] = value_list
         except ConfigValidationError as e:
-            config_dict[kw] = None
+            if not constraints.multi_occurrence:
+                config_dict[kw] = None
+
             errors.append(e)
 
     try:

--- a/tests/test_config_parsing/test_ert_config_parsing.py
+++ b/tests/test_config_parsing/test_ert_config_parsing.py
@@ -1168,3 +1168,24 @@ def test_parsing_workflow_with_multiple_args():
     ert_config = ErtConfig.from_file("config.ert")
 
     assert ert_config is not None
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_missing_arglist_does_not_affect_subsequent_calls():
+    """
+    Check that the summary without arglist causes a ConfigValidationError and
+    not an error from appending to None parsed from SUMMARY w/o arglist
+    """
+    with open("config.ert", mode="w", encoding="utf-8") as fh:
+        fh.write(
+            dedent(
+                """
+                NUM_REALIZATIONS 1
+                SUMMARY
+                SUMMARY B 2
+                """
+            )
+        )
+
+    with pytest.raises(ConfigValidationError, match="must have at least"):
+        _ = lark_parse("config.ert", schema=init_user_config_schema())

--- a/tests/test_config_parsing/test_new_observations_parser.py
+++ b/tests/test_config_parsing/test_new_observations_parser.py
@@ -1,4 +1,10 @@
-from ert.parsing.new_observations_parser import ObservationType, _parse_content
+import pytest
+
+from ert.parsing.new_observations_parser import (
+    ObservationConfigError,
+    ObservationType,
+    _parse_content,
+)
 
 
 def test_parse():
@@ -68,3 +74,11 @@ def test_parse():
             ),
         ]
     )
+
+
+def test_that_unexpected_character_gives_observation_config_error():
+    with pytest.raises(
+        ObservationConfigError,
+        match=".*i.*line 1.*include a;",
+    ):
+        _parse_content(content="include a;", filename="")

--- a/tests/test_config_parsing/test_parser_error_collection.py
+++ b/tests/test_config_parsing/test_parser_error_collection.py
@@ -121,8 +121,16 @@ def assert_that_config_leads_to_error(
 
     with pytest.raises(ConfigValidationError) as caught_error:
         ErtConfig.from_file(config_filename, use_new_parser=True)
+        # If the ert config did not raise any errors
+        # we manually raise an "empty" error to make
+        # this raise an assertion error that can be
+        # acted upon from assert_that_config_does_not_lead_to_error
+        raise ConfigValidationError(errors=[])
 
     collected_errors = caught_error.value.errors
+
+    if len(collected_errors) == 0:
+        raise AssertionError("Config did not lead to any errors")
 
     # Find errors in matching file
     errors_matching_filename = find_and_assert_errors_matching_filename(
@@ -1059,3 +1067,52 @@ def test_that_deprecations_are_handled(contents, expected_errors):
         assert_that_config_leads_to_warning(
             config_file_contents=contents, expected_error=expected_error
         )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_invalid_ensemble_result_file_errors():
+    assert_that_config_leads_to_error(
+        config_file_contents=dedent(
+            """
+NUM_REALIZATIONS  1
+GEN_DATA RFT_3-1_R_DATA INPUT_FORMAT:ASCII REPORT_STEPS:100 RESULT_FILE:RFT_3-1_R_<ITER>
+            """
+        ),
+        expected_error=ExpectedErrorInfo(
+            match="must have an embedded %d",
+            line=3,
+            column=61,
+            end_column=89,
+        ),
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_missing_report_steps_errors():
+    assert_that_config_leads_to_error(
+        config_file_contents=dedent(
+            """
+NUM_REALIZATIONS  1
+GEN_DATA RFT_3-1_R_DATA INPUT_FORMAT:ASCII RESULT_FILE:RFT_3-1_R%d
+            """
+        ),
+        expected_error=ExpectedErrorInfo(
+            match="REPORT_STEPS",
+            line=3,
+            column=1,
+            end_column=9,
+        ),
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_valid_gen_data_does_not_error():
+    assert_that_config_does_not_lead_to_error(
+        config_file_contents=dedent(
+            """
+NUM_REALIZATIONS  1
+GEN_DATA RFT_3-1_R_DATA INPUT_FORMAT:ASCII REPORT_STEPS:100 RESULT_FILE:RFT_3-1_R%d
+            """
+        ),
+        unexpected_error=ExpectedErrorInfo(),
+    )

--- a/tests/test_config_parsing/test_parser_error_collection.py
+++ b/tests/test_config_parsing/test_parser_error_collection.py
@@ -1069,40 +1069,35 @@ def test_that_deprecations_are_handled(contents, expected_errors):
         )
 
 
+@pytest.mark.parametrize("use_new_parser", [True, False])
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_invalid_ensemble_result_file_errors():
-    assert_that_config_leads_to_error(
-        config_file_contents=dedent(
-            """
+def test_that_invalid_ensemble_result_file_errors(use_new_parser):
+    write_files(
+        {
+            "test.ert": """
 NUM_REALIZATIONS  1
 GEN_DATA RFT_3-1_R_DATA INPUT_FORMAT:ASCII REPORT_STEPS:100 RESULT_FILE:RFT_3-1_R_<ITER>
             """
-        ),
-        expected_error=ExpectedErrorInfo(
-            match="must have an embedded %d",
-            line=3,
-            column=61,
-            end_column=89,
-        ),
+        }
     )
 
+    with pytest.raises(ConfigValidationError, match="must have an embedded %d"):
+        _ = ErtConfig.from_file("test.ert", use_new_parser=use_new_parser)
 
+
+@pytest.mark.parametrize("use_new_parser", [True, False])
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_missing_report_steps_errors():
-    assert_that_config_leads_to_error(
-        config_file_contents=dedent(
-            """
+def test_that_missing_report_steps_errors(use_new_parser):
+    write_files(
+        {
+            "test.ert": """
 NUM_REALIZATIONS  1
 GEN_DATA RFT_3-1_R_DATA INPUT_FORMAT:ASCII RESULT_FILE:RFT_3-1_R%d
             """
-        ),
-        expected_error=ExpectedErrorInfo(
-            match="REPORT_STEPS",
-            line=3,
-            column=1,
-            end_column=9,
-        ),
+        }
     )
+    with pytest.raises(ConfigValidationError, match="REPORT_STEPS"):
+        _ = ErtConfig.from_file("test.ert", use_new_parser=use_new_parser)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -113,36 +113,6 @@ def test_that_files_for_refcase_exists(setup_case, existing_suffix, expected_suf
         )
 
 
-@pytest.mark.parametrize(
-    "gen_data_str, expected",
-    [
-        pytest.param(
-            "GDK RESULT_FILE:Results INPUT_FORMAT:ASCII REPORT_STEPS:10",
-            None,
-            id="RESULT_FILE missing %d in file name",
-        ),
-        pytest.param(
-            "GDK RESULT_FILE:Results%d INPUT_FORMAT:ASCII",
-            None,
-            id="REPORT_STEPS missing",
-        ),
-        pytest.param(
-            "GDK RESULT_FILE:Results%d INPUT_FORMAT:ASCII REPORT_STEPS:10,20,30",
-            "Valid",
-            id="Valid case",
-        ),
-    ],
-)
-def test_gen_data_node(gen_data_str, expected):
-    node = EnsembleConfig.gen_data_node(gen_data_str.split(" "))
-    if expected is None:
-        assert node == expected
-    else:
-        assert node is not None
-        assert isinstance(node, GenDataConfig)
-        assert node.report_steps == [10, 20, 30]
-
-
 def test_get_surface_node(setup_case):
     _ = setup_case("configuration_tests", "ensemble_config.ert")
     surface_str = "TOP"

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ensemble_config.py
@@ -5,7 +5,6 @@ import pytest
 from ecl.summary import EclSum
 
 from ert._c_wrappers.enkf import ConfigKeys, EnsembleConfig, ErtConfig
-from ert._c_wrappers.enkf.config.gen_data_config import GenDataConfig
 from ert.parsing import ConfigValidationError, ConfigWarning
 
 


### PR DESCRIPTION
**Issue**
Backport of bugfixes #5728 #5724 #5723
Had to manually adapt #5724 to fit old parser, as the bugfix on main assumes depends on context provided only by the new parser. Tests relating to this PR in `test_parser_error_collection.py` are running for both new and old parser to check that it is compatible with both parsers.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
