### PR TITLE
Add types to waitCursor decorator

### DIFF
--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 import pkgutil
 from os.path import dirname
-from typing import cast, TYPE_CHECKING
+from typing import cast, Callable, TypeVar, Any, TYPE_CHECKING
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QCursor, QIcon, QMovie, QPixmap
@@ -16,7 +16,10 @@ def _get_ert_gui_dir():
     return dirname(ert_gui_loader.get_filename())
 
 
-def showWaitCursorWhileWaiting(func):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def showWaitCursorWhileWaiting(func: F) -> F:
     """A function decorator to show the wait cursor while the function is working."""
 
     def wrapper(*arg):
@@ -27,7 +30,7 @@ def showWaitCursorWhileWaiting(func):
         finally:
             QApplication.restoreOverrideCursor()
 
-    return wrapper
+    return cast(wrapper, F)
 
 
 def resourceIcon(name):


### PR DESCRIPTION
**Issue**

**Approach**
This adds typing to the `showWaitCursorWhileWaiting` decorator.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] ~~Updated documentation~~
- [ ] ~~Ensured that unit tests are added for all new behavior (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)), and changes to existing code have good test coverage.~~

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
