### PR TITLE
 Delete template_file_path from GenKwConfig

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -55,7 +55,6 @@ class GenKwConfig(ParameterConfig):
     output_file: Optional[str]
     transfer_function_definitions: List[str]
     forward_init_file: Optional[str] = None
-    template_file_path: Optional[Path] = None
 
     def __post_init__(self) -> None:
         self.transfer_functions: List[TransferFunction] = []
@@ -241,12 +240,15 @@ class GenKwConfig(ParameterConfig):
             if tf.use_log
         }
 
-        if self.template_file_path is not None and self.output_file is not None:
+        if self.template_file is not None and self.output_file is not None:
             target_file = self.output_file
             if target_file.startswith("/"):
                 target_file = target_file[1:]
             (run_path / target_file).parent.mkdir(exist_ok=True, parents=True)
-            with open(self.template_file_path, "r", encoding="utf-8") as f:
+            template_file_path = (
+                ensemble.experiment.mount_point / Path(self.template_file).name
+            )
+            with open(template_file_path, "r", encoding="utf-8") as f:
                 template = f.read()
             for key, value in data.items():
                 template = template.replace(f"<{key}>", f"{value:.6g}")
@@ -396,10 +398,10 @@ class GenKwConfig(ParameterConfig):
     def save_experiment_data(self, experiment_path: Path) -> None:
         if self.template_file:
             incoming_template_file_path = Path(self.template_file)
-            self.template_file_path = Path(
+            template_file_path = Path(
                 experiment_path / incoming_template_file_path.name
             )
-            shutil.copyfile(incoming_template_file_path, self.template_file_path)
+            shutil.copyfile(incoming_template_file_path, template_file_path)
 
 
 @dataclass

--- a/tests/unit_tests/config/test_gen_kw_config.py
+++ b/tests/unit_tests/config/test_gen_kw_config.py
@@ -563,5 +563,4 @@ def test_incorrect_values_in_forward_init_file_fails(tmp_path):
             None,
             [],
             str(tmp_path / "forward_init_%d"),
-            None,
         ).read_from_runpath(tmp_path, 1)


### PR DESCRIPTION
**Issue**
Resolves #6351 


**Approach**
Instead of storing relative path in `template_file_path`, it is deleted. It is done as `template_file_path` is used only in `write_to_runpath` function of  `GenKwConfig` class, and the correct path can be retrieved from ensemble reader on the go

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
