### PR TITLE
Rename RealizationState to RealizationStorageState and move it to storage module

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -27,7 +27,7 @@ from iterative_ensemble_smoother.experimental import (
 )
 
 from ert.config import Field, GenKwConfig, SurfaceConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 from ..config.analysis_module import ESSettings, IESSettings
 from . import misfit_preprocessor

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -27,7 +27,7 @@ from iterative_ensemble_smoother.experimental import (
 )
 
 from ert.config import Field, GenKwConfig, SurfaceConfig
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..config.analysis_module import ESSettings, IESSettings
 from . import misfit_preprocessor

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -27,7 +27,7 @@ from iterative_ensemble_smoother.experimental import (
 )
 
 from ert.config import Field, GenKwConfig, SurfaceConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 from ..config.analysis_module import ESSettings, IESSettings
 from . import misfit_preprocessor
@@ -510,10 +510,13 @@ def analysis_ES(
             AnalysisStatusEvent(msg="Loading observations and responses..")
         )
         try:
-            S, (
-                observation_values,
-                observation_errors,
-                update_snapshot,
+            (
+                S,
+                (
+                    observation_values,
+                    observation_errors,
+                    update_snapshot,
+                ),
             ) = _load_observations_and_responses(
                 source_fs,
                 alpha,
@@ -687,10 +690,13 @@ def analysis_IES(
             AnalysisStatusEvent(msg="Loading observations and responses..")
         )
         try:
-            S, (
-                observation_values,
-                observation_errors,
-                update_snapshot,
+            (
+                S,
+                (
+                    observation_values,
+                    observation_errors,
+                    update_snapshot,
+                ),
             ) = _load_observations_and_responses(
                 source_fs,
                 alpha,
@@ -829,7 +835,7 @@ def smoother_update(
     analysis_config = UpdateSettings() if analysis_config is None else analysis_config
     es_settings = ESSettings() if es_settings is None else es_settings
     ens_mask = prior_storage.get_realization_mask_from_state(
-        [RealizationState.HAS_DATA]
+        [RealizationStorageState.HAS_DATA]
     )
     _assert_has_enough_realizations(ens_mask, analysis_config)
 
@@ -887,7 +893,7 @@ def iterative_smoother_update(
     alpha = analysis_config.alpha
     std_cutoff = analysis_config.std_cutoff
     ens_mask = prior_storage.get_realization_mask_from_state(
-        [RealizationState.HAS_DATA]
+        [RealizationStorageState.HAS_DATA]
     )
 
     _assert_has_enough_realizations(ens_mask, analysis_config)

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -9,7 +9,7 @@ from ert.config import ParameterConfig, ResponseConfig, SummaryConfig
 from ert.run_arg import RunArg
 
 from .load_status import LoadResult, LoadStatus
-from .realization_state import RealizationState
+from .realization_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +105,9 @@ def forward_model_ok(
         final_result = response_result
 
     run_arg.ensemble_storage.state_map[run_arg.iens] = (
-        RealizationState.HAS_DATA
+        RealizationStorageState.HAS_DATA
         if final_result.status == LoadStatus.LOAD_SUCCESSFUL
-        else RealizationState.LOAD_FAILURE
+        else RealizationStorageState.LOAD_FAILURE
     )
 
     return final_result

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -9,7 +9,7 @@ from ert.config import ParameterConfig, ResponseConfig, SummaryConfig
 from ert.run_arg import RunArg
 
 from .load_status import LoadResult, LoadStatus
-from .realization_storage_state import RealizationStorageState
+from .storage.realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -9,7 +9,7 @@ from ert.config import ParameterConfig, ResponseConfig, SummaryConfig
 from ert.run_arg import RunArg
 
 from .load_status import LoadResult, LoadStatus
-from .realization_state import RealizationStorageState
+from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -107,7 +107,8 @@ class MeasuredData:
             group = obs.attrs["response"]
             try:
                 response = ensemble.load_responses(
-                    group, tuple(ensemble.realization_list(RealizationState.HAS_DATA))
+                    group,
+                    tuple(ensemble.realization_list(RealizationStorageState.HAS_DATA)),
                 )
                 _msg = f"No response loaded for observation key: {key}"
                 if not response:

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -15,7 +15,7 @@ from numpy.random import SeedSequence
 from .analysis.configuration import UpdateConfiguration, UpdateStep
 from .config import ParameterConfig
 from .job_queue import WorkflowRunner
-from .realization_state import RealizationStorageState
+from .realization_storage_state import RealizationStorageState
 from .run_context import RunContext
 from .runpaths import Runpaths
 from .substitution_list import SubstitutionList
@@ -202,7 +202,7 @@ def sample_prior(
             )
             ensemble.save_parameters(parameter, realization_nr, ds)
     for realization_nr in active_realizations:
-        ensemble.update_realization_state(
+        ensemble.update_realization_storage_state(
             realization_nr,
             [
                 RealizationStorageState.UNDEFINED,

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -15,9 +15,9 @@ from numpy.random import SeedSequence
 from .analysis.configuration import UpdateConfiguration, UpdateStep
 from .config import ParameterConfig
 from .job_queue import WorkflowRunner
-from .realization_storage_state import RealizationStorageState
 from .run_context import RunContext
 from .runpaths import Runpaths
+from .storage.realization_storage_state import RealizationStorageState
 from .substitution_list import SubstitutionList
 
 if TYPE_CHECKING:

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -7,25 +7,15 @@ import time
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Union
 
 import numpy as np
 from numpy.random import SeedSequence
 
 from .analysis.configuration import UpdateConfiguration, UpdateStep
-from .config import (
-    ParameterConfig,
-)
+from .config import ParameterConfig
 from .job_queue import WorkflowRunner
-from .realization_state import RealizationState
+from .realization_state import RealizationStorageState
 from .run_context import RunContext
 from .runpaths import Runpaths
 from .substitution_list import SubstitutionList
@@ -215,10 +205,10 @@ def sample_prior(
         ensemble.update_realization_state(
             realization_nr,
             [
-                RealizationState.UNDEFINED,
-                RealizationState.LOAD_FAILURE,
+                RealizationStorageState.UNDEFINED,
+                RealizationStorageState.LOAD_FAILURE,
             ],
-            RealizationState.INITIALIZED,
+            RealizationStorageState.INITIALIZED,
         )
 
     ensemble.sync()

--- a/src/ert/gui/ertwidgets/models/ertmodel.py
+++ b/src/ert/gui/ertwidgets/models/ertmodel.py
@@ -1,4 +1,4 @@
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.storage import StorageReader
 
 
@@ -17,9 +17,9 @@ def get_runnable_realizations_mask(storage: StorageReader, casename: str):
         return []
 
     runnable_states = [
-        RealizationState.UNDEFINED,
-        RealizationState.INITIALIZED,
-        RealizationState.LOAD_FAILURE,
-        RealizationState.HAS_DATA,
+        RealizationStorageState.UNDEFINED,
+        RealizationStorageState.INITIALIZED,
+        RealizationStorageState.LOAD_FAILURE,
+        RealizationStorageState.HAS_DATA,
     ]
     return ensemble.get_realization_mask_from_state(runnable_states)

--- a/src/ert/gui/ertwidgets/models/ertmodel.py
+++ b/src/ert/gui/ertwidgets/models/ertmodel.py
@@ -1,4 +1,4 @@
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.storage import StorageReader
 
 

--- a/src/ert/gui/ertwidgets/models/ertmodel.py
+++ b/src/ert/gui/ertwidgets/models/ertmodel.py
@@ -1,5 +1,5 @@
-from ert.realization_storage_state import RealizationStorageState
 from ert.storage import StorageReader
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def get_runnable_realizations_mask(storage: StorageReader, casename: str):

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -13,7 +13,7 @@ from cwrap import BaseCClass
 from ert._clib.queue import _get_submit_attempt, _kill, _refresh_status, _submit
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 from . import ResPrototype
 from .job_status import JobStatus
@@ -165,7 +165,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
     def run_exit_callback(self) -> None:
         self.run_arg.ensemble_storage.state_map[
             self.run_arg.iens
-        ] = RealizationState.LOAD_FAILURE
+        ] = RealizationStorageState.LOAD_FAILURE
 
     def is_running(self, given_status: Optional[JobStatus] = None) -> bool:
         status = given_status or self.queue_status

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -13,7 +13,7 @@ from cwrap import BaseCClass
 from ert._clib.queue import _get_submit_attempt, _kill, _refresh_status, _submit
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 from . import ResPrototype
 from .job_status import JobStatus

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -13,7 +13,7 @@ from cwrap import BaseCClass
 from ert._clib.queue import _get_submit_attempt, _kill, _refresh_status, _submit
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadStatus
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from . import ResPrototype
 from .job_status import JobStatus

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -23,9 +23,9 @@ from ert.config import (
 )
 from ert.data import MeasuredData
 from ert.data._measured_data import ObservationError, ResponseError
-from ert.realization_storage_state import RealizationStorageState
 from ert.shared.version import __version__
 from ert.storage import EnsembleReader
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from .analysis._es_update import UpdateSettings
 from .enkf_main import EnKFMain, ensemble_context

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -23,7 +23,7 @@ from ert.config import (
 )
 from ert.data import MeasuredData
 from ert.data._measured_data import ObservationError, ResponseError
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.shared.version import __version__
 from ert.storage import EnsembleReader
 
@@ -186,7 +186,7 @@ class LibresFacade:
         return self.config.model_config.num_realizations
 
     def get_active_realizations(self, ensemble: EnsembleReader) -> List[int]:
-        return ensemble.realization_list(RealizationState.HAS_DATA)
+        return ensemble.realization_list(RealizationStorageState.HAS_DATA)
 
     def get_queue_config(self) -> "QueueConfig":
         return self.config.queue_config
@@ -264,7 +264,7 @@ class LibresFacade:
         report_step: int,
         realization_index: Optional[int] = None,
     ) -> DataFrame:
-        realizations = ensemble.realization_list(RealizationState.HAS_DATA)
+        realizations = ensemble.realization_list(RealizationStorageState.HAS_DATA)
         if realization_index is not None:
             if realization_index not in realizations:
                 raise IndexError(f"No such realization {realization_index}")
@@ -338,8 +338,8 @@ class LibresFacade:
         """
         ens_mask = ensemble.get_realization_mask_from_state(
             [
-                RealizationState.INITIALIZED,
-                RealizationState.HAS_DATA,
+                RealizationStorageState.INITIALIZED,
+                RealizationStorageState.HAS_DATA,
             ]
         )
         realizations = (

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -23,7 +23,7 @@ from ert.config import (
 )
 from ert.data import MeasuredData
 from ert.data._measured_data import ObservationError, ResponseError
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.shared.version import __version__
 from ert.storage import EnsembleReader
 

--- a/src/ert/realization_state.py
+++ b/src/ert/realization_state.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class RealizationState(Enum):
+class RealizationStorageState(Enum):
     UNDEFINED = 1
     INITIALIZED = 2
     HAS_DATA = 4

--- a/src/ert/realization_state.py
+++ b/src/ert/realization_state.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-
-class RealizationStorageState(Enum):
-    UNDEFINED = 1
-    INITIALIZED = 2
-    HAS_DATA = 4
-    LOAD_FAILURE = 8
-    PARENT_FAILURE = 16

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.storage import EnsembleAccessor, StorageAccessor
 

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -8,9 +8,9 @@ import numpy as np
 
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from .base_run_model import BaseRunModel
 

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.storage import EnsembleAccessor, StorageAccessor
 
@@ -84,10 +84,10 @@ class EnsembleExperiment(BaseRunModel):
             state_map = prior_context.sim_fs.state_map
             for realization_nr in prior_context.active_realizations:
                 if state_map[realization_nr] in [
-                    RealizationState.UNDEFINED,
-                    RealizationState.LOAD_FAILURE,
+                    RealizationStorageState.UNDEFINED,
+                    RealizationStorageState.LOAD_FAILURE,
                 ]:
-                    state_map[realization_nr] = RealizationState.INITIALIZED
+                    state_map[realization_nr] = RealizationStorageState.INITIALIZED
         iteration = prior_context.iteration
         phase_count = iteration + 1
         self.setPhaseCount(phase_count)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -11,10 +11,10 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESRunArguments
 from ert.storage import StorageAccessor
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -11,7 +11,7 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESRunArguments
 from ert.storage import StorageAccessor

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -11,7 +11,7 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESRunArguments
 from ert.storage import StorageAccessor
@@ -19,11 +19,7 @@ from ert.storage import StorageAccessor
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
 from .base_run_model import BaseRunModel, ErtRunError
-from .event import (
-    RunModelStatusEvent,
-    RunModelUpdateBeginEvent,
-    RunModelUpdateEndEvent,
-)
+from .event import RunModelStatusEvent, RunModelUpdateBeginEvent, RunModelUpdateEndEvent
 
 if TYPE_CHECKING:
     from ert.config import QueueConfig
@@ -108,8 +104,8 @@ class EnsembleSmoother(BaseRunModel):
         )
 
         states = [
-            RealizationState.HAS_DATA,
-            RealizationState.INITIALIZED,
+            RealizationStorageState.HAS_DATA,
+            RealizationStorageState.INITIALIZED,
         ]
 
         self.send_event(

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -12,10 +12,10 @@ from ert.analysis import ErtAnalysisError, iterative_smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import SIESRunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import IESSettings

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -12,7 +12,7 @@ from ert.analysis import ErtAnalysisError, iterative_smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import SIESRunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
@@ -20,11 +20,7 @@ from ert.storage import EnsembleAccessor, StorageAccessor
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import IESSettings
 from .base_run_model import BaseRunModel, ErtRunError
-from .event import (
-    RunModelStatusEvent,
-    RunModelUpdateBeginEvent,
-    RunModelUpdateEndEvent,
-)
+from .event import RunModelStatusEvent, RunModelUpdateBeginEvent, RunModelUpdateEndEvent
 
 if TYPE_CHECKING:
     from ert.config import QueueConfig
@@ -144,8 +140,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
         )
         for current_iter in range(1, iteration_count + 1):
             states = [
-                RealizationState.HAS_DATA,
-                RealizationState.INITIALIZED,
+                RealizationStorageState.HAS_DATA,
+                RealizationStorageState.INITIALIZED,
             ]
             self.send_event(RunModelUpdateBeginEvent(iteration=current_iter - 1))
             self.send_event(

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -12,7 +12,7 @@ from ert.analysis import ErtAnalysisError, iterative_smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import SIESRunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -11,10 +11,10 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESMDARunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -11,7 +11,7 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESMDARunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
@@ -19,11 +19,7 @@ from ert.storage import EnsembleAccessor, StorageAccessor
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
 from .base_run_model import BaseRunModel, ErtRunError
-from .event import (
-    RunModelStatusEvent,
-    RunModelUpdateBeginEvent,
-    RunModelUpdateEndEvent,
-)
+from .event import RunModelStatusEvent, RunModelUpdateBeginEvent, RunModelUpdateEndEvent
 
 if TYPE_CHECKING:
     from ert.config import QueueConfig
@@ -146,8 +142,8 @@ class MultipleDataAssimilation(BaseRunModel):
                 )
             self.ert.runWorkflows(HookRuntime.PRE_UPDATE, self._storage, prior)
             states = [
-                RealizationState.HAS_DATA,
-                RealizationState.INITIALIZED,
+                RealizationStorageState.HAS_DATA,
+                RealizationStorageState.INITIALIZED,
             ]
             self.send_event(
                 RunModelStatusEvent(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -11,7 +11,7 @@ from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, HookRuntime
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESMDARunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ert import ErtScript
 from ert.exceptions import StorageError
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 
 class ExportMisfitDataJob(ErtScript):

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ert import ErtScript
 from ert.exceptions import StorageError
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 class ExportMisfitDataJob(ErtScript):

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ert import ErtScript
 from ert.exceptions import StorageError
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 
 class ExportMisfitDataJob(ErtScript):
@@ -24,7 +24,7 @@ class ExportMisfitDataJob(ErtScript):
         if self.ensemble is None:
             raise StorageError("No responses loaded")
 
-        realizations = self.ensemble.realization_list(RealizationState.HAS_DATA)
+        realizations = self.ensemble.realization_list(RealizationStorageState.HAS_DATA)
 
         if not realizations:
             raise StorageError("No responses loaded")

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -12,7 +12,7 @@ from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.models.path_model import PathModel
 from ert.gui.ertwidgets.pathchooser import PathChooser
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 
 def load_args(filename, column_names=None):

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -12,7 +12,7 @@ from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.models.path_model import PathModel
 from ert.gui.ertwidgets.pathchooser import PathChooser
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def load_args(filename, column_names=None):

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -7,15 +7,12 @@ import pandas as pd
 from PyQt5.QtWidgets import QCheckBox
 
 from ert import LibresFacade
-from ert.config import (
-    CancelPluginException,
-    ErtPlugin,
-)
+from ert.config import CancelPluginException, ErtPlugin
 from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.models.path_model import PathModel
 from ert.gui.ertwidgets.pathchooser import PathChooser
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 
 def load_args(filename, column_names=None):
@@ -176,7 +173,9 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                     )
 
                 rft_data = facade.load_gen_data(ensemble, data_key, report_step)
-                realizations = ensemble.realization_list(RealizationState.HAS_DATA)
+                realizations = ensemble.realization_list(
+                    RealizationStorageState.HAS_DATA
+                )
 
                 # Trajectory
                 trajectory_file = os.path.join(trajectory_path, f"{well}.txt")

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -11,9 +11,9 @@ import numpy as np
 from ert.config import HookRuntime
 from ert.enkf_main import create_run_path
 from ert.job_queue import JobQueue, JobStatus
-from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from .forward_model_status import ForwardModelStatus
 
@@ -35,7 +35,7 @@ def _run_forward_model(
 ) -> None:
     # run simplestep
     for realization_nr in run_context.active_realizations:
-        run_context.sim_fs.update_realization_state(
+        run_context.sim_fs.update_realization_storage_state(
             realization_nr,
             [
                 RealizationStorageState.UNDEFINED,

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -11,7 +11,7 @@ import numpy as np
 from ert.config import HookRuntime
 from ert.enkf_main import create_run_path
 from ert.job_queue import JobQueue, JobStatus
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
 

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -11,7 +11,7 @@ import numpy as np
 from ert.config import HookRuntime
 from ert.enkf_main import create_run_path
 from ert.job_queue import JobQueue, JobStatus
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
 
@@ -38,10 +38,10 @@ def _run_forward_model(
         run_context.sim_fs.update_realization_state(
             realization_nr,
             [
-                RealizationState.UNDEFINED,
-                RealizationState.LOAD_FAILURE,
+                RealizationStorageState.UNDEFINED,
+                RealizationStorageState.LOAD_FAILURE,
             ],
-            RealizationState.INITIALIZED,
+            RealizationStorageState.INITIALIZED,
         )
     run_context.sim_fs.sync()
 
@@ -112,7 +112,7 @@ class SimulationContext:
         for realization_nr in self._run_context.active_realizations:
             self._run_context.sim_fs.state_map[
                 realization_nr
-            ] = RealizationState.INITIALIZED
+            ] = RealizationStorageState.INITIALIZED
         create_run_path(self._run_context, global_substitutions, self._ert.ert_config)
         self._ert.runWorkflows(
             HookRuntime.PRE_SIMULATION, None, self._run_context.sim_fs

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadResult, LoadStatus
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 from ert.callbacks import forward_model_ok
 from ert.load_status import LoadResult, LoadStatus
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -35,7 +35,7 @@ def _load_realization(
     realisation: int,
     run_args: List[RunArg],
 ) -> Tuple[LoadResult, int]:
-    sim_fs.update_realization_state(
+    sim_fs.update_realization_storage_state(
         realisation,
         [RealizationStorageState.UNDEFINED],
         RealizationStorageState.INITIALIZED,
@@ -270,7 +270,7 @@ class LocalEnsembleAccessor(LocalEnsembleReader):
             data = {"state_map": [v.value for v in self._state_map]}
             f.write(json.dumps(data))
 
-    def update_realization_state(
+    def update_realization_storage_state(
         self,
         realization: int,
         old_states: List[RealizationStorageState],
@@ -339,7 +339,7 @@ class LocalEnsembleAccessor(LocalEnsembleReader):
         path.parent.mkdir(exist_ok=True)
 
         dataset.expand_dims(realizations=[realization]).to_netcdf(path, engine="scipy")
-        self.update_realization_state(
+        self.update_realization_storage_state(
             realization,
             [
                 RealizationStorageState.UNDEFINED,

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -28,7 +28,7 @@ from filelock import FileLock, Timeout
 from pydantic import BaseModel, Field
 
 from ert.config import ErtConfig
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.shared import __version__
 from ert.storage.local_ensemble import LocalEnsembleAccessor, LocalEnsembleReader
 from ert.storage.local_experiment import LocalExperimentAccessor, LocalExperimentReader

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -28,7 +28,7 @@ from filelock import FileLock, Timeout
 from pydantic import BaseModel, Field
 
 from ert.config import ErtConfig
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.shared import __version__
 from ert.storage.local_ensemble import LocalEnsembleAccessor, LocalEnsembleReader
 from ert.storage.local_experiment import LocalExperimentAccessor, LocalExperimentReader
@@ -309,11 +309,13 @@ class LocalStorageAccessor(LocalStorageReader):
             state_map = prior_ensemble.state_map
             for realization_nr, state in enumerate(state_map[: len(ens.state_map)]):
                 if state in [
-                    RealizationState.LOAD_FAILURE,
-                    RealizationState.PARENT_FAILURE,
-                    RealizationState.UNDEFINED,
+                    RealizationStorageState.LOAD_FAILURE,
+                    RealizationStorageState.PARENT_FAILURE,
+                    RealizationStorageState.UNDEFINED,
                 ]:
-                    ens.state_map[realization_nr] = RealizationState.PARENT_FAILURE
+                    ens.state_map[
+                        realization_nr
+                    ] = RealizationStorageState.PARENT_FAILURE
         self._ensembles[ens.id] = ens
         return ens
 

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -28,10 +28,10 @@ from filelock import FileLock, Timeout
 from pydantic import BaseModel, Field
 
 from ert.config import ErtConfig
-from ert.realization_storage_state import RealizationStorageState
 from ert.shared import __version__
 from ert.storage.local_ensemble import LocalEnsembleAccessor, LocalEnsembleReader
 from ert.storage.local_experiment import LocalExperimentAccessor, LocalExperimentReader
+from ert.storage.realization_storage_state import RealizationStorageState
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self

--- a/src/ert/storage/migration/block_fs.py
+++ b/src/ert/storage/migration/block_fs.py
@@ -24,7 +24,7 @@ from ert.config import (
     SurfaceConfig,
     field_transform,
 )
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.storage import EnsembleAccessor, StorageAccessor
 from ert.storage.local_storage import LocalStorageAccessor, local_storage_get_ert_config
 from ert.storage.migration._block_fs_native import DataFile, Kind

--- a/src/ert/storage/migration/block_fs.py
+++ b/src/ert/storage/migration/block_fs.py
@@ -24,10 +24,10 @@ from ert.config import (
     SurfaceConfig,
     field_transform,
 )
-from ert.realization_storage_state import RealizationStorageState
 from ert.storage import EnsembleAccessor, StorageAccessor
 from ert.storage.local_storage import LocalStorageAccessor, local_storage_get_ert_config
 from ert.storage.migration._block_fs_native import DataFile, Kind
+from ert.storage.realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 

--- a/src/ert/storage/realization_storage_state.py
+++ b/src/ert/storage/realization_storage_state.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class RealizationStorageState(Enum):
+    UNDEFINED = 1
+    INITIALIZED = 2
+    HAS_DATA = 4
+    LOAD_FAILURE = 8
+    PARENT_FAILURE = 16

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -10,12 +10,9 @@ import xarray as xr
 from flaky import flaky
 
 from ert.analysis import UpdateConfiguration, smoother_update
-from ert.config import (
-    ErtConfig,
-    SummaryConfig,
-)
+from ert.config import ErtConfig, SummaryConfig
 from ert.enkf_main import sample_prior
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.storage import open_storage
 from tests.performance_tests.performance_utils import make_poly_example
 
@@ -100,7 +97,7 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
                         ),
                         real,
                     )
-                source.state_map[real] = RealizationState.HAS_DATA
+                source.state_map[real] = RealizationStorageState.HAS_DATA
 
         sample_prior(source, realizations, ens_config.parameters)
 

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -12,7 +12,7 @@ from flaky import flaky
 from ert.analysis import UpdateConfiguration, smoother_update
 from ert.config import ErtConfig, SummaryConfig
 from ert.enkf_main import sample_prior
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
 from tests.performance_tests.performance_utils import make_poly_example
 

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -12,8 +12,8 @@ from flaky import flaky
 from ert.analysis import UpdateConfiguration, smoother_update
 from ert.config import ErtConfig, SummaryConfig
 from ert.enkf_main import sample_prior
-from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
+from ert.storage.realization_storage_state import RealizationStorageState
 from tests.performance_tests.performance_utils import make_poly_example
 
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -26,7 +26,7 @@ from ert.cli import ENSEMBLE_SMOOTHER_MODE
 from ert.cli.main import run_cli
 from ert.config import AnalysisConfig, ErtConfig, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings, IESSettings
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
 
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -26,8 +26,8 @@ from ert.cli import ENSEMBLE_SMOOTHER_MODE
 from ert.cli.main import run_cli
 from ert.config import AnalysisConfig, ErtConfig, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings, IESSettings
-from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 @pytest.fixture

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -26,7 +26,7 @@ from ert.cli import ENSEMBLE_SMOOTHER_MODE
 from ert.cli.main import run_cli
 from ert.config import AnalysisConfig, ErtConfig, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings, IESSettings
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.storage import open_storage
 
 
@@ -433,7 +433,7 @@ def test_snapshot_alpha(
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationState.HAS_DATA
+        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",
@@ -632,7 +632,7 @@ def test_gen_data_obs_data_mismatch(storage, uniform_parameter, update_config):
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationState.HAS_DATA
+        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",
@@ -688,7 +688,7 @@ def test_gen_data_missing(storage, update_config, uniform_parameter, obs):
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationState.HAS_DATA
+        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -7,7 +7,7 @@ from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.tools.manage_cases.case_init_configuration import (
     CaseInitializationConfigurationPanel,
 )
-from ert.realization_storage_state import RealizationStorageState
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 @pytest.mark.usefixtures("copy_poly_case")

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -7,7 +7,7 @@ from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.tools.manage_cases.case_init_configuration import (
     CaseInitializationConfigurationPanel,
 )
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 
 
 @pytest.mark.usefixtures("copy_poly_case")
@@ -24,7 +24,7 @@ def test_case_tool_init_prior(qtbot, storage):
     notifier.set_current_case(ensemble)
     assert (
         ensemble.state_map
-        == [RealizationState.UNDEFINED] * config.model_config.num_realizations
+        == [RealizationStorageState.UNDEFINED] * config.model_config.num_realizations
     )
     tool = CaseInitializationConfigurationPanel(
         config, notifier, config.model_config.num_realizations
@@ -35,7 +35,7 @@ def test_case_tool_init_prior(qtbot, storage):
     )
     assert (
         ensemble.state_map
-        == [RealizationState.INITIALIZED] * config.model_config.num_realizations
+        == [RealizationStorageState.INITIALIZED] * config.model_config.num_realizations
     )
 
 

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -7,7 +7,7 @@ from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.tools.manage_cases.case_init_configuration import (
     CaseInitializationConfigurationPanel,
 )
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 
 
 @pytest.mark.usefixtures("copy_poly_case")

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -1,6 +1,6 @@
 from ert.enkf_main import EnKFMain
-from ert.realization_storage_state import RealizationStorageState
 from ert.simulator import SimulationContext
+from ert.storage.realization_storage_state import RealizationStorageState
 from tests.utils import wait_until
 
 

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -1,5 +1,5 @@
 from ert.enkf_main import EnKFMain
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.simulator import SimulationContext
 from tests.utils import wait_until
 
@@ -60,10 +60,10 @@ def test_simulation_context(setup_case, storage):
             assert not even_ctx.didRealizationFail(iens)
             assert even_ctx.isRealizationFinished(iens)
 
-            assert even_half.state_map[iens] == RealizationState.HAS_DATA
+            assert even_half.state_map[iens] == RealizationStorageState.HAS_DATA
         else:
             assert odd_ctx.didRealizationSucceed(iens)
             assert not odd_ctx.didRealizationFail(iens)
             assert odd_ctx.isRealizationFinished(iens)
 
-            assert odd_half.state_map[iens] == RealizationState.HAS_DATA
+            assert odd_half.state_map[iens] == RealizationStorageState.HAS_DATA

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -1,5 +1,5 @@
 from ert.enkf_main import EnKFMain
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.simulator import SimulationContext
 from tests.utils import wait_until
 

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -30,8 +30,8 @@ from ert.ensemble_evaluator.state import (
     JOB_STATE_START,
     REALIZATION_STATE_FINISHED,
 )
-from ert.realization_storage_state import RealizationStorageState
 from ert.shared.feature_toggling import FeatureToggling
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def check_expression(original, path_expression, expected, msg_start):

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -30,7 +30,7 @@ from ert.ensemble_evaluator.state import (
     JOB_STATE_START,
     REALIZATION_STATE_FINISHED,
 )
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.shared.feature_toggling import FeatureToggling
 
 

--- a/tests/unit_tests/status/test_tracking_integration.py
+++ b/tests/unit_tests/status/test_tracking_integration.py
@@ -30,7 +30,7 @@ from ert.ensemble_evaluator.state import (
     JOB_STATE_START,
     REALIZATION_STATE_FINISHED,
 )
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.shared.feature_toggling import FeatureToggling
 
 
@@ -74,7 +74,7 @@ def check_expression(original, path_expression, expected, msg_start):
                     "The run is cancelled due to reaching MAX_RUNTIME",
                 ),
             ],
-            [RealizationState.LOAD_FAILURE] * 2,
+            [RealizationStorageState.LOAD_FAILURE] * 2,
             id="ee_poly_experiment_cancelled_by_max_runtime",
         ),
         pytest.param(
@@ -90,7 +90,7 @@ def check_expression(original, path_expression, expected, msg_start):
             1,
             1.0,
             [(".*", "reals.*.jobs.*.status", JOB_STATE_FINISHED)],
-            [RealizationState.HAS_DATA] * 2,
+            [RealizationStorageState.HAS_DATA] * 2,
             id="ee_poly_experiment",
         ),
         pytest.param(
@@ -108,7 +108,7 @@ def check_expression(original, path_expression, expected, msg_start):
             2,
             1.0,
             [(".*", "reals.*.jobs.*.status", JOB_STATE_FINISHED)],
-            [RealizationState.HAS_DATA] * 2,
+            [RealizationStorageState.HAS_DATA] * 2,
             id="ee_poly_smoother",
         ),
         pytest.param(
@@ -132,8 +132,8 @@ def check_expression(original, path_expression, expected, msg_start):
                 (".*", "reals.'1'.jobs.*.status", JOB_STATE_FINISHED),
             ],
             [
-                RealizationState.LOAD_FAILURE,
-                RealizationState.HAS_DATA,
+                RealizationStorageState.LOAD_FAILURE,
+                RealizationStorageState.HAS_DATA,
             ],
             id="ee_failing_poly_smoother",
         ),

--- a/tests/unit_tests/test_load_forward_model.py
+++ b/tests/unit_tests/test_load_forward_model.py
@@ -12,7 +12,7 @@ from resdata.summary import Summary
 from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context
 from ert.libres_facade import LibresFacade
-from ert.realization_state import RealizationState
+from ert.realization_state import RealizationStorageState
 from ert.storage import open_storage
 
 
@@ -87,7 +87,7 @@ def test_load_inconsistent_time_map_summary(caplog):
     storage = open_storage(facade.enspath, mode="w")
     ensemble = storage.get_ensemble_by_name("default_0")
     assert (
-        ensemble.state_map[realisation_number] == RealizationState.HAS_DATA
+        ensemble.state_map[realisation_number] == RealizationStorageState.HAS_DATA
     )  # Check prior state
 
     # Create a result that is incompatible with the refcase
@@ -128,7 +128,7 @@ def test_load_forward_model(snake_oil_default_storage):
         loaded = facade.load_from_forward_model(default, realizations, 0)
         assert loaded == 1
         assert (
-            default.state_map[realisation_number] == RealizationState.HAS_DATA
+            default.state_map[realisation_number] == RealizationStorageState.HAS_DATA
         )  # Check that status is as expected
 
 

--- a/tests/unit_tests/test_load_forward_model.py
+++ b/tests/unit_tests/test_load_forward_model.py
@@ -12,8 +12,8 @@ from resdata.summary import Summary
 from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context
 from ert.libres_facade import LibresFacade
-from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
+from ert.storage.realization_storage_state import RealizationStorageState
 
 
 @pytest.fixture()

--- a/tests/unit_tests/test_load_forward_model.py
+++ b/tests/unit_tests/test_load_forward_model.py
@@ -12,7 +12,7 @@ from resdata.summary import Summary
 from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context
 from ert.libres_facade import LibresFacade
-from ert.realization_state import RealizationStorageState
+from ert.realization_storage_state import RealizationStorageState
 from ert.storage import open_storage
 
 


### PR DESCRIPTION
**Issue**
In the upcoming Queue we would like reserve RealizationState to describe the execution state when running a single realization and therefore suggest renaming the current `RealizationState` to `RealizationStorageState`