### PR TITLE
Extract wait and findChild in gui tests

### DIFF
--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -8,7 +8,7 @@ import stat
 import time
 from datetime import datetime as dt
 from textwrap import dedent
-from typing import Tuple
+from typing import Tuple, Type, TypeVar
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -33,7 +33,7 @@ from ert.ensemble_evaluator.state import (
     STEP_STATE_UNKNOWN,
 )
 from ert.gui.ertwidgets import ClosableDialog
-from ert.gui.ertwidgets.caselist import AddRemoveWidget, CaseList
+from ert.gui.ertwidgets.caselist import AddRemoveWidget
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
 from ert.gui.main import GUILogHandler, _setup_main_window
@@ -52,10 +52,8 @@ from ert.storage import open_storage
 def find_cases_dialog_and_panel(
     gui, qtbot: QtBot
 ) -> Tuple[ClosableDialog, CaseInitializationConfigurationPanel]:
-    qtbot.waitUntil(lambda: gui.findChild(ClosableDialog, "manage-cases") is not None)
-    dialog = gui.findChild(ClosableDialog, "manage-cases")
-    cases_panel = dialog.findChild(CaseInitializationConfigurationPanel)
-    assert isinstance(cases_panel, CaseInitializationConfigurationPanel)
+    dialog = get_child(gui, ClosableDialog, waiter=qtbot, name="manage-cases")
+    cases_panel = get_child(dialog, CaseInitializationConfigurationPanel)
     return (dialog, cases_panel)
 
 
@@ -378,23 +376,16 @@ def mock_tracker():
 
 def load_results_manually(qtbot, gui, case_name="default"):
     def handle_load_results_dialog():
-        qtbot.waitUntil(
-            lambda: gui.findChild(ClosableDialog, name="load_results_manually_tool")
-            is not None
-        )
-        dialog = gui.findChild(ClosableDialog, name="load_results_manually_tool")
-        panel = dialog.findChild(LoadResultsPanel)
-        assert isinstance(panel, LoadResultsPanel)
+        dialog = get_child(gui, ClosableDialog, waiter=qtbot)
+        panel = get_child(dialog, LoadResultsPanel)
 
-        case_selector = panel.findChild(CaseSelector)
-        assert isinstance(case_selector, CaseSelector)
+        case_selector = get_child(panel, CaseSelector)
         index = case_selector.findText(case_name, Qt.MatchFlag.MatchContains)
         assert index != -1
         case_selector.setCurrentIndex(index)
 
         # click on "Load"
-        load_button = panel.parent().findChild(QPushButton, name="Load")
-        assert isinstance(load_button, QPushButton)
+        load_button = get_child(panel.parent(), QPushButton, name="Load")
 
         # Verify that the messagebox is the success kind
         def handle_popup_dialog():
@@ -421,14 +412,11 @@ def add_case_manually(qtbot, gui, case_name="default"):
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
         assert current_tab.objectName() == "create_new_case_tab"
-        create_widget = current_tab.findChild(AddRemoveWidget)
-        case_list = current_tab.findChild(CaseList)
-        assert isinstance(case_list, CaseList)
+        create_widget = get_child(current_tab, AddRemoveWidget)
 
         # Click add case and name it "iter-0"
         def handle_add_dialog():
-            qtbot.waitUntil(lambda: current_tab.findChild(ValidatedDialog) is not None)
-            dialog = gui.findChild(ValidatedDialog)
+            dialog = get_child(gui, ValidatedDialog, waiter=qtbot)
             dialog.param_name.setText(case_name)
             qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
 
@@ -440,3 +428,14 @@ def add_case_manually(qtbot, gui, case_name="default"):
     QTimer.singleShot(1000, handle_dialog)
     manage_tool = gui.tools["Manage cases"]
     manage_tool.trigger()
