### PR TITLE
Set default case_name for ES_MDA when none provided

### DIFF
--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -231,6 +231,9 @@ def _target_case_name(
     if analysis_config.case_format is not None:
         return analysis_config.case_format
 
+    if not hasattr(args, "current_case"):
+        return "default_%d"
+
     return f"{args.current_case}_%d"
 
 


### PR DESCRIPTION
Resolves fail caused by this PR https://github.com/equinor/ert/pull/6542

```
(ert) frode@LAPTOP-2N3JK273:~/code/ert$ ert es_mda test-data/poly_example/poly.ert
ERT crashed unexpectedly with "'Namespace' object has no attribute 'current_case'".
See logfile(s) for details:
   /home/frode/code/ert/logs/ert-log-poly-ert-2023-11-16T1755.txt
```

Current_case does not make sense for ES_MDA, so let's check for existence of said variable and return default string if not found. This is equivalent to previous implementation.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
