### PR TITLE
Remove ENKF_FORCE_NCOMP and add deprecation for ENKF_NCOMP & ENKF_SUBSPACE_DIMENSION

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -32,8 +32,6 @@ Keyword name                                                            Required
 :ref:`ECLBASE <eclbase>`                                                NO                                                                      Define a name for the ECLIPSE simulations.
 :ref:`STD_CUTOFF <std_cutoff>`                                          NO                                      1e-6                            Determines the threshold for ensemble variation in a measurement
 :ref:`ENKF_ALPHA <enkf_alpha>`                                          NO                                      3.0                             Parameter controlling outlier behaviour in EnKF algorithm
-:ref:`ENKF_FORCE_NCOMP <enkf_force_ncomp>`                              NO                                      0                               Indicate if ERT should force a specific number of principal components
-:ref:`ENKF_NCOMP <enkf_ncomp>`                                          NO                                                                      Number of PC to use when forcing a fixed number; used in combination with kw ENKF_FORCE_NCOMP
 :ref:`ENKF_TRUNCATION <enkf_truncation>`                                NO                                      0.99                            Cutoff used on singular value spectrum
 :ref:`ENSPATH <enspath>`                                                NO                                      storage                         Folder used for storage of simulation results
 :ref:`FIELD <field>`                                                    NO                                                                      Adds grid parameters
@@ -1217,23 +1215,6 @@ Keywords controlling the ES algorithm
         In theory and in practice this has worked well when one uses a small number of
         ensemble members.
 
-
-.. _enkf_force_ncomp:
-.. topic:: ENKF_FORCE_NCOMP
-
-        Bool specifying if we want to force the subspace dimension we want to use in
-        the EnKF updating scheme (SVD-based) to a specific integer. This is an
-        alternative to selecting the dimension using ENKF_TRUNCATION.
-
-        *Example:*
-
-        ::
-
-                -- Setting the the subspace dimension to 2
-                ENKF_FORCE_NCOMP     TRUE
-                ENKF_NCOMP              2
-
-
 .. _enkf_mode:
 .. topic:: ENKF_MODE
 
@@ -1257,12 +1238,6 @@ Keywords controlling the ES algorithm
 
         The ENKF_MODE keyword is optional.
 
-
-.. _enkf_ncomp:
-.. topic:: ENKF_NCOMP
-
-        Integer specifying the subspace dimension. Requires that ENKF_FORCE_NCOMP is
-        TRUE.
 
 .. _enkf_truncation:
 .. topic:: ENKF_TRUNCATION

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -156,4 +156,21 @@ deprecated_keywords_list = [
         "for the Ensemble Smoother update algorithm. "
         "Please use ENKF_ALPHA and STD_CUTOFF keywords instead.",
     ),
+    DeprecationInfo(
+        keyword="ENKF_FORCE_NCOMP",
+        message="The ENKF_FORCE_NCOMP keyword was removed in 2017 and has no "
+        "effect. It has been used in the past to force the subspace dimension set "
+        "using ENKF_NCOMP keyword",
+    ),
+    DeprecationInfo(
+        keyword="ENKF_NCOMP",
+        message="The ENKF_NCOMP keyword used to specify the subspace dimension "
+        "but has been deprecated and has replaced with the "
+        "ENKF_TRUNCATION keyword",
+    ),
+    DeprecationInfo(
+        keyword="ENKF_SUBSPACE_DIMENSION",
+        message="The ENKF_SUBSPACE_DIMENSION keyword has been deprecated and has been "
+        "replaced with the ENKF_TRUNCATION keyword",
+    ),
 ]

--- a/tests/unit_tests/analysis/test_analysis_module.py
+++ b/tests/unit_tests/analysis/test_analysis_module.py
@@ -68,6 +68,7 @@ def test_analysis_module_set_get_values():
         ies_am.set_var("INVERSION", key)
         assert ies_am.get_variable_value("IES_INVERSION") == value
 
+    # Deprecated keys, replaced by ENKF_TRUNCATION
     ies_am.set_var("ENKF_NCOMP", "0.2")
     assert ies_am.get_truncation() == 0.2
     ies_am.set_var("ENKF_SUBSPACE_DIMENSION", "0.3")
@@ -96,17 +97,6 @@ def test_set_get_var_out_of_bounds():
     assert ies.get_truncation() == enkf_trunc_max
 
     ies.set_var("ENKF_TRUNCATION", enkf_trunc_min - 1)
-    assert ies.get_truncation() == enkf_trunc_min
-
-    ies.set_var("ENKF_NCOMP", enkf_trunc_max + 1)
-    assert ies.get_truncation() == enkf_trunc_max
-
-    ies.set_var("ENKF_NCOMP", enkf_trunc_min - 1)
-    assert ies.get_truncation() == enkf_trunc_min
-
-    ies.set_var("ENKF_SUBSPACE_DIMENSION", enkf_trunc_max + 1)
-    assert ies.get_truncation() == enkf_trunc_max
-    ies.set_var("ENKF_SUBSPACE_DIMENSION", enkf_trunc_min - 1)
     assert ies.get_truncation() == enkf_trunc_min
 
     ies.set_var("IES_INVERSION", 5)

--- a/tests/unit_tests/config/test_parser_error_collection.py
+++ b/tests/unit_tests/config/test_parser_error_collection.py
@@ -977,6 +977,9 @@ UPDATE_PATH A B
 UPDATE_SETTINGS A
 
 DEFINE A <2>
+ENKF_FORCE_NCOMP true
+ENKF_NCOMP 2
+ENKF_SUBSPACE_DIMENSION 2
 """,
             [
                 ExpectedErrorInfo(
@@ -1068,6 +1071,24 @@ DEFINE A <2>
                     column=1,
                     end_column=12,
                     match="UPDATE_PATH keyword has been removed",
+                ),
+                ExpectedErrorInfo(
+                    line=38,
+                    column=1,
+                    end_column=17,
+                    match="The ENKF_FORCE_NCOMP keyword was removed in 2017",
+                ),
+                ExpectedErrorInfo(
+                    line=39,
+                    column=1,
+                    end_column=11,
+                    match="The ENKF_NCOMP keyword used to specify the subspace",
+                ),
+                ExpectedErrorInfo(
+                    line=40,
+                    column=1,
+                    end_column=24,
+                    match="The ENKF_SUBSPACE_DIMENSION keyword has been deprecated",
                 ),
             ],
         )


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)

```
    TRUNC_ALTERNATE_KEYS = ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION"]
...
        elif var_name in self.TRUNC_ALTERNATE_KEYS:
            self.set_var("ENKF_TRUNCATION", value)
```


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
