### PR TITLE
Make random seed be int only

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -282,7 +282,10 @@ Commonly used keywords
 .. _random_seed:
 .. topic:: RANDOM_SEED
 
-        Set specific seed for reproducibility.
+        Optional keyword, if provided must be an integer. Use a specific
+        seed for reproducibility. The default is that fresh unpredictable
+        entropy is used. Which seed is used is logged, and can then be used
+        to reproduce the results.
 
 .. _enspath:
 .. topic:: ENSPATH

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -67,7 +67,7 @@ class ErtConfig:
     ensemble_config: EnsembleConfig = field(default_factory=EnsembleConfig)
     ens_path: str = DEFAULT_ENSPATH
     env_vars: Dict[str, str] = field(default_factory=dict)
-    random_seed: Optional[str] = None
+    random_seed: Optional[int] = None
     analysis_config: AnalysisConfig = field(default_factory=AnalysisConfig)
     queue_config: QueueConfig = field(default_factory=QueueConfig)
     workflow_jobs: Dict[str, WorkflowJob] = field(default_factory=dict)

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -23,7 +23,6 @@ from .parsing import ConfigValidationError, ConfigWarning, ErrorInfo
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    from numpy.random import SeedSequence
 
     from ert.storage import EnsembleReader
 
@@ -181,7 +180,7 @@ class GenKwConfig(ParameterConfig):
             raise ConfigValidationError.from_collected(errors)
 
     def sample_or_load(
-        self, real_nr: int, random_seed: SeedSequence, ensemble_size: int
+        self, real_nr: int, random_seed: int, ensemble_size: int
     ) -> xr.Dataset:
         if self.forward_init_file:
             return self.read_from_runpath(Path(), real_nr)
@@ -191,7 +190,7 @@ class GenKwConfig(ParameterConfig):
         parameter_value = self._sample_value(
             self.name,
             keys,
-            str(random_seed.entropy),
+            str(random_seed),
             real_nr,
             ensemble_size,
         )

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import xarray as xr
 
 if TYPE_CHECKING:
-    from numpy.random import SeedSequence
-
     from ert.storage import EnsembleReader
 
 
@@ -35,7 +33,7 @@ class ParameterConfig(ABC):
     def sample_or_load(
         self,
         real_nr: int,
-        random_seed: SeedSequence,
+        random_seed: int,
         ensemble_size: int,
     ) -> xr.Dataset:
         return self.read_from_runpath(Path(), real_nr)

--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -317,7 +317,7 @@ def init_user_config_schema() -> ConfigSchemaDict:
         existing_path_keyword(ConfigKeys.DATA_FILE),
         existing_path_keyword(ConfigKeys.GRID),
         path_keyword(ConfigKeys.REFCASE),
-        string_keyword(ConfigKeys.RANDOM_SEED),
+        int_keyword(ConfigKeys.RANDOM_SEED),
         num_realizations_keyword(),
         run_template_keyword(),
         path_keyword(ConfigKeys.RUNPATH),

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -13,7 +13,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Sequence,
     Union,
 )
 
@@ -136,23 +135,19 @@ def _generate_parameter_files(
     _value_export_json(run_path, export_base_name, exports)
 
 
-def _seed_sequence(seed: Optional[str]) -> SeedSequence:
+def _seed_sequence(seed: Optional[int]) -> int:
     # Set up RNG
     if seed is None:
-        sequence = SeedSequence()
+        int_seed = SeedSequence().entropy
         logger.info(
             "To repeat this experiment, "
             "add the following random seed to your config file:"
         )
-        logger.info(f"RANDOM_SEED {sequence.entropy}")
-        return sequence
-
-    int_seed: Optional[Union[int, Sequence[int]]] = None
-    try:
-        int_seed = int(seed)
-    except ValueError:
-        int_seed = [ord(x) for x in seed]
-    return SeedSequence(int_seed)
+        logger.info(f"RANDOM_SEED {int_seed}")
+    else:
+        int_seed = seed
+    assert isinstance(int_seed, int)
+    return int_seed
 
 
 class EnKFMain:

--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -257,7 +257,7 @@ class ErtConfigValues:
     install_job: List[Tuple[str, str]]
     install_job_directory: List[str]
     license_path: str
-    random_seed: str
+    random_seed: int
     setenv: List[Tuple[str, str]]
     observations: List[Observation]
     refcase_smspec: Smspec
@@ -510,7 +510,7 @@ def ert_config_values(draw, use_eclbase=booleans):
             install_job=st.just(install_jobs),
             install_job_directory=small_list(directory_names()),
             license_path=directory_names(),
-            random_seed=words,
+            random_seed=st.integers(),
             setenv=small_list(st.tuples(words, words)),
             observations=st.just(obs),
             refcase_smspec=st.just(smspec),

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -135,7 +135,7 @@ def test_include_existing_file(tmpdir):
             fh.writelines(include_me_text)
 
         ert_config = ErtConfig.from_file("config.ert")
-        assert ert_config.random_seed == str(rand_seed)
+        assert ert_config.random_seed == rand_seed
 
 
 def test_init(minimum_case):

--- a/tests/unit_tests/test_enkf_main.py
+++ b/tests/unit_tests/test_enkf_main.py
@@ -129,30 +129,6 @@ def test_config(minimum_case):
     assert isinstance(minimum_case.getModelConfig(), ModelConfig)
 
 
-@pytest.mark.parametrize(
-    "random_seed", ["0", "1234", "123ABC", "123456789ABCDEFGHIJKLMNOPGRST", "123456"]
-)
-def test_random_seed_initialization_of_rngs(random_seed, tmpdir):
-    """
-    This is a regression test to make sure the seed can be sampled correctly,
-    and that it wraps on int32 overflow.
-    """
-    with tmpdir.as_cwd():
-        config_content = dedent(
-            f"""
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 10
-        RANDOM_SEED {random_seed}
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config_content)
-
-        ert_config = ErtConfig.from_file("config.ert")
-        EnKFMain(ert_config)
-        assert ert_config.random_seed == str(random_seed)
-
-
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_context():
     # Write a minimal config file with DEFINE


### PR DESCRIPTION
This is likely to have some user impact, but cant see how the extra complexity is worth it for the users, as seed in most other applications are int.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
