### PR TITLE
Fix flaky unit test test_submit_sleep_with_max_running

### DIFF
--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -403,9 +403,9 @@ async def test_submit_sleep(
 @pytest.mark.parametrize(
     "submit_sleep, realization_max_runtime, max_running",
     [
-        (0.01, 0.01, 1),
-        (0.01, 0.01, 10),
-        (0.01, 0.1, 5),
+        (0.15, 0.10, 1),
+        (0.15, 0.10, 10),
+        (0.15, 0.35, 5),
     ],
 )
 async def test_submit_sleep_with_max_running(


### PR DESCRIPTION
Fixed flaky test tests/unit_tests/scheduler/test_scheduler::test_submit_sleep_with_max_running by increasing parameters of submit_sleep and realization_max_runtime.

**Issue**
Resolves #7091

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
