### PR TITLE
Add validation of gen kw from runpath

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -311,6 +311,10 @@ class GenKwConfig(ParameterConfig):
             # internal order of sub-parameters:
             df = df.set_index(df.columns[0])
             return df.reindex(keys).values.flatten()
+        if not np.issubdtype(df.values.dtype, np.number):
+            raise ValueError(
+                f"The file {file_name} did not contain numbers, got {df.values.dtype}"
+            )
         return df.values.flatten()
 
     @staticmethod

--- a/tests/unit_tests/config/test_gen_kw_config.py
+++ b/tests/unit_tests/config/test_gen_kw_config.py
@@ -542,3 +542,20 @@ def test_gen_kw_config_validation():
                 ],
             }
         )
+
+
+def test_incorrect_values_in_forward_init_file_fails(tmp_path):
+    (tmp_path / "forward_init_1").write_text("incorrect", encoding="utf-8")
+    with pytest.raises(
+        ValueError,
+        match=f"{tmp_path / 'forward_init_1'} did not contain numbers, got object",
+    ):
+        GenKwConfig(
+            "GEN_KW",
+            True,
+            None,
+            None,
+            [],
+            str(tmp_path / "forward_init_%d"),
+            None,
+        ).read_from_runpath(tmp_path, 1)


### PR DESCRIPTION
Issue
Resolves https://github.com/equinor/ert/issues/6293

Gives a reasonable error message when forward_init_file does not contain numbers as expected.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
