### PR TITLE
Revert "Use start_simulations_thread in gui as in cli"

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -256,11 +256,13 @@ class RunDialog(QDialog):
             port_range = range(49152, 51819)
         evaluator_server_config = EvaluatorServerConfig(custom_port_range=port_range)
 
+        def run():
+            self._run_model.startSimulations(
+                evaluator_server_config=evaluator_server_config,
+            )
+
         simulation_thread = Thread(
-            name="ert_gui_simulation_thread",
-            target=self._run_model.start_simulations_thread,
-            args=(evaluator_server_config,),
-            daemon=True,
+            name="ert_gui_simulation_thread", target=run, daemon=True
         )
         simulation_thread.start()
 


### PR DESCRIPTION
This reverts commit b18021370ccc8a0fc4bc2d03481c3603385df21d.

**Issue**
Resolves #6311 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
