### PR TITLE
Replace usage of the deprecated pkg_resource package

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,9 @@
 #
 import os
 import sys
+from importlib import metadata
 
 sys.path.append(os.path.abspath("./_ext"))
-
-from pkg_resources import get_distribution  # noqa
 
 # -- Project information -----------------------------------------------------
 
@@ -25,7 +24,10 @@ project = "ERT"
 project_copyright = "Equinor ASA"
 author = "SCOUT - ScientifiC cOmpUTing team"
 
-dist_version = get_distribution("ert").version
+try:
+    dist_version = metadata.version("ert")
+except metadata.PackageNotFoundError:
+    dist_version = "0.0.0"
 
 # The short X.Y version
 version = ".".join(dist_version.split(".")[:2])

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -2,13 +2,24 @@
 import copy
 import logging
 import os
+import pkgutil
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
+from os.path import dirname
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union, overload
-
-import pkg_resources
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from ert.substitution_list import SubstitutionList
 
@@ -32,13 +43,18 @@ from .queue_config import QueueConfig
 from .workflow import Workflow
 from .workflow_job import ErtScriptLoadFailure, WorkflowJob
 
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
+
+
 logger = logging.getLogger(__name__)
 
 
 def site_config_location() -> str:
     if "ERT_SITE_CONFIG" in os.environ:
         return os.environ["ERT_SITE_CONFIG"]
-    return pkg_resources.resource_filename("ert.shared", "share/ert/site-config")
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    return dirname(ert_shared_loader.get_filename()) + "/share/ert/site-config"
 
 
 @dataclass

--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -1,8 +1,19 @@
 # isort: skip_file
-from pkg_resources import resource_filename
+import pkgutil
+from os.path import dirname
+from typing import cast, TYPE_CHECKING
+
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QCursor, QIcon, QMovie, QPixmap
 from qtpy.QtWidgets import QApplication
+
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
+
+
+def _get_ert_gui_dir():
+    ert_gui_loader = cast("FileLoader", pkgutil.get_loader("ert.gui"))
+    return dirname(ert_gui_loader.get_filename())
 
 
 def showWaitCursorWhileWaiting(func):
@@ -21,16 +32,16 @@ def showWaitCursorWhileWaiting(func):
 
 def resourceIcon(name):
     """Load an image as an icon"""
