### PR TITLE
Remove the state map for ensembles

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -28,7 +28,6 @@ from iterative_ensemble_smoother.experimental import (
 )
 
 from ert.config import Field, GenKwConfig, SurfaceConfig
-from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..config.analysis_module import ESSettings, IESSettings
 from . import misfit_preprocessor
@@ -250,7 +249,6 @@ def _save_temp_storage_to_disk(
                 target_fs.save_parameters(key, realization, _matrix.to_dataset())
             else:
                 raise NotImplementedError(f"{type(config_node)} is not supported")
-    target_fs.sync()
 
 
 def _create_temporary_parameter_storage(
@@ -946,9 +944,7 @@ def smoother_update(
         rng = np.random.default_rng()
     analysis_config = UpdateSettings() if analysis_config is None else analysis_config
     es_settings = ESSettings() if es_settings is None else es_settings
-    ens_mask = prior_storage.get_realization_mask_from_state(
-        [RealizationStorageState.HAS_DATA]
-    )
+    ens_mask = prior_storage.get_realization_mask_with_responses()
     _assert_has_enough_realizations(ens_mask, analysis_config)
 
     smoother_snapshot = _create_smoother_snapshot(
@@ -1008,9 +1004,7 @@ def iterative_smoother_update(
             "Can not combine IES_ENKF modules with multi step updates"
         )
 
-    ens_mask = prior_storage.get_realization_mask_from_state(
-        [RealizationStorageState.HAS_DATA]
-    )
+    ens_mask = prior_storage.get_realization_mask_with_responses()
     _assert_has_enough_realizations(ens_mask, update_settings)
 
     smoother_snapshot = _create_smoother_snapshot(

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -7,9 +7,9 @@ from typing import Iterable
 
 from ert.config import ParameterConfig, ResponseConfig, SummaryConfig
 from ert.run_arg import RunArg
+from ert.storage.realization_storage_state import RealizationStorageState
 
 from .load_status import LoadResult, LoadStatus
-from .storage.realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
@@ -103,11 +103,8 @@ def forward_model_ok(
     final_result = parameters_result
     if response_result.status != LoadStatus.LOAD_SUCCESSFUL:
         final_result = response_result
-
-    run_arg.ensemble_storage.state_map[run_arg.iens] = (
-        RealizationStorageState.HAS_DATA
-        if final_result.status == LoadStatus.LOAD_SUCCESSFUL
-        else RealizationStorageState.LOAD_FAILURE
-    )
+        run_arg.ensemble_storage.set_failure(
+            run_arg.iens, RealizationStorageState.LOAD_FAILURE, final_result.message
+        )
 
     return final_result

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from ert.storage.realization_storage_state import RealizationStorageState
-
 if TYPE_CHECKING:
     import numpy.typing as npt
 
@@ -110,7 +108,7 @@ class MeasuredData:
             try:
                 response = ensemble.load_responses(
                     group,
-                    tuple(ensemble.realization_list(RealizationStorageState.HAS_DATA)),
+                    tuple(ensemble.get_realization_list_with_responses()),
                 )
                 _msg = f"No response loaded for observation key: {key}"
                 if not response:

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -17,7 +17,6 @@ from .config import ParameterConfig
 from .job_queue import WorkflowRunner
 from .run_context import RunContext
 from .runpaths import Runpaths
-from .storage.realization_storage_state import RealizationStorageState
 from .substitution_list import SubstitutionList
 
 if TYPE_CHECKING:
@@ -192,17 +191,7 @@ def sample_prior(
                 ensemble_size=ensemble.ensemble_size,
             )
             ensemble.save_parameters(parameter, realization_nr, ds)
-    for realization_nr in active_realizations:
-        ensemble.update_realization_storage_state(
-            realization_nr,
-            [
-                RealizationStorageState.UNDEFINED,
-                RealizationStorageState.LOAD_FAILURE,
-            ],
-            RealizationStorageState.INITIALIZED,
-        )
 
-    ensemble.sync()
     logger.debug(f"sample_prior() time_used {(time.perf_counter() - t):.4f}s")
 
 

--- a/src/ert/gui/ertwidgets/models/ertmodel.py
+++ b/src/ert/gui/ertwidgets/models/ertmodel.py
@@ -1,5 +1,4 @@
 from ert.storage import StorageReader
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def get_runnable_realizations_mask(storage: StorageReader, casename: str):
@@ -16,10 +15,4 @@ def get_runnable_realizations_mask(storage: StorageReader, casename: str):
     except KeyError:
         return []
 
-    runnable_states = [
-        RealizationStorageState.UNDEFINED,
-        RealizationStorageState.INITIALIZED,
-        RealizationStorageState.LOAD_FAILURE,
-        RealizationStorageState.HAS_DATA,
-    ]
-    return ensemble.get_realization_mask_from_state(runnable_states)
+    return ensemble.get_realization_mask_without_parent_failure()

--- a/src/ert/gui/tools/manage_cases/case_init_configuration.py
+++ b/src/ert/gui/tools/manage_cases/case_init_configuration.py
@@ -162,12 +162,12 @@ class CaseInitializationConfigurationPanel(QTabWidget):
     def _showInfoForCase(self, index=None):
         if index is None:
             if self.notifier.current_case is not None:
-                states = self.notifier.current_case.state_map
+                states = self.notifier.current_case.get_ensemble_state()
             else:
                 states = []
         else:
             ensemble = self.show_case_info_case_selector.itemData(index)
-            states = ensemble.state_map if ensemble is not None else []
+            states = ensemble.get_ensemble_state() if ensemble is not None else []
 
         html = "<table>"
         for state_index, value in enumerate(states):

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -163,9 +163,9 @@ class JobQueueNode(BaseCClass):  # type: ignore
             self.callback_timeout(self.run_arg.iens)
 
     def run_exit_callback(self) -> None:
-        self.run_arg.ensemble_storage.state_map[
-            self.run_arg.iens
-        ] = RealizationStorageState.LOAD_FAILURE
+        self.run_arg.ensemble_storage.set_failure(
+            self.run_arg.iens, RealizationStorageState.LOAD_FAILURE
+        )
 
     def is_running(self, given_status: Optional[JobStatus] = None) -> bool:
         status = given_status or self.queue_status
@@ -322,6 +322,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         self.queue_status = queue_status
         if thread_status == ThreadStatus.DONE and queue_status != JobStatus.SUCCESS:
             self.run_exit_callback()
+
         self.thread_status = thread_status
 
     def _kill(self, driver: "Driver") -> None:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -376,7 +376,6 @@ class BaseRunModel:
             run_context.iteration,
         ).run_and_get_successful_realizations()
 
-        run_context.sim_fs.sync()
         return successful_realizations
 
     def _build_ensemble(

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -10,7 +10,6 @@ from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.storage import EnsembleAccessor, StorageAccessor
-from ert.storage.realization_storage_state import RealizationStorageState
 
 from .base_run_model import BaseRunModel
 
@@ -80,14 +79,7 @@ class EnsembleExperiment(BaseRunModel):
                 prior_context.active_realizations,
                 random_seed=self._simulation_arguments.random_seed,
             )
-        else:
-            state_map = prior_context.sim_fs.state_map
-            for realization_nr in prior_context.active_realizations:
-                if state_map[realization_nr] in [
-                    RealizationStorageState.UNDEFINED,
-                    RealizationStorageState.LOAD_FAILURE,
-                ]:
-                    state_map[realization_nr] = RealizationStorageState.INITIALIZED
+
         iteration = prior_context.iteration
         phase_count = iteration + 1
         self.setPhaseCount(phase_count)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -14,7 +14,6 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESRunArguments
 from ert.storage import StorageAccessor
-from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
@@ -103,11 +102,6 @@ class EnsembleSmoother(BaseRunModel):
             HookRuntime.PRE_UPDATE, self._storage, prior_context.sim_fs
         )
 
-        states = [
-            RealizationStorageState.HAS_DATA,
-            RealizationStorageState.INITIALIZED,
-        ]
-
         self.send_event(
             RunModelStatusEvent(iteration=0, msg="Creating posterior ensemble..")
         )
@@ -121,7 +115,8 @@ class EnsembleSmoother(BaseRunModel):
                 prior_ensemble=prior,
             ),
             runpaths=self.run_paths,
-            initial_mask=prior_context.sim_fs.get_realization_mask_from_state(states),
+            initial_mask=prior_context.sim_fs.get_realization_mask_with_parameters()
+            + prior_context.sim_fs.get_realization_mask_with_responses(),
             iteration=1,
         )
         try:

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -15,7 +15,6 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import SIESRunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
-from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import IESSettings
@@ -160,10 +159,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
             HookRuntime.PRE_FIRST_UPDATE, self._storage, prior_context.sim_fs
         )
         for current_iter in range(1, iteration_count + 1):
-            states = [
-                RealizationStorageState.HAS_DATA,
-                RealizationStorageState.INITIALIZED,
-            ]
             self.send_event(RunModelUpdateBeginEvent(iteration=current_iter - 1))
             self.send_event(
                 RunModelStatusEvent(
@@ -181,9 +176,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
             posterior_context = RunContext(
                 sim_fs=posterior,
                 runpaths=self.run_paths,
-                initial_mask=prior_context.sim_fs.get_realization_mask_from_state(
-                    states
-                ),
+                initial_mask=prior_context.sim_fs.get_realization_mask_with_parameters()
+                + prior_context.sim_fs.get_realization_mask_with_responses(),
                 iteration=current_iter,
             )
             update_success = False

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -14,7 +14,6 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESMDARunArguments
 from ert.storage import EnsembleAccessor, StorageAccessor
-from ert.storage.realization_storage_state import RealizationStorageState
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
@@ -141,10 +140,7 @@ class MultipleDataAssimilation(BaseRunModel):
                     HookRuntime.PRE_FIRST_UPDATE, self._storage, prior
                 )
             self.ert.runWorkflows(HookRuntime.PRE_UPDATE, self._storage, prior)
-            states = [
-                RealizationStorageState.HAS_DATA,
-                RealizationStorageState.INITIALIZED,
-            ]
+
             self.send_event(
                 RunModelStatusEvent(
                     iteration=iteration, msg="Creating posterior ensemble.."
@@ -159,9 +155,8 @@ class MultipleDataAssimilation(BaseRunModel):
                     prior_ensemble=prior_context.sim_fs,
                 ),
                 runpaths=self.run_paths,
-                initial_mask=prior_context.sim_fs.get_realization_mask_from_state(
-                    states
-                ),
+                initial_mask=prior_context.sim_fs.get_realization_mask_with_parameters()
+                + prior_context.sim_fs.get_realization_mask_with_responses(),
                 iteration=iteration + 1,
             )
             smoother_snapshot = self.update(

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -175,15 +175,18 @@ class Job:
         self.returncode.cancel()  # Triggers CancelledError
 
     async def _handle_failure(self) -> None:
-        self.real.run_arg.ensemble_storage.state_map[
-            self.iens
-        ] = RealizationStorageState.LOAD_FAILURE
         assert self._requested_max_submit is not None
-        logger.error(
+
+        error_msg = (
             f"Realization: {self.real.run_arg.iens} "
             f"failed after reaching max submit ({self._requested_max_submit}):"
             f"\n\t{self._callback_status_msg}"
         )
+
+        self.real.run_arg.ensemble_storage.set_failure(
+            self.real.run_arg.iens, RealizationStorageState.LOAD_FAILURE, error_msg
+        )
+        logger.error(error_msg)
         log_info_from_exit_file(Path(self.real.run_arg.runpath) / ERROR_file)
 
     async def _send(self, state: State) -> None:

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from ert import ErtScript
 from ert.exceptions import StorageError
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 class ExportMisfitDataJob(ErtScript):
@@ -24,7 +23,7 @@ class ExportMisfitDataJob(ErtScript):
         if self.ensemble is None:
             raise StorageError("No responses loaded")
 
-        realizations = self.ensemble.realization_list(RealizationStorageState.HAS_DATA)
+        realizations = self.ensemble.get_realization_list_with_responses()
 
         if not realizations:
             raise StorageError("No responses loaded")

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -117,7 +117,7 @@ class CSVExportJob(ErtPlugin):
             except KeyError as exc:
                 raise UserWarning(f"The case '{case}' does not exist!") from exc
 
-            if not ensemble.has_data:
+            if not ensemble.has_data():
                 raise UserWarning(f"The case '{case}' does not have any data!")
 
             case_data = ensemble.load_all_gen_kw_data()
@@ -220,5 +220,7 @@ class CSVExportJob(ErtPlugin):
         return default
 
     def getAllCaseList(self):
-        all_case_list = [case.name for case in self.storage.ensembles if case.has_data]
+        all_case_list = [
+            case.name for case in self.storage.ensembles if case.has_data()
+        ]
         return all_case_list

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -11,7 +11,6 @@ from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.models.path_model import PathModel
 from ert.gui.ertwidgets.pathchooser import PathChooser
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def load_args(filename, column_names=None):
@@ -140,7 +139,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
             except KeyError as exc:
                 raise UserWarning(f"The case '{case}' does not exist!") from exc
 
-            if not ensemble.has_data:
+            if not ensemble.has_data():
                 raise UserWarning(f"The case '{case}' does not have any data!")
 
             obs = ensemble.experiment.observations
@@ -170,9 +169,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                     )
 
                 rft_data = ensemble.load_gen_data(data_key, report_step)
-                realizations = ensemble.realization_list(
-                    RealizationStorageState.HAS_DATA
-                )
+                realizations = ensemble.get_realization_list_with_responses()
 
                 # Trajectory
                 trajectory_file = os.path.join(trajectory_path, f"{well}.txt")

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -23,7 +23,6 @@ from ert.cli.main import run_cli
 from ert.config import AnalysisConfig, ErtConfig, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings
 from ert.storage import open_storage
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 @pytest.fixture
@@ -263,7 +262,6 @@ def test_gen_data_obs_data_mismatch(storage, uniform_parameter, update_config):
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",
@@ -319,7 +317,6 @@ def test_gen_data_missing(storage, update_config, uniform_parameter, obs):
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",
@@ -382,7 +379,6 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior.save_parameters(
             "PARAMETER",

--- a/tests/integration_tests/status/test_tracking_integration.py
+++ b/tests/integration_tests/status/test_tracking_integration.py
@@ -31,7 +31,6 @@ from ert.ensemble_evaluator.state import (
     REALIZATION_STATE_FINISHED,
 )
 from ert.shared.feature_toggling import FeatureToggling
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def check_expression(original, path_expression, expected, msg_start):
@@ -52,7 +51,7 @@ def check_expression(original, path_expression, expected, msg_start):
 @pytest.mark.parametrize(
     (
         "extra_config, extra_poly_eval, cmd_line_arguments,"
-        "num_successful,num_iters,progress,assert_present_in_snapshot, expected_state"
+        "num_successful,num_iters,progress,assert_present_in_snapshot"
     ),
     [
         pytest.param(
@@ -75,7 +74,6 @@ def check_expression(original, path_expression, expected, msg_start):
                     "The run is cancelled due to reaching MAX_RUNTIME",
                 ),
             ],
-            [RealizationStorageState.LOAD_FAILURE] * 2,
             id="ee_poly_experiment_cancelled_by_max_runtime",
         ),
         pytest.param(
@@ -91,7 +89,6 @@ def check_expression(original, path_expression, expected, msg_start):
             1,
             1.0,
             [(".*", "reals.*.forward_models.*.status", FORWARD_MODEL_STATE_FINISHED)],
-            [RealizationStorageState.HAS_DATA] * 2,
             id="ee_poly_experiment",
         ),
         pytest.param(
@@ -109,7 +106,6 @@ def check_expression(original, path_expression, expected, msg_start):
             2,
             1.0,
             [(".*", "reals.*.forward_models.*.status", FORWARD_MODEL_STATE_FINISHED)],
-            [RealizationStorageState.HAS_DATA] * 2,
             id="ee_poly_smoother",
         ),
         pytest.param(
@@ -140,10 +136,6 @@ def check_expression(original, path_expression, expected, msg_start):
                     FORWARD_MODEL_STATE_FINISHED,
                 ),
             ],
-            [
-                RealizationStorageState.LOAD_FAILURE,
-                RealizationStorageState.HAS_DATA,
-            ],
             id="ee_failing_poly_smoother",
         ),
     ],
@@ -156,7 +148,6 @@ def test_tracking(
     num_iters,
     progress,
     assert_present_in_snapshot,
-    expected_state,
     tmpdir,
     source_root,
     storage,
@@ -264,8 +255,6 @@ def test_tracking(
                         f"Snapshot {i} did not match:\n",
                     )
         thread.join()
-        state_map = storage.get_ensemble_by_name("default").state_map
-        assert state_map[:2] == expected_state
     FeatureToggling.reset()
 
 

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -13,7 +13,6 @@ from ert.analysis import UpdateConfiguration, smoother_update
 from ert.config import ErtConfig, SummaryConfig
 from ert.enkf_main import sample_prior
 from ert.storage import open_storage
-from ert.storage.realization_storage_state import RealizationStorageState
 from tests.performance_tests.performance_utils import make_poly_example
 
 
@@ -98,7 +97,6 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
                         ),
                         real,
                     )
