### PR TITLE
Remove ANALYSIS_COPY

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -23,7 +23,6 @@ Table of keywords
 =====================================================================   ======================================  ==============================  ==============================================================================================================================================
 Keyword name                                                            Required                                Default value                   Purpose
 =====================================================================   ======================================  ==============================  ==============================================================================================================================================
-:ref:`ANALYSIS_COPY <analysis_copy>`                                    NO                                                                      Create new instance of analysis module
 :ref:`ANALYSIS_SET_VAR <analysis_set_var>`                              NO                                                                      Set analysis module internal state variable
 :ref:`ANALYSIS_SELECT <analysis_select>`                                NO                                      STD_ENKF                        Select analysis module to use in update
 :ref:`CASE_TABLE <case_table>`                                          NO                                                                      Deprecated
@@ -1303,29 +1302,6 @@ The keywords to load, select and modify the analysis modules are documented here
         analysis modules currently available. To use this you must know which
         variables the module supports setting this way. If you try to set an
         unknown variable you will get an error message on stderr.
-
-
-.. _analysis_copy:
-.. topic:: ANALYSIS_COPY
-
-        With the ANALYSIS_COPY keyword you can create a new instance of a module. This
-        can be convenient if you want to run the same algorithm with the different
-        settings:
-
-        ::
-
-                ANALYSIS_COPY  A1  A2
-
-        We copy `A1` -> `A2`, where `A1` must be one of available analysis
-        modules `STD_ENKF` and `IES_ENKF`. After the copy operation the modules `A1`
-        and `A2` are 100% identical. We then set the truncation to two different
-        values:
-
-        ::
-
-                ANALYSIS_SET_VAR A1 ENKF_TRUNCATION 0.95
-                ANALYSIS_SET_VAR A2 ENKF_TRUNCATION 0.98
-
 
 .. _iter_case:
 .. topic:: ITER_CASE

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -21,7 +21,6 @@ class AnalysisConfig:
         min_realization: int = 0,
         update_log_path: str = "update_log",
         analysis_iter_config: Optional[AnalysisIterConfig] = None,
-        analysis_copy: Optional[List[Tuple[str, str]]] = None,
         analysis_set_var: Optional[List[Tuple[str, str, str]]] = None,
         analysis_select: Optional[str] = None,
     ) -> None:
@@ -34,7 +33,6 @@ class AnalysisConfig:
         self._update_log_path = update_log_path
 
         self._analysis_set_var = analysis_set_var or []
-        self._analysis_copy = analysis_copy or []
         es_module = AnalysisModule.ens_smoother_module()
         ies_module = AnalysisModule.iterated_ens_smoother_module()
         self._modules: Dict[str, AnalysisModule] = {
@@ -42,22 +40,7 @@ class AnalysisConfig:
             AnalysisMode.ITERATED_ENSEMBLE_SMOOTHER: ies_module,
         }
         self._active_module = analysis_select or AnalysisMode.ENSEMBLE_SMOOTHER
-        self._copy_modules()
         self._set_modules_var_list()
-
-    def _copy_modules(self) -> None:
-        for src_name, dst_name in self._analysis_copy:
-            module = self._modules.get(src_name)
-            if module is not None:
-                if module.mode == AnalysisMode.ENSEMBLE_SMOOTHER:
-                    new_module = AnalysisModule.ens_smoother_module(dst_name)
-                else:
-                    new_module = AnalysisModule.iterated_ens_smoother_module(dst_name)
-                self._modules[dst_name] = new_module
-            else:
-                raise ConfigValidationError(
-                    f"Trying to copy module {src_name!r} which does not exist"
-                )
 
     def _set_modules_var_list(self) -> None:
         for module_name, var_name, value in self._analysis_set_var:
@@ -93,7 +76,6 @@ class AnalysisConfig:
             min_realization=min_realization,
             update_log_path=config_dict.get(ConfigKeys.UPDATE_LOG_PATH, "update_log"),
             analysis_iter_config=AnalysisIterConfig.from_dict(config_dict),
-            analysis_copy=config_dict.get(ConfigKeys.ANALYSIS_COPY, []),
             analysis_set_var=config_dict.get(ConfigKeys.ANALYSIS_SET_VAR, []),
             analysis_select=config_dict.get(ConfigKeys.ANALYSIS_SELECT),
         )
@@ -194,7 +176,6 @@ class AnalysisConfig:
             f"min_realization={self._min_realization}, "
             f"update_log_path={self._update_log_path}, "
             f"analysis_iter_config={self._analysis_iter_config}, "
-            f"analysis_copy={self._analysis_copy}, "
             f"analysis_set_var={self._analysis_set_var}, "
             f"analysis_select={self._active_module})"
         )

--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -101,12 +101,6 @@ def stop_long_running_keyword() -> SchemaItem:
     )
 
 
