### PR TITLE
Ensure job_dispatch exits cleanly on OSError

### DIFF
--- a/src/_ert_job_runner/cli.py
+++ b/src/_ert_job_runner/cli.py
@@ -119,7 +119,14 @@ def main(args):
     for job_status in job_runner.run(parsed_args.job):
         logger.info(f"Job status: {job_status}")
         for reporter in reporters:
-            reporter.report(job_status)
+            try:
+                reporter.report(job_status)
+            except OSError as oserror:
+                print(
+                    f"job_dispatch failed due to {oserror}. Stopping and cleaning up."
+                )
+                pgid = os.getpgid(os.getpid())
+                os.killpg(pgid, signal.SIGKILL)
 
         if isinstance(job_status, Finish) and not job_status.success():
             pgid = os.getpgid(os.getpid())


### PR DESCRIPTION
If the reporter is for some reason unable to write its json files, an OSError is raised and the job_dispatch.py process is stopped. When job_dispatch.py is interrupted, it will never wait() its child, which subsequently becomes a zombie process.

In this commit, we mark any OSError as a hard error from which we should exit (as before) and ensure we bring down the child.

**Issue**
Resolves #5549


**Approach**
Kill any childs if an OSError is raised.

In this PR, this `try-catch` surrounds the `reporter.report()` call. There are multiple places where this `try` could have been placed. Possibly only inside `reporting/file.py` since we obviously only care about file system errors in this PR, but that might give a longer diff. Perhaps it is more readable to put it higher as done here.

## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
