### PR TITLE
Always say job has started if an event is received

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -19,7 +19,7 @@ from ert.async_utils import background_tasks
 from ert.constant_filenames import CERT_FILE
 from ert.job_queue.queue import EVTYPE_ENSEMBLE_CANCELLED, EVTYPE_ENSEMBLE_STOPPED
 from ert.scheduler.driver import Driver
-from ert.scheduler.event import FinishedEvent, StartedEvent
+from ert.scheduler.event import FinishedEvent
 from ert.scheduler.job import Job
 from ert.scheduler.job import State as JobState
 
@@ -218,7 +218,8 @@ class Scheduler:
         while True:
             event = await self.driver.event_queue.get()
             job = self._jobs[event.iens]
-            if isinstance(event, StartedEvent):
+            if not job.started.is_set():
+                # Any event implies the job has at least started
                 job.started.set()
             elif isinstance(event, FinishedEvent):
                 if event.aborted:


### PR DESCRIPTION
If the queue system is very quick and the polling time period is long enough, the driver will never observe the job while it is in its running state.
