### PR TITLE
The startup feedback screen now uses equinor design system colors and icons

### DIFF
--- a/src/ert/config/parsing/error_info.py
+++ b/src/ert/config/parsing/error_info.py
@@ -64,7 +64,7 @@ class ErrorInfo:
                 return getattr(self, attr) > getattr(other, attr)
         return self.message > other.message
 
-    def __str__(self) -> str:
+    def location(self) -> str:
         msg = ""
         if self.filename is not None:
             msg += f"{self.filename}: "
@@ -74,8 +74,10 @@ class ErrorInfo:
             msg += f"(Column {self.column}): "
         if self.column is not None and self.end_column is not None:
             msg += f"(Column {self.column}-{self.end_column}): "
-        msg += self.message
         return msg
+
+    def __str__(self) -> str:
+        return self.location() + self.message
 
     def _attach_to_context(self, token: Optional[FileContextToken]) -> None:
         if token is not None:

--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -54,22 +54,18 @@ class CopyableLabel(QHBoxLayout):
 
         self.copy_button = QPushButton("")
         self.copy_button.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-        icon_path = path.join(current_dir, "..", "resources", "gui", "img", "copy.svg")
-        icon_path_check = path.join(
-            current_dir, "..", "resources", "gui", "img", "check.svg"
-        )
-        self.copy_button.setIcon(QIcon(icon_path))
+        self.copy_button.setIcon(QIcon("img:copy.svg"))
         self.restore_timer = QTimer(self)
 
         def restore_text():
-            self.copy_button.setIcon(QIcon(icon_path))
+            self.copy_button.setIcon(QIcon("img:copy.svg"))
 
         self.restore_timer.timeout.connect(restore_text)
 
         def copy_text() -> None:
             text = unescape_string(self.label.text())
             QApplication.clipboard().setText(text)
-            self.copy_button.setIcon(QIcon(icon_path_check))
+            self.copy_button.setIcon(QIcon("img:check.svg"))
 
             self.restore_timer.start(1000)
 

--- a/src/ert/gui/ertwidgets/suggestor_message.py
+++ b/src/ert/gui/ertwidgets/suggestor_message.py
@@ -1,50 +1,44 @@
+from PyQt5 import QtSvg
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QWidget
+
+
+def _svg_icon(image_name):
+    widget = QtSvg.QSvgWidget(f"img:{image_name}.svg")
+    widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+    widget.setStyleSheet("width: 40px; height: 40px;")
+    return widget
 
 
 class SuggestorMessage(QWidget):
-    def __init__(self, lbl_text, color, text):
-        QWidget.__init__(self)
-        common_style = """
-        border-style: outset;
-        border-width: 2px;
-        border-radius: 10px;
-        border-color: darkgrey;
-        padding: 6px;"""
+    def __init__(self, header, icon, info):
+        super().__init__()
+        self.setAttribute(Qt.WA_StyledBackground)
+        self.setStyleSheet("background-color: white;")
 
