### PR TITLE
Use 'test-summary/action' to generate a nice pytest report

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -46,23 +46,28 @@ jobs:
     - name: Test GUI
       if: inputs.test-type == 'gui-test'
       run: |
-        pytest tests -sv --mpl -m "requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -sv --mpl -m "requires_window_manager" --benchmark-disable
 
     - name: Unit Test
       if: inputs.test-type == 'unit-tests'
       run: |
-        pytest tests -n4 --show-capture=stderr -sv -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
+        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr -sv -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
 
     - name: Integration Test
       if: inputs.test-type == 'integration-tests'
       run: |
-        pytest tests -n4 --show-capture=stderr -sv -m "integration_test and not requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr -sv -m "integration_test and not requires_window_manager" --benchmark-disable
 
     - name: Test for a clean repository
       run: |
         # Run this before the 'Test CLI' entry below, which produces a few files that are accepted for now. Exclude the wheel.
         git status --porcelain | sed '/ert.*.whl$\|\/block_storage$/d'
         test -z "$(git status --porcelain | sed '/ert.*.whl$\\|\\/block_storage$/d')"
+
+    - uses: test-summary/action@v2.1
+      with:
+        paths: junit.xml
+      if: always()
 
     - name: Test CLI
       run: |


### PR DESCRIPTION
Adds a report of failed tests for each job on the github actions summary page. This makes it easier to figure out what failed.

![image](https://github.com/equinor/ert/assets/2150728/25bfc528-3a6d-4641-b0df-cd3a53cd4a5f)