-def analysis_copy_keyword() -> SchemaItem:
-    return SchemaItem(
-        kw=ConfigKeys.ANALYSIS_COPY, argc_min=2, argc_max=2, multi_occurrence=True
-    )
-
-
 def analysis_set_var_keyword() -> SchemaItem:
     return SchemaItem(
         kw=ConfigKeys.ANALYSIS_SET_VAR,
@@ -337,7 +331,6 @@ def init_user_config_schema() -> ConfigSchemaDict:
         int_keyword(ConfigKeys.MAX_RUNTIME),
         string_keyword(ConfigKeys.ANALYSIS_SELECT),
         stop_long_running_keyword(),
-        analysis_copy_keyword(),
         analysis_set_var_keyword(),
         string_keyword(ConfigKeys.ITER_CASE),
         int_keyword(ConfigKeys.ITER_COUNT),

--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -261,7 +261,6 @@ class ErtConfigValues:
     num_cpu: PositiveInt
     queue_system: Literal["LSF", "LOCAL", "TORQUE", "SLURM"]
     queue_option: List[Union[Tuple[str, str], Tuple[str, str, str]]]
-    analysis_copy: List[Tuple[str, str]]
     analysis_set_var: List[Tuple[str, str, Any]]
     analysis_select: str
     install_job: List[Tuple[str, str]]
@@ -310,7 +309,6 @@ class ErtConfigValues:
             ConfigKeys.NUM_CPU: self.num_cpu,
             ConfigKeys.QUEUE_SYSTEM: self.queue_system,
             ConfigKeys.QUEUE_OPTION: self.queue_option,
-            ConfigKeys.ANALYSIS_COPY: self.analysis_copy,
             ConfigKeys.ANALYSIS_SET_VAR: self.analysis_set_var,
             ConfigKeys.ANALYSIS_SELECT: self.analysis_select,
             ConfigKeys.INSTALL_JOB: self.install_job,
@@ -505,12 +503,6 @@ def ert_config_values(draw, use_eclbase=st.booleans()):
             num_cpu=positives,
             queue_system=st.just(queue_system),
             queue_option=small_list(queue_options(st.just(queue_system))),
-            analysis_copy=small_list(
-                st.tuples(
-                    st.sampled_from(["STD_ENKF", "IES_ENKF"]),
-                    words,
-                )
-            ),
             analysis_set_var=small_list(
                 st.tuples(
                     st.just("STD_ENKF"),
@@ -726,9 +718,6 @@ def to_config_file(filename, config_values):  # pylint: disable=too-many-branche
             elif keyword == ConfigKeys.INSTALL_JOB_DIRECTORY:
                 for install_dir in keyword_value:
                     config.write(f"{keyword} {install_dir}\n")
-            elif keyword == ConfigKeys.ANALYSIS_COPY:
-                for statement in keyword_value:
-                    config.write(f"{keyword} {statement[0]} {statement[1]}\n")
             elif keyword == ConfigKeys.ANALYSIS_SET_VAR:
                 for statement in keyword_value:
                     config.write(

--- a/tests/unit_tests/config/test_analysis_config.py
+++ b/tests/unit_tests/config/test_analysis_config.py
@@ -15,10 +15,7 @@ def analysis_config(use_tmpdir):
         NUM_REALIZATIONS 10
         NUM_REALIZATIONS 10
 
-        ANALYSIS_COPY     STD_ENKF    ENKF_HIGH_TRUNCATION
         ANALYSIS_SET_VAR  STD_ENKF     ENKF_NCOMP    2
-        ANALYSIS_SET_VAR  ENKF_HIGH_TRUNCATION  ENKF_TRUNCATION 0.99
-        ANALYSIS_SELECT   ENKF_HIGH_TRUNCATION
 
         QUEUE_SYSTEM LOCAL
         QUEUE_OPTION LOCAL MAX_RUNNING 50
@@ -54,25 +51,14 @@ def test_analysis_config_constructor(analysis_config):
             ConfigKeys.STOP_LONG_RUNNING: False,
             ConfigKeys.MAX_RUNTIME: 0,
             ConfigKeys.MIN_REALIZATIONS: 10,
-            ConfigKeys.ANALYSIS_COPY: [
-                (
-                    "STD_ENKF",
-                    "ENKF_HIGH_TRUNCATION",
-                )
-            ],
             ConfigKeys.ANALYSIS_SET_VAR: [
                 (
                     "STD_ENKF",
                     "ENKF_NCOMP",
                     2,
                 ),
-                (
-                    "ENKF_HIGH_TRUNCATION",
-                    "ENKF_TRUNCATION",
-                    0.99,
-                ),
             ],
-            ConfigKeys.ANALYSIS_SELECT: "ENKF_HIGH_TRUNCATION",
+            ConfigKeys.ANALYSIS_SELECT: "STD_ENKF",
         }
     )
 


### PR DESCRIPTION
This might have made sense when it was possible to select analysis module from the GUI. This is no longer the case. Also, not used according to Azure logs.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
