### PR TITLE
Remove usage of stringlist in lsf exclude hosts

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -772,14 +772,17 @@ static void lsf_driver_set_remote_server(lsf_driver_type *driver,
 
 void lsf_driver_add_exclude_hosts(lsf_driver_type *driver,
                                   const char *excluded) {
-    stringlist_type *host_list = stringlist_alloc_from_split(excluded, ", ");
-    for (int i = 0; i < stringlist_get_size(host_list); i++) {
-        const char *excluded = stringlist_iget(host_list, i);
-        const auto &iter =
-            std::find(driver->exclude_hosts.begin(),
-                      driver->exclude_hosts.end(), std::string(excluded));
+    auto excluded_list = std::string(excluded);
+    std::size_t offset = excluded_list.find_first_not_of(", ");
+    while (offset != std::string::npos) {
+        auto item_end = excluded_list.find_first_of(", ", offset);
+        auto item = excluded_list.substr(offset, item_end - offset);
+        const auto &iter = std::find(driver->exclude_hosts.begin(),
+                                     driver->exclude_hosts.end(), item);
         if (iter == driver->exclude_hosts.end())
-            driver->exclude_hosts.push_back(excluded);
+            driver->exclude_hosts.push_back(item);
+
+        offset = excluded_list.find_first_not_of(", ", item_end);
     }
 }
 


### PR DESCRIPTION
Removes usage of string_list.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
