### PR TITLE
Avoid wrong log statements about Schedulers intention

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -113,19 +113,16 @@ class Job:
     ) -> None:
         await start.wait()
 
-        for _ in range(max_submit):
+        for attempt in range(max_submit):
             await self._submit_and_run_once(sem)
 
             if self.returncode.done() or self.aborted.is_set():
                 break
-            else:
+            elif attempt < max_submit - 1:
                 message = f"Realization: {self.iens} failed, resubmitting"
                 logger.warning(message)
         else:
-            message = (
-                f"Realization: {self.iens} "
-                f"failed after reaching max submit {max_submit}"
-            )
+            message = f"Realization {self.iens} failed after {max_submit} attempt(s)"
             logger.error(message)
 
     async def _max_runtime_task(self) -> None:


### PR DESCRIPTION
Should not say it will resubmit if max_submit=1

Also tune the error message for improved readability

**Issue**
Resolves #6848 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
