### PR TITLE
Don't export `ert` components at the top-level

### DIFF
--- a/docs/about/release_notes.rst
+++ b/docs/about/release_notes.rst
@@ -105,7 +105,7 @@ Examples:
 
 .. code-block:: python
 
-   from ert import ErtScript
+   from ert.config import ErtScript
 
    class AScript(ErtScript):
        stop_on_fail = True

--- a/docs/getting_started/howto/plugin_system.rst
+++ b/docs/getting_started/howto/plugin_system.rst
@@ -132,7 +132,7 @@ Minimal example:
 
 .. code-block:: python
 
-   from ert import ErtScript
+   from ert.config import ErtScript
    from ert.shared.plugins.plugin_manager import hook_implementation
 
    class MyJob(ErtScript)
@@ -148,7 +148,7 @@ Full example:
 
 .. code-block:: python
 
-   from ert import ErtScript
+   from ert.config import ErtScript
    from ert.shared.plugins.plugin_manager import hook_implementation
 
    class MyJob(ErtScript)

--- a/docs/reference/workflows/configuring_jobs.rst
+++ b/docs/reference/workflows/configuring_jobs.rst
@@ -69,7 +69,7 @@ For example, this internal job script will stop on failure
 
 ::
 
-    from ert import ErtScript
+    from ert.config import ErtScript
     class AScript(ErtScript):
         stop_on_fail = True
 

--- a/src/ert/__init__.py
+++ b/src/ert/__init__.py
@@ -1,17 +1,3 @@
 """
 Ert - Ensemble Reservoir Tool - a package for reservoir modeling.
 """
-
-from .config import ErtScript
-from .data import MeasuredData
-from .job_queue import JobStatus
-from .libres_facade import LibresFacade
-from .simulator import BatchSimulator
-
-__all__ = [
-    "MeasuredData",
-    "LibresFacade",
-    "BatchSimulator",
-    "ErtScript",
-    "JobStatus",
-]

--- a/src/ert/gui/tools/plugins/plugin.py
+++ b/src/ert/gui/tools/plugins/plugin.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, List
 
-from ert import ErtScript
+from ert.config import ErtScript
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget

--- a/src/ert/shared/hook_implementations/workflows/disable_parameters.py
+++ b/src/ert/shared/hook_implementations/workflows/disable_parameters.py
@@ -1,5 +1,5 @@
-from ert import ErtScript
 from ert.analysis.configuration import UpdateStep
+from ert.config import ErtScript
 
 
 class DisableParametersUpdate(ErtScript):

--- a/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/shared/hook_implementations/workflows/export_misfit_data.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.exceptions import StorageError
 
 
@@ -27,7 +27,7 @@ class ExportMisfitDataJob(ErtScript):
 
         if not realizations:
             raise StorageError("No responses loaded")
-        from ert import LibresFacade
+        from ert.libres_facade import LibresFacade
 
         facade = LibresFacade(ert)
         misfit = facade.load_all_misfit_data(self.ensemble)

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -4,12 +4,12 @@ import re
 import pandas
 from qtpy.QtWidgets import QCheckBox
 
-from ert import LibresFacade
 from ert.config import CancelPluginException, ErtPlugin
 from ert.gui.ertwidgets.customdialog import CustomDialog
 from ert.gui.ertwidgets.listeditbox import ListEditBox
 from ert.gui.ertwidgets.models.path_model import PathModel
 from ert.gui.ertwidgets.pathchooser import PathChooser
