### PR TITLE
Make torque driver compatible with slurm-wlm-torque

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -670,7 +670,7 @@ job_status_type torque_driver_parse_status(const char *qstat_file,
     }
 
     /* Parse the qstat output, looking only for requested job_id */
-    std::string job_id_label("Job Id: ");
+    std::string job_id_label("Job Id:");
     std::string job_state("_void_");
     int exit_status = 0;
     std::ifstream qstatoutput(qstat_file);

--- a/tests/unit_tests/job_queue/test_torque_driver.py
+++ b/tests/unit_tests/job_queue/test_torque_driver.py
@@ -26,6 +26,8 @@ def test_job_create_submit_script():
         (None, "", JobStatus.STATUS_FAILURE),
         ("", "1234", JobStatus.STATUS_FAILURE),
         ("Job Id: 1\njob_state = R", "1", JobStatus.RUNNING),
+        ("Job Id: 1\n job_state = R", "1", JobStatus.RUNNING),
+        ("Job Id:\t1\n\tjob_state = R", "1", JobStatus.RUNNING),
         ("Job Id: 1.namespace\njob_state = R", "1", JobStatus.RUNNING),
         ("Job Id: 11\njob_state = R", "1", JobStatus.STATUS_FAILURE),
         ("Job Id: 1", "1", JobStatus.STATUS_FAILURE),


### PR DESCRIPTION
**Issue**
Resolves one issue observed when running with Torque through slurm-wlm-torque to a Slurm cluster.


**Approach**
Don't look for an explicit space.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
