### PR TITLE
Increase timeout

### DIFF
--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -287,7 +287,7 @@ class BaseService:
 
         # Note: If the caller actually pass None, we override that here...
         if timeout is None:
-            timeout = 120
+            timeout = 240
         t = -1
         while t < timeout:
             if (path / name).exists():


### PR DESCRIPTION
Because the new storage solution is a bit slower than the old one more users are noticing that the plotting is timing out.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Added appropriate release note label
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
