### PR TITLE
Remove cwd argument from python drivers

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -21,7 +21,13 @@ class Driver(ABC):
 
     @abstractmethod
     async def submit(
-        self, iens: int, executable: str, /, *args: str, cwd: str, name: str = "dummy"
+        self,
+        iens: int,
+        executable: str,
+        /,
+        *args: str,
+        name: str = "dummy",
+        runpath: Optional[str] = None,
     ) -> None:
         """Submit a program to execute on the cluster.
 

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -99,8 +99,9 @@ class Job:
             await self.driver.submit(
                 self.real.iens,
                 self.real.job_script,
-                cwd=self.real.run_arg.runpath,
+                self.real.run_arg.runpath,
                 name=self.real.run_arg.job_name,
+                runpath=self.real.run_arg.runpath,
             )
 
             await self._send(State.PENDING)

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -179,9 +179,13 @@ def copy_lsf_poly_case(copy_poly_case, tmp_path):
     "try_queue_and_scheduler",
     "monkeypatch",
 )
-@pytest.mark.scheduler(skip=True)  # Scheduler-LSF-driver does not support flaky bsub
+@pytest.mark.scheduler()
 @pytest.mark.integration_test
-def test_run_mocked_lsf_queue():
+def test_run_mocked_lsf_queue(request):
+    if "fail" in request.node.name and "scheduler" in request.node.name:
+        pytest.skip(
+            "Python LSF driver does not support general resubmission on bsub errors"
+        )
     run_cli(
         ert_parser(
             ArgumentParser(prog="test_main"),

--- a/tests/integration_tests/scheduler/bin/qsub
+++ b/tests/integration_tests/scheduler/bin/qsub
@@ -24,7 +24,7 @@ jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid="test${RANDOM}.localhost"
 
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
-cat <&0 > "${jobdir}/${jobid}.script"
+echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 
 bash "$(dirname $0)/runner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -48,13 +48,13 @@ async def poll(driver: Driver, expected: Set[int], *, started=None, finished=Non
 @pytest.mark.integration_test
 async def test_submit(tmp_path):
     driver = LsfDriver()
-    await driver.submit(0, f"echo test > {tmp_path}/test", cwd=str(tmp_path))
+    await driver.submit(0, f"echo test > {tmp_path}/test")
     await poll(driver, {0})
 
-    assert (tmp_path / "test").read_text(encoding="utf-8") == f"test {tmp_path}\n"
+    assert (tmp_path / "test").read_text(encoding="utf-8") == "test\n"
 
 
-async def test_submit_something_that_fails(tmp_path):
+async def test_submit_something_that_fails():
     driver = LsfDriver()
     finished_called = False
 
@@ -65,14 +65,14 @@ async def test_submit_something_that_fails(tmp_path):
         nonlocal finished_called
         finished_called = True
 
-    await driver.submit(0, "exit 1", cwd=str(tmp_path))
+    await driver.submit(0, "exit 1")
     await poll(driver, {0}, finished=finished)
 
     assert finished_called
 
 
 @pytest.mark.timeout(5)
-async def test_kill(tmp_path):
+async def test_kill():
     driver = LsfDriver()
     aborted_called = False
 
@@ -88,7 +88,7 @@ async def test_kill(tmp_path):
         nonlocal aborted_called
         aborted_called = True
 
-    await driver.submit(0, "sleep 3", cwd=str(tmp_path))
+    await driver.submit(0, "sleep 3")
     await poll(driver, {0}, started=started, finished=finished)
     assert aborted_called
 
@@ -96,7 +96,7 @@ async def test_kill(tmp_path):
 async def test_job_name():
     driver = LsfDriver()
     iens: int = 0
-    await driver.submit(iens, "sleep 99", cwd=".", name="my_job_name")
+    await driver.submit(iens, "sleep 99", name="my_job_name")
     jobid = driver._iens2jobid[iens]
     bjobs_process = await asyncio.create_subprocess_exec(
         "bjobs",

--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -54,16 +54,14 @@ async def poll(driver: Driver, expected: Set[int], *, started=None, finished=Non
 @pytest.mark.integration_test
 async def test_submit(tmp_path):
     driver = OpenPBSDriver()
-    await driver.submit(
-        0, "sh", "-c", f"echo test > {tmp_path}/test", cwd=str(tmp_path)
-    )
+    await driver.submit(0, f"echo test > {tmp_path}/test")
     await poll(driver, {0})
 
     assert (tmp_path / "test").read_text() == "test\n"
 
 
 @pytest.mark.integration_test
-async def test_returncode(tmp_path):
+async def test_returncode():
     driver = OpenPBSDriver()
     finished_called = False
 
@@ -75,13 +73,13 @@ async def test_returncode(tmp_path):
         nonlocal finished_called
         finished_called = True
 
-    await driver.submit(0, "sh", "-c", "exit 42", cwd=str(tmp_path))
+    await driver.submit(0, "exit 42")
     await poll(driver, {0}, finished=finished)
     assert finished_called
 
 
 @pytest.mark.integration_test
-async def test_kill(tmp_path):
+async def test_kill():
     driver = OpenPBSDriver()
     aborted_called = False
 
@@ -97,7 +95,7 @@ async def test_kill(tmp_path):
         nonlocal aborted_called
         aborted_called = True
 
-    await driver.submit(0, "sh", "-c", "sleep 60; exit 2", cwd=str(tmp_path))
+    await driver.submit(0, "sleep 60; exit 2")
     await poll(driver, {0}, started=started, finished=finished)
     assert aborted_called
 

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -112,7 +112,8 @@ async def test_job_submit_and_run_once(
     scheduler.driver.submit.assert_called_with(
         realization.iens,
         realization.job_script,
-        cwd=realization.run_arg.runpath,
+        realization.run_arg.runpath,
         name=realization.run_arg.job_name,
+        runpath=realization.run_arg.runpath,
     )
     scheduler.driver.submit.assert_called_once()


### PR DESCRIPTION
Whether to change directory to anything is the responsibility of the submitted script, the driver will not any longer guarantee it.

This makes it possible to unify the PBS and the LSF driver slightly.

The LSF driver still wants to write to lsf_info.json, thus it needs to know the runpath.

**Issue**
Resolves #7147  (it does not do exactly as suggested in the issue, but it will make it reproducible from the logs by going directly to job_dispatch as for LSF)

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
