### PR TITLE
Ensure SummaryConfig cannot be created with no keys

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -99,6 +99,18 @@ class ErtConfig:
             else os.getcwd()
         )
         self.enkf_obs: EnkfObs = self._create_observations()
+        if (
+            "summary" in self.ensemble_config
+            and len(self.ensemble_config["summary"].keys) == 0
+        ):
+            # There is a bug with storing empty responses so we have
+            # to warn that the forward model fails in this case
+            # https://github.com/equinor/ert/issues/6974
+            ConfigWarning.ert_context_warn(
+                "Setting ECLBASE without using SUMMARY, SUMMARY_OBSERVATION, "
+                "or HISTORY_OBSERVATION most likely causes the forward model to fail."
+                "To silence this warning just add 'SUMMARY *' to your config file.",
+            )
         self.observations: Dict[str, xr.Dataset] = self.enkf_obs.datasets
 
     @classmethod

--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -98,6 +98,11 @@ class EnkfObs:
         history_type: Optional[HistorySource],
         time_len: int,
     ) -> Dict[str, ObsVector]:
+        if "summary" not in ensemble_config:
+            raise ObservationConfigError.with_context(
+                "In order to use history observation, ECLBASE has to be set",
+                summary_key,
+            )
         response_config = ensemble_config["summary"]
         assert isinstance(response_config, SummaryConfig)
 
@@ -105,7 +110,9 @@ class EnkfObs:
         if refcase is None:
             raise ObservationConfigError("REFCASE is required for HISTORY_OBSERVATION")
         if history_type is None:
-            raise ValueError("Need a history type in order to use history observations")
+            raise ObservationConfigError(
+                "Need a history type in order to use history observations"
+            )
 
         if summary_key not in response_config.keys:
             response_config.keys.append(summary_key)
@@ -274,6 +281,11 @@ class EnkfObs:
         time_map: List[datetime],
     ) -> Dict[str, ObsVector]:
         summary_key = summary_dict["KEY"]
+        if "summary" not in ensemble_config:
+            raise ObservationConfigError.with_context(
+                "In order to use summary observation, ECLBASE has to be set",
+                obs_key,
+            )
         summary_config = ensemble_config["summary"]
         assert isinstance(summary_config, SummaryConfig)
         if summary_key not in summary_config.keys:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -31,6 +31,7 @@ class SummaryConfig(ResponseConfig):
         filename = self.input_file.replace("<IENS>", str(iens))
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
         if len(data) == 0 or len(keys) == 0:
+            # https://github.com/equinor/ert/issues/6974
             # There is a bug with storing empty responses so we have
             # to raise an error in that case
             raise ValueError(

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -113,6 +113,23 @@ def test_date_parsing_in_observations(datestring, errors):
             ErtConfig.from_file("config.ert")
 
 
+def test_that_using_summary_observations_without_eclbase_shows_user_error():
+    config_text = dedent(
+        """
+        NUM_REALIZATIONS 1
+        OBS_CONFIG observations_config
+        """
+    )
+    Path("observations_config").write_text(
+        "SUMMARY_OBSERVATION FOPR_1 "
+        "{ KEY=FOPR; VALUE=1; ERROR=1; DATE=2023-03-15; };",
+        encoding="utf-8",
+    )
+    Path("config.ert").write_text(config_text, encoding="utf-8")
+    with pytest.raises(ObservationConfigError, match="ECLBASE has to be set"):
+        ErtConfig.from_file("config.ert")
+
+
 def test_observations(minimum_case):
     observations = minimum_case.enkf_obs
     count = 10

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -159,6 +159,7 @@ parameter_configs = st.lists(
         st.builds(SurfaceConfig),
     ),
     unique_by=lambda x: x.name,
+    min_size=1,
 )
 
 response_configs = st.lists(
@@ -172,11 +173,12 @@ response_configs = st.lists(
             input_file=st.text(
                 alphabet=st.characters(min_codepoint=65, max_codepoint=90)
             ),
-            keys=st.lists(summary_keys, max_size=3),
+            keys=st.lists(summary_keys, max_size=3, min_size=1),
             refcase=st.just(None),
         ),
     ),
     unique_by=lambda x: x.name,
+    min_size=1,
 )
 
 ensemble_sizes = st.integers(min_value=1, max_value=1000)
@@ -404,11 +406,11 @@ class StatefulStorageTest(RuleBasedStateMachine):
         model_ensemble = Ensemble(ensemble.id)
         model_experiment.ensembles[ensemble.id] = model_ensemble
 
-        # https://github.com/equinor/ert/issues/7046
-        # assert (
-        #    ensemble.get_ensemble_state()
-        #    == [RealizationStorageState.UNDEFINED] * ensemble_size
-        # )
+        assert (
+            ensemble.get_ensemble_state()
+            == [RealizationStorageState.UNDEFINED] * ensemble_size
+        )
+        assert np.all(np.logical_not(ensemble.get_realization_mask_with_responses()))
 
         return model_ensemble
 
@@ -426,11 +428,10 @@ class StatefulStorageTest(RuleBasedStateMachine):
         assert ensemble in self.storage.ensembles
         model_ensemble = Ensemble(ensemble.id)
         self.model[experiment_id].ensembles[ensemble.id] = model_ensemble
-        # https://github.com/equinor/ert/issues/7046
-        # assert (
-        #    ensemble.get_ensemble_state()
-        #    == [RealizationStorageState.PARENT_FAILURE] * size
-        # )
+        assert (
+            ensemble.get_ensemble_state()
+            == [RealizationStorageState.PARENT_FAILURE] * size
+        )
 
         return model_ensemble
 


### PR DESCRIPTION
Resolves #7046 

* Ensures good behavior regarding setting ECLBASE but not using it.
* Document behavior of existence check in local_ensemble
* Updates and refactors stateful storage test to reflect this behavior


![image](https://github.com/equinor/ert/assets/32731672/24db15fd-71a3-4697-b693-2e30699d2935)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
