### PR TITLE
Use c++ reading of datetimes for performance

### DIFF
--- a/src/clib/lib/enkf/read_summary.cpp
+++ b/src/clib/lib/enkf/read_summary.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <ert/ecl/ecl_smspec.hpp>
 #include <ert/ecl/ecl_sum.hpp>
 #include <ert/python.hpp>
@@ -17,6 +18,16 @@ static bool matches(std::vector<std::string> patterns, std::string key) {
     return has_key;
 }
 ERT_CLIB_SUBMODULE("_read_summary", m) {
+    m.def("read_dates", [](Cwrap<ecl_sum_type> summary) {
+        time_t_vector_type *tvec = ecl_sum_alloc_time_vector(summary, true);
+        int size = time_t_vector_size(tvec);
+        std::vector<std::chrono::system_clock::time_point> result(size);
+        for (int i = 0; i < size; i++) {
+            result[i] = std::chrono::system_clock::from_time_t(
+                time_t_vector_iget(tvec, i));
+        }
+        return result;
+    });
     m.def("read_summary",
           [](Cwrap<ecl_sum_type> summary, std::vector<std::string> keys) {
               const int step2 = ecl_sum_get_last_report_step(summary);

--- a/src/clib/lib/include/ert/python.hpp
+++ b/src/clib/lib/include/ert/python.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Set, Union
 import xarray as xr
 from ecl.summary import EclSum
 
-from ert._clib._read_summary import read_summary  # pylint: disable=import-error
+from ert._clib._read_summary import (  # pylint: disable=import-error
+    read_dates,
+    read_summary,
+)
 
 from .response_config import ResponseConfig
 
@@ -42,9 +45,7 @@ class SummaryConfig(ResponseConfig):
                 "Could not find SUMMARY file or using non unified SUMMARY "
                 f"file from: {run_path}/{filename}.UNSMRY",
             ) from e
-
-        c_time = summary.alloc_time_vector(True)
-        time_map = [t.datetime() for t in c_time]
+        time_map = read_dates(summary)
         if self.refcase:
             assert isinstance(self.refcase, set)
             missing = self.refcase.difference(time_map)


### PR DESCRIPTION
In order to get a baseline for benchmarking we need to speed up datetime conversion which has been identified as a bottleneck.
## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
