### PR TITLE
Skip test_rft_csv_export_plugin_exports_rft_data

### DIFF
--- a/tests/unit_tests/gui/test_rft_export_plugin.py
+++ b/tests/unit_tests/gui/test_rft_export_plugin.py
@@ -64,6 +64,7 @@ def gen_data_in_runpath(tmp_path):
         )
 
 
+@pytest.mark.skip(reason="This test is causing Coverage GUI tests to hang")
 @pytest.mark.usefixtures("use_tmpdir")
 def test_rft_csv_export_plugin_exports_rft_data(
     qtbot, ert_rft_setup, well_file, gen_data_in_runpath


### PR DESCRIPTION
Skip rft_csv_export test that seems to be the cause for Coverage GUI tests to timeout at 40 min runtime.
Ref.
https://github.com/equinor/ert/actions/runs/6142757595/job/16665011088

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
