### PR TITLE
Refactor collecting job_status_get_count

### DIFF
--- a/src/clib/lib/job_queue/job_queue_status.cpp
+++ b/src/clib/lib/job_queue/job_queue_status.cpp
@@ -13,26 +13,15 @@ void job_queue_status_free(job_queue_status_type *status) { delete status; }
 
 int job_queue_status_get_count(job_queue_status_type *status_count,
                                int job_status_mask) {
-    int count = 0, index = 0, status = 1;
+    int count = 0;
     pthread_rwlock_rdlock(&status_count->rw_lock);
-    {
-        while (true) {
-            if ((status & job_status_mask) == status) {
-                job_status_mask -= status;
-                count += status_count->status_list[index];
-            }
 
-            if (job_status_mask == 0)
-                break;
-
-            index++;
-            status <<= 1;
-            if (index == JOB_QUEUE_MAX_STATE)
-                util_abort("%s: internal error: remaining unrecognized status "
-                           "value:%d \n",
-                           __func__, job_status_mask);
+    for (int i = 0; i < JOB_QUEUE_MAX_STATE; ++i) {
+        if (status_count->status_index[i] & job_status_mask) {
+            count += status_count->status_list[i];
         }
     }
+
     pthread_rwlock_unlock(&status_count->rw_lock);
     return count;
 }

--- a/src/clib/old_tests/job_queue/test_job_status.cpp
+++ b/src/clib/old_tests/job_queue/test_job_status.cpp
@@ -5,20 +5,10 @@
 #include <ert/job_queue/job_queue_status.hpp>
 #include <ert/util/test_util.hpp>
 
-void call_get_status(void *arg) {
-    auto job_status = static_cast<job_queue_status_type *>(arg);
-    job_queue_status_get_count(
-        job_status,
-        pow(2,
-            JOB_QUEUE_MAX_STATE)); // This enum value is completly missing; should give util_abort.
-}
-
 void test_create() {
     job_queue_status_type *status = job_queue_status_alloc();
     test_assert_int_equal(job_queue_status_get_count(status, JOB_QUEUE_DONE),
                           0);
-    test_assert_util_abort("job_queue_status_get_count", call_get_status,
-                           status);
     job_queue_status_free(status);
 }
 
@@ -160,7 +150,6 @@ void test_index() {
 }
 
 int main(int argc, char **argv) {
-    util_install_signals();
     test_create();
     test_index();
     test_update();


### PR DESCRIPTION
Simplify the way tests collect sum of statuses.
That function used to util_abort on unknown status, which makes little sense since it is only used in test code and not production code.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
