### PR TITLE
Fix typos in ENKF_ALPHA docs

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1377,7 +1377,7 @@ Keywords controlling the ES algorithm
 
         Including outliers in the Smoother algorithm can dramatically increase the
         coupling between the ensemble members. It is therefore important to filter out
-        these outliers data prior to data assimilation. An observation,
+        these outliers prior to data assimilation. An observation,
         :math:`\mathbf{d}^o_i`, will be classified as an outlier if
 
         :math:`|\mathbf{d}^o_i - \bar{\mathbf{d}}_i| > \mathrm{ENKF\_ALPHA} \left(\mathbf{s}_{\mathbf{d}_i} + \mathbf{s}^o_{\mathbf{d}_i}\right)`

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1371,22 +1371,22 @@ Keywords controlling the ES algorithm
 .. _enkf_alpha:
 .. topic:: ENKF_ALPHA
 
-        This controls the scaling factor used when detecting outliers. Increasing this
+        The scaling factor used when detecting outliers. Increasing this
         factor means that more observations will potentially be included in the
         assimilation. The default value is 3.00.
 
         Including outliers in the Smoother algorithm can dramatically increase the
         coupling between the ensemble members. It is therefore important to filter out
-        these outlier data prior to data assimilation. An observation, :math:`\textstyle
-        d^o_i`, will be classified as an outlier if
+        these outliers data prior to data assimilation. An observation,
+        :math:`\mathbf{d}^o_i`, will be classified as an outlier if
 
-        :math:`|d^o_i - \bar{d}_i| > \mathrm{ENKF\_ALPHA} \left(s_{d_i} + \sigma_{d^o_i}\right)`
+        :math:`|\mathbf{d}^o_i - \bar{\mathbf{d}}_i| > \mathrm{ENKF\_ALPHA} \left(\mathbf{s}_{\mathbf{d}_i} + \mathbf{s}^o_{\mathbf{d}_i}\right)`
 
-        where :math:`\textstyle\boldsymbol{d}^o` is the vector of observed data,
-        :math:`\textstyle\boldsymbol{\bar{d}}` is the average of the forecasted data ensemble,
-        :math:`\textstyle\boldsymbol{s_{d}}` is the vector of estimated standard deviations
-        for the forecasted data ensemble, and :math:`\textstyle\boldsymbol{s_{d}^o}` is the
-        vector standard deviations for the observation error (specified a priori).
+        where :math:`\mathbf{d}^o` is the vector of observed data,
+        :math:`\mathbf{\bar{d}}` is the average of the forecasted data ensemble,
+        :math:`\mathbf{s}_\mathbf{d}` is the vector of estimated standard deviations
+        for the forecasted data ensemble, and :math:`\mathbf{s}^o_{\mathbf{d}_i}` is the
+        vector of standard deviations for the observation error (specified a priori).
 
         Observe that for the updates many settings should be applied on the analysis
         module in question.

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1378,14 +1378,14 @@ Keywords controlling the ES algorithm
         Including outliers in the Smoother algorithm can dramatically increase the
         coupling between the ensemble members. It is therefore important to filter out
         these outliers prior to data assimilation. An observation,
-        :math:`\mathbf{d}^o_i`, will be classified as an outlier if
+        :math:`d^o_i`, will be classified as an outlier if
 
-        :math:`|\mathbf{d}^o_i - \bar{\mathbf{d}}_i| > \mathrm{ENKF\_ALPHA} \left(\mathbf{s}_{\mathbf{d}_i} + \mathbf{s}^o_{\mathbf{d}_i}\right)`
+        :math:`|d^o_i - \mathbf{\bar{d}}| > \mathrm{ENKF\_ALPHA} \left( s_{d_i} + s^o_{d_i} \right)`
 
         where :math:`\mathbf{d}^o` is the vector of observed data,
         :math:`\mathbf{\bar{d}}` is the average of the forecasted data ensemble,
         :math:`\mathbf{s}_\mathbf{d}` is the vector of estimated standard deviations
-        for the forecasted data ensemble, and :math:`\mathbf{s}^o_{\mathbf{d}_i}` is the
+        for the forecasted data ensemble, and :math:`\mathbf{s}^o_\mathbf{d}` is the
         vector of standard deviations for the observation error (specified a priori).
 
         Observe that for the updates many settings should be applied on the analysis

--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1380,7 +1380,7 @@ Keywords controlling the ES algorithm
         these outliers prior to data assimilation. An observation,
         :math:`d^o_i`, will be classified as an outlier if
 
-        :math:`|d^o_i - \mathbf{\bar{d}}| > \mathrm{ENKF\_ALPHA} \left( s_{d_i} + s^o_{d_i} \right)`
+        :math:`|d^o_i - \bar{\mathbf{d}}| > \mathrm{ENKF\_ALPHA} \left( s_{d_i} + s^o_{d_i} \right)`
 
         where :math:`\mathbf{d}^o` is the vector of observed data,
         :math:`\mathbf{\bar{d}}` is the average of the forecasted data ensemble,


### PR DESCRIPTION
Using simpler and more consistent LaTeX with upright bold for vectors, which is a typical convention. Fixes #6877.

**Issue**
Resolves #6877


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


## Pre review checklist

- [x] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [x] Prepare changes in small commits for more convenient review (optional)
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).

<!--
Adding labels helps the maintainers when writing release notes. This is the
[list of release note
labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
