### PR TITLE
Fix typing of __eq__ functions

### DIFF
--- a/src/ert/_c_wrappers/analysis/analysis_module.py
+++ b/src/ert/_c_wrappers/analysis/analysis_module.py
@@ -200,7 +200,10 @@ class AnalysisModule:
     def __repr__(self):
         return f"AnalysisModule(name = {self.name})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AnalysisModule):
+            return False
+
         if self.name != other.name:
             return False
 

--- a/src/ert/_c_wrappers/enkf/analysis_config.py
+++ b/src/ert/_c_wrappers/enkf/analysis_config.py
@@ -202,7 +202,10 @@ class AnalysisConfig:
             f"analysis_select={self._active_module})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AnalysisConfig):
+            return False
+
         if realpath(self.get_log_path()) != realpath(other.get_log_path()):
             return False
 

--- a/src/ert/_c_wrappers/enkf/ensemble_config.py
+++ b/src/ert/_c_wrappers/enkf/ensemble_config.py
@@ -528,7 +528,10 @@ class EnsembleConfig:
     def __contains__(self, key):
         return key in self.keys
 
-    def __eq__(self, other: EnsembleConfig):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, EnsembleConfig):
+            return False
+
         if self.keys != other.keys:
             return False
 

--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -60,7 +60,10 @@ class ErtConfig:
     config_path: str = field(init=False)
     warning_infos: List[WarningInfo] = field(default=list)
 
-    def __eq__(self, other: "ErtConfig"):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ErtConfig):
+            return False
+
         ignore_attrs = ["warning_infos"]
         return all(
             attr in ignore_attrs or getattr(self, attr) == getattr(other, attr)

--- a/src/ert/_c_wrappers/enkf/model_config.py
+++ b/src/ert/_c_wrappers/enkf/model_config.py
@@ -116,7 +116,9 @@ class ModelConfig:
             f"time_map_file: {self._time_map_file}"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ModelConfig):
+            return False
         return all(
             [
                 self.num_realizations == other.num_realizations,

--- a/src/ert/_c_wrappers/enkf/observations/gen_observation.py
+++ b/src/ert/_c_wrappers/enkf/observations/gen_observation.py
@@ -13,7 +13,9 @@ class GenObservation:
     indices: npt.NDArray[np.int32]
     std_scaling: npt.NDArray[np.double]
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GenObservation):
+            return False
         return (
             np.array_equal(self.values, other.values)
             and np.array_equal(self.stds, other.stds)

--- a/src/ert/gui/plottery/plot_limits.py
+++ b/src/ert/gui/plottery/plot_limits.py
@@ -94,7 +94,9 @@ class PlotLimits:
     """ :type: tuple[datetime.datetime|datetime.date,
     datetime.datetime|datetime.date] """
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PlotLimits):
+            return False
         equality = self.value_limits == other.value_limits
         equality = equality and self.index_limits == other.index_limits
         equality = equality and self.count_limits == other.count_limits

--- a/src/ert/gui/plottery/plot_style.py
+++ b/src/ert/gui/plottery/plot_style.py
@@ -107,7 +107,10 @@ class PlotStyle:
             f"s:{self.size} enabled:{self.isEnabled()} copy:{self._is_copy}"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PlotStyle):
+            return False
+
         equalness = self.alpha == other.alpha
         equalness = equalness and self.marker == other.marker
         equalness = equalness and self.line_style == other.line_style

--- a/tests/test_config_parsing/egrid_generator.py
+++ b/tests/test_config_parsing/egrid_generator.py
@@ -230,7 +230,7 @@ class GlobalGrid:
     zcorn: np.ndarray
     actnum: Optional[np.ndarray] = None
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, GlobalGrid):
             return False
         return (


### PR DESCRIPTION
**Issue**
Needed for #5214 


__eq__ needs to handle bare objects (and mypy complains about this).


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
