### PR TITLE
Make filename optional in ErrorInfo

### DIFF
--- a/src/ert/_c_wrappers/enkf/ert_config.py
+++ b/src/ert/_c_wrappers/enkf/ert_config.py
@@ -658,9 +658,6 @@ class ErtConfig:
                     ErrorInfo(
                         message="Cannot setup hook for non-existing"
                         f" job name {hook_name!r}",
-                        filename=hook_name.token.filename
-                        if hasattr(hook_name, "token")
-                        else "",
                     ).set_context(hook_name)
                 )
                 continue

--- a/src/ert/job_queue/workflow.py
+++ b/src/ert/job_queue/workflow.py
@@ -55,8 +55,7 @@ class Workflow:
                 if job_name not in job_dict:
                     errors.append(
                         ErrorInfo(
-                            filename=src_file,
-                            message=f"Job with name: {job_name}" f" is not recognized",
+                            f"Job with name: {job_name}" f" is not recognized"
                         ).set_context(job_name_with_context)
                     )
                     continue

--- a/src/ert/parsing/__init__.py
+++ b/src/ert/parsing/__init__.py
@@ -11,6 +11,7 @@ from .error_info import ErrorInfo, WarningInfo
 from .ext_job_keywords import ExtJobKeys
 from .ext_job_schema import init_ext_job_schema
 from .lark_parser import parse as lark_parse
+from .types import MaybeWithContext
 from .workflow_job_keywords import WorkflowJobKeys
 from .workflow_job_schema import init_workflow_job_schema
 from .workflow_schema import init_workflow_schema
@@ -32,4 +33,5 @@ __all__ = [
     "WarningInfo",
     "init_ext_job_schema",
     "ContextString",
+    "MaybeWithContext",
 ]

--- a/src/ert/parsing/config_schema_item.py
+++ b/src/ert/parsing/config_schema_item.py
@@ -90,9 +90,8 @@ class SchemaItem(BaseModel):
         if not self._is_in_allowed_values_for_arg_at_index(token, index):
             raise ConfigValidationError.from_info(
                 ErrorInfo(
-                    message=f"{self.kw!r} argument {index!r} must be one of"
+                    f"{self.kw!r} argument {index!r} must be one of"
                     f" {self.indexed_selection_set[index]!r} was {token.value!r}",
-                    filename=token.filename,
                 ).set_context(token)
             )
 
@@ -109,9 +108,8 @@ class SchemaItem(BaseModel):
             else:
                 raise ConfigValidationError.from_info(
                     ErrorInfo(
-                        message=f"{self.kw!r} must have a boolean value"
+                        f"{self.kw!r} must have a boolean value"
                         f" as argument {index + 1!r}",
-                        filename=token.filename,
                     ).set_context(token)
                 )
         if val_type == SchemaItemType.INT:
@@ -120,9 +118,8 @@ class SchemaItem(BaseModel):
             except ValueError:
                 raise ConfigValidationError.from_info(
                     ErrorInfo(
-                        message=f"{self.kw!r} must have an integer value"
+                        f"{self.kw!r} must have an integer value"
                         f" as argument {index + 1!r}",
-                        filename=token.filename,
                     ).set_context(token)
                 )
         if val_type == SchemaItemType.FLOAT:
@@ -131,9 +128,7 @@ class SchemaItem(BaseModel):
             except ValueError:
                 raise ConfigValidationError.from_info(
                     ErrorInfo(
-                        message=f"{self.kw!r} must have a number "
-                        f"as argument {index + 1!r}",
-                        filename=token.filename,
+                        f"{self.kw!r} must have a number as argument {index + 1!r}",
                     ).set_context(token)
                 )
 
@@ -152,9 +147,7 @@ class SchemaItem(BaseModel):
                 err = f'Cannot find file or directory "{token.value}". '
                 if path != token:
                     err += f"The configured value was {path!r} "
-                raise ConfigValidationError.from_info(
-                    ErrorInfo(message=err, filename=token.filename).set_context(token)
-                )
+                raise ConfigValidationError.from_info(ErrorInfo(err).set_context(token))
 
             assert isinstance(path, str)
             return ContextString(path, token, keyword)
