### PR TITLE
Ensure local queue in tests with site config

### DIFF
--- a/tests/integration_tests/storage/test_field_parameter.py
+++ b/tests/integration_tests/storage/test_field_parameter.py
@@ -25,6 +25,8 @@ def test_field_param_update(tmpdir):
         config = dedent(
             """
             NUM_REALIZATIONS 5
+            QUEUE_SYSTEM LOCAL
+            MAX_RUNNING 5
             OBS_CONFIG observations
 
             FIELD MY_PARAM PARAMETER my_param.grdecl INIT_FILES:my_param.grdecl FORWARD_INIT:True

--- a/tests/integration_tests/storage/test_parameter_sample_types.py
+++ b/tests/integration_tests/storage/test_parameter_sample_types.py
@@ -79,6 +79,7 @@ def storage(tmp_path):
         yield storage
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_str, expected, extra_files, expectation",
@@ -139,6 +140,7 @@ def test_gen_kw(storage, tmpdir, config_str, expected, extra_files, expectation)
             )
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_str, expected, extra_files",
@@ -195,6 +197,7 @@ def test_gen_kw_templating(
         )
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "relpath",
@@ -227,6 +230,7 @@ def test_gen_kw_outfile_will_use_paths(tmpdir, storage, relpath: str):
         assert os.path.exists(f"simulations/realization-0/iter-0/{relpath}kw.txt")
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_str, expected, extra_files",
@@ -267,6 +271,7 @@ def test_that_order_of_input_in_user_input_is_abritrary_for_gen_kw_init_files(
         )
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize("load_forward_init", [True, False])
 def test_gen_kw_forward_init(tmpdir, storage, load_forward_init):
@@ -309,6 +314,7 @@ def test_gen_kw_forward_init(tmpdir, storage, load_forward_init):
             assert value == 1.31
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 def test_surface_param_update(tmpdir):
     """Full update with a surface parameter, it mirrors the poly example,
@@ -318,7 +324,7 @@ def test_surface_param_update(tmpdir):
     with tmpdir.as_cwd():
         config = f"""
 NUM_REALIZATIONS {ensemble_size}
-QUEUE_OPTION LOCAL MAX_RUNNING 5
+QUEUE_OPTION LOCAL MAX_RUNNING {ensemble_size}
 OBS_CONFIG observations
 SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:surf.irap BASE_SURFACE:surf.irap FORWARD_INIT:True
 GEN_DATA MY_RESPONSE RESULT_FILE:gen_data_%d.out REPORT_STEPS:0 INPUT_FORMAT:ASCII
@@ -483,6 +489,7 @@ def test_field_param_memory(tmpdir):
         run_poly()
 
 
+@pytest.mark.usefixtures("set_site_config")
 def create_poly_with_field(field_dim: Tuple[int, int, int], realisations: int):
     """
     This replicates the poly example, only it uses FIELD parameter
@@ -577,6 +584,7 @@ def run_poly():
     run_cli(parsed)
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_str, expected",

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -275,6 +275,7 @@ expected_vars = {
 }
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.scheduler
 def test_that_setenv_config_is_parsed_correctly(
     setenv_config, monkeypatch, try_queue_and_scheduler
@@ -284,6 +285,7 @@ def test_that_setenv_config_is_parsed_correctly(
     assert config.env_vars == expected_vars
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.scheduler
 def test_that_setenv_sets_environment_variables_in_jobs(
     setenv_config, monkeypatch, try_queue_and_scheduler

--- a/tests/integration_tests/test_observation_times.py
+++ b/tests/integration_tests/test_observation_times.py
@@ -68,6 +68,8 @@ def test_small_time_mismatches_are_ignored(
         dedent(
             f"""
             NUM_REALIZATIONS 2
+            QUEUE_SYSTEM LOCAL
+            MAX_RUNNING 2
             ECLBASE CASE
             SUMMARY FOPR
             MAX_SUBMIT 1

--- a/tests/integration_tests/test_parameter_example.py
+++ b/tests/integration_tests/test_parameter_example.py
@@ -23,6 +23,8 @@ from .run_cli import run_cli
 
 config_contents = """
         NUM_REALIZATIONS {num_realizations}
+        QUEUE_SYSTEM LOCAL
+        MAX_RUNNING {num_realizations}
         FIELD PARAM_A  PARAMETER PARAM_A.grdecl  INIT_FILES:PARAM_A%d.grdecl
         FIELD AFI      PARAMETER AFI.grdecl      INIT_FILES:AFI.grdecl FORWARD_INIT:True
         FIELD A_ROFF   PARAMETER A_ROFF.roff     INIT_FILES:A_ROFF%d.roff

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -525,7 +525,7 @@ def test_run_dialog_memory_usage_showing(
 
 
 @pytest.mark.scheduler
-@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 def test_that_gui_runs_a_minimal_example(
     qtbot: QtBot, storage, try_queue_and_scheduler
 ):

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -120,6 +120,7 @@ def test_gui_iter_num(monkeypatch, qtbot):
     assert sim_panel.getSimulationArguments().iter_num == 10
 
 
+@pytest.mark.usefixtures("set_site_config")
 @pytest.mark.parametrize(
     "config, expected_message_types",
     [
@@ -167,6 +168,7 @@ def test_that_the_ui_show_no_errors_and_enables_update_for_poly_example(qapp):
         assert gui.windowTitle() == "ERT - poly.ert"
 
 
+@pytest.mark.usefixtures("set_site_config")
 def test_gui_shows_a_warning_and_disables_update_when_there_are_no_observations(
     qapp, tmp_path
 ):
@@ -216,7 +218,7 @@ def test_gui_shows_a_warning_and_disables_update_when_parameters_are_missing(
 
 
 @pytest.mark.scheduler
-@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 def test_that_run_dialog_can_be_closed_after_used_to_open_plots(
     qtbot, storage, try_queue_and_scheduler
 ):
@@ -293,6 +295,7 @@ def test_that_run_dialog_can_be_closed_after_used_to_open_plots(
             plot_window._central_tab.setCurrentWidget(tab)
 
 
+@pytest.mark.usefixtures("set_site_config")
 def test_help_buttons_in_suggester_dialog(tmp_path, qtbot):
     """
     WHEN I am shown an error in the gui
@@ -329,6 +332,7 @@ def test_that_run_workflow_component_disabled_when_no_workflows(qapp):
         assert not run_workflow_button.isEnabled()
 
 
+@pytest.mark.usefixtures("set_site_config")
 def test_that_run_workflow_component_enabled_when_workflows(qapp, tmp_path):
     config_file = tmp_path / "config.ert"
 
@@ -764,7 +768,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
 
 
-@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 def test_that_gui_plotter_works_when_no_data(qtbot, storage, monkeypatch):
     monkeypatch.setattr(PlotApi, "_get_all_cases", lambda _: [])
     config_file = "minimal_config.ert"


### PR DESCRIPTION
site config can be set by environment, so ensure tests run local queue even though site config specifies e.g. LSF.



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
