### PR TITLE
Display meaningful message upon job queue failure

### DIFF
--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -45,12 +45,8 @@ extern "C" PY_USED bool job_queue_node_kill_simple(job_queue_node_type *node,
 extern "C" void job_queue_node_free(job_queue_node_type *node);
 extern "C" job_status_type
 job_queue_node_get_status(const job_queue_node_type *node);
-extern "C" PY_USED job_status_type job_queue_node_refresh_status(
-    job_queue_node_type *node, queue_driver_type *driver);
 extern "C" int
 job_queue_node_get_submit_attempt(const job_queue_node_type *node);
-
-double job_queue_node_time_since_sim_start(const job_queue_node_type *node);
 
 int job_queue_node_get_queue_index(const job_queue_node_type *node);
 void job_queue_node_set_queue_index(job_queue_node_type *node, int queue_index);

--- a/src/ert/gui/ertwidgets/message_box.py
+++ b/src/ert/gui/ertwidgets/message_box.py
@@ -7,20 +7,26 @@ from qtpy.QtWidgets import (
     QTextEdit,
 )
 
+from ert.gui.tools.file.file_dialog import (
+    calculate_font_based_width,
+    calculate_screen_size_based_height,
+)
+
 
 # This might seem like NIH, however the QtMessageBox is notoriously
 # hard to work with if you need anything like for example resizing.
 class ErtMessageBox(QDialog):
     def __init__(self, text, detailed_text, parent=None):
         super().__init__(parent)
-        box = QDialogButtonBox(
+        self.box = QDialogButtonBox(
             QDialogButtonBox.Ok,
             centerButtons=True,
         )
-        box.accepted.connect(self.accept)
+        self.box.accepted.connect(self.accept)
 
         self.details_text = QTextEdit()
         self.details_text.setPlainText(detailed_text)
+        self.details_text.setObjectName("ErtMessageBox")
         self.details_text.setReadOnly(True)
 
         self.label_text = QLabel(text)
@@ -32,6 +38,8 @@ class ErtMessageBox(QDialog):
         lay.addWidget(self.label_icon, 1, 1, 1, 1)
         lay.addWidget(self.label_text, 1, 2, 1, 2)
         lay.addWidget(self.details_text, 2, 1, 1, 3)
-        lay.addWidget(box, 3, 1, 1, 3)
+        lay.addWidget(self.box, 3, 1, 1, 3)
 
-        self.setMinimumSize(640, 100)
+        fontWidth = self.box.fontMetrics().averageCharWidth()
+        min_width = calculate_font_based_width(fontWidth)
+        self.setMinimumSize(min_width, calculate_screen_size_based_height())

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -310,8 +310,10 @@ class RunDialog(QDialog):
         )
 
         if failed:
-            msg = ErtMessageBox("ERT experiment failed!", failed_msg)
-            msg.exec_()
+            self.fail_msg_box = ErtMessageBox(
+                "ERT experiment failed!", failed_msg, self
+            )
+            self.fail_msg_box.exec_()
 
     def _show_done_button(self):
         self.done_button.setHidden(False)

--- a/src/ert/gui/tools/file/file_dialog.py
+++ b/src/ert/gui/tools/file/file_dialog.py
@@ -14,6 +14,23 @@ from qtpy.QtWidgets import (
 from .file_update_worker import FileUpdateWorker
 
 
+def calculate_screen_size_based_height():
+    screen_height = QApplication.primaryScreen().geometry().height()
+    max_ratio_of_screen = 1.0 / 3.0
+    return floor(screen_height * max_ratio_of_screen)
+
+
+def calculate_font_based_width(charWidth):
+    desired_width_in_characters = 120
+    extra_bit_of_margin_space = 2
+    extra_space_for_vertical_scroll_bar = 5
+    return (
+        desired_width_in_characters
+        + extra_bit_of_margin_space
+        + extra_space_for_vertical_scroll_bar
+    ) * charWidth
+
+
 class FileDialog(QDialog):
     def __init__(
         self, file_name, job_name, job_number, realization, iteration, parent=None
@@ -29,7 +46,7 @@ class FileDialog(QDialog):
         try:
             # pylint: disable=consider-using-with
             # We take care to close this file in _quit_thread()
-            self._file = open(file_name, "r", encoding="utf-8")
+            self._file = open(file_name, "r", encoding="utf-8")  # noqa: SIM115
         except OSError as error:
             self._mb = QMessageBox(
                 QMessageBox.Critical,
@@ -63,17 +80,6 @@ class FileDialog(QDialog):
         self._thread.quit()
         self._thread.wait()
         self._file.close()
-
-    def _calculate_font_based_width(self):
-        font_metrics = self._view.fontMetrics()
-        desired_width_in_characters = 120
-        extra_bit_of_margin_space = 2
-        extra_space_for_vertical_scroll_bar = 5
-        return (
-            desired_width_in_characters
-            + extra_bit_of_margin_space
-            + extra_space_for_vertical_scroll_bar
-        ) * font_metrics.averageCharWidth()
 
     def _init_layout(self):
         dialog_buttons = QDialogButtonBox(QDialogButtonBox.Ok)  # type: ignore
@@ -144,13 +150,8 @@ class FileDialog(QDialog):
         self.adjustSize()
 
     def sizeHint(self) -> QSize:
+        fontWidth = self._view.fontMetrics().averageCharWidth()
         return QSize(
-            self._calculate_font_based_width(),
-            _calculate_screen_size_based_height(),
+            calculate_font_based_width(fontWidth),
+            calculate_screen_size_based_height(),
         )
-
-
-def _calculate_screen_size_based_height():
-    screen_height = QApplication.primaryScreen().geometry().height()
-    max_ratio_of_screen = 1.0 / 3.0
-    return floor(screen_height * max_ratio_of_screen)

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Optional
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
+from ert._clib.queue import _refresh_status  # pylint: disable=import-error
 from ert.load_status import LoadStatus
 
 from . import ResPrototype
@@ -76,10 +77,6 @@ class JobQueueNode(BaseCClass):  # type: ignore
 
     _get_status = ResPrototype(
         "job_status_type_enum job_queue_node_get_status(job_queue_node)"
-    )
-
-    _refresh_status = ResPrototype(
-        "job_status_type_enum job_queue_node_refresh_status(job_queue_node, driver)"
     )
     _set_queue_status = ResPrototype(
         "void job_queue_node_set_status(job_queue_node, job_status_type_enum)"
@@ -163,7 +160,10 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return self._get_submit_attempt()  # type: ignore
 
     def _poll_queue_status(self, driver: "Driver") -> JobStatusType:
-        return self._refresh_status(driver)  # type: ignore
+        result, msg = _refresh_status(self, driver)
+        if msg is not None:
+            self._status_msg = msg
+        return JobStatusType(result)
 
     @property
     def status(self) -> JobStatusType:
@@ -186,7 +186,10 @@ class JobQueueNode(BaseCClass):  # type: ignore
             self._set_queue_status(JobStatusType.JOB_QUEUE_FAILED)
         else:
             self._set_queue_status(JobStatusType.JOB_QUEUE_EXIT)
-        self._status_msg = status_msg
+        if self._status_msg != "":
+            self._status_msg = status_msg
+        else:
+            self._status_msg += "\nstatus from done callback:{status_msg}"
         return callback_status
 
     def run_timeout_callback(self) -> None:
@@ -318,7 +321,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
                     self._transition_to_failure(
                         message=f"Realization: {self.callback_arguments[0].iens} "
                         "failed after reaching max submit"
-                        f" {max_submit} with: {self._status_msg}"
+                        f" ({max_submit}):\n\t{self._status_msg}"
                     )
             elif current_status in self.FAILURE_STATES:
                 self._transition_to_failure(

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -189,7 +189,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         if self._status_msg != "":
             self._status_msg = status_msg
         else:
-            self._status_msg += "\nstatus from done callback:{status_msg}"
+            self._status_msg += f"\nstatus from done callback:{status_msg}"
         return callback_status
 
     def run_timeout_callback(self) -> None:

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -189,7 +189,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         if self._status_msg != "":
             self._status_msg = status_msg
         else:
-            self._status_msg += f"\nstatus from done callback:{status_msg}"
+            self._status_msg += f"\nstatus from done callback: {status_msg}"
         return callback_status
 
     def run_timeout_callback(self) -> None:

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -764,7 +764,7 @@ def test_that_the_model_warns_when_active_realizations_less_min_realizations():
 
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("copy_poly_case")
-def test_cli_error_message_():
+def test_failing_job_cli_error_message():
     # modify poly_eval.py
     with open("poly_eval.py", mode="a", encoding="utf-8") as poly_script:
         poly_script.writelines(["    raise RuntimeError('Argh')"])

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, call
 import numpy as np
 import pandas as pd
 import pytest
+import xtgeo
 
 import ert.shared
 from ert import LibresFacade, ensemble_evaluator
@@ -444,25 +445,26 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
     source_root,
     capsys,
 ):
+    # pylint: disable=too-many-arguments
     shutil.copytree(
         os.path.join(source_root, "test-data", "poly_example"),
         os.path.join(str(tmpdir), "poly_example"),
     )
 
     with tmpdir.as_cwd():
-        ert = EnKFMain(ErtConfig.from_file("poly_example/poly.ert"))
-        prior_mask = prior_mask or [True] * ert.getEnsembleSize()
-        storage = open_storage(ert.ert_config.ens_path, mode="w")
+        test_ert = EnKFMain(ErtConfig.from_file("poly_example/poly.ert"))
+        prior_mask = prior_mask or [True] * test_ert.getEnsembleSize()
+        storage = open_storage(test_ert.ert_config.ens_path, mode="w")
         experiment_id = storage.create_experiment(
-            ert.ensembleConfig().parameter_configuration
+            test_ert.ensembleConfig().parameter_configuration
         )
         ensemble = storage.create_ensemble(
-            experiment_id, name="iter-0", ensemble_size=ert.getEnsembleSize()
+            experiment_id, name="iter-0", ensemble_size=test_ert.getEnsembleSize()
         )
         prior_ensemble_id = ensemble.id
-        prior_context = ert.ensemble_context(ensemble, prior_mask, 0)
-        ert.sample_prior(prior_context.sim_fs, prior_context.active_realizations)
-        facade = LibresFacade(ert)
+        prior_context = test_ert.ensemble_context(ensemble, prior_mask, 0)
+        test_ert.sample_prior(prior_context.sim_fs, prior_context.active_realizations)
+        facade = LibresFacade(test_ert)
         prior_values = facade.load_all_gen_kw_data(
             storage.get_ensemble_by_name("iter-0")
         )
@@ -485,7 +487,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
         FeatureToggling.update_from_args(parsed)
         run_cli(parsed)
         post_facade = LibresFacade.from_config_file("poly.ert")
-        storage = open_storage(ert.ert_config.ens_path, mode="w")
+        storage = open_storage(test_ert.ert_config.ens_path, mode="w")
         parameter_values = post_facade.load_all_gen_kw_data(
             storage.get_ensemble(prior_ensemble_id)
         )
@@ -603,7 +605,6 @@ def test_surface_init_fails_during_forward_model_callback(copy_case):
     copy_case("snake_oil_field")
 
     rng = np.random.default_rng()
-    import xtgeo
 
     Path("./surface").mkdir()
     nx = 5
@@ -759,3 +760,41 @@ def test_that_the_model_warns_when_active_realizations_less_min_realizations():
         match="Due to active_realizations 5 is lower than MIN_REALIZATIONS",
     ):
         run_cli(parsed)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("copy_poly_case")
+def test_cli_error_message_():
+    # modify poly_eval.py
+    with open("poly_eval.py", mode="a", encoding="utf-8") as poly_script:
+        poly_script.writelines(["    raise RuntimeError('Argh')"])
+
+    args = Mock()
+    args.config = "poly_high_min_reals.ert"
+    parser = ArgumentParser(prog="test_main")
+
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            TEST_RUN_MODE,
+            "poly.ert",
+            "--port-range",
+            "1024-65535",
+        ],
+    )
+    expected_substrings = [
+        "Realization: 0 failed after reaching max submit (2)",
+        "job poly_eval failed",
+        "Process exited with status code 1",
+        "Traceback",
+        "raise RuntimeError('Argh')",
+        "RuntimeError: Argh",
+    ]
+    try:
+        run_cli(parsed)
+    except ErtCliError as error:
+        for substring in expected_substrings:
+            assert substring in f"{error}"
+    else:
+        pytest.fail(msg="Expected run cli to raise ErtCliError!")

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -375,7 +375,9 @@ def test_that_the_load_results_manually_tool_works(
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_run_with_failing_real_shows_error_msg(opened_main_window_clean, qtbot):
+def test_that_a_failing_job_shows_error_message_with_context(
+    opened_main_window_clean, qtbot
+):
     gui = opened_main_window_clean
 
     # break poly eval script so realz fail

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -1,4 +1,8 @@
+import contextlib
 import os
+import shutil
+import stat
+from textwrap import dedent
 from typing import Optional
 
 import pytest
@@ -21,6 +25,8 @@ from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.pathchooser import PathChooser
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
+from ert.gui.simulation.run_dialog import RunDialog
+from ert.gui.simulation.simulation_panel import SimulationPanel
 from ert.gui.tools.load_results.load_results_panel import LoadResultsPanel
 from ert.gui.tools.manage_cases.case_init_configuration import (
     CaseInitializationConfigurationPanel,
@@ -28,6 +34,7 @@ from ert.gui.tools.manage_cases.case_init_configuration import (
 from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
+from ert.run_models import SingleTestRun
 
 from .conftest import find_cases_dialog_and_panel
 
@@ -365,3 +372,72 @@ def test_that_the_load_results_manually_tool_works(
     QTimer.singleShot(1000, handle_load_results_dialog)
     load_results_tool = gui.tools["Load results manually"]
     load_results_tool.trigger()
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_run_with_failing_real_shows_error_msg(opened_main_window_clean, qtbot):
+    gui = opened_main_window_clean
+
+    # break poly eval script so realz fail
+    with open("poly_eval.py", "w", encoding="utf-8") as f:
+        f.write(
+            dedent(
+                """\
+                #!/usr/bin/env python
+
+                if __name__ == "__main__":
+                    raise RuntimeError('Argh')
+                """
+            )
+        )
+    os.chmod(
+        "poly_eval.py",
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    )
+
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree("poly_out")
+    # Select correct experiment in the simulation panel
+    simulation_panel = gui.findChild(SimulationPanel)
+    assert isinstance(simulation_panel, SimulationPanel)
+    simulation_mode_combo = simulation_panel.findChild(QComboBox)
+    assert isinstance(simulation_mode_combo, QComboBox)
+    simulation_mode_combo.setCurrentText(SingleTestRun.name())
+
+    # Click start simulation and agree to the message
+    start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+    assert start_simulation
+    assert isinstance(start_simulation, QToolButton)
+
+    def handle_dialog():
+        message_box = gui.findChild(QMessageBox)
+        assert message_box
+        qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+    def handle_error_dialog(run_dialog):
+        error_dialog = run_dialog.fail_msg_box
+        assert error_dialog
+        text = error_dialog.details_text.toPlainText()
+        label = error_dialog.label_text.text()
+        assert "ERT experiment failed" in label
+        expected_substrings = [
+            "Realization: 0 failed after reaching max submit (2)",
+            "job poly_eval failed",
+            "Process exited with status code 1",
+            "Traceback",
+            "raise RuntimeError('Argh')",
+            "RuntimeError: Argh",
+        ]
+        for substring in expected_substrings:
+            assert substring in text
+        qtbot.mouseClick(error_dialog.box.buttons()[0], Qt.LeftButton)
+
+    QTimer.singleShot(500, handle_dialog)
+    qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+
+    QTimer.singleShot(12000, lambda: handle_error_dialog(run_dialog))
+    qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -434,7 +434,7 @@ def test_tracking_missing_ecl(
                 if isinstance(event, EndEvent):
                     failures.append(event)
         assert (
-            f"Realization: 0 failed after reaching max submit 1 with: Could not find "
+            f"Realization: 0 failed after reaching max submit (1) with: Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
             f"{Path().absolute()}/simulations/realization-0/"
             "iter-0/ECLIPSE_CASE.UNSMRY"
@@ -443,7 +443,7 @@ def test_tracking_missing_ecl(
         # Just also check that it failed for the expected reason
         assert len(failures) == 1
         assert (
-            f"Realization: 0 failed after reaching max submit 1 with: Could not find "
+            f"Realization: 0 failed after reaching max submit (1) with: Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
             f"{Path().absolute()}/simulations/realization-0/"
             "iter-0/ECLIPSE_CASE.UNSMRY"

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -434,7 +434,9 @@ def test_tracking_missing_ecl(
                 if isinstance(event, EndEvent):
                     failures.append(event)
         assert (
-            f"Realization: 0 failed after reaching max submit (1) with: Could not find "
+            f"Realization: 0 failed after reaching max submit (1):\n\t\n"
+            "status from done callback: "
+            "Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
             f"{Path().absolute()}/simulations/realization-0/"
             "iter-0/ECLIPSE_CASE.UNSMRY"
@@ -443,7 +445,9 @@ def test_tracking_missing_ecl(
         # Just also check that it failed for the expected reason
         assert len(failures) == 1
         assert (
-            f"Realization: 0 failed after reaching max submit (1) with: Could not find "
+            f"Realization: 0 failed after reaching max submit (1):\n\t\n"
+            "status from done callback: "
+            "Could not find "
             f"SUMMARY file or using non unified SUMMARY file from: "
             f"{Path().absolute()}/simulations/realization-0/"
             "iter-0/ECLIPSE_CASE.UNSMRY"


### PR DESCRIPTION
**Issue**
When a realization fails, the user sees the very unhelpful line in the error dialog
```
Realization 23 failed with:
```
which seems to imply that there will be some reason as to why it failed, but alas there is nothing after the colon. Example screenshot:

![ert-fail-no-msg](https://github.com/equinor/ert/assets/15932677/0102ccc4-7d39-4fe5-a32a-98326a4e3e6d)

**Approach**
We fix this by taking the existing code for figuring out the failure reason, refactoring and changing it up a bit, and finally using it for displaying the error message. We also adjust the default size of the error dialog to accomodate for the displayed information.

**Screenshots**
single realization failed:

![ert-fail-one-real](https://github.com/equinor/ert/assets/15932677/d25b075c-ebc6-4ec1-842d-e3f252bff8e3)

many realizations failed:

![ert-fail-many-reals](https://github.com/equinor/ert/assets/15932677/fdcbb336-4b17-421f-8d1e-842febdd35fb)

## Pre review checklist

- [X] Added appropriate release note label
- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] Irrelevant - Updated documentation
- [X] Ensured new behaviour is tested