### PR TITLE
Add new workflow for dark storage performance benchmark

### DIFF
--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -5,7 +5,8 @@ on:
         - gh-pages
       paths:
         - /dev/dark_storage_performance_benchmark/**
-
+    workflow_dispatch:
+      
 permissions:
     # deployments permission to deploy GitHub pages website
     deployments: write

--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -4,9 +4,8 @@ on:
       branches:
         - gh-pages
       paths:
-        - /dev/dark_storage_performance_benchmark/**
-    workflow_dispatch:
-      
+        - /dev/dark_storage_performance_benchmark/output.json
+
 permissions:
     # deployments permission to deploy GitHub pages website
     deployments: write

--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -1,0 +1,36 @@
+name: Process Dark Storage Benchmark Result
+on:
+    push:
+      branches:
+        - gh-pages
+      paths:
+        - /dev/dark_storage_performance_benchmark/**
+
+permissions:
+    # deployments permission to deploy GitHub pages website
+    deployments: write
+    # contents permission to update benchmark contents in gh-pages branch
+    contents: write
+
+jobs:
+  benchmark:
+    name: Run pytest-benchmark dark storage
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+          lfs: true
+          ref: gh-pages
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Dark Storage Benchmark
+          tool: 'pytest'
+          output-file-path: dev/dark_storage_performance_benchmark/output.json
+          benchmark-data-dir-path: dev/dark_storage_performance_benchmark
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true

--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -35,3 +35,4 @@ jobs:
           benchmark-data-dir-path: dev/dark_storage_performance_benchmark
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
+          skip-fetch-gh-pages: true


### PR DESCRIPTION
Resolves #6945
Adds workflow for dark storage performance test, and uses a marketplace action for adding the result to a convenient dashboard in the gh-pages branch.

It is triggered when the corresponding workflow running on-prem publishes the result in the gh-branch.