### PR TITLE
Fix scheduler to work with Python 3.8

### DIFF
--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         pushd test-data/poly_example
         ert test_run poly.ert
+        ert test_run --enable-scheduler poly.ert
         popd
     - name: Test snake_oil
       run: |

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -19,10 +19,12 @@ class JobEvent(Enum):
 class Driver(ABC):
     """Adapter for the HPC cluster."""
 
-    event_queue: asyncio.Queue[Tuple[int, JobEvent]]
-
     def __init__(self) -> None:
-        self.event_queue = asyncio.Queue()
+        self.event_queue: Optional[asyncio.Queue[Tuple[int, JobEvent]]] = None
+
+    async def ainit(self) -> None:
+        if self.event_queue is None:
+            self.event_queue = asyncio.Queue()
 
     @abstractmethod
     async def submit(self, iens: int, executable: str, /, *args: str, cwd: str) -> None:
@@ -49,5 +51,4 @@ class Driver(ABC):
         Returns:
           `asyncio.Task`, or None if polling is not applicable (eg. for LocalDriver)
         """
-
         return None

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -109,4 +109,7 @@ class Job:
                 "queue_event_type": status,
             },
         )
+        if self._scheduler._events is None:
+            await self._scheduler.ainit()
+        assert self._scheduler._events is not None
         await self._scheduler._events.put(to_json(event))

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -32,6 +32,11 @@ class LocalDriver(Driver):
             cwd=cwd,
             preexec_fn=os.setpgrp,
         )
+
+        if self.event_queue is None:
+            await self.ainit()
+        assert self.event_queue is not None
+
         await self.event_queue.put((iens, JobEvent.STARTED))
         try:
             if await proc.wait() == 0:


### PR DESCRIPTION
**Issue**
Resolves #6774 


**Approach**
Delay initialization of asyncio.Queue

This is needed for Python 3.8 because the initialization is using
the current event loop, for which we have multiple given multiple
threads in Ert. Thus we need to initialize as late as possible.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
