### PR TITLE
Replace basemodel with dataclass in event.py

### DIFF
--- a/src/ert/ensemble_evaluator/event.py
+++ b/src/ert/ensemble_evaluator/event.py
@@ -1,11 +1,11 @@
+from dataclasses import dataclass
 from typing import Optional
-
-from pydantic import BaseModel
 
 from .snapshot import PartialSnapshot, Snapshot
 
 
-class _UpdateEvent(BaseModel):
+@dataclass
+class _UpdateEvent:
     phase_name: str
     current_phase: int
     total_phases: int
@@ -14,20 +14,17 @@ class _UpdateEvent(BaseModel):
     iteration: int
 
 
+@dataclass
 class FullSnapshotEvent(_UpdateEvent):
-    snapshot: Optional[Snapshot]
-
-    class Config:
-        arbitrary_types_allowed = True
+    snapshot: Optional[Snapshot] = None
 
 
+@dataclass
 class SnapshotUpdateEvent(_UpdateEvent):
-    partial_snapshot: Optional[PartialSnapshot]
-
-    class Config:
-        arbitrary_types_allowed = True
+    partial_snapshot: Optional[PartialSnapshot] = None
 
 
-class EndEvent(BaseModel):
+@dataclass
+class EndEvent:
     failed: bool
-    failed_msg: Optional[str]
+    failed_msg: Optional[str] = None


### PR DESCRIPTION
**Issue**
Resolves #2813


**Approach**
Replaced event.py classes based on Pydantic.BaseModel with @dateclass



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
