### PR TITLE
Remove usage of util_calloc

### DIFF
--- a/src/clib/lib/include/ert/abort.hpp
+++ b/src/clib/lib/include/ert/abort.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#define CHECK_ALLOC(a)                                                         \
+    if (!(a)) {                                                                \
+        std::perror("Failed to allocate memory!\n");                           \
+        abort();                                                               \
+    }

--- a/src/clib/lib/include/ert/job_queue/string_utils.hpp
+++ b/src/clib/lib/include/ert/job_queue/string_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <ert/abort.hpp>
 #include <string>
 
 /// strdup with realloc
@@ -9,6 +10,7 @@ static char *restrdup(char *old_string, const char *src) {
     if (src != nullptr) {
         size_t len = strlen(src) + 1;
         auto copy = (char *)realloc(old_string, len);
+        CHECK_ALLOC(copy);
         strncpy(copy, src, len);
         return copy;
     } else {

--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <vector>
 
+#include <ert/abort.hpp>
 #include <ert/except.hpp>
 #include <ert/job_queue/lsf_driver.hpp>
 #include <ert/job_queue/lsf_job_stat.hpp>
@@ -307,6 +308,7 @@ static char **lsf_driver_alloc_cmd(lsf_driver_type *driver,
 
     char **argv =
         static_cast<char **>(calloc(LSF_ARGV_SIZE + 1, sizeof(char *)));
+    CHECK_ALLOC(argv);
     int i = 0;
 
     char *quoted_resource_request = alloc_quoted_resource_string(driver);
@@ -397,14 +399,16 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
     char *tmp_file = (char *)util_alloc_tmp_file("/tmp", "enkf-bjobs", true);
 
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
-        char **argv = (char **)util_calloc(2, sizeof *argv);
+        char **argv = (char **)calloc(2, sizeof *argv);
+        CHECK_ALLOC(argv);
         argv[0] = driver->remote_lsf_server;
         argv[1] = util_alloc_sprintf("%s -a", driver->bjobs_cmd);
         spawn_blocking(driver->rsh_cmd, 2, (const char **)argv, tmp_file, NULL);
         free(argv[1]);
         free(argv);
     } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
-        const char **argv = (const char **)util_calloc(1, sizeof *argv);
+        const char **argv = (const char **)calloc(1, sizeof *argv);
+        CHECK_ALLOC(argv);
         argv[0] = "-a";
         spawn_blocking(driver->bjobs_cmd, 1, (const char **)argv, tmp_file,
                        NULL);
@@ -455,7 +459,8 @@ static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
     char *output_file = (char *)util_alloc_tmp_file("/tmp", "bhist", true);
 
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
-        char **argv = (char **)util_calloc(2, sizeof *argv);
+        char **argv = (char **)calloc(2, sizeof *argv);
+        CHECK_ALLOC(argv);
         argv[0] = driver->remote_lsf_server;
         argv[1] =
             util_alloc_sprintf("%s %s", driver->bhist_cmd, job->lsf_jobnr_char);
@@ -464,7 +469,8 @@ static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
         free(argv[1]);
         free(argv);
     } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
-        char **argv = (char **)util_calloc(1, sizeof *argv);
+        char **argv = (char **)calloc(1, sizeof *argv);
+        CHECK_ALLOC(argv);
         argv[0] = job->lsf_jobnr_char;
         spawn_blocking(driver->bjobs_cmd, 2, (const char **)argv, output_file,
                        NULL);
@@ -650,7 +656,8 @@ void lsf_driver_kill_job(void *__driver, void *__job) {
     auto driver = static_cast<lsf_driver_type *>(__driver);
     auto job = static_cast<lsf_job_type *>(__job);
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
-        char **argv = (char **)util_calloc(2, sizeof *argv);
+        char **argv = (char **)calloc(2, sizeof *argv);
+        CHECK_ALLOC(argv);
         argv[0] = driver->remote_lsf_server;
         argv[1] =
             util_alloc_sprintf("%s %s", driver->bkill_cmd, job->lsf_jobnr_char);

--- a/src/clib/lib/job_queue/slurm_driver.cpp
+++ b/src/clib/lib/job_queue/slurm_driver.cpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <ert/abort.hpp>
 #include <ert/job_queue/slurm_driver.hpp>
 #include <ert/job_queue/spawn.hpp>
 #include <ert/logging.hpp>
@@ -145,7 +146,8 @@ static std::string load_stdout(const char *cmd, int argc, const char **argv) {
 static std::string load_stdout(const char *cmd,
                                const std::vector<std::string> &args) {
     const char **argv =
-        static_cast<const char **>(util_calloc(args.size(), sizeof *argv));
+        static_cast<const char **>(calloc(args.size(), sizeof *argv));
+    CHECK_ALLOC(argv);
     for (std::size_t i = 0; i < args.size(); i++)
         argv[i] = args[i].c_str();
 
@@ -506,8 +508,8 @@ job_status_type slurm_driver_get_job_status(void *__driver, void *__job) {
 void slurm_driver_kill_job(void *__driver, void *__job) {
     auto driver = static_cast<slurm_driver_type *>(__driver);
     const auto *job = static_cast<const SlurmJob *>(__job);
-    const char **argv =
-        static_cast<const char **>(util_calloc(1, sizeof *argv));
+    const char **argv = static_cast<const char **>(calloc(1, sizeof *argv));
+    CHECK_ALLOC(argv);
 
     argv[0] = job->string_id.c_str();
     spawn_blocking(driver->scancel_cmd.c_str(), 1, argv, nullptr, nullptr);

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unistd.h>
 
+#include <ert/abort.hpp>
 #include <ert/job_queue/spawn.hpp>
 #include <ert/job_queue/string_utils.hpp>
 #include <ert/job_queue/torque_driver.hpp>
@@ -280,6 +281,7 @@ static char **torque_driver_alloc_cmd(torque_driver_type *driver,
 
     char **argv =
         static_cast<char **>(calloc(TORQUE_ARGV_SIZE + 1, sizeof(char *)));
+    CHECK_ALLOC(argv);
     int i = 0;
 
     argv[i++] = strdup(driver->qsub_cmd);

--- a/src/clib/old_tests/job_queue/test_job_status.cpp
+++ b/src/clib/old_tests/job_queue/test_job_status.cpp
@@ -2,6 +2,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 
+#include <ert/abort.hpp>
 #include <ert/job_queue/job_queue_status.hpp>
 #include <ert/util/test_util.hpp>
 
@@ -34,6 +35,7 @@ void *user_done(void *arg) {
 void test_update() {
     int N = 15000;
     pthread_t *thread_list = (pthread_t *)calloc(2 * N, sizeof *thread_list);
+    CHECK_ALLOC(thread_list);
 
     int num_exit_threads = 0, num_done_threads = 0;
     job_queue_status_type *status = job_queue_status_alloc();


### PR DESCRIPTION
This means introducing an abort statement as that is the only reasonable way to avoid undefined behavior if these small allocations fail.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
