### PR TITLE
Use QDir search paths instead of resourceIcon

### DIFF
--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -1,19 +1,7 @@
 # isort: skip_file
-import pkgutil
-from os.path import dirname
-from typing import cast, TYPE_CHECKING
-
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QCursor, QIcon, QMovie, QPixmap
+from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import QApplication
-
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
-
-
-def _get_ert_gui_dir():
-    ert_gui_loader = cast("FileLoader", pkgutil.get_loader("ert.gui"))
-    return dirname(ert_gui_loader.get_filename())
 
 
 def showWaitCursorWhileWaiting(func):
@@ -28,22 +16,6 @@ def showWaitCursorWhileWaiting(func):
             QApplication.restoreOverrideCursor()
 
     return wrapper
-
-
-def resourceIcon(name):
-    """Load an image as an icon"""
-    return QIcon(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
-
-
-def resourceImage(name) -> QPixmap:
-    """Load an image as a Pixmap"""
-    return QPixmap(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
-
-
-def resourceMovie(name) -> QMovie:
-    movie = QMovie(f"{_get_ert_gui_dir()}/resources/gui/img/{name}")
-    movie.start()
-    return movie
 
 
 # The following imports utilize the functions defined above:

--- a/src/ert/gui/ertwidgets/analysismoduleedit.py
+++ b/src/ert/gui/ertwidgets/analysismoduleedit.py
@@ -1,9 +1,10 @@
 from typing import Literal
 
 from qtpy.QtCore import QMargins, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QToolButton, QWidget
 
-from ert.gui.ertwidgets import ClosableDialog, resourceIcon
+from ert.gui.ertwidgets import ClosableDialog
 from ert.gui.ertwidgets.analysismodulevariablespanel import AnalysisModuleVariablesPanel
 from ert.libres_facade import LibresFacade
 
@@ -21,7 +22,7 @@ class AnalysisModuleEdit(QWidget):
         self._name = module_name
 
         variables_popup_button = QToolButton()
-        variables_popup_button.setIcon(resourceIcon("edit.svg"))
+        variables_popup_button.setIcon(QIcon("img:edit.svg"))
         variables_popup_button.clicked.connect(self.showVariablesPopup)
         variables_popup_button.setMaximumSize(20, 20)
 

--- a/src/ert/gui/ertwidgets/caselist.py
+++ b/src/ert/gui/ertwidgets/caselist.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -12,7 +13,6 @@ from qtpy.QtWidgets import (
 )
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
 from ert.libres_facade import LibresFacade
 from ert.storage import StorageAccessor
@@ -29,12 +29,12 @@ class AddRemoveWidget(QWidget):
         QWidget.__init__(self)
 
         self.addButton = QToolButton(self)
-        self.addButton.setIcon(resourceIcon("add_circle_outlined.svg"))
+        self.addButton.setIcon(QIcon("img:add_circle_outlined.svg"))
         self.addButton.setIconSize(QSize(16, 16))
         self.addButton.clicked.connect(addFunction)
 
         self.removeButton = QToolButton(self)
-        self.removeButton.setIcon(resourceIcon("remove_outlined.svg"))
+        self.removeButton.setIcon(QIcon("img:remove_outlined.svg"))
         self.removeButton.setIconSize(QSize(16, 16))
         self.removeButton.clicked.connect(removeFunction)
 

--- a/src/ert/gui/ertwidgets/checklist.py
+++ b/src/ert/gui/ertwidgets/checklist.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -11,7 +12,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import SearchBox, resourceIcon
+from ert.gui.ertwidgets import SearchBox
 
 
 class CheckList(QWidget):
@@ -73,13 +74,13 @@ class CheckList(QWidget):
 
     def _createCheckButtons(self):
         self._checkAllButton = QToolButton()
-        self._checkAllButton.setIcon(resourceIcon("check.svg"))
+        self._checkAllButton.setIcon(QIcon("img:check.svg"))
         self._checkAllButton.setIconSize(QSize(16, 16))
         self._checkAllButton.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._checkAllButton.setAutoRaise(True)
         self._checkAllButton.setToolTip("Select all")
         self._uncheckAllButton = QToolButton()
-        self._uncheckAllButton.setIcon(resourceIcon("checkbox_outline.svg"))
+        self._uncheckAllButton.setIcon(QIcon("img:checkbox_outline.svg"))
         self._uncheckAllButton.setIconSize(QSize(16, 16))
         self._uncheckAllButton.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._uncheckAllButton.setAutoRaise(True)

--- a/src/ert/gui/ertwidgets/listeditbox.py
+++ b/src/ert/gui/ertwidgets/listeditbox.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QCompleter,
     QHBoxLayout,
@@ -9,7 +10,6 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.validationsupport import ValidationSupport
 
 
@@ -84,7 +84,7 @@ class ListEditBox(QWidget):
         layout.addWidget(self._list_edit_line)
 
         dialog_button = QToolButton(self)
-        dialog_button.setIcon(resourceIcon("add_circle_outlined.svg"))
+        dialog_button.setIcon(QIcon("img:add_circle_outlined.svg"))
         dialog_button.setIconSize(QSize(16, 16))
         dialog_button.clicked.connect(self.addChoice)
 

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -3,9 +3,9 @@ import re
 from typing import Tuple
 
 from qtpy.QtCore import QSize
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QFileDialog, QHBoxLayout, QLineEdit, QToolButton, QWidget
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.validationsupport import ValidationSupport
 
 
@@ -41,7 +41,7 @@ class PathChooser(QWidget):
         layout.addWidget(self._path_line)
 
         dialog_button = QToolButton(self)
-        dialog_button.setIcon(resourceIcon("folder_open.svg"))
+        dialog_button.setIcon(QIcon("img:folder_open.svg"))
         dialog_button.setIconSize(QSize(16, 16))
         dialog_button.clicked.connect(self.selectPath)
         layout.addWidget(dialog_button)

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -6,7 +6,10 @@ import webbrowser
 from signal import SIG_DFL, SIGINT, signal
 from typing import Optional, cast
 
-from PyQt5.QtWidgets import (
+from PyQt5.QtGui import QIcon
+from qtpy.QtCore import QDir, QLocale, QSize, Qt
+from qtpy.QtWidgets import (
+    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -15,13 +18,11 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qtpy.QtCore import QLocale, QSize, Qt
-from qtpy.QtWidgets import QApplication
 
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
 from ert.enkf_main import EnKFMain
 from ert.gui.about_dialog import AboutDialog
-from ert.gui.ertwidgets import SuggestorMessage, SummaryPanel, resourceIcon
+from ert.gui.ertwidgets import SuggestorMessage, SummaryPanel
 from ert.gui.main_window import ErtMainWindow
 from ert.gui.simulation import SimulationPanel
 from ert.gui.tools.event_viewer import (
@@ -54,8 +55,12 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None):
     # happen in Qt slots.
     signal(SIGINT, SIG_DFL)
 
+    QDir.addSearchPath(
+        "img", os.path.join(os.path.dirname(__file__), "resources/gui/img")
+    )
+
     app = QApplication([])  # Early so that QT is initialized before other imports
-    app.setWindowIcon(resourceIcon("application/window_icon_cutout"))
+    app.setWindowIcon(QIcon("img:application/window_icon_cutout"))
     with add_gui_log_handler() as log_handler:
         window, ens_path, ensemble_size, parameter_config = _start_initial_gui_window(
             args, log_handler, plugin_manager

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -3,6 +3,7 @@ from threading import Thread
 
 from PyQt5.QtWidgets import QAbstractItemView
 from qtpy.QtCore import QModelIndex, QSize, Qt, QThread, QTimer, Signal, Slot
+from qtpy.QtGui import QMovie
 from qtpy.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -26,7 +27,6 @@ from ert.ensemble_evaluator import (
     SnapshotUpdateEvent,
 )
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceMovie
 from ert.gui.ertwidgets.message_box import ErtMessageBox
 from ert.gui.model.job_list import JobListProxyModel
 from ert.gui.model.progress_proxy import ProgressProxyModel
@@ -122,7 +122,7 @@ class RunDialog(QDialog):
         self.show_details_button.setCheckable(True)
 
         size = 20
-        spin_movie = resourceMovie("loading.gif")
+        spin_movie = QMovie("img:loading.gif")
         spin_movie.setSpeed(60)
         spin_movie.setScaledSize(QSize(size, size))
         spin_movie.start()

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from typing import Any, Dict
 
 from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QApplication,
     QComboBox,
@@ -19,7 +20,6 @@ from qtpy.QtWidgets import (
 from ert.cli.model_factory import create_model
 from ert.enkf_main import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceIcon
 from ert.libres_facade import LibresFacade
 
 from .ensemble_experiment_panel import EnsembleExperimentPanel
@@ -64,7 +64,7 @@ class SimulationPanel(QWidget):
         self.run_button = QToolButton()
         self.run_button.setObjectName("start_simulation")
         self.run_button.setText(EXPERIMENT_READY_TO_RUN_BUTTON_MESSAGE)
-        self.run_button.setIcon(resourceIcon("play_circle.svg"))
+        self.run_button.setIcon(QIcon("img:play_circle.svg"))
         self.run_button.setIconSize(QSize(32, 32))
         self.run_button.clicked.connect(self.runSimulation)
         self.run_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)

--- a/src/ert/gui/tools/event_viewer/tool.py
+++ b/src/ert/gui/tools/event_viewer/tool.py
@@ -1,6 +1,6 @@
 from qtpy.QtCore import QObject, Slot
+from qtpy.QtGui import QIcon
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.tools import Tool
 from ert.gui.tools.event_viewer import EventViewerPanel
 
@@ -9,7 +9,7 @@ class EventViewerTool(Tool, QObject):
     def __init__(self, gui_handler):
         super().__init__(
             "Event viewer",
-            resourceIcon("notifications.svg"),
+            QIcon("img:notifications.svg"),
         )
         self.log_handler = gui_handler
         self.logging_window = EventViewerPanel(self.log_handler)

--- a/src/ert/gui/tools/export/export_tool.py
+++ b/src/ert/gui/tools/export/export_tool.py
@@ -1,11 +1,11 @@
 import logging
 from weakref import ref
 
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QMessageBox
 
 from ert.enkf_main import EnKFMain
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.export import ExportPanel
@@ -14,7 +14,7 @@ from ert.shared.exporter import Exporter
 
 class ExportTool(Tool):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier):
-        super().__init__("Export data", resourceIcon("share.svg"))
+        super().__init__("Export data", QIcon("img:share.svg"))
         self.__export_widget = None
         self.__dialog = None
         self.__exporter = Exporter(ert, notifier)

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -1,7 +1,8 @@
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QPushButton
 
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceIcon, showWaitCursorWhileWaiting
+from ert.gui.ertwidgets import showWaitCursorWhileWaiting
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.load_results import LoadResultsPanel
@@ -13,7 +14,7 @@ class LoadResultsTool(Tool):
         self.facade = facade
         super().__init__(
             "Load results manually",
-            resourceIcon("upload.svg"),
+            QIcon("img:upload.svg"),
         )
         self._import_widget = None
         self._dialog = None

--- a/src/ert/gui/tools/manage_cases/manage_cases_tool.py
+++ b/src/ert/gui/tools/manage_cases/manage_cases_tool.py
@@ -1,4 +1,5 @@
-from ert.gui.ertwidgets import resourceIcon
+from qtpy.QtGui import QIcon
+
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.manage_cases.case_init_configuration import (
@@ -10,7 +11,7 @@ class ManageCasesTool(Tool):
     def __init__(self, ert, notifier):
         self.notifier = notifier
         self.ert = ert
-        super().__init__("Manage cases", resourceIcon("build_wrench.svg"))
+        super().__init__("Manage cases", QIcon("img:build_wrench.svg"))
 
     def trigger(self):
         case_management_widget = CaseInitializationConfigurationPanel(

--- a/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
+++ b/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QObject, Qt, Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -14,7 +15,6 @@ from qtpy.QtWidgets import (
     QWidgetAction,
 )
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.plottery import PlotConfig, PlotConfigFactory, PlotConfigHistory
 from ert.gui.tools.plot.widgets import CopyStyleToDialog
 
@@ -201,29 +201,29 @@ class CustomizePlotDialog(QDialog):
         self._button_layout = QHBoxLayout()
 
         self._reset_button = QToolButton()
-        self._reset_button.setIcon(resourceIcon("format_color_reset.svg"))
+        self._reset_button.setIcon(QIcon("img:format_color_reset.svg"))
         self._reset_button.setToolTip("Reset all settings back to default")
         self._reset_button.clicked.connect(self.resetSettings)
 
         self._undo_button = QToolButton()
-        self._undo_button.setIcon(resourceIcon("undo.svg"))
+        self._undo_button.setIcon(QIcon("img:undo.svg"))
         self._undo_button.setToolTip("Undo")
         self._undo_button.clicked.connect(self.undoSettings)
 
         self._redo_button = QToolButton()
-        self._redo_button.setIcon(resourceIcon("redo.svg"))
+        self._redo_button.setIcon(QIcon("img:redo.svg"))
         self._redo_button.setToolTip("Redo")
         self._redo_button.clicked.connect(self.redoSettings)
         self._redo_button.setEnabled(False)
 
         self._copy_from_button = QToolButton()
-        self._copy_from_button.setIcon(resourceIcon("download.svg"))
+        self._copy_from_button.setIcon(QIcon("img:download.svg"))
         self._copy_from_button.setToolTip("Copy settings from another key")
         self._copy_from_button.setPopupMode(QToolButton.InstantPopup)
         self._copy_from_button.setEnabled(False)
 
         self._copy_to_button = QToolButton()
-        self._copy_to_button.setIcon(resourceIcon("upload.svg"))
+        self._copy_to_button.setIcon(QIcon("img:upload.svg"))
         self._copy_to_button.setToolTip("Copy current plot settings to other keys")
         self._copy_to_button.setPopupMode(QToolButton.InstantPopup)
         self._copy_to_button.clicked.connect(self.initiateCopyStyleToDialog)

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -1,9 +1,7 @@
 from typing import Optional
 
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
-from qtpy.QtGui import QColor
-
-from ert.gui.ertwidgets import resourceIcon
+from qtpy.QtGui import QColor, QIcon
 
 
 class DataTypeKeysListModel(QAbstractItemModel):
@@ -14,7 +12,7 @@ class DataTypeKeysListModel(QAbstractItemModel):
     def __init__(self, keys):
         QAbstractItemModel.__init__(self)
         self._keys = keys
-        self.__icon = resourceIcon("star_filled.svg")
+        self.__icon = QIcon("img:star_filled.svg")
 
     def index(self, row, column, parent=None, *args, **kwargs):
         return self.createIndex(row, column)

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -1,7 +1,8 @@
 from qtpy.QtCore import Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QListView, QToolButton, QVBoxLayout, QWidget
 
-from ert.gui.ertwidgets import Legend, SearchBox, resourceIcon
+from ert.gui.ertwidgets import Legend, SearchBox
 
 from .data_type_keys_list_model import DataTypeKeysListModel
 from .data_type_proxy_model import DataTypeProxyModel
@@ -29,7 +30,7 @@ class DataTypeKeysWidget(QWidget):
         filter_layout.addWidget(self.search_box)
 
         filter_popup_button = QToolButton()
-        filter_popup_button.setIcon(resourceIcon("filter_list.svg"))
+        filter_popup_button.setIcon(QIcon("img:filter_list.svg"))
         filter_popup_button.clicked.connect(self.showFilterPopup)
         filter_layout.addWidget(filter_popup_button)
         layout.addLayout(filter_layout)

--- a/src/ert/gui/tools/plot/plot_case_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_case_selection_widget.py
@@ -1,7 +1,6 @@
 from qtpy.QtCore import QSignalMapper, Qt, Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QToolButton, QVBoxLayout, QWidget
-
-from ert.gui.ertwidgets import resourceIcon
 
 from .plot_case_model import PlotCaseModel
 
@@ -25,7 +24,7 @@ class CaseSelectionWidget(QWidget):
         self.__add_case_button.setObjectName("add_case_button")
         self.__add_case_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self.__add_case_button.setText("Add case to plot")
-        self.__add_case_button.setIcon(resourceIcon("add_circle_outlined.svg"))
+        self.__add_case_button.setIcon(QIcon("img:add_circle_outlined.svg"))
         self.__add_case_button.clicked.connect(self.addCaseSelector)
 
         add_button_layout.addStretch()
@@ -83,7 +82,7 @@ class CaseSelectionWidget(QWidget):
         button.setObjectName("case_delete_button")
         button.setAutoRaise(True)
         button.setDisabled(disabled)
-        button.setIcon(resourceIcon("delete_to_trash.svg"))
+        button.setIcon(QIcon("img:delete_to_trash.svg"))
         button.clicked.connect(self.__signal_mapper.map)
 
         layout.addWidget(button)

--- a/src/ert/gui/tools/plot/plot_tool.py
+++ b/src/ert/gui/tools/plot/plot_tool.py
@@ -1,4 +1,5 @@
-from ert.gui.ertwidgets import resourceIcon
+from qtpy.QtGui import QIcon
+
 from ert.gui.tools import Tool
 
 from .plot_window import PlotWindow
@@ -6,7 +7,7 @@ from .plot_window import PlotWindow
 
 class PlotTool(Tool):
     def __init__(self, config_file, main_window):
-        super().__init__("Create plot", resourceIcon("timeline.svg"))
+        super().__init__("Create plot", QIcon("img:timeline.svg"))
         self._config_file = config_file
         self.main_window = main_window
 

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -4,9 +4,8 @@ import traceback
 from matplotlib.backends.backend_qt5agg import FigureCanvas, NavigationToolbar2QT
 from matplotlib.figure import Figure
 from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QAction, QVBoxLayout, QWidget
-
-from ert.gui.ertwidgets import resourceIcon
 
 
 class CustomNavigationToolbar(NavigationToolbar2QT):
@@ -15,7 +14,7 @@ class CustomNavigationToolbar(NavigationToolbar2QT):
     def __init__(self, canvas, parent, coordinates=True):
         super().__init__(canvas, parent, coordinates)
 
-        gear = resourceIcon("edit.svg")
+        gear = QIcon("img:edit.svg")
         customize_action = QAction(gear, "Customize", self)
         customize_action.setToolTip("Customize plot settings")
         customize_action.triggered.connect(self.customizationTriggered)

--- a/src/ert/gui/tools/plot/widgets/clearable_line_edit.py
+++ b/src/ert/gui/tools/plot/widgets/clearable_line_edit.py
@@ -1,8 +1,6 @@
 from qtpy.QtCore import QSize, Qt
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QIcon
 from qtpy.QtWidgets import QLineEdit, QPushButton, QStyle
-
-from ert.gui.ertwidgets import resourceIcon
 
 
 class ClearableLineEdit(QLineEdit):
@@ -16,7 +14,7 @@ class ClearableLineEdit(QLineEdit):
         self._placeholder_active = False
 
         self._clear_button = QPushButton(self)
-        self._clear_button.setIcon(resourceIcon("remove_outlined.svg"))
+        self._clear_button.setIcon(QIcon("img:remove_outlined.svg"))
         self._clear_button.setFlat(True)
         self._clear_button.setFocusPolicy(Qt.NoFocus)
         self._clear_button.setFixedSize(17, 17)

--- a/src/ert/gui/tools/plot/widgets/copy_style_to_dialog.py
+++ b/src/ert/gui/tools/plot/widgets/copy_style_to_dialog.py
@@ -1,3 +1,4 @@
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QDialog,
     QFormLayout,
@@ -7,7 +8,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import CheckList, resourceIcon
+from ert.gui.ertwidgets import CheckList
 from ert.gui.tools.plot import FilterableKwListModel, FilterPopup
 
 
@@ -26,7 +27,7 @@ class CopyStyleToDialog(QDialog):
         self._filter_popup.filterSettingsChanged.connect(self.filterSettingsChanged)
 
         filter_popup_button = QToolButton()
-        filter_popup_button.setIcon(resourceIcon("filter_list.svg"))
+        filter_popup_button.setIcon(QIcon("img:filter_list.svg"))
         filter_popup_button.clicked.connect(self._filter_popup.show)
 
         self._list_model = FilterableKwListModel(key_defs)

--- a/src/ert/gui/tools/plot/widgets/custom_date_edit.py
+++ b/src/ert/gui/tools/plot/widgets/custom_date_edit.py
@@ -1,6 +1,7 @@
 import datetime
 
 from qtpy.QtCore import QDate
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QCalendarWidget,
     QHBoxLayout,
@@ -10,7 +11,6 @@ from qtpy.QtWidgets import (
     QWidgetAction,
 )
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.tools.plot.widgets.clearable_line_edit import ClearableLineEdit
 
 
@@ -23,7 +23,7 @@ class CustomDateEdit(QWidget):
         self._calendar_button.setPopupMode(QToolButton.InstantPopup)
         self._calendar_button.setFixedSize(26, 26)
         self._calendar_button.setAutoRaise(True)
-        self._calendar_button.setIcon(resourceIcon("calendar_date_range.svg"))
+        self._calendar_button.setIcon(QIcon("img:calendar_date_range.svg"))
         self._calendar_button.setStyleSheet(
             "QToolButton::menu-indicator { image: none; }"
         )

--- a/src/ert/gui/tools/plugins/plugins_tool.py
+++ b/src/ert/gui/tools/plugins/plugins_tool.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QMenu
 
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.tools import Tool
 
 from .plugin_runner import PluginRunner
@@ -17,7 +17,7 @@ class PluginsTool(Tool):
         self.notifier = notifier
         super().__init__(
             "Plugins",
-            resourceIcon("widgets.svg"),
+            QIcon("img:widgets.svg"),
             enabled,
             popup_menu=True,
         )

--- a/src/ert/gui/tools/plugins/process_job_dialog.py
+++ b/src/ert/gui/tools/plugins/process_job_dialog.py
@@ -1,4 +1,5 @@
 from qtpy.QtCore import QSize, Qt, Signal
+from qtpy.QtGui import QMovie
 from qtpy.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -11,8 +12,6 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
-from ert.gui.ertwidgets import resourceMovie
 
 
 class ProcessJobDialog(QDialog):
@@ -39,7 +38,7 @@ class ProcessJobDialog(QDialog):
         widget_layout = QHBoxLayout()
 
         size = 64
-        spin_movie = resourceMovie("loading.gif")
+        spin_movie = QMovie("img:loading.gif")
         spin_movie.setSpeed(60)
         spin_movie.setScaledSize(QSize(size, size))
         spin_movie.start()

--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 import numpy as np
 from qtpy.QtCore import QObject, Qt, QThread, Signal, Slot
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QApplication, QMessageBox
 
 from ert.analysis import ErtAnalysisError, Progress, smoother_update
 from ert.enkf_main import EnKFMain, _seed_sequence
 from ert.gui.ertnotifier import ErtNotifier
-from ert.gui.ertwidgets import resourceIcon
 from ert.gui.ertwidgets.statusdialog import StatusDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.run_analysis import RunAnalysisPanel
@@ -67,7 +67,7 @@ class Analyse(QObject):
 
 class RunAnalysisTool(Tool):
     def __init__(self, ert: EnKFMain, notifier: ErtNotifier):
-        super().__init__("Run analysis", resourceIcon("formula.svg"))
+        super().__init__("Run analysis", QIcon("img:formula.svg"))
         self.ert = ert
         self.notifier = notifier
         self._run_widget: Optional[RunAnalysisPanel] = None

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -5,6 +5,7 @@ from threading import Thread
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QSize, Qt, Signal
+from qtpy.QtGui import QIcon, QMovie
 from qtpy.QtWidgets import (
     QComboBox,
     QFormLayout,
@@ -15,7 +16,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets import CaseSelector, resourceIcon, resourceMovie
+from ert.gui.ertwidgets import CaseSelector
 from ert.gui.tools.workflows.workflow_dialog import WorkflowDialog
 from ert.job_queue import WorkflowRunner
 
@@ -49,7 +50,7 @@ class RunWorkflowWidget(QWidget):
         self.run_button = QToolButton()
         self.run_button.setIconSize(QSize(32, 32))
         self.run_button.setText("Start workflow")
-        self.run_button.setIcon(resourceIcon("play_circle.svg"))
+        self.run_button.setIcon(QIcon("img:play_circle.svg"))
         self.run_button.clicked.connect(self.startWorkflow)
         self.run_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
 
@@ -71,7 +72,7 @@ class RunWorkflowWidget(QWidget):
         layout = QHBoxLayout()
 
         size = 64
-        spin_movie = resourceMovie("loading.gif")
+        spin_movie = QMovie("img:loading.gif")
         spin_movie.setSpeed(60)
         spin_movie.setScaledSize(QSize(size, size))
         spin_movie.start()

--- a/src/ert/gui/tools/workflows/workflows_tool.py
+++ b/src/ert/gui/tools/workflows/workflows_tool.py
@@ -1,4 +1,5 @@
-from ert.gui.ertwidgets import resourceIcon
+from qtpy.QtGui import QIcon
+
 from ert.gui.ertwidgets.closabledialog import ClosableDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.workflows import RunWorkflowWidget
@@ -11,7 +12,7 @@ class WorkflowsTool(Tool):
         enabled = len(ert.ert_config.workflows) > 0
         super().__init__(
             "Run workflow",
-            resourceIcon("playlist_play.svg"),
+            QIcon("img:playlist_play.svg"),
             enabled,
         )
 

--- a/tests/unit_tests/gui/run_analysis/test_run_analysis.py
+++ b/tests/unit_tests/gui/run_analysis/test_run_analysis.py
@@ -36,7 +36,7 @@ def ert_mock():
 
 @pytest.fixture
 def mock_tool(mock_storage, ert_mock):
-    with patch("ert.gui.tools.run_analysis.run_analysis_tool.resourceIcon") as rs:
+    with patch("ert.gui.tools.run_analysis.run_analysis_tool.QIcon") as rs:
         rs.return_value = MockedQIcon()
         (target, source) = mock_storage
 


### PR DESCRIPTION
Make use of the "correct" way of adding search paths, rather than using the resourceIcon and co.

The most Qt way would be using `QResource` and the `qrc` compiler that ships with Qt. It takes an XML as input and produces a Qt resource file, which is a compressed archive of our contents. This, however, would mean having to pip-reinstall ERT every time we change the resources, which is a pain. Using this method allows us to keep distributing files as part of the Python wheel while being able to have Qt look up files directly.
