### PR TITLE
Fix bug where duplicate dates in summary caused update to crash

### DIFF
--- a/src/clib/lib/enkf/read_summary.cpp
+++ b/src/clib/lib/enkf/read_summary.cpp
@@ -23,12 +23,15 @@ ERT_CLIB_SUBMODULE("_read_summary", m) {
               const ecl_smspec_type *smspec = ecl_sum_get_smspec(summary);
               std::vector<std::pair<std::string, std::vector<double>>>
                   summary_vectors{};
-
+              std::vector<std::string> seen_keys{};
               for (int i = 0; i < ecl_smspec_num_nodes(smspec); i++) {
                   const ecl::smspec_node &smspec_node =
                       ecl_smspec_iget_node_w_node_index(smspec, i);
                   const char *key = smspec_node.get_gen_key1();
-                  if (matches(keys, key)) {
+                  if ((matches(keys, key)) &&
+                      !(std::find(seen_keys.begin(), seen_keys.end(), key) !=
+                        seen_keys.end())) {
+                      seen_keys.push_back(key);
                       int start = ecl_sum_get_first_report_step(summary);
                       int end = ecl_sum_get_last_report_step(summary);
                       std::vector<double> data{};

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -52,12 +52,12 @@ class SummaryConfig(ResponseConfig):
                     f"{last} from: {run_path}/{filename}.UNSMRY"
                 )
 
-        summary_data = read_summary(summary, self.keys)
+        summary_data = read_summary(summary, list(set(self.keys)))
         summary_data.sort(key=lambda x: x[0])
         data = [d for _, d in summary_data]
         keys = [k for k, _ in summary_data]
-
-        return xr.Dataset(
+        ds = xr.Dataset(
             {"values": (["name", "time"], data)},
             coords={"time": time_map, "name": keys},
         )
+        return ds.drop_duplicates("time")

--- a/tests/unit_tests/scenarios/test_summary_response.py
+++ b/tests/unit_tests/scenarios/test_summary_response.py
@@ -153,3 +153,24 @@ def run_sim(dates, value, fname="ECLIPSE_CASE"):
         )
         t_step["FOPR"] = value
     ecl_sum.fwrite()
+
+
+def test_that_duplicate_summary_time_steps_does_not_fail(
+    setup_configuration,
+    prior_ensemble,
+    target_ensemble,
+):
+    ert = setup_configuration
+    ert.sample_prior(prior_ensemble, list(range(ert.getEnsembleSize())))
+    response_times = [
+        [datetime(2014, 9, 9)],
+        [datetime(2014, 9, 9)],
+        [datetime(2014, 9, 9), datetime(2014, 9, 9)],
+        [datetime(2014, 9, 9)],
+        [datetime(2014, 9, 9), datetime(1988, 9, 9)],
+    ]
+    create_responses(ert, prior_ensemble, response_times)
+
+    es_update = ESUpdate(ert)
+
+    es_update.smootherUpdate(prior_ensemble, target_ensemble, "an id")


### PR DESCRIPTION
We drop all duplicate time steps from the summary dates, and only read the first one.

**Issue**
Resolves #5967


**Approach**
_Short description of the approach_


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Wait for tests in CI to pass (see "checks" below)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured new behaviour is tested (opened GUI? screenshots? tried workflows?)
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution
  guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
