### PR TITLE
Require pluggy>=1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ args = dict(
         "numpy<2",
         "packaging",
         "pandas",
-        "pluggy",
+        "pluggy>=1.3.0",
         "protobuf",
         "psutil",
         "pydantic >= 1.10.8, < 2",


### PR DESCRIPTION
We get failures with 1.0.0, 1.1.0 got yanked from pypi, 1.2.0 is just 1 month older than 1.3.0.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Wait for tests in CI to pass (see "checks" below)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested (opened GUI? screenshots? tried workflows?)
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution
  guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
