### PR TITLE
Raise error when parameters csv file contains strings instead of numbers

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -310,8 +310,13 @@ class GenKwConfig(ParameterConfig):
             # We need to sort the user input keys by the
             # internal order of sub-parameters:
             df = df.set_index(df.columns[0])
-            return df.reindex(keys).values.flatten()
-        return df.values.flatten()
+            return df.reindex(keys).values.flatten()  # type: ignore
+
+        if not np.issubdtype(df.dtype, np.number):
+            raise ValueError(
+                f"Entries in the {file_name} need to be numbers not strings!"
+            )
+        return df.values.flatten()  # type: ignore
 
     @staticmethod
     def _sample_value(


### PR DESCRIPTION
**Issue**
Resolves #6293 


**Approach**
We just raise if the values are read as strings and not numbers

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
