### PR TITLE
Invert torque driver option for qsub output

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -298,9 +298,10 @@ stringlist_type *torque_driver_alloc_cmd(torque_driver_type *driver,
 
     stringlist_type *argv = stringlist_alloc_new();
 
-    if (driver->keep_qsub_output) {
-        // Retain both standard output and standard error streams on the
-        // execution host:
+    if (!driver->keep_qsub_output) {
+        // API for qsub is unpredictable and args need to be updated when bugs occur
+        // Verify this manually using "qsub" and "qsub -k oe"
+        // Currently -k oe will NOT retain logfiles
         stringlist_append_copy(argv, "-k");
         stringlist_append_copy(argv, "oe");
     }


### PR DESCRIPTION
When testing in Azure, qsub gave these results

| Command        | Result           |
| ------------- |:-------------|
| qsub myjob |  Output and error file |
| qsub -k eo myjob | None |
| qsub -k oe myjob | None |
| qsub -k n myjob | Output and error file |
| qsub -k o myjob | Error file |
| qsub -k e myjob | Output file |

Where the expected result would be the inverse of this Documentation also supports it should have been inverse

**Issue**
Resolves #6189 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
