### PR TITLE
Relax requirement on return_code from mocked eclrun

### DIFF
--- a/tests/unit_tests/shared/share/test_ecl_run_new_config.py
+++ b/tests/unit_tests/shared/share/test_ecl_run_new_config.py
@@ -188,7 +188,9 @@ def test_failed_run_nonzero_returncode(monkeypatch):
     erun = ecl_run.EclRun("FOO.DATA", None)
     monkeypatch.setattr("ecl_run.EclRun.execEclipse", mock.MagicMock(return_value=1))
     with pytest.raises(
-        subprocess.CalledProcessError, match="Command .*eclrun.* non-zero exit status 1"
+        # The return code 1 is sometimes translated to 255.
+        subprocess.CalledProcessError,
+        match=r"Command .*eclrun.* non-zero exit status (1|255)\.$",
     ):
         erun.runEclipse(eclrun_config=eclrun_config)
 


### PR DESCRIPTION
The caught return code is apparently sometimes translated from 1 to 255, both variants observed on RHEL7.

**Issue**
Resolves Komodo bleeding test failure.

**Approach**
Relax test requirement.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
