### PR TITLE
Fix bug with gen_kw templating

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypedDict
 import numpy as np
 import pandas as pd
 import xarray as xr
-from jinja2 import Template
 
 from .parameter_config import ParameterConfig
 from .parsing.config_errors import ConfigValidationError
@@ -105,10 +104,11 @@ class GenKwConfig(ParameterConfig):
             )
 
         with open(self.template_file_path, "r", encoding="utf-8") as f:
-            template = Template(
-                f.read(), variable_start_string="<", variable_end_string=">"
-            )
+            template = f.read()
         data = dict(zip(array["names"].values.tolist(), array.values.tolist()))
+        for key, value in data.items():
+            template = template.replace(f"<{key}>", f"{value:.6g}")
+
         log10_data = {
             tf.name: math.log(data[tf.name], 10)
             for tf in self.transfer_functions
@@ -121,9 +121,7 @@ class GenKwConfig(ParameterConfig):
 
         (run_path / target_file).parent.mkdir(exist_ok=True, parents=True)
         with open(run_path / target_file, "w", encoding="utf-8") as f:
-            f.write(
-                template.render({key: f"{value:.6g}" for key, value in data.items()})
-            )
+            f.write(template)
         if log10_data:
             return {self.name: data, f"LOG10_{self.name}": log10_data}
         else:


### PR DESCRIPTION
Jinja templating was a bit to advanced for this use, creating a bunch of corner cases. Reverted to a much simpler approach of just replacing the known keys. The jinja templating would replace all items in <> and fixing this as well as comment treatment would be much harder to understand.

**Issue**
Resolves #5811 and solves #5812 and solves #5730


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
