### PR TITLE
Fix flaky test gui plotter button state

### DIFF
--- a/src/ert/gui/tools/plot/plot_case_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_case_selection_widget.py
@@ -25,6 +25,7 @@ class CaseSelectionWidget(QWidget):
         self.__add_case_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self.__add_case_button.setText("Add case to plot")
         self.__add_case_button.setIcon(QIcon("img:add_circle_outlined.svg"))
+        self.__add_case_button.setEnabled(len(self._cases) > 0)
         self.__add_case_button.clicked.connect(self.addCaseSelector)
 
         add_button_layout.addStretch()


### PR DESCRIPTION
**Issue**
Resolves #6683 

Executing tests onprem to verify test

```
(my-bleed + bleeding-py38-rhel7) [andrli@st-linrgs306 ert]$ pytest --flake-finder --flake-runs=200 tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data -vv
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0 -- /private/andrli/my-bleed/root/bin/python3
cachedir: .pytest_cache
hypothesis profile 'no_timeouts' -> deadline=None, suppress_health_check=[HealthCheck.too_slow], database=DirectoryBasedExampleDatabase('/private/andrli/project/ert/.hypothesis/examples')
PyQt5 5.15.9 -- Qt runtime 5.15.2 -- Qt compiled 5.15.2
Matplotlib: 3.7.2
Freetype: 2.6.1
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /private/andrli/project/ert
configfile: pyproject.toml
plugins: timeout-2.2.0, hypothesis-6.83.0, qt-4.2.0, snapshot-0.9.0, mpl-0.16.1, cov-4.1.0, flakefinder-1.1.0, flaky-3.7.0, raises-0.11, asyncio-0.21.1, benchmark-4.0.0, repeat-0.9.3, memray-1.5.0, mock-3.12.0, xdist-3.3.1, ert-storage-0.3.22, webviz-config-0.5.3, dash-2.11.1, anyio-3.7.1
asyncio: mode=auto
collected 200 items                                                                                                                                                                                  

tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[0] PASSED                                                                                [  0%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[1] PASSED                                                                                [  1%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[2] PASSED                                                                                [  1%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[3] PASSED                                                                                [  2%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[4] PASSED                                                                                [  2%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[5] PASSED                                                                                [  3%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[6] PASSED                                                                                [  3%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[7] PASSED                                                                                [  4%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[8] PASSED                                                                                [  4%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[9] PASSED                                                                                [  5%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[10] PASSED                                                                               [  5%]

```

200 iterations OK with fix.


Rerunning without fix for comparison, so far;
```
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[76] PASSED                                                                               [ 38%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[77] PASSED                                                                               [ 39%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[78] PASSED                                                                               [ 39%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[79] FAILED                                                                               [ 40%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[80] PASSED                                                                               [ 40%]
tests/unit_tests/gui/test_main_window.py::test_that_gui_plotter_disables_add_case_button_when_no_data[81] PASSED   
```

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
