### PR TITLE
Remove support for legacy Eclipse startup script

### DIFF
--- a/src/ert/shared/share/ert/forward-models/res/script/ecl100_config.yml
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl100_config.yml
@@ -1,57 +1,7 @@
-# NB: There are inter related dependencies between this file, the EclConfig
-#     class which essentially internalizes this file and the EclRun class
-#     which uses the EclConfig class.
-#
-# The information about eclipse versions installed at a particular site is
-# assembled in configuration files like this one, there are separate files for
-# ecl100, ecl300 and opm/flow. The file has only one required top level element:
-# 'versions' - which describe the versions which are installed. In
-# additon you can optionally have a top level element 'env' which is a
-# dictionary representing environment variables which should be set before the
-# simulator starts.
-#
-# In the example below the ecl100 simulator is installed in versions '2015.2'
-# and '2017.2'. Each version of the program can exist as a scalar single process
-# application and a parallel MPI application. When we have drilled all the way
-# down through versions['2105.2']['scalar'] the only required
-# attribute is 'executable' which is the full path to the executable program. In
-# addition you can add an env: setting which will be a dictionary of environment
-# variables which will be set before the simulator is invoked. The 2015.2 mpi
-# version has an example of such a settings.
-#
-# If it is an MPI simulation you must in addition to the executable attribute
-# also set an 'mpirun' attribute.
-
-versions:
-  '2015.2':  # without quotes this will be interpreted as a number
-    scalar:
-      executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse100
-    mpi:
-      executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse100_mpi
-      mpirun: /path/ecl/2015.2/intel/bin/mpirun
-      env:
-        MPI_ROOT: /path/to/mpi/root
-        LD_LIBRARY_PATH: /path/to/mpi/root/lib64:$LD_LIBRARY_PATH
-
-  '2017.2':
-    scalar:
-      executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse100
-      env:
-    mpi:
-      executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse100_mpi
-      mpirun: /path/ecl/2017.2/intel/bin/mpirun
-
-
-# You can have a shared 'env' attribute which is an environment variable map
-# which will be set before the simulator starts. If there are env settings in
-# the simulator as well they will be merged with these common settings, the
-# simulator specific take presedence.
-
 env:
   LM_LICENSE_FILE: license@company.com
   F_UFMTENDIAN: big
   ARCH: x86_64
-
 
 eclrun_env:
   SLBSLS_LICENSE_FILE: something@yourcompany.com

--- a/src/ert/shared/share/ert/forward-models/res/script/ecl300_config.yml
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl300_config.yml
@@ -1,26 +1,3 @@
-# This is an example configuration file for the local ecl300 installation, see
-# the ecl100_config.yml file for more extensive dcoujmentation.
-
-versions:
-  '2015.2':  # without quotes this will be interpreted as a number
-    scalar:
-      executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse300
-    mpi:
-      executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse300_mpi
-      mpirun: /path/ecl/2015.2/intel/bin/mpirun
-      env:
-        MPI_ROOT: /path/to/mpi/root
-        LD_LIBRARY_PATH: /path/to/mpi/root/lib64:$LD_LIBRARY_PATH
-
-  '2017.2':
-    scalar:
-      executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse300
-      env:
-    mpi:
-      executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse300_mpi
-      mpirun: /path/ecl/2017.2/intel/bin/mpirun
-
-
 env:
   LM_LICENSE_FILE: license@company.com
   F_UFMTENDIAN: big

--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_config.py
@@ -1,7 +1,6 @@
 import os
 import re
 import subprocess
-import sys
 from typing import Any, Dict, List, Optional
 
 import yaml


### PR DESCRIPTION
Only versions supported by eclrun are now supported

**Issue**
Solves https://github.com/equinor/ert/issues/4241
Follow up to https://github.com/equinor/ert-configurations/pull/81


**Approach**
✂️ 


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
