### PR TITLE
Dont run test summary if no input file is missing

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -48,6 +48,7 @@ jobs:
       run: |
         pytest tests --junit-xml=junit.xml -sv --mpl \
           -m "requires_window_manager" --benchmark-disable
+          sleep 900000
 
     - name: Unit Test
       if: inputs.test-type == 'unit-tests'

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -74,7 +74,7 @@ jobs:
     - uses: test-summary/action@v2.1
       with:
         paths: junit.xml
-      if: !cancelled()
+      if: ${{ !cancelled() }}$
 
     - name: Test CLI
       run: |

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -46,28 +46,34 @@ jobs:
     - name: Test GUI
       if: inputs.test-type == 'gui-test'
       run: |
-        pytest tests --junit-xml=junit.xml -sv --mpl -m "requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -sv --mpl \
+          -m "requires_window_manager" --benchmark-disable
 
     - name: Unit Test
       if: inputs.test-type == 'unit-tests'
       run: |
-        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr -sv -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
+        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr \
+          -sv -m "not integration_test and not requires_window_manager" \
+          --benchmark-disable --dist loadgroup
 
     - name: Integration Test
       if: inputs.test-type == 'integration-tests'
       run: |
-        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr -sv -m "integration_test and not requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr \
+          -sv -m "integration_test and not requires_window_manager" \
+          --benchmark-disable
 
     - name: Test for a clean repository
       run: |
-        # Run this before the 'Test CLI' entry below, which produces a few files that are accepted for now. Exclude the wheel.
+        # Run this before the 'Test CLI' entry below, which produces a few
+        # files that are accepted for now. Exclude the wheel.
         git status --porcelain | sed '/ert.*.whl$\|\/block_storage$/d'
         test -z "$(git status --porcelain | sed '/ert.*.whl$\\|\\/block_storage$/d')"
 
     - uses: test-summary/action@v2.1
       with:
         paths: junit.xml
-      if: always()
+      if: !cancelled()
 
     - name: Test CLI
       run: |


### PR DESCRIPTION

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] IRRELEVANT Updated documentation
- [ ] Ensured new behaviour is tested
  * gui test times out, is cancelled (gui tests "hang"), no junit file created AND we dont attempt to use the file: https://github.com/equinor/ert/actions/runs/5854251234/job/15869878650?pr=5871