### PR TITLE
Refactor queue_options in QueueConfig to be Tuple[str, str]

### DIFF
--- a/src/ert/job_queue/driver.py
+++ b/src/ert/job_queue/driver.py
@@ -30,16 +30,10 @@ class Driver(BaseCClass):  # type: ignore
 
     def set_option(self, option: str, value: str) -> bool:
         if option == "MAX_RUNNING":
-            self.set_max_running(int(value))
+            self.set_max_running(int(value) if value else 0)
             return True
         else:
             return self._set_option(option, str(value))
-
-    def unset_option(self, option: str) -> None:
-        if option == "MAX_RUNNING":
-            self.set_max_running(0)
-        else:
-            self._set_option(option, "")
 
     def get_option(self, option_key: str) -> str:
         if option_key == "MAX_RUNNING":
@@ -58,10 +52,7 @@ class Driver(BaseCClass):  # type: ignore
         driver = Driver(queue_config.queue_system)
         if queue_config.queue_system in queue_config.queue_options:
             for setting in queue_config.queue_options[queue_config.queue_system]:
-                if isinstance(setting, tuple):
-                    driver.set_option(*setting)
-                else:
-                    driver.unset_option(setting)
+                driver.set_option(*setting)
         return driver
 
     @property

--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -150,7 +150,6 @@ def test_overwriting_QUEUE_OPTIONS_warning(
         f.write("NUM_REALIZATIONS 1\n")
         f.write(f"QUEUE_SYSTEM {queue_system}\n")
         f.write(f"QUEUE_OPTION {queue_system} {queue_system_option} test_1\n")
-        f.write(f"QUEUE_OPTION {queue_system} {queue_system_option} \n")
     test_site_config = tmp_path / "test_site_config.ert"
     test_site_config.write_text(
         "JOB_SCRIPT job_dispatch.py\n"
@@ -185,3 +184,23 @@ def test_undefined_LSF_SERVER_environment_variable():
         ),
     ):
         ErtConfig.from_file(filename)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "queue_system, queue_system_option",
+    [("LSF", "LSF_SERVER"), ("SLURM", "SQUEUE"), ("TORQUE", "QUEUE")],
+)
+def test_initializing_empty_config_values(queue_system, queue_system_option):
+    filename = "config.ert"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("NUM_REALIZATIONS 1\n")
+        f.write(f"QUEUE_SYSTEM {queue_system}\n")
+        f.write(f"QUEUE_OPTION {queue_system} {queue_system_option}\n")
+        f.write(f"QUEUE_OPTION {queue_system} MAX_RUNNING\n")
+    config_object = ErtConfig.from_file(filename)
+    driver = Driver.create_driver(config_object.queue_config)
+    assert driver.get_option(queue_system_option) == ""
+    assert driver.get_option("MAX_RUNNING") == "0"
+    for options in config_object.queue_config.queue_options[queue_system]:
+        assert isinstance(options, tuple)

--- a/tests/unit_tests/job_queue/test_driver.py
+++ b/tests/unit_tests/job_queue/test_driver.py
@@ -12,7 +12,7 @@ def test_set_and_unset_option():
         queue_options={
             QueueSystem.LOCAL: [
                 ("MAX_RUNNING", "50"),
-                "MAX_RUNNING",
+                ("MAX_RUNNING", ""),
             ]
         },
     )
@@ -20,7 +20,11 @@ def test_set_and_unset_option():
     assert driver.get_option("MAX_RUNNING") == "0"
     assert driver.set_option("MAX_RUNNING", "42")
     assert driver.get_option("MAX_RUNNING") == "42"
-    driver.unset_option("MAX_RUNNING")
+    driver.set_option("MAX_RUNNING", "")
+    assert driver.get_option("MAX_RUNNING") == "0"
+    driver.set_option("MAX_RUNNING", "100")
+    assert driver.get_option("MAX_RUNNING") == "100"
+    driver.set_option("MAX_RUNNING", "0")
     assert driver.get_option("MAX_RUNNING") == "0"
 
 
@@ -54,6 +58,6 @@ def test_get_slurm_queue_config():
 
     assert driver.get_option("SBATCH") == "/path/to/sbatch"
     assert driver.get_option("SCONTROL") == "scontrol"
-    driver.unset_option("SCONTROL")
+    driver.set_option("SCONTROL", "")
     assert driver.get_option("SCONTROL") == ""
     assert driver.name == "SLURM"


### PR DESCRIPTION
**Issue**
Resolves #6149 

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
