### PR TITLE
Fix flakiness for gui unit_tests

### DIFF
--- a/tests/integration_tests/scheduler/test_integration_local_driver.py
+++ b/tests/integration_tests/scheduler/test_integration_local_driver.py
@@ -45,12 +45,13 @@ async def test_subprocesses_live_on_after_ert_dies(tmp_path, try_queue_and_sched
     create_ert_config(tmp_path)
 
     ert_process = subprocess.Popen(["ert", "test_run", "ert_config.ert"], cwd=tmp_path)
-    check_path_retry, check_path_max_retries = 0, 50
+    check_path_retry, check_path_max_retries = 0, 60
     expected_path = Path(tmp_path, "test_out/realization-0/iter-0/forward_model_pid")
     while not expected_path.exists() and check_path_retry < check_path_max_retries:
         check_path_retry += 1
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
 
+    assert ert_process.poll() is None
     assert expected_path.exists()
     child_process_id = expected_path.read_text(encoding="utf-8").strip()
     assert child_process_id

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -380,7 +380,7 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
         qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
         job_view = run_dialog._job_view
         qtbot.waitUntil(job_view.isVisible, timeout=20000)
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
 
         realization_widget = run_dialog.findChild(RealizationWidget)
 

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -40,7 +40,7 @@ from ert.gui.tools.plot.plot_case_selection_widget import (
     CaseSelectCheckButton,
     CaseSelectionWidget,
 )
-from ert.gui.tools.plot.plot_window import PlotWindow
+from ert.gui.tools.plot.plot_window import PlotApi, PlotWindow
 from ert.run_models import SingleTestRun
 from ert.services import StorageService
 from ert.shared.plugins.plugin_manager import ErtPluginManager
@@ -765,13 +765,13 @@ def test_that_a_failing_job_shows_error_message_with_context(
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_gui_plotter_works_when_no_data(qtbot, storage):
+def test_that_gui_plotter_works_when_no_data(qtbot, storage, monkeypatch):
+    monkeypatch.setattr(PlotApi, "_get_all_cases", lambda _: [])
     config_file = "minimal_config.ert"
     with open(config_file, "w", encoding="utf-8") as f:
         f.write("NUM_REALIZATIONS 1")
     args_mock = Mock()
     args_mock.config = config_file
-
     ert_config = ErtConfig.from_file(config_file)
     enkf_main = EnKFMain(ert_config)
     with StorageService.init_service(
@@ -782,7 +782,6 @@ def test_that_gui_plotter_works_when_no_data(qtbot, storage):
         gui.notifier.set_storage(storage)
         qtbot.addWidget(gui)
         gui.tools["Create plot"].trigger()
-
         plot_window = wait_for_child(gui, qtbot, PlotWindow)
         case_selection = get_child(plot_window, CaseSelectionWidget)
         assert isinstance(case_selection, CaseSelectionWidget)

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -279,7 +279,7 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(
         assert not run_dialog.isModal()
 
         qtbot.mouseClick(run_dialog.plot_button, Qt.LeftButton)
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
         qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
         # Ensure that once the run dialog is closed


### PR DESCRIPTION
Resolves #7071
Resolves #7042
Resolves #7070 

Improves flakiness of unit_tests/gui/test_main_window::test_that_run_dialog_can_be_closed_after_used_to_open_plots by increasing timeout time for done_button to be enabled. In a different fixture, the timeout for running the experiment is set to 200.000, while here it was only 20.000. This commit increases this timeout to 200.000.

When running some of the gui unit tests in parallell, they would share storage. This was very prevalent for the test unit_tests/gui/test_main_window.py::test_that_gui_plotter_works_when_no_data, where the PlotApi would return data from the other tests (which running esmda). This is fixed in this PR by mocking the return value from PlotApi.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
