### PR TITLE
Log messages from job queue

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -106,7 +106,7 @@ loggers:
   ert._c_wrappers:
     level: INFO
     propagate: yes
-  ert._c_wrappers.job_queue:
+  ert.job_queue:
     level: DEBUG
     propagate: yes
   ert.analysis:


### PR DESCRIPTION
Module was moved in e3943e24791930ac01a997db63ee3fabb837b14e, module reference in logger conf needed updating.


## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT NECESSARY - Updated documentation
- [x] TESTED LOCALLY - Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
