### PR TITLE
Count memory usage for grandchildren in job_dispatch

### DIFF
--- a/src/_ert_job_runner/job.py
+++ b/src/_ert_job_runner/job.py
@@ -117,7 +117,10 @@ class Job:
         max_memory_usage = 0
         while exit_code is None:
             try:
-                memory = process.memory_info().rss
+                memory = process.memory_info().rss + sum(
+                    child.memory_info().rss
+                    for child in process.children(recursive=True)
+                )
             except (NoSuchProcess, AccessDenied, ZombieProcess):
                 # In case of a process that has died and is in some transitional
                 # state, we ignore any failures. Only seen on OSX thus far.


### PR DESCRIPTION
job_dispatch/job_runner only picked up the memory usage for its direct child. When the direct child is only a wrapper for some potentially memory hungry processes, the memory usage reported from job_dispatch is essentially garbage.

This PR lets the job runner scan through all its grandchildren when estimating memory usage for a started forward model.

NB: This counts RSS (resident set size). When summing over multiple processes, the RSS sum will count shared memory pages multiple times, thus the sum is likely to be an overestimate for the actual memory load imposed. This is probably less of a problem, as the target memory consumption numbers that are of interest, stem from big datasets which are not shared among processes.

**Issue**
Resolves #6108 

**Approach**
Use the `children(recursive=True)` function in `psutil` to find all descendants.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
