### PR TITLE
Add experiment name

### DIFF
--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from qtpy.QtWidgets import QFormLayout, QLabel
+from qtpy.QtWidgets import QFormLayout, QLabel, QLineEdit
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets.caseselector import CaseSelector
@@ -21,6 +21,7 @@ class Arguments:
     realizations: str
     iter_num: int
     current_case: str
+    experiment_name: str
 
 
 class EnsembleExperimentPanel(SimulationConfigPanel):
@@ -30,6 +31,11 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
         self.setObjectName("Ensemble_experiment_panel")
 
         layout = QFormLayout()
+
+        self._name_field = QLineEdit()
+        self._name_field.setPlaceholderText("ensemble_experiment")
+        self._name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._name_field)
 
         self._case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", self._case_selector)
@@ -73,6 +79,9 @@ class EnsembleExperimentPanel(SimulationConfigPanel):
             current_case=self.notifier.current_case_name,
             iter_num=int(self._iter_field.text()),
             realizations=self._active_realizations_field.text(),
+            experiment_name=self._name_field.text()
+            if self._name_field.text() != ""
+            else self._name_field.placeholderText(),
         )
 
     def _realizations_from_fs(self):

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from qtpy.QtWidgets import QFormLayout, QLabel
+from qtpy.QtWidgets import QFormLayout, QLabel, QLineEdit
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit
@@ -26,6 +26,7 @@ class Arguments:
     target_case: str
     realizations: str
     current_case: str
+    experiment_name: str
 
 
 class EnsembleSmootherPanel(SimulationConfigPanel):
@@ -41,6 +42,11 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
         layout = QFormLayout()
 
         self.setObjectName("ensemble_smoother_panel")
+
+        self._name_field = QLineEdit()
+        self._name_field.setPlaceholderText("ensemble_smoother")
+        self._name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._name_field)
 
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
@@ -92,5 +98,8 @@ class EnsembleSmootherPanel(SimulationConfigPanel):
             current_case=self._case_format_model.getValue() % 0,
             target_case=self._case_format_model.getValue() % 1,
             realizations=self._active_realizations_field.text(),
+            experiment_name=self._name_field.text()
+            if self._name_field.text() != ""
+            else self._name_field.placeholderText(),
         )
         return arguments

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from qtpy.QtWidgets import QFormLayout, QLabel, QSpinBox
+from qtpy.QtWidgets import QFormLayout, QLabel, QLineEdit, QSpinBox
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import AnalysisModuleEdit, CaseSelector
@@ -27,6 +27,7 @@ class Arguments:
     target_case: str
     realizations: str
     num_iterations: int
+    experiment_name: str
 
 
 class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
@@ -41,6 +42,11 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         SimulationConfigPanel.__init__(self, IteratedEnsembleSmoother)
         self.analysis_config = analysis_config
         layout = QFormLayout()
+
+        self._name_field = QLineEdit()
+        self._name_field.setPlaceholderText("iterated_ensemble_smoother")
+        self._name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._name_field)
 
         case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
@@ -110,4 +116,7 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
             target_case=self._iterated_target_case_format_model.getValue(),
             realizations=self._active_realizations_field.text(),
             num_iterations=self._num_iterations_spinner.value(),
+            experiment_name=self._name_field.text()
+            if self._name_field.text() != ""
+            else self._name_field.placeholderText(),
         )

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List
 
-from qtpy.QtWidgets import QCheckBox, QFormLayout, QLabel
+from qtpy.QtWidgets import QCheckBox, QFormLayout, QLabel, QLineEdit
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import ActiveLabel, AnalysisModuleEdit, CaseSelector
@@ -33,6 +33,7 @@ class Arguments:
     weights: List[float]
     restart_run: bool
     prior_ensemble: str
+    experiment_name: str
 
 
 class MultipleDataAssimilationPanel(SimulationConfigPanel):
@@ -48,6 +49,11 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
 
         layout = QFormLayout()
         self.setObjectName("ES_MDA_panel")
+
+        self._name_field = QLineEdit()
+        self._name_field.setPlaceholderText("es_mda")
+        self._name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._name_field)
 
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
@@ -164,6 +170,9 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
             weights=self.weights,
             restart_run=self._restart_box.isChecked(),
             prior_ensemble=self._case_selector.currentText(),
+            experiment_name=self._name_field.text()
+            if self._name_field.text() != ""
+            else self._name_field.placeholderText(),
         )
 
     def setWeights(self, weights):

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -151,6 +151,10 @@ class SimulationPanel(QWidget):
         args = simulation_widget.getSimulationArguments()
         return args
 
+    def getExperimentName(self) -> str:
+        """Get the experiment name as provided by the user. Defaults to run mode if not set."""
+        return self.getSimulationArguments().experiment_name
+
     def runSimulation(self):
         args = self.getSimulationArguments()
         if args.mode == "es_mda":
@@ -184,7 +188,9 @@ class SimulationPanel(QWidget):
                     parameters=config.ensemble_config.parameter_configuration,
                     responses=config.ensemble_config.response_configuration,
                     observations=config.observations,
+                    name=args.experiment_name,
                 )
