### PR TITLE
Replace custom debug options with logging

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1656,18 +1656,6 @@ Available LSF configuration options
                 QUEUE_OPTION LSF BJOBS_TIMEOUT 0
 
 
-.. _debug_output:
-.. topic:: DEBUG_OUTPUT
-
-        Whether or not to output debug information to ``stdout`` (i.e. your
-        console). Default: ``FALSE``, but note that the LSF queue system will
-        change this value in various failure modes.
-
-        ::
-
-                QUEUE_OPTION LSF DEBUG_OUTPUT FALSE
-
-
 .. _submit_sleep:
 .. topic:: SUBMIT_SLEEP
 
@@ -1850,16 +1838,6 @@ bjobs.
         ::
 
                 QUEUE_OPTION TORQUE SUBMIT_SLEEP 0.5
-
-.. _torque_debug_output:
-.. topic:: DEBUG_OUTPUT
-
-        You can ask the TORQUE driver to store a debug log of the jobs submitted, and
-        the resulting job id. This is done with the queue option DEBUG_OUTPUT:
-
-        ::
-
-                QUEUE_OPTION TORQUE DEBUG_OUTPUT torque_log.txt
 
 .. _torque_queue_query_timeout:
 .. topic:: QUEUE_QUERY_TIMEOUT

--- a/src/clib/lib/python/logging.cpp
+++ b/src/clib/lib/python/logging.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 
 // Controls the prefix of the Python logger:
 //   logging.getLogger(f"{LOGGER_NAMESPACE}.{name}")
-#define LOGGER_NAMESPACE "res"s
+#define LOGGER_NAMESPACE "ert"s
 
 namespace {
 class Logger : public ert::ILogger {

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -19,6 +19,12 @@ handlers:
     filename: asyncio-log.txt
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
+  jobqueue_file:
+    level: DEBUG
+    formatter: simple_with_threading
+    filename: jobqueue-log.txt
+    (): ert.logging.TimestampedFileHandler
+    use_log_dir_from_env: true
   event_log_file:
     level: DEBUG
     formatter: simple_with_threading
@@ -97,6 +103,7 @@ loggers:
     propagate: no
   ert.job_queue:
     level: DEBUG
+    handlers: [jobqueue_file]
     propagate: yes
   ert.analysis:
     level: DEBUG

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -5,11 +5,11 @@ import pytest
 from ert._clib import _test_logger
 
 RECORDS = [
-    ("res._test_logger", logging.DEBUG, "debug: foo"),
-    ("res._test_logger", logging.INFO, "info: foo"),
-    ("res._test_logger", logging.WARNING, "warning: foo"),
-    ("res._test_logger", logging.ERROR, "error: foo"),
-    ("res._test_logger", logging.CRITICAL, "critical: foo"),
+    ("ert._test_logger", logging.DEBUG, "debug: foo"),
+    ("ert._test_logger", logging.INFO, "info: foo"),
+    ("ert._test_logger", logging.WARNING, "warning: foo"),
+    ("ert._test_logger", logging.ERROR, "error: foo"),
+    ("ert._test_logger", logging.CRITICAL, "critical: foo"),
 ]
 
 
@@ -27,5 +27,5 @@ def test_logging_from_c(caplog, level, records):
     caplog.set_level(level)
 
     _test_logger("foo")
-    check_logs = [log for log in caplog.record_tuples if log[0] == "res._test_logger"]
+    check_logs = [log for log in caplog.record_tuples if log[0] == "ert._test_logger"]
     assert check_logs == records


### PR DESCRIPTION
Now puts output into jobqueue-log.txt:
```
...
2023-10-30 07:42:59,032 - ert.job_queue.torque_driver - Thread-25 (_job_monitor) - DEBUG - Submit arguments: qsub -k oe -l nodes=1:ppn=1 -N SNAKE_OIL_FIELD -r n .../snake_oil/storage/snake_oil/runpath/realization-21/iter-0/qsub_script.sh 
2023-10-30 07:42:59,033 - ert.job_queue.torque_driver - Thread-27 (_job_monitor) - DEBUG - Submit arguments: qsub -k oe -l nodes=1:ppn=1 -N SNAKE_OIL_FIELD -r n .../snake_oil/storage/snake_oil/runpath/realization-23/iter-0/qsub_script.sh 
...
```

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
