### PR TITLE
Improve flaky test_port_handler _simulate_server function

### DIFF
--- a/tests/unit_tests/shared/test_port_handler.py
+++ b/tests/unit_tests/shared/test_port_handler.py
@@ -85,7 +85,7 @@ def test_gc_closes_socket(unused_tcp_port):
     assert orig_sock.fileno() != -1
 
 
-def _simulate_server(host, port, sock):
+def _simulate_server(host, port, sock: socket.socket):
     """
     This seems to be necessary to demonstrate TIME_WAIT on sockets.
     Just opening and closing sockets doesn't really activate underlying sockets.
@@ -101,6 +101,7 @@ def _simulate_server(host, port, sock):
             conn, addr = sock.accept()
             with contextlib.suppress(Exception):
                 self.data = conn.recv(1024).decode()
+                conn.sendall(b"Who's there?")
 
     dummy_server = ServerThread()
     dummy_server.start()
@@ -109,6 +110,7 @@ def _simulate_server(host, port, sock):
     client_socket = socket.socket()
     client_socket.connect((host, port))
     client_socket.sendall(b"Hi there")
+    assert client_socket.recv(1024).decode() == "Who's there?"
     dummy_server.join()
     assert getattr(dummy_server, "port", None) == port
     assert getattr(dummy_server, "data", None) == "Hi there"


### PR DESCRIPTION
Helper function _simulate_server runs our socket, but it makes sure the thread is finished before we move on by calling thread.join(). This might allow enough time to pass for TIME_WAIT to finish. Now we have two way communciation through the socket, so it will mimic more realistic traffic.

**Issue**
Resolves #6384


**Approach**
The simulate_server helper function to mimic traffic through the socket did not mimic realistic traffic


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
