### PR TITLE
Fix bugs uncovered in simulation context

### DIFF
--- a/src/ert/job_queue/driver.py
+++ b/src/ert/job_queue/driver.py
@@ -93,7 +93,13 @@ class LocalDriver(Driver):
         if process.returncode == 0:
             if output:
                 logger.info(output)
-            realization.runend()
+            if str(realization.current_state.id) == "RUNNING":
+                realization.runend()
+            else:
+                logger.debug(
+                    f"Realization {realization.realization.run_arg.iens} finished "
+                    f"successfully but was in state {realization.current_state.id}"
+                )
         else:
             if output:
                 logger.error(output)

--- a/src/ert/job_queue/realization_state.py
+++ b/src/ert/job_queue/realization_state.py
@@ -143,7 +143,11 @@ class RealizationState(StateMachine):  # type: ignore
                 failed_job = exit_file.find("job").text
                 error_reason = exit_file.find("reason").text
                 stderr_capture = exit_file.find("stderr").text
-                stderr_file = exit_file.find("stderr_file").text
+
+                stderr_file = ""
+                if stderr_file_node := exit_file.find("stderr_file"):
+                    stderr_file = stderr_file_node.text
+
                 logger.error(
                     f"job {failed_job} failed with: '{error_reason}'\n"
                     f"\tstderr file: '{stderr_file}',\n"

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -195,7 +195,7 @@ class SimulationContext:
         return self._run_context.sim_fs
 
     def stop(self) -> None:
-        self.job_queue.kill_all_jobs()
+        self.job_queue._queue_stopped = True
         self._sim_thread.join()
 
     def job_progress(self, iens: int) -> Optional[ForwardModelStatus]:


### PR DESCRIPTION
Poking an internal variable in queue, _queue_stopped. 

There should perhaps be an official way in order to stop the queue from a sync context
