### PR TITLE
Add STOP_ON_FAIL option for wf jobs

### DIFF
--- a/docs/reference/workflows/configuring_jobs.rst
+++ b/docs/reference/workflows/configuring_jobs.rst
@@ -42,8 +42,49 @@ executable:
     INTERNAL   FALSE                    -- Optional - Set to FALSE by default.
     EXECUTABLE path/to/program          -- Path to a program/script which will be invoked by the job.
 
+
 NB: note that relative paths are resolved from the location of the job
 configuration file, not the configuration file provided to ert.
+
+Stop Ert execution upon job failure
+-----------------------------------
+By default, failing jobs (both internal and external) will not stop the entire ert simulation.
+In some cases it is best to cancel the entire simulation if a job fails.
+This behavior can be achieved by adding the below line to the job file:
+
+::
+
+    STOP_ON_FAIL TRUE
+
+For example, if a job is defined as follows:
+
+::
+
+    INTERNAL   FALSE
+    EXECUTABLE script.sh
+    STOP_ON_FAIL TRUE                   -- Tell the job to stop ert on failure
+
+STOP_ON_FAIL can also be specified within the internal (python) or external (executable) job script.
+For example, this internal job script will stop on failure
+
+::
+
+    from ert import ErtScript
+    class AScript(ErtScript):
+        stop_on_fail = True
+
+        def run(self):
+            assert False, "failure"
+    """
+
+As will external .sh executables if they contain the line STOP_ON_FAIL=TRUE:
+
+::
+
+    #!/bin/bash
+    STOP_ON_FAIL=True #
+    ekho helo wordl
+
 
 Configuring the arguments
 -------------------------

--- a/src/ert/config/ert_script.py
+++ b/src/ert/config/ert_script.py
@@ -106,7 +106,8 @@ class ErtScript:
             self.output_stack_trace(error=error_msg)
             return None
         except Exception as e:
-            self.output_stack_trace(str(e))
+            full_trace = "".join(traceback.format_exception(*sys.exc_info()))
+            self.output_stack_trace(f"{str(e)}\n{full_trace}")
             return None
         finally:
             self.cleanup()
@@ -120,6 +121,8 @@ class ErtScript:
             f"The script '{self.__class__.__name__}' caused an "
             f"error while running:\n{str(stack_trace).strip()}\n"
         )
+
+        self._stderrdata = error
         self.__failed = True
 
     @staticmethod

--- a/src/ert/config/ert_script.py
+++ b/src/ert/config/ert_script.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class ErtScript:
+    stop_on_fail = False
+
     def __init__(
         self,
         ert: EnKFMain,

--- a/src/ert/config/parsing/workflow_job_keywords.py
+++ b/src/ert/config/parsing/workflow_job_keywords.py
@@ -18,6 +18,7 @@ class WorkflowJobKeys(StrEnum):
     EXECUTABLE = "EXECUTABLE"
     SCRIPT = "SCRIPT"
     INTERNAL = "INTERNAL"
+    STOP_ON_FAIL = "STOP_ON_FAIL"
 
 
 class ConfigArgAtIndex(StrEnum):

--- a/src/ert/config/parsing/workflow_job_schema.py
+++ b/src/ert/config/parsing/workflow_job_schema.py
@@ -67,6 +67,14 @@ def internal_keyword() -> SchemaItem:
     )
 
 
+def stop_on_fail_keyword() -> SchemaItem:
+    return SchemaItem(
+        kw=WorkflowJobKeys.STOP_ON_FAIL,
+        required_set=False,
+        type_map=[SchemaItemType.BOOL],
+    )
+
+
 class WorkflowJobSchemaDict(SchemaItemDict):
     @no_type_check
     def check_required(self, config_dict: ConfigDict, filename: str) -> None:
@@ -101,6 +109,7 @@ def init_workflow_job_schema() -> SchemaItemDict:
         min_arg_keyword(),
         max_arg_keyword(),
         arg_type_keyword(),
+        stop_on_fail_keyword(),
     ]:
         schema[item.kw] = item
 

--- a/src/ert/config/workflow_job.py
+++ b/src/ert/config/workflow_job.py
@@ -40,6 +40,7 @@ class WorkflowJob:
     arg_types: List[SchemaItemType]
     executable: Optional[str]
     script: Optional[str]
+    stop_on_fail: Optional[bool] = None  # If not None, overrides in-file specification
 
     def __post_init__(self) -> None:
         self.ert_script: Optional[type] = None
@@ -48,6 +49,7 @@ class WorkflowJob:
                 self.ert_script = ErtScript.loadScriptFromFile(
                     self.script,
                 )  # type: ignore
+
             # Bare Exception here as we have no control
             # of exceptions in the loaded ErtScript
             except Exception as err:  # noqa
@@ -79,15 +81,16 @@ class WorkflowJob:
         content_dict = workflow_job_parser(config_file)
         arg_types_list = cls._make_arg_types_list(content_dict)
         return cls(
-            name,
-            content_dict.get("INTERNAL"),  # type: ignore
-            content_dict.get("MIN_ARG"),  # type: ignore
-            content_dict.get("MAX_ARG"),  # type: ignore
-            arg_types_list,
-            content_dict.get("EXECUTABLE"),  # type: ignore
-            str(content_dict.get("SCRIPT"))  # type: ignore
+            name=name,
+            internal=content_dict.get("INTERNAL"),  # type: ignore
+            min_args=content_dict.get("MIN_ARG"),  # type: ignore
+            max_args=content_dict.get("MAX_ARG"),  # type: ignore
+            arg_types=arg_types_list,
+            executable=content_dict.get("EXECUTABLE"),  # type: ignore
+            script=str(content_dict.get("SCRIPT"))  # type: ignore
             if "SCRIPT" in content_dict
             else None,
+            stop_on_fail=content_dict.get("STOP_ON_FAIL"),  # type: ignore
         )
 
     def is_plugin(self) -> bool:


### PR DESCRIPTION
**Issue**
Resolves #2386 


**Approach**
Add kw to workflow job parser and halt execution if the `stop_on_fail` (defaults to `False`) attribute of a workflow job is True.

STOP_ON_FAIL=True can be added to ert scripts like this:

```python
from ert import ErtScript
class AScript(ErtScript):
    stop_on_fail = True
    ...
```

Or to `.sh` scripts like this:
```
#!/bin/bash
ekho helo wordl
STOP_ON_FAIL=TRUE
```

Or the workflow job declaration file:
```
STOP_ON_FAIL True
INTERNAL False
EXECUTABLE failing_script.sh
```

In all cases, this defaults to `False`. The declaration in the workflow job will have the highest priority, if it is declared in multiple places.

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