+
                 model = create_model(
                     config,
                     self._notifier.storage,

--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from qtpy.QtWidgets import QFormLayout
+from qtpy.QtWidgets import QFormLayout, QLineEdit
 
 from ert.gui.ertwidgets.caseselector import CaseSelector
 from ert.gui.ertwidgets.copyablelabel import CopyableLabel
@@ -14,14 +14,22 @@ from .simulation_config_panel import SimulationConfigPanel
 class Arguments:
     mode: str
     current_case: str
+    experiment_name: str
 
 
 class SingleTestRunPanel(SimulationConfigPanel):
     def __init__(self, run_path, notifier, ensemble_size: int):
         self.notifier = notifier
         SimulationConfigPanel.__init__(self, SingleTestRun)
+        self.notifier = notifier
         self.setObjectName("Single_test_run_panel")
+
         layout = QFormLayout()
+
+        self._name_field = QLineEdit()
+        self._name_field.setPlaceholderText("single_test_run")
+        self._name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._name_field)
 
         case_selector = CaseSelector(notifier)
         layout.addRow("Current case:", case_selector)
@@ -34,4 +42,10 @@ class SingleTestRunPanel(SimulationConfigPanel):
         self.setLayout(layout)
 
     def getSimulationArguments(self):
-        return Arguments("test_run", self.notifier.current_case_name)
+        experiment_name = (
+            self._name_field.text()
+            if self._name_field.text() != ""
+            else self._name_field.placeholderText()
+        )
+
+        return Arguments("test_run", self.notifier.current_case_name, experiment_name)

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -179,43 +179,58 @@ class LocalStorageAccessor(LocalStorageReader):
                 if version == 0:
                     from ert.storage.migration import (  # pylint: disable=C0415
                         block_fs,
+                        experiment_id,
                         observations,
                     )
 
                     block_fs.migrate(self.path)
+                    experiment_id.migrate(self.path)
                     observations.migrate(self.path)
                     self._add_migration_information(0, "block_fs")
                 elif version == 1:
                     from ert.storage.migration import (  # pylint: disable=C0415
+                        experiment_id,
                         gen_kw,
                         observations,
                         response_info,
                     )
 
+                    experiment_id.migrate(self.path)
                     gen_kw.migrate(self.path)
                     response_info.migrate(self.path)
                     observations.migrate(self.path)
                     self._add_migration_information(1, "gen_kw")
                 elif version == 2:
                     from ert.storage.migration import (  # pylint: disable=C0415
+                        experiment_id,
                         gen_kw,
                         observations,
                         response_info,
                     )
 
                     gen_kw.migrate(self.path)
+                    experiment_id.migrate(self.path)
                     response_info.migrate(self.path)
                     observations.migrate(self.path)
                     self._add_migration_information(2, "response")
                 elif version == 3:
                     from ert.storage.migration import (  # pylint: disable=C0415
+                        experiment_id,
                         gen_kw,
                         observations,
                     )
 
                     gen_kw.migrate(self.path)
+                    experiment_id.migrate(self.path)
                     observations.migrate(self.path)
                     self._add_migration_information(3, "observations")
+                elif version == 4:
+                    from ert.storage.migration import (
+                        experiment_id,
+                    )
+
+                    experiment_id.migrate(self.path)
+                    self._add_migration_information(4, "experiment_id")
             except Exception as err:  # pylint: disable=broad-exception-caught
                 logger.error(f"Migrating storage at {self.path} failed with {err}")
 
@@ -256,10 +271,12 @@ class LocalStorageAccessor(LocalStorageReader):
         parameters: Optional[List[ParameterConfig]] = None,
         responses: Optional[List[ResponseConfig]] = None,
         observations: Optional[Dict[str, xr.Dataset]] = None,
+        name: Optional[str] = None,
     ) -> LocalExperimentAccessor:
         exp_id = uuid4()
         path = self._experiment_path(exp_id)
         path.mkdir(parents=True, exist_ok=False)
+
         exp = LocalExperimentAccessor(
             self,
             exp_id,
@@ -267,6 +284,7 @@ class LocalStorageAccessor(LocalStorageReader):
             parameters=parameters,
             responses=responses,
             observations=observations,
+            name=name,
         )
         self._experiments[exp.id] = exp
         return exp

--- a/src/ert/storage/migration/experiment_id.py
+++ b/src/ert/storage/migration/experiment_id.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from uuid import UUID
+
+from ert.storage.local_experiment import _Index
+
+
+def migrate(path: Path) -> None:
+    for experiment in path.glob("experiments/*"):
+        if not experiment.joinpath("index.json").exists():
+            with open(
+                experiment.joinpath("index.json"), mode="w", encoding="utf-8"
+            ) as f:
+                print(
+                    _Index(
+                        id=UUID(experiment.name), name="default_experiment_name"
+                    ).json(),
+                    file=f,
+                )


### PR DESCRIPTION
**Issue**
Resolves #6386


**Approach**
Adds a text input field whose placeholder text is the simulation mode.

If no name is provided, the placeholder text is used as the experiment name.

![Screenshot 2023-11-27 at 13 14 24](https://github.com/equinor/ert/assets/10201831/0f898883-9a00-4119-a67b-fc9b3a7f154b)

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
