### PR TITLE
Revert "Avoid using util_alloc_temp_file"

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -357,11 +357,7 @@ static int lsf_driver_submit_shell_job(lsf_driver_type *driver,
                                        const char *submit_cmd, int num_cpu,
                                        const char *run_path) {
     int job_id;
-    constexpr int OUTPUT_FILE_SIZE = 32;
-    char tmp_file[OUTPUT_FILE_SIZE];
-    strncpy(tmp_file, "/tmp/enkf-submit-XXXXXXXXXX", OUTPUT_FILE_SIZE);
-    int fd = mkstemp(tmp_file);
-    close(fd);
+    char *tmp_file = (char *)util_alloc_tmp_file("/tmp", "enkf-submit", true);
 
     char **remote_argv = lsf_driver_alloc_cmd(driver, lsf_stdout, job_name,
                                               submit_cmd, num_cpu, run_path);
@@ -394,36 +390,36 @@ static int lsf_driver_submit_shell_job(lsf_driver_type *driver,
     free(remote_argv);
 
     job_id = lsf_job_parse_bsub_stdout(driver->bsub_cmd, tmp_file);
-    remove(tmp_file);
+    util_unlink_existing(tmp_file);
+    free(tmp_file);
     return job_id;
 }
 
-static void run_bjobs(lsf_driver_type *driver, char *output_file) {
-    if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
-        std::string remote_argv = fmt::format("%s -a", driver->bjobs_cmd);
-        char *const argv[4] = {driver->rsh_cmd, driver->remote_lsf_server,
-                               remote_argv.data(), nullptr};
-        spawn_blocking(argv, output_file, nullptr);
-    } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
-        char arg[] = "-a";
-        char *const argv[3] = {driver->bjobs_cmd, arg, nullptr};
-        spawn_blocking(argv, output_file, nullptr);
-    }
-}
-
 static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
-    constexpr int OUTPUT_FILE_SIZE = 32;
-    char tmp_file[OUTPUT_FILE_SIZE];
-    strncpy(tmp_file, "/tmp/enkf-submit-XXXXXXXXXX", OUTPUT_FILE_SIZE);
-    int fd = mkstemp(tmp_file);
-    close(fd);
+    char *tmp_file = (char *)util_alloc_tmp_file("/tmp", "enkf-bjobs", true);
 
-    run_bjobs(driver, tmp_file);
+    if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
+        char **argv = (char **)calloc(2, sizeof *argv);
+        CHECK_ALLOC(argv);
+        argv[0] = driver->remote_lsf_server;
+        argv[1] = saprintf("%s -a", driver->bjobs_cmd);
+        spawn_blocking(driver->rsh_cmd, 2, (const char **)argv, tmp_file, NULL);
+        free(argv[1]);
+        free(argv);
+    } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
+        const char **argv = (const char **)calloc(1, sizeof *argv);
+        CHECK_ALLOC(argv);
+        argv[0] = "-a";
+        spawn_blocking(driver->bjobs_cmd, 1, (const char **)argv, tmp_file,
+                       NULL);
+        free(argv);
+    }
 
     {
         char status[16];
         FILE *stream = fopen(tmp_file, "r");
         if (!stream) {
+            free(tmp_file);
             throw std::runtime_error("Unable to open bjobs output: " +
                                      std::string(strerror(errno)));
         }
@@ -448,6 +444,7 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
                             free(job_id);
                             free(line);
                             fclose(stream);
+                            free(tmp_file);
                             throw std::runtime_error(
                                 fmt::format("The lsf_status:{} for job:{} was "
                                             "not recognized\n",
@@ -461,60 +458,51 @@ static void lsf_driver_update_bjobs_table(lsf_driver_type *driver) {
         }
         fclose(stream);
     }
-    remove(tmp_file);
+    util_unlink_existing(tmp_file);
+    free(tmp_file);
 }
 
-/// Run bhist and store its output in output_file
-static void run_bhist(lsf_driver_type *driver, lsf_job_type *job,
-                      char *output_file) {
+static bool lsf_driver_run_bhist(lsf_driver_type *driver, lsf_job_type *job,
+                                 int *pend_time, int *run_time) {
+    bool bhist_ok = true;
+    char *output_file = (char *)util_alloc_tmp_file("/tmp", "bhist", true);
+
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL) {
-        std::string remote_argv =
-            fmt::format("{} {}", driver->bhist_cmd, job->lsf_jobnr_char);
-        char *const argv[4] = {driver->rsh_cmd, driver->remote_lsf_server,
-                               remote_argv.data(), nullptr};
-        spawn_blocking(argv, output_file, nullptr);
+        char **argv = (char **)calloc(2, sizeof *argv);
+        CHECK_ALLOC(argv);
+        argv[0] = driver->remote_lsf_server;
+        argv[1] = saprintf("%s %s", driver->bhist_cmd, job->lsf_jobnr_char);
+        spawn_blocking(driver->rsh_cmd, 2, (const char **)argv, output_file,
+                       NULL);
+        free(argv[1]);
+        free(argv);
     } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
-        char *const argv[3] = {driver->bhist_cmd, job->lsf_jobnr_char, nullptr};
-        spawn_blocking(argv, output_file, nullptr);
+        char **argv = (char **)calloc(1, sizeof *argv);
+        CHECK_ALLOC(argv);
+        argv[0] = job->lsf_jobnr_char;
+        spawn_blocking(driver->bjobs_cmd, 2, (const char **)argv, output_file,
+                       NULL);
+        free(argv);
     }
-}
 
