### PR TITLE
Remove addHelpToWidget

### DIFF
--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -5,15 +5,6 @@ from qtpy.QtGui import QCursor, QIcon, QMovie, QPixmap
 from qtpy.QtWidgets import QApplication
 
 
-def addHelpToWidget(widget, link):
-    original_enter_event = widget.enterEvent
-
-    def enterEvent(event):
-        original_enter_event(event)
-
-    widget.enterEvent = enterEvent
-
-
 def showWaitCursorWhileWaiting(func):
     """A function decorator to show the wait cursor while the function is working."""
 

--- a/src/ert/gui/ertwidgets/activelabel.py
+++ b/src/ert/gui/ertwidgets/activelabel.py
@@ -1,14 +1,11 @@
 from qtpy.QtGui import QFont
 from qtpy.QtWidgets import QLabel
 
-from ert.gui.ertwidgets import addHelpToWidget
-
 
 class ActiveLabel(QLabel):
-    def __init__(self, model, help_link=""):
+    def __init__(self, model):
         QLabel.__init__(self)
 
-        addHelpToWidget(self, help_link)
         self._model = model
 
         font = self.font()

--- a/src/ert/gui/ertwidgets/analysismoduleedit.py
+++ b/src/ert/gui/ertwidgets/analysismoduleedit.py
@@ -3,7 +3,7 @@ from typing import Literal
 from qtpy.QtCore import QMargins, Qt
 from qtpy.QtWidgets import QHBoxLayout, QToolButton, QWidget
 
-from ert.gui.ertwidgets import ClosableDialog, addHelpToWidget, resourceIcon
+from ert.gui.ertwidgets import ClosableDialog, resourceIcon
 from ert.gui.ertwidgets.analysismodulevariablespanel import AnalysisModuleVariablesPanel
 from ert.libres_facade import LibresFacade
 
@@ -13,12 +13,9 @@ class AnalysisModuleEdit(QWidget):
         self,
         facade: LibresFacade,
         module_name: Literal["IES_ENKF", "STD_ENKF"] = "STD_ENKF",
-        help_link: str = "",
     ):
         self.facade = facade
         QWidget.__init__(self)
-
-        addHelpToWidget(self, help_link)
 
         layout = QHBoxLayout()
         self._name = module_name

--- a/src/ert/gui/ertwidgets/caselist.py
+++ b/src/ert/gui/ertwidgets/caselist.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
 )
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import addHelpToWidget, resourceIcon
+from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
 from ert.libres_facade import LibresFacade
 from ert.storage import StorageAccessor
@@ -61,8 +61,6 @@ class CaseList(QWidget):
         self.facade = facade
         self.notifier = notifier
         QWidget.__init__(self)
-
-        addHelpToWidget(self, "init/case_list")
 
         layout = QVBoxLayout()
 

--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -6,7 +6,6 @@ from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QComboBox
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import addHelpToWidget
 
 if TYPE_CHECKING:
     from ert.storage import EnsembleReader
@@ -21,7 +20,6 @@ class CaseSelector(QComboBox):
         update_ert: bool = True,
         show_only_initialized: bool = False,
         ignore_current: bool = False,
-        help_link: str = "init/current_case_selection",
     ):
         super().__init__()
         self.notifier = notifier
@@ -33,7 +31,6 @@ class CaseSelector(QComboBox):
         # ignore the currently selected case if it changes
         self._ignore_current = ignore_current
 
-        addHelpToWidget(self, help_link)
         self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
         self.setEnabled(False)

--- a/src/ert/gui/ertwidgets/checklist.py
+++ b/src/ert/gui/ertwidgets/checklist.py
@@ -11,13 +11,11 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import SearchBox, addHelpToWidget, resourceIcon
+from ert.gui.ertwidgets import SearchBox, resourceIcon
 
 
 class CheckList(QWidget):
