### PR TITLE
Explicitly use mixed format when converting to dates 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ args = dict(
         "matplotlib",
         "numpy",
         "packaging",
-        "pandas",
+        "pandas>=2.0.0",
         "pluggy",
         "protobuf",
         "psutil",

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -158,7 +158,7 @@ class PlotApi:
             df = pd.read_parquet(stream)
 
             try:
-                df.columns = pd.to_datetime(df.columns)
+                df.columns = pd.to_datetime(df.columns, format="mixed")
             except (ParserError, ValueError):
                 df.columns = [int(s) for s in df.columns]
 


### PR DESCRIPTION

**Issue**
Resolves #5452


**Approach**
Re-introduce the changes from this:
[_Short description of the approach_](https://github.com/equinor/ert/commit/1d73cc3663c690f7496fe8e8dd8e8c2c6d248a15)

By pinning pandas>=2.0.0 we avoid the problems that prompted a revert of this commit. 
I think this pinning is safe now that pandas2 is more mature.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
