### PR TITLE
Add explicit logging when Scheduler was cancelled

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -187,12 +187,11 @@ class Job:
         log_info_from_exit_file(Path(self.real.run_arg.runpath) / ERROR_file)
 
     async def _handle_aborted(self) -> None:
-        info_msg = "Scheduler cancelled, stopping job"
-
         self.real.run_arg.ensemble_storage.set_failure(
-            self.real.run_arg.iens, RealizationStorageState.LOAD_FAILURE, info_msg
+            self.real.run_arg.iens,
+            RealizationStorageState.LOAD_FAILURE,
+            "Job cancelled",
         )
-        logger.debug(info_msg)
         log_info_from_exit_file(Path(self.real.run_arg.runpath) / ERROR_file)
 
     async def _send(self, state: State) -> None:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -172,6 +172,7 @@ class Scheduler:
             await self.driver.finish()
 
         if self._cancelled:
+            logger.debug("scheduler cancelled, stopping jobs...")
             return EVTYPE_ENSEMBLE_CANCELLED
 
         return EVTYPE_ENSEMBLE_STOPPED


### PR DESCRIPTION
**Issue**
We are logging the same info regardless the Scheduler failed (eg. max_submit reached) or it was cancelled. Therefore we should differentiate between these two states.


**Approach**
Add handler for aborted state.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
