### PR TITLE
Move inversion types to analysis module

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1236,33 +1236,68 @@ The keywords to load, select and modify the analysis modules are documented here
         These can be manipulated from the config file using the
         ANALYSIS_SET_VAR keyword for either the `STD_ENKF` or `IES_ENKF` module.
 
+        **STD_ENKF**
 
-        .. list-table:: Inversion Algorithms
-           :widths: 50 50 50
+
+        .. list-table:: Inversion Algorithms for Ensemble Smoother
+           :widths: 50 50 50 50
            :header-rows: 1
 
            * - Description
              - INVERSION
-             - IES_INVERSION
+             - IES_INVERSION (deprecated)
+             - Note
            * - Exact inversion with diagonal R=I
              - EXACT
              - 0
+             -
            * - Subspace inversion with exact R
-             - SUBSPACE_EXACT_R
+             - SUBSPACE_EXACT_R / SUBSPACE
              - 1
+             - Preferred name: SUBSPACE
            * - Subspace inversion using R=EE'
              - SUBSPACE_EE_R
              - 2
+             - Deprecated, maps to: SUBSPACE
            * - Subspace inversion using E
              - SUBSPACE_RE
              - 3
+             - Deprecated, maps to: SUBSPACE
 
-        Two ways of setting the same inversion method
+
+        **IES_ENKF**
+
+
+        .. list-table:: Inversion Algorithms for IES
+           :widths: 50 50 50 50
+           :header-rows: 1
+
+           * - Description
+             - INVERSION
+             - IES_INVERSION (deprecated)
+             - Note
+           * - Exact inversion with diagonal R=I
+             - EXACT / DIRECT
+             - 0
+             - Preferred name: DIRECT
+           * - Subspace inversion with exact R
+             - SUBSPACE_EXACT_R / SUBSPACE_EXACT
+             - 1
+             - Preferred name: SUBSPACE_EXACT
+           * - Subspace inversion using R=EE'
+             - SUBSPACE_EE_R / SUBSPACE_PROJECTED
+             - 2
+             - Preferred name: SUBSPACE_PROJECTED
+           * - Subspace inversion using E
+             - SUBSPACE_RE
+             - 3
+             - Deprecated, maps to: SUBSPACE_PROJECTED
+
+        Setting the inversion method
         ::
 
                 -- Example for the `STD_ENKF` module
