### PR TITLE
Let JobQueue create its driver

### DIFF
--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -11,7 +11,7 @@ from cloudevents.http.event import CloudEvent
 
 from ert.async_utils import get_event_loop
 from ert.ensemble_evaluator import identifiers
-from ert.job_queue import Driver, JobQueue
+from ert.job_queue import JobQueue
 
 from .._wait_for_evaluator import wait_for_evaluator
 from ._ensemble import Ensemble
@@ -42,9 +42,7 @@ class LegacyEnsemble(Ensemble):
             raise ValueError(f"{self} needs queue_config")
         if not analysis_config:
             raise ValueError(f"{self} needs analysis_config")
-        self._job_queue = JobQueue(
-            Driver.create_driver(queue_config), max_submit=queue_config.max_submit
-        )
+        self._job_queue = JobQueue(queue_config)
         self._analysis_config = analysis_config
         self._config: Optional[EvaluatorServerConfig] = None
 

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ert.config import HookRuntime
 from ert.enkf_main import create_run_path
-from ert.job_queue import Driver, JobQueue, JobStatus
+from ert.job_queue import JobQueue, JobStatus
 from ert.realization_state import RealizationState
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
@@ -89,10 +89,7 @@ class SimulationContext:
         self._ert = ert
         self._mask = mask
 
-        self._job_queue = JobQueue(
-            Driver.create_driver(ert.ert_config.queue_config),
-            max_submit=ert.ert_config.queue_config.max_submit,
-        )
+        self._job_queue = JobQueue(ert.ert_config.queue_config)
         # fill in the missing geo_id data
         global_substitutions = ert.ert_config.substitution_list
         global_substitutions["<CASE_NAME>"] = _slug(sim_fs.name)

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -51,9 +51,7 @@ async def test_happy_path(
     await wait_for_evaluator(base_url=url, timeout=5)
 
     ensemble = make_ensemble_builder(monkeypatch, tmpdir, 1, 1).build()
-    queue = JobQueue(
-        Driver.create_driver(queue_config), max_submit=queue_config.max_submit
-    )
+    queue = JobQueue(queue_config)
     for real in ensemble.reals:
         queue.add_realization(real, callback_timeout=None)
 

--- a/tests/unit_tests/job_queue/test_job_queue.py
+++ b/tests/unit_tests/job_queue/test_job_queue.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ert.config import QueueSystem
+from ert.config import QueueConfig, QueueSystem
 from ert.job_queue import Driver, JobQueue, JobQueueNode, JobStatus
 from ert.run_arg import RunArg
 from ert.storage import EnsembleAccessor
@@ -65,8 +65,11 @@ def create_local_queue(
     max_runtime: Optional[int] = None,
     callback_timeout: Optional["Callable[[int], None]"] = None,
 ):
-    driver = Driver(driver_type=QueueSystem.LOCAL)
-    job_queue = JobQueue(driver, max_submit=max_submit)
+    job_queue = JobQueue(
+        QueueConfig.from_dict(
+            {"driver_type": QueueSystem.LOCAL, "MAX_SUBMIT": max_submit}
+        )
+    )
 
     for iens in range(num_realizations):
         Path(DUMMY_CONFIG["run_path"].format(iens)).mkdir(exist_ok=False)
@@ -329,8 +332,7 @@ def test_stop_long_running():
         job_list[i]._start_time = 0
         job_list[i]._end_time = 5
 
-    driver = Driver(driver_type=QueueSystem.LOCAL)
-    queue = JobQueue(driver)
+    queue = JobQueue(QueueConfig.from_dict({"driver_type": QueueSystem.LOCAL}))
 
     with patch("ert.job_queue.JobQueue._add_job") as _add_job:
         for idx, job in enumerate(job_list):


### PR DESCRIPTION
The concept of a driver should be an implementation detail for JobQueue and not something its callees should prepare.

**Issue**
Preparations for refactoring JobQueue

**Approach**
🧠 

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
