### PR TITLE
Speed up summary_config by converting ecl_sum to datetime in C++

### DIFF
--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -8,12 +8,15 @@ from typing import TYPE_CHECKING, Set, Union
 import xarray as xr
 from ecl.summary import EclSum
 
-from ert._clib._read_summary import read_summary  # pylint: disable=import-error
+from ert._clib._read_summary import (  # pylint: disable=import-error
+    read_dates,
+    read_summary,
+)
 
 from .response_config import ResponseConfig
 
 if TYPE_CHECKING:
-    from typing import List, Optional
+    from typing import List
 
 
 logger = logging.getLogger(__name__)
@@ -42,9 +45,7 @@ class SummaryConfig(ResponseConfig):
                 "Could not find SUMMARY file or using non unified SUMMARY "
                 f"file from: {run_path}/{filename}.UNSMRY",
             ) from e
-
-        c_time = summary.alloc_time_vector(True)
-        time_map = [t.datetime() for t in c_time]
+        time_map = read_dates(summary)
         if self.refcase:
             assert isinstance(self.refcase, set)
             missing = self.refcase.difference(time_map)


### PR DESCRIPTION
based on #6217. 
updated to use manual conversion to python datetime instead of pybind11 doing it automatically.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
