### PR TITLE
Revert "Add warning when overwriting QUEUE_OPTION (#5993)"

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import re
 import shutil
-import warnings
-from collections import Counter, defaultdict
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, Union, no_type_check
 
 from ert import _clib
 
-from .parsing import ConfigDict, ConfigValidationError, ConfigWarning, ErrorInfo
+from .parsing import ConfigDict, ConfigValidationError, ErrorInfo
 from .queue_system import QueueSystem
 
 GENERIC_QUEUE_OPTIONS: List[str] = ["MAX_RUNNING"]
@@ -101,14 +100,6 @@ class QueueConfig:
         ):
             _validate_torque_options(queue_options[QueueSystem.TORQUE])
 
-        if (
-            selected_queue_system != QueueSystem.LOCAL
-            and queue_options[selected_queue_system]
-        ):
-            _check_for_overwritten_queue_system_options(
-                queue_options[selected_queue_system]
-            )
-
         return QueueConfig(job_script, max_submit, selected_queue_system, queue_options)
 
     def create_local_copy(self) -> QueueConfig:
@@ -118,26 +109,6 @@ class QueueConfig:
             QueueSystem.LOCAL,  # type: ignore
             self.queue_options,
         )
-
-
-def _check_for_overwritten_queue_system_options(
-    queue_system_options: List[Tuple[str, str]]
-) -> None:
-    keywords_counter = Counter(
-        [
-            option_string[0]
-            for option_string in queue_system_options
-            if option_string[0] != "MAX_RUNNING"
-        ]
-    )
-    for keyword, keyword_count in keywords_counter.items():
-        if keyword_count > 1:
-            warnings.warn(
-                ConfigWarning(
-                    f"Overwriting {keyword} keyword, this may lead to an error."
-                ),
-                stacklevel=1,
-            )
 
 
 def _validate_torque_options(torque_options: List[Tuple[str, str]]) -> None:

--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -7,13 +7,7 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
-from ert.config import (
-    ConfigValidationError,
-    ConfigWarning,
-    ErtConfig,
-    QueueConfig,
-    QueueSystem,
-)
+from ert.config import ConfigValidationError, ErtConfig, QueueConfig, QueueSystem
 from ert.job_queue import Driver
 
 
@@ -132,31 +126,4 @@ def test_torque_queue_config_invalid_memory_pr_job(memory_with_unit_str):
         f.write("QUEUE_SYSTEM TORQUE\n")
         f.write(f"QUEUE_OPTION TORQUE MEMORY_PER_JOB {memory_with_unit_str}")
     with pytest.raises(ConfigValidationError):
-        ErtConfig.from_file(filename)
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-@pytest.mark.parametrize(
-    "queue_system, queue_system_option",
-    [("LSF", "LSF_SERVER"), ("SLURM", "SQUEUE"), ("TORQUE", "QUEUE")],
-)
-def test_overwriting_QUEUE_OPTIONS_warning(
-    tmp_path, monkeypatch, queue_system, queue_system_option
-):
-    filename = "config.ert"
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1\n")
-        f.write(f"QUEUE_SYSTEM {queue_system}\n")
-        f.write(f"QUEUE_OPTION {queue_system} {queue_system_option} test_1\n")
-    test_site_config = tmp_path / "test_site_config.ert"
-    test_site_config.write_text(
-        "JOB_SCRIPT job_dispatch.py\n"
-        f"QUEUE_SYSTEM {queue_system}\n"
-        f"QUEUE_OPTION {queue_system} {queue_system_option} test_2\n"
-    )
-    monkeypatch.setenv("ERT_SITE_CONFIG", str(test_site_config))
-    with pytest.warns(
-        ConfigWarning,
-        match=rf"Overwriting {queue_system_option} keyword, this may lead to an error.",
-    ):
         ErtConfig.from_file(filename)


### PR DESCRIPTION
This reverts commit 1c9249507606a6dc2d5cc814d05158eec05bdebf.

Remove unwarranted warnings.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Wait for tests in CI to pass (see "checks" below)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured new behaviour is tested (opened GUI? screenshots? tried workflows?)
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution
  guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
