### PR TITLE
Add `EventSender` to resolve dependency cycle

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -683,16 +683,16 @@ def analysis_ES(
                 start = time.time()
                 for param_batch_idx in batches:
                     X_local = temp_storage[param_group.name][param_batch_idx, :]
-                    temp_storage[param_group.name][param_batch_idx, :] = (
-                        smoother_adaptive_es.assimilate(
-                            X=X_local,
-                            Y=S,
-                            D=D,
-                            alpha=1.0,  # The user is responsible for scaling observation covariance (esmda usage)
-                            correlation_threshold=module.correlation_threshold,
-                            cov_YY=cov_YY,
-                            progress_callback=adaptive_localization_progress_callback,
-                        )
+                    temp_storage[param_group.name][
+                        param_batch_idx, :
+                    ] = smoother_adaptive_es.assimilate(
+                        X=X_local,
+                        Y=S,
+                        D=D,
+                        alpha=1.0,  # The user is responsible for scaling observation covariance (esmda usage)
+                        correlation_threshold=module.correlation_threshold,
+                        cov_YY=cov_YY,
+                        progress_callback=adaptive_localization_progress_callback,
                     )
                 _logger.info(
                     f"Adaptive Localization of {param_group} completed in {(time.time() - start) / 60} minutes"
@@ -849,9 +849,9 @@ def analysis_IES(
             )
             if active_parameter_indices := param_group.index_list:
                 X = temp_storage[param_group.name][active_parameter_indices, :]
-                temp_storage[param_group.name][active_parameter_indices, :] = (
-                    X + X @ sies_smoother.W / np.sqrt(len(iens_active_index) - 1)
-                )
+                temp_storage[param_group.name][
+                    active_parameter_indices, :
+                ] = X + X @ sies_smoother.W / np.sqrt(len(iens_active_index) - 1)
             else:
                 X = temp_storage[param_group.name]
                 temp_storage[param_group.name] = X + X @ sies_smoother.W / np.sqrt(

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -447,10 +447,12 @@ class ErtConfig:
                     )
 
             @overload
-            def substitute(self, string: str) -> str: ...
+            def substitute(self, string: str) -> str:
+                ...
 
             @overload
-            def substitute(self, string: None) -> None: ...
+            def substitute(self, string: None) -> None:
+                ...
 
             def substitute(self, string):
                 if string is None:

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -107,7 +107,9 @@ def parse(filename: str) -> ConfContent:
         )
 
 
-def _parse_content(content: str, filename: str) -> List[
+def _parse_content(
+    content: str, filename: str
+) -> List[
     Union[
         SimpleHistoryDeclaration,
         Tuple[ObservationType, FileContextToken, Dict[FileContextToken, Any]],

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -12,7 +12,8 @@ class ResponseConfig(ABC):
     name: str
 
     @abstractmethod
-    def read_from_file(self, run_path: str, iens: int) -> xr.Dataset: ...
+    def read_from_file(self, run_path: str, iens: int) -> xr.Dataset:
+        ...
 
     def to_dict(self) -> Dict[str, Any]:
         data = dataclasses.asdict(self, dict_factory=CustomDict)

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -43,7 +43,8 @@ scheduler_logger = logging.getLogger("ert.scheduler")
 
 
 class _KillAllJobs(Protocol):
-    def kill_all_jobs(self) -> None: ...
+    def kill_all_jobs(self) -> None:
+        ...
 
 
 class LegacyEnsemble(Ensemble):

--- a/src/ert/ensemble_evaluator/identifiers.py
+++ b/src/ert/ensemble_evaluator/identifiers.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 ACTIVE = "active"
 CURRENT_MEMORY_USAGE = "current_memory_usage"
 DATA = "data"
@@ -30,6 +32,15 @@ EVTYPE_FORWARD_MODEL_RUNNING = "com.equinor.ert.forward_model_job.running"
 EVTYPE_FORWARD_MODEL_SUCCESS = "com.equinor.ert.forward_model_job.success"
 EVTYPE_FORWARD_MODEL_FAILURE = "com.equinor.ert.forward_model_job.failure"
 
+EvGroupRealizationType = Literal[
+    "com.equinor.ert.realization.failure",
+    "com.equinor.ert.realization.pending",
+    "com.equinor.ert.realization.running",
+    "com.equinor.ert.realization.success",
+    "com.equinor.ert.realization.unknown",
+    "com.equinor.ert.realization.waiting",
+    "com.equinor.ert.realization.timeout",
+]
 
 EVGROUP_REALIZATION = {
     EVTYPE_REALIZATION_FAILURE,

--- a/src/ert/scheduler/event_sender.py
+++ b/src/ert/scheduler/event_sender.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import ssl
+from typing import TYPE_CHECKING, Any, Mapping, Optional
+
+from cloudevents.conversion import to_json
+from cloudevents.http import CloudEvent
+from websockets import Headers, connect
+
+if TYPE_CHECKING:
+    from ert.ensemble_evaluator.identifiers import EvGroupRealizationType
+
+
+class EventSender:
+    def __init__(
+        self,
+        ens_id: Optional[str],
+        ee_uri: Optional[str],
+        ee_cert: Optional[str],
+        ee_token: Optional[str],
+    ) -> None:
+        self.ens_id = ens_id
+        self.ee_uri = ee_uri
+        self.ee_cert = ee_cert
+        self.ee_token = ee_token
+        self.events: asyncio.Queue[CloudEvent] = asyncio.Queue()
+
+    async def send(
+        self,
+        type: EvGroupRealizationType,
+        source: str,
+        attributes: Optional[Mapping[str, Any]] = None,
+        data: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        event = CloudEvent(
+            {
+                "type": type,
+                "source": f"/ert/ensemble/{self.ens_id}/{source}",
+                **(attributes or {}),
+            },
+            data,
+        )
+        await self.events.put(event)
+
+    async def publisher(self) -> None:
+        if not self.ee_uri:
+            return
+        tls: Optional[ssl.SSLContext] = None
+        if self.ee_cert:
+            tls = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            tls.load_verify_locations(cadata=self.ee_cert)
+        headers = Headers()
+        if self.ee_token:
+            headers["token"] = self.ee_token
+
+        async for conn in connect(
+            self.ee_uri,
+            ssl=tls,
+            extra_headers=headers,
+            open_timeout=60,
+            ping_timeout=60,
+            ping_interval=60,
+            close_timeout=60,
+        ):
+            while True:
+                event = await self.events.get()
+                await conn.send(to_json(event))

--- a/src/ert/shared/_doc_utils/ert_jobs.py
+++ b/src/ert/shared/_doc_utils/ert_jobs.py
@@ -123,9 +123,9 @@ class _ErtDocumentation(SphinxDirective):
     def _divide_into_categories(
         jobs: Dict[str, JobDoc],
     ) -> Dict[str, Dict[str, List[_ForwardModelDocumentation]]]:
-        categories: Dict[str, Dict[str, List[_ForwardModelDocumentation]]] = (
-            defaultdict(lambda: defaultdict(list))
-        )
+        categories: Dict[
+            str, Dict[str, List[_ForwardModelDocumentation]]
+        ] = defaultdict(lambda: defaultdict(list))
         for job_name, docs in jobs.items():
             # Job names in ERT traditionally used upper case letters
             # for the names of the job. However, at some point duplicate

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -1,24 +1,26 @@
 import asyncio
-import json
 import shutil
 from typing import List
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
-import ert
+import ert.scheduler.job
 from ert.ensemble_evaluator._builder._realization import Realization
 from ert.load_status import LoadResult, LoadStatus
 from ert.run_arg import RunArg
-from ert.scheduler import Scheduler
+from ert.scheduler.event_sender import EventSender
 from ert.scheduler.job import STATE_TO_LEGACY, Job, State
 
 
-def create_scheduler():
-    sch = AsyncMock()
-    sch._events = asyncio.Queue()
-    sch.driver = AsyncMock()
-    return sch
+@pytest.fixture
+def driver(mock_driver):
+    return mock_driver()
+
+
+@pytest.fixture
+def event_sender():
+    return EventSender(None, None, None, None)
 
 
 @pytest.fixture
@@ -43,36 +45,31 @@ def realization():
     return realization
 
 
-async def assert_scheduler_events(
-    scheduler: Scheduler, job_events: List[State]
-) -> None:
+async def assert_events(event_sender: EventSender, job_events: List[State]) -> None:
     for job_event in job_events:
-        queue_event = await scheduler._events.get()
-        output = json.loads(queue_event.decode("utf-8"))
-        event = output.get("data").get("queue_event_type")
+        queue_event = await event_sender.events.get()
+        event = (queue_event.get_data() or {}).get("queue_event_type")
         assert event == STATE_TO_LEGACY[job_event]
     # should be no more events
-    assert scheduler._events.empty()
+    assert event_sender.events.empty()
 
 
 @pytest.mark.timeout(5)
-async def test_submitted_job_is_cancelled(realization, mock_event):
-    scheduler = create_scheduler()
-    job = Job(scheduler, realization)
-    job._requested_max_submit = 1
+async def test_submitted_job_is_cancelled(
+    realization, mock_event, event_sender, driver
+):
+    job = Job(realization)
     job.started = mock_event()
     job.returncode.cancel()
-    job_task = asyncio.create_task(job._submit_and_run_once(asyncio.BoundedSemaphore()))
+    job_task = asyncio.create_task(
+        job(asyncio.BoundedSemaphore(), event_sender, driver, max_submit=1)
+    )
 
     await asyncio.wait_for(job.started._mock_waited, 5)
 
     assert job_task.cancel()
     await job_task
-    await assert_scheduler_events(
-        scheduler, [State.SUBMITTING, State.PENDING, State.ABORTING, State.ABORTED]
-    )
-    scheduler.driver.kill.assert_called_with(job.iens)
-    scheduler.driver.kill.assert_called_once()
+    await assert_events(event_sender, [State.SUBMITTING, State.PENDING, State.ABORTED])
 
 
 @pytest.mark.parametrize(
@@ -90,6 +87,8 @@ async def test_job_submit_and_run_once(
     forward_model_ok_result,
     expected_final_event: State,
     realization: Realization,
+    event_sender,
+    driver,
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -97,23 +96,13 @@ async def test_job_submit_and_run_once(
         "forward_model_ok",
         lambda _: LoadResult(forward_model_ok_result, ""),
     )
-    scheduler = create_scheduler()
-    job = Job(scheduler, realization)
-    job._requested_max_submit = 1
+    job = Job(realization)
     job.started.set()
     job.returncode.set_result(return_code)
 
-    await job._submit_and_run_once(asyncio.Semaphore())
+    await job(asyncio.BoundedSemaphore(), event_sender, driver, max_submit=1)
 
-    await assert_scheduler_events(
-        scheduler,
+    await assert_events(
+        event_sender,
         [State.SUBMITTING, State.PENDING, State.RUNNING, expected_final_event],
     )
-    scheduler.driver.submit.assert_called_with(
-        realization.iens,
-        realization.job_script,
-        realization.run_arg.runpath,
-        name=realization.run_arg.job_name,
-        runpath=realization.run_arg.runpath,
-    )
-    scheduler.driver.submit.assert_called_once()


### PR DESCRIPTION
`Scheduler` has a reference to `Job` and `Job` has a reference to `Scheduler`. Adding `EventSender` lets us resolve this cycle as now `Scheduler` has a reference to `Job`s and `EventSender`, but each `Job` only refers to `EventSender`.