### PR TITLE
Add scheduler fixture to gui tests

### DIFF
--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -335,9 +335,10 @@ def test_run_dialog(events, tab_widget_count, runmodel, qtbot: QtBot, mock_track
         qtbot.waitUntil(widget.done_button.isVisible, timeout=5000)
 
 
+@pytest.mark.scheduler
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
-    qtbot: QtBot, storage, source_root
+    qtbot: QtBot, storage, source_root, try_queue_and_scheduler
 ):
     """
     This is a regression test for a crash happening when
@@ -523,8 +524,11 @@ def test_run_dialog_memory_usage_showing(
         assert max_memory_value == "60000"
 
 
+@pytest.mark.scheduler
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_gui_runs_a_minimal_example(qtbot: QtBot, storage):
+def test_that_gui_runs_a_minimal_example(
+    qtbot: QtBot, storage, try_queue_and_scheduler
+):
     """
     This is a regression test for a crash happening when clicking show details
     when running a minimal example.

--- a/tests/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
 from pytestqt.qtbot import QtBot
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QComboBox, QMessageBox, QToolButton, QWidget
@@ -31,7 +32,10 @@ def handle_run_path_dialog(gui: ErtMainWindow, qtbot: QtBot, delete_run_path: bo
         qtbot.mouseClick(mb.buttons()[0], Qt.LeftButton)
 
 
-def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
+@pytest.mark.scheduler
+def test_run_path_is_deleted(
+    snake_oil_case_storage: ErtConfig, qtbot: QtBot, try_queue_and_scheduler
+):
     snake_oil_case = snake_oil_case_storage
     args_mock = Mock()
     args_mock.config = "snake_oil.ert"
@@ -85,7 +89,10 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
         assert not os.path.exists(run_path / dummy_file.name)
 
 
-def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
+@pytest.mark.scheduler
+def test_run_path_is_not_deleted(
+    snake_oil_case_storage: ErtConfig, qtbot: QtBot, try_queue_and_scheduler
+):
     snake_oil_case = snake_oil_case_storage
     args_mock = Mock()
     args_mock.config = "snake_oil.ert"

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -213,8 +213,11 @@ def test_gui_shows_a_warning_and_disables_update_when_parameters_are_missing(
         assert gui.windowTitle() == "ERT - poly-no-gen-kw.ert"
 
 
+@pytest.mark.scheduler
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_run_dialog_can_be_closed_after_used_to_open_plots(qtbot, storage):
+def test_that_run_dialog_can_be_closed_after_used_to_open_plots(
+    qtbot, storage, try_queue_and_scheduler
+):
     """
     This is a regression test for a bug where the plot window opened from run dialog
     would have run dialog as parent. Because of that it would be destroyed when
@@ -411,9 +414,10 @@ def test_that_ert_changes_to_config_directory(qtbot):
         assert gui.windowTitle() == "ERT - snake_oil_surface.ert"
 
 
+@pytest.mark.scheduler
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_the_plot_window_contains_the_expected_elements(
-    esmda_has_run, opened_main_window, qtbot
+    esmda_has_run, opened_main_window, qtbot, try_queue_and_scheduler
 ):
     gui = opened_main_window
     expected_cases = [
@@ -697,9 +701,10 @@ def test_that_load_results_manually_can_be_run_after_esmda(
     load_results_manually(qtbot, opened_main_window)
 
 
+@pytest.mark.scheduler
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_a_failing_job_shows_error_message_with_context(
-    opened_main_window_clean, qtbot
+    opened_main_window_clean, qtbot, try_queue_and_scheduler
 ):
     gui = opened_main_window_clean
 

--- a/tests/unit_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/unit_tests/gui/test_restart_ensemble_experiment.py
@@ -123,4 +123,3 @@ def test_restart_failed_realizations(
     assert list_model.rowCount() == len(failed_realizations)
 
     qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
-    qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)

--- a/tests/unit_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/unit_tests/gui/test_restart_ensemble_experiment.py
@@ -2,6 +2,7 @@ import os
 import stat
 from textwrap import dedent
 
+import pytest
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QComboBox, QMessageBox, QWidget
 
@@ -13,7 +14,10 @@ from tests.unit_tests.gui.simulation.test_run_path_dialog import handle_run_path
 from .conftest import wait_for_child
 
 
-def test_restart_failed_realizations(opened_main_window_clean, qtbot):
+@pytest.mark.scheduler
+def test_restart_failed_realizations(
+    opened_main_window_clean, qtbot, try_queue_and_scheduler
+):
     """This runs an ensemble experiment with some failing realizations, and then
     does a restart, checking that only the failed realizations are started.
     """
@@ -118,4 +122,5 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     list_model = realization_widget._real_view.model()
     assert list_model.rowCount() == len(failed_realizations)
 
+    qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
     qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)


### PR DESCRIPTION
**Issue**
Resolves #6936 


**Approach**
Use scheduler fixture in relevant tests

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