-    return QIcon(resource_filename("ert.gui", "resources/gui/img/" + name))
+    return QIcon(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
 
 
 def resourceImage(name) -> QPixmap:
     """Load an image as a Pixmap"""
-    return QPixmap(resource_filename("ert.gui", "resources/gui/img/" + name))
+    return QPixmap(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
 
 
 def resourceMovie(name) -> QMovie:
-    movie = QMovie(resource_filename("ert.gui", "resources/gui/img/" + name))
+    movie = QMovie(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
     movie.start()
     return movie
 

--- a/src/ert/shared/hook_implementations/jobs.py
+++ b/src/ert/shared/hook_implementations/jobs.py
@@ -1,14 +1,20 @@
 import os
+import pkgutil
+from os.path import dirname
+from typing import TYPE_CHECKING, cast
 
-import pkg_resources
 from jinja2 import Template
 
 from ert.shared.plugins.plugin_manager import hook_implementation
 from ert.shared.plugins.plugin_response import plugin_response
 
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
+
 
 def _resolve_ert_share_path():
-    return pkg_resources.resource_filename("ert.shared", "share/ert")
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    return dirname(ert_shared_loader.get_filename()) + "/share/ert"
 
 
 def _get_jobs_from_directories(directories):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 import fileinput
 import os
+import pkgutil
 import resource
 import shutil
 from argparse import ArgumentParser
+from os.path import dirname
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
-import pkg_resources
 import pytest
 from hypothesis import HealthCheck, settings
 
@@ -19,6 +21,9 @@ from ert.shared.feature_toggling import FeatureToggling
 from ert.storage import open_storage
 
 from .utils import SOURCE_DIR
+
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
 
 # Timeout settings are unreliable both on CI and
 # when running pytest with xdist so we disable it
@@ -40,7 +45,8 @@ def fixture_source_root():
 def class_source_root(request, source_root):
     request.cls.SOURCE_ROOT = source_root
     request.cls.TESTDATA_ROOT = source_root / "test-data"
-    request.cls.SHARE_ROOT = pkg_resources.resource_filename("ert.shared", "share")
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    request.cls.SHARE_ROOT = dirname(ert_shared_loader.get_filename()) + "/share"
     yield
 
 

--- a/tests/unit_tests/shared/share/test_forward_models.py
+++ b/tests/unit_tests/shared/share/test_forward_models.py
@@ -1,6 +1,10 @@
 import os
+import pkgutil
+from os.path import dirname
+from typing import TYPE_CHECKING, cast
 
-import pkg_resources
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
 
 
 def extract_executable(filename):
@@ -17,7 +21,8 @@ def file_exist_and_is_executable(file_path):
 
 
 def test_validate_scripts():
-    fm_path = pkg_resources.resource_filename("ert.shared", "share/ert/forward-models")
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    fm_path = dirname(ert_shared_loader.get_filename()) + "/share/ert/forward-models"
     for fm_dir in os.listdir(fm_path):
         fm_dir = os.path.join(fm_path, fm_dir)
         # get all sub-folder in forward-models

--- a/tests/unit_tests/shared/share/test_rms.py
+++ b/tests/unit_tests/shared/share/test_rms.py
@@ -1,17 +1,23 @@
 import json
 import os
+import pkgutil
 import shutil
 import stat
 import subprocess
 import sys
+from os.path import dirname
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
-import pkg_resources
 import pytest
 
 from tests.utils import SOURCE_DIR
 
 from ._import_from_location import import_from_location
+
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
+
 
 # import rms.py from ert/forward-models/res/script
 # package-data path which. These are kept out of the ert package to avoid the
@@ -46,6 +52,11 @@ then
 fi
 $@
 """
+
+
+def _get_ert_shared_dir():
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    return dirname(ert_shared_loader.get_filename())
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -244,9 +255,7 @@ def test_rms_load_env(monkeypatch, source_root, val, carry_over):
     with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
-    rms_exec = pkg_resources.resource_filename(
-        "ert.shared", "share/ert/forward-models/res/script/rms.py"
-    )
+    rms_exec = _get_ert_shared_dir() + "/share/ert/forward-models/res/script/rms.py"
     subprocess.check_call(
         [
             rms_exec,
@@ -315,9 +324,7 @@ def test_rms_drop_env(monkeypatch, source_root, val, carry_over):
     with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
-    rms_exec = pkg_resources.resource_filename(
-        "ert.shared", "share/ert/forward-models/res/script/rms.py"
-    )
+    rms_exec = _get_ert_shared_dir() + "/share/ert/forward-models/res/script/rms.py"
     subprocess.check_call(
         [
             rms_exec,
@@ -627,9 +634,7 @@ def test_rms_job_script_parser(monkeypatch, source_root):
     with open("run_path/action.json", "w", encoding="utf-8") as f:
         f.write(json.dumps(action))
 
-    rms_exec = pkg_resources.resource_filename(
-        "ert.shared", "share/ert/forward-models/res/script/rms.py"
-    )
+    rms_exec = _get_ert_shared_dir() + "/share/ert/forward-models/res/script/rms.py"
     subprocess.check_call(
         [
             rms_exec,

--- a/tests/unit_tests/shared/share/test_templating.py
+++ b/tests/unit_tests/shared/share/test_templating.py
@@ -1,14 +1,20 @@
 import json
 import os
+import pkgutil
 import subprocess
+from os.path import dirname
+from typing import TYPE_CHECKING, cast
 
 import jinja2
-import pkg_resources
 import pytest
 
 from tests.utils import SOURCE_DIR
 
 from ._import_from_location import import_from_location
+
+if TYPE_CHECKING:
+    from importlib.abc import FileLoader
+
 
 # import template_render.py from ert/forward-models/templating/script
 # package-data path which. These are kept out of the ert package to avoid the
@@ -218,9 +224,10 @@ def test_template_executable():
         "--template_file template "
         "--input_files other.json"
     )
-    template_render_exec = pkg_resources.resource_filename(
-        "ert.shared",
-        "share/ert/forward-models/templating/script/template_render.py",
+    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
+    template_render_exec = (
+        dirname(ert_shared_loader.get_filename())
+        + "/share/ert/forward-models/templating/script/template_render.py"
     )
 
     subprocess.call(template_render_exec + params, shell=True, stdout=subprocess.PIPE)

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -2,7 +2,6 @@ mypy
 mypy-protobuf<3.4
 types-aiofiles
 types-requests
-types-pkg_resources
 types-PyYAML
 types-python-dateutil
 types-decorator


### PR DESCRIPTION
**Issue**
Use of deprecated package pkg_resources.


**Approach**
Replace pkg_resources with importlib.metadata and ~~importlib.resources~~ pkgutil.get_loader.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
