### PR TITLE
Decrease timeout when connecting to websocket

### DIFF
--- a/src/ert/ensemble_evaluator/sync_ws_duplexer.py
+++ b/src/ert/ensemble_evaluator/sync_ws_duplexer.py
@@ -74,16 +74,14 @@ class SyncWebsocketDuplexer:
             extra_headers=self._extra_headers,
             max_size=2**26,
             max_queue=500,
-            open_timeout=60,
+            open_timeout=5,
             ping_timeout=60,
             ping_interval=60,
             close_timeout=60,
         )
 
         await wait_for_evaluator(
-            base_url=self._hc_uri,
-            token=self._token,
-            cert=self._cert,
+            base_url=self._hc_uri, token=self._token, cert=self._cert, timeout=5
         )
 
         self._ws = await connect


### PR DESCRIPTION
Set timeout in wait_for_evaluator

Without this, ert will wait for 60s before letting users know that a workflow has failed.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
