### PR TITLE
Ensure queue_system in QueueConfig is correct type

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -40,7 +40,9 @@ class QueueConfig:
     @no_type_check
     @classmethod
     def from_dict(cls, config_dict: ConfigDict) -> QueueConfig:
-        selected_queue_system = config_dict.get("QUEUE_SYSTEM", QueueSystem.LOCAL)
+        selected_queue_system = QueueSystem(
+            config_dict.get("QUEUE_SYSTEM", QueueSystem.LOCAL)
+        )
         job_script: str = config_dict.get(
             "JOB_SCRIPT", shutil.which("job_dispatch.py") or "job_dispatch.py"
         )


### PR DESCRIPTION
**Issue**
Resolves queue driver initialization failing due to queue_type being a str, not `QueueSystem`, specifically happens in Everest in everest2res. Ref: https://github.com/equinor/everest/actions/runs/6786195687/job/18553630322?pr=2153