### PR TITLE
Refactor JobQueue and Scheduler

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -95,6 +95,13 @@ class QueueConfig:
             self.queue_options,
         )
 
+    @property
+    def max_running(self) -> int:
+        for key, val in self.queue_options.get(self.queue_system, []):
+            if key == "MAX_RUNNING":
+                return int(val)
+        return 0
+
 
 def _check_for_overwritten_queue_system_options(
     selected_queue_system: QueueSystem,

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -133,7 +133,4 @@ class Job:
                 "queue_event_type": status,
             },
         )
-        if self._scheduler._events is None:
-            await self._scheduler.ainit()
-        assert self._scheduler._events is not None
         await self._scheduler._events.put(to_json(event))

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from functools import partial
 from threading import Thread
 from time import sleep
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
@@ -61,19 +60,12 @@ def _run_forward_model(
             ert.ert_config.preferred_num_cpu,
         )
 
-    queue_evaluators = None
-    if (
-        ert.ert_config.analysis_config.stop_long_running
-        and ert.ert_config.analysis_config.minimum_required_realizations > 0
-    ):
-        queue_evaluators = [
-            partial(
-                job_queue.stop_long_running_jobs,
-                ert.ert_config.analysis_config.minimum_required_realizations,
-            )
-        ]
-
-    asyncio.run(job_queue.execute(evaluators=queue_evaluators))
+    required_realizations = 0
+    if ert.ert_config.analysis_config.stop_long_running:
+        required_realizations = (
+            ert.ert_config.analysis_config.minimum_required_realizations
+        )
+    asyncio.run(job_queue.execute(required_realizations))
 
     run_context.sim_fs.sync()
 

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -51,12 +51,9 @@ async def test_happy_path(
     await wait_for_evaluator(base_url=url, timeout=5)
 
     ensemble = make_ensemble_builder(monkeypatch, tmpdir, 1, 1).build()
-    queue = JobQueue(queue_config)
-    for real in ensemble.reals:
-        queue.add_realization(real, callback_timeout=None)
+    queue = JobQueue(queue_config, ensemble.reals, ee_uri=url, ens_id="ee_0")
 
-    queue.set_ee_info(ee_uri=url, ens_id="ee_0")
-    await queue.execute(pool_sema=threading.BoundedSemaphore(value=10))
+    await queue.execute()
     done.set_result(None)
 
     await mock_ws_task

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -10,6 +10,7 @@ from ert.ensemble_evaluator import identifiers, state
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.ensemble_evaluator.monitor import Monitor
+from ert.job_queue.queue import JobQueue
 from ert.shared.feature_toggling import FeatureToggling
 
 
@@ -111,7 +112,7 @@ def test_run_legacy_ensemble_exception(tmpdir, make_ensemble_builder, monkeypatc
         )
         evaluator = EnsembleEvaluator(ensemble, config, 0)
 
-        with patch.object(ensemble._job_queue, "add_realization") as faulty_queue:
+        with patch.object(JobQueue, "add_realization") as faulty_queue:
             faulty_queue.side_effect = RuntimeError()
             evaluator._start_running()
             with Monitor(config) as monitor:


### PR DESCRIPTION
Initialisation of `JobQueue` and `Scheduler` is moved to where they are used.
This means that the current event loop is the same during initialisation
and use.

Changes:
- `add_realization`: We can simply pass realisations as a list to the
  given executor.
- `set_ee_info`: We can simply pass this information to the queues.
- `CONCURRENT_INITIALIZATION`: No longer passed to the queue as it's a
  constant.
- `timeout_callback`: Now passed to the queue, rather than with each realisation.
- `queue_evaluators`: Concept removed. Only used for
  "min_required_realizations", which we can call directly.