### PR TITLE
Fix validation of general observations ERROR/VALUE

### DIFF
--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -378,7 +378,7 @@ def _validate_gen_obs_values(
             output["RESTART"] = validate_positive_int(value, key)
         elif key == "VALUE":
             output["VALUE"] = validate_float(value, key)
-        elif key in ["ERROR", "ERROR_MIN", "DAYS", "HOURS"]:
+        elif key in ["ERROR", "DAYS", "HOURS"]:
             output[str(key)] = validate_positive_float(value, key)  # type: ignore
         elif key in ["DATE", "INDEX_LIST"]:
             output[str(key)] = value  # type: ignore
@@ -400,6 +400,15 @@ def _validate_gen_obs_values(
             output["DATA"] = value
         else:
             raise _unknown_key_error(key, name_token)
+    if "VALUE" in output and "ERROR" not in output:
+        raise ObservationConfigError(
+            [
+                ErrorInfo(
+                    f"For GENERAL_OBSERVATION {name_token}, with"
+                    f" VALUE = {output['VALUE']}, ERROR must also be given."
+                ).set_context(name_token)
+            ]
+        )
     return output
 
 


### PR DESCRIPTION
General observations were missing the validation of needing ERROR when values are given in term of VALUE.

Also removed redundant check for `ERROR_MIN` as it is not used for GENERAL_OBSERVATION and added more tests.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
