### PR TITLE
Get measured data using active realizations

### DIFF
--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -107,10 +107,11 @@ class MeasuredData:
                 response = ensemble.load_response(
                     group, tuple(ensemble.realization_list(RealizationState.HAS_DATA))
                 )
+                _msg = f"No response loaded for observation key: {key}"
+                if not response:
+                    raise ResponseError(_msg)
             except KeyError as e:
-                raise ResponseError(
-                    f"No response loaded for observation key: {key}"
-                ) from e
+                raise ResponseError(_msg) from e
             ds = obs.merge(
                 response,
                 join="left",

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import numpy as np
 import pandas as pd
 
+from ert.realization_state import RealizationState
+
 if TYPE_CHECKING:
     import numpy.typing as npt
 
@@ -103,7 +105,7 @@ class MeasuredData:
             group, obs = observations.get_dataset(key)
             try:
                 response = ensemble.load_response(
-                    group, tuple(range(self._facade.get_ensemble_size()))
+                    group, tuple(ensemble.realization_list(RealizationState.HAS_DATA))
                 )
             except KeyError as e:
                 raise ResponseError(

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -1,10 +1,10 @@
 import shutil
 
 import numpy as np
-import pytest
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QApplication, QComboBox, QMessageBox, QPushButton, QWidget
 
+from ert.data import MeasuredData
 from ert.gui.ertwidgets.caselist import CaseList
 from ert.gui.simulation.ensemble_experiment_panel import EnsembleExperimentPanel
 from ert.gui.simulation.run_dialog import RunDialog
@@ -15,7 +15,6 @@ from ert.validation import rangestring_to_mask
 from .conftest import find_cases_dialog_and_panel
 
 
-@pytest.mark.xfail(reason="flaky - under investigation")
 def test_that_the_manual_analysis_tool_works(
     ensemble_experiment_has_run, opened_main_window, qtbot, run_experiment
 ):
@@ -128,6 +127,9 @@ def test_that_the_manual_analysis_tool_works(
     storage = gui.notifier.storage
     df_prior = facade.load_all_gen_kw_data(storage.get_ensemble_by_name("iter-0"))
     df_posterior = facade.load_all_gen_kw_data(storage.get_ensemble_by_name("iter-1"))
+
+    # Making sure measured data works with failed realizations
+    MeasuredData(facade, storage.get_ensemble_by_name("iter-0"), ["POLY_OBS"])
 
     # We expect that ERT's update step lowers the
     # generalized variance for the parameters.


### PR DESCRIPTION
This bug caused misfit_preprocessor to fail on cases with failed realizations.

**Issue**
Resolves [#536](https://github.com/equinor/semeio/issues/536)

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
