### PR TITLE
Use newer macOS runners and build and test using also python 3.11 & 3.12

### DIFF
--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Upload wheel as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: macos-latest Python ${{ inputs.python-version }} wheel
+        name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
         path: dist/*

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-13-xl']
 
     runs-on: ${{ matrix.os }}
 
@@ -93,13 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        os: [ 'macos-latest', 'macos-latest-xlarge' ]
-        exclude: # m1 runner macos-latest-xlarge does not have python < 3.10
-          - os: macos-latest-xlarge
-            python-version: '3.8'
-          - os: macos-latest-xlarge
-            python-version: '3.9'
+        python-version: [ '3.10', '3.11', '3.12' ]
+        os: [ 'macos-13-xl' ]
 
     uses: ./.github/workflows/build-wheels-macos.yml
     with:
@@ -148,8 +143,8 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
-        python-version: [ '3.10' ]
-        os: [ macos-latest ]
+        python-version: [ '3.10', '3.11', '3.12' ]
+        os: [ 'macos-13-xl' ]
     uses: ./.github/workflows/test_ert.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -21,14 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13-xl]
         exclude:
         - python-version: '3.8'
-          os: macos-latest
-        - python-version: '3.10'
-          os: macos-latest
-        - python-version: '3.11'
-          os: macos-latest
+          os: macos-13-xl
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Our MacOS builds currently use the outdates `macos-latest` runners.
In this PR I've updated the runners, and performed some testing as a step to investigate which os versions and architecture types that would make most sense to update to.

Closing in on the summer 2024, GitHub have planned to update the `-latest` tags to the brand new beta macos-14 runners.

tldr; Consistently passes on ARM architecture macOS-13-xl runners, fails sometimes on regular x64 macos-13 runners.

The pricing scheme on the xl-runners are slightly higher than the regular ones, but this is mitigated by the fact that the runners are faster than the original ones, evening out the costs.

Moving to macOS-13-xl runners seem to be the safest and most logical move.

Added testing notes;

```
https://github.com/equinor/ert/actions/runs/7901919557/job/21566490730?pr=7140
Wed 14.2.24 14.43
test-mac (unit-tests, 3.11, macos-13)
test-mac (unit-tests, 3.12, macos-13)

Wed 14.2.24 14.44
All passed

https://github.com/equinor/ert/actions/runs/7901919557/job/21568051049?pr=7140
Wed 14.2.24 15.03
test-mac (integration-tests, 3.12, macos-13)
test-mac (unit-tests, 3.12, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21569323458?pr=7140
Wed 14.2.24 15.33
test-mac (unit-tests, 3.10, macos-13)
test-mac (unit-tests, 3.11, macos-13)
test-mac (unit-tests, 3.12, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21570709432?pr=7140
Wed 14.2.24 16.05
test-mac (unit-tests, 3.12, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21572282484?pr=7140
Wed 14.2.24 16.41
test-mac (unit-tests, 3.12, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21576900664?pr=7140
Wed 14.2.24 18.08
test-mac (integration-tests, 3.12, macos-13)

Wed 14.2.24 18.43
All passed

Wed 14.2.24 20.31
All passed

https://github.com/equinor/ert/actions/runs/7901919557/job/21586085532?pr=7140
Wed 14.2.24 23.00
test-mac (unit-tests, 3.11, macos-13)
test-mac (unit-tests, 3.12, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21597271018?pr=7140
Thu 15.2.24 07.39
test-mac (unit-tests, 3.10, macos-13)
test-mac (unit-tests, 3.11, macos-13)
test-mac (unit-tests, 3.12, macos-13)
test-mac (gui-test, 3.10, macos-13)

https://github.com/equinor/ert/actions/runs/7901919557/job/21604916038?pr=7140
Thu 15.2.24 11.42
test-mac (unit-tests, 3.11, macos-13)
```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
