### PR TITLE
Increase verbosity of too many realz failed error

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -547,8 +547,8 @@ class BaseRunModel:
                 f"({min_realization_count})"
             )
 
-        current_case = self._simulation_arguments.get("current_case", None)
-        target_case = self._simulation_arguments.get("target_case", None)
+        current_case = self._simulation_arguments.get("current_case")
+        target_case = self._simulation_arguments.get("target_case")
 
         if current_case is not None:
             try:
@@ -573,8 +573,12 @@ class BaseRunModel:
                 num_iterations = self._simulation_arguments["num_iterations"]
                 for i in range(num_iterations):
                     try:
-                        self._storage.get_ensemble_by_name(target_case % i)
-                        errors.append(f"- Target case: {target_case % i} exists")
+                        self._storage.get_ensemble_by_name(
+                            target_case % i  # noqa: S001
+                        )
+                        errors.append(
+                            f"- Target case: {target_case % i} exists"  # noqa: S001
+                        )
                     except KeyError:
                         pass
             else:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -315,8 +315,14 @@ class BaseRunModel:
             .have_enough_realisations(num_successful_realizations)
         ):
             raise ErtRunError(
-                "Too many simulations have failed! You can add/adjust MIN_REALIZATIONS "
-                + "to allow failures in your simulations."
+                "Too many simulations have failed! "
+                f"Number of successful simulations: {num_successful_realizations}, "
+                "number of active realizations: "
+                f"{self._simulation_arguments['active_realizations'].count(True)}, "
+                "expected minimal number of successful realizations: "
+                f"{self.ert().analysisConfig().minimum_required_realizations}\n"
+                "You can add/adjust MIN_REALIZATIONS "
+                "to allow (more) failures in your simulations."
             )
 
     def _checkMinimumActiveRealizations(self, active_realizations: int) -> None:


### PR DESCRIPTION
**Issue**
Debugging a user model case, i'm getting a "too many realizations failed" error, even though according to all data only one realization failed, and min_realizations is set to 80% (and num realizations is 202).

i don't understand how this error occurs, and would like to include more debugging in the error message.


**Approach**
We log
- how many realisationz were successfull,
- how many realißations are active, and
- how many are min required to be successful

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] NOT RELEVANT Updated documentation
- [X] Ensured new behaviour is tested - see screenshot

**Screenshot**

![test-new-error-msg](https://github.com/equinor/ert/assets/15932677/a4deaa15-b671-4e11-ac83-b55e6e0216da)
