### PR TITLE
Resolve ERT slowdown seen in Azure

### DIFF
--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -77,6 +77,8 @@ extern "C" PY_USED bool job_queue_node_kill_simple(job_queue_node_type *node,
 extern "C" void job_queue_node_free(job_queue_node_type *node);
 extern "C" job_status_type
 job_queue_node_get_status(const job_queue_node_type *node);
+extern "C" PY_USED job_status_type job_queue_node_refresh_status(
+    job_queue_node_type *node, queue_driver_type *driver);
 extern "C" int
 job_queue_node_get_submit_attempt(const job_queue_node_type *node);
 
@@ -85,5 +87,6 @@ void job_queue_node_set_queue_index(job_queue_node_type *node, int queue_index);
 
 extern "C" void job_queue_node_set_status(job_queue_node_type *node,
                                           job_status_type new_status);
-
+extern "C" const char *
+job_queue_node_get_failure_message(job_queue_node_type *node);
 #endif

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
-from ert._clib.queue import _refresh_status  # pylint: disable=import-error
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
 
@@ -85,6 +84,12 @@ class JobQueueNode(BaseCClass):  # type: ignore
     _get_submit_attempt = ResPrototype(
         "int job_queue_node_get_submit_attempt(job_queue_node)"
     )
+    _refresh_status = ResPrototype(
+        "job_status_type_enum job_queue_node_refresh_status(job_queue_node, driver)"
+    )
+    _get_failure_message = ResPrototype(
+        "char* job_queue_node_get_failure_message(job_queue_node)"
+    )
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -157,10 +162,10 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return self._get_submit_attempt()
 
     def _poll_queue_status(self, driver: "Driver") -> JobStatus:
-        result, msg = _refresh_status(self, driver)
-        if msg is not None:
-            self._status_msg = msg
-        return JobStatus(result)
+        status = self._refresh_status(driver)
+        msg = self._get_failure_message()
+        self._status_msg = msg if msg else self._status_msg
+        return status
 
     @property
     def status(self) -> JobStatus:


### PR DESCRIPTION
**Issue**
Resolves #6182 

[Move job_queue_node_refresh_status back to cwrap](https://github.com/equinor/ert/pull/6181/commits/788555e53a984180dd3678a5507fcb5af14d393d) 
Resolves the UI slowdowns found when running ERT in Azure
The offending function was refactored to use pybind in https://github.com/equinor/ert/pull/5841
This seem to cause resource starvation, most likely  due to the
GIL (global interpreter lock) used by python
Moving the function back to cwrap alleviates this issue

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
