### PR TITLE
Add ContextBoolEncoder to facilitate json serialization of ContextBools.

### DIFF
--- a/src/ert/config/parsing/context_values.py
+++ b/src/ert/config/parsing/context_values.py
@@ -1,8 +1,14 @@
-from typing import List, TypeVar, Union, no_type_check
+from json import JSONEncoder
+from typing import Any, List, TypeVar, Union, no_type_check
 
 from .file_context_token import FileContextToken
 
 # mypy: disable-error-code="attr-defined"
+
+
+class ContextBoolEncoder(JSONEncoder):
+    def default(self, o: Any) -> Any:
+        return o.val if isinstance(o, ContextBool) else JSONEncoder.default(self, o)
 
 
 class ContextBool:

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -20,6 +20,7 @@ from ert.config import (
     SummaryConfig,
     SurfaceConfig,
 )
+from ert.config.parsing.context_values import ContextBoolEncoder
 from ert.config.response_config import ResponseConfig
 
 if TYPE_CHECKING:
@@ -230,4 +231,4 @@ class LocalExperimentAccessor(LocalExperimentReader):
         with open(
             self.mount_point / self._simulation_arguments_file, "w", encoding="utf-8"
         ) as f:
-            json.dump(dataclasses.asdict(info), f)
+            json.dump(dataclasses.asdict(info), f, cls=ContextBoolEncoder)

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import os.path
@@ -19,6 +20,14 @@ from ert.config import (
 )
 from ert.config.ert_config import site_config_location
 from ert.config.parsing import ConfigKeys, ConfigWarning
+from ert.config.parsing.context_values import (
+    ContextBool,
+    ContextBoolEncoder,
+    ContextFloat,
+    ContextInt,
+    ContextList,
+    ContextString,
+)
 from ert.job_queue import Driver
 
 from .config_dict_generator import config_generators
@@ -1545,3 +1554,37 @@ def test_that_removed_analysis_module_keywords_raises_error(
         match=error_msg,
     ):
         _ = ErtConfig.from_file(test_config_file_name)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_context_types_are_json_serializable():
+    bf = ContextBool(val=False, token=None, keyword_token=None)
+    bt = ContextBool(val=True, token=None, keyword_token=None)
+    i = ContextInt(val=23, token=None, keyword_token=None)
+    s = ContextString(val="forty_two", token=None, keyword_token=None)
+    fl = ContextFloat(val=4.2, token=None, keyword_token=None)
+    cl = ContextList.with_values(None, values=[bf, bt, i, s, fl])
+
+    payload = {
+        "context_bool_false": bf,
+        "context_bool_true": bt,
+        "context_int": i,
+        "context_str": s,
+        "context_float": fl,
+        "context_list": cl,
+    }
+
+    with open("test.json", "w", encoding="utf-8") as f:
+        json.dump(payload, f, cls=ContextBoolEncoder)
+
+    with open("test.json", "r", encoding="utf-8") as f:
+        r = json.load(f)
+
+    assert isinstance(r["context_bool_false"], bool)
+    assert isinstance(r["context_bool_true"], bool)
+    assert r["context_bool_false"] is False
+    assert r["context_bool_true"] is True
+    assert isinstance(r["context_int"], int)
+    assert isinstance(r["context_str"], str)
+    assert isinstance(r["context_float"], float)
+    assert isinstance(r["context_list"], list)


### PR DESCRIPTION
**Issue**
Resolves #6713


**Approach**
Add a json encoder to be used when serializing objects that might contain a ContextBool class


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
