### PR TITLE
Unify execute API of JobQueue, refactor websocket connection

### DIFF
--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from functools import partial
 from threading import Thread
 from time import sleep
@@ -72,7 +73,7 @@ def _run_forward_model(
             )
         ]
 
-    job_queue.execute_queue(queue_evaluators)
+    asyncio.run(job_queue.execute(evaluators=queue_evaluators))
 
     run_context.sim_fs.sync()
 

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -55,9 +55,8 @@ async def test_happy_path(
     for real in ensemble.reals:
         queue.add_realization(real, callback_timeout=None)
 
-    await queue.execute_queue_via_websockets(
-        url, "ee_0", threading.BoundedSemaphore(value=10), None
-    )
+    queue.set_ee_info(ee_uri=url, ens_id="ee_0")
+    await queue.execute(pool_sema=threading.BoundedSemaphore(value=10))
     done.set_result(None)
 
     await mock_ws_task

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -78,7 +78,7 @@ def test_run_and_cancel_legacy_ensemble(tmpdir, make_ensemble_builder, monkeypat
             assert not os.path.isfile(f"real_{i}/status.txt")
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(10)
 def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder, monkeypatch):
     num_reals = 2
     custom_port_range = range(1024, 65535)


### PR DESCRIPTION
* Put websocket connection handling into only one (async) function, that will run until it is finished.
* Reduce the execute functions to only one, letting both legacy ensemble and simulation context use it. 

The simulation_context now has to call it in an async loop, and it is also doing slightly more work (logging changes) than before.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
