### PR TITLE
Use get function instead of if block

### DIFF
--- a/src/ert/gui/plottery/plots/histogram.py
+++ b/src/ert/gui/plottery/plots/histogram.py
@@ -139,7 +139,7 @@ def _plotCategoricalHistogram(
     style = plot_config.histogramStyle()
 
     counts = data.value_counts()
-    freq = [counts[category] if category in counts else 0 for category in categories]
+    freq = [counts.get(category, 0) for category in categories]
     pos = numpy.arange(len(categories))
     width = 1.0
     axes.set_xticks(pos + (width / 2.0))


### PR DESCRIPTION
Suggested by ruff:  SIM401 Use `counts.get(category, 0)` instead of an `if` block

`counts` is here a Pandas Series object, that object also posesses the `get()` function similar to a `dict` (tested interactively).

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
