### PR TITLE
Have continous updating of the target case field

### DIFF
--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -41,7 +41,9 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
 
         self._case_format_model = TargetCaseModel(facade, notifier, format_mode=True)
         self._case_format_field = StringBox(
-            self._case_format_model, "config/simulation/target_case_format"
+            self._case_format_model,
+            self._case_format_model.getDefaultValue(),
+            True,
         )
         self._case_format_field.setValidator(ProperNameFormatArgument())
         layout.addRow("Case format:", self._case_format_field)

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -49,7 +49,9 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
             facade, notifier, format_mode=True
         )
         self._target_case_format_field = StringBox(
-            self._target_case_format_model, "config/simulation/target_case_format"
+            self._target_case_format_model,
+            self._target_case_format_model.getDefaultValue(),
+            True,
         )
         self._target_case_format_field.setValidator(ProperNameFormatArgument())
         layout.addRow("Target case format:", self._target_case_format_field)


### PR DESCRIPTION
**Issue**
Closes #6637

When changing the Target case format in ES-MDA and Ensemble smoother the changes in the text box are not taken into account unless pressing enter in the text field.

![Skjermbilde 2023-11-22 kl  09 10 49](https://github.com/equinor/ert/assets/44577479/b70d3397-fcfe-4a76-a7e8-117643fa521b)


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
