### PR TITLE
Fix ert dark storage performance tests

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -87,8 +87,9 @@ def get_observations_for_obs_keys(
     ensemble: EnsembleReader, observation_keys: List[str]
 ) -> List[Dict[str, Any]]:
     observations = []
+    experiment_observations = ensemble.experiment.observations
     for key in observation_keys:
-        dataset = ensemble.experiment.observations[key]
+        dataset = experiment_observations[key]
         observation = {
             "name": key,
             "values": list(dataset["observations"].values.flatten()),
@@ -105,8 +106,9 @@ def get_observations_for_obs_keys(
 
 
 def get_observation_name(ensemble: EnsembleReader, observation_keys: List[str]) -> str:
+    observations_dict = ensemble.experiment.observations
     for key in observation_keys:
-        observation = ensemble.experiment.observations[key]
+        observation = observations_dict[key]
         if observation.response == "summary":
             return observation.name.values.flatten()[0]
         return key


### PR DESCRIPTION
Fixed ert dark storage performance tests timing out by changing src/ert/dark_storage/common.py get_observations_for_obs_keys(). Moved observations dict outside of loop to only generate dict once instead of every loop iteration.

**Issue**
Resolves #7106


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
