### PR TITLE
Mark two scheduler tests as flaky

### DIFF
--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -8,6 +8,7 @@ from typing import List
 
 import pytest
 from cloudevents.http import CloudEvent, from_json
+from flaky import flaky
 
 from ert.constant_filenames import CERT_FILE
 from ert.ensemble_evaluator._builder._realization import Realization
@@ -346,6 +347,7 @@ async def test_that_long_running_jobs_were_stopped(storage, tmp_path, mock_drive
     assert killed_iens == [6, 7, 8, 9]
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.parametrize(
     "submit_sleep, iens_stride, realization_runtime",
     [(0, 1, 0.1), (0.1, 1, 0.1), (0.1, 1, 0), (0.1, 2, 0)],
@@ -388,6 +390,7 @@ async def test_submit_sleep(
     assert max(deltas) <= submit_sleep + 0.1
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.parametrize(
     "submit_sleep, realization_max_runtime, max_running",
     [


### PR DESCRIPTION
These have been seen to be flaky but will pass on retries

**Approach**
Rerun instead of tuning timing limits

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
