### PR TITLE
Log no websocket connection as error, not debug

### DIFF
--- a/src/_ert_job_runner/client.py
+++ b/src/_ert_job_runner/client.py
@@ -110,6 +110,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                     _error_msg = (
                         f"Not able to establish the "
                         f"websocket connection {self.url}! Max retries reached!"
+                        " Check for firewall issues."
                         f" Exception from {type(exception)}: {str(exception)}"
                     )
                     raise ClientConnectionError(_error_msg) from exception

--- a/src/_ert_job_runner/reporting/event.py
+++ b/src/_ert_job_runner/reporting/event.py
@@ -106,7 +106,7 @@ class Event(Reporter):
                     event = None
                 except ClientConnectionError as exception:
                     # Possible intermittent failure, we retry sending the event
-                    logger.debug(str(exception))
+                    logger.error(str(exception))
                     pass
                 except ClientConnectionClosedOK as exception:
                     # The receiving end has closed the connection, we stop


### PR DESCRIPTION
In a scenario with misconfigured firewall, this debug log message was not taken seriously when it actually exposed a real error. Thus, elevate this to the ERROR log level.

The only two usages of ClientConnectionError in client.py are situations which should yield an ERROR on the log

**Issue**
Possibly makes future debugging easier

Relates to #6056 and https://github.com/equinor/komodo-releases/issues/4313

**Approach**
Elevate log level and add hint in message.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
