### PR TITLE
Use larger port default portrange on localhost

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -17,7 +17,7 @@ from ert.cli import (
 from ert.cli.model_factory import create_model
 from ert.cli.monitor import Monitor
 from ert.cli.workflow import execute_workflow
-from ert.config import ErtConfig
+from ert.config import ErtConfig, QueueSystem
 from ert.enkf_main import EnKFMain
 from ert.ensemble_evaluator import EvaluatorServerConfig, EvaluatorTracker
 from ert.libres_facade import LibresFacade
@@ -78,7 +78,6 @@ def run_cli(args: Namespace, _: Any = None) -> None:
         execute_workflow(ert, storage, args.name)
         return
 
-    evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)
     experiment = storage.create_experiment(
         parameters=ert.ensembleConfig().parameter_configuration,
         responses=ert.ensembleConfig().response_configuration,
@@ -93,6 +92,11 @@ def run_cli(args: Namespace, _: Any = None) -> None:
         )
     except ValueError as e:
         raise ErtCliError(e) from e
+
+    if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
+        args.port_range = range(49152, 51819)
+
+    evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)
 
     experiment.write_simulation_arguments(model.simulation_arguments)
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from ert.config import QueueSystem
 from ert.ensemble_evaluator import (
     EndEvent,
     EvaluatorServerConfig,
@@ -250,7 +251,10 @@ class RunDialog(QDialog):
         self._snapshot_model.reset()
         self._tab_widget.clear()
 
-        evaluator_server_config = EvaluatorServerConfig()
+        port_range = None
+        if self._run_model.queue_system == QueueSystem.LOCAL:
+            port_range = range(49152, 51819)
+        evaluator_server_config = EvaluatorServerConfig(custom_port_range=port_range)
 
         simulation_thread = Thread(
             name="ert_gui_simulation_thread",

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from ert.cli import MODULE_MODE
-from ert.config import HookRuntime
+from ert.config import HookRuntime, QueueSystem
 from ert.enkf_main import EnKFMain
 from ert.ensemble_evaluator import (
     Ensemble,
@@ -105,6 +105,10 @@ class BaseRunModel:
         self._iter_map: Dict[int, str] = {}
         self.validate()
         self._context_env_keys: List[str] = []
+
+    @property
+    def queue_system(self) -> QueueSystem:
+        return self._queue_config.queue_system
 
     @property
     def simulation_arguments(self) -> Dict[str, Any]:

--- a/tests/performance_tests/conftest.py
+++ b/tests/performance_tests/conftest.py
@@ -84,8 +84,6 @@ def template_config(request, source_root, tmp_path_factory):
                 [
                     ENSEMBLE_EXPERIMENT_MODE,
                     "poly.ert",
-                    "--port-range",
-                    "1024-65535",
                 ],
             )
             run_cli(parsed)

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -165,8 +165,6 @@ def test_that_posterior_has_lower_variance_than_prior(copy_case):
             "--realizations",
             "1-50",
             "poly.ert",
-            "--port-range",
-            "1024-65535",
         ],
     )
 
@@ -414,8 +412,6 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert(copy_case
         [
             ENSEMBLE_SMOOTHER_MODE,
             "snake_oil_surface.ert",
-            "--port-range",
-            "1024-65535",
             "--target-case",
             "es_udpate",
         ],
@@ -464,8 +460,6 @@ def test_update_multiple_param(copy_case):
             "snake_oil.ert",
             "--target-case",
             "posterior",
-            "--port-range",
-            "1024-65535",
         ],
     )
 

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -69,8 +69,6 @@ def test_runpath_file(tmpdir, source_root):
                 "--realizations",
                 "1,2,4,8,16,32,64",
                 "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
 
@@ -98,8 +96,6 @@ def test_ensemble_evaluator(tmpdir, source_root):
                 "--realizations",
                 "1,2,4,8,16,32,64",
                 "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
         FeatureToggling.update_from_args(parsed)
@@ -131,8 +127,6 @@ def test_es_mda(tmpdir, source_root, snapshot):
                 "--realizations",
                 "1,2,4,8,16",
                 "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
         FeatureToggling.update_from_args(parsed)
@@ -222,8 +216,6 @@ def test_ensemble_evaluator_disable_monitoring(tmpdir, source_root):
                 "--realizations",
                 "1,2,4,8,16,32,64",
                 "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
         FeatureToggling.update_from_args(parsed)
@@ -241,15 +233,7 @@ def test_cli_test_run(tmpdir, source_root, mock_cli_run):
 
     with tmpdir.as_cwd():
         parser = ArgumentParser(prog="test_main")
