### PR TITLE
Do not close main asyncio event loop of ert in scheduler

### DIFF
--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -149,14 +149,11 @@ class LegacyEnsemble(Ensemble):
                 cert=self._config.cert,
             ),
         )
-        try:
-            get_event_loop().run_until_complete(
-                self._evaluate_inner(
-                    cloudevent_unary_send=getattr(self, ce_unary_send_method_name)
-                )
+        get_event_loop().run_until_complete(
+            self._evaluate_inner(
+                cloudevent_unary_send=getattr(self, ce_unary_send_method_name)
             )
-        finally:
-            get_event_loop().close()
+        )
 
     async def _evaluate_inner(  # pylint: disable=too-many-branches
         self,


### PR DESCRIPTION
**Issue**
closing asyncio event loop from scheduler causes problems for any other part of ert that uses the main asyncio event loop.


**Approach**
deleted code that closed the event loop

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
