### PR TITLE
Have restart_from combobox in es_mda be default disabled

### DIFF
--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -71,12 +71,12 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         layout.addRow("Active realizations:", self._active_realizations_field)
 
         self._restart_box = QCheckBox("")
-        self._restart_box.toggled.connect(self.restart_run)
+        self._restart_box.toggled.connect(self.restart_run_toggled)
         layout.addRow("Restart run:", self._restart_box)
 
         self._case_selector = CaseSelector(notifier)
+        self._case_selector.case_populated.connect(self.restart_run_toggled)
         layout.addRow("Restart from:", self._case_selector)
-        self._case_selector.setDisabled(True)
 
         self._target_case_format_field.getValidationSupport().validationChanged.connect(  # noqa
             self.simulationConfigurationChanged
@@ -90,11 +90,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
 
         self.setLayout(layout)
 
-    def restart_run(self):
-        if self._restart_box.isChecked():
-            self._case_selector.setEnabled(True)
-        else:
-            self._case_selector.setEnabled(False)
+    def restart_run_toggled(self):
+        self._case_selector.setEnabled(self._restart_box.isChecked())
 
     def _createInputForWeights(self, layout):
         relative_iteration_weights_model = ValueModel(self.weights)


### PR DESCRIPTION
**Issue**
Resolves #6544 

The combobox will be enabled when being populated, so we need to listen for the content in the box to change to make a decision on if the box should be enabled or not.
Slight refactor to toggle-function.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
