### PR TITLE
Fix bug where truncated normal was not truncated

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -332,8 +332,7 @@ class TransferFunction:
     def trans_truncated_normal(x: float, arg: List[float]) -> float:
         _mean, _std, _min, _max = arg[0], arg[1], arg[2], arg[3]
         y = x * _std + _mean
-        max(min(y, _max), _min)  # clamp
-        return y
+        return max(min(y, _max), _min)  # clamp
 
     @staticmethod
     def trans_lognormal(x: float, arg: List[float]) -> float:


### PR DESCRIPTION
(cherry picked from commit d54ed181370385a0004c26dd18cf21c81a35a738)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
