### PR TITLE
Remove unused ExtParamConfig lookup by int

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -64,6 +64,10 @@ ignore_errors = False
 ignore_missing_imports = False
 ignore_errors = False
 
+[mypy-ert._c_wrappers.ext_param_config]
+ignore_missing_imports = False
+ignore_errors = False
+
 [mypy-cwrap.*]
 ignore_missing_imports = True
 ignore_errors = True

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -118,7 +118,7 @@ class BatchSimulator:
     ) -> None:
         def _check_suffix(
             ext_config: "ExtParamConfig",
-            key: Union[str, int],
+            key: str,
             assignment: Union[Dict[str, Any], Tuple[str, str], str, int],
         ) -> None:
             if key not in ext_config:
@@ -132,7 +132,7 @@ class BatchSimulator:
                         f"these suffixes: {missingsuffixes}"
                     )
                 for suffix in assignment:
-                    if suffix not in suffixes:
+                    if suffix not in suffixes:  # type: ignore[comparison-overlap]
                         raise KeyError(
                             f"Key {key} has suffixes {suffixes}. "
                             f"Can't find the requested suffix {suffix}"

--- a/tests/unit_tests/config/test_ext_param_config.py
+++ b/tests/unit_tests/config/test_ext_param_config.py
@@ -15,11 +15,6 @@ def test_ext_param_config():
     with pytest.raises(IndexError):
         _ = config[100]
 
-    keys = []
-    for key in config.keys():
-        keys.append(key)
-
-    assert keys == input_keys
     assert "key1" in config
 
 
@@ -52,9 +47,4 @@ def test_ext_param_config_suffixes():
         assert configsuffixes in input_suffixes
 
     with pytest.raises(IndexError):
-        _ = config[100]
-
-    with pytest.raises(IndexError):
         _ = config["no_such_key"]
-
-    assert dict(config.items()) == input_dict


### PR DESCRIPTION
**Issue**
Needed for #5214 

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
