### PR TITLE
Let ERT handle a flaky qdel as for qsub and qstat

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -639,7 +639,7 @@ Keywords controlling the simulations
 
         ::
 
-                -- Let each realizations run for 50 seconds
+                -- Let each realization run for a maximum of 50 seconds
                 MAX_RUNTIME 50
 
         The MAX_RUNTIME key is optional.
@@ -1869,7 +1869,8 @@ bjobs.
         ERT will do exponential sleeps, starting at 2 seconds, and the provided
         timeout is a maximum. Let the timeout be sums of series like 2+4+8+16+32+64
         in order to be explicit about the number of retries. Set to zero to disallow
-        flakyness.
+        flakyness, setting it to 2 will allow for one re-attempt, and 6 will give two
+        re-attempts.
 
         ::
 

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -845,10 +845,57 @@ job_status_type torque_driver_get_job_status(void *__driver, void *__job) {
 
 void torque_driver_kill_job(void *__driver, void *__job) {
 
+    char *tmp_std_file =
+        (char *)util_alloc_tmp_file("/tmp", "ert-qdel-std", true);
+    char *tmp_err_file =
+        (char *)util_alloc_tmp_file("/tmp", "ert-qdel-err", true);
+
     auto driver = static_cast<torque_driver_type *>(__driver);
     auto job = static_cast<torque_job_type *>(__job);
-    spawn_blocking(driver->qdel_cmd, 1, (const char **)&job->torque_jobnr_char,
-                   NULL, NULL);
+    torque_debug(driver, "Killing Torque job: '%s %s'", driver->qdel_cmd,
+                 job->torque_jobnr_char);
+
+    /* The qdel command might fail intermittently for acceptable reasons,
+           retry a couple of times with exponential sleep. */
+    int return_value = -1;
+    bool qdel_succeeded = false;
+    int retry_interval = 2; /* seconds */
+    int slept_time = 0;
+    while ((return_value != 0) && (slept_time <= driver->timeout)) {
+        return_value = spawn_blocking(driver->qdel_cmd, 1,
+                                      (const char **)&job->torque_jobnr_char,
+                                      tmp_std_file, tmp_err_file);
+        if (return_value != 0) {
+            if (slept_time + retry_interval <= driver->timeout) {
+                torque_debug(driver,
+                             "qdel failed for job %s with exit code "
+                             "%d, retrying in %d seconds",
+                             job->torque_jobnr_char, return_value,
+                             retry_interval);
+                sleep(retry_interval);
+                slept_time += retry_interval;
+                retry_interval *= 2;
+            } else {
+                torque_debug(driver,
+                             "qdel failed for job %s, no (more) retries",
+                             job->torque_jobnr_char);
+                char *stderr_content =
+                    util_fread_alloc_file_content(tmp_err_file, NULL);
+                torque_debug(driver, "qdel stderr: %s\n", stderr_content);
+                free(stderr_content);
+                break;
+            }
+        } else {
+            if (slept_time > 0) {
+                torque_debug(driver,
+                             "qdel succeeded for job %s after waiting "
+                             "%d seconds",
+                             job->torque_jobnr_char, slept_time);
+            }
+        }
+    }
+    free(tmp_std_file);
+    free(tmp_err_file);
 }
 
 void torque_driver_free(torque_driver_type *driver) {


### PR DESCRIPTION
Use the same exponential retry schema as for qsub
and qstat, and conserve stdout/stderr for future debugging

**Issue**
Resolves #5121 


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
