### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -45,15 +45,10 @@ jobs:
       if: ${{ always() }}
       run: ./script/cmake-format --check
 
-    - name: Run isort
+    - name: Run ruff
       if: ${{ always() }}
       run: |
-        isort --check script/ src/ tests/ test-data/
-
-    - name: Lint with flake8
-      if: ${{ always() }}
-      run: |
-        flake8
+        ruff check .
 
     - name: Run black
       if: ${{ always() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,26 +29,18 @@ markers = [
 log_cli = "false"
 asyncio_mode = "auto"
 
-[tool.isort]
-profile = "black"
-
 [tool.black]
 include = '(\.pyi?|\.ipynb|\.py\.j2)$'
 
 [tool.setuptools_scm]
 write_to = "src/ert/shared/version.py"
 
-[tool.flake8]
-per-file-ignores = [
-    # Ignore all protobuf v2 files
-    "*_pb2.py: E"
+[tool.ruff]
+src = ["src"]
+select = [
+  "W",   # pycodestyle
+  "I",   # isort 
+  "B",   # flake-8-bugbear
+  "SIM", # flake-8-simplify
 ]
-ignore = [
-    # whitespace before ':', solved by black:
-    "E203",
-    # line break before binary operator, solved by black:
-    "W503",
-    # The minimal set of ignores that makes flake8 pass when flake8-bugbear is installed:
-    "B019"
-]
-max-line-length = 88
+line-length = 88

--- a/src/_ert_job_runner/cli.py
+++ b/src/_ert_job_runner/cli.py
@@ -101,7 +101,7 @@ def main(args):
             ee_cert_path = jobs_data.get("ee_cert_path")
             dispatch_url = jobs_data.get("dispatch_url")
     except ValueError as e:
-        raise IOError(f"Job Runner cli failed to load JSON-file.{e}")
+        raise IOError("Job Runner cli failed to load JSON-file.") from e
 
     is_interactive_run = len(parsed_args.job) > 0
     reporters = _setup_reporters(

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -167,8 +167,8 @@ def valid_num_iterations(user_input: str) -> str:
 def attemp_int_conversion(val: str) -> int:
     try:
         return int(val)
-    except ValueError:
-        raise ArgumentTypeError(f"{val} is not a valid integer")
+    except ValueError as e:
+        raise ArgumentTypeError(f"{val} is not a valid integer") from e
 
 
 def convert_port(val: str) -> int:

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -308,11 +308,11 @@ def _get_obs_and_measure_data(
         ds = source_fs.load_response(group, ens_active_list)
         try:
             filtered_ds = observation.merge(ds, join="left")
-        except KeyError:
+        except KeyError as e:
             raise ErtAnalysisError(
                 f"Mismatched index for: "
                 f"Observation: {obs_key} attached to response: {group}"
-            )
+            ) from e
 
         observation_keys.append([obs_key] * len(filtered_ds.observations.data.ravel()))
         observation_values.append(filtered_ds["observations"].data.ravel())
@@ -525,7 +525,7 @@ def analysis_IES(
                 update_step.observation_config(),
             )
         except IndexError as e:
-            raise ErtAnalysisError(e)
+            raise ErtAnalysisError(str(e)) from e
         # pylint: disable=unsupported-assignment-operation
         smoother_snapshot.update_step_snapshots[update_step.name] = update_snapshot
         if len(observation_values) == 0:

--- a/src/ert/config/analysis_module.py
+++ b/src/ert/config/analysis_module.py
@@ -188,12 +188,12 @@ class AnalysisModule:
                 else:
                     var["value"] = new_value
 
-            except ValueError:
+            except ValueError as e:
                 raise ConfigValidationError(
                     f"Variable {var_name!r} with value {value!r} has incorrect type."
                     f" Expected type {var['type'].__name__!r} but received"
                     f" value {value!r} of type {type(value).__name__!r}"
-                )
+                ) from e
         else:
             raise ConfigValidationError(
                 f"Variable {var_name!r} not found in {self.name!r} analysis module"

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -286,13 +286,18 @@ class ErtConfig:  # pylint: disable=too-many-instance-attributes
             hex_str = error_words[error_words.index("byte") + 1]
             try:
                 unknown_char = chr(int(hex_str, 16))
-            except ValueError:
+            except ValueError as ve:
                 unknown_char = f"hex:{hex_str}"
+                raise ConfigValidationError(
+                    f"Unsupported non UTF-8 character {unknown_char!r} "
+                    f"found in file: {file_path!r}",
+                    config_file=file_path,
+                ) from ve
             raise ConfigValidationError(
                 f"Unsupported non UTF-8 character {unknown_char!r} "
                 f"found in file: {file_path!r}",
                 config_file=file_path,
-            )
+            ) from e
 
     @classmethod
     def _read_templates(cls, config_dict) -> List[Tuple[str, str]]:

--- a/src/ert/config/ert_script.py
+++ b/src/ert/config/ert_script.py
@@ -86,13 +86,10 @@ class ErtScript:
     ) -> Any:
         arguments = []
         for index, arg_value in enumerate(argument_values):
-            if index < len(argument_types):
-                arg_type = argument_types[index]
-            else:
-                arg_type = str
+            arg_type = argument_types[index] if index < len(argument_types) else str
 
             if arg_value is not None:
-                arguments.append(arg_type(arg_value))
+                arguments.append(arg_type(arg_value))  # type: ignore
             else:
                 arguments.append(None)
 

--- a/src/ert/config/ext_job.py
+++ b/src/ert/config/ext_job.py
@@ -110,4 +110,4 @@ class ExtJob:
                 help_text=content_dict.get("HELP_TEXT", ""),
             )
         except IOError as err:
-            raise ConfigValidationError.with_context(str(err), config_file)
+            raise ConfigValidationError.with_context(str(err), config_file) from err

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -370,8 +370,10 @@ class GenKwConfig(ParameterConfig):
             for p in param_args[2:]:
                 try:
                     param_floats.append(float(p))
-                except ValueError:
-                    raise ConfigValidationError(f"Unable to convert float number: {p}")
+                except ValueError as e:
+                    raise ConfigValidationError(
+                        f"Unable to convert float number: {p}"
+                    ) from e
 
             params = dict(zip(param_names, param_floats))
 

--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -79,7 +79,7 @@ class ModelConfig:  # pylint: disable=too-many-instance-attributes
             except (ValueError, IOError) as err:
                 raise ConfigValidationError.with_context(
                     f"Could not read timemap file {time_map_file}: {err}", time_map_file
-                )
+                ) from err
 
     @no_type_check
     @classmethod

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -111,19 +111,19 @@ class SchemaItem(BaseModel):
         if val_type == SchemaItemType.INT:
             try:
                 return ContextInt(int(token), token, keyword)
-            except ValueError:
+            except ValueError as e:
                 raise ConfigValidationError.with_context(
                     f"{self.kw!r} must have an integer value"
                     f" as argument {index + 1!r}",
                     token,
-                )
+                ) from e
         if val_type == SchemaItemType.FLOAT:
             try:
                 return ContextFloat(float(token), token, keyword)