-                source.state_map[real] = RealizationStorageState.HAS_DATA
 
         sample_prior(source, realizations, ens_config.parameters)
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -23,6 +23,7 @@ from ert.analysis.row_scaling import RowScaling
 from ert.config import Field, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings, IESSettings
 from ert.field_utils import Shape
+from ert.storage import open_storage
 from ert.storage.realization_storage_state import RealizationStorageState
 
 
@@ -226,9 +227,7 @@ def test_update_snapshot(
         sies_smoother = None
 
         # The initial_mask equals ens_mask on first iteration
-        initial_mask = prior_ens.get_realization_mask_from_state(
-            [RealizationStorageState.HAS_DATA]
-        )
+        initial_mask = prior_ens.get_realization_mask_with_responses()
 
         # Call an iteration of SIES algorithm. Producing snapshot and SIES obj
         iterative_smoother_update(
@@ -418,7 +417,6 @@ def test_snapshot_alpha(
     )
     rng = np.random.default_rng(1234)
     for iens in range(prior_storage.ensemble_size):
-        prior_storage.state_map[iens] = RealizationStorageState.HAS_DATA
         data = rng.uniform(0, 1)
         prior_storage.save_parameters(
             "PARAMETER",
@@ -455,9 +453,7 @@ def test_snapshot_alpha(
     sies_smoother = None
 
     # The initial_mask equals ens_mask on first iteration
-    initial_mask = prior_storage.get_realization_mask_from_state(
-        [RealizationStorageState.HAS_DATA]
-    )
+    initial_mask = prior_storage.get_realization_mask_with_responses()
 
     result_snapshot, _ = iterative_smoother_update(
         prior_storage=prior_storage,
@@ -581,7 +577,6 @@ def test_and_benchmark_adaptive_localization_with_fields(
     )
 
     for iens in range(prior.ensemble_size):
-        prior.state_map[iens] = RealizationStorageState.HAS_DATA
         prior.save_parameters(
             param_group,
             iens,

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,6 +1,5 @@
 import contextlib
 import os
-import shutil
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +10,6 @@ from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.ensemble_evaluator.monitor import Monitor
 from ert.job_queue.queue import JobQueue
-from ert.shared.feature_toggling import FeatureToggling
 
 
 @pytest.mark.timeout(60)

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -1,6 +1,7 @@
 import shutil
 
 import numpy as np
+import pytest
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QApplication, QComboBox, QMessageBox, QPushButton, QWidget
 

--- a/tests/unit_tests/gui/tools/test_case_tool.py
+++ b/tests/unit_tests/gui/tools/test_case_tool.py
@@ -23,9 +23,10 @@ def test_case_tool_init_prior(qtbot, storage):
     )
     notifier.set_current_case(ensemble)
     assert (
-        ensemble.state_map
+        ensemble.get_ensemble_state()
         == [RealizationStorageState.UNDEFINED] * config.model_config.num_realizations
     )
+
     tool = CaseInitializationConfigurationPanel(
         config, notifier, config.model_config.num_realizations
     )
@@ -34,7 +35,7 @@ def test_case_tool_init_prior(qtbot, storage):
         Qt.LeftButton,
     )
     assert (
-        ensemble.state_map
+        ensemble.get_ensemble_state()
         == [RealizationStorageState.INITIALIZED] * config.model_config.num_realizations
     )
 
@@ -59,6 +60,7 @@ def test_case_tool_init_updates_the_case_info_tab(qtbot, storage):
     # Change to the "case info" tab
     tool.setCurrentIndex(2)
     assert "UNDEFINED" in html_edit.toPlainText()
+    assert not "RealizationStorageState.UNDEFINED" in html_edit.toPlainText()
 
     # Change to the "initialize from scratch" tab
     tool.setCurrentIndex(1)
@@ -70,3 +72,4 @@ def test_case_tool_init_updates_the_case_info_tab(qtbot, storage):
     # Change to the "case info" tab
     tool.setCurrentIndex(2)
     assert "INITIALIZED" in html_edit.toPlainText()
+    assert not "RealizationStorageState.INITIALIZED" in html_edit.toPlainText()

--- a/tests/unit_tests/simulator/test_simulation_context.py
+++ b/tests/unit_tests/simulator/test_simulation_context.py
@@ -2,7 +2,6 @@ import pytest
 
 from ert.enkf_main import EnKFMain
 from ert.simulator import SimulationContext
-from ert.storage.realization_storage_state import RealizationStorageState
 from tests.utils import wait_until
 
 
@@ -62,11 +61,7 @@ def test_simulation_context(setup_case, storage, monkeypatch, try_queue_and_sche
             assert even_ctx.didRealizationSucceed(iens)
             assert not even_ctx.didRealizationFail(iens)
             assert even_ctx.isRealizationFinished(iens)
-
-            assert even_half.state_map[iens] == RealizationStorageState.HAS_DATA
         else:
             assert odd_ctx.didRealizationSucceed(iens)
             assert not odd_ctx.didRealizationFail(iens)
             assert odd_ctx.isRealizationFinished(iens)
-
-            assert odd_half.state_map[iens] == RealizationStorageState.HAS_DATA

--- a/tests/unit_tests/test_run_path_creation.py
+++ b/tests/unit_tests/test_run_path_creation.py
@@ -224,7 +224,7 @@ def test_run_template_replace_in_file_name(prior_ensemble):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_sampling_prior_makes_initialized_fs(prior_ensemble):
+def test_that_sampling_prior_makes_initialized_fs(storage):
     """
     This checks that creating the run path initializes the selected case,
     for that parameters are needed, so add a simple GEN_KW.
@@ -233,7 +233,7 @@ def test_that_sampling_prior_makes_initialized_fs(prior_ensemble):
         """
         NUM_REALIZATIONS 1
         JOBNAME my_case%d
-        GEN_KW KW_NAME template.txt kw.txt prior.txt
+        GEN_KW KW_NAME template.txt kw.txt prior.txt FORWARD_INIT:False
         """
     )
     Path("template.tmpl").write_text(
@@ -244,9 +244,20 @@ def test_that_sampling_prior_makes_initialized_fs(prior_ensemble):
         fh.writelines("MY_KEYWORD <MY_KEYWORD>")
     with open("prior.txt", "w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD NORMAL 0 1")
-    assert not prior_ensemble.is_initalized
+
+    ert_config = ErtConfig.from_file("config.ert")
+
+    prior_ensemble = storage.create_ensemble(
+        storage.create_experiment(
+            parameters=ert_config.ensemble_config.parameter_configuration
+        ),
+        name="prior",
+        ensemble_size=ert_config.model_config.num_realizations,
+    )
+
+    assert not prior_ensemble.is_initalized()
     sample_prior(prior_ensemble, [0])
-    assert prior_ensemble.is_initalized
+    assert prior_ensemble.is_initalized()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #6736 


**Approach**
Remove the state map from local_ensemble.py. This is replaced  by checking the state based on the actual files present in the ensemble directory on disk. We also store any errors with a possible error message on disk in the ensemble.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
