### PR TITLE
Add type hinting to `ert.shared.plugins`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ args = dict(
         "cryptography",
         "cwrap",
         "dask_jobqueue",
-        "decorator",
         "deprecation",
         "dnspython >= 2",
         "ecl >= 2.14.1",

--- a/src/ert/shared/plugins/plugin_response.py
+++ b/src/ert/shared/plugins/plugin_response.py
@@ -1,26 +1,39 @@
-from decorator import decorator
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable, Generic, Optional, TypeVar
+
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
 
 
-@decorator
-def plugin_response(_func=None, plugin_name="", *args, **kwargs):
-    if _func is None:
-        return None
+def plugin_response(
+    plugin_name: str = "",
+) -> Callable[[Callable[P, T]], Callable[P, Optional[PluginResponse[T]]]]:
+    def outer(func: Callable[P, T]) -> Callable[P, Optional[PluginResponse[T]]]:
+        @wraps(func)
+        def inner(*args: P.args, **kwargs: P.kwargs) -> Optional[PluginResponse[T]]:
+            response = func(*args, **kwargs)
+            return (
+                PluginResponse(response, PluginMetadata(plugin_name, func.__name__))
+                if response is not None
+                else None
+            )
 
-    response = _func(*args, **kwargs)
-    return (
-        PluginResponse(response, PluginMetadata(plugin_name, _func.__name__))
-        if response is not None
-        else None
-    )
+        return inner
 
-
-class PluginResponse:
-    def __init__(self, data, plugin_metadata):
-        self.data = data
-        self.plugin_metadata = plugin_metadata
+    return outer
 
 
 class PluginMetadata:
-    def __init__(self, plugin_name, function_name):
+    def __init__(self, plugin_name: str, function_name: str) -> None:
         self.plugin_name = plugin_name
         self.function_name = function_name
+
+
+class PluginResponse(Generic[T]):
+    def __init__(self, data: T, plugin_metadata: PluginMetadata) -> None:
+        self.data = data
+        self.plugin_metadata = plugin_metadata


### PR DESCRIPTION
This module used the `decorator` package for a single function. We can re-write the decorator to be a standard Python decorator with type-hinting, and remove a dependency on this `decorator` package.