### PR TITLE
Revert skipping test export misfit causing tables illegal instruction on macos

### DIFF
--- a/tests/unit_tests/all/plugins/test_export_misfit.py
+++ b/tests/unit_tests/all/plugins/test_export_misfit.py
@@ -1,5 +1,3 @@
-import sys
-
 import pandas as pd
 import pytest
 
@@ -10,11 +8,6 @@ from ert.shared.hook_implementations.workflows.export_misfit_data import (
 from ert.shared.plugins import ErtPluginManager
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("darwin"),
-    reason="https://github.com/equinor/ert/issues/7123 "
-    "(pandas.to_hdf causes illegal instruction on mac)",
-)
 def test_export_misfit(snake_oil_case_storage, snake_oil_default_storage, snapshot):
     ExportMisfitDataJob(
         snake_oil_case_storage, storage=None, ensemble=snake_oil_default_storage


### PR DESCRIPTION
**Issue**
Resolves #7123

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
