### PR TITLE
Pin hypothesis at 6.83.0 for python 3.8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,8 @@ flake8-bugbear
 flake8-simplify
 furo
 grpcio-tools
-hypothesis
+hypothesis<=6.83.0;python_version=='3.8' # ipython pinned to 8.12.2 for python 3.8 support
+hypothesis;python_version>='3.9'
 isort
 jsonpath_ng
 jupytext


### PR DESCRIPTION
Bleeding build is failing due to API mismatch between installed `ipython` packages and `hypothesis` for python version `3.8`

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Wait for tests in CI to pass (see "checks" below)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured new behaviour is tested (opened GUI? screenshots? tried workflows?)
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution
  guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
