### PR TITLE
Prevent closing of the main window when simulations are running

### DIFF
--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -15,6 +15,7 @@ class ErtNotifier(QObject):
         self._config_file = config_file
         self._storage: Optional[StorageReader] = None
         self._current_case = None
+        self._is_simulation_running = False
 
     @property
     def storage(self) -> StorageReader:
@@ -35,6 +36,10 @@ class ErtNotifier(QObject):
             return "default"
         return self._current_case.name
 
+    @property
+    def is_simulation_running(self) -> bool:
+        return self._is_simulation_running
+
     @Slot()
     def emitErtChange(self):
         self.ertChanged.emit()
@@ -48,3 +53,7 @@ class ErtNotifier(QObject):
     def set_current_case(self, case: Optional[EnsembleReader] = None) -> None:
         self._current_case = case
         self.current_case_changed.emit(case)
+
+    @Slot(bool)
+    def set_is_simulation_running(self, is_running: bool) -> None:
+        self._is_simulation_running = is_running

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -20,7 +20,9 @@ from ert.shared.plugins import ErtPluginManager
 class ErtMainWindow(QMainWindow):
     close_signal = Signal()
 
-    def __init__(self, config_file, plugin_manager: Optional[ErtPluginManager] = None):
+    def __init__(
+        self, config_file: str, plugin_manager: Optional[ErtPluginManager] = None
+    ):
         QMainWindow.__init__(self)
         self.notifier = ErtNotifier(config_file)
         self.tools = {}
@@ -101,9 +103,13 @@ class ErtMainWindow(QMainWindow):
     def closeEvent(self, event):
         # Use QT settings saving mechanism
         # settings stored in ~/.config/Equinor/ErtGui.conf
-        self.__saveSettings()
-        self.close_signal.emit()
-        QMainWindow.closeEvent(self, event)
+
+        if self.notifier.is_simulation_running:
+            event.ignore()
+        else:
+            self.__saveSettings()
+            self.close_signal.emit()
+            QMainWindow.closeEvent(self, event)
 
     def __fetchSettings(self):
         settings = QSettings("Equinor", "Ert-Gui")

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -32,8 +32,8 @@ from .single_test_run_panel import SingleTestRunPanel
 
 class SimulationPanel(QWidget):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier, config_file: str):
-        self.notifier = notifier
         QWidget.__init__(self)
+        self._notifier = notifier
         self.ert = ert
         self.facade = LibresFacade(ert)
         self._config_file = config_file
@@ -131,7 +131,7 @@ class SimulationPanel(QWidget):
 
     def runSimulation(self):
         message = (
-            f"Are you sure you want to use case '{self.notifier.current_case_name}' "
+            f"Are you sure you want to use case '{self._notifier.current_case_name}' "
             "for initialization of the initial ensemble when running the experiments?"
         )
         if (
@@ -143,13 +143,13 @@ class SimulationPanel(QWidget):
             abort = False
             try:
                 args = self.getSimulationArguments()
-                experiment = self.notifier.storage.create_experiment(
+                experiment = self._notifier.storage.create_experiment(
                     parameters=self.ert.ensembleConfig().parameter_configuration
                 )
 
                 model = create_model(
                     self.ert,
-                    self.notifier.storage,
+                    self._notifier.storage,
                     args,
                     experiment.id,
                 )
@@ -183,7 +183,9 @@ class SimulationPanel(QWidget):
                     abort = True
 
             if not abort:
-                dialog = RunDialog(self._config_file, model, self.parent())
+                dialog = RunDialog(
+                    self._config_file, model, self._notifier, self.parent()
+                )
                 self.run_button.setDisabled(True)
                 self.run_button.setText("Experiment running...")
                 dialog.startSimulation()
@@ -192,11 +194,11 @@ class SimulationPanel(QWidget):
                 def exit_handler():
                     self.run_button.setText("Run Experiment")
                     self.run_button.setDisabled(False)
-                    self.notifier.emitErtChange()
+                    self._notifier.emitErtChange()
 
                 dialog.finished.connect(exit_handler)
 
-                self.notifier.emitErtChange()  # experiments may have added new cases
+                self._notifier.emitErtChange()  # experiments may have added new cases
 
     def toggleSimulationMode(self):
         current_model = self.getCurrentSimulationModel()

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -25,7 +25,8 @@ from ert.services import StorageService
 
 
 def test_success(runmodel, qtbot: QtBot, mock_tracker):
-    widget = RunDialog("poly.ert", runmodel)
+    notifier = Mock()
+    widget = RunDialog("poly.ert", runmodel, notifier)
     widget.show()
     qtbot.addWidget(widget)
 
@@ -41,7 +42,8 @@ def test_success(runmodel, qtbot: QtBot, mock_tracker):
 
 # pylint: disable=no-member
 def test_kill_simulations(runmodel, qtbot: QtBot, mock_tracker):
-    widget = RunDialog("poly.ert", runmodel)
+    notifier = Mock()
+    widget = RunDialog("poly.ert", runmodel, notifier)
     widget.show()
     qtbot.addWidget(widget)
 
@@ -69,7 +71,8 @@ def test_kill_simulations(runmodel, qtbot: QtBot, mock_tracker):
 def test_large_snapshot(
     runmodel, large_snapshot, qtbot: QtBot, mock_tracker, timeout_per_iter=5000
 ):
-    widget = RunDialog("poly.ert", runmodel)
+    notifier = Mock()
+    widget = RunDialog("poly.ert", runmodel, notifier)
     widget.show()
     qtbot.addWidget(widget)
 
@@ -317,7 +320,8 @@ def test_large_snapshot(
     ],
 )
 def test_run_dialog(events, tab_widget_count, runmodel, qtbot: QtBot, mock_tracker):
-    widget = RunDialog("poly.ert", runmodel)
+    notifier = Mock()
+    widget = RunDialog("poly.ert", runmodel, notifier)
     widget.show()
     qtbot.addWidget(widget)
 


### PR DESCRIPTION
**Issue**
Resolves #5938 


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
