### PR TITLE
Reduce poly-case to 2 realizations by default in integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,9 +84,12 @@ def maximize_ulimits():
 
 @pytest.fixture(name="setup_case")
 def fixture_setup_case(tmp_path, source_root, monkeypatch):
-    def copy_case(path, config_file):
+    def copy_case(path, config_file, appended_config):
         shutil.copytree(os.path.join(source_root, "test-data", path), "test_data")
         monkeypatch.chdir(tmp_path / "test_data")
+        if appended_config:
+            with open(config_file, mode="a", encoding="utf-8") as config_filehandle:
+                config_filehandle.write("\n" + appended_config)
         return ErtConfig.from_file(config_file)
 
     monkeypatch.chdir(tmp_path)
@@ -95,7 +98,16 @@ def fixture_setup_case(tmp_path, source_root, monkeypatch):
 
 @pytest.fixture()
 def poly_case(setup_case):
-    return EnKFMain(setup_case("poly_example", "poly.ert"))
+    return EnKFMain(
+        setup_case("poly_example", "poly.ert", appended_config=f"NUM_REALIZATIONS 2")
+    )
+
+
+@pytest.fixture()
+def poly_case_10(setup_case):
+    return EnKFMain(
+        setup_case("poly_example", "poly.ert", appended_config=f"NUM_REALIZATIONS 10")
+    )
 
 
 @pytest.fixture()

--- a/tests/unit_tests/cli/test_model_factory.py
+++ b/tests/unit_tests/cli/test_model_factory.py
@@ -40,8 +40,8 @@ def test_default_realizations(poly_case):
     )
 
 
-def test_custom_realizations(poly_case):
-    facade = LibresFacade(poly_case)
+def test_custom_realizations(poly_case_10):
+    facade = LibresFacade(poly_case_10)
     args = Namespace(realizations="0-4,7,8")
     ensemble_size = facade.get_ensemble_size()
     active_mask = [False] * ensemble_size
@@ -83,8 +83,8 @@ def test_setup_ensemble_experiment(poly_case, storage):
     assert "active_realizations" in sim_args_as_dict
 
 
-def test_setup_ensemble_smoother(poly_case, storage):
-    ert = poly_case
+def test_setup_ensemble_smoother(poly_case_10, storage):
+    ert = poly_case_10
 
     args = Namespace(
         realizations="0-4,7,8", current_case="default", target_case="test_case"
@@ -103,8 +103,8 @@ def test_setup_ensemble_smoother(poly_case, storage):
     assert "target_case" in sim_args_as_dict
 
 
-def test_setup_multiple_data_assimilation(poly_case, storage):
-    ert = poly_case
+def test_setup_multiple_data_assimilation(poly_case_10, storage):
+    ert = poly_case_10
     args = Namespace(
         realizations="0-4,7,8",
         weights="6,4,2",
@@ -127,8 +127,8 @@ def test_setup_multiple_data_assimilation(poly_case, storage):
     assert "weights" in sim_args_as_dict
 
 
-def test_setup_iterative_ensemble_smoother(poly_case, storage):
-    ert = poly_case
+def test_setup_iterative_ensemble_smoother(poly_case_10, storage):
+    ert = poly_case_10
     args = Namespace(
         realizations="0-4,7,8",
         current_case="default",


### PR DESCRIPTION
**Issue**
Scales down the poly-case used in tests, motivated by a potential speed increase.


**Approach**
Appending extra lines to the poly.ert file. This is slightly non-pretty, as it means we give a config to ert with repeated keywords.


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
