### PR TITLE
Add option to delete run_path

### DIFF
--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtWidgets import (
     QApplication,
+    QCheckBox,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -170,30 +171,54 @@ class SimulationPanel(QWidget):
 
             QApplication.restoreOverrideCursor()
 
+            delete_runpath_checkbox = None
+
+            if not abort and model.check_if_runpath_exists():
+                msg_box = QMessageBox(self)
+                msg_box.setObjectName("RUN_PATH_WARNING_BOX")
+
+                msg_box.setIcon(QMessageBox.Warning)
+
+                msg_box.setText("Run experiments")
+                msg_box.setInformativeText(
+                    (
+                        "ERT is running in an existing runpath.\n\n"
+                        "Please be aware of the following:\n"
+                        "- Previously generated results "
+                        "might be overwritten.\n"
+                        "- Previously generated files might "
+                        "be used if not configured correctly.\n"
+                        "Are you sure you want to continue?"
+                    )
+                )
+
+                delete_runpath_checkbox = QCheckBox()
+                delete_runpath_checkbox.setText("Delete run_path")
+                msg_box.setCheckBox(delete_runpath_checkbox)
+
+                msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+                msg_box.setDefaultButton(QMessageBox.No)
+
+                msg_box.setWindowModality(Qt.ApplicationModal)
+
+                msg_box_res = msg_box.exec()
+
             if (
                 not abort
                 and model.check_if_runpath_exists()
-                and (
-                    QMessageBox.warning(
-                        self,
-                        "Run experiments?",
-                        (
-                            "ERT is running in an existing runpath.\n\n"
-                            "Please be aware of the following:\n"
-                            "- Previously generated results "
-                            "might be overwritten.\n"
-                            "- Previously generated files might "
-                            "be used if not configured correctly.\n"
-                            "Are you sure you want to continue?"
-                        ),
-                        QMessageBox.Yes | QMessageBox.No,
-                    )
-                    == QMessageBox.No
-                )
+                and msg_box_res == QMessageBox.No
             ):
                 abort = True
 
             if not abort:
+                if (
+                    delete_runpath_checkbox is not None
+                    and delete_runpath_checkbox.checkState() == Qt.Checked
+                ):
+                    QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+                    model.rm_run_path()
+                    QApplication.restoreOverrideCursor()
+
                 dialog = RunDialog(
                     self._config_file, model, self._notifier, self.parent()
                 )

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import time
 import uuid
 from contextlib import contextmanager
@@ -391,6 +392,10 @@ class BaseRunModel:
                 if Path(run_path).exists():
                     return True
         return False
+
+    def rm_run_path(self) -> None:
+        run_path = Path(self.facade.run_path).parents[1]
+        shutil.rmtree(run_path)
 
     def validate(self) -> None:
         errors = []

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -47,6 +47,7 @@ from ert.gui.tools.manage_cases.case_init_configuration import (
 from ert.run_models import EnsembleExperiment, MultipleDataAssimilation
 from ert.services import StorageService
 from ert.storage import open_storage
+from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path_dialog
 
 
 def find_cases_dialog_and_panel(
@@ -160,6 +161,10 @@ def run_experiment_fixture(request, opened_main_window):
         def handle_dialog():
             message_box = gui.findChild(QMessageBox)
             qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+            QTimer.singleShot(
+                500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False)
+            )
 
         QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -22,6 +22,7 @@ from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.simulation.view.realization import RealizationWidget
 from ert.gui.tools.file import FileDialog
 from ert.services import StorageService
+from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path_dialog
 
 
 def test_success(runmodel, qtbot: QtBot, mock_tracker):
@@ -369,6 +370,13 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
             qtbot.waitUntil(lambda: gui.findChild(QMessageBox) is not None)
             message_box = gui.findChild(QMessageBox)
             qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
+
+            QTimer.singleShot(
+                500,
+                lambda: handle_run_path_dialog(
+                    gui=gui, qtbot=qtbot, delete_run_path=False
+                ),
+            )
 
         QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)

--- a/tests/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -1,0 +1,139 @@
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QComboBox, QMessageBox, QToolButton, QWidget
+
+from ert.enkf_main import EnKFMain
+from ert.gui.main import _setup_main_window
+from ert.gui.main_window import ErtMainWindow
+from ert.gui.simulation.run_dialog import RunDialog
+from ert.gui.simulation.simulation_panel import SimulationPanel
+from ert.gui.tools.event_viewer.panel import GUILogHandler
+from ert.run_models.ensemble_experiment import EnsembleExperiment
+from ert.run_models.single_test_run import SingleTestRun
+from ert.services.storage_service import StorageService
+from ert.storage import open_storage
+
+
+def handle_run_path_dialog(gui: ErtMainWindow, qtbot: QtBot, delete_run_path: bool):
+    mb = gui.findChild(QMessageBox, "RUN_PATH_WARNING_BOX")
+
+    if mb is not None:
+        assert mb
+        assert isinstance(mb, QMessageBox)
+
+        if delete_run_path:
+            qtbot.mouseClick(mb.checkBox(), Qt.LeftButton)
+
+        qtbot.mouseClick(mb.buttons()[0], Qt.LeftButton)
+
+
+def test_run_path_is_deleted(snake_oil_case_storage: EnKFMain, qtbot: QtBot):
+    snake_oil_case = snake_oil_case_storage
+    args_mock = Mock()
+    args_mock.config = "snake_oil.ert"
+
+    with StorageService.init_service(
+        ert_config=args_mock.config,
+        project=os.path.abspath(snake_oil_case.ert_config.ens_path),
+    ), open_storage(snake_oil_case.ert_config.ens_path, mode="w") as storage:
+        gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler())
+        gui.notifier.set_storage(storage)
+        simulation_panel = gui.findChild(SimulationPanel)
+
+        assert isinstance(simulation_panel, SimulationPanel)
+        simulation_mode_combo = simulation_panel.findChild(QComboBox)
+        assert isinstance(simulation_mode_combo, QComboBox)
+        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+
+        # Click start simulation and agree to the message
+        start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+        assert start_simulation
+        assert isinstance(start_simulation, QToolButton)
+
+        run_path = Path(
+            snake_oil_case.ert_config.model_config.runpath_format_string.replace(
+                "<IENS>", "0"
+            )
+        ).parent
+        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+            dummy_file.close()
+
+        def handle_dialog():
+            qtbot.waitUntil(lambda: gui.findChild(QMessageBox) is not None)
+            message_box = gui.findChild(QMessageBox)
+            assert message_box
+            qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+            QTimer.singleShot(
+                500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
+            )
+
+        QTimer.singleShot(500, handle_dialog)
+        qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+        assert not os.path.exists(run_path / dummy_file.name)
+
+
+def test_run_path_is_not_deleted(snake_oil_case_storage: EnKFMain, qtbot: QtBot):
+    snake_oil_case = snake_oil_case_storage
+    args_mock = Mock()
+    args_mock.config = "snake_oil.ert"
+
+    with StorageService.init_service(
+        ert_config=args_mock.config,
+        project=os.path.abspath(snake_oil_case.ert_config.ens_path),
+    ), open_storage(snake_oil_case.ert_config.ens_path, mode="w") as storage:
+        gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler())
+        gui.notifier.set_storage(storage)
+        simulation_panel = gui.findChild(SimulationPanel)
+
+        assert isinstance(simulation_panel, SimulationPanel)
+        simulation_mode_combo = simulation_panel.findChild(QComboBox)
+        assert isinstance(simulation_mode_combo, QComboBox)
+        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+
+        # Click start simulation and agree to the message
+        start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+        assert start_simulation
+        assert isinstance(start_simulation, QToolButton)
+
+        run_path = Path(
+            snake_oil_case.ert_config.model_config.runpath_format_string.replace(
+                "<IENS>", "0"
+            )
+        ).parent
+        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+            dummy_file.close()
+
+        def handle_dialog():
+            qtbot.waitUntil(lambda: gui.findChild(QMessageBox) is not None)
+            message_box = gui.findChild(QMessageBox)
+            assert message_box
+            qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+            QTimer.singleShot(
+                500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False)
+            )
+
+        QTimer.singleShot(500, handle_dialog)
+        qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=10000)
+        run_dialog = gui.findChild(RunDialog)
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+        assert os.path.exists(run_path / dummy_file.name)

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -11,6 +11,7 @@ from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.simulation.simulation_panel import SimulationPanel
 from ert.run_models import EnsembleExperiment
 from ert.validation import rangestring_to_mask