-    def __init__(
-        self, model, label: str = "", help_link: str = "", custom_filter_button=None
-    ):
+    def __init__(self, model, label: str = "", custom_filter_button=None):
         """
         :param custom_filter_button:  if needed, add a button that opens a
         custom filter menu. Useful when search alone isn't enough to filter the
@@ -27,9 +25,6 @@ class CheckList(QWidget):
         QWidget.__init__(self)
 
         self._model = model
-
-        if help_link != "":
-            addHelpToWidget(self, help_link)
 
         layout = QVBoxLayout()
 

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -4,8 +4,6 @@ from qtpy.QtCore import Qt, QTimer
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
 
-from ert.gui.ertwidgets import addHelpToWidget
-
 # Get the absolute path of the directory that contains the current script
 current_dir = path.dirname(path.abspath(__file__))
 
@@ -48,7 +46,7 @@ class CopyableLabel(QHBoxLayout):
     """CopyableLabel shows a string that is copyable via
     selection or clicking of a copy button"""
 
-    def __init__(self, text, executeAddHelpToWidget=True) -> None:
+    def __init__(self, text) -> None:
         super().__init__()
 
         self.label = QLabel(f"<b>{escape_string(text)}</b>")
@@ -79,6 +77,3 @@ class CopyableLabel(QHBoxLayout):
 
         self.addWidget(self.label)
         self.addWidget(self.copy_button, alignment=Qt.AlignLeft)
-
-        if executeAddHelpToWidget:
-            addHelpToWidget(self.label, "")

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from qtpy.QtCore import QSize
 from qtpy.QtWidgets import QFileDialog, QHBoxLayout, QLineEdit, QToolButton, QWidget
 
-from ert.gui.ertwidgets import addHelpToWidget, resourceIcon
+from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.validationsupport import ValidationSupport
 
 
@@ -29,13 +29,12 @@ class PathChooser(QWidget):
     #    MUST_EXIST = 8
     #    EXECUTABLE = 16
 
-    def __init__(self, model, help_link=""):
+    def __init__(self, model):
         """
         :type model: ert.gui.ertwidgets.models.path_model.PathModel
         :param help_link: str
         """
         QWidget.__init__(self)
-        addHelpToWidget(self, help_link)
         self._validation_support = ValidationSupport(self)
 
         self._editing = True

--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -1,14 +1,14 @@
 from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QLineEdit
 
-from ert.gui.ertwidgets import ValidationSupport, addHelpToWidget
+from ert.gui.ertwidgets import ValidationSupport
 
 
 class StringBox(QLineEdit):
     """StringBox shows a string. The data structure expected and sent to the
     getter and setter is a string."""
 
-    def __init__(self, model, help_link="", default_string="", continuous_update=False):
+    def __init__(self, model, default_string="", continuous_update=False):
         """
         :type model: ert.gui.ertwidgets.models.valuemodel.ValueModel
         :type help_link: str
