### PR TITLE
Extend license retry to more error messages

### DIFF
--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
@@ -384,7 +384,9 @@ class EclRun:
             try:
                 self.assertECLEND()
             except RuntimeError as err:
-                if "LICENSE FAILURE" in err.args[0] and retries_left > 0:
+                if (
+                    "LICENSE ERROR" in err.args[0] or "LICENSE FAILURE" in err.args[0]
+                ) and retries_left > 0:
                     time_to_wait = backoff_sleep + int(
                         random() * self.LICENSE_RETRY_STAGGER_FACTOR
                     )


### PR DESCRIPTION
Extend the license retry rule to one more error message.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
