### PR TITLE
Return numpy bool from _realizations

### DIFF
--- a/tests/unit_tests/cli/test_model_factory.py
+++ b/tests/unit_tests/cli/test_model_factory.py
@@ -35,7 +35,7 @@ def test_default_realizations(poly_case):
     facade = LibresFacade(poly_case)
     args = Namespace(random_seed=None, realizations=None)
     assert (
-        model_factory._realizations(args, facade.get_ensemble_size())
+        model_factory._realizations(args, facade.get_ensemble_size()).tolist()
         == [True] * facade.get_ensemble_size()
     )
 
@@ -52,7 +52,7 @@ def test_custom_realizations(poly_case):
     active_mask[4] = True
     active_mask[7] = True
     active_mask[8] = True
-    assert model_factory._realizations(args, ensemble_size) == active_mask
+    assert model_factory._realizations(args, ensemble_size).tolist() == active_mask
 
 
 def test_setup_single_test_run(poly_case, storage):


### PR DESCRIPTION
Run arguments still need a list of ints to be json serializable.

I propose this just to get rid of this really:

```python
    active_realizations_count = len(
        [i for i in range(len(active_realizations)) if active_realizations[i]]
    )
```
    
It can be replaced by:

```python
active_realizations_count = int(np.sum(active_realizations))
```

The `int()` should not be necessary but `mypy` complains.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
