### PR TITLE
Solve flake8-bugbear B014

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ ignore =
     # The minimal set of ignores that makes flake8 pass when flake8-bugbear is installed:
     B008
     B009
-    B014
     B019
     B028
 max-line-length = 88

--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -103,9 +103,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
             except (
                 InvalidHandshake,
                 InvalidURI,
-                asyncio.TimeoutError,
-                ConnectionRefusedError,
                 OSError,
+                asyncio.TimeoutError,
             ) as exception:
                 if retry == self._max_retries:
                     _error_msg = (


### PR DESCRIPTION
Remove ConnectionRefusedError, as it is a subclass of OSError which is already caught.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
