### PR TITLE
Use WAIT status when jobs PENDING and queue WAIT

### DIFF
--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -166,8 +166,14 @@ def determine_realization_status_color(job_colors) -> QColor:
         COLOR_FINISHED,
         COLOR_WAITING,
         COLOR_PENDING,
-        COLOR_RUNNING,
-        COLOR_FAILED,
     ]
 
-    return max(job_colors, key=states.index, default=COLOR_UNKNOWN)
+    current_index = 0
+
+    for color in job_colors:
+        if color in [COLOR_RUNNING, COLOR_FAILED]:
+            return color
+        elif states.index(color) > current_index:
+            current_index = states.index(color)
+
+    return states[current_index]


### PR DESCRIPTION
**Issue**
Resolves #6248 

Use WAIT status when jobs PENDING and queue WAIT
Replace colors used for inner details
This is a result of the jobs only having one waiting status, while ert/the queue system has two states:
Pending: submitted, not yet running
Waiting: not yet submitted
I.e. in cases where we dont know waiting or pending, we need to chose what the queue system is reporting.

Have failing jobs show running status on resubmit
The current implementation would not allow to show running state when jobs fail and gets resubmitted

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
