### PR TITLE
Fix incorrect import of xtgeo.gridproperty_from_file

### DIFF
--- a/tests/integration_tests/storage/test_field_parameter.py
+++ b/tests/integration_tests/storage/test_field_parameter.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
             )
 
             # check shapre of written data
-            prop0 = xtgeo.grid_property.gridproperty_from_file(
+            prop0 = xtgeo.gridproperty_from_file(
                 "simulations/realization-0/iter-0/my_param.grdecl",
                 fformat="grdecl",
                 grid=grid,
@@ -290,7 +290,7 @@ if __name__ == "__main__":
                 np.logical_not(prop0.values1d.mask), mask_list
             )
 
-            prop1 = xtgeo.grid_property.gridproperty_from_file(
+            prop1 = xtgeo.gridproperty_from_file(
                 "simulations/realization-0/iter-0/my_param.grdecl",
                 fformat="grdecl",
                 grid=grid,


### PR DESCRIPTION
Fixes an import of xtgeo which is being deprecated (the function is re-exported in `xtgeo`).


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
