### PR TITLE
Add property to check storage availability

### DIFF
--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -18,8 +18,12 @@ class ErtNotifier(QObject):
         self._is_simulation_running = False
 
     @property
+    def is_storage_available(self) -> bool:
+        return self._storage is not None
+
+    @property
     def storage(self) -> StorageReader:
-        assert self._storage is not None
+        assert self.is_storage_available
         return self._storage
 
     @property

--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -42,7 +42,7 @@ class CaseSelector(QComboBox):
         notifier.ertChanged.connect(self.populate)
         notifier.storage_changed.connect(self.populate)
 
-        if notifier._storage is not None:
+        if notifier.is_storage_available:
             self.populate()
 
     def populate(self):

--- a/src/ert/gui/tools/plugins/plugin.py
+++ b/src/ert/gui/tools/plugins/plugin.py
@@ -26,7 +26,9 @@ class Plugin:
     def __loadPlugin(self) -> "ErtPlugin":
         script_obj = ErtScript.loadScriptFromFile(self.__workflow_job.script)
         script = script_obj(
-            self.__ert, self.__notifier._storage, ensemble=self.__notifier.current_case
+            self.__ert,
+            self.__notifier._storage,
+            ensemble=self.__notifier.current_case,
         )
         return script
 


### PR DESCRIPTION
Avoids having to call notifiers private _storage

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
