### PR TITLE
Fix flaky adaptive localization test by increasing the ensemble size

### DIFF
--- a/tests/unit_tests/analysis/test_adaptive_localization.py
+++ b/tests/unit_tests/analysis/test_adaptive_localization.py
@@ -103,8 +103,9 @@ def test_that_adaptive_localization_with_cutoff_0_equals_ESupdate(copy_poly_case
 
 @pytest.mark.integration_test
 def test_that_posterior_generalized_variance_increases_in_cutoff(copy_poly_case):
-    cutoff1 = np.random.uniform(0, 1)
-    cutoff2 = np.random.uniform(cutoff1, 1)
+    rng = np.random.default_rng(42)
+    cutoff1 = rng.uniform(0, 1)
+    cutoff2 = rng.uniform(cutoff1, 1)
 
     set_adaptive_localization_cutoff1 = dedent(
         f"""
@@ -121,6 +122,10 @@ def test_that_posterior_generalized_variance_increases_in_cutoff(copy_poly_case)
 
     with open("poly.ert", "r+", encoding="utf-8") as f:
         lines = f.readlines()
+        for i, line in enumerate(lines):
+            if "NUM_REALIZATIONS 100" in line:
+                lines[i] = "NUM_REALIZATIONS 200\n"
+                break
         lines.insert(2, random_seed_line)
         lines.insert(9, set_adaptive_localization_cutoff1)
 


### PR DESCRIPTION
**Issue**
Resolves #6462 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
