### PR TITLE
Reinsert Start iteration field in gui

### DIFF
--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -115,9 +115,11 @@ def _setup_multiple_data_assimilation(ert, storage, args, experiment_id):
     # have a different way to get the restart information.
     if hasattr(args, "restart_case"):
         restart_run = args.restart_case is not None
+        start_iteration = args.start_iteration
         prior_ensemble = args.restart_case
     else:
         restart_run = args.restart_run
+        start_iteration = args.start_iteration
         prior_ensemble = args.prior_ensemble
     simulations_argument = {
         "active_realizations": _realizations(args, ert.getEnsembleSize()),
@@ -126,6 +128,7 @@ def _setup_multiple_data_assimilation(ert, storage, args, experiment_id):
         "weights": args.weights,
         "num_iterations": len(args.weights),
         "restart_run": restart_run,
+        "start_iteration": start_iteration,
         "prior_ensemble": prior_ensemble,
     }
     model = MultipleDataAssimilation(

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -12,12 +12,14 @@ from ert.gui.ertwidgets import (
 )
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
+from ert.gui.ertwidgets.models.init_iter_value import IterValueModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
 from ert.gui.ertwidgets.models.valuemodel import ValueModel
 from ert.gui.ertwidgets.stringbox import StringBox
 from ert.libres_facade import LibresFacade
 from ert.run_models import MultipleDataAssimilation
 from ert.validation import (
+    IntegerArgument,
     NumberListStringArgument,
     ProperNameFormatArgument,
     RangeStringArgument,
@@ -33,6 +35,7 @@ class Arguments:
     realizations: str
     weights: List[float]
     restart_run: bool
+    start_iteration: int
     prior_ensemble: str
 
 
@@ -90,6 +93,15 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout.addRow("Restart from:", self._case_selector)
         self._case_selector.setDisabled(True)
 
+        value_model = IterValueModel(notifier, default_value=1)
+        self._iter_field = StringBox(value_model, "config/simulation/iter_num")
+        self._iter_field.setValidator(
+            IntegerArgument(from_value=1),
+        )
+
+        self._iter_field.setDisabled(True)
+        layout.addRow("Start iteration:", self._iter_field)
+
         self._target_case_format_field.getValidationSupport().validationChanged.connect(  # noqa
             self.simulationConfigurationChanged
         )
@@ -104,8 +116,10 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
 
     def restart_run(self):
         if self._restart_box.isChecked():
+            self._iter_field.setEnabled(True)
             self._case_selector.setEnabled(True)
         else:
+            self._iter_field.setEnabled(False)
             self._case_selector.setEnabled(False)
 
     def _createInputForWeights(self, layout):
@@ -165,6 +179,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
             target_case=self._target_case_format_model.getValue(),
             realizations=self._active_realizations_field.text(),
             weights=self.weights,
+            start_iteration=int(self._iter_field.model.getValue()),
             restart_run=self._restart_box.isChecked(),
             prior_ensemble=self._case_selector.currentText(),
         )

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -87,10 +87,12 @@ class MultipleDataAssimilation(BaseRunModel):
 
         enumerated_weights = list(enumerate(weights))
         restart_run = self._simulation_arguments["restart_run"]
+        starting_iteration = self._simulation_arguments["start_iteration"]
         case_format = self._simulation_arguments["target_case"]
         prior_ensemble = self._simulation_arguments["prior_ensemble"]
 
         if restart_run:
+            assert starting_iteration > 0
             try:
                 prior_fs = self._storage.get_ensemble_by_name(prior_ensemble)
                 self.set_env_key("_ERT_ENSEMBLE_ID", str(prior_fs.id))
@@ -98,7 +100,7 @@ class MultipleDataAssimilation(BaseRunModel):
                 prior_context = self.ert().ensemble_context(
                     prior_fs,
                     self._simulation_arguments["active_realizations"],
-                    iteration=prior_fs.iteration,
+                    iteration=starting_iteration - 1,
                 )
             except KeyError as err:
                 raise ErtRunError(
@@ -121,7 +123,7 @@ class MultipleDataAssimilation(BaseRunModel):
                 prior_context.sim_fs, prior_context.active_realizations
             )
             self._simulateAndPostProcess(prior_context, evaluator_server_config)
-        starting_iteration = prior_fs.iteration + 1
+
         weights_to_run = enumerated_weights[max(starting_iteration - 1, 0) :]
 
         for iteration, weight in weights_to_run:

--- a/tests/unit_tests/cli/test_model_factory.py
+++ b/tests/unit_tests/cli/test_model_factory.py
@@ -125,6 +125,32 @@ def test_setup_multiple_data_assimilation(poly_case, storage):
     assert "weights" in model._simulation_arguments
 
 
+def test_setup_multiple_data_assimilation_with_restart(poly_case, storage):
+    ert = poly_case
+    args = Namespace(
+        realizations="0-4,7,8",
+        weights="6,4,2",
+        current_case="default",
+        target_case="test_case_%d",
+        start_iteration="1",
+        restart_run=True,
+        prior_ensemble="default",
+    )
+
+    model = model_factory._setup_multiple_data_assimilation(
+        ert,
+        storage,
+        args,
+        UUID(int=0),
+    )
+    assert isinstance(model, MultipleDataAssimilation)
+    assert len(model._simulation_arguments.keys()) == 7
+    assert "active_realizations" in model._simulation_arguments
+    assert "target_case" in model._simulation_arguments
+    assert "analysis_module" in model._simulation_arguments
+    assert "weights" in model._simulation_arguments
+
+
 def test_setup_iterative_ensemble_smoother(poly_case, storage):
     ert = poly_case
     args = Namespace(


### PR DESCRIPTION
**Issue**
related to #5737 , but closed without review/merging because we found a bug in the implementation of storage that @pinkwah is fixing and would also fix this.


**Approach**
Reinsert code removed (possibly without intention).


## Pre review checklist

- [ ] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation: would make the gui to correspond to the documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
