### PR TITLE
Avoid div-by-zero when no realizations to calculate

### DIFF
--- a/src/ert/gui/simulation/view/progress.py
+++ b/src/ert/gui/simulation/view/progress.py
@@ -67,7 +67,7 @@ class ProgressDelegate(QStyledItemDelegate):
 
         nr_reals = data["nr_reals"]
         status = data["status"]
-        delta = option.rect.width() / nr_reals
+        delta = option.rect.width() / nr_reals if nr_reals else 1
 
         painter.save()
 


### PR DESCRIPTION
**Issue**
Resolves #6465

I re-ran the setup multiple times and see that when we hit this corner case where we are terminating jobs, but they manage to complete before termination, we can still re-run and not get this div-by-zero issue.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
