### PR TITLE
Fix slow observation parsing

### DIFF
--- a/tests/unit_tests/config/parsing/test_observations_parser.py
+++ b/tests/unit_tests/config/parsing/test_observations_parser.py
@@ -1,13 +1,25 @@
+from contextlib import suppress
 from pathlib import Path
 
+import hypothesis.extra.lark as stlark
 import pytest
+from hypothesis import given
 
 from ert.config.parsing.observations_parser import (
     ObservationConfigError,
     ObservationType,
     _parse_content,
     _validate_conf_content,
+    observations_parser,
 )
+
+observation_contents = stlark.from_lark(observations_parser)
+
+
+@given(observation_contents)
+def test_parsing_contents_succeeds_or_gives_config_error(contents):
+    with suppress(ObservationConfigError):
+        _ = _parse_content(contents, "observations.txt")
 
 
 @pytest.fixture
@@ -26,7 +38,7 @@ def file_contents():
         GENERAL_OBSERVATION WPR_DIFF_1 {
            DATA       = SNAKE_OIL_WPR_DIFF;
            INDEX_LIST = 400,800,1200,1800;
-           DATE       = 2015-06-13;  -- (RESTART = 199)
+           DATE       = 2015-06-13;-- (RESTART = 199)
            OBS_FILE   = wpr_diff_obs.txt;
         };
 
@@ -102,7 +114,7 @@ def test_parse(file_contents):
 def test_that_unexpected_character_gives_observation_config_error():
     with pytest.raises(
         ObservationConfigError,
-        match=".*i.*line 1.*include a;",
+        match="Line 1.*include a;",
     ):
         _parse_content(content="include a;", filename="")
 


### PR DESCRIPTION
Note that although there are no official behavioral changes, there might be cornercases related to "--" and values which contain "-" such as dates. This made the grammar potentially ambiguous in some cases and the previous algorithm might have backtracked to find an interpretation.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
