### PR TITLE
Make sure job_queue will not timeout when sending event

### DIFF
--- a/src/ert/job_queue/queue_differ.py
+++ b/src/ert/job_queue/queue_differ.py
@@ -17,6 +17,18 @@ class QueueDiffer:
         self._qindex_to_iens[queue_index] = iens
         self._state.append(state)
 
+    def get_old_and_new_state(
+        self,
+        job_list: List[JobQueueNode],
+    ) -> Tuple[List[JobStatus], List[JobStatus]]:
+        """Calculate a new state, do not transition, return both old and new state."""
+        new_state = [job.status.value for job in job_list]
+        old_state = copy.copy(self._state)
+        return old_state, new_state
+
+    def transition_to_new_state(self, new_state: List[JobStatus]) -> None:
+        self._state = new_state
+
     def transition(
         self,
         job_list: List[JobQueueNode],


### PR DESCRIPTION
**Issue**
Make sure that queue will not Timeout when sending event.


**Approach**
Catch TimeoutError


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
