### PR TITLE
Convert refcase into list of datetime

### DIFF
--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -154,10 +154,10 @@ class EnsembleConfig:
         time_map = []
         if refcase_file_path is not None:
             refcase = cls._load_refcase(refcase_file_path)
-            time_map = [
+            time_map = set(
                 datetime(date.year, date.month, date.day)
                 for date in refcase.report_dates
-            ]
+            )
         optional_keys = []
         summary_keys = [item for sublist in summary_list for item in sublist]
         for key in summary_keys:

--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union, no_type_check, overload
 
@@ -150,8 +151,13 @@ class EnsembleConfig:
         if ecl_base is not None:
             ecl_base = ecl_base.replace("%d", "<IENS>")
         refcase = None
+        time_map = []
         if refcase_file_path is not None:
             refcase = cls._load_refcase(refcase_file_path)
+            time_map = [
+                datetime(date.year, date.month, date.day)
+                for date in refcase.report_dates
+            ]
         optional_keys = []
         summary_keys = [item for sublist in summary_list for item in sublist]
         for key in summary_keys:
@@ -165,7 +171,7 @@ class EnsembleConfig:
                 name="summary",
                 input_file=ecl_base,
                 keys=optional_keys,
-                refcase=refcase,
+                refcase=time_map,
             )
 
         return cls(

--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -117,7 +117,7 @@ class EnkfObs:
         response_config = ensemble_config["summary"]
         assert isinstance(response_config, SummaryConfig)
 
-        refcase = response_config.refcase
+        refcase = ensemble_config.refcase
         if refcase is None:
             raise ObservationConfigError("REFCASE is required for HISTORY_OBSERVATION")
         if history_type is None:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -26,19 +26,6 @@ class SummaryConfig(ResponseConfig):
     keys: List[str]
     refcase: Optional[List[datetime]] = None
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, SummaryConfig):
-            return False
-
-        return all(
-            [
-                self.name == other.name,
-                self.input_file == other.input_file,
-                self.keys == other.keys,
-                self.refcase == other.refcase,
-            ]
-        )
-
     def read_from_file(self, run_path: str, iens: int) -> xr.Dataset:
         filename = self.input_file.replace("<IENS>", str(iens))
         try:

--- a/tests/unit_tests/test_load_forward_model.py
+++ b/tests/unit_tests/test_load_forward_model.py
@@ -73,11 +73,10 @@ def test_load_inconsistent_time_map_summary(caplog):
     with caplog.at_level(logging.WARNING):
         loaded = facade.load_from_forward_model(ensemble, realizations, 0)
     assert (
-        "Realization: 0, load warning: 1 inconsistencies in time map, first: "
-        "Time mismatch for step: 1, response time: 2000-01-10 00:00:00, "
-        "reference case: 2010-01-10 00:00:00, last: Time mismatch for step: "
-        "1, response time: 2000-01-10 00:00:00, reference case: 2010-01-10 "
-        f"00:00:00 from: {run_path.absolute()}/SNAKE_OIL_FIELD.UNSMRY"
+        "Realization: 0, load warning: 200 inconsistencies in time map, first: "
+        "Time mismatch for response time: 2010-01-10 00:00:00, last: Time mismatch "
+        f"for response time: 2015-06-23 00:00:00 from: {run_path.absolute()}"
+        f"/SNAKE_OIL_FIELD.UNSMRY"
     ) in caplog.messages
     assert loaded == 1
 


### PR DESCRIPTION
It was very slow to continously read a summary file, this changes the refcase into a list of datetimes, which is what we would like to validate.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Added appropriate release note label
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Updated documentation
- [x] Ensured new behaviour is tested

Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
