### PR TITLE
Update status border color based on job status

### DIFF
--- a/tests/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/unit_tests/gui/simulation/view/test_realization.py
@@ -1,10 +1,20 @@
+import pytest
 from qtpy import QtCore
 from qtpy.QtCore import QModelIndex, QSize
 from qtpy.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 
 from ert.gui.model.node import Node
 from ert.gui.model.snapshot import SnapshotModel
-from ert.gui.simulation.view.realization import RealizationWidget
+from ert.gui.simulation.view.realization import (
+    COLOR_FAILED,
+    COLOR_FINISHED,
+    COLOR_PENDING,
+    COLOR_RUNNING,
+    COLOR_UNKNOWN,
+    COLOR_WAITING,
+    RealizationWidget,
+    determine_realization_status_color,
+)
 
 
 class MockDelegate(QStyledItemDelegate):
@@ -82,3 +92,19 @@ def test_selection_success(large_snapshot, qtbot):
             QtCore.Qt.LeftButton,
             pos=selection_rect.center(),
         )
+
+
+@pytest.mark.parametrize(
+    "colors, result",
+    [
+        ([COLOR_FINISHED, COLOR_PENDING, COLOR_WAITING, COLOR_RUNNING], COLOR_RUNNING),
+        ([COLOR_FINISHED, COLOR_PENDING, COLOR_WAITING, COLOR_FAILED], COLOR_FAILED),
+        ([COLOR_FINISHED, COLOR_UNKNOWN, COLOR_PENDING, COLOR_WAITING], COLOR_PENDING),
+        ([COLOR_FINISHED, COLOR_UNKNOWN, COLOR_WAITING], COLOR_WAITING),
+        ([COLOR_FINISHED, COLOR_FINISHED, COLOR_UNKNOWN], COLOR_FINISHED),
+        ([COLOR_UNKNOWN, COLOR_UNKNOWN], COLOR_UNKNOWN),
+        ([], COLOR_UNKNOWN),
+    ],
+)
+def test_determine_realization_status_color(colors, result):
+    assert determine_realization_status_color(colors) == result


### PR DESCRIPTION
Use inner status colours to determine the overall status drawn outside the realization boxes

Resolves #6191 

Tested on Azure.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
