### PR TITLE
Replace Reader/Accessor with a Mode enum

### DIFF
--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -16,7 +16,7 @@ from ert.gui.ertwidgets.statusdialog import StatusDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.run_analysis import RunAnalysisPanel
 from ert.run_models.event import RunModelEvent, RunModelStatusEvent, RunModelTimeEvent
-from ert.storage import EnsembleAccessor, EnsembleReader, StorageAccessor
+from ert.storage import EnsembleAccessor, EnsembleReader
 
 
 class Analyse(QObject):
@@ -177,11 +177,7 @@ class RunAnalysisTool(Tool):
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
 
     def _init_analyse(self, source_fs: EnsembleReader, target: str):
-        with add_context_to_error(
-            "Could not get StorageAccessor for writing to ensemble"
-        ):
-            accessor: StorageAccessor = self.notifier.storage.to_accessor()
-        target_fs: EnsembleAccessor = accessor.create_ensemble(
+        target_fs = self.notifier.storage.create_ensemble(
             source_fs.experiment_id,
             name=target,
             ensemble_size=source_fs.ensemble_size,

--- a/src/ert/shared/exporter.py
+++ b/src/ert/shared/exporter.py
@@ -47,7 +47,7 @@ class Exporter:
 
         runpath_job_runner.run(
             ert=self.ert,
-            storage=self._notifier.storage,  # type: ignore
+            storage=self._notifier.storage,
             arguments=[],
         )
         if runpath_job_runner.hasFailed():
@@ -56,7 +56,7 @@ class Exporter:
         export_job_runner = WorkflowJobRunner(export_job)
         export_job_runner.run(
             ert=self.ert,
-            storage=self._notifier.storage,  # type: ignore
+            storage=self._notifier.storage,
             arguments=[
                 str(self.ert.ert_config.runpath_file),
                 parameters["output_file"],

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
-from typing import Literal, Union, overload
+from pathlib import Path
+from typing import Union
 
-from ert.storage.local_ensemble import LocalEnsembleAccessor, LocalEnsembleReader
-from ert.storage.local_experiment import LocalExperimentAccessor, LocalExperimentReader
-from ert.storage.local_storage import LocalStorageAccessor, LocalStorageReader
+from ert.storage.local_ensemble import LocalEnsemble
+from ert.storage.local_experiment import LocalExperiment
+from ert.storage.local_storage import LocalStorage
+from ert.storage.mode import Mode, ModeLiteral
 
 # Alias types. The Local* variants are meant to co-exist with Remote* classes
 # that connect to a remote ERT Storage Server, as well as an in-memory Memory*
@@ -13,41 +15,29 @@ from ert.storage.local_storage import LocalStorageAccessor, LocalStorageReader
 # However, currently there is only one implementation, so to keep things simple
 # we simply alias these types. In the future these will probably be subclasses
 # of typing.Protocol
-StorageReader = LocalStorageReader
-StorageAccessor = LocalStorageAccessor
-ExperimentReader = LocalExperimentReader
-ExperimentAccessor = LocalExperimentAccessor
-EnsembleReader = LocalEnsembleReader
-EnsembleAccessor = LocalEnsembleAccessor
+Storage = LocalStorage
+Ensemble = LocalEnsemble
+Experiment = LocalExperiment
 
-
-@overload
-def open_storage(
-    path: Union[str, os.PathLike[str]], mode: Literal["r"] = "r"
-) -> StorageReader: ...
-
-
-@overload
-def open_storage(
-    path: Union[str, os.PathLike[str]], mode: Literal["w"]
-) -> StorageAccessor: ...
+# Kept here to avoid having to have to rewrite a lot of files
+StorageReader = LocalStorage
+StorageAccessor = LocalStorage
+ExperimentReader = LocalExperiment
+ExperimentAccessor = LocalExperiment
+EnsembleReader = LocalEnsemble
+EnsembleAccessor = LocalEnsemble
 
 
 def open_storage(
-    path: Union[str, os.PathLike[str]], mode: Literal["r", "w"] = "r"
-) -> Union[StorageReader, StorageAccessor]:
-    if mode == "r":
-        return LocalStorageReader(path)
-    else:
-        return LocalStorageAccessor(path)
+    path: Union[str, os.PathLike[str]], mode: Union[ModeLiteral, Mode] = "r"
+) -> Storage:
+    return LocalStorage(Path(path), Mode(mode))
 
 
 __all__ = [
-    "EnsembleReader",
-    "EnsembleAccessor",
-    "ExperimentReader",
-    "ExperimentAccessor",
-    "StorageReader",
-    "StorageAccessor",
+    "Ensemble",
+    "Experiment",
+    "Storage",
+    "Mode",
     "open_storage",
 ]

--- a/src/ert/storage/mode.py
+++ b/src/ert/storage/mode.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import Enum
+from functools import wraps
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Literal,
+)
+
+if TYPE_CHECKING:
+    from typing_extensions import Concatenate, ParamSpec, TypeVar
+
+ModeLiteral = Literal["r", "w"]
+
+
+class ModeError(ValueError):
+    pass
+
+
+class Mode(str, Enum):
+    READ = "r"
+    WRITE = "w"
+
+    @property
+    def can_write(self) -> bool:
+        return self == self.WRITE
+
+
+class BaseMode:
+    def __init__(self, mode: Mode) -> None:
+        self.__mode = mode
+
+    @property
+    def mode(self) -> Mode:
+        return self.__mode
+
+    @property
+    def can_write(self) -> bool:
+        return self.__mode.can_write
+
+    def assert_can_write(self) -> None:
+        if not self.can_write:
+            raise ModeError(
+                "This operation requires write access, but we only have read access"
+            )
+
+
+if TYPE_CHECKING:
+    P = ParamSpec("P")
+    T = TypeVar("T")
+    C = TypeVar("C", bound=BaseMode)
+    F = Callable[Concatenate[C, P], T]
+
+
+def require_write(func: F[C, P, T]) -> F[C, P, T]:
+    @wraps(func)
+    def inner(self_: C, /, *args: P.args, **kwargs: P.kwargs) -> T:
+        self_.assert_can_write()
+        return func(self_, *args, **kwargs)
+
+    return inner

--- a/tests/unit_tests/gui/run_analysis/test_run_analysis.py
+++ b/tests/unit_tests/gui/run_analysis/test_run_analysis.py
@@ -43,7 +43,6 @@ def mock_tool(mock_storage, ert_mock):
         run_widget.source_case.return_value = source
         run_widget.target_case.return_value = target.name
         notifier = Mock(spec_set=ErtNotifier)
-        notifier.storage.to_accessor.return_value = notifier.storage
         notifier.storage.create_ensemble.return_value = target
         tool = RunAnalysisTool(ert_mock, notifier)
         tool._run_widget = run_widget

--- a/tests/unit_tests/storage/migration/test_version_1.py
+++ b/tests/unit_tests/storage/migration/test_version_1.py
@@ -16,7 +16,7 @@ def set_ert_config(block_storage_path):
     local_storage_set_ert_config(None)
 
 
-def test_migrate_gen_kw(setup_case, set_ert_config):
+def test_migrate_gen_kw(setup_case):
     setup_case("block_storage/version-1/poly_example", "poly.ert")
     with open_storage("storage", "w") as storage:
         assert len(list(storage.experiments)) == 1

--- a/tests/unit_tests/storage/test_mode.py
+++ b/tests/unit_tests/storage/test_mode.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ert.storage.mode import (
+    BaseMode,
+    Mode,
+    ModeError,
+    require_write,
+)
+
+
+class SomeClass(BaseMode):
+    def write_or_default(self) -> str:
+        return "good" if self.can_write else "fail"
+
+    @require_write
+    def raises_unless_write(self) -> bool:
+        return True
+
+    @require_write
+    def concat_if_write(self, a: str, b: str) -> str:
+        return a + b
+
+
+def test_read_mode():
+    obj = SomeClass(Mode.READ)
+    assert obj.write_or_default() == "fail"
+    with pytest.raises(
+        ModeError,
+        match="This operation requires write access, but we only have read access",
+    ):
+        obj.raises_unless_write()
+        obj.concat_if_write("foo", "bar")
+
+
+def test_write_mode():
+    obj = SomeClass(Mode.WRITE)
+    assert obj.write_or_default() == "good"
+    assert obj.raises_unless_write()
+    assert obj.concat_if_write("foo", "bar") == "foobar"


### PR DESCRIPTION
Resolves: #6941 

This commit extends the "mode" concept and replaces the Reader/Accessor
pattern that was in `ert.storage` previously. This is to make it
possible to delete ensembles and experiments in a safe way.

The modes are `NONE` (`""`), `READ` (`"r"`) and `READ_WRITE` (`"w"`).
The -Reader classes are equivalent to `READ` and the -Accessor classes
are equivalent to `READ_WRITE`. `NONE` has no equivalent in the previous
code. With this change it is possible to downgrade the access-level of
objects without having to reopen them. This is in particular useful when
deleting ensembles and experiments.

Suppose there is a new method called `.delete_ensemble` which does what
it says. Consider the following code using the Reader/Accessor pattern:

```py
with open_storage(path, mode="w") as storage:
    ens = storage.get_ensemble_by_name("default")
    storage.delete_ensemble(ens)

    # ... sometime later:

    # ens is EnsembleAccessor, so writing is valid:
    ens.save_responses(group, real, data)
```

Uh-oh! We've accidentally saved data to a deleted object. Now, consider
with the capability pattern:

```py
with open_storage(path, mode="w") as storage:
    ens = storage.get_ensemble_by_name("default")
    storage.delete_ensemble(ens)

    # ... sometime later:

    # ens was reduced to Capability.NONE. Calling this method raises CapabilityError.
    ens.save_responses(group, real, data)
```

This should also make it easier to understand the module.