### PR TITLE
Fix bug that caused experiment name to be overwritten

### DIFF
--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -143,15 +143,15 @@ class LocalExperimentAccessor(LocalExperimentReader):
         storage: LocalStorageAccessor,
         uuid: UUID,
         path: Path,
+        name: str,
         parameters: Optional[List[ParameterConfig]] = None,
         responses: Optional[List[ResponseConfig]] = None,
         observations: Optional[Dict[str, xr.Dataset]] = None,
-        name: Optional[str] = None,
     ) -> None:
         self._storage: LocalStorageAccessor = storage
         self._id = uuid
         self._path = path
-        self._name = name if name is not None else datetime.today().strftime("%Y-%m-%d")
+        self._name = name
 
         parameters = [] if parameters is None else parameters
         parameter_file = self.mount_point / self._parameter_file


### PR DESCRIPTION
**Issue**
Resolves #6861

**Approach**
Added `_load_experiment` method for `LocalStorageAccessor` and pass experiment name from experiment `index.json` file.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
