### PR TITLE
Mark memory usage count test as flaky

### DIFF
--- a/tests/unit_tests/job_runner/test_job.py
+++ b/tests/unit_tests/job_runner/test_job.py
@@ -3,6 +3,7 @@ import stat
 from unittest.mock import PropertyMock, patch
 
 import pytest
+from flaky import flaky
 
 from _ert_job_runner.job import Job
 from _ert_job_runner.reporting.message import Exited, Running, Start
@@ -33,6 +34,7 @@ def test_run_with_process_failing(
         next(run)
 
 
+@flaky
 @pytest.mark.usefixtures("use_tmpdir")
 def test_memory_usage_counts_grandchildren():
     scriptname = "recursive_memory_hog.py"


### PR DESCRIPTION
Counting memory usage is unreliable. See a marginally small amount of failures with this test.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).


