### PR TITLE
Fix summary problems

### DIFF
--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -248,7 +248,7 @@ def _check_vals(
 
 def _read_spec(
     spec: str, fetch_keys: Sequence[str]
-) -> Tuple[int, datetime, DateUnit, List[str], npt.NDArray[np.int32]]:
+) -> Tuple[int, datetime, DateUnit, List[str], npt.NDArray[np.int64]]:
     date = None
     n = None
     nx = None
@@ -382,7 +382,7 @@ def _read_spec(
     rearranged = keys_array.argsort()
     keys_array = keys_array[rearranged]
 
-    indices_array = np.array(indices)[rearranged]
+    indices_array = np.array(indices, dtype=np.int64)[rearranged]
 
     units = arrays["UNITS   "]
     if units is None:
@@ -424,7 +424,7 @@ def _read_summary(
     summary: str,
     start_date: datetime,
     unit: DateUnit,
-    indices: npt.NDArray[np.int32],
+    indices: npt.NDArray[np.int64],
     date_index: int,
 ) -> Tuple[npt.NDArray[np.float32], List[datetime]]:
     if summary.lower().endswith("funsmry"):
@@ -463,7 +463,7 @@ def _read_summary(
             if kw == "SEQHDR  ":
                 read_params()
         read_params()
-    return np.array(values).T, dates
+    return np.array(values, dtype=np.float32).T, dates
 
 
 def _should_load_summary_key(data_key: Any, user_set_keys: Sequence[str]) -> bool:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -30,6 +30,12 @@ class SummaryConfig(ResponseConfig):
     def read_from_file(self, run_path: str, iens: int) -> xr.Dataset:
         filename = self.input_file.replace("<IENS>", str(iens))
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
+        if len(data) == 0 or len(keys) == 0:
+            # There is a bug with storing empty responses so we have
+            # to raise an error in that case
+            raise ValueError(
+                f"Did not find any summary values matching {self.keys} in {filename}"
+            )
         ds = xr.Dataset(
             {"values": (["name", "time"], data)},
             coords={"time": time_map, "name": keys},

--- a/tests/unit_tests/config/test_summary_config.py
+++ b/tests/unit_tests/config/test_summary_config.py
@@ -1,6 +1,10 @@
+import hypothesis.strategies as st
 import pytest
+from hypothesis import given
 
 from ert.config import ConfigValidationError, ErtConfig, SummaryConfig
+
+from .summary_generator import summaries
 
 
 def test_summary_config():
@@ -32,3 +36,13 @@ def test_bad_user_config_file_error_message(tmp_path):
         " the config must also specify ECLBASE",
     ):
         _ = ErtConfig.from_file(str(tmp_path / "test.ert"))
+
+
+@given(summaries(summary_keys=st.just(["WOPR:OP1"])))
+@pytest.mark.usefixtures("use_tmpdir")
+def test_rading_empty_summaries_raises(wopr_summary):
+    smspec, unsmry = wopr_summary
+    smspec.to_file("CASE.SMSPEC")
+    unsmry.to_file("CASE.UNSMRY")
+    with pytest.raises(ValueError, match="Did not find any summary values"):
+        SummaryConfig("summary", "CASE", ["WWCT:OP1"], None).read_from_file(".", 0)


### PR DESCRIPTION
**Issue**
Does not solve #6974 , but ensures that reading no summary data does not lock up storage.



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
