### PR TITLE
Provide more descriptive feedback on USE_EE and USE_GE

### DIFF
--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -1520,8 +1520,8 @@ def test_validate_no_logs_when_overwriting_with_same_value(caplog):
 @pytest.mark.parametrize(
     "obsolete_analysis_keyword,error_msg",
     [
-        ("USE_EE", "Extra inputs are not permitted"),
-        ("USE_GE", "Extra inputs are not permitted"),
+        ("USE_EE", "Keyword USE_EE has been replaced"),
+        ("USE_GE", "Keyword USE_GE has been replaced"),
         ("ENKF_NCOMP", r"ENKF_NCOMP keyword\(s\) has been removed"),
         (
             "ENKF_SUBSPACE_DIMENSION",


### PR DESCRIPTION
```
ANALYSIS_SET_VAR STD_ENKF USE_EE 1
ANALYSIS_SET_VAR STD_ENKF USE_GE 1

ANALYSIS_SET_VAR STD_ENKF LOL 1

ANALYSIS_SET_VAR STD_ENKF ENKF_NCOMP 1
ANALYSIS_SET_VAR STD_ENKF ENKF_SUBSPACE_DIMENSION 1
```

![Screenshot 2024-01-18 at 13 57 17](https://github.com/equinor/ert/assets/114403625/abdb4897-c0fa-4b1c-bad2-299cf62e9d10)


**Issue**
Resolves #6621 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