-        parsed = ert_parser(
-            parser,
-            [
-                TEST_RUN_MODE,
-                "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
-            ],
-        )
+        parsed = ert_parser(parser, [TEST_RUN_MODE, "poly_example/poly.ert"])
         run_cli(parsed)
 
     monitor_mock, thread_join_mock, thread_start_mock = mock_cli_run
@@ -276,8 +260,6 @@ def test_ies(tmpdir, source_root):
                 "--realizations",
                 "1,2,4,8,16",
                 "poly_example/poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
         FeatureToggling.update_from_args(parsed)
@@ -444,8 +426,6 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
                 ENSEMBLE_EXPERIMENT_MODE,
                 "poly_example/poly.ert",
                 "--current-case=iter-0",
-                "--port-range",
-                "1024-65535",
                 "--realizations",
                 reals_rerun_option,
             ],
@@ -488,13 +468,7 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
     args.config = "poly-no-gen-kw.ert"
     parser = ArgumentParser(prog="test_main")
 
-    ert_args = [
-        mode,
-        "poly-no-gen-kw.ert",
-        "--port-range",
-        "1024-65535",
-        "--target-case",
-    ]
+    ert_args = [mode, "poly-no-gen-kw.ert", "--target-case"]
 
     testcase = "testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d"
     ert_args.append(testcase)
@@ -517,16 +491,7 @@ def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
     args.config = "poly.ert"
     parser = ArgumentParser(prog="test_main")
 
-    ert_args = [
-        "es_mda",
-        "poly.ert",
-        "--port-range",
-        "1024-65535",
-        "--target-case",
-        "testcase-%d",
-        "--weights",
-        "0",
-    ]
+    ert_args = ["es_mda", "poly.ert", "--target-case", "testcase-%d", "--weights", "0"]
 
     parsed = ert_parser(
         parser,
@@ -671,8 +636,6 @@ def test_that_the_model_raises_exception_if_active_less_than_minimum_realization
     ert_args = [
         mode,
         "poly_high_min_reals.ert",
-        "--port-range",
-        "1024-65535",
         "--realizations",
         "0-19",
         "--target-case",
@@ -714,8 +677,6 @@ def test_that_the_model_warns_when_active_realizations_less_min_realizations():
     ert_args = [
         "ensemble_experiment",
         "poly_lower_active_reals.ert",
-        "--port-range",
-        "1024-65535",
         "--realizations",
         "0-4",
     ]
@@ -746,12 +707,7 @@ def test_failing_job_cli_error_message():
     parser = ArgumentParser(prog="test_main")
     parsed = ert_parser(
         parser,
-        [
-            TEST_RUN_MODE,
-            "poly.ert",
-            "--port-range",
-            "1024-65535",
-        ],
+        [TEST_RUN_MODE, "poly.ert"],
     )
     expected_substrings = [
         "Realization: 0 failed after reaching max submit (2)",
@@ -833,8 +789,6 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
         [
             TEST_RUN_MODE,
             str(setenv_config),
-            "--port-range",
-            "1024-65535",
         ],
     )
 

--- a/tests/unit_tests/dark_storage/conftest.py
+++ b/tests/unit_tests/dark_storage/conftest.py
@@ -38,8 +38,6 @@ def poly_example_tmp_dir_shared(
                 "--realizations",
                 "1,2,4",
                 "poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
         run_cli(parsed)

--- a/tests/unit_tests/job_queue/test_lsf_driver.py
+++ b/tests/unit_tests/job_queue/test_lsf_driver.py
@@ -185,8 +185,6 @@ def test_run_mocked_lsf_queue():
             [
                 ENSEMBLE_EXPERIMENT_MODE,
                 "poly.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
     )

--- a/tests/unit_tests/storage/test_field_parameter.py
+++ b/tests/unit_tests/storage/test_field_parameter.py
@@ -532,8 +532,6 @@ if __name__ == "__main__":
                 "--target-case",
                 "smoother_update",
                 "config.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
 
@@ -661,8 +659,6 @@ if __name__ == "__main__":
                 "--target-case",
                 "smoother_update",
                 "config.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
 

--- a/tests/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/unit_tests/storage/test_parameter_sample_types.py
@@ -732,8 +732,6 @@ if __name__ == "__main__":
                 "--target-case",
                 "smoother_update",
                 "config.ert",
-                "--port-range",
-                "1024-65535",
             ],
         )
 
@@ -888,8 +886,6 @@ def run_poly():
             "--target-case",
             "smoother_update",
             "config.ert",
-            "--port-range",
-            "1024-65535",
         ],
     )
 


### PR DESCRIPTION
The chosen port range is so that it excludes ports used for outbound connections by default and is
within the ephemeral ports as suggested by RFC 6335.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
