### PR TITLE
Enable scheduler by default for LOCAL queue

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -21,6 +21,7 @@ from ert.config import ErtConfig, QueueSystem
 from ert.enkf_main import EnKFMain
 from ert.ensemble_evaluator import EvaluatorServerConfig, EvaluatorTracker
 from ert.namespace import Namespace
+from ert.shared.feature_toggling import FeatureToggling
 from ert.storage import open_storage
 from ert.storage.local_storage import local_storage_set_ert_config
 
@@ -40,6 +41,11 @@ def run_cli(args: Namespace, _: Any = None) -> None:
     # the config file to be the base name of the original config
     args.config = os.path.basename(args.config)
     ert_config = ErtConfig.from_file(args.config)
+    if (
+        FeatureToggling.is_enabled("scheduler")
+        and ert_config.queue_config.queue_system != QueueSystem.LOCAL
+    ):
+        raise ErtCliError("Scheduler only support LOCAL queue at the moment!")
     local_storage_set_ert_config(ert_config)
 
     # Create logger inside function to make sure all handlers have been added to

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -178,6 +178,11 @@ class LegacyEnsemble(Ensemble):
         """
         event_creator = self.generate_event_creator(experiment_id=experiment_id)
         timeout_queue: Optional[asyncio.Queue[Any]] = None
+        if (
+            self._queue_config.queue_system in [QueueSystem.LOCAL]
+            and FeatureToggling.value("scheduler") is not False
+        ):
+            FeatureToggling._conf["scheduler"].value = True
         if not FeatureToggling.is_enabled("scheduler"):
             # Set up the timeout-mechanism
             timeout_queue = asyncio.Queue()

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -10,7 +10,7 @@ from PyQt5.QtGui import QIcon
 from qtpy.QtCore import QDir, QLocale, Qt
 from qtpy.QtWidgets import QApplication
 
-from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
+from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, QueueSystem
 from ert.enkf_main import EnKFMain
 from ert.gui.ertwidgets import SummaryPanel
 from ert.gui.main_window import ErtMainWindow
@@ -30,6 +30,7 @@ from ert.gui.tools.workflows import WorkflowsTool
 from ert.libres_facade import LibresFacade
 from ert.namespace import Namespace
 from ert.services import StorageService
+from ert.shared.feature_toggling import FeatureToggling
 from ert.shared.plugins.plugin_manager import ErtPluginManager
 from ert.storage import open_storage
 from ert.storage.local_storage import local_storage_set_ert_config
@@ -99,6 +100,13 @@ def _start_initial_gui_window(
             # the config file to be the base name of the original config
             args.config = os.path.basename(args.config)
             ert_config = ErtConfig.from_file(args.config)
+            if (
+                FeatureToggling.is_enabled("scheduler")
+                and ert_config.queue_config.queue_system != QueueSystem.LOCAL
+            ):
+                raise ConfigValidationError(
+                    "Scheduler only support LOCAL queue at the moment!"
+                )
             local_storage_set_ert_config(ert_config)
             ert = EnKFMain(ert_config)
         except ConfigValidationError as error:

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -2,9 +2,10 @@ import logging
 import os
 from argparse import ArgumentParser
 from copy import deepcopy
-from typing import Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from ert.namespace import Namespace
+if TYPE_CHECKING:
+    from ert.namespace import Namespace
 
 
 class _Feature:
@@ -98,7 +99,7 @@ class FeatureToggling:
                 )
 
     @staticmethod
-    def update_from_args(args: Namespace) -> None:
+    def update_from_args(args: "Namespace") -> None:
         pattern = "feature-"
         feature_args = [arg for arg in vars(args).items() if arg[0].startswith(pattern)]
         for name, value in feature_args:

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -94,7 +94,11 @@ class SimulationContext:
         self._ert = ert
         self._mask = mask
 
-        if FeatureToggling.is_enabled("scheduler"):
+        if (
+            ert.ert_config.queue_config.queue_system in [QueueSystem.LOCAL]
+            and FeatureToggling.value("scheduler") is not False
+        ):
+            FeatureToggling._conf["scheduler"].value = True
             if ert.ert_config.queue_config.queue_system != QueueSystem.LOCAL:
                 raise NotImplementedError()
             driver = create_driver(ert.ert_config.queue_config)

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from websockets.exceptions import ConnectionClosed
@@ -95,6 +95,7 @@ def test_run_legacy_ensemble_with_bare_exception(
 ):
     """This test function is not ported to Scheduler, as it will not
     catch general exceptions."""
+    monkeypatch.setattr(FeatureToggling._conf["scheduler"], "_value", False)
     num_reals = 2
     custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():


### PR DESCRIPTION
**Issue**
Resolves #6983 


**Approach**
Check whether the queue_system is LOCAL and toggle the Scheduler in FeatureToggling.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
