### PR TITLE
Sample a single value instead of ensemble_size

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -188,7 +188,6 @@ class GenKwConfig(ParameterConfig):
             keys,
             str(random_seed),
             real_nr,
-            ensemble_size,
         )
 
         return xr.Dataset(
@@ -322,8 +321,31 @@ class GenKwConfig(ParameterConfig):
         keys: List[str],
         global_seed: str,
         realization: int,
-        nr_samples: int,
     ) -> npt.NDArray[np.double]:
+        """
+        Generate a sample value for each key in a parameter group.
+
+        The sampling is reproducible and dependent on a global seed combined
+        with the parameter group name and individual key names. The 'realization' parameter
+        determines the specific sample point from the distribution for each parameter.
+
+        Parameters:
+        - parameter_group_name (str): The name of the parameter group, used to ensure unique RNG
+        seeds for different groups.
+        - keys (List[str]): A list of parameter keys for which the sample values are generated.
+        - global_seed (str): A global seed string used for RNG seed generation to ensure
+        reproducibility across runs.
+        - realization (int): An integer used to advance the RNG to a specific point in its
+        sequence, effectively selecting the 'realization'-th sample from the distribution.
+
+        Returns:
+        - npt.NDArray[np.double]: An array of sample values, one for each key in the provided list.
+
+        Note:
+        The method uses SHA-256 for hash generation and numpy's default random number generator
+        for sampling. The RNG state is advanced to the 'realization' point before generating
+        a single sample, enhancing efficiency by avoiding the generation of large, unused sample sets.
+        """
         parameter_values = []
         for key in keys:
             key_hash = sha256(
@@ -332,8 +354,13 @@ class GenKwConfig(ParameterConfig):
             )
             seed = np.frombuffer(key_hash.digest(), dtype="uint32")
             rng = np.random.default_rng(seed)
-            values = rng.standard_normal(nr_samples)
-            parameter_values.append(values[realization])
+
+            # Advance the RNG state to the realization point
+            rng.standard_normal(realization)
+
+            # Generate a single sample
+            value = rng.standard_normal(1)
+            parameter_values.append(value[0])
         return np.array(parameter_values)
 
     @staticmethod


### PR DESCRIPTION
It is not necessary to sample #ensemble_size values and then discard all but one.
This instead advances the rng using the realization number and then samples just one value.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
