### PR TITLE
Add explicit stacklevel for warnings.warn

### DIFF
--- a/.github/workflows/annotate_python.yml
+++ b/.github/workflows/annotate_python.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "changed_files=$(git diff --name-only ${{github.sha}} ${{github.event.pull_request.base.sha}} | tr ' ' '\n' |  xargs ls -d 2>/dev/null | grep -E '.py$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       - run: echo ::add-matcher::.github/flake8-matcher.json
       - name: run flake8
-        run: flake8 --exit-zero --ignore "B028, W503, E203" ${{steps.find_changed_files.outputs.changed_files}}
+        run: flake8 --exit-zero --ignore "W503, E203" ${{steps.find_changed_files.outputs.changed_files}}
         if: steps.find_changed_files.outputs.changed_files != ''
       - run: echo ::add-matcher::.github/mypy-matcher.json
       - name: generate grpc typing stubs

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ ignore =
     B009
     B014
     B019
-    B028
 max-line-length = 88
 [mutmut]
 paths_to_mutate=src/ert/config/parsing/

--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -81,6 +81,7 @@ def _setup_ensemble_experiment(ert, storage, args, experiment_id):
             f"MIN_REALIZATIONS {min_realizations_count}, MIN_REALIZATIONS has been "
             f"set to match active_realizations.",
             category=ConfigWarning,
+            stacklevel=1,
         )
 
     simulations_argument = {

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -533,7 +533,8 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                         f"Loading workflow job {workflow_job[0]!r}"
                         f" failed with '{err}'. It will not be loaded.",
                         workflow_job[0],
-                    )
+                    ),
+                    stacklevel=1,
                 )
             except ConfigValidationError as err:
                 errors.append(
@@ -549,6 +550,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                     ConfigWarning.with_context(
                         f"Unable to open job directory {job_path}", job_path
                     ),
+                    stacklevel=1,
                 )
                 continue
 
@@ -565,6 +567,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                             f" failed with '{err}'. It will not be loaded.",
                             file_name,
                         ),
+                        stacklevel=1,
                     )
                 except ConfigValidationError as err:
                     errors.append(
@@ -589,7 +592,8 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                     warnings.warn(
                         ConfigWarning.with_context(
                             f"Workflow {filename!r} was added twice", work[0]
-                        )
+                        ),
+                        stacklevel=1,
                     )
             except ConfigValidationError as err:
                 warnings.warn(
@@ -599,6 +603,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                         + err.cli_message(),
                         work[0],
                     ),
+                    stacklevel=1,
                 )
 
         errors = []
@@ -642,6 +647,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                         f"{job_config_file!r} over {jobs[name].executable!r}",
                         name,
                     ),
+                    stacklevel=1,
                 )
             jobs[name] = new_job
 
@@ -665,6 +671,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                     ConfigWarning.with_context(
                         f"No files found in job directory {job_path}", job_path
                     ),
+                    stacklevel=1,
                 )
                 continue
 
@@ -685,6 +692,7 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
                             f"choosing {full_path!r} over {jobs[name].executable!r}",
                             name,
                         ),
+                        stacklevel=1,
                     )
                 jobs[name] = new_job
 

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -67,6 +67,7 @@ class Field(ParameterConfig):  # pylint: disable=too-many-instance-attributes
                     f"this has no effect and can be removed",
                     config_list,
                 ),
+                stacklevel=1,
             )
 
         errors = []

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -78,6 +78,7 @@ class GenKwConfig(ParameterConfig):
                     "DISABLE_PARAMETERS key instead.\n",
                     gen_kw[0],
                 ),
+                stacklevel=1,
             )
 
         options = option_dict(gen_kw, 4)

--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -158,6 +158,7 @@ class EnkfObs:
                         " Truncating start of segment to 0.",
                         segment_name,
                     ),
+                    stacklevel=1,
                 )
                 start = 0
             if stop >= time_len:
@@ -167,6 +168,7 @@ class EnkfObs:
                         f" end of segment to {time_len - 1}.",
                         segment_name,
                     ),
+                    stacklevel=1,
                 )
                 stop = time_len - 1
             if start > stop:
@@ -176,6 +178,7 @@ class EnkfObs:
                         f" end of segment to {start}.",
                         segment_name,
                     ),
+                    stacklevel=1,
                 )
                 stop = start
             if np.size(std_dev[start:stop]) == 0:
@@ -187,6 +190,7 @@ class EnkfObs:
                         "time map.",
                         segment_name,
                     ),
+                    stacklevel=1,
                 )
             std_dev[start:stop] = cls._handle_error_mode(
                 values[start:stop],
@@ -207,6 +211,7 @@ class EnkfObs:
                             f" {summary_key}:{i} - ignored",
                             summary_key,
                         ),
+                        stacklevel=1,
                     )
                     continue
                 data[dates[i - 1]] = SummaryObservation(
@@ -237,6 +242,7 @@ class EnkfObs:
                             " Please use ISO date format YYYY-MM-DD",
                             date_str,
                         ),
+                        stacklevel=1,
                     )
                     return date, f"DATE={date_str}"
                 except ValueError as err:
@@ -427,6 +433,7 @@ class EnkfObs:
                     f" - ignoring observation {obs_key}",
                     state_kw,
                 ),
+                stacklevel=1,
             )
             return {}
         config_node = ensemble_config.getNode(state_kw)
@@ -454,6 +461,7 @@ class EnkfObs:
                     "The observation will be ignored",
                     obs_key,
                 ),
+                stacklevel=1,
             )
             return {}
         response_report_steps = (
@@ -469,6 +477,7 @@ class EnkfObs:
                     " - The observation will be ignored",
                     state_kw,
                 ),
+                stacklevel=1,
             )
             return {}
         restart = 0 if restart is None else restart

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -160,6 +160,7 @@ def _substitute_token(
                     "Probably this causes a loop.",
                     token,
                 ),
+                stacklevel=1,
             )
 
     return current
@@ -185,7 +186,7 @@ def _tree_to_dict(
         kw, *args = node  # type: ignore
         if kw not in schema:
             warnings.warn(
-                ConfigWarning.with_context(f"Unknown keyword {kw!r}", kw),
+                ConfigWarning.with_context(f"Unknown keyword {kw!r}", kw), stacklevel=1
             )
             continue
 

--- a/src/ert/config/parsing/schema_dict.py
+++ b/src/ert/config/parsing/schema_dict.py
@@ -106,7 +106,8 @@ class SchemaItemDict(_UserDict):
                             filename=filename,
                             message=deprecation.resolve_message(line),
                         ).set_context_keyword(line)
-                    )
+                    ),
+                    stacklevel=1,
                 )
 
     @abc.abstractmethod

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -190,7 +190,7 @@ this locale. It is highly recommended that you set the decimalpoint to '.'
 using one of the environment variables 'LANG', LC_ALL', or 'LC_NUMERIC' to
 either the 'C' locale or alternatively a locale which uses '.' as
 decimalpoint.\n"""  # noqa
-        warnings.warn(msg, category=ConfigWarning)
+        warnings.warn(msg, category=ConfigWarning, stacklevel=1)
 
 
 def _clicked_help_button(menu_label: str, link: str):


### PR DESCRIPTION
The stacklevel is 1 by default, this PR makes it explicit so flake8 can enforce that we are conscious about the stacklevel. stacklevel=1 is correct when the line-number where warn() is called is the relevant context for the warning recipient.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
