### PR TITLE
Implement adaptive batch size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ types = [
     "types-decorator",
     "types-docutils",
     "types-tqdm",
+    "types-psutil"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
The `batch_size` has so far been hard-coded to `1000`.
I chose this value based on the memory available while working on Troll.
This was before we implemented the streaming algorithm and there was not much available memory.
A larger batch size means fewer loops and better performance so we want it to be as large as we can fit in memory.
This PR proposes a batch size that is a function of available memory that should increase performance quite a bit.

## Benchmarks

Drogon run (with seismic):
Ran twice, once manually and once as part of an `Ensemble Smoother` run.
In both cases updates took approximately 1h 30min, which is down from approx. 10h with a fixed batch size of 1000.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
