### PR TITLE
Give proper error message when eclrun fails with nonzero return code

### DIFF
--- a/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
+++ b/src/ert/shared/share/ert/forward-models/res/script/ecl_run.py
@@ -16,7 +16,7 @@ from ecl_config import EclrunConfig
 from packaging import version
 
 
-def await_process_tee(process, *out_files):
+def await_process_tee(process, *out_files) -> int:
     """Wait for process to finish, "tee"-ing the subprocess' stdout into all the
     given file objects.
 
@@ -337,7 +337,7 @@ class EclRun:
                 logname_extension = "LOG"
         return f"{self.base_name}.{logname_extension}"
 
-    def execEclipse(self, eclrun_config=None):
+    def execEclipse(self, eclrun_config=None) -> int:
         use_eclrun = eclrun_config is not None
         log_name = self._get_log_name(eclrun_config=eclrun_config)
 
@@ -379,7 +379,12 @@ class EclRun:
                 f.write("ECLIPSE simulation complete - NOT checked for errors.")
         else:
             if return_code != 0:
-                raise subprocess.CalledProcessError(return_code, self.sim.executable)
+                command = (
+                    self._get_run_command(eclrun_config)
+                    if self.sim is None
+                    else self._get_legacy_run_command()
+                )
+                raise subprocess.CalledProcessError(return_code, command)
 
             try:
                 self.assertECLEND()

--- a/tests/unit_tests/shared/share/test_ecl_run.py
+++ b/tests/unit_tests/shared/share/test_ecl_run.py
@@ -408,6 +408,15 @@ def test_run_nonzero_exit_code(init_ecl100_config, source_root):
 
 
 @pytest.mark.requires_eclipse
+def test_non_existing_eclipse_version(init_ecl100_config, source_root):
+    Path("FOO.DATA").write_text("", encoding="utf-8")
+    econfig = ecl_config.Ecl100Config()
+
+    with pytest.raises(KeyError, match="2079.3"):
+        econfig.sim("2079.3")
+
+
+@pytest.mark.requires_eclipse
 def test_run_api(init_ecl100_config, source_root):
     shutil.copy(
         source_root / "test-data/eclipse/SPE1.DATA",

--- a/tests/unit_tests/shared/share/test_ecl_run_new_config.py
+++ b/tests/unit_tests/shared/share/test_ecl_run_new_config.py
@@ -4,6 +4,8 @@ import os
 import re
 import shutil
 import stat
+import subprocess
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -174,6 +176,20 @@ def test_failed_run(source_root):
     eclrun_config = ecl_config.EclrunConfig(econfig, "2019.3")
     erun = ecl_run.EclRun("SPE1_ERROR", None)
     with pytest.raises(Exception, match="ERROR"):
+        erun.runEclipse(eclrun_config=eclrun_config)
+
+
+@pytest.mark.requires_eclipse
+@pytest.mark.usefixtures("use_tmpdir", "init_eclrun_config")
+def test_failed_run_nonzero_returncode(monkeypatch):
+    Path("FOO.DATA").write_text("")
+    econfig = ecl_config.Ecl100Config()
+    eclrun_config = ecl_config.EclrunConfig(econfig, "2021.3")
+    erun = ecl_run.EclRun("FOO.DATA", None)
+    monkeypatch.setattr("ecl_run.EclRun.execEclipse", mock.MagicMock(return_value=1))
+    with pytest.raises(
+        subprocess.CalledProcessError, match="Command .*eclrun.* non-zero exit status 1"
+    ):
         erun.runEclipse(eclrun_config=eclrun_config)
 
 


### PR DESCRIPTION
**Issue**
Resolves #6495 


**Approach**
Do not try to access `self.sim` when we use `eclrun`. 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
