### PR TITLE
Remove Protocol Buffers snippet from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,13 +243,6 @@ make -j$(nproc)
 ctest --output-on-failure
 ```
 
-### Compiling protocol buffers
-
-Use the following command to (re)compile protocol buffers manually:
-```shell
-python setup.py compile_protocol_buffers
-```
-
 ## Example usage
 
 ### Basic ERT test


### PR DESCRIPTION
Seems like there was some residue in the readme-file regarding protocol buffers.
Support for protocol buffers was removed in commit 664fce778

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