@@ -16,7 +16,6 @@ class StringBox(QLineEdit):
         :type continuous_update: bool
         """
         QLineEdit.__init__(self)
-        addHelpToWidget(self, help_link)
         self.setMinimumWidth(250)
         self._validation = ValidationSupport(self)
         self._validator = None

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -4,7 +4,6 @@ from qtpy.QtWidgets import QFormLayout, QLabel
 
 from ert.enkf_main import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import addHelpToWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
@@ -43,9 +42,6 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
 
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"
-        )
-        addHelpToWidget(
-            number_of_realizations_label, "config/ensemble/num_realizations"
         )
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -4,7 +4,7 @@ from qtpy.QtWidgets import QFormLayout, QLabel
 
 from ert.enkf_main import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import AnalysisModuleEdit, addHelpToWidget
+from ert.gui.ertwidgets import AnalysisModuleEdit
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
@@ -43,9 +43,6 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
-        addHelpToWidget(
-            number_of_realizations_label, "config/ensemble/num_realizations"
-        )
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
         self._target_case_model = TargetCaseModel(facade, notifier)
@@ -58,7 +55,6 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         self._analysis_module_edit = AnalysisModuleEdit(
             facade,
             module_name="STD_ENKF",
-            help_link="config/analysis/analysis_module",
         )
         self._analysis_module_edit.setObjectName("ensemble_smoother_edit")
         layout.addRow("Analysis module:", self._analysis_module_edit)

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from qtpy.QtWidgets import QFormLayout, QLabel, QSpinBox
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import AnalysisModuleEdit, CaseSelector, addHelpToWidget
+from ert.gui.ertwidgets import AnalysisModuleEdit, CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -41,9 +41,6 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         number_of_realizations_label = QLabel(
             f"<b>{self.facade.get_ensemble_size()}</b>"
         )
-        addHelpToWidget(
-            number_of_realizations_label, "config/ensemble/num_realizations"
-        )
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
         # The num_iterations_spinner does not track any external changes (will
@@ -52,9 +49,6 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         self._num_iterations_spinner.setMinimum(1)
         self._num_iterations_spinner.setMaximum(100)
         self._num_iterations_spinner.setValue(self.facade.get_number_of_iterations())
-        addHelpToWidget(
-            self._num_iterations_spinner, "config/simulation/number_of_iterations"
-        )
         self._num_iterations_spinner.valueChanged[int].connect(self.setNumberIterations)
 
         layout.addRow("Number of iterations:", self._num_iterations_spinner)
@@ -72,7 +66,6 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         self._analysis_module_edit = AnalysisModuleEdit(
             self.facade,
             module_name="IES_ENKF",
-            help_link="config/analysis/analysis_module",
         )
         layout.addRow("Analysis module:", self._analysis_module_edit)
 

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -4,12 +4,7 @@ from typing import List
 from qtpy.QtWidgets import QCheckBox, QFormLayout, QLabel
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import (
-    ActiveLabel,
-    AnalysisModuleEdit,
-    CaseSelector,
-    addHelpToWidget,
-)
+from ert.gui.ertwidgets import ActiveLabel, AnalysisModuleEdit, CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
 from ert.gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
 from ert.gui.ertwidgets.models.targetcasemodel import TargetCaseModel
@@ -48,9 +43,6 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")
-        addHelpToWidget(
-            number_of_realizations_label, "config/ensemble/num_realizations"
-        )
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
         self._target_case_format_model = TargetCaseModel(
@@ -69,7 +61,6 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         self._analysis_module_edit = AnalysisModuleEdit(
             facade,
             module_name="STD_ENKF",
-            help_link="config/analysis/analysis_module",
         )
         layout.addRow("Analysis module:", self._analysis_module_edit)
 
@@ -112,7 +103,6 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         relative_iteration_weights_model = ValueModel(self.weights)
         self._relative_iteration_weights_box = StringBox(
             relative_iteration_weights_model,
-            help_link="config/simulation/iteration_weights",
             continuous_update=True,
         )
         self._relative_iteration_weights_box.setValidator(NumberListStringArgument())
@@ -121,9 +111,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         relative_iteration_weights_model.valueChanged.connect(self.setWeights)
 
         normalized_weights_model = ValueModel()
-        normalized_weights_widget = ActiveLabel(
-            normalized_weights_model, help_link="config/simulation/iteration_weights"
-        )
+        normalized_weights_widget = ActiveLabel(normalized_weights_model)
         layout.addRow("Normalized weights:", normalized_weights_widget)
 
         def updateVisualizationOfNormalizedWeights():

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
 from ert.cli.model_factory import create_model
 from ert.enkf_main import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import addHelpToWidget, resourceIcon
+from ert.gui.ertwidgets import resourceIcon
 from ert.libres_facade import LibresFacade
 
 from .ensemble_experiment_panel import EnsembleExperimentPanel
@@ -43,7 +43,6 @@ class SimulationPanel(QWidget):
 
         self._simulation_mode_combo = QComboBox()
         self._simulation_mode_combo.setObjectName("Simulation_mode")
-        addHelpToWidget(self._simulation_mode_combo, "run/simulation_mode")
 
         self._simulation_mode_combo.currentIndexChanged.connect(
             self.toggleSimulationMode
@@ -65,7 +64,6 @@ class SimulationPanel(QWidget):
         self.run_button.setIconSize(QSize(32, 32))
         self.run_button.clicked.connect(self.runSimulation)
         self.run_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        addHelpToWidget(self.run_button, "run/start_simulation")
 
         simulation_mode_layout.addWidget(self.run_button)
         simulation_mode_layout.addStretch(1)

--- a/src/ert/gui/tools/event_viewer/tool.py
+++ b/src/ert/gui/tools/event_viewer/tool.py
@@ -9,7 +9,6 @@ class EventViewerTool(Tool, QObject):
     def __init__(self, gui_handler):
         super().__init__(
             "Event viewer",
-            "tools/event_viewer",
             resourceIcon("notifications.svg"),
         )
         self.log_handler = gui_handler

--- a/src/ert/gui/tools/export/export_tool.py
+++ b/src/ert/gui/tools/export/export_tool.py
@@ -14,7 +14,7 @@ from ert.shared.exporter import Exporter
 
 class ExportTool(Tool):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier):
-        super().__init__("Export data", "tools/export", resourceIcon("share.svg"))
+        super().__init__("Export data", resourceIcon("share.svg"))
         self.__export_widget = None
         self.__dialog = None
         self.__exporter = Exporter(ert, notifier)

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -11,7 +11,6 @@ class LoadResultsTool(Tool):
         self.facade = facade
         super().__init__(
             "Load results manually",
-            "tools/load_manually",
             resourceIcon("upload.svg"),
         )
         self.__import_widget = None

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import addHelpToWidget, showWaitCursorWhileWaiting
+from ert.gui.ertwidgets import showWaitCursorWhileWaiting
 from ert.gui.ertwidgets.caselist import CaseList
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.checklist import CheckList
@@ -24,9 +24,7 @@ def createCheckLists(ert):
         return ert.ensembleConfig().parameters
 
     parameter_model.getList = getParameterList
-    parameter_check_list = CheckList(
-        parameter_model, "Parameters", "init/select_parameters"
-    )
+    parameter_check_list = CheckList(parameter_model, "Parameters")
     parameter_check_list.setMaximumWidth(300)
 
     members_model = SelectableListModel([])
@@ -35,7 +33,7 @@ def createCheckLists(ert):
         return [str(member) for member in range(ert.getEnsembleSize())]
 
     members_model.getList = getMemberList
-    member_check_list = CheckList(members_model, "Members", "init/select_members")
+    member_check_list = CheckList(members_model, "Members")
     member_check_list.setMaximumWidth(150)
     return (
         createRow(parameter_check_list, member_check_list),
@@ -101,7 +99,6 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         initialize_button = QPushButton(
             "Initialize", objectName="initialize_from_scratch_button"
         )
-        addHelpToWidget(initialize_button, "init/initialize_from_scratch")
         initialize_button.setMinimumWidth(75)
         initialize_button.setMaximumWidth(150)
 
@@ -135,7 +132,6 @@ class CaseInitializationConfigurationPanel(QTabWidget):
         case_selector = CaseSelector(
             self.notifier,
             update_ert=False,
-            help_link="init/selected_case_info",
         )
         row1 = createRow(QLabel("Select case:"), case_selector)
 

--- a/src/ert/gui/tools/manage_cases/manage_cases_tool.py
+++ b/src/ert/gui/tools/manage_cases/manage_cases_tool.py
@@ -10,9 +10,7 @@ class ManageCasesTool(Tool):
     def __init__(self, ert, notifier):
         self.notifier = notifier
         self.ert = ert
-        super().__init__(
-            "Manage cases", "tools/manage_cases", resourceIcon("build_wrench.svg")
-        )
+        super().__init__("Manage cases", resourceIcon("build_wrench.svg"))
 
     def trigger(self):
         case_management_widget = CaseInitializationConfigurationPanel(

--- a/src/ert/gui/tools/plot/plot_tool.py
+++ b/src/ert/gui/tools/plot/plot_tool.py
@@ -6,7 +6,7 @@ from .plot_window import PlotWindow
 
 class PlotTool(Tool):
     def __init__(self, config_file, main_window):
-        super().__init__("Create plot", "tools/plot", resourceIcon("timeline.svg"))
+        super().__init__("Create plot", resourceIcon("timeline.svg"))
         self._config_file = config_file
         self.main_window = main_window
 

--- a/src/ert/gui/tools/plugins/plugins_tool.py
+++ b/src/ert/gui/tools/plugins/plugins_tool.py
@@ -17,7 +17,6 @@ class PluginsTool(Tool):
         self.notifier = notifier
         super().__init__(
             "Plugins",
-            "tools/plugins",
             resourceIcon("widgets.svg"),
             enabled,
             popup_menu=True,

--- a/src/ert/gui/tools/run_analysis/run_analysis_panel.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_panel.py
@@ -13,10 +13,7 @@ class RunAnalysisPanel(QWidget):
         self.setWindowTitle("Run analysis")
         self.activateWindow()
 
-        self.analysis_module = AnalysisModuleEdit(
-            LibresFacade(ert),
-            help_link="config/analysis/analysis_module",
-        )
+        self.analysis_module = AnalysisModuleEdit(LibresFacade(ert))
         self.target_case_text = QLineEdit()
         self.source_case_selector = CaseSelector(notifier, update_ert=False)
 

--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -64,9 +64,7 @@ class Analyse(QObject):
 
 class RunAnalysisTool(Tool):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier):
-        super().__init__(
-            "Run analysis", "tools/run_analysis", resourceIcon("formula.svg")
-        )
+        super().__init__("Run analysis", resourceIcon("formula.svg"))
         self.ert = ert
         self.notifier = notifier
         self._run_widget: Optional[RunAnalysisPanel] = None

--- a/src/ert/gui/tools/tool.py
+++ b/src/ert/gui/tools/tool.py
@@ -5,7 +5,6 @@ class Tool:
     def __init__(
         self,
         name,
-        help_link="",
         icon=None,
         enabled=True,
         checkable=False,
@@ -17,7 +16,6 @@ class Tool:
         self.__parent = None
         self.__enabled = enabled
         self.__checkable = checkable
-        self.__help_link = help_link
         self.__is_popup_menu = popup_menu
 
         self.__action = QAction(self.getIcon(), self.getName(), None)
@@ -44,9 +42,6 @@ class Tool:
 
     def isEnabled(self):
         return self.__enabled
-
-    def getHelpLink(self):
-        return self.__help_link
 
     def getAction(self):
         return self.__action

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -15,12 +15,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import (
-    CaseSelector,
-    addHelpToWidget,
-    resourceIcon,
-    resourceMovie,
-)
+from ert.gui.ertwidgets import CaseSelector, resourceIcon, resourceMovie
 from ert.gui.tools.workflows.workflow_dialog import WorkflowDialog
 from ert.job_queue import WorkflowRunner
 
@@ -42,8 +37,6 @@ class RunWorkflowWidget(QWidget):
         layout = QFormLayout()
 
         self._workflow_combo = QComboBox()
-        addHelpToWidget(self._workflow_combo, "run/workflow")
-
         self._workflow_combo.addItems(
             sorted(ert.resConfig().workflows.keys(), key=str.lower)
         )

--- a/src/ert/gui/tools/workflows/workflows_tool.py
+++ b/src/ert/gui/tools/workflows/workflows_tool.py
@@ -11,7 +11,6 @@ class WorkflowsTool(Tool):
         enabled = len(ert.resConfig().workflows) > 0
         super().__init__(
             "Run workflow",
-            "tools/workflows",
             resourceIcon("playlist_play.svg"),
             enabled,
         )


### PR DESCRIPTION
This function was used to provide more context to buttons when Ert had a help dialog. It currently does nothing and if we decide to reimplement it, we should do it differently.