### PR TITLE
Increase max_running for test_that_long_running_jobs_were_stopped

### DIFF
--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -350,7 +350,9 @@ async def test_that_long_running_jobs_were_stopped(storage, tmp_path, mock_drive
         for iens in range(ensemble_size)
     ]
 
-    sch = scheduler.Scheduler(mock_driver(wait=wait, kill=kill), realizations)
+    sch = scheduler.Scheduler(
+        mock_driver(wait=wait, kill=kill), realizations, max_running=ensemble_size
+    )
 
     assert await sch.execute(min_required_realizations=5) == EVTYPE_ENSEMBLE_STOPPED
     assert killed_iens == [6, 7, 8, 9]


### PR DESCRIPTION
**Issue**
By default  `max_running = 1` in Scheduler which might render  `test_that_long_running_jobs_were_stopped` flaky on some architectures. Hence increase to ensemble_size.


**Approach**
Increase!

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
