### PR TITLE
Allow TORQUE driver with --enable-scheduler

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -41,11 +41,15 @@ def run_cli(args: Namespace, _: Any = None) -> None:
     # the config file to be the base name of the original config
     args.config = os.path.basename(args.config)
     ert_config = ErtConfig.from_file(args.config)
-    if (
-        FeatureToggling.is_enabled("scheduler")
-        and ert_config.queue_config.queue_system != QueueSystem.LOCAL
-    ):
-        raise ErtCliError("Scheduler only support LOCAL queue at the moment!")
+    if FeatureToggling.is_enabled(
+        "scheduler"
+    ) and ert_config.queue_config.queue_system not in [
+        QueueSystem.LOCAL,
+        QueueSystem.TORQUE,
+    ]:
+        raise ErtCliError(
+            "Scheduler only supports LOCAL and TORQUE queue at the moment!"
+        )
     local_storage_set_ert_config(ert_config)
 
     # Create logger inside function to make sure all handlers have been added to

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -103,12 +103,14 @@ def _start_initial_gui_window(
             # the config file to be the base name of the original config
             args.config = os.path.basename(args.config)
             ert_config = ErtConfig.from_file(args.config)
-            if (
-                FeatureToggling.is_enabled("scheduler")
-                and ert_config.queue_config.queue_system != QueueSystem.LOCAL
-            ):
+            if FeatureToggling.is_enabled(
+                "scheduler"
+            ) and ert_config.queue_config.queue_system not in [
+                QueueSystem.LOCAL,
+                QueueSystem.TORQUE,
+            ]:
                 raise ConfigValidationError(
-                    "Scheduler only support LOCAL queue at the moment!"
+                    "Scheduler only supports LOCAL and TORQUE queue at the moment!"
                 )
             local_storage_set_ert_config(ert_config)
             ert = EnKFMain(ert_config)


### PR DESCRIPTION
**Issue**
OpenPBS for scheduler was added earlier, but there was still a check that disallowed all but LOCAL driver when using scheduler.


**Approach**
Allow TORQUE option too

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
