### PR TITLE
Support submit sleep in scheduler

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -32,6 +32,7 @@ VALID_QUEUE_OPTIONS: Dict[Any, List[str]] = {
 class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
     max_submit: int = 2
+    submit_sleep: float = 0.0
     queue_system: QueueSystem = QueueSystem.LOCAL
     queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = field(
         default_factory=dict
@@ -48,6 +49,7 @@ class QueueConfig:
         )
         job_script = job_script or "job_dispatch.py"
         max_submit: int = config_dict.get("MAX_SUBMIT", 2)
+        submit_sleep: float = config_dict.get("SUBMIT_SLEEP", 0.0)
         queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = defaultdict(list)
         for queue_system, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             if option_name not in VALID_QUEUE_OPTIONS[queue_system]:
@@ -67,6 +69,12 @@ class QueueConfig:
                     " usually provided by the site-configuration file, beware that"
                     " you are effectively replacing the default value provided."
                 )
+            if (
+                values
+                and option_name == "SUBMIT_SLEEP"
+                and selected_queue_system == queue_system
+            ):
+                submit_sleep = float(values[0])
 
         for queue_system_val in queue_options:
             if queue_options[queue_system_val]:
@@ -85,12 +93,15 @@ class QueueConfig:
                 queue_options[selected_queue_system],
             )
 
-        return QueueConfig(job_script, max_submit, selected_queue_system, queue_options)
+        return QueueConfig(
+            job_script, max_submit, submit_sleep, selected_queue_system, queue_options
+        )
 
     def create_local_copy(self) -> QueueConfig:
         return QueueConfig(
             self.job_script,
             self.max_submit,
+            self.submit_sleep,
             QueueSystem.LOCAL,
             self.queue_options,
         )

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -202,6 +202,7 @@ class LegacyEnsemble(Ensemble):
                     self.active_reals,
                     max_submit=self._queue_config.max_submit,
                     max_running=self._queue_config.max_running,
+                    submit_sleep=self._queue_config.submit_sleep,
                     ens_id=self.id_,
                     ee_uri=self._config.dispatch_uri,
                     ee_cert=self._config.cert,

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -92,6 +92,8 @@ class Job:
         timeout_task: Optional[asyncio.Task[None]] = None
 
         try:
+            if self._scheduler.submit_sleep_state:
+                await self._scheduler.submit_sleep_state.sleep_until_we_can_submit()
             await self._send(State.SUBMITTING)
             await self.driver.submit(
                 self.real.iens, self.real.job_script, cwd=self.real.run_arg.runpath


### PR DESCRIPTION
**Issue**
Resolves #6856 


**Approach**
Use a singleton object to be responsible for determining whether  `Job` needs to wait more before it proceeds when doing its `__call__`.

## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [x] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [x] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
