### PR TITLE
Only add -k oe when keep_qsub_output is set

### DIFF
--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -99,11 +99,8 @@ jobs:
         QUEUE_SYSTEM TORQUE
         QUEUE_OPTION TORQUE QSTAT_CMD $(pwd)/qstat
         QUEUE_OPTION TORQUE QSTAT_OPTIONS -f
-        QUEUE_OPTION TORQUE KEEP_QSUB_OUTPUT 1
         EOF
         # QSTAT_OPTIONS must be from the default "-f -x" to "-f" as "-x" is not supported on slurm
-        # KEEP_QSUB_OUTPUT is needed to avoid (!) "-k oe" being added to qsub arguments, as "-k" is not
-        # supported on slurm. The logic is also reversed, due to misconfiguration (?) on Azure PBS.
 
         pushd poly_torque
         time ert ensemble_experiment poly.ert

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -274,10 +274,7 @@ static char **torque_driver_alloc_cmd(torque_driver_type *driver,
 
     argv[i++] = strdup(driver->qsub_cmd);
 
-    if (!driver->keep_qsub_output) {
-        // API for qsub is unpredictable and args need to be updated when bugs occur
-        // Verify this manually using "qsub" and "qsub -k oe"
-        // Currently -k oe will NOT retain logfiles
+    if (driver->keep_qsub_output) {
         argv[i++] = strdup("-k");
         argv[i++] = strdup("oe");
     }


### PR DESCRIPTION
Verified manually to be correct that the Azure cluster on s034 only provides output files when -k oe is set

**Issue**
Resolves #6437 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
