### PR TITLE
Fix deprecation info for Analysis Module

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -42,6 +42,24 @@ deprecated_keywords_list = [
         )
         for kw in ["DEFINE", "DATA_KW"]
     ],
+    *[
+        DeprecationInfo(
+            keyword=kw,
+            message=partial(
+                lambda line, kw: f"The {line[1]} keyword has been deprecated "
+                "and has replaced with the ENKF_TRUNCATION keyword."
+                if line[1] in ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION"]
+                else f"The {line[1]} keyword was removed in 2017 and has no "
+                "effect. It has been used in the past to force the subspace "
+                "dimension set using ENKF_NCOMP keyword. "
+                "This can be safely removed.",
+                kw=kw,
+            ),
+            check=lambda line: str(line[1])
+            in ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION", "ENKF_FORCE_NCOMP"],
+        )
+        for kw in ["ANALYSIS_SET_VAR"]
+    ],
     DeprecationInfo(
         keyword="RUNPATH",
         message=lambda line: "RUNPATH keyword contains deprecated value "
@@ -157,22 +175,5 @@ deprecated_keywords_list = [
         "effect. It has been used in the past to adjust control parameters "
         "for the Ensemble Smoother update algorithm. "
         "Please use ENKF_ALPHA and STD_CUTOFF keywords instead.",
-    ),
-    DeprecationInfo(
-        keyword="ENKF_FORCE_NCOMP",
-        message="The ENKF_FORCE_NCOMP keyword was removed in 2017 and has no "
-        "effect. It has been used in the past to force the subspace dimension set "
-        "using ENKF_NCOMP keyword",
-    ),
-    DeprecationInfo(
-        keyword="ENKF_NCOMP",
-        message="The ENKF_NCOMP keyword used to specify the subspace dimension "
-        "but has been deprecated and has replaced with the "
-        "ENKF_TRUNCATION keyword",
-    ),
-    DeprecationInfo(
-        keyword="ENKF_SUBSPACE_DIMENSION",
-        message="The ENKF_SUBSPACE_DIMENSION keyword has been deprecated and has been "
-        "replaced with the ENKF_TRUNCATION keyword",
     ),
 ]

--- a/tests/unit_tests/config/test_parser_error_collection.py
+++ b/tests/unit_tests/config/test_parser_error_collection.py
@@ -975,11 +975,10 @@ DELETE_RUNPATH
 PLOT_SETTINGS
 UPDATE_PATH A B
 UPDATE_SETTINGS A
-
+ANALYSIS_SET_VAR STD_ENKF ENKF_FORCE_NCOMP true
+ANALYSIS_SET_VAR STD_ENKF ENKF_NCOMP 0.45
+ANALYSIS_SET_VAR STD_ENKF ENKF_SUBSPACE_DIMENSION 2
 DEFINE A <2>
-ENKF_FORCE_NCOMP true
-ENKF_NCOMP 2
-ENKF_SUBSPACE_DIMENSION 2
 """,
             [
                 ExpectedErrorInfo(
@@ -1073,21 +1072,21 @@ ENKF_SUBSPACE_DIMENSION 2
                     match="UPDATE_PATH keyword has been removed",
                 ),
                 ExpectedErrorInfo(
-                    line=38,
+                    line=36,
                     column=1,
                     end_column=17,
                     match="The ENKF_FORCE_NCOMP keyword was removed in 2017",
                 ),
                 ExpectedErrorInfo(
-                    line=39,
+                    line=37,
                     column=1,
-                    end_column=11,
-                    match="The ENKF_NCOMP keyword used to specify the subspace",
+                    end_column=17,
+                    match="The ENKF_NCOMP keyword has been deprecated",
                 ),
                 ExpectedErrorInfo(
-                    line=40,
+                    line=38,
                     column=1,
-                    end_column=24,
+                    end_column=17,
                     match="The ENKF_SUBSPACE_DIMENSION keyword has been deprecated",
                 ),
             ],


### PR DESCRIPTION
The deprecation suggestions where initially testing for `ENKF_NCOMP 1`
instead of the proper syntax
`ANALYSIS_SET_VAR <MODULE> ENKF_NCOMP 1`
Also fixed for ENKF_SUBSPACE_DIMENSION and ENKF_FORCE_NCOMP

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
