### PR TITLE
Show a helpful error message when reading time map fails

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -113,7 +113,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
         model_config = None
 
         try:
-            model_config = ModelConfig.from_dict(ensemble_config.refcase, config_dict)
+            model_config = ModelConfig.from_dict(config_dict)
             runpath = model_config.runpath_format_string
             eclbase = model_config.eclbase_format_string
             substitution_list["<RUNPATH>"] = runpath

--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -500,8 +500,8 @@ class EnkfObs:
     ) -> "EnkfObs":
         obs_config_file = config.model_config.obs_config_file
         obs_time_list: List[datetime] = []
-        if config.model_config.refcase is not None:
-            refcase = config.model_config.refcase
+        if config.ensemble_config.refcase is not None:
+            refcase = config.ensemble_config.refcase
             obs_time_list = [refcase.get_start_time()] + [
                 CTime(t).datetime() for t in refcase.alloc_time_vector(True)
             ]

--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -281,6 +281,7 @@ class ErtConfigValues:
     refcase_smspec: Smspec
     refcase_unsmry: Unsmry
     egrid: EGrid
+    datetimes: List[datetime.datetime]
 
     def to_config_dict(self, config_file, cwd, all_defines=True):
         result = {
@@ -488,7 +489,7 @@ def ert_config_values(draw, use_eclbase=st.booleans()):
             else st.just(None),
             runpath=st.just("runpath-" + draw(format_runpath_file_name)),
             enspath=st.just(draw(words) + ".enspath"),
-            time_map=st.just(draw(file_names) + ".timemap"),
+            time_map=st.builds(lambda fn: fn + ".timemap", file_names),
             obs_config=st.just("obs-config-" + draw(file_names)),
             history_source=st.just("REFCASE_SIMULATED"),
             refcase=st.just("refcase/" + draw(file_names)),
@@ -529,6 +530,7 @@ def ert_config_values(draw, use_eclbase=st.booleans()):
             refcase_smspec=st.just(smspec),
             refcase_unsmry=st.just(unsmry),
             egrid=egrids,
+            datetimes=st.just(dates),
         )
     )
 
@@ -631,7 +633,6 @@ def config_generators(draw, use_eclbase=st.booleans()):
                 "runpath",
                 "runpath_file",
                 "enspath",
-                "time_map",
                 "obs_config",
                 "data_file",
                 "job_script",
@@ -677,6 +678,9 @@ def config_generators(draw, use_eclbase=st.booleans()):
                 os.mkdir("./refcase")
             config_values.refcase_smspec.to_file(f"./refcase/{summary_basename}.SMSPEC")
             config_values.refcase_unsmry.to_file(f"./refcase/{summary_basename}.UNSMRY")
+            with open(config_values.time_map, "w", encoding="utf-8") as fh:
+                for dt in config_values.datetimes:
+                    fh.write(dt.date().isoformat() + "\n")
 
             config_values.egrid.to_file(config_values.grid_file)
 

--- a/tests/unit_tests/config/test_model_config.py
+++ b/tests/unit_tests/config/test_model_config.py
@@ -50,4 +50,4 @@ def test_suggested_deprecated_model_config_run_path(tmpdir):
 )
 def test_model_config_jobname_and_eclbase(extra_config, expected):
     config_dict = {"NUM_REALIZATIONS": 1, "ENSPATH": "Ensemble", **extra_config}
-    assert ModelConfig.from_dict(None, config_dict).jobname_format_string == expected
+    assert ModelConfig.from_dict(config_dict).jobname_format_string == expected


### PR DESCRIPTION
If reading the time map failed, the behavior used to be logging, but should be a user error message.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
