### PR TITLE
Log warning when get_machine_name uses fallback

### DIFF
--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -45,7 +45,8 @@ def get_machine_name() -> str:
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name
         return socket.getfqdn()
-    except (socket.gaierror, exception.DNSException):
+    except (socket.gaierror, exception.DNSException) as exc:
+        logger.warning(f"Could not obtain hostname due to {exc} of type {type(exc)}.")
         return "localhost"
 
 


### PR DESCRIPTION
This is believed to also occur through flakyness on MacOS. Whenever flakyness reoccurs, the exception might shed some light on the type of flakyness.

**Issue**
Aids to resolve #6194 


**Approach**
logger.warning.



## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
