### PR TITLE
Don't keep output in JobQueue Torque

### DIFF
--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -80,25 +80,3 @@ jobs:
         EOF
 
         time ert ensemble_experiment poly.ert
-
-
-    - name: Test Torque driver through slurm
-      run: |
-        set -e
-
-        sudo apt install slurm-wlm-torque
-
-        # Patch qstat from slurm-wlm-torque (patch is submitted upstream):
-        cp /usr/bin/qstat qstat
-        # shellcheck disable=SC2016
-        sed -i '516 i printf("    Exit_status = %s\\n", $job->{"exit_code"});' qstat
-        cp -a test-data/poly_example poly_torque
-
-        cat << EOF >> poly_torque/poly.ert
-        NUM_REALIZATIONS 5
-        QUEUE_SYSTEM TORQUE
-        QUEUE_OPTION TORQUE QSTAT_CMD $(pwd)/qstat
-        EOF
-
-        pushd poly_torque
-        time ert ensemble_experiment poly.ert

--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -324,7 +324,7 @@ static char **torque_driver_alloc_cmd(torque_driver_type *driver,
 
     argv[i++] = strdup(driver->qsub_cmd);
 
-    if (driver->keep_qsub_output) {
+    if (!driver->keep_qsub_output) {
         argv[i++] = strdup("-k");
         argv[i++] = strdup("oe");
     }


### PR DESCRIPTION
The `-k` option in `qsub` counter-intuitively means which things to discard. `-koe` means to discard both stdout and stderr of the job, which is what we want.

See: man page of OpenPBS' `qsub`.