### PR TITLE
Make test code more robust

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,9 @@ def fixture_copy_case(tmp_path_factory, source_root, monkeypatch):
     def _copy_case(path):
         tmp_path = tmp_path_factory.mktemp(path.replace("/", "-"))
         shutil.copytree(
-            os.path.join(source_root, "test-data", path), tmp_path / "test_data"
+            os.path.join(source_root, "test-data", path),
+            tmp_path / "test_data",
+            ignore=shutil.ignore_patterns("storage"),
         )
         monkeypatch.chdir(tmp_path / "test_data")
 

--- a/tests/unit_tests/cli/test_integration_cli.py
+++ b/tests/unit_tests/cli/test_integration_cli.py
@@ -174,15 +174,14 @@ def test_cli_does_not_run_without_observations(tmpdir, source_root, mode, target
         os.path.join(str(tmpdir), "poly_example"),
     )
 
-    def remove_line(file_name, line_num):
-        with open(file_name, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-        with open(file_name, "w", encoding="utf-8") as f:
-            f.writelines(lines[: line_num - 1] + lines[line_num:])
+    def remove_linestartswith(file_name: str, startswith: str):
+        lines = Path(file_name).read_text(encoding="utf-8").split("\n")
+        lines = [line for line in lines if not line.startswith(startswith)]
+        Path(file_name).write_text("\n".join(lines), encoding="utf-8")
 
     with tmpdir.as_cwd():
         # Remove observations from config file
-        remove_line("poly_example/poly.ert", 8)
+        remove_linestartswith("poly_example/poly.ert", "OBS_CONFIG")
 
         parser = ArgumentParser(prog="test_main")
         parsed = ert_parser(


### PR DESCRIPTION
If you have already run the snake-case and there
is some storage lying around, it should not trip the test.

Also make robust towards slight changes in poly.ert

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
