### PR TITLE
Ensure consistent log levels in integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import fileinput
+import logging
 import os
 import pkgutil
 import resource
@@ -28,6 +29,18 @@ from .utils import SOURCE_DIR
 
 if TYPE_CHECKING:
     from importlib.abc import FileLoader
+
+
+@pytest.fixture(autouse=True)
+def log_check():
+    logger = logging.getLogger()
+    logger.setLevel(logging.WARNING)
+    yield
+    logger_after = logging.getLogger()
+    level_after = logger_after.getEffectiveLevel()
+    assert (
+        level_after == logging.WARNING
+    ), f"Detected differences in log environment: Changed to {level_after}"
 
 
 @pytest.fixture

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,22 +1,9 @@
-import logging
 import os
 import sys
 
 import pytest
 
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
-
-
-@pytest.fixture(autouse=True)
-def log_check():
-    logger = logging.getLogger()
-    logger.setLevel(logging.WARNING)
-    yield
-    logger_after = logging.getLogger()
-    level_after = logger_after.getEffectiveLevel()
-    assert (
-        level_after == logging.WARNING
-    ), f"Detected differences in log environment: Changed to {level_after}"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Some tests were moved from unit_tests to integration_tests in a810eb0f8715e182d4e1b1dc1636356b97023711 that were sensitive to log level details. This dependency was not triggered in Github actions workflows but in komodo bleeding nightly tests.

**Issue**
Resolves #6863 


**Approach**
Move logging fixture from `unit_tests` to one level up, thus ensuring this in all tests.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
