### PR TITLE
Fix visible and copyable run_path stripped of placeholders

### DIFF
--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -37,7 +37,7 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
 
         self._case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", self._case_selector)
-        runpath_label = CopyableLabel(text=self.facade.run_path)
+        runpath_label = CopyableLabel(text=self.facade.run_path_stripped)
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -39,7 +39,7 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         self._case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", self._case_selector)
 
-        runpath_label = CopyableLabel(text=facade.run_path)
+        runpath_label = CopyableLabel(text=facade.run_path_stripped)
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -35,7 +35,7 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
 
-        runpath_label = CopyableLabel(text=self.facade.run_path)
+        runpath_label = CopyableLabel(text=self.facade.run_path_stripped)
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -39,7 +39,7 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout = QFormLayout()
         self.setObjectName("ES_MDA_panel")
 
-        runpath_label = CopyableLabel(text=facade.run_path)
+        runpath_label = CopyableLabel(text=facade.run_path_stripped)
         layout.addRow("Runpath:", runpath_label)
 
         number_of_realizations_label = QLabel(f"<b>{facade.get_ensemble_size()}</b>")

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -29,7 +29,7 @@ class SingleTestRunPanel(SimulationConfigPanel):
         case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
 
-        runpath_label = CopyableLabel(text=facade.run_path)
+        runpath_label = CopyableLabel(text=facade.run_path_stripped)
         layout.addRow("Runpath:", runpath_label)
 
         self._active_realizations_model = ActiveRealizationsModel(facade)

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -185,6 +185,20 @@ class LibresFacade:
     def run_path(self) -> str:
         return self._enkf_main.getModelConfig().runpath_format_string
 
+    @property
+    def run_path_stripped(self) -> str:
+        rp_stripped = ""
+        for s in self.run_path.split("/"):
+            if all(substring not in s for substring in ("<IENS>", "<ITER>")) and s:
+                rp_stripped += "/" + s
+        if not rp_stripped:
+            rp_stripped = "/"
+
+        if self.run_path and not self.run_path.startswith("/"):
+            rp_stripped = rp_stripped[1:]
+
+        return rp_stripped
+
     def get_run_paths(self, realizations: List[int], iteration: int) -> List[str]:
         run_paths = self._enkf_main.runpaths.get_paths(realizations, iteration)
         return list(run_paths)

--- a/tests/unit_tests/test_libres_facade.py
+++ b/tests/unit_tests/test_libres_facade.py
@@ -497,3 +497,21 @@ def test_load_gen_kw_not_sorted(storage, tmpdir, snapshot):
         facade = LibresFacade.from_config_file("config.ert")
         data = facade.load_all_gen_kw_data(ensemble)
         snapshot.assert_match(data.round(12).to_csv(), "gen_kw_unsorted")
+
+
+@pytest.mark.parametrize(
+    "run_path, expected",
+    [
+        ("", "/"),
+        ("///", "/"),
+        ("simulation/mypath", "simulation/mypath"),
+        ("/local/path", "/local/path"),
+        ("/local/reals-iters/real-<IENS>/iter-<ITER>", "/local/reals-iters"),
+        ("/local/iters/iter-<ITER>", "/local/iters"),
+        ("/local/reals/real-<IENS>", "/local/reals"),
+    ],
+)
+def test_run_path_stripped(monkeypatch, snake_oil_case_storage, run_path, expected):
+    facade = LibresFacade(snake_oil_case_storage)
+    monkeypatch.setattr("ert.libres_facade.LibresFacade.run_path", run_path)
+    assert facade.run_path_stripped == expected


### PR DESCRIPTION
**Issue**
Resolves #6337 

![Screenshot 2023-10-24 at 13 41 54](https://github.com/equinor/ert/assets/114403625/4b0098b0-5018-4d2d-8ee8-de17e7f64224)

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
