### PR TITLE
Add fixture for running tests with scheduler and job queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ markers = [
     "quick_only",
     "requires_eclipse",
     "requires_window_manager",
+    "scheduler",
     "script",
     "slow",
     "unstable",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,20 @@ def _qt_excepthook(monkeypatch):
     monkeypatch.setattr(sys, "excepthook", excepthook)
 
 
+@pytest.fixture(params=[False, True])
+def try_queue_and_scheduler(request, monkeypatch):
+    should_enable_scheduler = request.param
+    scheduler_mark = request.node.get_closest_marker("scheduler")
+    assert scheduler_mark
+    if scheduler_mark.kwargs.get("skip") and should_enable_scheduler:
+        pytest.skip("Skipping running test with scheduler enabled")
+    monkeypatch.setattr(
+        FeatureToggling._conf["scheduler"], "is_enabled", should_enable_scheduler
+    )
+    yield
+    monkeypatch.undo()
+
+
 def pytest_collection_modifyitems(config, items):
     for item in items:
         fixtures = getattr(item, "fixturenames", ())


### PR DESCRIPTION
Adds fixture for running integration tests with both scheduler and job queue. The fixture might be dependent on the test having the monkeypatch fixture explicitly used.
The commit also adds a marker for scheduler tests. The marker can take skip=True as a parameter, to only run the test with job queue.