### PR TITLE
Several mitigations against crashes when running with many realizations

### DIFF
--- a/.mypy-strict.ini
+++ b/.mypy-strict.ini
@@ -4,7 +4,6 @@ strict = True
 exclude = (?x)(
     src/ert/shared
     | src/ert/dark_storage
-    | src/ert/ensemble_evaluator
   )
 
 [mypy-ert.shared.*]
@@ -69,9 +68,6 @@ ignore_missing_imports = True
 
 [mypy-dask_jobqueue.*]
 ignore_missing_imports = True
-
-[mypy-ert.ensemble_evaluator.*]
-ignore_errors = True
 
 [mypy-ert.experiment_server.*]
 ignore_errors = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -41,7 +41,6 @@ ignore_errors = True
 
 [mypy-ert.ensemble_evaluator.*]
 ignore_missing_imports = True
-ignore_errors = True
 
 [mypy-ert.shared.hook_implementations.*]
 ignore_missing_imports = True

--- a/src/ert/ensemble_evaluator/_builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_builder/_ensemble.py
@@ -192,7 +192,6 @@ class Ensemble:
                     reals[str(real.iens)].steps[str(step.id_)].jobs[str(job.id_)] = Job(
                         status=state.JOB_STATE_START,
                         index=job.index,
-                        data={},
                         name=job.name,
                     )
         top = SnapshotDict(

--- a/src/ert/ensemble_evaluator/_builder/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_builder/_ensemble.py
@@ -104,7 +104,10 @@ class Ensemble:
         self.metadata = metadata
         self._snapshot = self._create_snapshot()
         self.status = self._snapshot.status
-        self._status_tracker = _EnsembleStateTracker(self._snapshot.status)
+        if self._snapshot.status:
+            self._status_tracker = _EnsembleStateTracker(self._snapshot.status)
+        else:
+            self._status_tracker = _EnsembleStateTracker()
         self._id: str = id_
 
     def __repr__(self) -> str:
@@ -142,7 +145,7 @@ class Ensemble:
         for event in events:
             snapshot_mutate_event.from_cloudevent(event)
         self._snapshot.merge_event(snapshot_mutate_event)
-        if self.status != self._snapshot.status:
+        if self._snapshot.status is not None and self.status != self._snapshot.status:
             self.status = self._status_tracker.update_state(self._snapshot.status)
         return snapshot_mutate_event
 

--- a/src/ert/ensemble_evaluator/_builder/_realization.py
+++ b/src/ert/ensemble_evaluator/_builder/_realization.py
@@ -5,14 +5,14 @@ from typing import List, Optional, Sequence, Tuple
 
 from typing_extensions import Self
 
-from ._step import Step, StepBuilder
+from ._step import LegacyStep, StepBuilder
 
 SOURCE_TEMPLATE_REAL = "/real/{iens}"
 
 logger = logging.getLogger(__name__)
 
 
-def _sort_steps(steps: Sequence["Step"]) -> Tuple[str, ...]:
+def _sort_steps(steps: Sequence["LegacyStep"]) -> Tuple[str, ...]:
     """Return a tuple comprised by step names in the order they should be
     executed."""
     graph = defaultdict(set)
@@ -42,7 +42,7 @@ class Realization:
     def __init__(  # pylint: disable=too-many-arguments
         self,
         iens: int,
-        steps: Sequence[Step],
+        steps: Sequence[LegacyStep],
         active: bool,
         source: str,
         ts_sorted_steps: Optional[Tuple[str, ...]] = None,

--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -8,6 +8,7 @@ import tempfile
 import typing
 from base64 import b64encode
 from datetime import datetime, timedelta
+from typing import Optional
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -23,7 +24,7 @@ from .evaluator_connection_info import EvaluatorConnectionInfo
 logger = logging.getLogger(__name__)
 
 
-def get_machine_name():
+def get_machine_name() -> str:
     """Returns a name that can be used to identify this machine in a network
     A fully qualified domain name is returned if available. Otherwise returns
     the string `localhost`
@@ -133,7 +134,7 @@ class EvaluatorServerConfig:
 
        https://github.com/python/cpython/blob/b34dd58fee707b8044beaf878962a6fa12b304dc/Lib/asyncio/selector_events.py#L607-L611
 
-    """  # noqa
+    """  # noqa pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
@@ -153,9 +154,9 @@ class EvaluatorServerConfig:
         if generate_cert:
             cert, key, pw = _generate_certificate(ip_address=self.host)
         else:
-            cert, key, pw = None, None, None  # type: ignore
+            cert, key, pw = None, None, None
         self.cert = cert
-        self._key = key
+        self._key: Optional[bytes] = key
         self._key_pw = pw
 
         self.token = _generate_authentication() if use_token else None
@@ -187,8 +188,9 @@ class EvaluatorServerConfig:
                     filehandle_1.write(self.cert)
 
                 key_path = tmp_path / "ee.key"
-                with open(key_path, "wb") as filehandle_2:
-                    filehandle_2.write(self._key)
+                if self._key is not None:
+                    with open(key_path, "wb") as filehandle_2:
+                        filehandle_2.write(self._key)
                 context = ssl.SSLContext(protocol=protocol)
                 context.load_cert_chain(cert_path, key_path, self._key_pw)
                 return context

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -1,6 +1,6 @@
 import asyncio
-import contextlib
 import logging
+import threading
 import time
 import traceback
 from collections import OrderedDict, defaultdict
@@ -10,98 +10,101 @@ from ert.ensemble_evaluator import identifiers
 logger = logging.getLogger(__name__)
 
 
-class BatchingDispatcher:
-    def __init__(self, loop, timeout, max_batch=1000):
-        self._timeout = timeout
+class BatchingDispatcher:  # pylint: disable=too-many-instance-attributes
+    def __init__(self, sleep_between_batches_seconds, max_batch=1000):
+        self._sleep_between_batches_seconds = sleep_between_batches_seconds
         self._max_batch = max_batch
 
         self._LOOKUP_MAP = defaultdict(list)
         self._running = True
+        self._finished = False
         self._buffer = []
+        self._buffer_lock = threading.Lock()
 
-        # Schedule task
-        self._task = asyncio.ensure_future(self._job(), loop=loop)
-        self._task.add_done_callback(self._done_callback)
+        self._dispatcher_thread = threading.Thread(
+            name="ert_ee_batch_dispatcher",
+            target=self.run_dispatcher,
+        )
+        self._dispatcher_thread.start()
 
-    def _done_callback(self, *args):
-        try:
-            failure = self._task.exception()
-            if failure is not None:
-                logger.error(f"exception in batcher: {failure}")
-                trace_info = traceback.format_exception(
-                    type(failure), failure, failure.__traceback__
-                )
-                logger.error("".join(trace_info))
-            else:
-                logger.debug("batcher finished normally")
-                return
-        except asyncio.CancelledError as ex:
-            logger.warning(f"batcher was cancelled: {ex}")
-
-        # call any registered handlers for FAILED. since we don't have
-        # an event, pass empty list and let handler decide how to proceed
-        funcs = self._LOOKUP_MAP[identifiers.EVTYPE_ENSEMBLE_FAILED]
-        asyncio.gather(*[f([]) for f, _ in funcs])
-
-    async def _work(self):
+    def _work(self):
         if len(self._buffer) == 0:
             logger.debug("no events to be processed in queue")
             return
 
-        t0 = time.time()
-        batch_of_events_for_processing, self._buffer = (
-            self._buffer[: self._max_batch],
-            self._buffer[self._max_batch :],
-        )
-        left_in_queue = len(self._buffer)
-
-        function_to_events_map = OrderedDict()
-        for f, event in batch_of_events_for_processing:
-            if f not in function_to_events_map:
-                function_to_events_map[f] = []
-            function_to_events_map[f].append(event)
-
-        def done_logger(_):
-            logger.debug(
-                f"processed {len(batch_of_events_for_processing)} events in "
-                f"{(time.time()-t0):.6f}s. "
-                f"{left_in_queue} left in queue"
+        with self._buffer_lock:
+            t0 = time.time()
+            batch_of_events_for_processing, self._buffer = (
+                self._buffer[: self._max_batch],
+                self._buffer[self._max_batch :],
             )
+            left_in_queue = len(self._buffer)
+        function_to_events_map = OrderedDict()
+        for func, event in batch_of_events_for_processing:
+            if func not in function_to_events_map:
+                function_to_events_map[func] = []
+            function_to_events_map[func].append(event)
 
-        events_handling = asyncio.gather(
-            *[f(events) for f, events in function_to_events_map.items()]
+        for func, events in function_to_events_map.items():
+            func(events)
+
+        logger.debug(
+            f"processed {len(batch_of_events_for_processing)} events in "
+            f"{(time.time()-t0):.6f}s. "
+            f"{left_in_queue} left in queue"
         )
-        events_handling.add_done_callback(done_logger)
-        await events_handling
 
-    async def _job(self):
+    def run_dispatcher(self):
+        try:
+            self._job()
+        except Exception as failure:  # pylint: disable=broad-exception-caught
+            logger.exception(f"exception in batching dispatcher: {failure}")
+            trace_info = traceback.format_exception(
+                type(failure), failure, failure.__traceback__
+            )
+            logger.exception(f"{trace_info}")
+        else:
+            logger.debug("batcher finished normally")
+            return
+        finally:
+            self._finished = True
+
+        # call any registered handlers for FAILED. since we don't have
+        # an event, pass empty list and let handler decide how to proceed
+        funcs = self._LOOKUP_MAP[identifiers.EVTYPE_ENSEMBLE_FAILED]
+        for f in funcs:
+            f([])
+
+        logger.debug("Dispatcher thread exiting.")
+
+    def _job(self):
         while self._running:
-            await asyncio.sleep(self._timeout)
-            await self._work()
-
+            if len(self._buffer) < self._max_batch:
+                time.sleep(self._sleep_between_batches_seconds)
+            else:
+                # sleep(0) is used to play nice with other threads.
+                # It will release the GIL and let other threads run.
+                time.sleep(0)
+            self._work()
         # Make sure no events are lingering
-        await self._work()
+        self._work()
 
-    async def join(self):
+    async def wait_until_finished(self):
         self._running = False
-        # if result is exception it should have been handled by
-        # done-handler, but also avoid killing the caller here
-        with contextlib.suppress(BaseException):
-            await self._task
+        while not self._finished:
+            await asyncio.sleep(0.01)
 
-    def register_event_handler(self, event_types, function, batching=True):
+    def register_event_handler(self, event_types, function):
         if not isinstance(event_types, set):
             event_types = {event_types}
         for event_type in event_types:
-            self._LOOKUP_MAP[event_type].append((function, batching))
+            self._LOOKUP_MAP[event_type].append(function)
 
     async def handle_event(self, event):
-        for function, batching in self._LOOKUP_MAP[event["type"]]:
-            if batching:
-                if self._task.done():
-                    raise asyncio.InvalidStateError(
-                        "trying to handle event after batcher is done"
-                    )
+        if not self._running:
+            raise asyncio.InvalidStateError(
+                "trying to handle event after batcher is done"
+            )
+        for function in self._LOOKUP_MAP[event["type"]]:
+            with self._buffer_lock:
                 self._buffer.append((function, event))
-            else:
-                await function(event)

--- a/src/ert/ensemble_evaluator/dispatch.py
+++ b/src/ert/ensemble_evaluator/dispatch.py
@@ -16,7 +16,17 @@ class BatchingDispatcher:  # pylint: disable=too-many-instance-attributes
         self._sleep_between_batches_seconds = sleep_between_batches_seconds
         self._max_batch = max_batch
 
-        self._LOOKUP_MAP: Mapping[set, Callable] = defaultdict(lambda: (lambda _: None))
+        def log_unknown_event_type(events: List[CloudEvent]) -> None:
+            if len(events) > 0:
+                event_type = events[0]["type"]
+                logger.warning(
+                    "tried to lookup handle function for unknown "
+                    f"event type: {event_type}"
+                )
+
+        self._LOOKUP_MAP: Dict[str, Callable[[List[CloudEvent]], None]] = defaultdict(
+            lambda: log_unknown_event_type
+        )
         self._running = True
         self._finished = False
         self._buffer = []

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -71,12 +71,12 @@ class EnsembleEvaluator:
 
         for e_type, f in (
             (EVGROUP_FM_ALL, self._fm_handler),
-            (EVTYPE_ENSEMBLE_STARTED, self._started_handler),
-            (EVTYPE_ENSEMBLE_STOPPED, self._stopped_handler),
-            (EVTYPE_ENSEMBLE_CANCELLED, self._cancelled_handler),
-            (EVTYPE_ENSEMBLE_FAILED, self._failed_handler),
+            ({EVTYPE_ENSEMBLE_STARTED}, self._started_handler),
+            ({EVTYPE_ENSEMBLE_STOPPED}, self._stopped_handler),
+            ({EVTYPE_ENSEMBLE_CANCELLED}, self._cancelled_handler),
+            ({EVTYPE_ENSEMBLE_FAILED}, self._failed_handler),
         ):
-            self._dispatcher.register_event_handler(e_type, f)
+            self._dispatcher.set_event_handler(e_type, f)
 
         self._result = None
         self._ws_thread = threading.Thread(

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -34,6 +34,7 @@ from .identifiers import (
     EVTYPE_ENSEMBLE_STOPPED,
 )
 from .monitor import Monitor
+from .snapshot import PartialSnapshot
 from .state import (
     ENSEMBLE_STATE_CANCELLED,
     ENSEMBLE_STATE_FAILED,
@@ -51,7 +52,7 @@ class EnsembleEvaluator:
         # Without information on the iteration, the events emitted from the
         # evaluator are ambiguous. In the future, an experiment authority* will
         # "own" the evaluators and can add iteration information to events they
-        # emit. In the mean time, it is added here.
+        # emit. In the meantime, it is added here.
         # * https://github.com/equinor/ert/issues/1250
         self._iter: int = iter_
         self._config: EvaluatorServerConfig = config
@@ -61,10 +62,10 @@ class EnsembleEvaluator:
         self._done = self._loop.create_future()
 
         self._clients: Set[WebSocketServerProtocol] = set()
-        self._dispatchers_connected: asyncio.Queue = None
+        self._dispatchers_connected: Optional[asyncio.Queue] = None
+        self._snapshot_mutex = threading.Lock()
         self._dispatcher = BatchingDispatcher(
-            self._loop,
-            timeout=2,
+            sleep_between_batches_seconds=2,
             max_batch=1000,
         )
 
@@ -90,28 +91,44 @@ class EnsembleEvaluator:
     def ensemble(self):
         return self._ensemble
 
-    async def _fm_handler(self, events):
-        snapshot_update_event = self.ensemble.update_snapshot(events)
-        await self._send_snapshot_update(snapshot_update_event)
-
-    async def _started_handler(self, events):
-        if self.ensemble.status != ENSEMBLE_STATE_FAILED:
+    def _fm_handler(self, events):
+        with self._snapshot_mutex:
             snapshot_update_event = self.ensemble.update_snapshot(events)
-            await self._send_snapshot_update(snapshot_update_event)
+        send_future = asyncio.run_coroutine_threadsafe(
+            self._send_snapshot_update(snapshot_update_event), self._loop
+        )
+        send_future.result()
 
-    async def _stopped_handler(self, events):
+    def _started_handler(self, events):
+        if self.ensemble.status != ENSEMBLE_STATE_FAILED:
+            with self._snapshot_mutex:
+                snapshot_update_event = self.ensemble.update_snapshot(events)
+            send_future = asyncio.run_coroutine_threadsafe(
+                self._send_snapshot_update(snapshot_update_event), self._loop
+            )
+            send_future.result()
+
+    def _stopped_handler(self, events):
         if self.ensemble.status != ENSEMBLE_STATE_FAILED:
             self._result = events[0].data  # normal termination
-            snapshot_update_event = self.ensemble.update_snapshot(events)
-            await self._send_snapshot_update(snapshot_update_event)
+            with self._snapshot_mutex:
+                snapshot_update_event = self.ensemble.update_snapshot(events)
+            send_future = asyncio.run_coroutine_threadsafe(
+                self._send_snapshot_update(snapshot_update_event), self._loop
+            )
+            send_future.result()
 
-    async def _cancelled_handler(self, events):
+    def _cancelled_handler(self, events):
         if self.ensemble.status != ENSEMBLE_STATE_FAILED:
-            snapshot_update_event = self.ensemble.update_snapshot(events)
-            await self._send_snapshot_update(snapshot_update_event)
-            self._stop()
+            with self._snapshot_mutex:
+                snapshot_update_event = self.ensemble.update_snapshot(events)
+            send_future = asyncio.run_coroutine_threadsafe(
+                self._send_snapshot_update(snapshot_update_event), self._loop
+            )
+            send_future.result()
+            self._loop.call_soon_threadsafe(self._stop)
 
-    async def _failed_handler(self, events):
+    def _failed_handler(self, events):
         if self.ensemble.status not in (
             ENSEMBLE_STATE_STOPPED,
             ENSEMBLE_STATE_CANCELLED,
@@ -122,11 +139,15 @@ class EnsembleEvaluator:
             # api for setting state in the ensemble
             if len(events) == 0:
                 events = [self._create_cloud_event(EVTYPE_ENSEMBLE_FAILED)]
-            snapshot_update_event = self.ensemble.update_snapshot(events)
-            await self._send_snapshot_update(snapshot_update_event)
+            with self._snapshot_mutex:
+                snapshot_update_event = self.ensemble.update_snapshot(events)
+            send_future = asyncio.run_coroutine_threadsafe(
+                self._send_snapshot_update(snapshot_update_event), self._loop
+            )
+            send_future.result()
             self._signal_cancel()  # let ensemble know it should stop
 
-    async def _send_snapshot_update(self, snapshot_update_event):
+    async def _send_snapshot_update(self, snapshot_update_event: PartialSnapshot):
         message = self._create_cloud_message(
             EVTYPE_EE_SNAPSHOT_UPDATE,
             snapshot_update_event.to_dict(),
@@ -187,8 +208,10 @@ class EnsembleEvaluator:
 
     async def handle_client(self, websocket, path):
         with self.store_client(websocket):
+            with self._snapshot_mutex:
+                current_snapshot_dict = self._ensemble.snapshot.to_dict()
             event = self._create_cloud_message(
-                EVTYPE_EE_SNAPSHOT, self._ensemble.snapshot.to_dict()
+                EVTYPE_EE_SNAPSHOT, current_snapshot_dict
             )
             await websocket.send(event)
 
@@ -308,11 +331,13 @@ class EnsembleEvaluator:
             else:
                 logger.debug("Got done signal. No dispatchers connected")
 
-            logger.debug("Joining batcher...")
+            logger.debug("Waiting for batcher to finish...")
             try:
-                await asyncio.wait_for(self._dispatcher.join(), timeout=20)
+                await asyncio.wait_for(
+                    self._dispatcher.wait_until_finished(), timeout=20
+                )
             except asyncio.TimeoutError:
-                logger.debug("Timed out waiting for batcher")
+                logger.debug("Timed out waiting for batcher to finish")
 
             terminated_attrs = {}
             terminated_data = None
@@ -367,7 +392,7 @@ class EnsembleEvaluator:
             self._ensemble.cancel()
         else:
             logger.debug("Stopping current ensemble")
-            self._stop()
+            self._loop.call_soon_threadsafe(self._stop)
 
     def run_and_get_successful_realizations(self) -> int:
         monitor = self.run()

--- a/src/ert/ensemble_evaluator/evaluator_tracker.py
+++ b/src/ert/ensemble_evaluator/evaluator_tracker.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import logging
 import queue
 import threading
@@ -144,7 +145,7 @@ class EvaluatorTracker:
                     indeterminate=self._model.isIndeterminate(),
                     progress=self._progress(),
                     iteration=iter_,
-                    snapshot=snapshot,
+                    snapshot=copy.deepcopy(snapshot),
                 )
             elif event["type"] == EVTYPE_EE_SNAPSHOT_UPDATE:
                 iter_ = event.data["iter"]

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -175,6 +175,8 @@ class PartialSnapshot:
         return self
 
     def to_dict(self) -> Mapping[str, Any]:
+        """used to send snapshot updates - for thread safety, this method should not
+        access the _snapshot property"""
         _dict = {}
         if self._metadata:
             _dict["metadata"] = self._metadata

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -245,9 +245,7 @@ class SnapshotModel(QAbstractItemModel):
 
                         for attr in (ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE):
                             if job.get(ids.DATA) and attr in job.get(ids.DATA):
-                                job_node.data[ids.DATA][attr] = job.get(ids.DATA).get(
-                                    attr
-                                )
+                                job_node.data[ids.DATA][attr] = job.get(attr)
 
                     if jobs_changed:
                         job_top_left = self.index(min(jobs_changed), 0, step_index)
@@ -301,7 +299,6 @@ class SnapshotModel(QAbstractItemModel):
                 for job_id in metadata[SORTED_JOB_IDS][real_id][step_id]:
                     job = snapshot.get_job(real_id, step_id, job_id)
                     job_dict = dict(job)
-                    job_dict[ids.DATA] = job.data
                     job_node = Node(job_id, job_dict, NodeType.JOB)
                     step_node.add_child(job_node)
 

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing as mp
 import random
+import sys
 import time
+import traceback
+from ctypes import c_int
 from threading import Lock, Semaphore, Thread
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
 from ert._clib.queue import _refresh_status  # pylint: disable=import-error
 from ert.load_status import LoadStatus
+from ert.realization_state import RealizationState
 
 from . import ResPrototype
 from .job_status_type_enum import JobStatusType
@@ -18,6 +23,8 @@ from .job_submit_status_type_enum import JobSubmitStatusType
 from .thread_status_type_enum import ThreadStatus
 
 if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized, SynchronizedString
+
     from ert.callbacks import Callback, CallbackArgs
 
     from .driver import Driver
@@ -177,9 +184,25 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return self._submit(driver)  # type: ignore
 
     def run_done_callback(self) -> Optional[LoadStatus]:
-        callback_status, status_msg = self.done_callback_function(
-            *self.callback_arguments
-        )
+        if sys.platform == "linux":
+            callback_status, status_msg = self.run_done_callback_forking()
+        else:
+            try:
+                callback_status, status_msg = self.done_callback_function(
+                    *self.callback_arguments
+                )
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                exception_with_stack = "".join(
+                    traceback.format_exception(type(err), err, err.__traceback__)
+                )
+                error_message = (
+                    "got exception while running forward_model_ok "
+                    f"callback:\n{exception_with_stack}"
+                )
+                print(error_message)
+                logger.exception(err)
+                callback_status = LoadStatus.LOAD_FAILURE
+                status_msg = error_message
         if callback_status == LoadStatus.LOAD_SUCCESSFUL:
             self._set_queue_status(JobStatusType.JOB_QUEUE_SUCCESS)
         elif callback_status == LoadStatus.TIME_MAP_FAILURE:
@@ -195,6 +218,62 @@ class JobQueueNode(BaseCClass):  # type: ignore
     def run_timeout_callback(self) -> None:
         if self.callback_timeout:
             self.callback_timeout(*self.callback_arguments)
+
+    # this function only works on systems where multiprocessing.Process uses forking
+    def run_done_callback_forking(self) -> Tuple[LoadStatus, str]:
+        # status_msg has a maximum length of 1024 bytes.
+        # the size is immutable after creation due to being backed by a c array.
+        status_msg: "SynchronizedString" = mp.Array("c", b" " * 1024)  # type: ignore
+        callback_status: "Synchronized[c_int]" = mp.Value("i", 2)  # type: ignore
+        pcontext = ProcessWithException(
+            target=self.done_callback_wrapper,
+            kwargs={
+                "callback_arguments": self.callback_arguments,
+                "callback_status_shared": callback_status,
+                "status_msg_shared": status_msg,
+            },
+        )
+        pcontext.start()
+        try:
+            pcontext.wait_and_throw_if_exception()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            exception_with_stack = "".join(
+                traceback.format_exception(type(err), err, err.__traceback__)
+            )
+            error_message = (
+                "got exception while running forward_model_ok "
+                f"callback:\n{exception_with_stack}"
+            )
+            print(error_message)
+            logger.exception(err)
+        pcontext.join()
+
+        load_status = LoadStatus(callback_status.value)
+
+        # this step was added because the state_map update in
+        #      forward_model_ok does not propagate from the spawned process.
+        run_arg = self.callback_arguments[0]
+        run_arg.ensemble_storage.state_map[run_arg.iens] = (
+            RealizationState.HAS_DATA
+            if load_status == LoadStatus.LOAD_SUCCESSFUL
+            else RealizationState.LOAD_FAILURE
+        )
+
+        return load_status, status_msg.value.decode("utf-8")
+
+    def done_callback_wrapper(
+        self,
+        callback_arguments: CallbackArgs,
+        callback_status_shared: "Synchronized[c_int]",
+        status_msg_shared: "SynchronizedString",
+    ) -> None:
+        callback_status: Optional[LoadStatus]
+        status_msg: str
+        callback_status, status_msg = self.done_callback_function(*callback_arguments)
+
+        if callback_status is not None:
+            callback_status_shared.value = callback_status.value  # type: ignore
+        status_msg_shared.value = bytes(status_msg, "utf-8")
 
     def run_exit_callback(self) -> None:
         self.exit_callback_function(*self.callback_arguments)
@@ -394,3 +473,26 @@ class JobQueueNode(BaseCClass):  # type: ignore
 
     def _set_thread_status(self, new_status: ThreadStatus) -> None:
         self._thread_status = new_status
+
+
+class ProcessWithException(mp.Process):
+    """Used to run something in a subprocess, and capture exceptions. In order to catch
+    an exception, wait_and_throw_if_exception should be tried - before one joins the
+    process!"""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        mp.Process.__init__(self, *args, **kwargs)
+        self._parent_connection, self._child_connection = mp.Pipe(False)
+        self._exception = None
+
+    def run(self) -> None:
+        try:
+            mp.Process.run(self)
+            self._child_connection.send(None)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            self._child_connection.send(err)
+
+    def wait_and_throw_if_exception(self) -> None:
+        exception = self._parent_connection.recv()
+        if exception:
+            raise exception

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -41,6 +41,12 @@ handlers:
     filename: ee-log.txt
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
+  websocketsfile:
+    level: DEBUG
+    formatter: simple_with_threading
+    filename: websockets-log.txt
+    (): ert.logging.TimestampedFileHandler
+    use_log_dir_from_env: true
   migration_handler:
     level: DEBUG
     formatter: simple
@@ -100,8 +106,8 @@ loggers:
   subscript:
     level: INFO
   websockets:
-    level: WARN
-    handlers: [eefile]
+    level: DEBUG
+    handlers: [websocketsfile]
     propagate: no
   ert.job_queue:
     level: DEBUG

--- a/tests/performance_tests/test_snapshot.py
+++ b/tests/performance_tests/test_snapshot.py
@@ -50,7 +50,6 @@ def simulate_forward_model_event_handling(
             reals[f"{real}"].steps["0"].jobs[str(job_idx)] = Job(
                 status=state.JOB_STATE_START,
                 index=job_idx,
-                data={},
                 name=f"FM_{job_idx}",
             )
     top = SnapshotDict(

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -8,7 +8,7 @@ import threading
 from argparse import ArgumentParser
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pandas as pd
@@ -892,3 +892,43 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
         assert lines[2].strip() == "TheThirdValue"
         # now MYVAR now set, so should be expanded inside the value of FOURTH
         assert lines[3].strip() == "fourth:foo"
+
+
+@pytest.mark.integration_test
+def test_cli_test_run_catches_forward_model_ok_callback_exception(
+    tmpdir, source_root, caplog
+):
+    shutil.copytree(
+        os.path.join(source_root, "test-data", "poly_example"),
+        os.path.join(str(tmpdir), "poly_example"),
+    )
+    with open(
+        os.path.join(str(tmpdir), "poly_example", "poly.ert"),
+        mode="a",
+        encoding="utf-8",
+    ) as config_file:
+        config_file.writelines(["MAX_SUBMIT 1"])
+    caplog.set_level(logging.ERROR)
+
+    error_message = "Argh"
+
+    with tmpdir.as_cwd(), patch(
+        "ert.run_models.base_run_model.forward_model_ok"
+    ) as bad_fm_ok_callback:
+        bad_fm_ok_callback.side_effect = RuntimeError(error_message)
+        parser = ArgumentParser(prog="test_main")
+        parsed = ert_parser(
+            parser,
+            [
+                TEST_RUN_MODE,
+                "poly_example/poly.ert",
+                "--port-range",
+                "1024-65535",
+            ],
+        )
+        with pytest.raises(ErtCliError):
+            run_cli(parsed)
+
+    assert "RuntimeError" in caplog.text
+    assert error_message in caplog.text
+    assert "Traceback" in caplog.text

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -3,7 +3,7 @@ import os
 import stat
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -99,6 +99,7 @@ def make_ensemble_builder(queue_config):
             @dataclass
             class RunArg:
                 iens: int
+                ensemble_storage = MagicMock()
 
             for iens in range(0, num_reals):
                 run_path = Path(tmpdir / f"real_{iens}")

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -27,7 +27,6 @@ def snapshot():
             job_id="0",
             index="0",
             name="job0",
-            data={},
             status="Unknown",
         )
         .add_job(
@@ -35,7 +34,6 @@ def snapshot():
             job_id="1",
             index="1",
             name="job1",
-            data={},
             status="Unknown",
         )
         .add_job(
@@ -43,7 +41,6 @@ def snapshot():
             job_id="2",
             index="2",
             name="job2",
-            data={},
             status="Unknown",
         )
         .add_job(
@@ -51,15 +48,14 @@ def snapshot():
             job_id="3",
             index="3",
             name="job3",
-            data={},
             status="Unknown",
         )
         .build(["0", "1", "3", "4", "5", "9"], status="Unknown")
     )
 
 
-@pytest.fixture
-def queue_config():
+@pytest.fixture(name="queue_config")
+def queue_config_fixture():
     return QueueConfig(
         job_script="job_dispatch.py",
         max_submit=100,
@@ -191,8 +187,8 @@ def _dump_ext_job(ext_job, index):
     }
 
 
-@pytest.fixture
-def make_ee_config():
+@pytest.fixture(name="make_ee_config")
+def make_ee_config_fixture():
     def _ee_config(**kwargs):
         return EvaluatorServerConfig(custom_port_range=range(1024, 65535), **kwargs)
 

--- a/tests/unit_tests/ensemble_evaluator/test_dispatch.py
+++ b/tests/unit_tests/ensemble_evaluator/test_dispatch.py
@@ -7,30 +7,25 @@ from ert.ensemble_evaluator.dispatch import BatchingDispatcher
 
 
 class DummyEventHandler:
-    def __init__(self, batching=False):
+    def __init__(self):
         self.dispatcher = BatchingDispatcher(
-            loop=None,
-            timeout=1,
+            sleep_between_batches_seconds=0,
         )
         self.dispatcher._LOOKUP_MAP.clear()
         self.mock_all = Mock()
         self.mock_step = Mock()
         self.mock_none = Mock()
 
-        self.dispatcher.register_event_handler(
-            ids.EVGROUP_FM_ALL, self.all, batching=batching
-        )
-        self.dispatcher.register_event_handler(
-            ids.EVGROUP_FM_STEP, self.step, batching=batching
-        )
+        self.dispatcher.register_event_handler(ids.EVGROUP_FM_ALL, self.all)
+        self.dispatcher.register_event_handler(ids.EVGROUP_FM_STEP, self.step)
 
     async def join(self):
-        await self.dispatcher.join()
+        await self.dispatcher.wait_until_finished()
 
-    async def all(self, event):
+    def all(self, event):
         self.mock_all(event)
 
-    async def step(self, event):
+    def step(self, event):
         self.mock_step(event)
 
 
@@ -44,10 +39,13 @@ async def test_event_dispatcher_one_handler():
 
     event = _create_dummy_event(ids.EVTYPE_FM_JOB_SUCCESS)
     await event_handler.dispatcher.handle_event(event)
+    await event_handler.join()
 
-    event_handler.mock_all.assert_called_with(event)
+    event_handler.mock_all.assert_called_with([event])
     event_handler.mock_step.assert_not_called()
     event_handler.mock_none.assert_not_called()
+
+    await event_handler.join()
 
 
 @pytest.mark.asyncio
@@ -56,10 +54,13 @@ async def test_event_dispatcher_two_handlers():
 
     event = _create_dummy_event(ids.EVTYPE_FM_STEP_UNKNOWN)
     await event_handler.dispatcher.handle_event(event)
+    await event_handler.join()
 
-    event_handler.mock_all.assert_called_with(event)
-    event_handler.mock_step.assert_called_with(event)
+    event_handler.mock_all.assert_called_with([event])
+    event_handler.mock_step.assert_called_with([event])
     event_handler.mock_none.assert_not_called()
+
+    await event_handler.join()
 
 
 @pytest.mark.asyncio
@@ -73,10 +74,12 @@ async def test_event_dispatcher_no_handlers():
     event_handler.mock_step.assert_not_called()
     event_handler.mock_none.assert_not_called()
 
+    await event_handler.join()
+
 
 @pytest.mark.asyncio
 async def test_event_dispatcher_batching_two_handlers():
-    event_handler = DummyEventHandler(batching=True)
+    event_handler = DummyEventHandler()
 
     event1 = _create_dummy_event(ids.EVTYPE_FM_STEP_UNKNOWN)
     event2 = _create_dummy_event(ids.EVTYPE_FM_STEP_UNKNOWN)

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -172,7 +172,7 @@ def test_dying_batcher(evaluator):
     def exploding_handler(events):
         raise ValueError("Boom!")
 
-    evaluator._dispatcher.register_event_handler("EXPLODING", exploding_handler)
+    evaluator._dispatcher.set_event_handler({"EXPLODING"}, exploding_handler)
 
     with evaluator.run() as monitor:
         token = evaluator._config.token

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -1,13 +1,5 @@
-from unittest.mock import patch
-
-import pytest
-from aiohttp import ServerTimeoutError
-from websockets.exceptions import ConnectionClosedError
-from websockets.version import version as websockets_version
-
 from _ert_job_runner.client import Client
 from ert.ensemble_evaluator import Snapshot, identifiers
-from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.ensemble_evaluator.monitor import Monitor
 from ert.ensemble_evaluator.state import (
     ENSEMBLE_STATE_FAILED,
@@ -18,11 +10,13 @@ from ert.ensemble_evaluator.state import (
     JOB_STATE_RUNNING,
 )
 
-from .ensemble_evaluator_utils import AutorunTestEnsemble, send_dispatch_event
+from .ensemble_evaluator_utils import send_dispatch_event
 
 
 def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
-    with evaluator.run() as monitor:
+    evaluator._start_running()
+    conn_info = evaluator._config.get_connection_info()
+    with Monitor(conn_info) as monitor:
         events = monitor.track()
         token = evaluator._config.token
         cert = evaluator._config.cert
@@ -115,7 +109,9 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
 
 
 def test_ensure_multi_level_events_in_order(evaluator):
-    with evaluator.run() as monitor:
+    evaluator._start_running()
+    config_info = evaluator._config.get_connection_info()
+    with Monitor(config_info) as monitor:
         events = monitor.track()
 
         token = evaluator._config.token
@@ -174,7 +170,10 @@ def test_dying_batcher(evaluator):
 
     evaluator._dispatcher.set_event_handler({"EXPLODING"}, exploding_handler)
 
-    with evaluator.run() as monitor:
+    evaluator._start_running()
+    config_info = evaluator._config.get_connection_info()
+
+    with Monitor(config_info) as monitor:
         token = evaluator._config.token
         cert = evaluator._config.cert
         url = evaluator._config.url
@@ -220,112 +219,3 @@ def test_dying_batcher(evaluator):
         list(monitor.track())
 
         assert ENSEMBLE_STATE_FAILED == evaluator.ensemble.snapshot.status
-
-
-@pytest.mark.parametrize("num_realizations, num_failing", [(10, 5), (10, 10)])
-def test_ens_eval_run_and_get_successful_realizations_connection_refused_no_recover(
-    make_ee_config, num_realizations, num_failing
-):
-    ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = AutorunTestEnsemble(
-        _iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
-    )
-    for i in range(num_failing):
-        ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0)
-
-    with patch.object(
-        Monitor, "track", side_effect=ConnectionRefusedError("Connection error")
-    ) as mock:
-        num_successful = ee.run_and_get_successful_realizations()
-        assert mock.call_count == 3
-    assert num_successful == num_realizations - num_failing
-
-
-def test_ens_eval_run_and_get_successful_realizations_timeout(make_ee_config):
-    ee_config = make_ee_config(use_token=False, generate_cert=False)
-    ensemble = AutorunTestEnsemble(_iter=1, reals=1, steps=1, jobs=2, id_="0")
-    ee = EnsembleEvaluator(ensemble, ee_config, 0)
-
-    with patch.object(
-        Monitor, "track", side_effect=ServerTimeoutError("timed out")
-    ) as mock:
-        num_successful = ee.run_and_get_successful_realizations()
-        assert mock.call_count == 3
-    assert num_successful == 1
-
-
-def get_connection_closed_exception():
-    # The API of the websockets exception was changed in version 10,
-    # and are not backwards compatible. However, we still need to
-    # support version 9, as this is the latest version that also supports
-    # Python 3.6
-    if int(websockets_version.split(".", maxsplit=1)[0]) < 10:
-        return ConnectionClosedError(1006, "Connection closed")
-    else:
-        return ConnectionClosedError(None, None)
-
-
-def dummy_iterator(dummy_str: str):
-    yield from dummy_str
-    raise get_connection_closed_exception()
-
-
-@pytest.mark.parametrize("num_realizations, num_failing", [(10, 5), (10, 10)])
-def test_recover_from_failure_in_run_and_get_successful_realizations(
-    make_ee_config, num_realizations, num_failing
-):
-    ee_config = make_ee_config(
-        use_token=False, generate_cert=False, custom_host="localhost"
-    )
-    ensemble = AutorunTestEnsemble(
-        _iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
-    )
-
-    for i in range(num_failing):
-        ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0)
-    with patch.object(
-        Monitor,
-        "track",
-        side_effect=[get_connection_closed_exception()] * 2
-        + [ConnectionRefusedError("Connection error")]
-        + [dummy_iterator("DUMMY TRACKING ITERATOR")]
-        + [get_connection_closed_exception()] * 2
-        + [ConnectionRefusedError("Connection error")] * 2
-        + ["DUMMY TRACKING ITERATOR2"],
-    ) as mock:
-        num_successful = ee.run_and_get_successful_realizations()
-        assert mock.call_count == 9
-    assert num_successful == num_realizations - num_failing
-
-
-@pytest.mark.parametrize("num_realizations, num_failing", [(10, 5), (10, 10)])
-def test_exhaust_retries_in_run_and_get_successful_realizations(
-    make_ee_config, num_realizations, num_failing
-):
-    ee_config = make_ee_config(
-        use_token=False, generate_cert=False, custom_host="localhost"
-    )
-    ensemble = AutorunTestEnsemble(
-        _iter=1, reals=num_realizations, steps=1, jobs=2, id_="0"
-    )
-
-    for i in range(num_failing):
-        ensemble.addFailJob(real=i, step=0, job=1)
-    ee = EnsembleEvaluator(ensemble, ee_config, 0)
-    with patch.object(
-        Monitor,
-        "track",
-        side_effect=[get_connection_closed_exception()] * 2
-        + [ConnectionRefusedError("Connection error")]
-        + [dummy_iterator("DUMMY TRACKING ITERATOR")]
-        + [get_connection_closed_exception()] * 2
-        + [ConnectionRefusedError("Connection error")] * 3
-        + [
-            "DUMMY TRACKING ITERATOR2"
-        ],  # This should not be reached, hence we assert call_count == 9
-    ) as mock:
-        num_successful = ee.run_and_get_successful_realizations()
-        assert mock.call_count == 9
-    assert num_successful == num_realizations - num_failing

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -94,8 +94,9 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
             assert full_snapshot_event["type"] == identifiers.EVTYPE_EE_SNAPSHOT
             snapshot = Snapshot(full_snapshot_event.data)
             assert snapshot.status == ENSEMBLE_STATE_UNKNOWN
-            assert snapshot.get_job("0", "0", "0").status == JOB_STATE_RUNNING
             assert snapshot.get_job("1", "0", "0").status == JOB_STATE_FINISHED
+            assert snapshot.get_job("0", "0", "0").status == JOB_STATE_RUNNING
+            assert snapshot.get_job("1", "0", "1").status == JOB_STATE_FAILURE
 
             # one monitor requests that server exit
             monitor.signal_cancel()
@@ -266,8 +267,7 @@ def get_connection_closed_exception():
 
 
 def dummy_iterator(dummy_str: str):
-    for c in dummy_str:
-        yield c
+    yield from dummy_str
     raise get_connection_closed_exception()
 
 

--- a/tests/unit_tests/ensemble_evaluator/test_snapshot.py
+++ b/tests/unit_tests/ensemble_evaluator/test_snapshot.py
@@ -18,13 +18,6 @@ from ert.ensemble_evaluator.snapshot import (
 
 def test_snapshot_merge(snapshot: Snapshot):
     update_event = PartialSnapshot(snapshot)
-    update_event.update_status(status=state.ENSEMBLE_STATE_STARTED)
-
-    snapshot.merge_event(update_event)
-
-    assert snapshot.status == state.ENSEMBLE_STATE_STARTED
-
-    update_event = PartialSnapshot(snapshot)
     update_event.update_job(
         real_id="1",
         step_id="0",
@@ -60,7 +53,7 @@ def test_snapshot_merge(snapshot: Snapshot):
 
     snapshot.merge_event(update_event)
 
-    assert snapshot.status == state.ENSEMBLE_STATE_STARTED
+    assert snapshot.status == state.ENSEMBLE_STATE_UNKNOWN
 
     assert snapshot.get_job(real_id="1", step_id="0", job_id="0") == Job(
         status="Finished",

--- a/tests/unit_tests/ensemble_evaluator/test_snapshot.py
+++ b/tests/unit_tests/ensemble_evaluator/test_snapshot.py
@@ -27,7 +27,6 @@ def test_snapshot_merge(snapshot: Snapshot):
             index="0",
             start_time=datetime(year=2020, month=10, day=27),
             end_time=datetime(year=2020, month=10, day=28),
-            data={"memory": 1000},
         ),
     )
     update_event.update_job(
@@ -60,23 +59,14 @@ def test_snapshot_merge(snapshot: Snapshot):
         index="0",
         start_time=datetime(year=2020, month=10, day=27),
         end_time=datetime(year=2020, month=10, day=28),
-        data={"memory": 1000},
-        error=None,
         name="job0",
-        stderr=None,
-        stdout=None,
     )
 
     assert snapshot.get_job(real_id="1", step_id="0", job_id="1") == Job(
         status="Running",
         index="1",
         start_time=datetime(year=2020, month=10, day=27),
-        end_time=None,
-        data={},
-        error=None,
         name="job1",
-        stderr=None,
-        stdout=None,
     )
 
     assert snapshot.get_job(real_id="9", step_id="0", job_id="0").status == "Running"
@@ -84,12 +74,7 @@ def test_snapshot_merge(snapshot: Snapshot):
         status="Running",
         index="0",
         start_time=datetime(year=2020, month=10, day=27),
-        end_time=None,
-        data={},
-        error=None,
         name="job0",
-        stderr=None,
-        stdout=None,
     )
 
 
@@ -128,11 +113,15 @@ def test_update_partial_from_multiple_cloudevents(snapshot):
     partial = PartialSnapshot(snapshot)
     partial.from_cloudevent(
         CloudEvent(
-            {
+            attributes={
                 "id": "0",
                 "type": ids.EVTYPE_FM_JOB_RUNNING,
                 "source": "/real/0/step/0/job/0",
-            }
+            },
+            data={
+                "current_memory_usage": 5,
+                "max_memory_usage": 6,
+            },
         )
     )
     partial.from_cloudevent(

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -17,7 +17,6 @@ from qtpy.QtWidgets import QComboBox, QMessageBox, QWidget
 
 from ert.config import ErtConfig
 from ert.enkf_main import EnKFMain
-from ert.ensemble_evaluator.identifiers import CURRENT_MEMORY_USAGE, MAX_MEMORY_USAGE
 from ert.ensemble_evaluator.snapshot import (
     Job,
     RealizationSnapshot,
@@ -58,8 +57,8 @@ def find_cases_dialog_and_panel(
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-@pytest.fixture(scope="module")
-def opened_main_window(source_root, tmpdir_factory):
+@pytest.fixture(name="opened_main_window", scope="module")
+def opened_main_window_fixture(source_root, tmpdir_factory):
     with pytest.MonkeyPatch.context() as mp:
         tmp_path = tmpdir_factory.mktemp("test-data")
         shutil.copytree(
@@ -136,8 +135,8 @@ def esmda_has_run(run_experiment):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-@pytest.fixture(scope="module")
-def run_experiment(request, opened_main_window):
+@pytest.fixture(name="run_experiment", scope="module")
+def run_experiment_fixture(request, opened_main_window):
     def func(experiment_mode):
         qtbot = QtBot(request)
         gui = opened_main_window
@@ -266,10 +265,8 @@ def full_snapshot() -> Snapshot:
                         error="error",
                         stdout="std_out_file",
                         stderr="std_err_file",
-                        data={
-                            CURRENT_MEMORY_USAGE: "123",
-                            MAX_MEMORY_USAGE: "312",
-                        },
+                        current_memory_usage="123",
+                        max_memory_usage="312",
                     ),
                     "1": Job(
                         start_time=dt.now(),
@@ -280,10 +277,8 @@ def full_snapshot() -> Snapshot:
                         error="error",
                         stdout="std_out_file",
                         stderr="std_err_file",
-                        data={
-                            CURRENT_MEMORY_USAGE: "123",
-                            MAX_MEMORY_USAGE: "312",
-                        },
+                        current_memory_usage="123",
+                        max_memory_usage="312",
                     ),
                     "2": Job(
                         start_time=dt.now(),
@@ -294,10 +289,8 @@ def full_snapshot() -> Snapshot:
                         error="error",
                         stdout="std_out_file",
                         stderr="std_err_file",
-                        data={
-                            CURRENT_MEMORY_USAGE: "123",
-                            MAX_MEMORY_USAGE: "312",
-                        },
+                        current_memory_usage="123",
+                        max_memory_usage="312",
                     ),
                 },
             )
@@ -322,7 +315,8 @@ def large_snapshot() -> Snapshot:
             job_id=str(i),
             index=str(i),
             name=f"job_{i}",
-            data={MAX_MEMORY_USAGE: 1000, CURRENT_MEMORY_USAGE: 500},
+            current_memory_usage="500",
+            max_memory_usage="1000",
             status=JOB_STATE_START,
             stdout=f"job_{i}.stdout",
             stderr=f"job_{i}.stderr",
@@ -342,7 +336,8 @@ def small_snapshot() -> Snapshot:
             job_id=str(i),
             index=str(i),
             name=f"job_{i}",
-            data={MAX_MEMORY_USAGE: 1000, CURRENT_MEMORY_USAGE: 500},
+            current_memory_usage="500",
+            max_memory_usage="1000",
             status=JOB_STATE_START,
             stdout=f"job_{i}.stdout",
             stderr=f"job_{i}.stderr",
@@ -353,8 +348,8 @@ def small_snapshot() -> Snapshot:
     return builder.build(real_ids, REALIZATION_STATE_UNKNOWN)
 
 
-@pytest.fixture
-def active_realizations() -> Mock:
+@pytest.fixture(name="active_realizations")
+def active_realizations_fixture() -> Mock:
     active_reals = MagicMock()
     active_reals.count = Mock(return_value=10)
     active_reals.__iter__.return_value = [True] * 10

--- a/tests/unit_tests/gui/model/gui_models_utils.py
+++ b/tests/unit_tests/gui/model/gui_models_utils.py
@@ -1,9 +1,9 @@
-from ert.ensemble_evaluator.snapshot import Job, PartialSnapshot, RealizationSnapshot
+from ert.ensemble_evaluator.snapshot import Job, PartialSnapshot
 from ert.ensemble_evaluator.state import JOB_STATE_FINISHED
 
 
 def partial_snapshot(snapshot) -> PartialSnapshot:
     partial = PartialSnapshot(snapshot)
-    partial.update_real("0", RealizationSnapshot(status=JOB_STATE_FINISHED))
+    partial._realization_states["0"].update({"status": JOB_STATE_FINISHED})
     partial.update_job("0", "0", "0", Job(status=JOB_STATE_FINISHED))
     return partial

--- a/tests/unit_tests/gui/model/test_progress_proxy.py
+++ b/tests/unit_tests/gui/model/test_progress_proxy.py
@@ -2,7 +2,7 @@ import pytest
 from PyQt5.QtCore import QModelIndex
 from pytestqt.qt_compat import qt_api
 
-from ert.ensemble_evaluator.snapshot import PartialSnapshot, RealizationSnapshot
+from ert.ensemble_evaluator.snapshot import PartialSnapshot
 from ert.ensemble_evaluator.state import (
     REALIZATION_STATE_FINISHED,
     REALIZATION_STATE_UNKNOWN,
@@ -19,9 +19,8 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     model = ProgressProxyModel(source_model, parent=None)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
-        model, reporting_mode
-    )
+    # pylint: disable=unused-variable
+    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
@@ -39,9 +38,8 @@ def test_progression(full_snapshot):
     model = ProgressProxyModel(source_model, parent=None)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
-        model, reporting_mode
-    )
+    # pylint: disable=unused-variable
+    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
 
@@ -51,7 +49,7 @@ def test_progression(full_snapshot):
     }
 
     partial = PartialSnapshot(full_snapshot)
-    partial.update_real("0", RealizationSnapshot(status=REALIZATION_STATE_FINISHED))
+    partial._realization_states["0"].update({"status": REALIZATION_STATE_FINISHED})
     source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
 
     assert model.data(model.index(0, 0, QModelIndex()), ProgressRole) == {
@@ -66,9 +64,8 @@ def test_progression_start_iter_not_zero(full_snapshot):
     model = ProgressProxyModel(source_model, parent=None)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
-        model, reporting_mode
-    )
+    # pylint: disable=unused-variable
+    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
 
@@ -78,7 +75,7 @@ def test_progression_start_iter_not_zero(full_snapshot):
     }
 
     partial = PartialSnapshot(full_snapshot)
-    partial.update_real("0", RealizationSnapshot(status=REALIZATION_STATE_FINISHED))
+    partial._realization_states["0"].update({"status": REALIZATION_STATE_FINISHED})
     source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
 
     assert model.data(model.index(0, 0, QModelIndex()), ProgressRole) == {

--- a/tests/unit_tests/gui/model/test_real_list.py
+++ b/tests/unit_tests/gui/model/test_real_list.py
@@ -1,7 +1,6 @@
 from PyQt5.QtCore import QModelIndex
 from pytestqt.qt_compat import qt_api
 
-from ert.ensemble_evaluator.snapshot import RealizationSnapshot
 from ert.ensemble_evaluator.state import (
     REALIZATION_STATE_FINISHED,
     REALIZATION_STATE_UNKNOWN,
@@ -19,9 +18,8 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
-        model, reporting_mode
-    )
+    # pylint: disable=unused-variable
+    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
@@ -40,9 +38,8 @@ def test_change_iter(full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
-        model, reporting_mode
-    )
+    # pylint: disable=unused-variable
+    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
 
@@ -56,7 +53,7 @@ def test_change_iter(full_snapshot):
     model.setIter(1)
 
     partial = partial_snapshot(full_snapshot)
-    partial.update_real("0", RealizationSnapshot(status=REALIZATION_STATE_FINISHED))
+    partial._realization_states["0"].update({"status": REALIZATION_STATE_FINISHED})
     source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
 
     assert (

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -10,7 +10,6 @@ from qtpy.QtWidgets import QMessageBox, QToolButton
 
 from ert.config import ErtConfig
 from ert.enkf_main import EnKFMain
-from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
 from ert.ensemble_evaluator.event import (
     EndEvent,
@@ -118,7 +117,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="0",
                             index="0",
                             name="job_0",
-                            data={},
                             status=state.JOB_STATE_START,
                         )
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
@@ -159,10 +157,8 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="0",
                             index="0",
                             name="job_0",
-                            data={
-                                ids.MAX_MEMORY_USAGE: 1000,
-                                ids.CURRENT_MEMORY_USAGE: 500,
-                            },
+                            max_memory_usage="1000",
+                            current_memory_usage="500",
                             status=state.JOB_STATE_START,
                         )
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
@@ -203,7 +199,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="0",
                             index="0",
                             name="job_0",
-                            data={},
                             status=state.JOB_STATE_START,
                         )
                         .add_job(
@@ -211,7 +206,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="1",
                             index="1",
                             name="job_1",
-                            data={},
                             status=state.JOB_STATE_START,
                         )
                         .build(["0", "1"], state.REALIZATION_STATE_UNKNOWN)
@@ -233,7 +227,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             index="0",
                             status=state.JOB_STATE_FINISHED,
                             name="job_0",
-                            data={},
                         )
                         .build(["1"], status=state.REALIZATION_STATE_RUNNING)
                     ),
@@ -254,7 +247,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             index="1",
                             status=state.JOB_STATE_FAILURE,
                             name="job_1",
-                            data={},
                         )
                         .build(["0"], status=state.REALIZATION_STATE_FAILED)
                     ),
@@ -281,7 +273,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="0",
                             index="0",
                             name="job_0",
-                            data={},
                             status=state.JOB_STATE_START,
                         )
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
@@ -302,7 +293,6 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
                             job_id="0",
                             index="0",
                             name="job_0",
-                            data={},
                             status=state.JOB_STATE_START,
                         )
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -97,7 +97,9 @@ def test_large_snapshot(runmodel, large_snapshot, qtbot: QtBot, mock_tracker):
         widget.startSimulation()
 
     with qtbot.waitExposed(widget, timeout=30000):
-        qtbot.waitUntil(lambda: widget._total_progress_bar.value() == 100, timeout=5000)
+        qtbot.waitUntil(
+            lambda: widget._total_progress_bar.value() == 100, timeout=15000
+        )
         qtbot.mouseClick(widget.show_details_button, Qt.LeftButton)
         qtbot.waitUntil(lambda: widget._tab_widget.count() == 2, timeout=5000)
 

--- a/tests/unit_tests/job_queue/test_job_queue.py
+++ b/tests/unit_tests/job_queue/test_job_queue.py
@@ -62,6 +62,7 @@ sys.exit(1)
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 def create_local_queue(

--- a/tests/unit_tests/job_queue/test_job_queue_manager.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import BoundedSemaphore
 from typing import Callable, List, TypedDict
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,6 +16,7 @@ from ert.load_status import LoadStatus
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 class Config(TypedDict):

--- a/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import BoundedSemaphore
 from typing import Callable, TypedDict
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -35,6 +36,7 @@ def fixture_dummy_config():
 @dataclass
 class RunArg:
     iens: int
+    ensemble_storage = MagicMock()
 
 
 class JobConfig(TypedDict):


### PR DESCRIPTION
**Issue**
Resolves #5273 


**Approach**
- rewrite snapshot class in ensemble evaluator to be faster
- remove code that was tracking ensemble evaluator and crashing ert upon connection errors
- move batching dispatcher into own thread
- move forward model done callback (IO FS storage heavy) into own process

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] IRRELEVANT - Updated documentation
- [X] Ensured new behaviour is tested: Johan Sverdrup case ran through with this once, should test with other users