### PR TITLE
Reduce accuracy of surface-order test

### DIFF
--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -186,7 +186,7 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert(
         with pytest.raises(AssertionError):
             np.testing.assert_array_equal(surf_prior[i], surf_posterior[i])
         np.testing.assert_almost_equal(
-            surf_prior[i].values, surf_posterior[i].values, decimal=3
+            surf_prior[i].values, surf_posterior[i].values, decimal=2
         )
 
 


### PR DESCRIPTION
Test is flaky.
Test makes sure ERT does not change order of arrays and numerical accuracy is not important.

**Issue**
Resolves #6898 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
