### PR TITLE
Free allocated memory in torque driver

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -819,15 +819,16 @@ void torque_driver_kill_job(void *__driver, void *__job) {
 void torque_driver_free(torque_driver_type *driver) {
     torque_driver_set_debug_output(driver, NULL);
     free(driver->queue_name);
-    free(driver->qdel_cmd);
+    free(driver->qsub_cmd);
     free(driver->qstat_cmd);
     free(driver->qstat_opts);
-    free(driver->qsub_cmd);
+    free(driver->qdel_cmd);
     free(driver->num_cpus_per_node_char);
     free(driver->num_nodes_char);
     if (driver->job_prefix)
         free(driver->job_prefix);
-
+    if (driver->cluster_label)
+        free(driver->cluster_label);
     free(driver);
 }
 


### PR DESCRIPTION
This is a minor memory leak if the cluster_label struct member is set in the driver.

Also sort the free statements to match the order in the defining struct.

**Issue**
Resolves unnoticeable memory leak.


**Approach**
`free()`


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
