### PR TITLE
Avoid qstat proxy in mocked test

### DIFF
--- a/tests/unit_tests/job_queue/test_job_queue_node.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node.py
@@ -189,6 +189,9 @@ def status_output(draw, driver_name: str, jobid: int, status: JobStatus) -> str:
 @pytest.mark.usefixtures("use_tmpdir")
 @given(job_queue_nodes, drivers, st.integers(min_value=1, max_value=2**30), st.data())
 def test_submitting_updates_status(tmp_path, job_queue_node, driver, jobid, data):
+    if driver.name == "TORQUE":
+        # Ensure qstat proxy is avoided:
+        driver.set_option("QSTAT_CMD", "qstat")
     reset_command_queue(tmp_path)
     next_command_output("submit", submit_success_output(driver.name, jobid))
     next_command_output("job_script", "")


### PR DESCRIPTION
Solves flaky test behaviour

**Issue**
Resolves #6265 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
