### PR TITLE
Modify error message for mismatched ensemble size

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -427,10 +427,10 @@ class BaseRunModel:
                 case = self._storage.get_ensemble_by_name(current_case)
                 if case.ensemble_size != self._simulation_arguments.ensemble_size:
                     errors.append(
-                        f"- Existing case: {current_case} was created with ensemble "
-                        f"size smaller than specified in the ert configuration file ("
-                        f"{case.ensemble_size} "
-                        f" < {self._simulation_arguments.ensemble_size})"
+                        f"- Existing case: '{current_case}' was created with a "
+                        f"different ensemble size than the one specified in the ert "
+                        f"configuration file \n ({case.ensemble_size} "
+                        f" != {self._simulation_arguments.ensemble_size})"
                     )
             except KeyError:
                 pass


### PR DESCRIPTION
Clarifies the error message which is given when the ensemble size in config file does not match the current case ensemble size.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
