### PR TITLE
Fix failing mac cpp tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,6 +32,11 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y valgrind
 
+    - uses: actions/setup-python@v4
+      id: setup_python
+      with:
+        python-version: '3.11'
+
     - uses: actions/cache@v3
       with:
         path: ~/.conan/


### PR DESCRIPTION
cpp tess on mac are failing due to default python on mac github runners have changed to py 3.12


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
