### PR TITLE
Fix a regression of using REFCASE with extension

### DIFF
--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -211,6 +211,11 @@ def _find_file_matching(
 
 
 def _get_summary_filenames(filepath: str) -> Tuple[str, str]:
+    if filepath.lower().endswith(".data"):
+        # For backwards compatability, it is
+        # allowed to give REFCASE and ECLBASE both
+        # with and without .DATA extensions
+        filepath = filepath[:-5]
     summary = _find_file_matching("unified summary file", filepath, _is_unsmry)
     spec = _find_file_matching("smspec file", filepath, _is_smspec)
     return summary, spec

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -682,6 +682,7 @@ def test_that_out_of_bounds_segments_are_truncated(tmpdir, start, stop, message)
             ErtConfig.from_file("config.ert")
 
 
+@pytest.mark.parametrize("with_ext", [True, False])
 @pytest.mark.parametrize(
     "keys",
     [
@@ -689,14 +690,14 @@ def test_that_out_of_bounds_segments_are_truncated(tmpdir, start, stop, message)
         [("WWIR", "SM3/DAY", "WNAME"), ("WWIRH", "SM3/DAY", "WNAME")],
     ],
 )
-def test_that_history_observations_are_loaded(tmpdir, keys):
+def test_that_history_observations_are_loaded(tmpdir, keys, with_ext):
     with tmpdir.as_cwd():
         config = dedent(
-            """
+            f"""
         NUM_REALIZATIONS 2
 
         ECLBASE ECLIPSE_CASE
-        REFCASE ECLIPSE_CASE
+        REFCASE ECLIPSE_CASE{".DATA" if with_ext else ""}
         OBS_CONFIG observations
         """
         )


### PR DESCRIPTION
Fixes summary loading when ECLBASE contains ".DATA" extension.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
