### PR TITLE
Export more of interface used by Everest

### DIFF
--- a/src/ert/__init__.py
+++ b/src/ert/__init__.py
@@ -5,12 +5,16 @@ from .config import ErtScript
 from .data import MeasuredData
 from .job_queue import JobStatus
 from .libres_facade import LibresFacade
-from .simulator import BatchSimulator
+from .simulator import BatchContext, BatchSimulator, Status
+from .storage import open_storage
 
 __all__ = [
     "MeasuredData",
     "LibresFacade",
     "BatchSimulator",
+    "BatchContext",
     "ErtScript",
     "JobStatus",
+    "Status",
+    "open_storage",
 ]

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -51,7 +51,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
     and as such changes here should not be taken lightly."""
 
     def __init__(self, enkf_main: EnKFMain):
-        self._enkf_main = enkf_main
+        self._enkf_main = enkf_main  # This field is friendly for ert.simulator
         self._es_update = ESUpdate(enkf_main)
 
     def write_runpath_list(
@@ -556,3 +556,13 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         cls, config_file: str, read_only: bool = False
     ) -> "LibresFacade":
         return cls(EnKFMain(ErtConfig.from_file(config_file), read_only))
+
+    @classmethod
+    def site_config(cls) -> Dict[str, Any]:
+        return ErtConfig.read_site_config()  # type: ignore
+
+    @classmethod
+    def from_config_dict(
+        cls, config_dict: Dict[str, Any], read_only: bool = False
+    ) -> LibresFacade:
+        return cls(EnKFMain(ErtConfig.from_dict(config_dict), read_only))

--- a/src/ert/simulator/__init__.py
+++ b/src/ert/simulator/__init__.py
@@ -1,9 +1,10 @@
 from .batch_simulator import BatchSimulator
-from .batch_simulator_context import BatchContext
+from .batch_simulator_context import BatchContext, Status
 from .simulation_context import SimulationContext
 
 __all__ = [
     "BatchSimulator",
     "BatchContext",
     "SimulationContext",
+    "Status",
 ]

--- a/src/ert/simulator/batch_simulator_context.py
+++ b/src/ert/simulator/batch_simulator_context.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
-    from ert.enkf_main import EnKFMain
+    from ert import LibresFacade
     from ert.storage import EnsembleAccessor
 
 Status = namedtuple("Status", "waiting pending running complete failed")
@@ -24,7 +24,7 @@ class BatchContext(SimulationContext):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         result_keys: "Iterable[str]",
-        ert: "EnKFMain",
+        ert: LibresFacade,
         fs: EnsembleAccessor,
         mask: List[bool],
         itr: int,
@@ -35,7 +35,6 @@ class BatchContext(SimulationContext):
         """
         super().__init__(ert, fs, mask, itr, case_data)
         self.result_keys = result_keys
-        self.ert_config = ert.resConfig()
 
     def join(self) -> None:
         """

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -1,12 +1,12 @@
-from ert.enkf_main import EnKFMain
+from ert import LibresFacade
 from ert.realization_state import RealizationState
 from ert.simulator import SimulationContext
 from tests.utils import wait_until
 
 
-def test_simulation_context(setup_case, storage):
-    ert_config = setup_case("batch_sim", "sleepy_time.ert")
-    ert = EnKFMain(ert_config)
+def test_simulation_context(copy_case, storage):
+    copy_case("batch_sim")
+    ert = LibresFacade.from_config_file("sleepy_time.ert")
 
     size = 4
     even_mask = [True, False] * (size // 2)
@@ -14,10 +14,10 @@ def test_simulation_context(setup_case, storage):
 
     experiment_id = storage.create_experiment()
     even_half = storage.create_ensemble(
-        experiment_id, name="even_half", ensemble_size=ert.getEnsembleSize()
+        experiment_id, name="even_half", ensemble_size=ert.get_ensemble_size()
     )
     odd_half = storage.create_ensemble(
-        experiment_id, name="odd_half", ensemble_size=ert.getEnsembleSize()
+        experiment_id, name="odd_half", ensemble_size=ert.get_ensemble_size()
     )
 
     case_data = [(geo_id, {}) for geo_id in range(size)]


### PR DESCRIPTION
This should make it possible to use the exported members without importing symbols that are not exported.


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
