### PR TITLE
Use full run_path in UI and cut to valid path for clipboard

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -42,6 +42,20 @@ def unescape_string(string):
     )
 
 
+def strip_run_path_magic_keywords(run_path: str) -> str:
+    rp_stripped = ""
+    for s in run_path.split("/"):
+        if all(substring not in s for substring in ("<IENS>", "<ITER>")) and s:
+            rp_stripped += "/" + s
+    if not rp_stripped:
+        rp_stripped = "/"
+
+    if run_path and not run_path.startswith("/"):
+        rp_stripped = rp_stripped[1:]
+
+    return rp_stripped
+
+
 class CopyableLabel(QHBoxLayout):
     """CopyableLabel shows a string that is copyable via
     selection or clicking of a copy button"""
@@ -63,7 +77,8 @@ class CopyableLabel(QHBoxLayout):
         self.restore_timer.timeout.connect(restore_text)
 
         def copy_text() -> None:
-            text = unescape_string(self.label.text())
+            text = strip_run_path_magic_keywords(unescape_string(self.label.text()))
+
             QApplication.clipboard().setText(text)
             self.copy_button.setIcon(QIcon("img:check.svg"))
 

--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -87,13 +87,11 @@ class SimulationPanel(QWidget):
         self._simulation_widgets = OrderedDict()
         """ :type: OrderedDict[BaseRunModel,SimulationConfigPanel]"""
         self.addSimulationConfigPanel(
-            SingleTestRunPanel(self.facade.run_path_stripped, notifier, ensemble_size),
+            SingleTestRunPanel(self.facade.run_path, notifier, ensemble_size),
             True,
         )
         self.addSimulationConfigPanel(
-            EnsembleExperimentPanel(
-                ensemble_size, self.facade.run_path_stripped, notifier
-            ),
+            EnsembleExperimentPanel(ensemble_size, self.facade.run_path, notifier),
             True,
         )
         config = self.facade.config
@@ -103,19 +101,19 @@ class SimulationPanel(QWidget):
         analysis_config = self.facade.config.analysis_config
         self.addSimulationConfigPanel(
             EnsembleSmootherPanel(
-                analysis_config, self.facade.run_path_stripped, notifier, ensemble_size
+                analysis_config, self.facade.run_path, notifier, ensemble_size
             ),
             simulation_mode_valid,
         )
         self.addSimulationConfigPanel(
             MultipleDataAssimilationPanel(
-                analysis_config, self.facade.run_path_stripped, notifier, ensemble_size
+                analysis_config, self.facade.run_path, notifier, ensemble_size
             ),
             simulation_mode_valid,
         )
         self.addSimulationConfigPanel(
             IteratedEnsembleSmootherPanel(
-                analysis_config, self.facade.run_path_stripped, notifier, ensemble_size
+                analysis_config, self.facade.run_path, notifier, ensemble_size
             ),
             simulation_mode_valid,
         )

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -155,20 +155,6 @@ class LibresFacade:
     def run_path(self) -> str:
         return self.config.model_config.runpath_format_string
 
-    @property
-    def run_path_stripped(self) -> str:
-        rp_stripped = ""
-        for s in self.run_path.split("/"):
-            if all(substring not in s for substring in ("<IENS>", "<ITER>")) and s:
-                rp_stripped += "/" + s
-        if not rp_stripped:
-            rp_stripped = "/"
-
-        if self.run_path and not self.run_path.startswith("/"):
-            rp_stripped = rp_stripped[1:]
-
-        return rp_stripped
-
     def load_from_forward_model(
         self,
         ensemble: EnsembleAccessor,

--- a/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
+++ b/tests/unit_tests/gui/ertwidgets/test_copyablelabel.py
@@ -2,11 +2,18 @@ import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QWidget
 
-from ert.gui.ertwidgets.copyablelabel import CopyableLabel
+from ert.gui.ertwidgets.copyablelabel import (
+    CopyableLabel,
+    strip_run_path_magic_keywords,
+)
 
 
 @pytest.fixture(
-    params=[("<b>hehehehe</b>", "hehehehe"), ("<b>foooo-<ITER></b>", "foooo-<ITER>")]
+    params=[
+        ("<b>hehe/hoho</b>", "hehe/hoho"),
+        ("<b>fooo/hoho-<ITER></b>", "fooo"),
+        ("<b>booo/hoho-<IENS></b>", "booo"),
+    ]
 )
 def label_testcase(request):
     return request.param
@@ -24,3 +31,19 @@ def test_copy_clickbtn(qtbot, tmpdir, monkeypatch, label_testcase):
     qtbot.mouseClick(copyable_label.copy_button, Qt.MouseButton.LeftButton)
 
     assert QApplication.clipboard().text() == label
+
+
+@pytest.mark.parametrize(
+    "run_path, expected",
+    [
+        ("", "/"),
+        ("///", "/"),
+        ("simulation/mypath", "simulation/mypath"),
+        ("/local/path", "/local/path"),
+        ("/local/reals-iters/real-<IENS>/iter-<ITER>", "/local/reals-iters"),
+        ("/local/iters/iter-<ITER>", "/local/iters"),
+        ("/local/reals/real-<IENS>", "/local/reals"),
+    ],
+)
+def test_run_path_stripped(run_path, expected):
+    assert strip_run_path_magic_keywords(run_path) == expected

--- a/tests/unit_tests/test_libres_facade.py
+++ b/tests/unit_tests/test_libres_facade.py
@@ -498,21 +498,3 @@ def test_load_gen_kw_not_sorted(storage, tmpdir, snapshot):
 
         data = ensemble.load_all_gen_kw_data()
         snapshot.assert_match(data.round(12).to_csv(), "gen_kw_unsorted")
-
-
-@pytest.mark.parametrize(
-    "run_path, expected",
-    [
-        ("", "/"),
-        ("///", "/"),
-        ("simulation/mypath", "simulation/mypath"),
-        ("/local/path", "/local/path"),
-        ("/local/reals-iters/real-<IENS>/iter-<ITER>", "/local/reals-iters"),
-        ("/local/iters/iter-<ITER>", "/local/iters"),
-        ("/local/reals/real-<IENS>", "/local/reals"),
-    ],
-)
-def test_run_path_stripped(monkeypatch, snake_oil_case_storage, run_path, expected):
-    facade = LibresFacade(snake_oil_case_storage)
-    monkeypatch.setattr("ert.libres_facade.LibresFacade.run_path", run_path)
-    assert facade.run_path_stripped == expected


### PR DESCRIPTION
Based on user request; https://equinor.slack.com/archives/CDPJULWR4/p1706009576422619

Reverted functionality introduced in commit 7532dd0c072f74d2518f4957ad32c139a9bc17c8
Cut path provided via copy button to just include valid parts, i.e. no magic strings

Green section shows what is available via the copy-button.

![Screenshot 2024-01-23 at 13 56 20](https://github.com/equinor/ert/assets/114403625/c9be037e-869c-4205-adae-0b743439bcbd)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
