### PR TITLE
Use tmpdir in tests that are currently polluting source dir

### DIFF
--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -2,6 +2,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 from uuid import UUID
 
 import numpy as np
+import pytest
 
 from ert.config import HookRuntime
 from ert.run_models import (
@@ -21,6 +22,7 @@ EXPECTED_CALL_ORDER = [
 ]
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_hook_call_order_ensemble_smoother(storage):
     """
     The goal of this test is to assert that the hook call order is the same
@@ -52,6 +54,7 @@ def test_hook_call_order_ensemble_smoother(storage):
     assert ert_mock.runWorkflows.mock_calls == expected_calls
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_hook_call_order_es_mda(storage):
     """
     The goal of this test is to assert that the hook call order is the same
@@ -102,6 +105,7 @@ class MockEsUpdate:
         w_container.iteration_nr += 1
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_hook_call_order_iterative_ensemble_smoother(storage):
     """
     The goal of this test is to assert that the hook call order is the same

--- a/tests/unit_tests/cli/test_run_context.py
+++ b/tests/unit_tests/cli/test_run_context.py
@@ -2,11 +2,13 @@ from unittest.mock import MagicMock
 from uuid import UUID
 
 import numpy as np
+import pytest
 
 from ert.run_models import MultipleDataAssimilation
 from ert.storage import EnsembleAccessor
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_all_iterations_gets_correct_name_and_iteration_number(storage):
     minimum_args = {
         "start_iteration": 0,

--- a/tests/unit_tests/config/test_analysis_config.py
+++ b/tests/unit_tests/config/test_analysis_config.py
@@ -8,6 +8,7 @@ from ert.config import AnalysisConfig, ConfigValidationError, ErtConfig
 from ert.config.parsing import ConfigKeys, ConfigWarning
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_analysis_config_from_file_is_same_as_from_dict():
     with open("analysis_config", "w", encoding="utf-8") as fout:
         fout.write(

--- a/tests/unit_tests/config/test_ensemble_config.py
+++ b/tests/unit_tests/config/test_ensemble_config.py
@@ -118,6 +118,7 @@ def test_that_files_for_refcase_exists(existing_suffix, expected_suffix):
         )
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_ensemble_config_duplicate_node_names():
     duplicate_name = "Test_name"
     Path("MULTFLT.TXT").write_text("", encoding="utf-8")

--- a/tests/unit_tests/job_queue/test_ert_qstat_proxy.py
+++ b/tests/unit_tests/job_queue/test_ert_qstat_proxy.py
@@ -378,7 +378,8 @@ def test_no_such_job_id(tmpdir, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No flock on MacOS")
-def test_proxy_fails_if_backend_fails():
+def test_proxy_fails_if_backend_fails(tmpdir, monkeypatch):
+    monkeypatch.chdir(tmpdir)
     with pytest.raises(subprocess.CalledProcessError), testpath.MockCommand(
         "qstat", python=MOCKED_QSTAT_BACKEND_FAILS
     ):

--- a/tests/unit_tests/shared/test_main_entry.py
+++ b/tests/unit_tests/shared/test_main_entry.py
@@ -7,6 +7,7 @@ import pytest
 import ert.__main__ as main
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_main_logging(monkeypatch, caplog):
     parser_mock = MagicMock()
     parser_mock.func.side_effect = ValueError("This is a test")


### PR DESCRIPTION
**Approach**
Ran `pytest tests -m "not integration_test and not requires_window_manager"` to see which files are generated in source dir. Found the tests that produced them. Added use of tmpdir to those tests.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
