### PR TITLE
Pin sphinx <7.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,7 +29,7 @@ requests
 scikit-build
 setuptools_scm
 sortedcontainers
-sphinx
+sphinx<7.2
 sphinx-argparse
 sphinx-autoapi
 sphinx-copybutton


### PR DESCRIPTION
**Issue**
An excpetion occours when using sphinx version 7.2.0. Possible incompatability with Furo theme.

Created issue https://github.com/equinor/ert/issues/5893


**Approach**
Pin and create issue to unpin

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