-        self.type_lbl = QLabel(lbl_text)
-        self.type_lbl.setAlignment(Qt.AlignCenter)
-        self.type_lbl.setStyleSheet(
-            common_style
-            + f"""
-            background-color: {color};
-            font: bold 14px;
-            max-width: 6em;
-            min-width: 6em;
-            max-height: 1em;"""
+        self.icon = icon
+        self.lbl = QLabel(
+            "<b>" + header + "</b>" + info.message + "<p>" + info.location() + "</p>"
         )
-
-        self.lbl = QLabel(text)
+        self.lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.lbl.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.lbl.setWordWrap(True)
-        self.lbl.setStyleSheet(common_style + "background-color: lightgray;")
 
         self.hbox = QHBoxLayout()
-        self.hbox.addWidget(self.type_lbl)
+        self.hbox.setSpacing(16)
+        self.hbox.setContentsMargins(16, 0, 16, 0)
+        self.hbox.addWidget(self.icon, alignment=Qt.AlignLeft)
         self.hbox.addWidget(self.lbl)
         self.setLayout(self.hbox)
 
     @classmethod
-    def error_msg(cls, text):
-        color = "#ff0000"
-        return SuggestorMessage("ERROR", color, text)
+    def error_msg(cls, info):
+        return SuggestorMessage("Error: ", _svg_icon("error_bgcircle"), info)
 
     @classmethod
-    def warning_msg(cls, text):
-        color = "#ff6a00"
-        return SuggestorMessage("WARNING", color, text)
+    def warning_msg(cls, info):
+        return SuggestorMessage("Warning: ", _svg_icon("warning_bgcircle"), info)
 
     @classmethod
-    def deprecation_msg(cls, text):
-        color = "#faf339"
-        return SuggestorMessage("DEPRECATION", color, text)
+    def deprecation_msg(cls, info):
+        return SuggestorMessage("Deprecation: ", _svg_icon("thumbdown_bgcircle"), info)

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -7,12 +7,11 @@ from signal import SIG_DFL, SIGINT, signal
 from typing import Optional, cast
 
 from PyQt5.QtGui import QIcon
-from qtpy.QtCore import QDir, QLocale, QSize, Qt
+from qtpy.QtCore import QDir, QLocale, Qt
 from qtpy.QtWidgets import (
     QApplication,
     QFrame,
     QHBoxLayout,
-    QLabel,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
@@ -58,7 +57,6 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None):
     QDir.addSearchPath(
         "img", os.path.join(os.path.dirname(__file__), "resources/gui/img")
     )
-
     app = QApplication([])  # Early so that QT is initialized before other imports
     app.setWindowIcon(QIcon("img:application/window_icon_cutout"))
     with add_gui_log_handler() as log_handler:
@@ -111,18 +109,18 @@ def _start_initial_gui_window(
             ert = EnKFMain(ert_config)
         except ConfigValidationError as error:
             config_warnings = [
-                str(w.message)
+                w.message.info
                 for w in all_warnings
                 if w.category == ConfigWarning
                 and not cast(ConfigWarning, w.message).info.is_deprecation
             ]
             deprecations = [
-                str(w.message)
+                w.message.info
                 for w in all_warnings
                 if w.category == ConfigWarning
                 and cast(ConfigWarning, w.message).info.is_deprecation
             ]
-            error_messages += error.messages()
+            error_messages += error.errors
             logger.info("Error in config file shown in gui: '%s'", str(error))
             return (
                 _setup_suggester(
@@ -136,13 +134,13 @@ def _start_initial_gui_window(
                 None,
             )
     config_warnings = [
-        str(w.message)
+        w.message.info
         for w in all_warnings
         if w.category == ConfigWarning
         and not cast(ConfigWarning, w.message).info.is_deprecation
     ]
     deprecations = [
-        str(w.message)
+        w.message.info
         for w in all_warnings
         if w.category == ConfigWarning
         and cast(ConfigWarning, w.message).info.is_deprecation
@@ -157,7 +155,7 @@ def _start_initial_gui_window(
         logger.info("Suggestion shown in gui '%s'", msg)
     for msg in config_warnings:
         logger.info("Warning shown in gui '%s'", msg)
-    _main_window = _setup_main_window(ert, args, log_handler)
+    _main_window = _setup_main_window(ert, args, log_handler, plugin_manager)
     if deprecations or config_warnings:
         return (
             _setup_suggester(
@@ -210,6 +208,44 @@ def _clicked_about_button(about_dialog):
     about_dialog.show()
 
 
+BUTTON_STYLE = """
+QPushButton {
+    background-color: #007079;
+    color: white;
+    border-radius: 4px;
+    border-color: #005860;
+    height: 36px;
+    padding: 0px 16px 0px 16px;
+}
+QPushButton:hover {
+    background: #004f55;
+};
+"""
+
+LINK_STYLE = """
+QPushButton {
+    background-color: white;
+    color: #3d3d3d;
+    border: 0px solid white;
+    height: 36px;
+    padding: 0px 12px 0px 12px;
+}
+QPushButton:hover {
+    color: #005860;
+    border-bottom: 4px solid #005860;
+};
+"""
+
+DIABLED_BUTTON_STYLE = """
+    background-color: #eaeaea;
+    color: #bebebe;
+    border-radius: 4px;
+    border-color: #dcdcdc;
+    height: 36px;
+    padding: 0px 16px 0px 16px;
+"""
+
+
 def _setup_suggester(
     errors,
     warning_msgs,
@@ -218,48 +254,37 @@ def _setup_suggester(
     plugin_manager: Optional[ErtPluginManager] = None,
 ):
     container = QWidget()
+    container.setStyleSheet("background-color: white;")
     if ert_window is not None:
         container.notifier = ert_window.notifier
     container.setWindowTitle("Some problems detected")
     container_layout = QVBoxLayout()
+    container_layout.setSpacing(0)
+    container_layout.setContentsMargins(0, 0, 0, 0)
 
     help_button_frame = QFrame()
     help_buttons_layout = QHBoxLayout()
     help_button_frame.setLayout(help_buttons_layout)
 
-    button_size = QSize(-1, -1)
-    helpbuttons = []
-
-    help_label = QLabel("Help:")
-    help_buttons_layout.addWidget(help_label)
     help_links = plugin_manager.get_help_links() if plugin_manager else {}
 
     for menu_label, link in help_links.items():
         button = QPushButton(menu_label)
+        button.setStyleSheet(LINK_STYLE)
         button.setObjectName(menu_label)
         button.clicked.connect(
             functools.partial(_clicked_help_button, menu_label, link)
         )
-        helpbuttons.append(button)
         help_buttons_layout.addWidget(button)
 
     about_button = QPushButton("About")
+    about_button.setStyleSheet(LINK_STYLE)
     about_button.setObjectName("about_button")
-    helpbuttons.append(about_button)
     help_buttons_layout.addWidget(about_button)
+    help_buttons_layout.addStretch(-1)
 
     diag = AboutDialog(container)
     about_button.clicked.connect(lambda: _clicked_about_button(diag))
-
-    for b in helpbuttons:
-        b.adjustSize()
-        if b.size().width() > button_size.width():
-            button_size = b.size()
-
-    for b in helpbuttons:
-        b.setMinimumSize(button_size)
-
-    help_buttons_layout.insertStretch(-1, -1)
 
     container_layout.addWidget(help_button_frame)
 
@@ -268,27 +293,21 @@ def _setup_suggester(
     suggest_layout = QVBoxLayout()
     buttons_layout = QHBoxLayout()
 
-    text = ""
     for msg in errors:
-        text += msg + "\n"
         suggest_layout.addWidget(SuggestorMessage.error_msg(msg))
     for msg in warning_msgs:
-        text += msg + "\n"
         suggest_layout.addWidget(SuggestorMessage.warning_msg(msg))
     for msg in suggestions:
-        text += msg + "\n"
         suggest_layout.addWidget(SuggestorMessage.deprecation_msg(msg))
 
     suggest_layout.addStretch()
     suggest_msgs.setLayout(suggest_layout)
     scroll = QScrollArea()
+    scroll.setStyleSheet("background-color: #EAF4F9;")
     scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
     scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
     scroll.setWidgetResizable(True)
     scroll.setWidget(suggest_msgs)
-
-    def copy_text():
-        QApplication.clipboard().setText(text)
 
     def run_pressed():
         ert_window.show()
@@ -298,17 +317,19 @@ def _setup_suggester(
         container.close()
 
     run = QPushButton("Open ERT")
+    if ert_window is None:
+        run.setStyleSheet(DIABLED_BUTTON_STYLE)
+        run.setEnabled(False)
+    else:
+        run.setStyleSheet(BUTTON_STYLE)
+        run.setEnabled(True)
     give_up = QPushButton("Exit")
-    copy = QPushButton("Copy messages")
+    give_up.setStyleSheet(BUTTON_STYLE)
 
     run.setObjectName("run_ert_button")
-    run.setEnabled(ert_window is not None)
     run.pressed.connect(run_pressed)
-    copy.pressed.connect(copy_text)
     give_up.pressed.connect(container.close)
 
-    buttons_layout.addWidget(copy)
-    buttons_layout.insertStretch(-1, -1)
     buttons_layout.addWidget(run)
     buttons_layout.addWidget(give_up)
 

--- a/src/ert/gui/resources/gui/img/error_bgcircle.svg
+++ b/src/ert/gui/resources/gui/img/error_bgcircle.svg
@@ -1,0 +1,16 @@
+<svg
+   fill="#eb0037"
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+>
+  <circle
+     style="fill: #ffc1c1"
+     cx="20"
+     cy="20"
+     r="20"
+  />
+  <g transform="translate(8.0 8.0)">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2ZM13 13V7h-2v6h2Zm0 4v-2h-2v2h2Zm-9-5c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8-8 3.58-8 8Z"/>
+  </g>
+</svg>

--- a/src/ert/gui/resources/gui/img/thumbdown_bgcircle.svg
+++ b/src/ert/gui/resources/gui/img/thumbdown_bgcircle.svg
@@ -1,0 +1,16 @@
+<svg
+   fill="#243746"
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+>
+  <circle
+     style="fill: #d5eaf4"
+     cx="20"
+     cy="20"
+     r="20"
+  />
+  <g transform="translate(8.0 8.0)">
+    <path data-testid="eds-icon-path" d="M15 2H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 22l6.59-6.59c.36-.36.58-.86.58-1.41V4c0-1.1-.9-2-2-2Zm0 12-4.34 4.34L12 13H3v-2l3-7h9v10Zm8-12h-4v12h4V2Z" fill-rule="evenodd" clip-rule="evenodd" class="sc-guDMob iNmBhu"></path>
+  </g>
+</svg>

--- a/src/ert/gui/resources/gui/img/warning_bgcircle.svg
+++ b/src/ert/gui/resources/gui/img/warning_bgcircle.svg
@@ -1,0 +1,16 @@
+<svg
+   fill="#ff9200"
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+>
+  <circle
+     style="fill: #ffe7d6"
+     cx="20"
+     cy="20"
+     r="20"
+  />
+  <g transform="translate(8.0 7.0)">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m1 21.5 11-19 11 19H1Zm18.53-2L12 6.49 4.47 19.5h15.06Zm-8.53-3v2h2v-2h-2Zm0-6h2v4h-2v-4Z"/>
+  </g>
+</svg>

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -117,10 +117,10 @@ def test_gui_iter_num(monkeypatch, qtbot):
             "INSTALL_JOB job job\n"
             "INSTALL_JOB job job\n"
             "FORWARD_MODEL not_installed\n",
-            ["ERROR", "WARNING"],
+            ["Error", "Warning"],
         ),
-        ("NUM_REALIZATIONS you_cant_do_this\n", ["ERROR"]),
-        ("NUM_REALIZATIONS 1\n UMASK 0222\n", ["DEPRECATION"]),
+        ("NUM_REALIZATIONS you_cant_do_this\n", ["Error"]),
+        ("NUM_REALIZATIONS 1\n UMASK 0222\n", ["Deprecation"]),
     ],
 )
 def test_both_errors_and_warning_can_be_shown_in_suggestor(
@@ -137,8 +137,8 @@ def test_both_errors_and_warning_can_be_shown_in_suggestor(
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
         assert gui.windowTitle() == "Some problems detected"
         suggestions = gui.findChildren(SuggestorMessage)
-        shown_messages = [elem.type_lbl.text() for elem in suggestions]
-        assert shown_messages == expected_message_types
+        shown_messages = [elem.lbl.text() for elem in suggestions]
+        assert all(e in m for m, e in zip(shown_messages, expected_message_types))
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
The following image shows the general idea. The PR does not as of yet set the font until we can figure out how to handle CDN.

![image](https://github.com/equinor/ert/assets/32731672/013682cf-5e30-4dcf-aec9-c8146a28a2dc)

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
