### PR TITLE
Rephrase start simulation button

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -306,13 +306,13 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         "--current-case",
         type=valid_name,
         default="default",
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored.",
     )
 
     # ensemble_experiment_parser
     ensemble_experiment_description = (
-        "Run simulations in cli without performing any updates on the parameters."
+        "Run experiments in cli without performing any updates on the parameters."
     )
     ensemble_experiment_parser = subparsers.add_parser(
         ENSEMBLE_EXPERIMENT_MODE,
@@ -322,16 +322,16 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     ensemble_experiment_parser.add_argument(
         "--realizations",
         type=valid_realizations,
-        help="These are the realizations that will be used to perform simulations. "
+        help="These are the realizations that will be used to perform experiments. "
         "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
-        "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+        "then only realizations 0,1,2,3,...,9 will be used to perform experiments "
         "while realizations 10,11, 12,...,49 will be excluded.",
     )
     ensemble_experiment_parser.add_argument(
         "--current-case",
         type=valid_case,
         default="default",
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored.",
     )
 
@@ -346,7 +346,7 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
 
     # ensemble_smoother_parser
     ensemble_smoother_description = (
-        "Run simulations in cli while performing one update"
+        "Run experiments in cli while performing one update"
         " on the parameters by using the ensemble smoother algorithm."
     )
     ensemble_smoother_parser = subparsers.add_parser(
@@ -364,22 +364,22 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     ensemble_smoother_parser.add_argument(
         "--realizations",
         type=valid_realizations,
-        help="These are the realizations that will be used to perform simulations."
+        help="These are the realizations that will be used to perform experiments."
         "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
-        "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+        "then only realizations 0,1,2,3,...,9 will be used to perform experiments "
         "while realizations 10,11, 12,...,49 will be excluded",
     )
     ensemble_smoother_parser.add_argument(
         "--current-case",
         type=valid_name,
         default="default",
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored.",
     )
 
     # iterative_ensemble_smoother_parser
     iterative_ensemble_smoother_description = (
-        "Run simulations in cli while performing updates"
+        "Run experiments in cli while performing updates"
         " on the parameters using the iterative ensemble smoother algorithm."
     )
     iterative_ensemble_smoother_parser = subparsers.add_parser(
@@ -399,16 +399,16 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     iterative_ensemble_smoother_parser.add_argument(
         "--realizations",
         type=valid_realizations,
-        help="These are the realizations that will be used to perform simulations."
+        help="These are the realizations that will be used to perform experiments."
         "For example, if 'Number of realizations:50 and active realizations are 0-9', "
-        "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+        "then only realizations 0,1,2,3,...,9 will be used to perform experiments "
         "while realizations 10,11, 12,...,49 will be excluded.",
     )
     iterative_ensemble_smoother_parser.add_argument(
         "--current-case",
         type=valid_name,
         default="default",
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored.",
     )
     iterative_ensemble_smoother_parser.add_argument(
@@ -427,7 +427,7 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         "--current-case",
         type=valid_name,
         default="default",
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored.",
     )
     es_mda_parser.add_argument(
@@ -441,9 +441,9 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     es_mda_parser.add_argument(
         "--realizations",
         type=valid_realizations,
-        help="These are the realizations that will be used to perform simulations."
+        help="These are the realizations that will be used to perform experiments."
         "For example, if 'Number of realizations:50 and active realizations are 0-9', "
-        "then only realizations 0,1,2,3,...,9 will be used to perform simulations "
+        "then only realizations 0,1,2,3,...,9 will be used to perform experiments "
         "while realizations 10,11, 12,...,49 will be excluded.",
     )
     es_mda_parser.add_argument(
@@ -458,7 +458,7 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         "--restart-case",
         type=valid_name,
         default=None,
-        help="Name of the case where the results for the simulation "
+        help="Name of the case where the results for the experiment "
         "using the prior parameters will be stored. Iteration number is read "
         "from this case. If provided this will be a restart a run",
     )

--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -105,11 +105,11 @@ class Monitor:
 
     def _print_result(self, failed, failed_message):
         if failed:
-            msg = f"Simulations failed with the following error: {failed_message}"
+            msg = f"Experiment failed with the following error: {failed_message}"
             print(self._colorize(msg, fg=COLOR_FAILED), file=self._out)
         else:
             print(
-                self._colorize("Simulations completed.", fg=COLOR_FINISHED),
+                self._colorize("Experiment completed.", fg=COLOR_FINISHED),
                 file=self._out,
             )
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -49,7 +49,7 @@ class RunDialog(QDialog):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setWindowFlags(Qt.Window)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
-        self.setWindowTitle(f"Simulations - {config_file}")
+        self.setWindowTitle(f"Experiment - {config_file}")
 
         self._snapshot_model = SnapshotModel(self)
         self._run_model = run_model
@@ -109,7 +109,7 @@ class RunDialog(QDialog):
         self.plot_button.clicked.connect(self.plot_tool.trigger)
         self.plot_button.setEnabled(ert is not None)
 
-        self.kill_button = QPushButton("Kill simulations")
+        self.kill_button = QPushButton("Terminate experiment")
         self.done_button = QPushButton("Done")
         self.done_button.setHidden(True)
         self.restart_button = QPushButton("Restart")
@@ -283,9 +283,9 @@ class RunDialog(QDialog):
         self._worker_thread.start()
 
     def killJobs(self):
-        msg = "Are you sure you want to kill the currently running simulations?"
+        msg = "Are you sure you want to terminate the currently running experiment?"
         kill_job = QMessageBox.question(
-            self, "Kill simulations?", msg, QMessageBox.Yes | QMessageBox.No
+            self, "Terminate experiment", msg, QMessageBox.Yes | QMessageBox.No
         )
 
         if kill_job == QMessageBox.Yes:
@@ -310,7 +310,7 @@ class RunDialog(QDialog):
         )
 
         if failed:
-            msg = ErtMessageBox("ERT simulation failed!", failed_msg)
+            msg = ErtMessageBox("ERT experiment failed!", failed_msg)
             msg.exec_()
 
     def _show_done_button(self):

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -60,7 +60,7 @@ class SimulationPanel(QWidget):
 
         self.run_button = QToolButton()
         self.run_button.setObjectName("start_simulation")
-        self.run_button.setText("Start simulation")
+        self.run_button.setText("Run Experiment")
         self.run_button.setIcon(resourceIcon("play_circle.svg"))
         self.run_button.setIconSize(QSize(32, 32))
         self.run_button.clicked.connect(self.runSimulation)
@@ -134,11 +134,11 @@ class SimulationPanel(QWidget):
     def runSimulation(self):
         message = (
             f"Are you sure you want to use case '{self.notifier.current_case_name}' "
-            "for initialization of the initial ensemble when running the simulations?"
+            "for initialization of the initial ensemble when running the experiments?"
         )
         if (
             QMessageBox.question(
-                self, "Start simulations?", message, QMessageBox.Yes | QMessageBox.No
+                self, "Run experiments?", message, QMessageBox.Yes | QMessageBox.No
             )
             == QMessageBox.Yes
         ):
@@ -163,7 +163,7 @@ class SimulationPanel(QWidget):
                 if (
                     QMessageBox.warning(
                         self,
-                        "Start simulations?",
+                        "Run experiments?",
                         (
                             "ERT is running in an existing runpath.\n\n"
                             "Please be aware of the following:\n"
@@ -182,18 +182,18 @@ class SimulationPanel(QWidget):
             if not abort:
                 dialog = RunDialog(self._config_file, model, self.parent())
                 self.run_button.setDisabled(True)
-                self.run_button.setText("Simulation running...")
+                self.run_button.setText("Experiment running...")
                 dialog.startSimulation()
                 dialog.show()
 
                 def exit_handler():
-                    self.run_button.setText("Start simulation")
+                    self.run_button.setText("Run Experiment")
                     self.run_button.setDisabled(False)
                     self.notifier.emitErtChange()
 
                 dialog.finished.connect(exit_handler)
 
-                self.notifier.emitErtChange()  # simulations may have added new cases
+                self.notifier.emitErtChange()  # experiments may have added new cases
 
     def toggleSimulationMode(self):
         current_model = self.getCurrentSimulationModel()

--- a/tests/unit_tests/cli/test_cli_monitor.py
+++ b/tests/unit_tests/cli/test_cli_monitor.py
@@ -45,7 +45,7 @@ def test_result_success():
 
     monitor._print_result(False, None)
 
-    assert out.getvalue() == "Simulations completed.\n"
+    assert out.getvalue() == "Experiment completed.\n"
 
 
 def test_result_failure():
@@ -54,7 +54,7 @@ def test_result_failure():
 
     monitor._print_result(True, "fail")
 
-    assert out.getvalue() == "Simulations failed with the following error: fail\n"
+    assert out.getvalue() == "Experiment failed with the following error: fail\n"
 
 
 def test_print_progress():


### PR DESCRIPTION

**Issue**
Resolves #4374


**Approach**
Rephrased "Start Simulation"-button to "Run Experiment" as "start simulation" can be misleading.



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
