### PR TITLE
Make lsf driver submit signal invalid instead of abort

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -167,7 +167,7 @@ void lsf_job_free(lsf_job_type *job) {
 }
 
 int lsf_job_parse_bsub_stdout(const char *bsub_cmd, const char *stdout_file) {
-    int jobid = 0;
+    int jobid = -1;
     if ((fs::exists(stdout_file)) && (util_file_size(stdout_file) > 0)) {
         FILE *stream = util_fopen(stdout_file, "r");
         if (util_fseek_string(stream, "<", true, true)) {
@@ -178,16 +178,14 @@ int lsf_job_parse_bsub_stdout(const char *bsub_cmd, const char *stdout_file) {
             }
         }
         fclose(stream);
-
-        if (jobid == 0) {
-            std::ifstream ifs(stdout_file);
-            std::cerr << "Failed to get lsf job id from file: " << stdout_file;
-            std::cerr << "\n";
-            std::cerr << "bsub command                      : " << bsub_cmd;
-            std::cerr << "\n";
-            std::cerr << &ifs << std::endl;
-            util_abort("%s: \n", __func__);
-        }
+    }
+    if (jobid == -1) {
+        std::ifstream ifs(stdout_file);
+        std::cerr << "Failed to get lsf job id from file: " << stdout_file;
+        std::cerr << "\n";
+        std::cerr << "bsub command                      : " << bsub_cmd;
+        std::cerr << "\n";
+        std::cerr << ifs.rdbuf() << std::endl;
     }
     return jobid;
 }

--- a/src/clib/old_tests/job_queue/test_job_lsf_parse_bsub_stdout.cpp
+++ b/src/clib/old_tests/job_queue/test_job_lsf_parse_bsub_stdout.cpp
@@ -11,7 +11,7 @@ void test_empty_file() {
         FILE *stream = util_fopen(stdout_file, "w");
         fclose(stream);
     }
-    test_assert_int_equal(lsf_job_parse_bsub_stdout("bsub", stdout_file), 0);
+    test_assert_int_equal(lsf_job_parse_bsub_stdout("bsub", stdout_file), -1);
 }
 
 void test_OK() {
@@ -28,23 +28,7 @@ void test_OK() {
 
 void test_file_does_not_exist() {
     test_assert_int_equal(lsf_job_parse_bsub_stdout("bsub", "does/not/exist"),
-                          0);
-}
-
-void parse_invalid(void *arg) {
-    const char *filename = (const char *)arg;
-    lsf_job_parse_bsub_stdout("bsub", filename);
-}
-
-void test_parse_fail_abort() {
-    const char *stdout_file = "bsub_abort";
-    {
-        FILE *stream = util_fopen(stdout_file, "w");
-        fprintf(stream, "Job 12345 is submitted to default queue <normal>.\n");
-        fclose(stream);
-    }
-    test_assert_util_abort("lsf_job_parse_bsub_stdout", parse_invalid,
-                           (void *)stdout_file);
+                          -1);
 }
 
 int main(int argc, char **argv) {
@@ -53,6 +37,5 @@ int main(int argc, char **argv) {
         test_empty_file();
         test_file_does_not_exist();
         test_OK();
-        test_parse_fail_abort();
     }
 }


### PR DESCRIPTION
Fixes an issue where lsf driver submit fail would inconsistently abort instead of signal failure.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