+from ert.libres_facade import LibresFacade
 
 
 def loadDesignMatrix(filename) -> pandas.DataFrame:

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from ert import LibresFacade
 from ert.__main__ import ert_parser
 from ert.analysis import (
     ErtAnalysisError,
@@ -25,6 +24,7 @@ from ert.cli import ENSEMBLE_SMOOTHER_MODE
 from ert.cli.main import run_cli
 from ert.config import AnalysisConfig, ErtConfig, GenDataConfig, GenKwConfig
 from ert.config.analysis_module import ESSettings
+from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
 from ert.storage.realization_storage_state import RealizationStorageState
 

--- a/tests/integration_tests/cli/test_integration_cli.py
+++ b/tests/integration_tests/cli/test_integration_cli.py
@@ -14,7 +14,6 @@ import pandas as pd
 import pytest
 
 import ert.shared
-from ert import LibresFacade
 from ert.__main__ import ert_parser
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
@@ -26,6 +25,7 @@ from ert.cli import (
 from ert.cli.main import ErtCliError, run_cli
 from ert.config import ErtConfig
 from ert.enkf_main import sample_prior
+from ert.libres_facade import LibresFacade
 from ert.shared.feature_toggling import FeatureToggling
 from ert.storage import open_storage
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -434,7 +434,7 @@ def test_that_setenv_sets_environment_variables_in_jobs(
             ),
             "failing_ert_script.py",
             """
-from ert import ErtScript
+from ert.config import ErtScript
 class AScript(ErtScript):
     stop_on_fail = True
 
@@ -453,7 +453,7 @@ class AScript(ErtScript):
             ),
             "failing_ert_script.py",
             """
-from ert import ErtScript
+from ert.config import ErtScript
 class AScript(ErtScript):
     stop_on_fail = True
 

--- a/tests/performance_tests/enkf/test_load_state.py
+++ b/tests/performance_tests/enkf/test_load_state.py
@@ -1,5 +1,5 @@
-from ert import LibresFacade
 from ert.config import ErtConfig
+from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
 
 

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -385,7 +385,7 @@ def test_that_get_plugin_jobs_fetches_exactly_ert_plugins():
         fh.write(
             dedent(
                 """
-                from ert import ErtScript
+                from ert.config import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass
@@ -806,7 +806,7 @@ def test_that_magic_strings_get_substituted_in_workflow():
         fh.write(
             dedent(
                 """
-                from ert import ErtScript
+                from ert.config import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass
@@ -1320,7 +1320,7 @@ def test_parsing_workflow_with_multiple_args():
         fh.write(
             dedent(
                 """
-                from ert import ErtScript
+                from ert.config import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass

--- a/tests/unit_tests/job_queue/test_ert_script.py
+++ b/tests/unit_tests/job_queue/test_ert_script.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ert import ErtScript
+from ert.config import ErtScript
 
 from .workflow_common import WorkflowCommon
 
@@ -48,7 +48,7 @@ def test_ert_script_from_file():
         f.write("from ert import DoesNotExist\n")
 
     with open("empty_script.py", "w", encoding="utf-8") as f:
-        f.write("from ert import ErtScript\n")
+        f.write("from ert.config import ErtScript\n")
 
     script_object = ErtScript.loadScriptFromFile("subtract_script.py")
 

--- a/tests/unit_tests/job_queue/test_workflow_job.py
+++ b/tests/unit_tests/job_queue/test_workflow_job.py
@@ -107,7 +107,7 @@ def test_stop_on_fail_is_parsed_internal():
     with open("fail_script.py", "w+", encoding="utf-8") as f:
         f.write(
             """
-from ert import ErtScript
+from ert.config import ErtScript
 
 class SevereErtFailureScript(ErtScript):
     def __init__(self, ert, storage, ensemble=None):

--- a/tests/unit_tests/job_queue/workflow_common.py
+++ b/tests/unit_tests/job_queue/workflow_common.py
@@ -43,7 +43,7 @@ class WorkflowCommon:
     @staticmethod
     def createErtScriptsJob():
         with open("subtract_script.py", "w", encoding="utf-8") as f:
-            f.write("from ert import ErtScript\n")
+            f.write("from ert.config import ErtScript\n")
             f.write("\n")
             f.write("class SubtractScript(ErtScript):\n")
             f.write("    def run(self, arg1, arg2):\n")
@@ -60,7 +60,7 @@ class WorkflowCommon:
     @staticmethod
     def createWaitJob():  # noqa: PLR0915
         with open("wait_job.py", "w", encoding="utf-8") as f:
-            f.write("from ert import ErtScript\n")
+            f.write("from ert.config import ErtScript\n")
             f.write("import time\n")
             f.write("\n")
             f.write("class WaitScript(ErtScript):\n")

--- a/tests/unit_tests/scenarios/test_summary_response.py
+++ b/tests/unit_tests/scenarios/test_summary_response.py
@@ -9,11 +9,11 @@ import pandas as pd
 import pytest
 from resdata.summary import Summary
 
-from ert import LibresFacade
 from ert.analysis import ErtAnalysisError, UpdateConfiguration, smoother_update
 from ert.config import ErtConfig
 from ert.data import MeasuredData
 from ert.enkf_main import sample_prior
+from ert.libres_facade import LibresFacade
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_summary_response.py
+++ b/tests/unit_tests/test_summary_response.py
@@ -3,9 +3,9 @@ import shutil
 from pathlib import Path
 from textwrap import dedent
 
-from ert import LibresFacade
 from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context
+from ert.libres_facade import LibresFacade
 
 
 def test_load_summary_response_restart_not_zero(tmpdir, snapshot, request, storage):


### PR DESCRIPTION
This is to make it snappier to import eg. `ert.storage`.

---

To accomplish this well I've been looking for dependants on Ert and fixing them. However, this will probably explode in some user's faces so we should be up-front about it with them.

This is also a breaking change.