### PR TITLE
Remove `USE_EE` & `USE_GE` analysis keywords

### DIFF
--- a/src/ert/config/analysis_module.py
+++ b/src/ert/config/analysis_module.py
@@ -110,9 +110,8 @@ def get_mode_variables(mode: AnalysisMode) -> Dict[str, "VariableInfo"]:
 
 
 class AnalysisModule:
-    DEPRECATED_KEYS = ["USE_EE", "USE_GE"]
     TRUNC_ALTERNATE_KEYS = ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION"]
-    SPECIAL_KEYS = ["INVERSION", *TRUNC_ALTERNATE_KEYS, *DEPRECATED_KEYS]
+    SPECIAL_KEYS = ["INVERSION", *TRUNC_ALTERNATE_KEYS]
 
     def __init__(
         self,
@@ -160,11 +159,7 @@ class AnalysisModule:
     def handle_special_key_set(
         self, var_name: str, value: Union[float, int, bool, str]
     ) -> None:
-        if var_name in self.DEPRECATED_KEYS:
-            logger.warning(
-                f"The {var_name} key have been removed" f"use the INVERSION key instead"
-            )
-        elif var_name == "INVERSION":
+        if var_name == "INVERSION":
             inversion_str_map = {
                 "EXACT": 0,
                 "SUBSPACE_EXACT_R": 1,

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -1493,3 +1493,26 @@ def test_validate_no_logs_when_overwriting_with_same_value(caplog):
         and "Private arg '<VAR2>':'20' chosen over global '20' in forward model job_name"
         not in caplog.text
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("obsolete_analysis_keyword", ["USE_EE", "USE_GE"])
+def test_that_use_ee_and_use_ge_keywords_raises_error(obsolete_analysis_keyword):
+    test_config_file_name = "test.ert"
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS  1
+        """
+    )
+    with open(test_config_file_name, "w", encoding="utf-8") as fh:
+        fh.write(test_config_contents)
+        obsolete_keyword = (
+            "ANALYSIS_SET_VAR STD_ENKF " + obsolete_analysis_keyword + " 1"
+        )
+        fh.write(obsolete_keyword)
+
+    with pytest.raises(
+        ConfigValidationError,
+        match=f"Variable '{obsolete_analysis_keyword}' not found in 'STD_ENKF' analysis module",
+    ):
+        _ = ErtConfig.from_file(test_config_file_name)


### PR DESCRIPTION
Remove silent handling of removed/deprecated keywords, and rather raise ConfigValidationError instead.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
