### PR TITLE
Pin PyTables to below 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ dependencies=[
     "xarray",
     "xtgeo >= 3.3.0",
     "netCDF4",
-    "sortedcontainers"
+    "sortedcontainers",
+    "tables < 3.9"
 ]
 
 [project.scripts]


### PR DESCRIPTION
ERT does not directly depend on this, but xtgeo does. PyTables 3.9 requires Python 3.9 but ERT still needs to support Python 3.8.
This pin can be removed once ERT stop supporting Python 3.8.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
