### PR TITLE
Implement MockDriver

### DIFF
--- a/src/ert/async_utils.py
+++ b/src/ert/async_utils.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from contextlib import asynccontextmanager
-from traceback import print_exception
 from typing import (
     Any,
     AsyncGenerator,
@@ -74,7 +72,6 @@ def _done_callback(task: asyncio.Task[_T_co]) -> None:
         if (exc := task.exception()) is None:
             return
 
-        print(f"Exception during {task.get_name()}", file=sys.stderr)
-        print_exception(exc, file=sys.stderr)
+        logger.error(f"Exception occurred during {task.get_name()}", exc_info=exc)
     except asyncio.CancelledError:
         pass

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -17,11 +17,13 @@ class Driver(ABC):
     """Adapter for the HPC cluster."""
 
     def __init__(self) -> None:
-        self.event_queue: Optional[asyncio.Queue[Tuple[int, JobEvent]]] = None
+        self._event_queue: Optional[asyncio.Queue[Tuple[int, JobEvent]]] = None
 
-    async def ainit(self) -> None:
-        if self.event_queue is None:
-            self.event_queue = asyncio.Queue()
+    @property
+    def event_queue(self) -> asyncio.Queue[Tuple[int, JobEvent]]:
+        if self._event_queue is None:
+            self._event_queue = asyncio.Queue()
+        return self._event_queue
 
     @abstractmethod
     async def submit(self, iens: int, executable: str, /, *args: str, cwd: str) -> None:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -59,9 +59,7 @@ class Scheduler:
         if self._events is None:
             self._events = asyncio.Queue()
 
-    def add_realization(
-        self, real: Realization, callback_timeout: Callable[[int], None]
-    ) -> None:
+    def add_realization(self, real: Realization, callback_timeout: Any = None) -> None:
         self._jobs[real.iens] = Job(self, real)
 
     def kill_all_jobs(self) -> None:

--- a/tests/unit_tests/scheduler/conftest.py
+++ b/tests/unit_tests/scheduler/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+from ert.scheduler.local_driver import LocalDriver
+
+
+class MockDriver(LocalDriver):
+    def __init__(self, init=None, wait=None, kill=None):
+        super().__init__()
+        self._mock_init = init
+        self._mock_wait = wait
+        self._mock_kill = kill
+
+    async def _init(self, *args, **kwargs):
+        if self._mock_init is not None:
+            await self._mock_init(*args, **kwargs)
+
+    async def _wait(self, *args):
+        if self._mock_wait is not None:
+            result = await self._mock_wait()
+            return True if result is None else bool(result)
+        return True
+
+    async def _kill(self, *args):
+        if self._mock_kill is not None:
+            await self._mock_kill()
+
+
+@pytest.fixture
+def mock_driver():
+    return MockDriver

--- a/tests/unit_tests/scheduler/test_local_driver.py
+++ b/tests/unit_tests/scheduler/test_local_driver.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import pytest
+
+from ert.scheduler import local_driver
+from ert.scheduler.driver import JobEvent
+from ert.scheduler.local_driver import LocalDriver
+
+
+async def test_success(tmp_path):
+    driver = LocalDriver()
+
+    await driver.submit(42, "/usr/bin/env", "touch", "testfile", cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.STARTED)
+    assert await driver.event_queue.get() == (42, JobEvent.COMPLETED)
+
+    assert (tmp_path / "testfile").exists()
+
+
+async def test_failure(tmp_path):
+    driver = LocalDriver()
+
+    await driver.submit(42, "/usr/bin/env", "false", cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.STARTED)
+    assert await driver.event_queue.get() == (42, JobEvent.FAILED)
+
+
+async def test_file_not_found(tmp_path):
+    driver = LocalDriver()
+
+    await driver.submit(42, "/file/not/found", cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.FAILED)
+
+
+async def test_kill(tmp_path):
+    driver = LocalDriver()
+
+    await driver.submit(42, "/usr/bin/env", "sleep", "10", cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.STARTED)
+    await driver.kill(42)
+    assert await driver.event_queue.get() == (42, JobEvent.ABORTED)
+
+
+@pytest.mark.timeout(5)
+async def test_kill_unresponsive_process(monkeypatch, tmp_path):
+    # Reduce timeout to something more appropriate for a test
+    monkeypatch.setattr(local_driver, "_TERMINATE_TIMEOUT", 0.1)
+
+    (tmp_path / "script").write_text(
+        """\
+    trap "" 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+    sleep 60
+    """
+    )
+
+    driver = LocalDriver()
+
+    await driver.submit(42, "/bin/sh", tmp_path / "script", cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.STARTED)
+    await driver.kill(42)
+    assert await driver.event_queue.get() == (42, JobEvent.ABORTED)
+
+
+@pytest.mark.parametrize(
+    "cmd,event", [("true", JobEvent.COMPLETED), ("false", JobEvent.FAILED)]
+)
+async def test_kill_when_job_completed(tmp_path, cmd, event):
+    driver = LocalDriver()
+
+    await driver.submit(42, "/usr/bin/env", cmd, cwd=tmp_path)
+    assert await driver.event_queue.get() == (42, JobEvent.STARTED)
+    await asyncio.sleep(0.5)
+    await driver.kill(42)
+    assert await driver.event_queue.get() == (42, event)


### PR DESCRIPTION
LocalDriver differs from the HPC drivers in that it is made of three
parts that are run in sequence. `init` the subprocess, `wait` for the
process to complete and `kill` when the user wants to cancel. Between
the three parts the driver needs to send `JobEvent`s to the `Scheduler`.

This commit implements a `MockDriver`, where the user can optionally
specify a simplified version of each of `init`, `wait` or `kill`,
depending on what they wish to do.