### PR TITLE
Change the display name of the build and test GA workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Build and test ERT and docs
 
 on:
  push:
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-test-cmake:
-    name: CMake
+    name: Run C++ tests and coverage
 
     strategy:
       fail-fast: false
@@ -102,9 +102,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest ]
-        test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         exclude:
           - os: ubuntu-latest
             python-version: '3.9'
@@ -123,9 +123,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         python-version: [ '3.10' ]
         os: [ macos-latest ]
-        test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
     uses: ./.github/workflows/test_ert.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
**Issue**
The display name of the GitHub Actions workflow was hard to read as the important information was at the end of the line. 


**Approach**
Change the order of the parameters


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
