### PR TITLE
Solve flake8-bugbears B017

### DIFF
--- a/tests/unit_tests/services/test_base_service.py
+++ b/tests/unit_tests/services/test_base_service.py
@@ -143,7 +143,7 @@ sys.exit(1)
 """
 )
 def test_authtoken_fail(server):
-    with pytest.raises(Exception):
+    with pytest.raises(ServerBootFail):
         server.fetch_conn_info()
 
 

--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -188,13 +188,17 @@ def test_flow(init_flow_config, source_root):
     ecl_run.run(flow_config, ["SPE1.DATA"])
 
     flow_run = ecl_run.EclRun("SPE1_ERROR.DATA", sim)
-    with pytest.raises(Exception):
+    with pytest.raises(
+        Exception, match="The eclipse executable exited with error status"
+    ):
         flow_run.runEclipse()
 
     ecl_run.run(flow_config, ["SPE1_ERROR.DATA", "--ignore-errors"])
 
     # Invalid version
-    with pytest.raises(Exception):
+    with pytest.raises(
+        Exception, match="The eclipse executable exited with error status"
+    ):
         ecl_run.run(flow_config, ["SPE1.DATA", "--version=no/such/version"])
 
 
@@ -401,7 +405,9 @@ def test_run_nonzero_exit_code(init_ecl100_config, source_root):
     erun = ecl_run.EclRun("FOO.DATA", sim)
     erun.sim.executable = source_root / "tests/unit_tests/shared/share/ecl_run_fail"
 
-    with pytest.raises(Exception):
+    with pytest.raises(
+        Exception, match="The eclipse executable exited with error status"
+    ):
         erun.runEclipse()
 
 

--- a/tests/unit_tests/shared/share/test_ecl_versioning_config.py
+++ b/tests/unit_tests/shared/share/test_ecl_versioning_config.py
@@ -36,7 +36,7 @@ def test_loading_of_eclipse_configurations(monkeypatch):
     assert source_file is not None
     ecl_config_path = os.path.dirname(source_file)
     monkeypatch.setenv("ECL100_SITE_CONFIG", "file/does/not/exist")
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         conf = ecl_config.Ecl100Config()
 
     monkeypatch.setenv(
@@ -48,7 +48,7 @@ def test_loading_of_eclipse_configurations(monkeypatch):
         f.write("this:\n -should\n-be\ninvalid:yaml?")
 
     monkeypatch.setenv("ECL100_SITE_CONFIG", "file.yml")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Failed parse: file.yml as yaml"):
         conf = ecl_config.Ecl100Config()
 
     scalar_exe = "bin/scalar_exe"
@@ -140,7 +140,9 @@ def test_loading_of_eclipse_configurations(monkeypatch):
     assert sim.executable == scalar_exe
     assert sim.mpirun is None
 
-    with pytest.raises(Exception):
+    with pytest.raises(
+        OSError, match="The executable: '/does/not/exist' can not be executed by user"
+    ):
         simulators = conf.simulators()
 
     simulators = conf.simulators(strict=False)
@@ -192,8 +194,12 @@ def test_default_version_definitions(monkeypatch):
     assert ecl_config.Keys.default not in conf
     assert conf.default_version is None
 
-    with pytest.raises(Exception):
+    with pytest.raises(
+        ValueError, match="The default version has not not been set in the config file"
+    ):
         sim = conf.sim()
 
-    with pytest.raises(Exception):
+    with pytest.raises(
+        ValueError, match="The default version has not not been set in the config file"
+    ):
         sim = conf.sim(ecl_config.Keys.default)


### PR DESCRIPTION
**Issue**
Resolves #5284

Flake8-bugbear error B017 states that assertRaises(Exception) and pytest.raises(Exception) should be considered evil. They can lead to your test passing even if the code being tested is never executed due to a typo. Assert for a more specific exception (builtin or custom), or use assertRaisesRegex (if using assertRaises), or add the match keyword argument (if using pytest.raises), or use the context manager form with a target.

**Approach**
Updated affected tests to specify which exception type should be raised, and the message (if there is one.)



## Pre review checklist

- [x] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] Updated documentation
- [X] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