+
+
+V = TypeVar("V")
+
+
+def get_child(gui, typ: Type[V], *args, waiter=None, **kwargs) -> V:
+    if waiter:
+        waiter.waitUntil(lambda: gui.findChild(typ, *args, **kwargs) is not None)
+    child = gui.findChild(typ, *args, **kwargs)
+    assert isinstance(child, typ)
+    return child

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -12,7 +12,7 @@ from ert.gui.simulation.simulation_panel import SimulationPanel
 from ert.run_models import EnsembleExperiment
 from ert.validation import rangestring_to_mask
 
-from .conftest import find_cases_dialog_and_panel, get_child
+from .conftest import get_child, with_manage_tool
 
 
 def test_that_the_manual_analysis_tool_works(
@@ -57,9 +57,7 @@ def test_that_the_manual_analysis_tool_works(
     analysis_tool.trigger()
 
     # Open the manage cases dialog
-    def handle_manage_dialog():
-        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
-
+    def handle_manage_dialog(dialog, cases_panel):
         # In the "create new case" tab, it should now contain "iter-1"
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
@@ -68,9 +66,7 @@ def test_that_the_manual_analysis_tool_works(
         assert len(case_list._list.findItems("iter-1", Qt.MatchFlag.MatchContains)) == 1
         dialog.close()
 
-    QTimer.singleShot(1000, handle_manage_dialog)
-    manage_tool = gui.tools["Manage cases"]
-    manage_tool.trigger()
+    with_manage_tool(gui, qtbot, handle_manage_dialog)
 
     # Select correct experiment in the simulation panel
     simulation_panel = get_child(gui, SimulationPanel)

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -12,7 +12,7 @@ from ert.gui.simulation.simulation_panel import SimulationPanel
 from ert.run_models import EnsembleExperiment
 from ert.validation import rangestring_to_mask
 
-from .conftest import get_child, with_manage_tool
+from .conftest import get_child, wait_for_child, with_manage_tool
 
 
 def test_that_the_manual_analysis_tool_works(
@@ -107,14 +107,14 @@ def test_that_the_manual_analysis_tool_works(
     start_simulation = get_child(simulation_panel, QWidget, name="start_simulation")
 
     def handle_dialog():
-        message_box = get_child(gui, QMessageBox, waiter=qtbot)
+        message_box = wait_for_child(gui, qtbot, QMessageBox)
         qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
 
     QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
     # The Run dialog opens, click show details and wait until done appears
     # then click it
-    run_dialog = get_child(gui, RunDialog, waiter=qtbot)
+    run_dialog = wait_for_child(gui, qtbot, RunDialog)
     qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -12,7 +12,7 @@ from ert.gui.simulation.simulation_panel import SimulationPanel
 from ert.run_models import EnsembleExperiment
 from ert.validation import rangestring_to_mask
 
-from .conftest import find_cases_dialog_and_panel
+from .conftest import find_cases_dialog_and_panel, get_child
 
 
 def test_that_the_manual_analysis_tool_works(
@@ -49,7 +49,7 @@ def test_that_the_manual_analysis_tool_works(
 
         QTimer.singleShot(1000, handle_dialog)
         qtbot.mouseClick(
-            dialog.findChild(QPushButton, name="RUN"),
+            get_child(dialog, QPushButton, name="RUN"),
             Qt.LeftButton,
         )
 
@@ -64,8 +64,7 @@ def test_that_the_manual_analysis_tool_works(
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
         assert current_tab.objectName() == "create_new_case_tab"
-        case_list = current_tab.findChild(CaseList)
-        assert isinstance(case_list, CaseList)
+        case_list = get_child(current_tab, CaseList)
         assert len(case_list._list.findItems("iter-1", Qt.MatchFlag.MatchContains)) == 1
         dialog.close()
 
@@ -74,9 +73,9 @@ def test_that_the_manual_analysis_tool_works(
     manage_tool.trigger()
 
     # Select correct experiment in the simulation panel
-    simulation_panel = gui.findChild(SimulationPanel)
-    simulation_mode_combo = simulation_panel.findChild(QComboBox)
-    simulation_settings = simulation_panel.findChild(EnsembleExperimentPanel)
+    simulation_panel = get_child(gui, SimulationPanel)
+    simulation_mode_combo = get_child(simulation_panel, QComboBox)
+    simulation_settings = get_child(simulation_panel, EnsembleExperimentPanel)
     simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
     shutil.rmtree("poly_out")
 
@@ -109,18 +108,17 @@ def test_that_the_manual_analysis_tool_works(
     ) < len([r for r in active_reals if r])
 
     # Click start simulation and agree to the message
-    start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+    start_simulation = get_child(simulation_panel, QWidget, name="start_simulation")
 
     def handle_dialog():
-        message_box = gui.findChild(QMessageBox)
+        message_box = get_child(gui, QMessageBox, waiter=qtbot)
         qtbot.mouseClick(message_box.buttons()[0], Qt.LeftButton)
 
     QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
     # The Run dialog opens, click show details and wait until done appears
     # then click it
-    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-    run_dialog = gui.findChild(RunDialog)
+    run_dialog = get_child(gui, RunDialog, waiter=qtbot)
     qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -20,7 +20,7 @@ from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
 
-from .conftest import get_child
+from .conftest import get_child, wait_for_child
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -273,13 +273,13 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         start_simulation = get_child(gui, QToolButton, name="start_simulation")
 
         def handle_dialog():
-            message_box = get_child(gui, QMessageBox, waiter=qtbot)
+            message_box = wait_for_child(gui, qtbot, QMessageBox)
             qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
 
         QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)
 
-        run_dialog = get_child(gui, RunDialog, waiter=qtbot)
+        run_dialog = wait_for_child(gui, qtbot, RunDialog)
 
         # Ensure that once the run dialog is opened
         # another simulation cannot be started
@@ -303,7 +303,7 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         # another simulation can be started
         assert start_simulation.isEnabled()
 
-        plot_window = get_child(gui, PlotWindow, waiter=qtbot)
+        plot_window = wait_for_child(gui, qtbot, PlotWindow)
 
         # Cycle through showing all the tabs
         for tab in plot_window._plot_widgets:

--- a/tests/unit_tests/gui/test_gui_load.py
+++ b/tests/unit_tests/gui/test_gui_load.py
@@ -20,6 +20,8 @@ from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
 
+from .conftest import get_child
+
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gui_load(qtbot):
@@ -33,16 +35,16 @@ def test_gui_load(qtbot):
     )
     qtbot.addWidget(gui)
 
-    sim_panel = gui.findChild(QWidget, name="Simulation_panel")
-    single_run_panel = gui.findChild(QWidget, name="Single_test_run_panel")
+    sim_panel = get_child(gui, QWidget, name="Simulation_panel")
+    single_run_panel = get_child(gui, QWidget, name="Single_test_run_panel")
     assert (
         sim_panel.getCurrentSimulationModel() == single_run_panel.getSimulationModel()
     )
 
-    sim_mode = gui.findChild(QWidget, name="Simulation_mode")
+    sim_mode = get_child(gui, QWidget, name="Simulation_mode")
     qtbot.keyClick(sim_mode, Qt.Key_Down)
 
-    ensemble_panel = gui.findChild(QWidget, name="Ensemble_experiment_panel")
+    ensemble_panel = get_child(gui, QWidget, name="Ensemble_experiment_panel")
     assert sim_panel.getCurrentSimulationModel() == ensemble_panel.getSimulationModel()
 
 
@@ -113,18 +115,18 @@ def test_gui_iter_num(monkeypatch, qtbot):
     )
     qtbot.addWidget(gui)
 
-    sim_mode = gui.findChild(QWidget, name="Simulation_mode")
+    sim_mode = get_child(gui, QWidget, name="Simulation_mode")
     qtbot.keyClick(sim_mode, Qt.Key_Down)
 
-    sim_panel = gui.findChild(QWidget, name="Simulation_panel")
+    sim_panel = get_child(gui, QWidget, name="Simulation_panel")
 
-    ensemble_panel = gui.findChild(QWidget, name="Ensemble_experiment_panel")
+    ensemble_panel = get_child(gui, QWidget, name="Ensemble_experiment_panel")
     # simulate entering number 10 as iter_num
     qtbot.keyClick(ensemble_panel._iter_field, Qt.Key_Backspace)
     qtbot.keyClicks(ensemble_panel._iter_field, "10")
     qtbot.keyClick(ensemble_panel._iter_field, Qt.Key_Enter)
 
-    start_simulation = gui.findChild(QWidget, name="start_simulation")
+    start_simulation = get_child(gui, QWidget, name="start_simulation")
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
     assert sim_panel.getSimulationArguments().iter_num == 10
 
@@ -178,7 +180,7 @@ def test_that_the_ui_show_no_warnings_when_observations_found(qapp):
     args.config = "poly.ert"
     with add_gui_log_handler() as log_handler:
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
-        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        combo_box = get_child(gui, QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
 
         for i in range(combo_box.count()):
@@ -195,7 +197,7 @@ def test_that_the_ui_show_warnings_when_there_are_no_observations(qapp, tmp_path
     args.config = str(config_file)
     with add_gui_log_handler() as log_handler:
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
-        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        combo_box = get_child(gui, QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
 
         for i in range(2):
@@ -220,7 +222,7 @@ def test_that_the_ui_show_warnings_when_parameters_are_missing(qapp, tmp_path):
     args.config = "poly-no-gen-kw.ert"
     with add_gui_log_handler() as log_handler:
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
-        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        combo_box = get_child(gui, QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
 
         for i in range(2):
@@ -267,18 +269,17 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         gui = _setup_main_window(enkf_main, args_mock, GUILogHandler())
         gui.notifier.set_storage(storage)
         qtbot.addWidget(gui)
-        simulation_mode = gui.findChild(QComboBox, name="Simulation_mode")
-        start_simulation = gui.findChild(QToolButton, name="start_simulation")
-        assert isinstance(start_simulation, QToolButton)
+        simulation_mode = get_child(gui, QComboBox, name="Simulation_mode")
+        start_simulation = get_child(gui, QToolButton, name="start_simulation")
 
         def handle_dialog():
-            message_box = gui.findChild(QMessageBox)
+            message_box = get_child(gui, QMessageBox, waiter=qtbot)
             qtbot.mouseClick(message_box.button(QMessageBox.Yes), Qt.LeftButton)
 
         QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(start_simulation, Qt.LeftButton)
 
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = get_child(gui, RunDialog, waiter=qtbot)
 
         # Ensure that once the run dialog is opened
         # another simulation cannot be started
@@ -289,9 +290,6 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         for ind in range(simulation_mode.count()):
             simulation_mode.setCurrentIndex(ind)
             assert not start_simulation.isEnabled()
-
-        run_dialog = gui.findChild(RunDialog)
-        assert isinstance(run_dialog, RunDialog)
 
         # The user expects to be able to open e.g. the even viewer
         # while the run dialog is open
@@ -305,10 +303,9 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
         # another simulation can be started
         assert start_simulation.isEnabled()
 
-        qtbot.waitUntil(lambda: gui.findChild(PlotWindow) is not None)
+        plot_window = get_child(gui, PlotWindow, waiter=qtbot)
 
         # Cycle through showing all the tabs
-        plot_window = gui.findChild(PlotWindow)
         for tab in plot_window._plot_widgets:
             plot_window._central_tab.setCurrentWidget(tab)
 
@@ -333,18 +330,17 @@ def test_help_buttons_in_suggester_dialog(tmp_path, qtbot):
         )
         assert gui.windowTitle() == "Some problems detected"
 
-        about_button = gui.findChild(QWidget, name="about_button")
+        about_button = get_child(gui, QWidget, name="about_button")
         qtbot.mouseClick(about_button, Qt.LeftButton)
 
-        help_dialog = gui.findChild(AboutDialog)
-        assert isinstance(help_dialog, AboutDialog)
+        help_dialog = get_child(gui, AboutDialog)
         assert help_dialog.windowTitle() == "About"
 
-        about_close_button = help_dialog.findChild(QWidget, name="close_button")
+        about_close_button = get_child(help_dialog, QWidget, name="close_button")
         qtbot.mouseClick(about_close_button, Qt.LeftButton)
 
         with patch("webbrowser.open", MagicMock(return_value=True)) as browser_open:
-            github_button = gui.findChild(QWidget, name="GitHub page")
+            github_button = get_child(gui, QWidget, name="GitHub page")
             qtbot.mouseClick(github_button, Qt.LeftButton)
             assert browser_open.called
 
@@ -393,7 +389,7 @@ def test_that_es_mda_is_disabled_when_weights_are_invalid(qtbot):
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
         assert gui.windowTitle() == "ERT - poly.ert"
 
-        combo_box = gui.findChild(QComboBox, name="Simulation_mode")
+        combo_box = get_child(gui, QComboBox, name="Simulation_mode")
         assert combo_box.count() == 5
         combo_box.setCurrentIndex(3)
 
@@ -402,10 +398,10 @@ def test_that_es_mda_is_disabled_when_weights_are_invalid(qtbot):
             == "Multiple Data Assimilation (ES MDA) - Recommended"
         )
 
-        es_mda_panel = gui.findChild(QWidget, name="ES_MDA_panel")
+        es_mda_panel = get_child(gui, QWidget, name="ES_MDA_panel")
         assert es_mda_panel
 
-        run_sim_button = gui.findChild(QToolButton, name="start_simulation")
+        run_sim_button = get_child(gui, QToolButton, name="start_simulation")
         assert run_sim_button
         assert run_sim_button.isEnabled()
 

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -29,7 +29,7 @@ from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.run_models import SingleTestRun
 
-from .conftest import get_child, load_results_manually, with_manage_tool
+from .conftest import get_child, load_results_manually, wait_for_child, with_manage_tool
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -50,7 +50,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
     plot_tool.trigger()
 
     # Then the plot window opens
-    plot_window = get_child(gui, PlotWindow, waiter=qtbot)
+    plot_window = wait_for_child(gui, qtbot, PlotWindow)
 
     case_selection = get_child(plot_window, CaseSelectionWidget)
     data_types = get_child(plot_window, DataTypeKeysWidget)
@@ -141,7 +141,7 @@ def test_that_the_manage_cases_tool_can_be_used(
 
         # Click add case and name it "new_case"
         def handle_add_dialog():
-            dialog = get_child(current_tab, ValidatedDialog, waiter=qtbot)
+            dialog = wait_for_child(current_tab, qtbot, ValidatedDialog)
             dialog.param_name.setText("new_case")
             qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
 
@@ -153,7 +153,7 @@ def test_that_the_manage_cases_tool_can_be_used(
 
         # Click add case and try to name it "new_case" again
         def handle_add_dialog_again():
-            dialog = get_child(current_tab, ValidatedDialog, waiter=qtbot)
+            dialog = wait_for_child(current_tab, qtbot, ValidatedDialog)
             dialog.param_name.setText("new_case")
             assert not dialog.ok_button.isEnabled()
             qtbot.mouseClick(dialog.cancel_button, Qt.LeftButton)
@@ -202,9 +202,9 @@ def test_that_inversion_type_can_be_set_from_gui(qtbot, opened_main_window):
     # A helpful discussion on the topic is here:
     # https://github.com/pytest-dev/pytest-qt/issues/256
     def handle_dialog_first_time():
-        var_panel = get_child(gui, AnalysisModuleVariablesPanel, waiter=qtbot)
-        inversion_spin_box = get_child(
-            var_panel, QSpinBox, waiter=qtbot, name="IES_INVERSION"
+        var_panel = wait_for_child(gui, qtbot, AnalysisModuleVariablesPanel)
+        inversion_spin_box = wait_for_child(
+            var_panel, qtbot, QSpinBox, name="IES_INVERSION"
         )
         assert inversion_spin_box.value() == 0
         qtbot.keyClick(inversion_spin_box, Qt.Key_Up)
@@ -215,9 +215,9 @@ def test_that_inversion_type_can_be_set_from_gui(qtbot, opened_main_window):
     qtbot.mouseClick(get_child(es_edit, QToolButton), Qt.LeftButton, delay=1)
 
     def handle_dialog_second_time():
-        var_panel = get_child(gui, AnalysisModuleVariablesPanel, waiter=qtbot)
-        inversion_spin_box = get_child(
-            var_panel, QSpinBox, waiter=qtbot, name="IES_INVERSION"
+        var_panel = wait_for_child(gui, qtbot, AnalysisModuleVariablesPanel)
+        inversion_spin_box = wait_for_child(
+            var_panel, qtbot, QSpinBox, name="IES_INVERSION"
         )
         assert inversion_spin_box.value() == 1
         var_panel.parent().close()
@@ -242,7 +242,7 @@ def test_that_csv_export_plugin_generates_a_file(
         nonlocal file_name
 
         # Find the case selection box in the dialog
-        export_dialog = get_child(gui, CustomDialog, waiter=qtbot)
+        export_dialog = wait_for_child(gui, qtbot, CustomDialog)
         case_selection = get_child(export_dialog, ListEditBox)
 
         # Select default_0 as the case to be exported
@@ -257,7 +257,7 @@ def test_that_csv_export_plugin_generates_a_file(
         """
         Click on the plugin finised dialog once it pops up
         """
-        finished_message = get_child(gui, QMessageBox, waiter=qtbot)
+        finished_message = wait_for_child(gui, qtbot, QMessageBox)
         assert "completed" in finished_message.text()
         qtbot.mouseClick(finished_message.button(QMessageBox.Ok), Qt.LeftButton)
 
@@ -287,7 +287,7 @@ def test_that_the_manage_cases_tool_can_be_used_with_clean_storage(
 
         # Click add case and name it "new_case"
         def handle_add_dialog():
-            dialog = get_child(current_tab, ValidatedDialog, waiter=qtbot)
+            dialog = wait_for_child(current_tab, qtbot, ValidatedDialog)
             dialog.param_name.setText("new_case")
             qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
 
@@ -359,7 +359,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
 
     def handle_dialog():
         qtbot.mouseClick(
-            get_child(gui, QMessageBox, waiter=qtbot).buttons()[0], Qt.LeftButton
+            wait_for_child(gui, qtbot, QMessageBox).buttons()[0], Qt.LeftButton
         )
 
     def handle_error_dialog(run_dialog):
@@ -383,7 +383,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
     QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(start_simulation, Qt.LeftButton)
 
-    run_dialog = get_child(gui, RunDialog, waiter=qtbot)
+    run_dialog = wait_for_child(gui, qtbot, RunDialog)
     qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
     QTimer.singleShot(20000, lambda: handle_error_dialog(run_dialog))

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -29,7 +29,7 @@ from ert.gui.tools.plot.plot_case_selection_widget import CaseSelectionWidget
 from ert.gui.tools.plot.plot_window import PlotWindow
 from ert.run_models import SingleTestRun
 
-from .conftest import find_cases_dialog_and_panel, get_child, load_results_manually
+from .conftest import get_child, load_results_manually, with_manage_tool
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -128,8 +128,7 @@ def test_that_the_manage_cases_tool_can_be_used(
     gui = opened_main_window
 
     # Click on "Manage Cases"
-    def handle_dialog():
-        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
+    def handle_dialog(dialog, cases_panel):
         # Open the create new cases tab
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
@@ -187,9 +186,7 @@ def test_that_the_manage_cases_tool_can_be_used(
 
         dialog.close()
 
-    QTimer.singleShot(1000, handle_dialog)
-    manage_tool = gui.tools["Manage cases"]
-    manage_tool.trigger()
+    with_manage_tool(gui, qtbot, handle_dialog)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -278,8 +275,7 @@ def test_that_the_manage_cases_tool_can_be_used_with_clean_storage(
     gui = opened_main_window_clean
 
     # Click on "Manage Cases"
-    def handle_dialog():
-        dialog, cases_panel = find_cases_dialog_and_panel(gui, qtbot)
+    def handle_dialog(dialog, cases_panel):
         # Open the create new cases tab
         cases_panel.setCurrentIndex(0)
         current_tab = cases_panel.currentWidget()
@@ -318,9 +314,7 @@ def test_that_the_manage_cases_tool_can_be_used_with_clean_storage(
 
         dialog.close()
 
-    QTimer.singleShot(1000, handle_dialog)
-    manage_tool = gui.tools["Manage cases"]
-    manage_tool.trigger()
+    with_manage_tool(gui, qtbot, handle_dialog)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/gui/test_rft_export_plugin.py
+++ b/tests/unit_tests/gui/test_rft_export_plugin.py
@@ -16,7 +16,12 @@ from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.services import StorageService
 from ert.storage import open_storage
 
-from .conftest import add_case_manually, get_child, load_results_manually
+from .conftest import (
+    add_case_manually,
+    get_child,
+    load_results_manually,
+    wait_for_child,
+)
 
 
 @pytest.fixture
@@ -93,12 +98,12 @@ def test_rft_csv_export_plugin_exports_rft_data(
             """
             Click on the plugin finised dialog once it pops up
             """
-            finished_message = get_child(gui, QMessageBox, waiter=qtbot)
+            finished_message = wait_for_child(gui, qtbot, QMessageBox)
             assert "completed" in finished_message.text()
             qtbot.mouseClick(finished_message.button(QMessageBox.Ok), Qt.LeftButton)
 
         def handle_rft_plugin_dialog():
-            dialog = get_child(gui, CustomDialog, waiter=qtbot)
+            dialog = wait_for_child(gui, qtbot, CustomDialog)
             trajectory_field = get_child(dialog, PathChooser, name="trajectory_chooser")
             trajectory_field._model.setValue(".")
             list_field = get_child(dialog, ListEditBox, name="list_of_cases")

--- a/tests/unit_tests/gui/test_rft_export_plugin.py
+++ b/tests/unit_tests/gui/test_rft_export_plugin.py
@@ -16,7 +16,7 @@ from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.services import StorageService
 from ert.storage import open_storage
 
-from .conftest import add_case_manually, load_results_manually
+from .conftest import add_case_manually, get_child, load_results_manually
 
 
 @pytest.fixture
@@ -93,17 +93,15 @@ def test_rft_csv_export_plugin_exports_rft_data(
             """
             Click on the plugin finised dialog once it pops up
             """
-            qtbot.waitUntil(lambda: isinstance(gui.findChild(QMessageBox), QMessageBox))
-            finished_message = gui.findChild(QMessageBox)
+            finished_message = get_child(gui, QMessageBox, waiter=qtbot)
             assert "completed" in finished_message.text()
             qtbot.mouseClick(finished_message.button(QMessageBox.Ok), Qt.LeftButton)
 
         def handle_rft_plugin_dialog():
-            qtbot.waitUntil(lambda: gui.findChild(CustomDialog) is not None)
-            dialog = gui.findChild(CustomDialog)
-            trajectory_field = dialog.findChild(PathChooser, name="trajectory_chooser")
+            dialog = get_child(gui, CustomDialog, waiter=qtbot)
+            trajectory_field = get_child(dialog, PathChooser, name="trajectory_chooser")
             trajectory_field._model.setValue(".")
-            list_field = dialog.findChild(ListEditBox, name="list_of_cases")
+            list_field = get_child(dialog, ListEditBox, name="list_of_cases")
             list_field._list_edit_line.setText("default")
             qtbot.mouseClick(dialog.ok_button, Qt.LeftButton)
 


### PR DESCRIPTION
Create a small utility for getting children of qtwidgets in tests

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
