### PR TITLE
Move call to .fit outisde of param loop

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -423,16 +423,16 @@ def analysis_ES(
         noise = rng.standard_normal(size=(len(observation_values), S.shape[1]))
 
         smoother = ies.ES()
+        smoother.fit(
+            S,
+            observation_errors,
+            observation_values,
+            noise=noise,
+            truncation=module.get_truncation(),
+            inversion=ies.InversionType(module.inversion),
+            param_ensemble=param_ensemble,
+        )
         for parameter in update_step.parameters:
-            smoother.fit(
-                S,
-                observation_errors,
-                observation_values,
-                noise=noise,
-                truncation=module.get_truncation(),
-                inversion=ies.InversionType(module.inversion),
-                param_ensemble=param_ensemble,
-            )
             if active_indices := parameter.index_list:
                 temp_storage[parameter.name][active_indices, :] = smoother.update(
                     temp_storage[parameter.name][active_indices, :]
@@ -519,17 +519,17 @@ def analysis_IES(
             )
 
         noise = rng.standard_normal(size=(len(observation_values), S.shape[1]))
+        iterative_ensemble_smoother.fit(
+            S,
+            observation_errors,
+            observation_values,
+            noise=noise,
+            ensemble_mask=ens_mask,
+            inversion=ies.InversionType(module.inversion),
+            truncation=module.get_truncation(),
+            param_ensemble=param_ensemble,
+        )
         for parameter in update_step.parameters:
-            iterative_ensemble_smoother.fit(
-                S,
-                observation_errors,
-                observation_values,
-                noise=noise,
-                ensemble_mask=ens_mask,
-                inversion=ies.InversionType(module.inversion),
-                truncation=module.get_truncation(),
-                param_ensemble=param_ensemble,
-            )
             if active_indices := parameter.index_list:
                 temp_storage[parameter.name][
                     active_indices, :


### PR DESCRIPTION
Removes redundant calls to .fit.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
