### PR TITLE
Fix inconsistent failure handling between torque and lsf

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -399,7 +399,7 @@ static int torque_job_parse_qsub_stdout(const torque_driver_type *driver,
             fprintf(stderr, "qsub errors:  %s\n", stderr_content);
             free(stdout_content);
             free(stderr_content);
-            util_exit("%s: \n", __func__);
+            jobid = -1;
         }
         free(jobid_string);
         fclose(stdout_stream);

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -26,7 +26,7 @@ VALID_QUEUE_OPTIONS: Dict[Any, List[str]] = {
 class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
     max_submit: int = 2
-    queue_system: QueueSystem = QueueSystem.NULL  # type: ignore
+    queue_system: QueueSystem = QueueSystem.LOCAL  # type: ignore
     queue_options: Dict[QueueSystem, List[Union[Tuple[str, str], str]]] = field(
         default_factory=dict
     )
@@ -62,11 +62,7 @@ class QueueConfig:
     def from_dict(cls, config_dict: ConfigDict) -> QueueConfig:
         queue_system = config_dict.get("QUEUE_SYSTEM", "LOCAL")
 
-        valid_queue_systems = []
-
-        for driver_names in QueueSystem.enums():
-            if driver_names.name not in str(QueueSystem.NULL):
-                valid_queue_systems.append(driver_names.name)
+        valid_queue_systems = [s.name for s in QueueSystem.enums()]
 
         if queue_system not in valid_queue_systems:
             raise ConfigValidationError(

--- a/src/ert/config/queue_system.py
+++ b/src/ert/config/queue_system.py
@@ -3,14 +3,12 @@ from cwrap import BaseCEnum
 
 class QueueSystem(BaseCEnum):  # type: ignore
     TYPE_NAME = "queue_driver_enum"
-    NULL = None
     LSF = None
     LOCAL = None
     TORQUE = None
     SLURM = None
 
 
-QueueSystem.addEnum("NULL", 0)
 QueueSystem.addEnum("LSF", 1)
 QueueSystem.addEnum("LOCAL", 2)
 QueueSystem.addEnum("TORQUE", 4)

--- a/src/ert/ensemble_evaluator/_builder/_step.py
+++ b/src/ert/ensemble_evaluator/_builder/_step.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from ert.config.ext_job import ExtJob
@@ -27,6 +26,4 @@ class LegacyStep:
     max_runtime: Optional[int]
     run_arg: "RunArg"
     num_cpu: int
-    run_path: Path
     job_script: str
-    job_name: str

--- a/src/ert/job_queue/job_queue_manager.py
+++ b/src/ert/job_queue/job_queue_manager.py
@@ -50,19 +50,19 @@ class JobQueueManager:
     def isJobComplete(self, job_index: int) -> bool:
         return not (
             self.queue.job_list[job_index].is_running()
-            or self.queue.job_list[job_index].status == JobStatus.WAITING
+            or self.queue.job_list[job_index].queue_status == JobStatus.WAITING
         )
 
     def isJobWaiting(self, job_index: int) -> bool:
-        return self.queue.job_list[job_index].status == JobStatus.WAITING
+        return self.queue.job_list[job_index].queue_status == JobStatus.WAITING
 
     def didJobSucceed(self, job_index: int) -> bool:
-        return self.queue.job_list[job_index].status == JobStatus.SUCCESS
+        return self.queue.job_list[job_index].queue_status == JobStatus.SUCCESS
 
     def getJobStatus(self, job_index: int) -> JobStatus:
         # See comment about return type in the prototype section at
         # the top of class.
-        int_status = self.queue.job_list[job_index].status
+        int_status = self.queue.job_list[job_index].queue_status
         return JobStatus(int_status)
 
     def __repr__(self) -> str:

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -122,10 +122,6 @@ class JobQueueNode(BaseCClass):  # type: ignore
             num_cpu,
             status_file,
             exit_file,
-            None,
-            None,
-            None,
-            None,
         )
 
         if c_ptr is not None:

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -90,8 +90,6 @@ class JobQueueNode(BaseCClass):  # type: ignore
     def __init__(
         self,
         job_script: str,
-        job_name: str,
-        run_path: str,
         num_cpu: int,
         status_file: str,
         exit_file: str,
@@ -103,23 +101,21 @@ class JobQueueNode(BaseCClass):  # type: ignore
         self.run_arg = run_arg
         argc = 1
         argv = StringList()
-        argv.append(run_path)
+        argv.append(run_arg.runpath)
 
         self._thread_status: ThreadStatus = ThreadStatus.READY
         self._thread: Optional[Thread] = None
         self._mutex = Lock()
         self._tried_killing = 0
 
-        self.run_path = run_path
         self._max_runtime = max_runtime
         self._start_time: Optional[float] = None
         self._end_time: Optional[float] = None
         self._timed_out = False
         self._status_msg = ""
-        self._job_name = job_name
         c_ptr = self._alloc(
-            job_name,
-            run_path,
+            run_arg.job_name,
+            run_arg.runpath,
             job_script,
             argc,
             argv,
@@ -142,10 +138,14 @@ class JobQueueNode(BaseCClass):  # type: ignore
 
     def __str__(self) -> str:
         return (
-            f"JobNode: Name:{self._job_name}, Status: {self.status}, "
+            f"JobNode: Name:{self.run_arg.job_name}, Status: {self.status}, "
             f"Timed_out: {self.timed_out}, "
             f"Submit_attempt: {self.submit_attempt}"
         )
+
+    @property
+    def run_path(self) -> str:
+        return self.run_arg.runpath
 
     @property
     def timed_out(self) -> bool:

--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -147,7 +147,7 @@ class JobQueue(BaseCClass):  # type: ignore
         return None
 
     def count_status(self, status: JobStatus) -> int:
-        return len([job for job in self.job_list if job.status == status])
+        return len([job for job in self.job_list if job.queue_status == status])
 
     @property
     def stopped(self) -> bool:
@@ -172,7 +172,7 @@ class JobQueue(BaseCClass):  # type: ignore
         job.convertToCReference(None)
         queue_index: int = self._add_job(job)
         self.job_list.append(job)
-        self._differ.add_state(queue_index, iens, job.status.value)
+        self._differ.add_state(queue_index, iens, job.queue_status.value)
         return queue_index
 
     def count_running(self) -> int:
@@ -206,7 +206,7 @@ class JobQueue(BaseCClass):  # type: ignore
                     "Unexpected job status type after "
                     "running job: {} with thread status: {}"
                 )
-                raise AssertionError(msg.format(job.status, job.thread_status))
+                raise AssertionError(msg.format(job.queue_status, job.thread_status))
 
     def launch_jobs(self, pool_sema: Semaphore) -> None:
         # Start waiting jobs
@@ -515,7 +515,9 @@ class JobQueue(BaseCClass):  # type: ignore
         stage.run_arg.queue_index = self.add_job(job, iens)
 
     def stop_long_running_jobs(self, minimum_required_realizations: int) -> None:
-        completed_jobs = [job for job in self.job_list if job.status == JobStatus.DONE]
+        completed_jobs = [
+            job for job in self.job_list if job.queue_status == JobStatus.DONE
+        ]
         finished_realizations = len(completed_jobs)
 
         if not finished_realizations:

--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -481,13 +481,8 @@ class JobQueue(BaseCClass):  # type: ignore
         max_runtime: Optional[int],
         num_cpu: int,
     ) -> None:
-        job_name = run_arg.job_name
-        run_path = run_arg.runpath
-
         job = JobQueueNode(
             job_script=job_script,
-            job_name=job_name,
-            run_path=run_path,
             num_cpu=num_cpu,
             status_file=self.status_file,
             exit_file=self.exit_file,
@@ -506,8 +501,6 @@ class JobQueue(BaseCClass):  # type: ignore
     ) -> None:
         job = JobQueueNode(
             job_script=stage.job_script,
-            job_name=stage.job_name,
-            run_path=str(stage.run_path),
             num_cpu=stage.num_cpu,
             status_file=self.status_file,
             exit_file=self.exit_file,

--- a/src/ert/job_queue/queue_differ.py
+++ b/src/ert/job_queue/queue_differ.py
@@ -22,7 +22,7 @@ class QueueDiffer:
         job_list: List[JobQueueNode],
     ) -> Tuple[List[JobStatus], List[JobStatus]]:
         """Calculate a new state, do not transition, return both old and new state."""
-        new_state = [job.status.value for job in job_list]
+        new_state = [job.queue_status.value for job in job_list]
         old_state = copy.copy(self._state)
         return old_state, new_state
 
@@ -34,7 +34,7 @@ class QueueDiffer:
         job_list: List[JobQueueNode],
     ) -> Tuple[List[JobStatus], List[JobStatus]]:
         """Transition to a new state, return both old and new state."""