-                ANALYSIS_SET_VAR  STD_ENKF  INVERSION  SUBSPACE_EXACT_R
-                ANALYSIS_SET_VAR  STD_ENKF  IES_INVERSION  1
+                ANALYSIS_SET_VAR  STD_ENKF  INVERSION  DIRECT
 
 
 .. _ies_max_steplength:

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -591,21 +591,12 @@ def analysis_ES(
 
         num_obs = len(observation_values)
 
-        inversion_types = {0: "exact", 1: "subspace", 2: "subspace", 3: "subspace"}
-        try:
-            inversion_type = inversion_types[module.ies_inversion]
-        except KeyError as e:
-            raise ErtAnalysisError(
-                f"Mismatched inversion type for: "
-                f"Specified: {module.ies_inversion}, with possible: {inversion_types}"
-            ) from e
-
         smoother_es = ies.ESMDA(
             covariance=observation_errors**2,
             observations=observation_values,
             alpha=1,  # The user is responsible for scaling observation covariance (esmda usage)
             seed=rng,
-            inversion=inversion_type,
+            inversion=module.inversion,
         )
         truncation = module.enkf_truncation
 
@@ -737,7 +728,7 @@ def analysis_ES(
             observation_errors=observation_errors,
             observation_values=observation_values,
             truncation=truncation,
-            inversion_type=inversion_type,
+            inversion_type=module.inversion,
             progress_callback=progress_callback,
             rng=rng,
         )
@@ -766,21 +757,6 @@ def analysis_IES(
     # Then the result is [0,1,1,1]
     # This is needed for the SIES library
     masking_of_initial_parameters = ens_mask[initial_mask]
-
-    # Map paper (current in ERT) inversion-types to SIES inversion-types
-    inversion_types = {
-        0: "direct",
-        1: "subspace_exact",
-        2: "subspace_projected",
-        3: "subspace_projected",
-    }
-    try:
-        inversion_type = inversion_types[analysis_config.ies_inversion]
-    except KeyError as e:
-        raise ErtAnalysisError(
-            f"Mismatched inversion type for: "
-            f"Specified: {analysis_config.ies_inversion}, with possible: {inversion_types}"
-        ) from e
 
     # It is not the iterations relating to IES or ESMDA.
     # It is related to functionality for turning on/off groups of parameters and observations.
@@ -830,7 +806,7 @@ def analysis_IES(
                 covariance=observation_errors**2,
                 observations=observation_values,
                 seed=rng,
-                inversion=inversion_type,
+                inversion=analysis_config.inversion,
                 truncation=analysis_config.enkf_truncation,
             )
 

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -81,6 +81,11 @@ class AnalysisConfig:
             if var_name in ["INVERSION", "IES_INVERSION"]:
                 if value in inversion_str_map[module_name]:
                     value = inversion_str_map[module_name][value]
+                    if var_name == "IES_INVERSION":
+                        ConfigWarning.ert_context_warn(
+                            "IES_INVERSION is deprecated, please use INVERSION instead:\n"
+                            f"ANALYSIS_SET_VAR {module_name} INVERSION {value.upper()}"
+                        )
                 var_name = "inversion"
             key = var_name.lower()
             options[module_name][key] = value

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -45,10 +45,18 @@ class AnalysisConfig:
         options: Dict[str, Dict[str, Any]] = {"STD_ENKF": {}, "IES_ENKF": {}}
         analysis_set_var = [] if analysis_set_var is None else analysis_set_var
         inversion_str_map: Final = {
-            "EXACT": 0,
-            "SUBSPACE_EXACT_R": 1,
-            "SUBSPACE_EE_R": 2,
-            "SUBSPACE_RE": 3,
+            "STD_ENKF": {
+                **dict.fromkeys(["EXACT", "0"], "exact"),
+                **dict.fromkeys(["SUBSPACE_EXACT_R", "1"], "subspace"),
+                **dict.fromkeys(["SUBSPACE_EE_R", "2"], "subspace"),
+                **dict.fromkeys(["SUBSPACE_RE", "3"], "subspace"),
+            },
+            "IES_ENKF": {
+                **dict.fromkeys(["EXACT", "0"], "direct"),
+                **dict.fromkeys(["SUBSPACE_EXACT_R", "1"], "subspace_exact"),
+                **dict.fromkeys(["SUBSPACE_EE_R", "2"], "subspace_projected"),
+                **dict.fromkeys(["SUBSPACE_RE", "3"], "subspace_projected"),
+            },
         }
         deprecated_keys = ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION"]
         deprecated_inversion_keys = ["USE_EE", "USE_GE"]
@@ -61,9 +69,6 @@ class AnalysisConfig:
                 continue
             if var_name == "ENKF_FORCE_NCOMP":
                 continue
-            if var_name == "INVERSION":
-                value = str(inversion_str_map[value])
-                var_name = "IES_INVERSION"
             if var_name in deprecated_inversion_keys:
                 all_errors.append(
                     ConfigValidationError(
@@ -73,6 +78,10 @@ class AnalysisConfig:
                     )
                 )
                 continue
+            if var_name in ["INVERSION", "IES_INVERSION"]:
+                if value in inversion_str_map[module_name]:
+                    value = inversion_str_map[module_name][value]
+                var_name = "inversion"
             key = var_name.lower()
             options[module_name][key] = value
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -101,7 +101,7 @@ def test_update_report(
             ert_config.ensemble_config.parameters,
         ),
         UpdateSettings(misfit_preprocess=misfit_preprocess),
-        ESSettings(ies_inversion=1),
+        ESSettings(inversion="subspace"),
         log_path=Path("update_log"),
     )
     log_file = Path(ert_config.analysis_config.log_path) / "id.txt"
@@ -237,7 +237,7 @@ def test_update_snapshot(
             run_id="id",
             update_config=update_configuration,
             update_settings=UpdateSettings(),
-            analysis_config=IESSettings(ies_inversion=1),
+            analysis_config=IESSettings(inversion="subspace_exact"),
             sies_step_length=sies_step_length,
             initial_mask=initial_mask,
             rng=rng,
@@ -249,7 +249,7 @@ def test_update_snapshot(
             "id",
             update_configuration,
             UpdateSettings(),
-            ESSettings(ies_inversion=1),
+            ESSettings(inversion="subspace"),
             rng=rng,
         )
 
@@ -357,7 +357,7 @@ def test_localization(
         "id",
         update_config,
         UpdateSettings(),
-        ESSettings(ies_inversion=1),
+        ESSettings(inversion="subspace"),
         rng=np.random.default_rng(42),
         log_path=Path("update_log"),
     )

--- a/tests/unit_tests/config/test_analysis_config.py
+++ b/tests/unit_tests/config/test_analysis_config.py
@@ -157,7 +157,9 @@ def test_setting_case_format(analysis_config):
 
 
 def test_incorrect_variable_raises_validation_error():
-    with pytest.raises(ConfigValidationError, match="Input should be a valid integer"):
+    with pytest.raises(
+        ConfigValidationError, match="Input should be 'exact' or 'subspace'"
+    ):
         _ = AnalysisConfig.from_dict(
             {
                 ConfigKeys.ANALYSIS_SET_VAR: [["STD_ENKF", "IES_INVERSION", "FOO"]],

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -585,17 +585,16 @@ def test_that_inversion_type_can_be_set_from_gui(qtbot, opened_main_window):
     # https://github.com/pytest-dev/pytest-qt/issues/256
     def handle_analysis_module_panel():
         var_panel = wait_for_child(gui, qtbot, AnalysisModuleVariablesPanel)
-        rb0 = wait_for_child(var_panel, qtbot, QRadioButton, name="IES_INVERSION_0")
-        rb1 = wait_for_child(var_panel, qtbot, QRadioButton, name="IES_INVERSION_1")
-        rb2 = wait_for_child(var_panel, qtbot, QRadioButton, name="IES_INVERSION_2")
-        rb3 = wait_for_child(var_panel, qtbot, QRadioButton, name="IES_INVERSION_3")
+        dropdown = wait_for_child(var_panel, qtbot, QComboBox)
         spinner = wait_for_child(var_panel, qtbot, QDoubleSpinBox, "enkf_truncation")
-
-        for b in [rb0, rb1, rb2, rb3, rb0]:
-            b.click()
-            assert b.isChecked()
+        assert [dropdown.itemText(i) for i in range(dropdown.count())] == [
+            "EXACT",
+            "SUBSPACE",
+        ]
+        for i in range(dropdown.count()):
+            dropdown.setCurrentIndex(i)
             # spinner should be enabled if not rb0 set
-            assert spinner.isEnabled() == (b != rb0)
+            assert spinner.isEnabled() == (i != 0)
 
         var_panel.parent().close()
 


### PR DESCRIPTION
**Issue**
The options for the inversion were out of sync with what was actually being used in the update algorithms. Moved configuration from _es_update to the configuration, and split it on IES and ES.

**Approach**
_Short description of the approach_

![image](https://github.com/equinor/ert/assets/44577479/15ec1bdc-a743-43fe-a69d-1a3a9543d5d6)

Forgive my mac:
![image](https://github.com/equinor/ert/assets/44577479/ac382b5a-0498-4de6-bbb8-69728993d6b5)


old behavior:

![image](https://github.com/equinor/ert/assets/44577479/88d5fd2b-19c3-4896-bf08-41b5442f2633)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
