### PR TITLE
Fix a performance problem with summary reading

### DIFF
--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -341,6 +341,7 @@ def _read_spec(
 
     indices: List[int] = []
     keys: List[str] = []
+    index_mapping: Dict[str, int] = {}
     date_index = None
 
     def optional_get(arr: Optional[npt.NDArray[Any]], idx: int) -> Any:
@@ -368,12 +369,13 @@ def _read_spec(
 
         key = make_summary_key(keyword, num, name, nx, ny, lgr_name, li, lj, lk)
         if key is not None and _should_load_summary_key(key, fetch_keys):
-            if key in keys:
+            if key in index_mapping:
                 # only keep the index of the last occurrence of a key
                 # this is done for backwards compatability
                 # and to have unique keys
-                indices[keys.index(key)] = i
+                indices[index_mapping[key]] = i
             else:
+                index_mapping[key] = len(indices)
                 indices.append(i)
                 keys.append(key)
 


### PR DESCRIPTION

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