@@ -170,18 +163,16 @@ class SchemaItem(BaseModel):
 
             if absolute_path is None:
                 raise ConfigValidationError.from_info(
-                    ErrorInfo(
-                        message=f"Could not find executable {token.value!r}",
-                        filename=token.filename,
-                    ).set_context(token)
+                    ErrorInfo(f"Could not find executable {token.value!r}").set_context(
+                        token
+                    )
                 )
 
             if os.path.isdir(absolute_path):
                 raise ConfigValidationError.from_info(
                     ErrorInfo(
-                        message=f"Expected executable file, "
+                        f"Expected executable file, "
                         f"but {token.value!r} is a directory.",
-                        filename=token.filename,
                     ).set_context(token)
                 )
 
@@ -192,10 +183,7 @@ class SchemaItem(BaseModel):
                     else f"{token.value!r}"
                 )
                 raise ConfigValidationError.from_info(
-                    ErrorInfo(
-                        message=f"File not executable: {context}",
-                        filename=token.filename,
-                    ).set_context(token)
+                    ErrorInfo(f"File not executable: {context}").set_context(token)
                 )
             return ContextString(absolute_path, token, keyword)
         return ContextString(str(token), token, keyword)
@@ -234,8 +222,7 @@ class SchemaItem(BaseModel):
         elif self.argc_max != -1 and len(args) > self.argc_max:
             errors.append(
                 ErrorInfo(
-                    message=f"{self.kw} must have maximum {self.argc_max} arguments",
-                    filename=keyword.filename,
+                    f"{self.kw} must have maximum {self.argc_max} arguments",
                 ).set_context(ContextString.from_token(keyword))
             )
 

--- a/src/ert/parsing/error_info.py
+++ b/src/ert/parsing/error_info.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Optional, Sequence, Union
 
 from typing_extensions import Self
 
@@ -12,7 +12,7 @@ from .types import MaybeWithContext
 # pylint: disable=too-many-instance-attributes
 class ErrorInfo:
     message: str
-    filename: Optional[str]
+    filename: Optional[str] = None
     start_pos: Optional[int] = None
     line: Optional[int] = None
     column: Optional[int] = None
@@ -42,7 +42,7 @@ class ErrorInfo:
         self._attach_to_context(self._take(context, "keyword_token"))
         return self
 
-    def set_context_list(self, context_list: List[MaybeWithContext]) -> Self:
+    def set_context_list(self, context_list: Sequence[MaybeWithContext]) -> Self:
         parsed_context_list = []
         for context in context_list:
             the_context = self._take(context, attr="token")
@@ -70,6 +70,7 @@ class ErrorInfo:
 
     def _attach_to_context(self, token: Optional[FileContextToken]):
         if token is not None:
+            self.filename = token.filename
             self.originates_from = token
             self.start_pos = token.start_pos
             self.line = token.line

--- a/src/ert/parsing/new_observations_parser.py
+++ b/src/ert/parsing/new_observations_parser.py
@@ -218,7 +218,6 @@ def _validate_unique_names(conf_content: ConfContent) -> None:
     errors = [
         ErrorInfo(
             f"Duplicate observation name {n}",
-            n.filename,
         ).set_context(n)
         for n in duplicate_names
     ]
@@ -357,7 +356,6 @@ def _validate_gen_obs_values(
                         ErrorInfo(
                             "The following keywords did not"
                             " resolve to a valid path:\n OBS_FILE",
-                            key.filename,
                         ).set_context(value)
                     ]
                 )
@@ -393,7 +391,7 @@ def validate_error_mode(inp: FileContextToken) -> ErrorModes:
     raise ObservationConfigError(
         [
             ErrorInfo(
-                f'Unexpected ERROR_MODE {inp}. Failed to validate "{inp}"', inp.filename
+                f'Unexpected ERROR_MODE {inp}. Failed to validate "{inp}"'
             ).set_context(inp)
         ]
     )
@@ -421,7 +419,6 @@ def validate_positive_float(val: str, key: FileContextToken):
                 ErrorInfo(
                     f'Failed to validate "{val}" in {key}={val}.'
                     f" {key} must be given a positive value.",
-                    key.filename,
                 ).set_context(val)
             ]
         )
