### PR TITLE
Fix issue where ert would not work if you are using vpn

### DIFF
--- a/src/ert/shared/port_handler.py
+++ b/src/ert/shared/port_handler.py
@@ -126,17 +126,4 @@ def get_family(host: str) -> socket.AddressFamily:
 
 # See https://stackoverflow.com/a/28950776
 def _get_ip_address() -> str:
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.settimeout(0)
-        # try pinging a reserved, internal address in order
-        # to determine IP representing the default route
-        s.connect(("10.255.255.255", 1))
-        retval = s.getsockname()[0]
-    except BaseException:  # pylint: disable=broad-except
-        logger.warning("Cannot determine ip-address. Fallback to localhost...")
-        retval = "127.0.0.1"
-    finally:
-        s.close()
-    logger.debug(f"ip-address: {retval}")
-    return retval
+    return socket.gethostbyname(socket.gethostname())


### PR DESCRIPTION
The previous method used to get the ip address of localhost fails on e.g. vpn. Changed to using a standard library method.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
