### PR TITLE
Set default max_submit to 1 in tests

### DIFF
--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -55,7 +55,7 @@ def snapshot():
 def queue_config_fixture():
     return QueueConfig(
         job_script="job_dispatch.py",
-        max_submit=100,
+        max_submit=1,
         queue_system=QueueSystem.LOCAL,
         queue_options={QueueSystem.LOCAL: [("MAX_RUNNING", "50")]},
     )


### PR DESCRIPTION
There is no reason to have it as large as 100 by default and in bad situations it could cause excessive test runtimes.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
