### PR TITLE
Fix bug where one missing index.json caused no ensembles to be loaded

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -118,22 +118,21 @@ class LocalStorageReader:
 
     @no_type_check
     def _load_ensembles(self):
-        try:
-            ensembles = []
-            for ensemble_path in (self.path / "ensembles").iterdir():
+        if not (self.path / "ensembles").exists():
+            return {}
+        ensembles = []
+        for ensemble_path in (self.path / "ensembles").iterdir():
+            try:
                 ensemble = self._load_ensemble(ensemble_path)
                 ensembles.append(ensemble)
-
-            # Make sure that the ensembles are sorted by name in reverse. Given
-            # multiple ensembles with a common name, iterating over the ensemble
-            # dictionary will yield the newest ensemble first.
-            ensembles = sorted(ensembles, key=lambda x: x.started_at, reverse=True)
-            return {
-                x.id: x
-                for x in sorted(ensembles, key=lambda x: x.started_at, reverse=True)
-            }
-        except FileNotFoundError:
-            return {}
+            except FileNotFoundError:
+                continue
+        # Make sure that the ensembles are sorted by name in reverse. Given
+        # multiple ensembles with a common name, iterating over the ensemble
+        # dictionary will yield the newest ensemble first.
+        return {
+            x.id: x for x in sorted(ensembles, key=lambda x: x.started_at, reverse=True)
+        }
 
     def _load_ensemble(self, path: Path) -> Any:
         return LocalEnsembleReader(self, path)


### PR DESCRIPTION
This is not without pitfalls, as the missing ensemble could be related to an ensemble that still exists.

**Issue**
Resolves #6968 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
