### PR TITLE
Solve flakyness by mocking test-irrelevant code paths

### DIFF
--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
@@ -1,4 +1,4 @@
-from dns import resolver  # noqa # pylint: disable=unused-import
+from dns import resolver, reversename  # noqa # pylint: disable=unused-import
 
 from ert.ensemble_evaluator.config import EvaluatorServerConfig, get_machine_name
 
@@ -55,6 +55,13 @@ def test_that_get_machine_name_is_predictive(mocker):
     # as an implementation detail.
     expected_resolved_name = ptr_records[0].rstrip(".")
 
+    # Avoid possibility of flakyness in code paths not relevant
+    # for this test:
+    mocker.patch("socket.gethostname", return_value=None)
+    mocker.patch("socket.gethostbyname", return_value=None)
+    mocker.patch("dns.reversename.from_address", return_value=None)
+
+    # This call is what this test wants to test:
     mocker.patch("dns.resolver.resolve", return_value=ptr_records)
 
     # ASSERT the returned name


### PR DESCRIPTION
There is a certain degree of flakyness on MacOS for the get_machine_name() function where it returns localhost. Most probably this is the reversename.from_address() call that is marginally flaky by sometimes throwing an exception.

**Issue**
Resolves #6194 


**Approach**
Mock irrelevant code paths.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
