### PR TITLE
Gather all observation configuration errors before reporting to user

### DIFF
--- a/tests/unit_tests/config/parsing/test_observations_parser.py
+++ b/tests/unit_tests/config/parsing/test_observations_parser.py
@@ -19,7 +19,7 @@ observation_contents = stlark.from_lark(observations_parser)
 @given(observation_contents)
 def test_parsing_contents_succeeds_or_gives_config_error(contents):
     with suppress(ObservationConfigError):
-        _ = _parse_content(contents, "observations.txt")
+        _ = _validate_conf_content(".", _parse_content(contents, "observations.txt"))
 
 
 @pytest.fixture

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -244,7 +244,7 @@ def test_that_having_no_refcase_but_history_observations_causes_exception(tmpdir
 
         with pytest.raises(
             expected_exception=ObservationConfigError,
-            match="Missing REFCASE or TIME_MAP",
+            match="REFCASE is required for HISTORY_OBSERVATION",
         ):
             ErtConfig.from_file("config.ert")
 
@@ -517,7 +517,7 @@ def run_sim(start_date, keys=None, values=None, days=None):
             pytest.raises(
                 ObservationConfigError,
                 match=r"Could not find 2014-09-12 00:00:00 \(DAYS=2.0\)"
-                " in the time map for observation FOPR_1",
+                " in the time map for observations FOPR_1",
             ),
             id="Outside tolerance days",
         ),
@@ -528,7 +528,7 @@ def run_sim(start_date, keys=None, values=None, days=None):
             pytest.raises(
                 ObservationConfigError,
                 match=r"Could not find 2014-09-12 00:00:00 \(HOURS=48.0\)"
-                " in the time map for observation FOPR_1",
+                " in the time map for observations FOPR_1",
             ),
             id="Outside tolerance hours",
         ),
@@ -539,7 +539,7 @@ def run_sim(start_date, keys=None, values=None, days=None):
             pytest.raises(
                 ObservationConfigError,
                 match=r"Could not find 2014-09-12 00:00:00 \(DATE=2014-09-12\)"
-                " in the time map for observation FOPR_1",
+                " in the time map for observations FOPR_1",
             ),
             id="Outside tolerance in date",
         ),


### PR DESCRIPTION
Gather observation errors instead of failing on first one and add location context to them when possible

**Issue**
Resolves #6999 


**Approach**
collecting errors instead of failing immediately.
used ObservationConfigError to add location information about the parsed token that failed.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