+from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path_dialog
 
 from .conftest import find_cases_dialog_and_panel
 
@@ -114,6 +115,11 @@ def test_that_the_manual_analysis_tool_works(
     def handle_dialog():
         message_box = gui.findChild(QMessageBox)
         qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+        QTimer.singleShot(
+            500,
+            lambda: handle_run_path_dialog(gui=gui, qtbot=qtbot, delete_run_path=False),
+        )
 
     QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(start_simulation, Qt.LeftButton)

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -19,6 +19,7 @@ from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
+from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path_dialog
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -274,6 +275,13 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         def handle_dialog():
             message_box = gui.findChild(QMessageBox)
             qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
+
+            QTimer.singleShot(
+                500,
+                lambda: handle_run_path_dialog(
+                    gui=gui, qtbot=qtbot, delete_run_path=False
+                ),
+            )
 
         QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -33,6 +33,7 @@ from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.run_models import SingleTestRun
+from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path_dialog
 
 from .conftest import find_cases_dialog_and_panel, load_results_manually
 
@@ -392,6 +393,11 @@ def test_that_a_failing_job_shows_error_message_with_context(
         message_box = gui.findChild(QMessageBox)
         assert message_box
         qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
+
+        QTimer.singleShot(
+            500,
+            lambda: handle_run_path_dialog(gui=gui, qtbot=qtbot, delete_run_path=False),
+        )
 
     def handle_error_dialog(run_dialog):
         error_dialog = run_dialog.fail_msg_box


### PR DESCRIPTION
**Issue**
Resolves #5966

**Approach**
Added a checkbox to the overwrite run_path dialog (defaults to unchecked). Deletes run_path if checkbox is checked

![Screenshot 2023-09-26 at 14 14 29](https://github.com/equinor/ert/assets/10201831/6cd884fc-b862-499b-9f11-7f1dc14e8496)

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] ~~Updated documentation~~
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
