### PR TITLE
Rename ert2 to ert in github action jobs

### DIFF
--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -15,7 +15,7 @@ env:
   ERT_SHOW_BACKTRACE: 1
 
 jobs:
-  run-ert2-test-data:
+  run-ert-test-data:
     timeout-minutes: 20
     strategy:
       fail-fast: false


### PR DESCRIPTION
Legacy name, ert2 was only a thing while ert3 was a thing

**Issue**
Resolves disturbing legacy term in github action overview pages.


**Approach**
Rename


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
