### PR TITLE
Add test for queue name in LSF driver

### DIFF
--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -1,0 +1,34 @@
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from ert.scheduler import LsfDriver
+
+
+@pytest.fixture
+def capturing_bsub(monkeypatch, tmp_path):
+    os.chdir(tmp_path)
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
+    bsub_path = bin_path / "bsub"
+    bsub_path.write_text(
+        "#!/bin/sh\necho $@ > captured_bsub_args; echo 'Job <1>'", encoding="utf-8"
+    )
+    bsub_path.chmod(bsub_path.stat().st_mode | stat.S_IEXEC)
+
+
+@pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_with_named_queue():
+    driver = LsfDriver(queue_name="foo")
+    await driver.submit(0, "sleep")
+    assert "-q foo" in Path("captured_bsub_args").read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_with_default_queue():
+    driver = LsfDriver()
+    await driver.submit(0, "sleep")
+    assert "-q" not in Path("captured_bsub_args").read_text(encoding="utf-8")


### PR DESCRIPTION
**Issue**
Resolves lacking test function for specifying queue name in lsf driver

**Approach**
+

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
