### PR TITLE
Use python 3.10 on run-ert-test-data for macOS

### DIFF
--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ['3.8', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest]
         exclude:
-        - python-version: '3.10'
+        - python-version: '3.8'
           os: macos-latest
         - python-version: '3.11'
           os: macos-latest


### PR DESCRIPTION
Relates to [#update gui tests
](https://github.com/equinor/ert/pull/6095)

Use python version 3.10 for macOS.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
