### PR TITLE
Add debug information to coverage gui tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Test GUI
       if: matrix.test-type == 'gui-tests'
       run: |
-        pytest tests/ --cov=ert -m "requires_window_manager" --cov-report=xml:cov.xml
+        pytest tests/ --cov=ert -m "requires_window_manager" --cov-report=xml:cov.xml -s -vv
 
     - name: Test Integration
       if: matrix.test-type == 'integration-tests'


### PR DESCRIPTION
Sometimes, `test_gui_snapshot` aborts without printing any error messages (see https://github.com/equinor/ert/actions/runs/6309057927/job/17128253204?pr=6167). This PR makes the logging more verbose so that we can debug what is going on.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