-/// Get the bhist output from output_file and return
-/// tuple of pend_time and run_time
-static std::pair<int, int> parse_bhist_output(char *output_file, char *job_id) {
-    std::ifstream stream(output_file);
-    std::string line;
-    std::getline(stream, line); // skip header lines
-    std::getline(stream, line);
-    stream >> std::skipws;
-    int pend_time = 0, run_time = 0;
-    std::string tmp_str;
-    stream >> tmp_str; // skip job id
-    if (tmp_str != job_id) {
-        logger->warning(fmt::format(
-            "bhist showed job id {} while looking for {}", tmp_str, job_id));
+    {
+        FILE *stream = fopen(output_file, "r");
+        if (!stream) {
+            free(output_file);
+            throw std::runtime_error("Unable to open bhist output: " +
+                                     std::string(strerror(errno)));
+        }
+        util_fskip_lines(stream, 2);
+
+        if (fscanf(stream, "%*s %*s %*s %d %*d %d", pend_time, run_time) != 2)
+            bhist_ok = false;
+
+        fclose(stream);
     }
-    stream >> tmp_str; // skip user
-    stream >> tmp_str; // skip job name
-    stream >> pend_time;
-    stream >> tmp_str; // skip psusp
-    stream >> run_time;
-    return std::make_pair(pend_time, run_time);
-}
+    util_unlink_existing(output_file);
+    free(output_file);
 
-static std::pair<int, int> get_bhist_stats(lsf_driver_type *driver,
-                                           lsf_job_type *job) {
-    constexpr int OUTPUT_FILE_SIZE = 32;
-    char output_file[OUTPUT_FILE_SIZE];
-    strncpy(output_file, "/tmp/bhist-XXXXXXXXXX", OUTPUT_FILE_SIZE);
-    int fd = mkstemp(output_file);
-    close(fd);
-
-    run_bhist(driver, job, output_file);
-    auto result = parse_bhist_output(output_file, job->lsf_jobnr_char);
-
-    remove(output_file);
-    return result;
+    return bhist_ok;
 }
 
 /**
@@ -543,38 +531,31 @@ static std::pair<int, int> get_bhist_stats(lsf_driver_type *driver,
 */
 static int lsf_driver_get_bhist_status_shell(lsf_driver_type *driver,
                                              lsf_job_type *job) {
-    constexpr int SLEEP_TIME = 4;
+    int status = JOB_STAT_UNKWN;
+    int sleep_time = 4;
+    int run_time1, run_time2, pend_time1, pend_time2;
 
-    std::pair<int, int> stats1{}, stats2{};
-    try {
-        stats1 = get_bhist_stats(driver, job);
-    } catch (std::exception &err) {
-        logger->warning(fmt::format("bhist failed: {}", err.what()));
-        return JOB_STAT_UNKWN;
-    }
+    logger->error(
+        "** Warning: could not find status of job:{}/{} using \'bjobs\'"
+        " - trying with \'bhist\'.\n",
+        job->lsf_jobnr_char, job->job_name);
+    if (!lsf_driver_run_bhist(driver, job, &pend_time1, &run_time1))
+        return status;
 
-    sleep(SLEEP_TIME);
+    sleep(sleep_time);
+    if (!lsf_driver_run_bhist(driver, job, &pend_time2, &run_time2))
+        return status;
 
-    try {
-        stats2 = get_bhist_stats(driver, job);
-    } catch (std::exception &err) {
-        logger->warning(fmt::format("bhist failed: {}", err.what()));
-        return JOB_STAT_UNKWN;
-    }
-
-    if (stats1 == stats2)
-        return JOB_STAT_DONE;
-
-    auto [pend_time1, run_time1] = stats1;
-    auto [pend_time2, run_time2] = stats2;
+    if ((run_time1 == run_time2) && (pend_time1 == pend_time2))
+        status = JOB_STAT_DONE;
 
     if (pend_time2 > pend_time1)
-        return JOB_STAT_PEND;
+        status = JOB_STAT_PEND;
 
     if (run_time2 > run_time1)
-        return JOB_STAT_RUN;
+        status = JOB_STAT_RUN;
 
-    return JOB_STAT_UNKWN;
+    return status;
 }
 
 static int lsf_driver_get_job_status_shell(void *__driver, void *__job) {
@@ -609,19 +590,15 @@ static int lsf_driver_get_job_status_shell(void *__driver, void *__job) {
                 // it has completed/exited and fallen out of the bjobs status
                 // table maintained by LSF. We try calling bhist to get the
                 // status.
+                logger->warning(
+                    "In lsf_driver we found that job was not in the "
+                    "status cache, this *might* mean that it has "
+                    "completed/exited and fallen out of the bjobs "
+                    "status table maintained by LSF.");
                 if (!driver->debug_output) {
                     driver->debug_output = true;
                     logger->info("Have turned lsf debug info ON.");
                 }
-
-                logger->error(
-                    "In lsf_driver we found that job {}/{} was not in the "
-                    "status cache, this *might* mean that it has "
-                    "completed/exited and fallen out of the bjobs "
-                    "status table maintained by LSF. "
-                    " - trying with \'bhist\'.\n",
-                    job->lsf_jobnr_char, job->job_name);
-
                 status = lsf_driver_get_bhist_status_shell(driver, job);
                 hash_insert_int(driver->bjobs_cache, job->lsf_jobnr_char,
                                 status);

--- a/tests/unit_tests/job_queue/test_job_queue_node.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node.py
@@ -58,10 +58,15 @@ job_queue_nodes = st.builds(
 
 
 def reset_command_queue(tmp_path):
-    for command in ("job_script", "submit", "status", "history"):
-        with suppress(OSError):
-            os.remove(tmp_path / f"{command}fifo")
-        os.mkfifo(tmp_path / f"{command}fifo", 0o777)
+    with suppress(OSError):
+        os.remove(tmp_path / "job_scriptfifo")
+    with suppress(OSError):
+        os.remove(tmp_path / "submitfifo")
+    with suppress(OSError):
+        os.remove(tmp_path / "statusfifo")
+    os.mkfifo(tmp_path / "job_scriptfifo", 0o777)
+    os.mkfifo(tmp_path / "submitfifo", 0o777)
+    os.mkfifo(tmp_path / "statusfifo", 0o777)
 
 
 @pytest.fixture(autouse=True)
@@ -72,7 +77,6 @@ def setup_mock_queue(monkeypatch, tmp_path):
         ("submit", "qsub"),
         ("submit", "sbatch"),
         ("status", "bjobs"),
-        ("history", "bhist"),
         ("status", "squeue"),
         ("status", "qstat"),
         ("job_script", "mock_job_script"),
@@ -93,7 +97,7 @@ def setup_mock_queue(monkeypatch, tmp_path):
 
 
 def next_command_output(command, msg, delay=0.0):
-    assert command in ("job_script", "submit", "status", "history")
+    assert command in ("job_script", "submit", "status")
 
     def write_to_queue():
         with open(f"./{command}fifo", "w", encoding="utf-8") as fifo:
@@ -294,49 +298,3 @@ def test_that_queue_name_is_passed_to_bsub(tmp_path, job_queue_node):
     job_queue_node.submit(driver)
     submitinput = Path("submitinput.txt").read_text(encoding="utf-8")
     assert "-q name" in submitinput
-
-
-@settings(max_examples=1, suppress_health_check=[HealthCheck.function_scoped_fixture])
-@pytest.mark.usefixtures("use_tmpdir")
-@given(job_queue_nodes, st.data())
-@pytest.mark.parametrize(
-    "hist_before, hist_after, expected_status",
-    [
-        (
-            "info_line\nheader_line\n 1 user name 1 2 2 2\n",
-            "info_line\nheader_line\n 1 user name 6 2 2 2\n",
-            JobStatus.PENDING,
-        ),
-        (
-            "info_line\nheader_line\n 1 user name 2 2 2 2\n",
-            "info_line\nheader_line\n 1 user name 2 2 6 2\n",
-            JobStatus.RUNNING,
-        ),
-        (
-            "info_line\nheader_line\n 1 user name 1 2 3 4\n",
-            "info_line\nheader_line\n 1 user name 1 2 3 4\n",
-            JobStatus.DONE,
-        ),
-    ],
-)
-def test_that_bhist_is_called_if_job_not_in_bstat(
-    hist_before, hist_after, expected_status, tmp_path, job_queue_node, data
-):
-    queue_config = QueueConfig(
-        job_script=os.path.abspath("script.sh"),
-        queue_system=QueueSystem.LSF,
-        max_submit=2,
-        queue_options={QueueSystem.LSF: [("LSF_QUEUE", "name")]},
-    )
-    driver = Driver.create_driver(queue_config)
-    reset_command_queue(tmp_path)
-
-    # submit gave id 1
-    next_command_output("submit", submit_success_output("LSF", 1))
-    job_queue_node.submit(driver)
-
-    # status only found for job 2
-    next_command_output("status", status_output(data.draw, "LSF", 2, JobStatus.DONE))
-    next_command_output("history", hist_before)
-    next_command_output("history", hist_after, delay=4.0)
-    assert job_queue_node._poll_queue_status(driver) == expected_status


### PR DESCRIPTION
This reverts commit 0b46bc1d730544b4ee57248d7c9aa4cd6b67a3a5.

**Issue**
Resolves submission to LSF cluster

**Approach**
Revert

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
