### PR TITLE
Move C functions to pybind with GIL release

### DIFF
--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -62,8 +62,6 @@ struct job_queue_node_struct {
 typedef bool(job_callback_ftype)(void *);
 typedef struct job_queue_node_struct job_queue_node_type;
 
-extern "C" PY_USED submit_status_type job_queue_node_submit_simple(
-    job_queue_node_type *node, queue_driver_type *driver);
 void job_queue_node_fscanf_EXIT(job_queue_node_type *node);
 void job_queue_node_free_data(job_queue_node_type *node);
 
@@ -73,13 +71,9 @@ job_queue_node_alloc(const char *job_name, const char *run_path,
                      const stringlist_type *arguments, int num_cpu,
                      const char *status_file, const char *exit_file);
 
-extern "C" PY_USED bool job_queue_node_kill_simple(job_queue_node_type *node,
-                                                   queue_driver_type *driver);
 extern "C" void job_queue_node_free(job_queue_node_type *node);
 extern "C" job_status_type
 job_queue_node_get_status(const job_queue_node_type *node);
-extern "C" int
-job_queue_node_get_submit_attempt(const job_queue_node_type *node);
 
 int job_queue_node_get_queue_index(const job_queue_node_type *node);
 void job_queue_node_set_queue_index(job_queue_node_type *node, int queue_index);

--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -43,6 +43,7 @@ struct job_queue_node_struct {
     /** The commandline arguments. */
     char **argv;
     int queue_index = 0;
+    bool confirmed_running = false;
 
     std::optional<std::string> fail_message{};
 

--- a/src/clib/lib/include/ert/job_queue/job_node.hpp
+++ b/src/clib/lib/include/ert/job_queue/job_node.hpp
@@ -77,8 +77,6 @@ extern "C" PY_USED bool job_queue_node_kill_simple(job_queue_node_type *node,
 extern "C" void job_queue_node_free(job_queue_node_type *node);
 extern "C" job_status_type
 job_queue_node_get_status(const job_queue_node_type *node);
-extern "C" PY_USED job_status_type job_queue_node_refresh_status(
-    job_queue_node_type *node, queue_driver_type *driver);
 extern "C" int
 job_queue_node_get_submit_attempt(const job_queue_node_type *node);
 
@@ -87,6 +85,5 @@ void job_queue_node_set_queue_index(job_queue_node_type *node, int queue_index);
 
 extern "C" void job_queue_node_set_status(job_queue_node_type *node,
                                           job_status_type new_status);
-extern "C" const char *
-job_queue_node_get_failure_message(job_queue_node_type *node);
+
 #endif

--- a/src/clib/lib/job_queue/job_node.cpp
+++ b/src/clib/lib/job_queue/job_node.cpp
@@ -196,6 +196,9 @@ void job_queue_node_set_status(job_queue_node_type *node,
     // which are registered in the state JOB_QUEUE_RUNNING.
     if (new_status == JOB_QUEUE_WAITING || new_status == JOB_QUEUE_RUNNING)
         node->sim_start = time(NULL);
+
+    if (!(new_status & JOB_QUEUE_COMPLETE_STATUS))
+        return;
 }
 
 submit_status_type job_queue_node_submit_simple(job_queue_node_type *node,
@@ -258,54 +261,51 @@ bool job_queue_node_kill_simple(job_queue_node_type *node,
     return result;
 }
 
-const char *job_queue_node_get_failure_message(job_queue_node_type *node) {
-    if (node->fail_message.has_value())
-        return node->fail_message->c_str();
-    else
-        return "";
-}
+ERT_CLIB_SUBMODULE("queue", m) {
+    using namespace py::literals;
+    m.def("_refresh_status", [](Cwrap<job_queue_node_type> node,
+                                Cwrap<queue_driver_type> driver) {
+        pthread_mutex_lock(&node->data_mutex);
+        job_status_type current_status = job_queue_node_get_status(node);
 
-job_status_type job_queue_node_refresh_status(job_queue_node_type *node,
-                                              queue_driver_type *driver) {
-    pthread_mutex_lock(&node->data_mutex);
-    job_status_type current_status = job_queue_node_get_status(node);
-
-    if (!node->job_data) {
-        pthread_mutex_unlock(&node->data_mutex);
-        return current_status;
-    }
-
-    std::optional<std::string> msg = std::nullopt;
-
-    if ((current_status & JOB_QUEUE_RUNNING) &&
-        (node->status_file && !(fs::exists(node->status_file)))) {
-        // it's running, but not confirmed running.
-        time_t runtime = time(nullptr) - node->sim_start;
-        if (runtime >= MAX_CONFIRMED_WAIT) {
-            std::string error_msg = fmt::format(
-                "max_confirm_wait ({}) has passed since sim_start"
-                "without success; {} is assumed dead (attempt {})",
-                MAX_CONFIRMED_WAIT, node->job_name, node->submit_attempt);
-            logger->info(error_msg);
-            msg = error_msg;
-            job_status_type new_status = JOB_QUEUE_DO_KILL_NODE_FAILURE;
-            job_queue_node_set_status(node, new_status);
+        if (!node->job_data) {
+            pthread_mutex_unlock(&node->data_mutex);
+            return std::make_pair<int, std::optional<std::string>>(
+                int(current_status), std::nullopt);
         }
-    }
 
-    current_status = job_queue_node_get_status(node);
-    if (current_status & JOB_QUEUE_CAN_UPDATE_STATUS) {
-        job_status_type new_status =
-            queue_driver_get_status(driver, node->job_data);
-        if (new_status == JOB_QUEUE_EXIT)
-            job_queue_node_fscanf_EXIT(node);
-        job_queue_node_set_status(node, new_status);
+        std::optional<std::string> msg = std::nullopt;
+
+        if ((current_status & JOB_QUEUE_RUNNING) &&
+            (node->status_file && !(fs::exists(node->status_file)))) {
+            // it's running, but not confirmed running.
+            time_t runtime = time(nullptr) - node->sim_start;
+            if (runtime >= MAX_CONFIRMED_WAIT) {
+                std::string error_msg = fmt::format(
+                    "max_confirm_wait ({}) has passed since sim_start"
+                    "without success; {} is assumed dead (attempt {})",
+                    MAX_CONFIRMED_WAIT, node->job_name, node->submit_attempt);
+                logger->info(error_msg);
+                msg = error_msg;
+                job_status_type new_status = JOB_QUEUE_DO_KILL_NODE_FAILURE;
+                job_queue_node_set_status(node, new_status);
+            }
+        }
+
         current_status = job_queue_node_get_status(node);
-    }
+        if (current_status & JOB_QUEUE_CAN_UPDATE_STATUS) {
+            job_status_type new_status =
+                queue_driver_get_status(driver, node->job_data);
+            if (new_status == JOB_QUEUE_EXIT)
+                job_queue_node_fscanf_EXIT(node);
+            job_queue_node_set_status(node, new_status);
+            current_status = job_queue_node_get_status(node);
+        }
+        if (node->fail_message.has_value() and !msg.has_value())
+            msg = node->fail_message;
 
-    if (msg.has_value())
-        node->fail_message = std::move(msg);
-
-    pthread_mutex_unlock(&node->data_mutex);
-    return current_status;
+        pthread_mutex_unlock(&node->data_mutex);
+        return std::make_pair<int, std::optional<std::string>>(
+            int(current_status), std::move(msg));
+    });
 }

--- a/src/clib/lib/job_queue/job_node.cpp
+++ b/src/clib/lib/job_queue/job_node.cpp
@@ -265,6 +265,9 @@ ERT_CLIB_SUBMODULE("queue", m) {
     using namespace py::literals;
     m.def("_refresh_status", [](Cwrap<job_queue_node_type> node,
                                 Cwrap<queue_driver_type> driver) {
+        // release the GIL
+        py::gil_scoped_release release;
+
         pthread_mutex_lock(&node->data_mutex);
         job_status_type current_status = job_queue_node_get_status(node);
 

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Callable, Optional
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
-from ert._clib.queue import _refresh_status  # pylint: disable=import-error
+from ert._clib.queue import (  # pylint: disable=import-error
+    _get_submit_attempt,
+    _kill,
+    _refresh_status,
+    _submit,
+)
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
 
@@ -71,19 +76,11 @@ class JobQueueNode(BaseCClass):  # type: ignore
         bind=False,
     )
     _free = ResPrototype("void job_queue_node_free(job_queue_node)")
-    _submit = ResPrototype(
-        "job_submit_status_type_enum job_queue_node_submit_simple(job_queue_node, driver)"  # noqa
-    )
-    _run_kill = ResPrototype("bool job_queue_node_kill_simple(job_queue_node, driver)")
-
     _get_status = ResPrototype(
         "job_status_type_enum job_queue_node_get_status(job_queue_node)"
     )
     _set_queue_status = ResPrototype(
         "void job_queue_node_set_status(job_queue_node, job_status_type_enum)"
-    )
-    _get_submit_attempt = ResPrototype(
-        "int job_queue_node_get_submit_attempt(job_queue_node)"
     )
 
     # pylint: disable=too-many-arguments
@@ -150,7 +147,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
 
     @property
     def submit_attempt(self) -> int:
-        return self._get_submit_attempt()
+        return _get_submit_attempt(self)
 
     def _poll_queue_status(self, driver: "Driver") -> JobStatus:
         result, msg = _refresh_status(self, driver)
@@ -167,7 +164,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return self._set_queue_status(value)
 
     def submit(self, driver: "Driver") -> SubmitStatus:
-        return self._submit(driver)
+        return SubmitStatus(_submit(self, driver))
 
     def run_done_callback(self) -> Optional[LoadStatus]:
         callback_status, status_msg = forward_model_ok(self.run_arg)
@@ -342,7 +339,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         self.thread_status = thread_status
 
     def _kill(self, driver: "Driver") -> None:
-        self._run_kill(driver)
+        _kill(self, driver)
         self._tried_killing += 1
 
     def run(self, driver: "Driver", pool_sema: Semaphore, max_submit: int = 2) -> None:

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 from cwrap import BaseCClass
 from ecl.util.util import StringList
 
+from ert._clib.queue import _refresh_status  # pylint: disable=import-error
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
 
@@ -84,12 +85,6 @@ class JobQueueNode(BaseCClass):  # type: ignore
     _get_submit_attempt = ResPrototype(
         "int job_queue_node_get_submit_attempt(job_queue_node)"
     )
-    _refresh_status = ResPrototype(
-        "job_status_type_enum job_queue_node_refresh_status(job_queue_node, driver)"
-    )
-    _get_failure_message = ResPrototype(
-        "char* job_queue_node_get_failure_message(job_queue_node)"
-    )
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -158,10 +153,10 @@ class JobQueueNode(BaseCClass):  # type: ignore
         return self._get_submit_attempt()
 
     def _poll_queue_status(self, driver: "Driver") -> JobStatus:
-        status = self._refresh_status(driver)
-        msg = self._get_failure_message()
-        self._status_msg = msg if msg else self._status_msg
-        return status
+        result, msg = _refresh_status(self, driver)
+        if msg is not None:
+            self._status_msg = msg
+        return JobStatus(result)
 
     @property
     def queue_status(self) -> JobStatus:


### PR DESCRIPTION
**Issue**
Resolves #6199

**Releasing the GIL with pybind**

```
        // release the GIL
         py::gil_scoped_release release;
```

This seem to work fine, mostly due to this being a relatively simple function, and the data inside it is guarded by the job_node mutex.

**Regarding confirmed_running:**

We determined that the way the refresh function was refactored, it was reading/checking for the same file over-and-over again needlessly. This way we limit the checking from when the state is `JOB_QUEUE_RUNNING` and only until the existence of the file is proven.

```
 if (current_status & JOB_QUEUE_RUNNING && !node->confirmed_running) {
             node->confirmed_running =
                 !node->status_file || fs::exists(node->status_file);
```


**Re-add submit+kill functions that was reverted earlier**

A month ago we reverted some functions that was ported from cwrap to pybind, where the experience was a slowdown/lockdown of the whole application.
Using gil_scoped_release we can re-add these functions again, with the same premises as other code in this PR.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
