### PR TITLE
Let the Scheduler ensemble be stoppable from evaluator.py

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -78,6 +78,8 @@ class Job:
             await self.started.wait()
 
             await self._send(State.RUNNING)
+            while not self.returncode.done():
+                await asyncio.sleep(0.01)
             returncode = await self.returncode
             if (
                 returncode == 0

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -99,7 +99,7 @@ async def test_cancel(tmp_path: Path, realization):
 
     scheduler_task = asyncio.create_task(sch.execute())
 
-    # Wait for the job to start
+    # Wait for the job to start (i.e. let the file "a" be touched)
     await asyncio.sleep(1)
 
     # Kill all jobs and wait for the scheduler to complete


### PR DESCRIPTION
For some reason, kill_all_jobs() was not able to kill tasks, seemingly the await self.returncode call was blocking. Solved by "busy waiting" with asyncio.sleep to let the async code accept the cancellation.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
