### PR TITLE
Resolve logical issue with counting bjobs cache

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -592,7 +592,7 @@ static int lsf_driver_get_job_status_shell(void *__driver, void *__job) {
                 bool update_cache =
                     ((difftime(time(NULL), driver->last_bjobs_update) >
                       driver->bjobs_refresh_interval) ||
-                     (!driver->bjobs_cache.count(job->lsf_jobnr_char) > 0));
+                     driver->bjobs_cache.count(job->lsf_jobnr_char) < 1);
                 if (update_cache) {
                     lsf_driver_update_bjobs_table(driver);
                     driver->last_bjobs_update = time(NULL);


### PR DESCRIPTION
**Issue**
Resolves #my_issue

```
[13/19] Building CXX object lib/CMakeFiles/_clib.dir/job_queue/lsf_driver.cpp.o
/Users/ANDRLI/Project/ert/src/clib/lib/job_queue/lsf_driver.cpp:595:23: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
                     (!driver->bjobs_cache.count(job->lsf_jobnr_char) > 0));
                      ^                                               ~
/Users/ANDRLI/Project/ert/src/clib/lib/job_queue/lsf_driver.cpp:595:23: note: add parentheses after the '!' to evaluate the comparison first
                     (!driver->bjobs_cache.count(job->lsf_jobnr_char) > 0));
                      ^
                       (                                                 )
/Users/ANDRLI/Project/ert/src/clib/lib/job_queue/lsf_driver.cpp:595:23: note: add parentheses around left hand side expression to silence this warning
                     (!driver->bjobs_cache.count(job->lsf_jobnr_char) > 0));
                      ^
                      (                                              )
1 warning generated.
```

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
