### PR TITLE
Add retry loop into the scheduler handling resubmitting when running state failed 

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import (
-    Optional,
-    Tuple,
-)
+from typing import Optional, Tuple
 
 
 class JobEvent(Enum):
@@ -48,3 +45,7 @@ class Driver(ABC):
     @abstractmethod
     async def poll(self) -> None:
         """Poll for new job events"""
+
+    @abstractmethod
+    async def finish(self) -> None:
+        """make sure that all the jobs / realizations are complete."""


### PR DESCRIPTION
**Issue**
Resolves #6771 


**Approach**
Use while retry to iterate from running to waiting states. It includes a
simple test to check if job has started several times. Max_submit is a function
parameter of job.__call__ that is passed on from scheduler.

Additionally, function driver.finish will implement the basic clean up
functionally. For the local driver it makes sure that all tasks have
been awaited correctly.


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
