### PR TITLE
Fix summary observations listing in GUI

### DIFF
--- a/src/ert/gui/ertwidgets/models/ertsummary.py
+++ b/src/ert/gui/ertwidgets/models/ertsummary.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Set, Tuple
 
 from ert.config import (
     EnkfObservationImplementationType,
@@ -6,6 +6,7 @@ from ert.config import (
     GenKwConfig,
     SurfaceConfig,
 )
+from ert.config.summary_observation import SummaryObservation
 from ert.enkf_main import EnKFMain
 
 
@@ -40,22 +41,11 @@ class ErtSummary:
             EnkfObservationImplementationType.SUMMARY_OBS
         )
 
-        keys = []
-        summary_keys_count = {}
-        summary_keys = []
+        summary_keys: Set[str] = set()
         for key in summary_obs:
-            data_key = self.ert.getObservations()[key].data_key
+            for obs in self.ert.getObservations()[key].observations.values():
+                if isinstance(obs, SummaryObservation):
+                    summary_keys.add(obs.observation_key)
 
-            if data_key not in summary_keys_count:
-                summary_keys_count[data_key] = 1
-                summary_keys.append(data_key)
-            else:
-                summary_keys_count[data_key] += 1
-
-            if key == data_key:
-                keys.append(key)
-            else:
-                keys.append(f"{key} [{data_key}]")
-
-        obs_keys = list(gen_obs) + summary_keys
+        obs_keys = set(gen_obs) | summary_keys
         return sorted(obs_keys, key=lambda k: k.lower())

--- a/tests/unit_tests/gui/ertwidgets/models/test_ertsummary.py
+++ b/tests/unit_tests/gui/ertwidgets/models/test_ertsummary.py
@@ -35,3 +35,26 @@ def test_getParameters(mock_ert):
     parameter_list, parameter_count = ErtSummary(mock_ert).getParameters()
     assert parameter_list == expected_list
     assert parameter_count == 223
+
+
+def test_snake_oil(snake_oil_case):
+    summary = ErtSummary(snake_oil_case)
+
+    assert summary.getForwardModels() == [
+        "SNAKE_OIL_SIMULATOR",
+        "SNAKE_OIL_NPV",
+        "SNAKE_OIL_DIFF",
+    ]
+
+    assert summary.getParameters() == (["SNAKE_OIL_PARAM (10)"], 10)
+
+    assert summary.getObservations() == [
+        "FOPR",
+        "WOPR_OP1_108",
+        "WOPR_OP1_144",
+        "WOPR_OP1_190",
+        "WOPR_OP1_36",
+        "WOPR_OP1_72",
+        "WOPR_OP1_9",
+        "WPR_DIFF_1",
+    ]


### PR DESCRIPTION
Resolves: #5853

All summary observations were listed as "summary" in the GUI, due to how they are stored in the storage. This commit makes it so that they are fully listed.