### PR TITLE
Restrict numpy to less than 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ args = dict(
         "jinja2",
         "lark",
         "matplotlib",
-        "numpy",
+        "numpy<2",
         "packaging",
         "pandas",
         "pluggy",


### PR DESCRIPTION
This is in accordance with https://github.com/numpy/numpy/issues/24300



## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
