### PR TITLE
Adjust the size of ERT main window after config warnings

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -294,6 +294,7 @@ def _setup_suggester(
         ert_window.show()
         ert_window.activateWindow()
         ert_window.raise_()
+        ert_window.adjustSize()
         container.close()
 
     run = QPushButton("Open ERT")

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -27,7 +27,6 @@ class ErtMainWindow(QMainWindow):
         self.notifier = ErtNotifier(config_file)
         self.tools = {}
 
-        self.resize(300, 700)
         self.setWindowTitle(f"ERT - {config_file}")
 
         self.plugin_manager = plugin_manager


### PR DESCRIPTION
**Issue**
Resolves #6461 

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
