### PR TITLE
Remove canceling of grouped github actions

### DIFF
--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -2,10 +2,6 @@ name: Annotate Cpp
 
 on: [pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   annotate-cpp:
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,11 +8,6 @@ on:
    tags: "*"
  pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # We don't cancel on protected branches which codecov uses as a base
-  cancel-in-progress: ${{ ! github.ref_protected }}
-
 env:
   ERT_SHOW_BACKTRACE: 1
   ECL_SKIP_SIGNAL: 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,11 +8,6 @@ on:
    tags: "*"
  pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # We don't cancel on protected branches which codecov uses as a base
-  cancel-in-progress: ${{ ! github.ref_protected }}
-
 jobs:
   python-test-coverage:
     name: Python Coverage

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -8,10 +8,6 @@ on:
    tags: "*"
  pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   python-doctest:
     name: 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,10 +7,6 @@ on:
      - 'version-**'
  pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check-style:
     timeout-minutes: 15

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -7,10 +7,6 @@ name: Test Semeio
 
 on: [pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test-semeio:
     name: Test Semeio

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -7,10 +7,6 @@ on:
      - 'version-**'
  pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   type-checking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Seems to be causing problems at the moment and is just avoiding overspending resources in an niche case.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
