### PR TITLE
Only set realization color to running when jobs running

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -409,19 +409,16 @@ class SnapshotModel(QAbstractItemModel):
 
             is_running = False
 
-            for step_id in node.parent.data[SORTED_JOB_IDS][node.id]:
-                for job_id in node.parent.data[SORTED_JOB_IDS][node.id][step_id]:
-                    if node.data[REAL_JOB_STATUS_AGGREGATED][job_id] == COLOR_RUNNING:
-                        is_running = True
+            if COLOR_RUNNING in node.data[REAL_JOB_STATUS_AGGREGATED].values():
+                is_running = True
 
             for step_id in node.parent.data[SORTED_JOB_IDS][node.id]:
                 for job_id in node.parent.data[SORTED_JOB_IDS][node.id][step_id]:
                     # if queue system status is WAIT, jobs should indicate WAIT
                     if (
-                        not is_running
-                        and node.data[REAL_JOB_STATUS_AGGREGATED][job_id]
-                        == COLOR_PENDING
+                        node.data[REAL_JOB_STATUS_AGGREGATED][job_id] == COLOR_PENDING
                         and node.data[REAL_STATUS_COLOR] == COLOR_WAITING
+                        and not is_running
                     ):
                         colors.append(COLOR_WAITING)
                     else:

--- a/tests/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/unit_tests/gui/simulation/view/test_realization.py
@@ -1,20 +1,10 @@
-import pytest
 from qtpy import QtCore
 from qtpy.QtCore import QModelIndex, QSize
 from qtpy.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 
 from ert.gui.model.node import Node
 from ert.gui.model.snapshot import SnapshotModel
-from ert.gui.simulation.view.realization import (
-    COLOR_FAILED,
-    COLOR_FINISHED,
-    COLOR_PENDING,
-    COLOR_RUNNING,
-    COLOR_UNKNOWN,
-    COLOR_WAITING,
-    RealizationWidget,
-    determine_realization_status_color,
-)
+from ert.gui.simulation.view.realization import RealizationWidget
 
 
 class MockDelegate(QStyledItemDelegate):
@@ -92,19 +82,3 @@ def test_selection_success(large_snapshot, qtbot):
             QtCore.Qt.LeftButton,
             pos=selection_rect.center(),
         )
-
-
-@pytest.mark.parametrize(
-    "colors, result",
-    [
-        ([COLOR_FINISHED, COLOR_PENDING, COLOR_WAITING, COLOR_RUNNING], COLOR_RUNNING),
-        ([COLOR_FINISHED, COLOR_PENDING, COLOR_WAITING, COLOR_FAILED], COLOR_FAILED),
-        ([COLOR_FINISHED, COLOR_UNKNOWN, COLOR_PENDING, COLOR_WAITING], COLOR_PENDING),
-        ([COLOR_FINISHED, COLOR_UNKNOWN, COLOR_WAITING], COLOR_WAITING),
-        ([COLOR_FINISHED, COLOR_FINISHED, COLOR_UNKNOWN], COLOR_FINISHED),
-        ([COLOR_UNKNOWN, COLOR_UNKNOWN], COLOR_UNKNOWN),
-        ([], COLOR_UNKNOWN),
-    ],
-)
-def test_determine_realization_status_color(colors, result):
-    assert determine_realization_status_color(colors) == result


### PR DESCRIPTION
**Issue**
Resolves #6319 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
