### PR TITLE
Make sure job_queue will not timeout when sending event

### DIFF
--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -568,7 +568,7 @@ class JobQueue(BaseCClass):  # type: ignore
         old_state, new_state = self._differ.transition(self.job_list)
         return self._differ.diff_states(old_state, new_state)
 
-    def changes_without_transition(self) -> Tuple[Dict[int, str], List[JobStatus]]:
+    def changes_without_transition(self) -> Tuple[Dict[int, str], List[JobStatusType]]:
         old_state, new_state = self._differ.get_old_and_new_state(self.job_list)
         return self._differ.diff_states(old_state, new_state), new_state
 

--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -12,7 +12,17 @@ import threading
 import time
 from collections import deque
 from threading import Semaphore
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
@@ -289,7 +299,7 @@ class JobQueue(BaseCClass):  # type: ignore
             ]
         )
         while events:
-            await asyncio.wait_for(ee_connection.send(to_json(events[0])), 60)
+            await ee_connection.send(to_json(events[0]))
             events.popleft()
 
     async def _execution_loop_queue_via_websockets(
@@ -307,7 +317,7 @@ class JobQueue(BaseCClass):  # type: ignore
             for func in evaluators:
                 func()
 
-            changes = self.changes_after_transition()
+            changes, new_state = self.changes_without_transition()
             # logically not necessary the way publish changes is implemented at the
             # moment, but highly relevant before, and might be relevant in the
             # future in case publish changes becomes expensive again
@@ -317,6 +327,7 @@ class JobQueue(BaseCClass):  # type: ignore
                     changes,
                     ee_connection,
                 )
+                self._differ.transition_to_new_state(new_state)
 
             if self.stopped:
                 raise asyncio.CancelledError
@@ -556,6 +567,10 @@ class JobQueue(BaseCClass):  # type: ignore
     def changes_after_transition(self) -> Dict[int, str]:
         old_state, new_state = self._differ.transition(self.job_list)
         return self._differ.diff_states(old_state, new_state)
+
+    def changes_without_transition(self) -> Tuple[Dict[int, str], List[JobStatus]]:
+        old_state, new_state = self._differ.get_old_and_new_state(self.job_list)
+        return self._differ.diff_states(old_state, new_state), new_state
 
     def add_dispatch_information_to_jobs_file(
         self,

--- a/src/ert/job_queue/queue_differ.py
+++ b/src/ert/job_queue/queue_differ.py
@@ -20,13 +20,13 @@ class QueueDiffer:
     def get_old_and_new_state(
         self,
         job_list: List[JobQueueNode],
-    ) -> Tuple[List[JobStatus], List[JobStatus]]:
+    ) -> Tuple[List[JobStatusType], List[JobStatusType]]:
         """Calculate a new state, do not transition, return both old and new state."""
         new_state = [job.status.value for job in job_list]
         old_state = copy.copy(self._state)
         return old_state, new_state
 
-    def transition_to_new_state(self, new_state: List[JobStatus]) -> None:
+    def transition_to_new_state(self, new_state: List[JobStatusType]) -> None:
         self._state = new_state
 
     def transition(

--- a/src/ert/job_queue/queue_differ.py
+++ b/src/ert/job_queue/queue_differ.py
@@ -17,6 +17,18 @@ class QueueDiffer:
         self._qindex_to_iens[queue_index] = iens
         self._state.append(state)
 
+    def get_old_and_new_state(
+        self,
+        job_list: List[JobQueueNode],
+    ) -> Tuple[List[JobStatus], List[JobStatus]]:
+        """Calculate a new state, do not transition, return both old and new state."""
+        new_state = [job.status.value for job in job_list]
+        old_state = copy.copy(self._state)
+        return old_state, new_state
+
+    def transition_to_new_state(self, new_state: List[JobStatus]) -> None:
+        self._state = new_state
+
     def transition(
         self,
         job_list: List[JobQueueNode],


### PR DESCRIPTION
This removes wait_for and thus potenital timeouterror and let async loop iterator handle the connection exceptions. Additionally this make publish changes in job queue more resilient where the changes are not applied until we published all changes.

## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
