### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/setup-python@v4
       id: setup_python
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - uses: actions/cache@v3
       with:
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     uses: ./.github/workflows/build-wheels-linux.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         os: [ 'macos-latest', 'macos-latest-xlarge' ]
         exclude: # m1 runner macos-latest-xlarge does not have python < 3.10
           - os: macos-latest-xlarge
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         os: [ ubuntu-latest ]
         exclude:
           - os: ubuntu-latest
@@ -120,6 +120,9 @@ jobs:
             test-type: 'gui-test'
           - os: ubuntu-latest
             python-version: '3.10'
+            test-type: 'gui-test'
+          - os: ubuntu-latest
+            python-version: '3.11'
             test-type: 'gui-test'
     uses: ./.github/workflows/test_ert.yml
     with:
@@ -133,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     uses: ./.github/workflows/test_ert_with_slurm.yml
     with:
       os: ${{ matrix.os }}
@@ -159,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install with dependencies
       run: |

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -20,10 +20,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest]
         exclude:
         - python-version: '3.8'
+          os: macos-latest
+        - python-version: '3.10'
           os: macos-latest
         - python-version: '3.11'
           os: macos-latest

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install ert
       run: |

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/ci/github/build_linux_wheel.sh
+++ b/ci/github/build_linux_wheel.sh
@@ -6,6 +6,7 @@ case "$1" in
     3.9) pyver=cp39-cp39 ;;
     3.10) pyver=cp310-cp310 ;;
     3.11) pyver=cp311-cp311 ;;
+    3.12) pyver=cp312-cp312 ;;
     *)
         echo "Unknown Python version $1"
         exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools<64",
+    "setuptools<64; python_version < '3.12'",
+    "setuptools; python_version >= '3.12'",
     "setuptools_scm[toml]>=6.2",
     "wheel",
     "scikit-build",
@@ -32,6 +33,7 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies=[
     "resdata",
     "fastapi",
     "filelock",
+    "importlib_resources;python_version <= '3.8'",
     "iterative_ensemble_smoother>=0.2.0",
     "typing_extensions>=4.5",
     "jinja2",

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -1,11 +1,16 @@
 import logging
 import os
+import sys
 import warnings
 import webbrowser
 from signal import SIG_DFL, SIGINT, signal
 from typing import Optional, cast
 
-import pkg_resources
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+else:
+    from importlib_resources import files
+
 from PyQt5.QtGui import QIcon
 from qtpy.QtCore import QDir, QLocale, Qt
 from qtpy.QtWidgets import QApplication
@@ -48,9 +53,7 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None):
     # happen in Qt slots.
     signal(SIGINT, SIG_DFL)
 
-    QDir.addSearchPath(
-        "img", pkg_resources.resource_filename("ert.gui", "resources/gui/img")
-    )
+    QDir.addSearchPath("img", str(files("ert.gui").joinpath("resources/gui/img")))
 
     app = QApplication([])  # Early so that QT is initialized before other imports
     app.setWindowIcon(QIcon("img:application/window_icon_cutout"))

--- a/src/ert/shared/share/ert/shell_scripts/copy_directory.py
+++ b/src/ert/shared/share/ert/shell_scripts/copy_directory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import distutils.dir_util
 import os
+import shutil
 import sys
 
 from make_directory import mkdir
@@ -18,7 +18,7 @@ def copy_directory(src_path, target_path):
         print(f"Copying directory structure {src_path} -> {target_path}")
         if os.path.isdir(target_path):
             target_path = os.path.join(target_path, src_basename)
-        distutils.dir_util.copy_tree(src_path, target_path, preserve_times=0)
+        shutil.copytree(src_path, target_path, dirs_exist_ok=True)
     else:
         raise IOError(
             f"Input argument:'{src_path}' "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,11 @@ from os.path import dirname
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
-import pkg_resources
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+else:
+    from importlib_resources import files
+
 import pytest
 from hypothesis import HealthCheck, settings
 from qtpy.QtCore import QDir
@@ -46,9 +50,7 @@ def log_check():
 @pytest.fixture
 def _qt_add_search_paths(qapp):
     "Ensure that icons and such are found by the tests"
-    QDir.addSearchPath(
-        "img", pkg_resources.resource_filename("ert.gui", "resources/gui/img")
-    )
+    QDir.addSearchPath("img", str(files("ert.gui").joinpath("resources/gui/img")))
 
 
 # Timeout settings are unreliable both on CI and


### PR DESCRIPTION
**Issue**
ERT does not support Python 3.12


**Approach**
Add support for Python 3.12


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
