### PR TITLE
Make forward_model_ok run in it's own process.

### DIFF
--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -8,7 +8,7 @@ import time
 from ctypes import c_int
 from multiprocessing.sharedctypes import Synchronized, SynchronizedString
 from threading import Lock, Semaphore, Thread
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from cwrap import BaseCClass
 from ecl.util.util import StringList
@@ -169,7 +169,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return callback_status
 
     # this function only works on systems where multiprocessing.Process uses forking
-    def run_done_callback_forking(self) -> (LoadStatus, str):
+    def run_done_callback_forking(self) -> Tuple[LoadStatus, str]:
         # status_msg has a maximum length of 1024 bytes.
         # the size is immutable after creation due to being backed by a c array.
         status_msg: SynchronizedString = mp.Array("c", b" " * 1024)  # type: ignore

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue.py
@@ -61,6 +61,7 @@ sys.exit(1)
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 def create_local_queue(

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import BoundedSemaphore
 from typing import Callable, List, TypedDict
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,6 +22,7 @@ from ert.load_status import LoadStatus
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 class Config(TypedDict):

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_job_queue_manager_torque.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import BoundedSemaphore
 from typing import Callable, TypedDict
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -34,6 +35,7 @@ def fixture_dummy_config():
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 class JobConfig(TypedDict):

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -3,7 +3,7 @@ import os
 import stat
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -104,6 +104,7 @@ def make_ensemble_builder(queue_config):
             @dataclass
             class RunArg:
                 iens: int
+                ensemble_storage = MagicMock()
 
             for iens in range(0, num_reals):
                 run_path = Path(tmpdir / f"real_{iens}")


### PR DESCRIPTION
This should fix the issue of ensemble evaluator not being able to respond to keep alive ping pong from monitor.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
