### PR TITLE
Use hashable type in load_responses

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -328,9 +328,7 @@ def _get_obs_and_measure_data(
                 f"Observation: {obs.name} attached to response: {group}"
             ) from e
 
-        observation_keys.append(
-            [obs.name] * len(filtered_response.observations.data.ravel())
-        )
+        observation_keys.append([obs.name] * filtered_response["observations"].size)
         observation_values.append(filtered_response["observations"].data.ravel())
         observation_errors.append(filtered_response["std"].data.ravel())
         measured_data.append(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 import numpy as np
@@ -368,9 +368,7 @@ class LocalEnsembleReader:
         return self._load_dataset(group, realizations)
 
     @lru_cache  # noqa: B019
-    def load_responses(
-        self, key: str, realizations: npt.NDArray[np.int_]
-    ) -> xr.Dataset:
+    def load_responses(self, key: str, realizations: Tuple[int]) -> xr.Dataset:
         if key not in self.experiment.response_configuration:
             raise ValueError(f"{key} is not a response")
         loaded = []
@@ -380,9 +378,7 @@ class LocalEnsembleReader:
                 raise KeyError(f"No response for key {key}, realization: {realization}")
             ds = xr.open_dataset(input_path, engine="scipy")
             loaded.append(ds)
-        response = xr.combine_nested(loaded, concat_dim="realization")
-        assert isinstance(response, xr.Dataset)
-        return response
+        return xr.combine_nested(loaded, concat_dim="realization")
 
     def load_responses_summary(self, key: str) -> xr.Dataset:
         loaded = []


### PR DESCRIPTION
All arguments must be hashable since @lru_cache is used


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
