### PR TITLE
Allow garbage collection for cached responses

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ ignore =
     B008
     B009
     B014
-    B019
     B028
 max-line-length = 88
 [mutmut]

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -27,6 +27,7 @@ from iterative_ensemble_smoother.experimental import (
 
 from ert.config import Field, GenKwConfig, SurfaceConfig
 from ert.realization_state import RealizationState
+from ert.storage import static_load_response
 
 from .row_scaling import RowScaling
 from .update import Parameter, RowScalingParameter
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
 
     from ert.config import AnalysisConfig, AnalysisModule, EnkfObs, EnsembleConfig
     from ert.enkf_main import EnKFMain
-    from ert.storage import EnsembleAccessor, EnsembleReader, static_load_response
+    from ert.storage import EnsembleAccessor, EnsembleReader
 
     from .configuration import UpdateConfiguration
 

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from ert.config import AnalysisConfig, AnalysisModule, EnkfObs, EnsembleConfig
     from ert.enkf_main import EnKFMain
-    from ert.storage import EnsembleAccessor, EnsembleReader
+    from ert.storage import EnsembleAccessor, EnsembleReader, static_load_response
 
     from .configuration import UpdateConfiguration
 
@@ -322,7 +322,7 @@ def _get_obs_and_measure_data(
             .transpose(..., "realization")
             .values.reshape((-1, len(filtered_ds.realization)))
         )
-    source_fs.load_response.cache_clear()
+    static_load_response.cache_clear()
     return (
         np.concatenate(measured_data, axis=0),
         np.concatenate(observation_values),

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import os
 from typing import Literal, Union, overload
 
-from ert.storage.local_ensemble import LocalEnsembleAccessor, LocalEnsembleReader
+from ert.storage.local_ensemble import (
+    LocalEnsembleAccessor,
+    LocalEnsembleReader,
+    static_load_response,
+)
 from ert.storage.local_experiment import LocalExperimentAccessor, LocalExperimentReader
 from ert.storage.local_storage import LocalStorageAccessor, LocalStorageReader
 
@@ -52,4 +56,5 @@ __all__ = [
     "StorageReader",
     "StorageAccessor",
     "open_storage",
+    "static_load_response",
 ]

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -209,7 +209,7 @@ class LocalEnsembleReader:
 
 @lru_cache
 def static_load_response(
-    mount_point: str, key: str, realizations: Tuple[int, ...]
+    mount_point: Path, key: str, realizations: Tuple[int, ...]
 ) -> xr.Dataset:
     loaded = []
     for realization in realizations:


### PR DESCRIPTION
Using lru_cache on class methods may lead to memory leakages, as the cache stores the self reference.

Rewriting the load_response() function to a static function, and using the lru_cache on that instead.

flake8-bugbear: issue B019

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