-            except ValueError:
+            except ValueError as e:
                 raise ConfigValidationError.with_context(
                     f"{self.kw!r} must have a number as argument {index + 1!r}", token
-                )
+                ) from e
 
         path: Optional[str] = str(token)
         if val_type in [

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -434,7 +434,7 @@ def _parse_file(file: str) -> Tree[Instruction]:
                 end_column=e.column + 1,
                 filename=file,
             )
-        )
+        ) from e
     except UnicodeDecodeError as e:
         error_words = str(e).split(" ")
         hex_str = error_words[error_words.index("byte") + 1]
@@ -476,7 +476,7 @@ def _parse_file(file: str) -> Tree[Instruction]:
                 )
                 for bad_line in bad_byte_lines
             ]
-        )
+        ) from e
 
 
 def parse(

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -138,7 +138,7 @@ def _parse_content(
                 column=e.column,
                 end_column=e.column + 1,
             )
-        )
+        ) from e
 
 
 observations_parser = Lark(

--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -50,10 +50,7 @@ def data_for_key(
     elif key in res.get_gen_data_keys():
         key_parts = key.split("@")
         key = key_parts[0]
-        if len(key_parts) > 1:
-            report_step = int(key_parts[1])
-        else:
-            report_step = 0
+        report_step = int(key_parts[1]) if len(key_parts) > 1 else 0
 
         try:
             data = res.load_gen_data(

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -105,8 +105,10 @@ class MeasuredData:
                 response = ensemble.load_response(
                     group, tuple(range(self._facade.get_ensemble_size()))
                 )
-            except KeyError:
-                raise ResponseError(f"No response loaded for observation key: {key}")
+            except KeyError as e:
+                raise ResponseError(
+                    f"No response loaded for observation key: {key}"
+                ) from e
             ds = obs.merge(
                 response,
                 join="left",

--- a/src/ert/data/record/_record.py
+++ b/src/ert/data/record/_record.py
@@ -115,7 +115,7 @@ class BlobRecord(Record):
         try:
             self._data = self._validate_data(data)
         except BeartypeException as e:
-            raise RecordValidationError(str(e))
+            raise RecordValidationError(str(e)) from e
 
     @beartype
     def _validate_data(self, data: blob_record_data) -> blob_record_data:
@@ -167,7 +167,7 @@ class NumericalRecord(Record):
         try:
             self._validate_data(data)
         except BeartypeException as e:
-            raise RecordValidationError(str(e))
+            raise RecordValidationError(str(e)) from e
 
         self._data: numerical_record_data
         if isinstance(data, int):
@@ -296,7 +296,7 @@ class RecordTree(Record, Generic[RecordGen]):
         try:
             self._validate_data(self._flat_record_dict)
         except BeartypeException as e:
-            raise RecordValidationError(str(e))
+            raise RecordValidationError(str(e)) from e
 
     @beartype
     def _validate_data(self, flat_record_dict: Dict[str, RecordGen]) -> None:

--- a/src/ert/ensemble_evaluator/_wait_for_evaluator.py
+++ b/src/ert/ensemble_evaluator/_wait_for_evaluator.py
@@ -27,15 +27,14 @@ async def attempt_connection(
 ) -> None:
     timeout = aiohttp.ClientTimeout(connect=connection_timeout)
     headers = {} if token is None else {"token": token}
-    async with aiohttp.ClientSession() as session:
-        async with session.request(
-            method="get",
-            url=url,
-            ssl=get_ssl_context(cert),
-            headers=headers,
-            timeout=timeout,
-        ) as resp:
-            resp.raise_for_status()
+    async with aiohttp.ClientSession() as session, session.request(
+        method="get",
+        url=url,
+        ssl=get_ssl_context(cert),
+        headers=headers,
+        timeout=timeout,
+    ) as resp:
+        resp.raise_for_status()
 
 
 async def wait_for_evaluator(  # pylint: disable=too-many-arguments

--- a/src/ert/gui/ertwidgets/listeditbox.py
+++ b/src/ert/gui/ertwidgets/listeditbox.py
@@ -139,10 +139,7 @@ class ListEditBox(QWidget):
 
         validity_type = ValidationSupport.WARNING
 
-        if not valid:
-            color = ValidationSupport.ERROR_COLOR
-        else:
-            color = self._valid_color
+        color = ValidationSupport.ERROR_COLOR if not valid else self._valid_color
 
         self._validation_support.setValidationMessage(message, validity_type)
         self._list_edit_line.setToolTip(message)

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -107,10 +107,7 @@ class PathChooser(QWidget):
 
         validity_type = ValidationSupport.WARNING
 
-        if not valid:
-            color = ValidationSupport.ERROR_COLOR
-        else:
-            color = self.valid_color
+        color = ValidationSupport.ERROR_COLOR if not valid else self.valid_color
 
         self._validation_support.setValidationMessage(message, validity_type)
         self._path_line.setToolTip(message)

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -8,9 +8,8 @@ from dateutil import tz
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QSize, Qt, QVariant
 from qtpy.QtGui import QColor, QFont
 
-from ert.ensemble_evaluator import PartialSnapshot, Snapshot
+from ert.ensemble_evaluator import PartialSnapshot, Snapshot, state
 from ert.ensemble_evaluator import identifiers as ids
-from ert.ensemble_evaluator import state
 from ert.gui.model.node import Node, NodeType
 from ert.shared.status.utils import byte_with_unit
 
@@ -114,9 +113,9 @@ class SnapshotModel(QAbstractItemModel):
                 snapshot.data()[ids.REALS].keys(), key=int
             )
             metadata[SORTED_JOB_IDS] = {}
-            for real_id in snapshot.reals.keys():
+            for real_id in snapshot.reals:
                 metadata[SORTED_JOB_IDS][real_id] = {}
-                for step_id in snapshot.steps(real_id).keys():
+                for step_id in snapshot.steps(real_id):
                     indices = [
                         (job.index, job_id)
                         for job_id, job in snapshot.jobs(real_id, step_id).items()
@@ -136,7 +135,7 @@ class SnapshotModel(QAbstractItemModel):
                 for step in real[ids.STEPS].values():
                     if ids.JOBS not in step:
                         continue
-                    for job_id in step[ids.JOBS].keys():
+                    for job_id in step[ids.JOBS]:
                         status = step[ids.JOBS][job_id][ids.STATUS]
                         color = _QCOLORS[state.JOB_STATE_TO_COLOR[status]]
                         metadata[REAL_JOB_STATUS_AGGREGATED][real_id][job_id] = color
@@ -328,10 +327,7 @@ class SnapshotModel(QAbstractItemModel):
     def rowCount(self, parent: QModelIndex = None):
         if parent is None:
             parent = QModelIndex()
-        if not parent.isValid():
-            parentItem = self.root
-        else:
-            parentItem = parent.internalPointer()
+        parentItem = self.root if not parent.isValid() else parent.internalPointer()
 
         if parent.column() > 0:
             return 0
@@ -476,10 +472,7 @@ class SnapshotModel(QAbstractItemModel):
         if not self.hasIndex(row, column, parent):
             return QModelIndex()
 
-        if not parent.isValid():
-            parent_item = self.root
-        else:
-            parent_item = parent.internalPointer()
+        parent_item = self.root if not parent.isValid() else parent.internalPointer()
 
         child_item = None
         try:

--- a/src/ert/gui/plottery/plots/distribution.py
+++ b/src/ert/gui/plottery/plots/distribution.py
@@ -66,10 +66,7 @@ def _plotDistribution(
     index,
     previous_data,
 ):
-    if data.empty:
-        data = pd.Series(dtype="float64")
-    else:
-        data = data[0]
+    data = pd.Series(dtype="float64") if data.empty else data[0]
 
     axes.set_xlabel(plot_config.xLabel())
     axes.set_ylabel(plot_config.yLabel())

--- a/src/ert/gui/plottery/plots/histogram.py
+++ b/src/ert/gui/plottery/plots/histogram.py
@@ -72,15 +72,9 @@ def plotHistogram(
         else:
             current_min = data[case].min()
             current_max = data[case].max()
-            if minimum is None:
-                minimum = current_min
-            else:
-                minimum = min(minimum, current_min)
+            minimum = current_min if minimum is None else min(minimum, current_min)
 
-            if maximum is None:
-                maximum = current_max
-            else:
-                maximum = max(maximum, current_max)
+            maximum = current_max if maximum is None else max(maximum, current_max)
 
             max_element_count = max(max_element_count, len(data[case].index))
 

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -129,10 +129,7 @@ class RealizationDelegate(QStyledItemDelegate):
 
             for y in range(grid_dim):
                 for x in range(grid_dim):
-                    if k >= job_nr:
-                        color = QColorConstants.Gray
-                    else:
-                        color = colors[k]
+                    color = QColorConstants.Gray if k >= job_nr else colors[k]
                     foreground_image.setPixel(x, y, color.rgb())
                     k += 1
             _image_cache[colors_hash] = foreground_image

--- a/src/ert/gui/tools/load_results/__init__.py
+++ b/src/ert/gui/tools/load_results/__init__.py
@@ -1,4 +1,2 @@
-# flake8: noqa F401
-
-from .load_results_panel import LoadResultsPanel
-from .load_results_tool import LoadResultsTool
+from .load_results_panel import LoadResultsPanel  # noqa: F401
+from .load_results_tool import LoadResultsTool  # noqa: F401

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -161,10 +161,7 @@ class CaseInitializationConfigurationPanel(QTabWidget):
                 states = []
         else:
             ensemble = self.show_case_info_case_selector.itemData(index)
-            if ensemble is not None:
-                states = ensemble.state_map
-            else:
-                states = []
+            states = ensemble.state_map if ensemble is not None else []
 
         html = "<table>"
         for state_index, value in enumerate(states):

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -184,8 +184,8 @@ class PlotApi:
             self._check_response(response)
             try:
                 obs = response.json()[0]
-            except (KeyError, IndexError, JSONDecodeError):
-                raise httpx.RequestError("Observation schema might have changed")
+            except (KeyError, IndexError, JSONDecodeError) as e:
+                raise httpx.RequestError("Observation schema might have changed") from e
             try:
                 int(obs["x_axis"][0])
                 key_index = [int(v) for v in obs["x_axis"]]

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -219,8 +219,8 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
             vals = ensemble.load_response(key, tuple(realizations)).sel(
                 report_step=report_step, drop=True
             )
-        except KeyError:
-            raise KeyError(f"Missing response: {key}")
+        except KeyError as e:
+            raise KeyError(f"Missing response: {key}") from e
         index = pd.Index(vals.index.values, name="axis")
         return pd.DataFrame(
             data=vals["values"].values.reshape(len(vals.realization), -1).T,
@@ -235,10 +235,7 @@ class LibresFacade:  # pylint: disable=too-many-public-methods
         if key in self.get_gen_data_keys():
             key_parts = key.split("@")
             data_key = key_parts[0]
-            if len(key_parts) > 1:
-                data_report_step = int(key_parts[1])
-            else:
-                data_report_step = 0
+            data_report_step = int(key_parts[1]) if len(key_parts) > 1 else 0
 
             obs_key = None
 

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -208,8 +208,8 @@ class MultipleDataAssimilation(BaseRunModel):
                     logger.info("Warning: 0 weight, will ignore")
                 else:
                     result.append(f)
-            except ValueError:
-                raise ValueError(f"Warning: cannot parse weight {element}")
+            except ValueError as e:
+                raise ValueError(f"Warning: cannot parse weight {element}") from e
 
         return result
 

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -38,7 +38,7 @@ class FeatureToggling:
 
     @staticmethod
     def add_feature_toggling_args(parser: ArgumentParser) -> None:
-        for feature_name in FeatureToggling._conf.keys():
+        for feature_name in FeatureToggling._conf:
             parser.add_argument(
                 f"--{FeatureToggling._get_arg_name(feature_name)}",
                 action="store_true",
@@ -49,7 +49,7 @@ class FeatureToggling:
     @staticmethod
     def update_from_args(args: Namespace) -> None:
         args_dict = vars(args)
-        for feature_name in FeatureToggling._conf.keys():
+        for feature_name in FeatureToggling._conf:
             arg_name = FeatureToggling._get_arg_name(feature_name)
             feature_name_escaped = arg_name.replace("-", "_")
 

--- a/src/ert/shared/plugins/plugin_manager.py
+++ b/src/ert/shared/plugins/plugin_manager.py
@@ -266,7 +266,7 @@ class ErtPluginManager(pluggy.PluginManager):
                 self.hook.installable_jobs(), include_plugin_data=True
             ).items()
         }
-        for k in job_docs.keys():
+        for k in job_docs:
             job_docs[k].update(
                 ErtPluginManager._evaluate_job_doc_hook(
                     self.hook.job_documentation,
@@ -349,7 +349,7 @@ class ErtPluginContext:
                 )
 
     def _reset_environment(self) -> None:
-        for name in self.env.keys():
+        for name in self.env:
             if self.backup_env.get(name) is None and name in os.environ:
                 logging.debug(f"Resetting environment variable {name}")
                 del os.environ[name]

--- a/src/ert/shared/port_handler.py
+++ b/src/ert/shared/port_handler.py
@@ -99,10 +99,12 @@ def _bind_socket(
             f"an invalid hostname ({host}). "
             f"Actual "
             f"error msg is: {err_info.strerror}"
-        )
+        ) from err_info
     except OSError as err_info:
         if err_info.errno in (48, 98):
-            raise PortAlreadyInUseException(f"Port {port} already in use.")
+            raise PortAlreadyInUseException(
+                f"Port {port} already in use."
+            ) from err_info
         raise OSError(f"Unknown `OSError` while binding port {port}") from err_info
 
 

--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
@@ -83,8 +83,8 @@ class EclConfig:
         with open(config_file, encoding="utf-8") as f:
             try:
                 config = yaml.safe_load(f)
-            except yaml.YAMLError:
-                raise ValueError(f"Failed parse: {config_file} as yaml")
+            except yaml.YAMLError as e:
+                raise ValueError(f"Failed parse: {config_file} as yaml") from e
 
         self._config: dict = config
         self._config_file: str = os.path.abspath(config_file)
@@ -133,10 +133,7 @@ class EclConfig:
     def _get_sim(self, version: Optional[str], exe_type: str) -> Simulator:
         version = self._get_version(version)
         binaries: Dict[str, str] = self._config[Keys.versions][version][exe_type]
-        if exe_type == Keys.mpi:
-            mpirun = binaries[Keys.mpirun]
-        else:
-            mpirun = None
+        mpirun = binaries[Keys.mpirun] if exe_type == Keys.mpi else None
         return Simulator(
             version,
             binaries[Keys.executable],
@@ -160,8 +157,8 @@ class EclConfig:
 
     def simulators(self, strict: bool = True) -> List[Simulator]:
         simulators = []
-        for version in self._config[Keys.versions].keys():
-            for exe_type in self._config[Keys.versions][version].keys():
+        for version in self._config[Keys.versions]:
+            for exe_type in self._config[Keys.versions][version]:
                 if strict:
                     sim = self._get_sim(version, exe_type)
                 else:

--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
@@ -90,10 +90,7 @@ def _expand_SLURM_task_count(task_count_string):
         print(match_dict)
         count = int(match_dict["count"])
         mult_string = match_dict["mult"]
-        if mult_string is None:
-            mult = 1
-        else:
-            mult = int(mult_string)
+        mult = 1 if mult_string is None else int(mult_string)
 
         return [count] * mult
     else:

--- a/src/ert/shared/share/ert/forward-models/res/script/rms.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/rms.py
@@ -21,8 +21,8 @@ class RMSConfig:
         with open(config_file, encoding="utf-8") as f:
             try:
                 config = yaml.safe_load(f)
-            except yaml.YAMLError:
-                raise ValueError(f"Failed to parse: {config_file} as yaml")
+            except yaml.YAMLError as e:
+                raise ValueError(f"Failed to parse: {config_file} as yaml") from e
 
         self._config = config
 

--- a/src/ert/shared/share/ert/shell_scripts/make_directory.py
+++ b/src/ert/shared/share/ert/shell_scripts/make_directory.py
@@ -15,7 +15,7 @@ def mkdir(path):
             # synchronization issues?
             if not os.path.isdir(path):
                 msg = f'ERROR: Failed to create directory "{path}": {error}.'
-                raise OSError(msg)
+                raise OSError(msg) from error
 
 
 if __name__ == "__main__":

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -170,10 +170,10 @@ class LocalEnsembleReader:
                 self.mount_point / f"realization-{realization}" / f"{group}.nc",
                 engine="scipy",
             )
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             raise KeyError(
                 f"No dataset '{group}' in storage for realization {realization}"
-            )
+            ) from e
 
     def _load_dataset(
         self,
@@ -203,7 +203,7 @@ class LocalEnsembleReader:
     ) -> xr.DataArray:
         return self._load_dataset(group, realizations)[var]
 
-    @lru_cache
+    @lru_cache  # noqa: B019
     def load_response(self, key: str, realizations: Tuple[int, ...]) -> xr.Dataset:
         loaded = []
         for realization in realizations:

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -197,12 +197,12 @@ class LocalStorageAccessor(LocalStorageReader):
         self._lock = FileLock(self.path / "storage.lock")
         try:
             self._lock.acquire(timeout=self.LOCK_TIMEOUT)
-        except Timeout:
+        except Timeout as e:
             raise TimeoutError(
                 f"Not able to acquire lock for: {self.path}."
                 " You may already be running ERT,"
                 " or another user is using the same ENSPATH."
-            )
+            ) from e
 
         super().__init__(path)
 
@@ -238,10 +238,7 @@ class LocalStorageAccessor(LocalStorageReader):
         name: Optional[str] = None,
         prior_ensemble: Optional[Union[LocalEnsembleReader, UUID]] = None,
     ) -> LocalEnsembleAccessor:
-        if isinstance(experiment, UUID):
-            experiment_id = experiment
-        else:
-            experiment_id = experiment.id
+        experiment_id = experiment if isinstance(experiment, UUID) else experiment.id
 
         uuid = uuid4()
         path = self._ensemble_path(uuid)

--- a/style-requirements.txt
+++ b/style-requirements.txt
@@ -1,8 +1,5 @@
 cmake-format
-Flake8-pyproject
-flake8
-flake8-bugbear
-flake8-simplify
-isort
+black
+ruff
 pylint
 pylint-protobuf

--- a/tests/unit_tests/analysis/test_row_scaling.py
+++ b/tests/unit_tests/analysis/test_row_scaling.py
@@ -88,7 +88,7 @@ def test_row_scaling_factor_0_for_all_parameters():
     ((A, row_scaling),) = ensemble_smoother_update_step_row_scaling(
         S, [(A, row_scaling)], np.full(observations.shape, 0.5), observations
     )
-    assert np.all(A == A_copy)
+    assert np.all(A_copy == A)
 
 
 def test_row_scaling_factor_1_for_either_parameter():

--- a/tests/unit_tests/config/test_forward_model_data_to_json.py
+++ b/tests/unit_tests/config/test_forward_model_data_to_json.py
@@ -211,7 +211,7 @@ def validate_ext_job(ext_job, ext_job_config):
         assert ext_job.environment == ExtJob.default_env
     else:
         assert ext_job.environment.keys() == ext_job_config["environment"].keys()
-        for key in ext_job_config["environment"].keys():
+        for key in ext_job_config["environment"]:
             assert ext_job.environment[key] == ext_job_config["environment"][key]
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -16,7 +16,7 @@ def log_check():
     logger_after = logging.getLogger()
     level_after = logger_after.getEffectiveLevel()
     assert (
-        logging.WARNING == level_after
+        level_after == logging.WARNING
     ), f"Detected differences in log environment: Changed to {level_after}"
 
 

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -324,4 +324,4 @@ def test_dying_batcher(evaluator):
         # drain the monitor
         list(monitor.track())
 
-        assert ENSEMBLE_STATE_FAILED == evaluator.ensemble.snapshot.status
+        assert evaluator.ensemble.snapshot.status == ENSEMBLE_STATE_FAILED

--- a/tests/unit_tests/gui/model/test_job_list.py
+++ b/tests/unit_tests/gui/model/test_job_list.py
@@ -35,9 +35,9 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
+    tester = qt_api.QtTest.QAbstractItemModelTester(
         model, reporting_mode
-    )
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
@@ -56,9 +56,9 @@ def test_changes(full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
+    tester = qt_api.QtTest.QAbstractItemModelTester(
         model, reporting_mode
-    )
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     assert (
@@ -98,9 +98,9 @@ def test_duration(mock_datetime, timezone, full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
+    tester = qt_api.QtTest.QAbstractItemModelTester(
         model, reporting_mode
-    )
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     assert (
@@ -146,7 +146,7 @@ def test_no_cross_talk(full_snapshot):
     model.setSourceModel(source_model)
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa, prevent GC
+    qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)

--- a/tests/unit_tests/gui/model/test_progress_proxy.py
+++ b/tests/unit_tests/gui/model/test_progress_proxy.py
@@ -20,7 +20,9 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     # pylint: disable=unused-variable
-    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
+    tester = qt_api.QtTest.QAbstractItemModelTester(
+        model, reporting_mode
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
@@ -39,7 +41,9 @@ def test_progression(full_snapshot):
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     # pylint: disable=unused-variable
-    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
+    tester = qt_api.QtTest.QAbstractItemModelTester(
+        model, reporting_mode
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
 
@@ -65,7 +69,9 @@ def test_progression_start_iter_not_zero(full_snapshot):
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     # pylint: disable=unused-variable
-    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
+    tester = qt_api.QtTest.QAbstractItemModelTester(
+        model, reporting_mode
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
 

--- a/tests/unit_tests/gui/model/test_real_list.py
+++ b/tests/unit_tests/gui/model/test_real_list.py
@@ -19,7 +19,9 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     # pylint: disable=unused-variable
-    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
+    tester = qt_api.QtTest.QAbstractItemModelTester(
+        model, reporting_mode
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
@@ -39,7 +41,9 @@ def test_change_iter(full_snapshot):
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     # pylint: disable=unused-variable
-    tester = qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
+    tester = qt_api.QtTest.QAbstractItemModelTester(
+        model, reporting_mode
+    )  # noqa: F841, prevent GC
 
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
 

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -13,9 +13,9 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     model = SnapshotModel()
 
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
-    tester = qt_api.QtTest.QAbstractItemModelTester(  # noqa, prevent GC
+    tester = qt_api.QtTest.QAbstractItemModelTester(
         model, reporting_mode
-    )
+    )  # noqa: F841, prevent GC
 
     model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
     model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)

--- a/tests/unit_tests/services/test_base_service.py
+++ b/tests/unit_tests/services/test_base_service.py
@@ -22,7 +22,7 @@ class _DummyService(BaseService):
     service_name = "dummy"
 
     def __init__(self, exec_args, *args, **kwargs):
-        super().__init__(exec_args=exec_args, timeout=10, *args, **kwargs)
+        super().__init__(exec_args=exec_args, timeout=10, *args, **kwargs)  # noqa: B026
 
     def start(self):
         """Helper function for non-singleton testing"""

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -1,8 +1,7 @@
 import pytest
 
-from ert.storage import StorageReader
+from ert.storage import StorageReader, open_storage
 from ert.storage import local_storage as local
-from ert.storage import open_storage
 
 
 def _cases(storage):


### PR DESCRIPTION
Flake8 does not support pyproject.toml out-of-the box and ruff is faster.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
