### PR TITLE
Raise when duplicate GEN_KW keys

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -157,7 +157,17 @@ class GenKwConfig(ParameterConfig):
                     ).set_context(self.name)
                 )
 
+        unique_keys = set()
         for prior in self.get_priors():
+            key = prior["key"]
+            if key in unique_keys:
+                errors.append(
+                    ErrorInfo(
+                        f"Duplicate GEN_KW keys {key!r} found, keys must be unique."
+                    ).set_context(self.name)
+                )
+            unique_keys.add(key)
+
             if prior["function"] == "LOGNORMAL":
                 _check_non_negative_parameter("MEAN", prior)
                 _check_non_negative_parameter("STD", prior)

--- a/tests/unit_tests/config/test_gen_kw_config.py
+++ b/tests/unit_tests/config/test_gen_kw_config.py
@@ -35,6 +35,26 @@ def test_gen_kw_config():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+def test_gen_kw_config_duplicate_keys_raises():
+    with pytest.raises(
+        ConfigValidationError,
+        match="Duplicate GEN_KW keys 'KEY2' found, keys must be unique.",
+    ):
+        GenKwConfig(
+            name="KEY",
+            forward_init=False,
+            template_file="",
+            transfer_function_definitions=[
+                "KEY1 UNIFORM 0 1",
+                "KEY2 UNIFORM 0 1",
+                "KEY2 UNIFORM 0 1",
+                "KEY3 UNIFORM 0 1",
+            ],
+            output_file="kw.txt",
+        )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_config_get_priors():
     parameter_file = "parameters.txt"
     template_file = "template.txt"


### PR DESCRIPTION
**Issue**
Resolves #6074 


**Approach**
Verifies that GEN_KW keys are unique

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
