### PR TITLE
Fix MockTracker track bug

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -299,6 +299,8 @@ class RunDialog(QDialog):
             # Normally this slot would be invoked by the signal/slot system,
             # but the worker is busy tracking the evaluation.
             self._tracker.request_termination()
+            self._worker_thread.quit()
+            self._worker_thread.wait()
             self._on_finished()
             self.reject()
         return kill_job

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -349,17 +349,20 @@ def runmodel(active_realizations) -> Mock:
 class MockTracker:
     def __init__(self, events) -> None:
         self._events = events
+        self._is_running = True
 
     def track(self):
         for event in self._events:
-            yield event
+            if not self._is_running:
+                break
             time.sleep(0.1)
+            yield event
 
     def reset(self):
         pass
 
     def request_termination(self):
-        pass
+        self._is_running = False
 
 
 @pytest.fixture

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -119,6 +119,9 @@ def test_large_snapshot(
         qtbot.waitUntil(
             lambda: widget._tab_widget.count() == 2, timeout=timeout_per_iter
         )
+        qtbot.waitUntil(
+            lambda: widget.done_button.isVisible(), timeout=timeout_per_iter
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #6348

There was a bug discovered in unittest/gui/simulation/test_run_dialog.py::test_large_snapshot, where the mock tracker would yield the EndEvent, then sleep. This incorrect order caused the run_dialog to get the end event and close the dialog window while the QThread was still running time.sleep(), resulting in the "Thread: Destroyed while thread is still running" error. The test itself was also flaky, as it would assume the experiment was finished when it saw the boxes being drawn; not waiting for the done-button to show.