### PR TITLE
Force fortran order for row scaling

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -186,15 +186,33 @@ def _get_param_with_row_scaling(
     temp_storage: TempStorage,
     parameter: RowScalingParameter,
 ) -> List[Tuple[npt.NDArray[np.double], RowScaling]]:
+    """The row-scaling functionality is implemented in C++ and is made
+    accessible through the pybind11 library.
+    pybind11 requires that numpy arrays passed to it are in
+    Fortran-contiguous order (column-major), which is different from
+    numpy's default row-major (C-contiguous) order.
+    To ensure compatibility, numpy arrays are explicitly converted to Fortran order.
+    It's important to note that if an array originally in C-contiguous
+    order is passed to a function expecting Fortran order,
+    pybind11 will automatically create a Fortran-ordered copy of the array.
+    """
     matrices = []
+
     if parameter.index_list is None:
         matrices.append(
-            (temp_storage[parameter.name].astype(np.double), parameter.row_scaling)
+            (
+                np.asfortranarray(temp_storage[parameter.name].astype(np.double)),
+                parameter.row_scaling,
+            )
         )
     else:
         matrices.append(
             (
-                temp_storage[parameter.name][parameter.index_list, :].astype(np.double),
+                np.asfortranarray(
+                    temp_storage[parameter.name][parameter.index_list, :].astype(
+                        np.double
+                    )
+                ),
                 parameter.row_scaling,
             ),
         )


### PR DESCRIPTION
Row scaling calls C++ code via pybind11 that expects Fortran order.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
