### PR TITLE
Revert "Avoid unsafe memory handling in lsf scanf"

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -413,7 +413,8 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
     }
 
     {
-        char *status;
+        char user[32];
+        char status[16];
         FILE *stream = util_fopen(tmp_file, "r");
         bool at_eof = false;
         hash_clear(driver->bjobs_cache);
@@ -423,7 +424,7 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
             if (line != NULL) {
                 int job_id_int;
 
-                if (sscanf(line, "%d %*s %ms", &job_id_int, &status) == 2) {
+                if (sscanf(line, "%d %s %s", &job_id_int, user, status) == 3) {
                     char *job_id = saprintf("%d", job_id_int);
                     // Consider only jobs submitted by this ERT instance - not
                     // old jobs lying around from the same user.
@@ -438,7 +439,6 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
                                       "LSF administrator - sorry :-( \n",
                                       status, job_id);
                     }
-                    free(status);
                     free(job_id);
                 }
                 free(line);
@@ -474,10 +474,14 @@ static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
     }
 
     {
+        char job_id[16], user[32], job_name[32];
+        int psusp_time;
+
         FILE *stream = util_fopen(output_file, "r");
         util_fskip_lines(stream, 2);
 
-        if (fscanf(stream, "%*s %*s %*s %d %*d %d", pend_time, run_time) != 2)
+        if (fscanf(stream, "%s %s %s %d %d %d", job_id, user, job_name,
+                   pend_time, &psusp_time, run_time) != 6)
             bhist_ok = false;
 
         fclose(stream);


### PR DESCRIPTION
This reverts commit 58090b6476c89c578c706a9cb2e559ffdd7de8a8. It doesn't work on mac because of https://stackoverflow.com/questions/54461111/scanfms-p-not-working-on-osx-system

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
