### PR TITLE
Fix incorrect suggestion for RUNPATH deprecation

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -43,8 +43,8 @@ deprecated_keywords_list = [
         keyword="RUNPATH",
         message=lambda line: "RUNPATH keyword contains deprecated value "
         f"placeholders: %d, instead use: "
-        f"{line[0].replace('%d', '<IENS>', 1).replace('%d', 'ITER', 1)}",
-        check=lambda line: "%d" in " ".join([str(v) for v in line]),
+        f"{line[0].replace('%d', '<IENS>', 1).replace('%d', '<ITER>', 1)}",
+        check=lambda line: any("%d" in str(v) for v in line),
     ),
     *[
         DeprecationInfo(


### PR DESCRIPTION
## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
