### PR TITLE
Add timeout to c test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-test-cmake:
     name: Run C++ tests and coverage
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The default is 6 hours, normally takes 5 minutes. Had an issue where one of the tests hanged.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
