### PR TITLE
Add mailmap for a684814

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -37,6 +37,7 @@ Fredrik Gundersen <fgun@statoil.com> iLoop2 <iLoop2@users.noreply.github.com>
 Frode Aarstad <frodeaarstad@gmail.com>
 Geir Evensen <geev@norceresearch.no> <geve@iris.no>
 Geir Evensen <geev@norceresearch.no> geirev <geir.evensen@gmail.com>
+Geir Evensen <geev@norceresearch.no> a684814 <a684814@ecb61f28-d21e-0410-a4b6-a828cfe0ca3a>
 Håvard Berland <havb@equinor.com>
 Håvard Berland <havb@equinor.com> <berland@pvv.ntnu.no>
 Håvard Berland <havb@equinor.com> Havard Berland <havb@equinor.com>


### PR DESCRIPTION
There is one commit (d2ca5c02230ed513cb97f2cb40de890424ed08d2) for this name where the message seems to be signed GE.

I was hoping @geirev remembered whether this is his commit.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
