### PR TITLE
Fix flaky test: test_subprocesses_live_on_after_ert_dies

### DIFF
--- a/tests/integration_tests/scheduler/test_integration_local_driver.py
+++ b/tests/integration_tests/scheduler/test_integration_local_driver.py
@@ -45,12 +45,13 @@ async def test_subprocesses_live_on_after_ert_dies(tmp_path, try_queue_and_sched
     create_ert_config(tmp_path)
 
     ert_process = subprocess.Popen(["ert", "test_run", "ert_config.ert"], cwd=tmp_path)
-    check_path_retry, check_path_max_retries = 0, 50
+    check_path_retry, check_path_max_retries = 0, 60
     expected_path = Path(tmp_path, "test_out/realization-0/iter-0/forward_model_pid")
     while not expected_path.exists() and check_path_retry < check_path_max_retries:
         check_path_retry += 1
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
 
+    assert ert_process.poll() is None
     assert expected_path.exists()
     child_process_id = expected_path.read_text(encoding="utf-8").strip()
     assert child_process_id


### PR DESCRIPTION
**Issue**
Resolves #7070


**Approach**
Increased timeout period should improve the flakiness.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
