### PR TITLE
Test ert slurm driver with ad-hoc cluster

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y valgrind
-    
+
     - uses: actions/cache@v3
       with:
         path: ~/.conan/
@@ -117,6 +117,18 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       test-type: ${{ matrix.test-type }}
+
+  test-slurm:
+    needs: [build-linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+    uses: ./.github/workflows/test_ert_with_slurm.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
 
   test-mac:
     needs: [build-mac]

--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -1,0 +1,76 @@
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+      python-version:
+        type: string
+jobs:
+  test-poly-on-slurm:
+    name: Run ert tests
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      id: setup_python
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: "pip"
+        cache-dependency-path: |
+          setup.py
+          pyproject.toml
+
+    - name: Get wheels
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
+
+    - name: Install wheel
+      run: |
+        find . -name "*.whl" -exec pip install "{}[dev]" \;
+
+    - name: Install and setup slurm
+      run: |
+        set -e
+
+        sudo apt install slurmd slurmctld -y
+
+        cat <<EOF > slurm.conf
+        ClusterName=localcluster
+        SlurmctldHost=localhost
+        SelectType=select/cons_res  # Select nodes based on consumable resources
+        SelectTypeParameters=CR_Core  # Cores are the consumable resource
+        ProctrackType=proctrack/linuxproc  # Use /proc to track processes
+        PartitionName=LocalQ Nodes=ALL Default=YES MaxTime=INFINITE State=UP
+        EOF
+
+        # Self-configure the node:
+        slurmd -C | grep NodeName >> slurm.conf
+
+        cat slurm.conf
+
+        sudo mv slurm.conf /etc/slurm/
+        sudo systemctl start slurmd  # The compute node slurm daemon
+        sudo systemctl start slurmctld  # The slurm controller daemon
+
+        # Show partition and node information configured:
+        sinfo
+
+    - name: Verify slurm cluster works
+      # Timeout is set low to catch a misconfigured cluster where srun will hang.
+      timeout-minutes: 1
+      run: |
+        srun env | grep SLURM
+        # Several SLURM_* env variables are defined only when run through slurm
+
+
+    - name: Test poly-example on slurm
+      run: |
+        set -e
+
+        cd test-data/poly_example
+        echo "QUEUE_SYSTEM SLURM" >> poly.ert
+        time ert ensemble_experiment poly.ert


### PR DESCRIPTION
**Issue**
Resolves #6296

**Approach**
Install the Slurm software on the github action runner, declare the action runner host as a compute node, and run poly example. 

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
