### PR TITLE
Filter out deprecation warnings from main entry point

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -5,6 +5,7 @@ import logging.config
 import os
 import re
 import sys
+import warnings
 from argparse import ArgumentParser, ArgumentTypeError
 from typing import Any, Dict, Optional, Sequence, Union
 from uuid import UUID
@@ -531,6 +532,7 @@ def log_process_usage() -> None:
 def main() -> None:
     import locale
 
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     locale.setlocale(locale.LC_NUMERIC, "C")
 
     args = ert_parser(None, sys.argv[1:])

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -5,6 +5,7 @@ import logging.config
 import os
 import socket
 import sys
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
@@ -177,6 +178,7 @@ if __name__ == "__main__":
     with open(STORAGE_LOG_CONFIG, encoding="utf-8") as conf_file:
         logging_conf = yaml.safe_load(conf_file)
         logging.config.dictConfig(logging_conf)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     uvicorn.config.LOGGING_CONFIG.clear()
     uvicorn.config.LOGGING_CONFIG.update(logging_conf)
     terminate_on_parent_death()


### PR DESCRIPTION
**Issue**
Resolves #7051


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
