### PR TITLE
Do no create experiment and case on start-up

### DIFF
--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, Optional
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QComboBox
 
 from ert.gui.ertnotifier import ErtNotifier
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class CaseSelector(QComboBox):
+    case_populated = Signal()
+
     def __init__(
         self,
         notifier: ErtNotifier,
@@ -34,6 +36,8 @@ class CaseSelector(QComboBox):
         addHelpToWidget(self, help_link)
         self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
+        self.setEnabled(False)
+
         if update_ert:
             # Update ERT when this combo box is changed
             self.currentIndexChanged[int].connect(self._on_current_index_changed)
@@ -52,6 +56,9 @@ class CaseSelector(QComboBox):
 
         self.clear()
 
+        if self._case_list():
+            self.setEnabled(True)
+
         for case in self._case_list():
             self.addItem(case.name, userData=case)
 
@@ -62,6 +69,8 @@ class CaseSelector(QComboBox):
             self.setCurrentIndex(max(current_index, 0))
 
         self.blockSignals(block)
+
+        self.case_populated.emit()
 
     def _case_list(self) -> Iterable[EnsembleReader]:
         if self._show_only_initialized:

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -4,7 +4,7 @@ import os
 import warnings
 import webbrowser
 from signal import SIG_DFL, SIGINT, signal
-from typing import List, Optional
+from typing import Optional
 
 from PyQt5.QtWidgets import (
     QFrame,
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
 from qtpy.QtCore import QLocale, QSize, Qt
 from qtpy.QtWidgets import QApplication
 
-from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, ParameterConfig
+from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
 from ert.enkf_main import EnKFMain
 from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertwidgets import SuggestorMessage, SummaryPanel, resourceIcon
@@ -40,7 +40,7 @@ from ert.libres_facade import LibresFacade
 from ert.namespace import Namespace
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
-from ert.storage import EnsembleAccessor, StorageReader, open_storage
+from ert.storage import open_storage
 from ert.storage.local_storage import local_storage_set_ert_config
 
 
@@ -78,11 +78,7 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None):
             ert_config=args.config, project=os.path.abspath(ens_path)
         ), open_storage(ens_path, mode=mode) as storage:
             if hasattr(window, "notifier"):
-                default_case = _get_or_create_default_case(
-                    storage, ensemble_size, parameter_config
-                )
                 window.notifier.set_storage(storage)
-                window.notifier.set_current_case(default_case)
             return show_window()
 
 
@@ -161,21 +157,6 @@ def _start_initial_gui_window(
             ert_config.model_config.num_realizations,
             ert_config.ensemble_config.parameter_configuration,
         )
-
-
-def _get_or_create_default_case(
-    storage: StorageReader, ensemble_size: int, parameter_config: List[ParameterConfig]
-) -> Optional[EnsembleAccessor]:
-    try:
-        storage_accessor = storage.to_accessor()
-        try:
-            return storage_accessor.get_ensemble_by_name("default")
-        except KeyError:
-            return storage_accessor.create_experiment(
-                parameters=parameter_config
-            ).create_ensemble(name="default", ensemble_size=ensemble_size)
-    except TypeError:
-        return None
 
 
 def _check_locale():

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -115,6 +115,11 @@ class CaseInitializationConfigurationPanel(QTabWidget):
                 parameters=parameters,
             )
 
+        def update_button_state():
+            initialize_button.setEnabled(target_case.count() > 0)
+
+        update_button_state()
+        target_case.case_populated.connect(update_button_state)
         initialize_button.clicked.connect(initializeFromScratch)
         layout.addWidget(initialize_button, 0, Qt.AlignCenter)
 


### PR DESCRIPTION
This fixes the bug where we end up with two default-cases when running a single experiment.

I propose we initially set the drop-down list of cases as inactive:

![Screenshot 2023-08-07 at 09 19 37](https://github.com/equinor/ert/assets/45088507/c2c4e5b4-f6c8-45ff-9c24-0857de069506)

The drop-down list will be set to active when gui updates. The drop-down list stays inactive while the simulation window is open though. This could perhaps be fixed.

![Screenshot 2023-08-07 at 09 22 09](https://github.com/equinor/ert/assets/45088507/720d7f0f-6dfc-46ce-a37c-e334ce835f44)

Once closed though, the list is updated:

![Screenshot 2023-08-07 at 09 24 28](https://github.com/equinor/ert/assets/45088507/46779e28-c073-457f-9da5-772d57840577)

The `Initialize` button in "Initialize from scratch" is now deactivated if there are no cases:

![Screenshot 2023-08-07 at 12 24 37](https://github.com/equinor/ert/assets/45088507/d7559239-c57f-41e3-afcc-4469dc201938)

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
