### PR TITLE
Catch OSError so that Ctrl-c works for ERT

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -139,7 +139,8 @@ def run_cli(args: Namespace, _: Any = None) -> None:
 
         try:
             monitor.monitor(tracker.track())
-        except (SystemExit, KeyboardInterrupt):
+        except (SystemExit, KeyboardInterrupt, OSError):
+            # _base_service.py translates CTRL-c to OSError
             print("\nKilling simulations...")
             tracker.request_termination()
 


### PR DESCRIPTION
_base_service.py registers an interrupt handler that translates ctrl-c to an OSError. Since this is not caught, the main thread dies, but the remaining threads continue (but inherits the same interrupt handler).

**Issue**
Resolves #7025 


**Approach**
Catch 🎣 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
