### PR TITLE
Remove websocket connection open/closed from logging

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -100,7 +100,7 @@ loggers:
   subscript:
     level: INFO
   websockets:
-    level: INFO
+    level: WARN
     handlers: [eefile]
     propagate: no
   ert._c_wrappers:


### PR DESCRIPTION
**Issue**
Resolves #5158
Websocket opening and closing connection created a lot of unnecessary noise in the logs.

**Approach**
Updated logger config to only log websocket messages of level warning and up.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
