### PR TITLE
Raise error on invalid use of runpath placeholders

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -477,8 +477,8 @@ Commonly used keywords
         will be replaced by the realization number and iteration number when ERT creates the folders.
         By default, RUNPATH is set to "simulations/realization-<IENS>/iter-<ITER>".
 
-        Deprecated syntax still allow use of two %d specifers. Use of less than two %d is prohibited.
-        The behaviour is identical to the default substitution.
+        Deprecated syntax still allow use of two `%d` specifers. Use of more than two `%d` specifiers,
+        using multiple `<IENS>` or `<ITER>` keywords or mixing styles is prohibited.
 
         *Example:*
 

--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -54,11 +54,31 @@ class ModelConfig:
         self.history_source = history_source
         self.jobname_format_string = _replace_runpath_format(jobname_format_string)
         self.eclbase_format_string = _replace_runpath_format(eclbase_format_string)
+
+        # do not combine styles
+        if "%d" in runpath_format_string and any(
+            x in runpath_format_string for x in ["<ITER>", "<IENS>"]
+        ):
+            raise ConfigValidationError(
+                f"RUNPATH cannot combine deprecated and new style placeholders: `{runpath_format_string}`. Valid example `{DEFAULT_RUNPATH}`"
+            )
+
+        # do not allow multiple occurrences
+        for kw in ["<ITER>", "<IENS>"]:
+            if runpath_format_string.count(kw) > 1:
+                raise ConfigValidationError(
+                    f"RUNPATH cannot contain multiple {kw} placeholders: `{runpath_format_string}`. Valid example `{DEFAULT_RUNPATH}`"
+                )
+
+        # do not allow too many placeholders
+        if runpath_format_string.count("%d") > 2:
+            raise ConfigValidationError(
+                f"RUNPATH cannot contain more than two value placeholders: `{runpath_format_string}`. Valid example `{DEFAULT_RUNPATH}`"
+            )
+
         self.runpath_format_string = _replace_runpath_format(runpath_format_string)
 
-        if self.runpath_format_string is not None and not any(
-            x in self.runpath_format_string for x in ["<ITER>", "<IENS>"]
-        ):
+        if not any(x in self.runpath_format_string for x in ["<ITER>", "<IENS>"]):
             logger.warning(
                 "RUNPATH keyword contains no value placeholders: "
                 f"`{runpath_format_string}`. Valid example: "


### PR DESCRIPTION
**Issue**
Resolves #6617 

According to FMU-docs:
```
Deprecated syntax still allow use of two %d specifers. Use of less than two %d is prohibited. The behaviour is identical to the default substitution.
```
https://fmu-docs.equinor.com/docs/ert/reference/configuration/keywords.html#runpath

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See 
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
