### PR TITLE
Non-working commit for testing dark_storage with scheduler

### DIFF
--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -103,6 +103,7 @@ class JobQueue(BaseCClass):  # type: ignore
         return self.__repr__()
 
     def __init__(self, queue_config: QueueConfig):
+        raise ValueError
         self.job_list: List[JobQueueNode] = []
         self._stopped = False
         self.driver: Driver = Driver.create_driver(queue_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,7 +246,7 @@ def _qt_excepthook(monkeypatch):
 
 
 @pytest.fixture(params=[False, True])
-def try_queue_and_scheduler(request, monkeypatch):
+def try_queue_and_scheduler(monkeypatch, request):
     should_enable_scheduler = request.param
     scheduler_mark = request.node.get_closest_marker("scheduler")
     assert scheduler_mark

--- a/tests/unit_tests/dark_storage/conftest.py
+++ b/tests/unit_tests/dark_storage/conftest.py
@@ -18,6 +18,7 @@ from ert.dark_storage import enkf
 def poly_example_tmp_dir_shared(
     tmp_path_factory,
     source_root,
+    try_queue_and_scheduler
 ):
     tmpdir = tmp_path_factory.mktemp("my_poly_tmp")
     poly_dir = path.local(os.path.join(str(tmpdir), "poly_example"))
@@ -45,13 +46,13 @@ def poly_example_tmp_dir_shared(
 
 
 @pytest.fixture()
-def poly_example_tmp_dir(poly_example_tmp_dir_shared):
+def poly_example_tmp_dir(poly_example_tmp_dir_shared, monkeypatch):
     with poly_example_tmp_dir_shared.as_cwd():
         yield
 
 
 @pytest.fixture
-def dark_storage_client(monkeypatch):
+def dark_storage_client(monkeypatch, try_queue_and_scheduler):
     with dark_storage_app_(monkeypatch) as dark_app:
         monkeypatch.setenv("ERT_STORAGE_RES_CONFIG", "poly.ert")
         with TestClient(dark_app) as client:

--- a/tests/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/unit_tests/dark_storage/test_http_endpoints.py
@@ -3,11 +3,14 @@ import json
 import uuid
 
 import pandas as pd
+import pytest
 from numpy.testing import assert_array_equal
 from requests import Response
 
 
-def test_get_experiment(poly_example_tmp_dir, dark_storage_client):
+def test_get_experiment(
+   poly_example_tmp_dir, dark_storage_client, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     answer_json = resp.json()
     assert len(answer_json) == 1
@@ -17,7 +20,10 @@ def test_get_experiment(poly_example_tmp_dir, dark_storage_client):
     assert answer_json[0]["name"] == "default"
 
 
-def test_get_ensemble(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_ensemble(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     experiment_json = resp.json()
     assert len(experiment_json) == 1
@@ -32,7 +38,10 @@ def test_get_ensemble(poly_example_tmp_dir, dark_storage_client):
     assert ensemble_json["userdata"]["name"] in ("alpha", "beta")
 
 
-def test_get_experiment_ensemble(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_experiment_ensemble(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     experiment_json = resp.json()
     assert len(experiment_json) == 1
@@ -48,7 +57,10 @@ def test_get_experiment_ensemble(poly_example_tmp_dir, dark_storage_client):
     assert ensembles_json[0]["userdata"]["name"] in ("alpha", "beta")
 
 
-def test_get_responses_with_observations(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_responses_with_observations(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     experiment_json = resp.json()
     ensemble_id = experiment_json[0]["ensemble_ids"][1]
@@ -61,7 +73,10 @@ def test_get_responses_with_observations(poly_example_tmp_dir, dark_storage_clie
     assert ensemble_json["POLY_RES@0"]["has_observations"] is True
 
 
-def test_get_response(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_response(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     experiment_json = resp.json()
 
@@ -142,7 +157,10 @@ def test_get_response(poly_example_tmp_dir, dark_storage_client):
     assert len(record_df1_indexed.index) == 1
 
 
-def test_get_ensemble_parameters(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_ensemble_parameters(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     answer_json = resp.json()
     ensemble_id = answer_json[0]["ensemble_ids"][0]
@@ -168,7 +186,10 @@ def test_get_ensemble_parameters(poly_example_tmp_dir, dark_storage_client):
     }
 
 
-def test_refresh_facade(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_refresh_facade(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.post("/updates/facade")
     assert resp.status_code == 200
 
@@ -187,7 +208,10 @@ def test_get_experiment_observations(poly_example_tmp_dir, dark_storage_client):
     assert len(response_json[0]["x_axis"]) == 5
 
 
-def test_get_record_observations(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_record_observations(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     answer_json = resp.json()
     ensemble_id = answer_json[0]["ensemble_ids"][0]
@@ -204,7 +228,10 @@ def test_get_record_observations(poly_example_tmp_dir, dark_storage_client):
     assert len(response_json[0]["x_axis"]) == 5
 
 
-def test_misfit_endpoint(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_misfit_endpoint(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     experiment_json = resp.json()
     ensemble_id = experiment_json[0]["ensemble_ids"][0]
@@ -219,7 +246,10 @@ def test_misfit_endpoint(poly_example_tmp_dir, dark_storage_client):
     assert misfit.shape == (3, 5)
 
 
-def test_get_record_labels(poly_example_tmp_dir, dark_storage_client):
+@pytest.mark.scheduler
+def test_get_record_labels(
+    poly_example_tmp_dir, dark_storage_client, monkeypatch, try_queue_and_scheduler
+):
     resp: Response = dark_storage_client.get("/experiments")
     answer_json = resp.json()
     ensemble_id = answer_json[0]["ensemble_ids"][0]


### PR DESCRIPTION
There are issues with fixture order, so that the monkeypatching to use the scheduler is ignored when the fixture dark_storage_client is running ert_cli before the test starts.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
