### PR TITLE
Add line number and file to warnings

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -51,9 +51,6 @@ def run_cli(args, _=None):
     for job in ert_config.forward_model_list:
         logger.info("Config contains forward model job %s", job.name)
 
-    for suggestion in ErtConfig.make_suggestion_list(args.config):
-        print(f"Warning: {suggestion}")
-
     ert = EnKFMain(ert_config)
     facade = LibresFacade(ert)
     if not facade.have_observations and args.mode not in [

--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -34,6 +34,7 @@ from .parsing import (
     ConfigWarning,
     ErrorInfo,
     MaybeWithContext,
+    WarningInfo,
 )
 from .response_config import ResponseConfig
 from .summary_config import SummaryConfig
@@ -203,12 +204,16 @@ class EnsembleConfig:
 
             if gen_kw_key == "PRED":
                 warnings.warn(
-                    "GEN_KW PRED used to hold a special meaning and be excluded from "
-                    "being updated.\n"
-                    "If the intention was to exclude this from updates, please "
-                    "use the DisableParametersUpdate workflow though the "
-                    "DISABLE_PARAMETERS key instead.\n"
-                    f"Ref. GEN_KW {gen_kw[0]} {gen_kw[1]} {gen_kw[2]} {gen_kw[3]}",
+                    ConfigWarning(
+                        WarningInfo(
+                            "GEN_KW PRED used to hold a special meaning and be "
+                            "excluded from being updated.\n If the intention was "
+                            "to exclude this from updates, please use the "
+                            "DisableParametersUpdate workflow though the "
+                            "DISABLE_PARAMETERS key instead.\n fRef. GEN_KW "
+                            "{gen_kw[0]} {gen_kw[1]} {gen_kw[2]} {gen_kw[3]}"
+                        ).set_context(gen_kw[0])
+                    ),
                     category=ConfigWarning,
                 )
 
@@ -360,8 +365,12 @@ class EnsembleConfig:
 
         if input_transform:
             warnings.warn(
-                f"Got INPUT_TRANSFORM for FIELD: {name}, "
-                f"this has no effect and can be removed",
+                ConfigWarning(
+                    WarningInfo(
+                        f"Got INPUT_TRANSFORM for FIELD: {name}, "
+                        f"this has no effect and can be removed"
+                    ).set_context(name)
+                ),
                 category=ConfigWarning,
             )
         if init_transform and init_transform not in TRANSFORM_FUNCTIONS:

--- a/src/ert/config/parsing/config_dict.py
+++ b/src/ert/config/parsing/config_dict.py
@@ -1,13 +1,8 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 from .context_values import ContextString, ContextValue
-from .error_info import WarningInfo
 
-
-class ConfigDict(
-    Dict[
-        ContextString,
-        Union[ContextValue, List[ContextValue], List[List[ContextValue]]],
-    ]
-):
-    warning_infos: Optional[List[WarningInfo]] = None
+ConfigDict = Dict[
+    ContextString,
+    Union[ContextValue, List[ContextValue], List[List[ContextValue]]],
+]

--- a/src/ert/config/parsing/config_errors.py
+++ b/src/ert/config/parsing/config_errors.py
@@ -14,6 +14,9 @@ class ConfigWarning(UserWarning):
             super().__init__(info.message)
             self.info = info
 
+    def __str__(self) -> str:
+        return str(self.info)
+
 
 class ConfigValidationError(ValueError):
     def __init__(

--- a/src/ert/config/parsing/schema_dict.py
+++ b/src/ert/config/parsing/schema_dict.py
@@ -102,7 +102,6 @@ class SchemaItemDict(_UserDict):
                 elif isinstance(v[0], list):
                     for arglist in v:
                         push_deprecation(deprecation_info, arglist)
-
         if detected_deprecations:
             for deprecation, line in detected_deprecations:
                 warnings.warn(

--- a/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -1,6 +1,8 @@
+import warnings
+
 import pytest
 
-from ert.config import ErtConfig
+from ert.config import ConfigWarning, ErtConfig
 from ert.config.parsing.config_schema_deprecations import (
     JUST_REMOVE_KEYWORDS,
     REPLACE_WITH_GEN_KW,
@@ -9,17 +11,27 @@ from ert.config.parsing.config_schema_deprecations import (
 )
 
 
+def make_suggestion_list(path):
+    with warnings.catch_warnings(record=True) as all_warnings:
+        _ = ErtConfig.from_file(path)
+    return [
+        str(w.message)
+        for w in all_warnings
+        if w.category == ConfigWarning and w.message.info.is_deprecation
+    ]
+
+
 @pytest.mark.parametrize("kw", JUST_REMOVE_KEYWORDS)
 def test_that_suggester_gives_simple_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
-    assert any(s.startswith(f"The keyword {kw} no longer") for s in suggestions)
+    assert any(f"The keyword {kw} no longer" in s for s in suggestions)
 
 
 def test_that_suggester_gives_havana_fault_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nHAVANA_FAULT\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The behavior of HAVANA_FAULT can be reproduced using" in s for s in suggestions
@@ -29,7 +41,7 @@ def test_that_suggester_gives_havana_fault_migration(tmp_path):
 @pytest.mark.parametrize("kw", REPLACE_WITH_GEN_KW)
 def test_that_suggester_gives_gen_kw_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "ert.readthedocs.io/en/latest/reference/configuration/keywords.html#gen-kw" in s
@@ -40,7 +52,7 @@ def test_that_suggester_gives_gen_kw_migrations(tmp_path, kw):
 @pytest.mark.parametrize("kw", RSH_KEYWORDS)
 def test_that_suggester_gives_rsh_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "deprecated and removed support for RSH queues." in s for s in suggestions
@@ -50,7 +62,7 @@ def test_that_suggester_gives_rsh_migrations(tmp_path, kw):
 @pytest.mark.parametrize("kw", USE_QUEUE_OPTION)
 def test_that_suggester_gives_queue_option_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         f"The {kw} keyword has been removed. For most cases " in s for s in suggestions
@@ -59,7 +71,7 @@ def test_that_suggester_gives_queue_option_migrations(tmp_path, kw):
 
 def test_that_suggester_gives_refcase_list_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nREFCASE_LIST case.DATA\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The corresponding plotting functionality was removed in 2015" in s
@@ -69,7 +81,7 @@ def test_that_suggester_gives_refcase_list_migration(tmp_path):
 
 def test_that_suggester_gives_rftpath_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRFTPATH rfts/\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The corresponding plotting functionality was removed in 2015" in s
@@ -79,14 +91,14 @@ def test_that_suggester_gives_rftpath_migration(tmp_path):
 
 def test_that_suggester_gives_end_date_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nEND_DATE 2023.01.01\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any("only display a warning in case of problems" in s for s in suggestions)
 
 
 def test_that_suggester_gives_rerun_start_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRERUN_START 2023.01.01\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "used for the deprecated run mode ENKF_ASSIMILATION" in s for s in suggestions
@@ -95,7 +107,7 @@ def test_that_suggester_gives_rerun_start_migration(tmp_path):
 
 def test_that_suggester_gives_delete_runpath_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nDELETE_RUNPATH TRUE\n")
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any("It was removed in 2017" in s for s in suggestions)
 
@@ -104,7 +116,7 @@ def test_suggester_gives_runpath_deprecated_specifier_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nRUNPATH real-%d/iter-%d\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "RUNPATH keyword contains deprecated value placeholders" in s
@@ -116,12 +128,12 @@ def test_suggester_gives_no_runpath_deprecated_specifier_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nRUNPATH real-<IENS>/iter-<ITER>\n"
     )
-    no_suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    no_suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     (tmp_path / "config.wrong.ert").write_text(
         "NUM_REALIZATIONS 1\nRUNPATH real-%d/iter-%d\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.wrong.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.wrong.ert"))
 
     assert not any(
         "RUNPATH keyword contains deprecated value placeholders" in s
@@ -136,7 +148,7 @@ def test_suggester_gives_plot_settings_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nPLOT_SETTINGS some args\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The keyword PLOT_SETTINGS was removed in 2019 and has no effect" in s
@@ -148,7 +160,7 @@ def test_suggester_gives_update_settings_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nUPDATE_SETTINGS some args\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The UPDATE_SETTINGS keyword has been removed and no longer" in s
@@ -164,7 +176,7 @@ def test_suggester_gives_deprecated_define_migration_hint(tmp_path):
         "DEFINE <A<B>> C\n"
         "DEFINE <A><B> C\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     any("DEFINE" in s and "Please change A to <A>" in s for s in suggestions)
     any("DEFINE" in s and "Please change <A<B>> to <AB>" in s for s in suggestions)
@@ -180,7 +192,7 @@ def test_suggester_does_not_report_non_existent_path_due_to_missing_pre_defines(
     )
     assert [
         x
-        for x in ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+        for x in make_suggestion_list(str(tmp_path / "config.ert"))
         if "DATA_KW" not in x and "DEFINE" not in x
     ] == []
 
@@ -189,7 +201,7 @@ def test_that_suggester_gives_schedule_prediciton_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nSCHEDULE_PREDICTION_FILE no no no\n"
     )
-    suggestions = ErtConfig.make_suggestion_list(str(tmp_path / "config.ert"))
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "The 'SCHEDULE_PREDICTION_FILE' config keyword has been removed" in s

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -417,7 +417,7 @@ def test_that_having_observations_on_starting_date_errors(tmpdir):
         (
             100,
             10,
-            "Segment start after stop",
+            "Segment FIRST_YEAR start after stop",
         ),
         (
             50,
@@ -427,17 +427,17 @@ def test_that_having_observations_on_starting_date_errors(tmpdir):
         (
             -1,
             1,
-            "Segment out of bounds",
+            "Segment FIRST_YEAR out of bounds",
         ),
         (
             1,
             1000,
-            "Segment out of bounds",
+            "Segment FIRST_YEAR out of bounds",
         ),
         (
             1,
             1000,
-            "Segment out of bounds",
+            "Segment FIRST_YEAR out of bounds",
         ),
     ],
 )


### PR DESCRIPTION
Cleans up the handling of warning infos and adds context info to remaining warning calls.

![image](https://github.com/equinor/ert/assets/32731672/cb3d789e-1e99-4092-8f94-1b758d702e9b)


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