-        new_state = [job.status.value for job in job_list]
+        new_state = [job.queue_status.value for job in job_list]
         old_state = copy.copy(self._state)
         self._state = new_state
         return old_state, new_state

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -396,9 +396,7 @@ class BaseRunModel:
                         max_runtime=self.ert().analysisConfig().max_runtime,
                         run_arg=run_arg,
                         num_cpu=self.ert().get_num_cpu(),
-                        run_path=Path(run_arg.runpath),
                         job_script=self.ert().resConfig().queue_config.job_script,
-                        job_name=run_arg.job_name,
                     )
                 )
             builder.add_realization(real)

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -2,7 +2,7 @@ import json
 import os
 import stat
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -13,6 +13,8 @@ from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.ensemble_evaluator.snapshot import SnapshotBuilder
 from ert.job_queue import JobQueueNode
 from ert.load_status import LoadStatus
+from ert.run_arg import RunArg
+from ert.storage import EnsembleAccessor
 
 from .ensemble_evaluator_utils import TestEnsemble
 
@@ -122,13 +124,18 @@ def make_ensemble_builder(queue_config):
 
                 step = ert.ensemble_evaluator.LegacyStep(
                     id_="0",
-                    job_name="job dispatch",
                     job_script="job_dispatch.py",
                     max_runtime=10,
-                    run_arg=Mock(iens=iens),
+                    run_arg=RunArg(
+                        str(iens),
+                        MagicMock(spec=EnsembleAccessor),
+                        iens,
+                        0,
+                        str(run_path),
+                        f"job_name_{iens}",
+                    ),
                     # the first callback_argument is expected to be a run_arg
                     # from the run_arg, the queue wants to access the iens prop
-                    run_path=run_path,
                     num_cpu=1,
                     name="dummy step",
                     jobs=[

--- a/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -72,9 +72,7 @@ class TestEnsemble(Ensemble):
                         name=f"step-{step_no}",
                         max_runtime=0,
                         num_cpu=0,
-                        run_path=None,
                         run_arg=None,
-                        job_name=None,
                         job_script=None,
                     )
                     for step_no in range(0, steps)

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_builder.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_builder.py
@@ -1,4 +1,3 @@
-import pathlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,10 +23,8 @@ def test_build_ensemble(active_real):
             .set_iens(2)
             .add_step(
                 LegacyStep(
-                    run_path=pathlib.Path("."),
                     run_arg=MagicMock(),
                     job_script="job_script",
-                    job_name="job_name",
                     num_cpu=1,
                     jobs=[
                         LegacyJob(

--- a/tests/unit_tests/job_queue/test_job_queue.py
+++ b/tests/unit_tests/job_queue/test_job_queue.py
@@ -113,7 +113,7 @@ def test_kill_jobs(tmpdir, monkeypatch, never_ending_script):
     job_queue._differ.transition(job_queue.job_list)
 
     for q_index, job in enumerate(job_queue.job_list):
-        assert job.status == JobStatus.IS_KILLED
+        assert job.queue_status == JobStatus.IS_KILLED
         iens = job_queue._differ.qindex_to_iens(q_index)
         assert job_queue.snapshot()[iens] == str(JobStatus.IS_KILLED)
 
@@ -162,7 +162,7 @@ def test_failing_jobs(tmpdir, monkeypatch, failing_script):
     assert job_queue.fetch_next_waiting() is None
 
     for q_index, job in enumerate(job_queue.job_list):
-        assert job.status == JobStatus.FAILED
+        assert job.queue_status == JobStatus.FAILED
         iens = job_queue._differ.qindex_to_iens(q_index)
         assert job_queue.snapshot()[iens] == str(JobStatus.FAILED)
 
@@ -196,7 +196,7 @@ def test_timeout_jobs(tmpdir, monkeypatch, never_ending_script):
     job_queue._differ.transition(job_queue.job_list)
 
     for q_index, job in enumerate(job_queue.job_list):
-        assert job.status == JobStatus.IS_KILLED
+        assert job.queue_status == JobStatus.IS_KILLED
         iens = job_queue._differ.qindex_to_iens(q_index)
         assert job_queue.snapshot()[iens] == str(JobStatus.IS_KILLED)
 
@@ -269,7 +269,7 @@ def test_add_dispatch_info_cert_none(tmpdir, monkeypatch, simple_script):
 
 class MockedJob:
     def __init__(self, status):
-        self.status = status
+        self.queue_status = status
         self._start_time = 0
         self._current_time = 0
         self._end_time = None
@@ -279,7 +279,7 @@ class MockedJob:
         return self._end_time - self._start_time
 
     def stop(self):
-        self.status = JobStatus.FAILED
+        self.queue_status = JobStatus.FAILED
 
     def convertToCReference(self, _):
         pass
@@ -294,17 +294,17 @@ def test_stop_long_running():
     job_list = [MockedJob(JobStatus.WAITING) for _ in range(10)]
 
     for i in range(5):
-        job_list[i].status = JobStatus.DONE
+        job_list[i].queue_status = JobStatus.DONE
         job_list[i]._start_time = 0
         job_list[i]._end_time = 10
 
     for i in range(5, 8):
-        job_list[i].status = JobStatus.RUNNING
+        job_list[i].queue_status = JobStatus.RUNNING
         job_list[i]._start_time = 0
         job_list[i]._end_time = 20
 
     for i in range(8, 10):
-        job_list[i].status = JobStatus.RUNNING
+        job_list[i].queue_status = JobStatus.RUNNING
         job_list[i]._start_time = 0
         job_list[i]._end_time = 5
 
@@ -320,15 +320,15 @@ def test_stop_long_running():
     queue._differ.transition(queue.job_list)
 
     for i in range(5):
-        assert job_list[i].status == JobStatus.DONE
+        assert job_list[i].queue_status == JobStatus.DONE
         assert queue.snapshot()[i] == str(JobStatus.DONE)
 
     for i in range(5, 8):
-        assert job_list[i].status == JobStatus.FAILED
+        assert job_list[i].queue_status == JobStatus.FAILED
         assert queue.snapshot()[i] == str(JobStatus.FAILED)
 
     for i in range(8, 10):
-        assert job_list[i].status == JobStatus.RUNNING
+        assert job_list[i].queue_status == JobStatus.RUNNING
         assert queue.snapshot()[i] == str(JobStatus.RUNNING)
 
 

--- a/tests/unit_tests/job_queue/test_job_queue.py
+++ b/tests/unit_tests/job_queue/test_job_queue.py
@@ -10,6 +10,8 @@ import pytest
 
 from ert.config import QueueSystem
 from ert.job_queue import Driver, JobQueue, JobQueueNode, JobStatus
+from ert.run_arg import RunArg
+from ert.storage import EnsembleAccessor
 
 
 def wait_for(
@@ -61,12 +63,17 @@ def create_local_queue(
         Path(DUMMY_CONFIG["run_path"].format(iens)).mkdir(exist_ok=False)
         job = JobQueueNode(
             job_script=executable_script,
-            job_name=DUMMY_CONFIG["job_name"].format(iens),
-            run_path=DUMMY_CONFIG["run_path"].format(iens),
             num_cpu=DUMMY_CONFIG["num_cpu"],
             status_file=job_queue.status_file,
             exit_file=job_queue.exit_file,
-            run_arg=MagicMock(),
+            run_arg=RunArg(
+                str(iens),
+                MagicMock(spec=EnsembleAccessor),
+                0,
+                0,
+                DUMMY_CONFIG["run_path"].format(iens),
+                DUMMY_CONFIG["job_name"].format(iens),
+            ),
             max_runtime=max_runtime,
             callback_timeout=callback_timeout,
         )

--- a/tests/unit_tests/job_queue/test_job_queue_manager.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager.py
@@ -141,7 +141,7 @@ def test_max_submit_reached(tmpdir, max_submit_num, monkeypatch, failing_script)
 
     for job in job_queue.job_list:
         # one for every realization
-        assert job.status == JobStatus.FAILED
+        assert job.queue_status == JobStatus.FAILED
         assert job.submit_attempt == job_queue.max_submit
 
 
@@ -155,4 +155,4 @@ def test_kill_queue(tmpdir, max_submit_num, monkeypatch, simple_script):
 
     assert not Path("STATUS").exists()
     for job in job_queue.job_list:
-        assert job.status == JobStatus.FAILED
+        assert job.queue_status == JobStatus.FAILED

--- a/tests/unit_tests/job_queue/test_job_queue_manager.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager.py
@@ -9,6 +9,8 @@ import pytest
 
 from ert.config import QueueSystem
 from ert.job_queue import Driver, JobQueue, JobQueueManager, JobQueueNode, JobStatus
+from ert.run_arg import RunArg
+from ert.storage import EnsembleAccessor
 
 
 class Config(TypedDict):
@@ -42,12 +44,17 @@ def create_local_queue(
         Path(DUMMY_CONFIG["run_path"].format(iens)).mkdir()
         job = JobQueueNode(
             job_script=executable_script,
-            job_name=DUMMY_CONFIG["job_name"].format(iens),
-            run_path=os.path.realpath(DUMMY_CONFIG["run_path"].format(iens)),
             num_cpu=DUMMY_CONFIG["num_cpu"],
             status_file=job_queue.status_file,
             exit_file=job_queue.exit_file,
-            run_arg=MagicMock(),
+            run_arg=RunArg(
+                str(iens),
+                MagicMock(spec=EnsembleAccessor),
+                0,
+                0,
+                os.path.realpath(DUMMY_CONFIG["run_path"].format(iens)),
+                DUMMY_CONFIG["job_name"].format(iens),
+            ),
         )
         job_queue.add_job(job, iens)
     return job_queue
@@ -70,12 +77,17 @@ def test_num_cpu_submitted_correctly_lsf(tmpdir, simple_script):
 
     job = JobQueueNode(
         job_script=simple_script,
-        job_name=DUMMY_CONFIG["job_name"].format(job_id),
-        run_path=os.path.realpath(DUMMY_CONFIG["run_path"].format(job_id)),
         num_cpu=4,
         status_file="STATUS",
         exit_file="ERROR",
-        run_arg=MagicMock(),
+        run_arg=RunArg(
+            str(job_id),
+            MagicMock(spec=EnsembleAccessor),
+            0,
+            0,
+            os.path.realpath(DUMMY_CONFIG["run_path"].format(job_id)),
+            DUMMY_CONFIG["job_name"].format(job_id),
+        ),
     )
 
     pool_sema = BoundedSemaphore(value=2)

--- a/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
@@ -260,4 +260,4 @@ def test_torque_job_status_from_qstat_output(
     pool_sema = BoundedSemaphore(value=2)
     job.run(driver, pool_sema)
     job.wait_for()
-    assert job.status == expected_status
+    assert job.queue_status == expected_status

--- a/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_manager_torque.py
@@ -9,6 +9,8 @@ import pytest
 
 from ert.config import QueueSystem
 from ert.job_queue import Driver, JobQueueNode, JobStatus
+from ert.run_arg import RunArg
+from ert.storage import EnsembleAccessor
 
 
 @pytest.fixture(name="temp_working_directory")
@@ -116,12 +118,17 @@ def _build_jobqueuenode(job_script, dummy_config: JobConfig, job_id=0):
 
     job = JobQueueNode(
         job_script=job_script,
-        job_name=dummy_config["job_name"].format(job_id),
-        run_path=os.path.realpath(dummy_config["run_path"].format(job_id)),
         num_cpu=1,
         status_file="STATUS",
         exit_file="ERROR",
-        run_arg=MagicMock(),
+        run_arg=RunArg(
+            str(job_id),
+            MagicMock(spec=EnsembleAccessor),
+            0,
+            0,
+            os.path.realpath(dummy_config["run_path"].format(job_id)),
+            dummy_config["job_name"].format(job_id),
+        ),
     )
     return job, runpath
 

--- a/tests/unit_tests/job_queue/test_job_queue_node.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node.py
@@ -1,0 +1,63 @@
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+
+from ert.config import QueueSystem
+from ert.job_queue.driver import Driver
+from ert.job_queue.job_queue_node import JobQueueNode
+from ert.job_queue.submit_status import SubmitStatus
+from ert.run_arg import RunArg
+from ert.storage import EnsembleAccessor
+
+queue_systems = st.sampled_from(QueueSystem.enums())
+
+drivers = st.builds(Driver, queue_systems)
+
+job_script = "mock_job_script"
+mock_ensemble_storage = MagicMock(spec=EnsembleAccessor)
+
+runargs = st.builds(
+    RunArg,
+    iens=st.just(1),
+    itr=st.just(0),
+    runpath=st.just("."),
+    run_id=st.text(),
+    job_name=st.text(),
+    ensemble_storage=st.just(mock_ensemble_storage),
+)
+job_queue_nodes = st.builds(
+    JobQueueNode,
+    job_script=st.just(job_script),
+    num_cpu=st.just(1),
+    status_file=st.just("STATUS"),
+    exit_file=st.just("EXIT"),
+    run_arg=runargs,
+)
+
+
+def setup_mock_queue():
+    for command in ["bsub", "qsub", "sbatch", "mock_job_script"]:
+        Path(command).write_text("#! /usr/bin/true\n")
+        Path(command).chmod(stat.S_IEXEC | stat.S_IWUSR)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@given(job_queue_nodes, drivers.filter(lambda d: d.name != "LOCAL"))
+def test_when_submit_command_returns_invalid_output_then_submit_fails(
+    job_queue_node, driver
+):
+    setup_mock_queue()
+    assert job_queue_node.submit(driver) == SubmitStatus.DRIVER_FAIL
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@given(job_queue_nodes)
+def test_submitting_empty_job_on_local_succeeds(job_queue_node):
+    driver = Driver(QueueSystem.LOCAL)
+    setup_mock_queue()
+    assert job_queue_node.submit(driver) == SubmitStatus.OK
+    job_queue_node._poll_until_done(driver)


### PR DESCRIPTION
Resolves an issue where parsing of qsub output would exit rather than return a failure signal. Returning a failure signal is consisten with how the other queue_drivers work.

In order to be able to test this code easily, some refactoring was necessary which is what the other commits do.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
