### PR TITLE
Improve license error retry

### DIFF
--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -603,9 +603,10 @@ def test_ecl100_retries_once_on_license_failure(tmp_path, monkeypatch):
     econfig = ecl_config.Ecl100Config()
     sim = econfig.sim("2015.2")
     erun = ecl_run.EclRun(str(case_path), sim)
-    erun.LICENSE_FAILURE_SLEEP_SECONDS = 1
+    erun.LICENSE_FAILURE_SLEEP_FACTOR = 1
+    erun.LICENSE_RETRY_STAGGER_FACTOR = 1
 
     with pytest.raises(RuntimeError, match="LICENSE FAILURE"):
         erun.runEclipse()
-    max_attempts = 2
+    max_attempts = 3
     assert (tmp_path / "mock_log").read_text() == "Called mock\n" * max_attempts


### PR DESCRIPTION
We have observed that there are two kind of events that leads to license errors

* 100% cpu, which means the server is unresponsive for ~25s
* service restart which takes 2-3 minutes

Therefore, we set the first retry to happen after 1 minute to hoping that the server gets enough time to get off 100% cpu.

The second retry happens between 3 and 6 minutes later, ensuring that there is enough time for the server to restart.

There is also a stagger factor added to avoid all retries happening simultanously. It is set to maximum 25s.

-----------------------------

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
