### PR TITLE
Add field and observations to state storage test

### DIFF
--- a/tests/unit_tests/config/egrid_generator.py
+++ b/tests/unit_tests/config/egrid_generator.py
@@ -267,6 +267,11 @@ class EGrid:
     file_head: Filehead
     global_grid: GlobalGrid
 
+    @property
+    def shape(self) -> Tuple[int, int, int]:
+        grid_head = self.global_grid.grid_head
+        return (grid_head.num_x, grid_head.num_y, grid_head.num_z)
+
     def to_file(
         self,
         filelike,

--- a/tests/unit_tests/storage/test_local_ensemble.py
+++ b/tests/unit_tests/storage/test_local_ensemble.py
@@ -1,6 +1,3 @@
-import os
-from datetime import datetime
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -11,8 +8,6 @@ from ert.config import GenKwConfig
 from ert.config.field import Field
 from ert.field_utils import FieldFileFormat
 from ert.storage import open_storage
-from ert.storage.local_ensemble import _Failure
-from ert.storage.realization_storage_state import RealizationStorageState
 
 
 def test_that_egrid_files_are_saved_and_loaded_correctly(tmp_path):
@@ -160,23 +155,3 @@ def test_that_loading_parameter_via_response_api_fails(tmp_path):
         )
         with pytest.raises(ValueError, match="PARAMETER is not a response"):
             prior.load_responses("PARAMETER", (0,))
-
-
-def test_get_failure(tmp_path):
-    with open_storage(tmp_path, mode="w") as storage:
-        experiment = storage.create_experiment()
-        ensemble = storage.create_ensemble(experiment, name="foo", ensemble_size=1)
-
-        error_file = ensemble._path / "realization-9" / ensemble._error_log_name
-        os.makedirs(os.path.dirname(error_file), exist_ok=True)
-
-        error = _Failure(
-            type=RealizationStorageState.PARENT_FAILURE,
-            message="Something is wrong",
-            time=datetime.now(),
-        )
-        with open(error_file, mode="w", encoding="utf-8") as f:
-            print(error.json(), file=f)
-
-        assert ensemble.get_failure(9) == error
-        assert ensemble.get_failure(8) is None


### PR DESCRIPTION
As of yet, does not replace many tests as some of the tested behavior tests all the way from config into storage. This tests only the storage interface. By adding tests that tests parameters and responses on a cli level, we can remove a lot of other tests that call `create_runpath` .

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
