### PR TITLE
Avoid generating the starting date in observations

### DIFF
--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -382,6 +382,7 @@ def ert_config_values(draw, use_eclbase=booleans):
             st.sampled_from([g[0] for g in gen_data]) if gen_data else None,
             summary_keys(smspec) if len(smspec.keywords) > 1 else None,
             std_cutoff=std_cutoff,
+            start_date=first_date,
         )
     )
     need_eclbase = any(


### PR DESCRIPTION
**Issue**
Resolves #7194


**Approach**
Avoids generating the start date in observations. This was mistakenly made possible in 789d7dc2a7


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