@@ -439,7 +436,6 @@ def validate_positive_int(val: str, key: FileContextToken):
                 ErrorInfo(
                     f'Failed to validate "{val}" in {key}={val}.'
                     f" {key} must be given a positive value.",
-                    key.filename,
                 ).set_context(val)
             ]
         )
@@ -451,9 +447,9 @@ def _missing_value_error(
 ) -> ObservationConfigError:
     return ObservationConfigError(
         [
-            ErrorInfo(
-                f'Missing item "{value_key}" in {name_token}', name_token.filename
-            ).set_context(name_token)
+            ErrorInfo(f'Missing item "{value_key}" in {name_token}').set_context(
+                name_token
+            )
         ]
     )
 
@@ -466,7 +462,6 @@ def _conversion_error(
             ErrorInfo(
                 f"Could not convert {value} to "
                 f'{type_name}. Failed to validate "{value}"',
-                token.filename,
             ).set_context(token)
         ]
     )
@@ -474,7 +469,7 @@ def _conversion_error(
 
 def _unknown_key_error(key: FileContextToken, name: str) -> ObservationConfigError:
     raise ObservationConfigError(
-        [ErrorInfo(f"Unknown {key} in {name}", key.filename).set_context(key)]
+        [ErrorInfo(f"Unknown {key} in {name}").set_context(key)]
     )
 
 
@@ -487,7 +482,6 @@ def _unknown_declaration_error(
         [
             ErrorInfo(
                 f"Unexpected declaration in observations {decl}",
-                decl[1].filename,
             ).set_context(decl[1])
         ]
     )

--- a/tests/test_config_parsing/test_parser_error_collection.py
+++ b/tests/test_config_parsing/test_parser_error_collection.py
@@ -438,15 +438,13 @@ def test_include_with_too_many_args_error_is_located_indirect(tmpdir):
         ),
         expected_error=ExpectedErrorInfo(
             filename="something.ert",
-            line=3,
-            column=9,
-            end_column=22,
+            line=1,
+            column=14,
+            end_column=39,
             match=r"Keyword:INCLUDE must have exactly one argument",
             other_files={
                 "something.ert": FileDetail(
-                    contents="""
-INCLUDE arg1 arg2 arg3 dot dotdot argN
-"""
+                    contents="INCLUDE arg1 arg2 arg3 dot dotdot argN"
                 )
             },
         ),
@@ -840,7 +838,7 @@ LOAD_WORKFLOW_JOB exists_but_not_runnable
             line=3,
             column=19,
             end_column=42,
-            filename="exists_but_not_runnable",
+            filename="test.ert",
             other_files={
                 "exists_but_not_runnable": FileDetail(is_readable=False, contents="")
             },
@@ -859,7 +857,7 @@ WORKFLOW_JOB_DIRECTORY hello
             """
         ),
         expected_error=ExpectedErrorInfo(
-            filename="exists_but_not_runnable",
+            filename="test.ert",
             line=3,
             column=24,
             end_column=29,

--- a/tests/unit_tests/c_wrappers/res/enkf/test_ert_config.py
+++ b/tests/unit_tests/c_wrappers/res/enkf/test_ert_config.py
@@ -112,7 +112,7 @@ expand_config_defs(config_defines, snake_oil_structure_config)
 
 
 def test_invalid_user_config():
-    with pytest.raises(IOError):
+    with pytest.raises(FileNotFoundError):
         ErtConfig.from_file("this/is/not/a/file")
 
 

--- a/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
+++ b/tests/unit_tests/c_wrappers/res/job_queue/test_ext_job.py
@@ -11,7 +11,7 @@ from ert.parsing import ConfigValidationError, ConfigWarning, SchemaItemType
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_forward_model_raises_on_missing():
-    with pytest.raises(ConfigValidationError, match="file(.+?)not found"):
+    with pytest.raises(ConfigValidationError, match="No such file or directory"):
         _ = ExtJob.from_config_file("CONFIG_FILE")
 
 


### PR DESCRIPTION
This is in order to make the callsite not have to worry about the type of tokens. Instead location info can be silently added by set_context if available.

This changes some locations to be more precise so the tests have to be changed.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
