### PR TITLE
Create backup for jobs.json when running in existing runpath

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -369,6 +369,8 @@ class EnKFMain:  # pylint: disable=too-many-public-methods
                     run_context.iteration,
                 )
 
+                path = run_path / "jobs.json"
+                _backup_if_existing(path)
                 with open(run_path / "jobs.json", mode="w", encoding="utf-8") as fptr:
                     forward_model_output = ert_config.forward_model_data_to_json(
                         run_arg.run_id,


### PR DESCRIPTION
**Issue**
Resolves #5989 


**Approach**
Use function `_backup_if_existing(path)` in function `createRunPath` in `ert/src/ert/enkf_main.py` before `jobs.json` is re-written.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
