### PR TITLE
Require tables for all Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ dependencies=[
     "xtgeo >= 3.3.0",
     "netCDF4",
     "sortedcontainers",
-    "tables<3.9;python_version == '3.8'"
+    "tables<3.9;python_version == '3.8'",
+    "tables; python_version >= '3.9'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The export_misfit_data workflow depends on tables
which means that ERT depends on it.
We've previously gotten this dependency via xtgeo, but the latest release of xtgeo does not install tables for macOS.


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
