### PR TITLE
Do no create experiment and case on start-up

### DIFF
--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, Optional
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QComboBox
 
 from ert.gui.ertnotifier import ErtNotifier
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class CaseSelector(QComboBox):
+    case_populated = Signal()
+
     def __init__(
         self,
         notifier: ErtNotifier,
@@ -34,6 +36,8 @@ class CaseSelector(QComboBox):
         addHelpToWidget(self, help_link)
         self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
+        self.setEnabled(False)
+
         if update_ert:
             # Update ERT when this combo box is changed
             self.currentIndexChanged[int].connect(self._on_current_index_changed)
@@ -52,6 +56,9 @@ class CaseSelector(QComboBox):
 
         self.clear()
 
+        if self._case_list():
+            self.setEnabled(True)
+
         for case in self._case_list():
             self.addItem(case.name, userData=case)
 
@@ -62,6 +69,8 @@ class CaseSelector(QComboBox):
             self.setCurrentIndex(max(current_index, 0))
 
         self.blockSignals(block)
+
+        self.case_populated.emit()
 
     def _case_list(self) -> Iterable[EnsembleReader]:
         if self._show_only_initialized:

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 import warnings
 import webbrowser
-from typing import List, Optional
+from typing import Optional
 
 from PyQt5.QtWidgets import (
     QFrame,
@@ -19,7 +19,6 @@ from qtpy.QtCore import QLocale, QSize, Qt
 from qtpy.QtWidgets import QApplication
 
 from ert._c_wrappers.enkf import EnKFMain, ErtConfig
-from ert._c_wrappers.enkf.config.parameter_config import ParameterConfig
 from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertwidgets import SuggestorMessage, SummaryPanel, resourceIcon
 from ert.gui.main_window import ErtMainWindow
@@ -41,7 +40,7 @@ from ert.namespace import Namespace
 from ert.parsing import ConfigValidationError, ConfigWarning
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
-from ert.storage import EnsembleAccessor, StorageReader, open_storage
+from ert.storage import open_storage
 from ert.storage.local_storage import local_storage_set_ert_config
 
 
@@ -70,11 +69,7 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None):
             ert_config=args.config, project=os.path.abspath(ens_path)
         ), open_storage(ens_path, mode=mode) as storage:
             if hasattr(window, "notifier"):
-                default_case = _get_or_create_default_case(
-                    storage, ensemble_size, parameter_config
-                )
                 window.notifier.set_storage(storage)
-                window.notifier.set_current_case(default_case)
             return show_window()
 
 
@@ -181,21 +176,6 @@ def _start_initial_gui_window(
             ert_config.model_config.num_realizations,
             ert_config.ensemble_config.parameter_configuration,
         )
-
-
-def _get_or_create_default_case(
-    storage: StorageReader, ensemble_size: int, parameter_config: List[ParameterConfig]
-) -> Optional[EnsembleAccessor]:
-    try:
-        storage_accessor = storage.to_accessor()
-        try:
-            return storage_accessor.get_ensemble_by_name("default")
-        except KeyError:
-            return storage_accessor.create_experiment(
-                parameters=parameter_config
-            ).create_ensemble(name="default", ensemble_size=ensemble_size)
-    except TypeError:
-        return None
 
 
 def _check_locale():

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -115,6 +115,11 @@ class CaseInitializationConfigurationPanel(QTabWidget):
                 parameters=parameters,
             )
 
+        def update_button_state():
+            initialize_button.setEnabled(target_case.count() > 0)
+
+        update_button_state()
+        target_case.case_populated.connect(update_button_state)
         initialize_button.clicked.connect(initializeFromScratch)
         layout.addWidget(initialize_button, 0, Qt.AlignCenter)
 


### PR DESCRIPTION
This fixes the bug where we end up with two default-cases when running a single experiment.

Deactivating current case drop-down list, and
initialize-button in initialize from scratch if there are no cases.

(cherry picked from commit bc879571804da301c33271477a822911c9af3fbc)


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
