### PR TITLE
Add tests for LSF driver kills

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -135,12 +135,12 @@ class LsfDriver(Driver):
 
     async def kill(self, iens: int) -> None:
         if iens not in self._iens2jobid:
-            logger.error(f"LSF driver does not know of realization {iens}")
+            logger.error(f"LSF kill failed due to missing jobid for realization {iens}")
             return
 
         job_id = self._iens2jobid[iens]
 
-        logger.info(f"Killing realization {iens} with LSF-id {job_id}")
+        logger.debug(f"Killing realization {iens} with LSF-id {job_id}")
         process = await asyncio.create_subprocess_exec(
             self._bkill_cmd,
             job_id,
@@ -166,8 +166,6 @@ class LsfDriver(Driver):
                 f"{stdout_decoded} {stderr.decode()}"
             )
             return
-
-        del self._iens2jobid[iens]
 
     async def poll(self) -> None:
         while True:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -163,18 +163,19 @@ class OpenPBSDriver(Driver):
         self._iens2jobid[iens] = job_id_
 
     async def kill(self, iens: int) -> None:
-        try:
-            job_id = self._iens2jobid[iens]
-
-            logger.debug(f"Killing realization {iens} with PBS-id {job_id}")
-
-            process_success, process_message = await self._execute_with_retry(
-                ["qdel", str(job_id)], exit_codes_triggering_retries=QDEL_EXIT_CODES
-            )
-            if not process_success:
-                raise RuntimeError(process_message)
-        except KeyError:
+        if iens not in self._iens2jobid:
+            logger.error(f"PBS kill failed due to missing jobid for realization {iens}")
             return
+
+        job_id = self._iens2jobid[iens]
+
+        logger.debug(f"Killing realization {iens} with PBS-id {job_id}")
+
+        process_success, process_message = await self._execute_with_retry(
+            ["qdel", str(job_id)], exit_codes_triggering_retries=QDEL_EXIT_CODES
+        )
+        if not process_success:
+            raise RuntimeError(process_message)
 
     async def poll(self) -> None:
         while True:

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -92,3 +92,96 @@ async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
     driver = LsfDriver()
     with expectation:
         await driver.submit(0, "sleep")
+
+
+@pytest.mark.parametrize(
+    "mocked_iens2jobid, iens_to_kill, bkill_returncode, bkill_stdout, bkill_stderr, expected_logged_error",
+    [
+        pytest.param(
+            {"1": "11"},
+            "1",
+            0,
+            "Job <11> is being terminated",
+            "",
+            None,
+            id="happy_path",
+        ),
+        pytest.param(
+            {"1": "11"},
+            "2",
+            1,
+            "",
+            "",
+            "LSF driver does not know of realization",
+            id="internal_ert_error",
+        ),
+        pytest.param(
+            {"1": "11"},
+            "1",
+            255,
+            "",
+            "Job <22>: No matching job found",
+            "No matching job found",
+            id="inconsistency_ert_vs_lsf",
+        ),
+        pytest.param(
+            {"1": "11"},
+            "1",
+            0,
+            "wrong_stdout...",
+            "",
+            "wrong_stdout...",
+            id="artifical_bkill_stdout_giving_logged_error",
+        ),
+        pytest.param(
+            {"1": "11"},
+            "1",
+            0,
+            "",
+            "wrong_on_stderr",
+            "wrong_on_stderr",
+            id="artifical_bkill_stderr_giving_logged_error",
+        ),
+        pytest.param(
+            {"1": "11"},
+            "1",
+            1,
+            "",
+            "wrong_on_stderr",
+            "wrong_on_stderr",
+            id="artifical_bkill_stderr_and_returncode_giving_logged_error",
+        ),
+    ],
+)
+async def test_kill(
+    monkeypatch,
+    tmp_path,
+    mocked_iens2jobid,
+    iens_to_kill,
+    bkill_returncode,
+    bkill_stdout,
+    bkill_stderr,
+    expected_logged_error,
+    caplog,
+):
+    os.chdir(tmp_path)
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
+    bkill_path = bin_path / "bkill"
+    bkill_path.write_text(
+        f"#!/bin/sh\necho '{bkill_stdout}'\n"
+        f"echo '{bkill_stderr}' >&2\n"
+        f"exit {bkill_returncode}",
+        encoding="utf-8",
+    )
+    bkill_path.chmod(bkill_path.stat().st_mode | stat.S_IEXEC)
+
+    driver = LsfDriver()
+
+    driver._iens2jobid = mocked_iens2jobid
+    await driver.kill(iens_to_kill)
+    if expected_logged_error:
+        assert expected_logged_error in caplog.text
+    else:
+        assert iens_to_kill not in driver._iens2jobid

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -112,7 +112,7 @@ async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
             1,
             "",
             "",
-            "LSF driver does not know of realization",
+            "LSF kill failed due to missing",
             id="internal_ert_error",
         ),
         pytest.param(
@@ -172,6 +172,7 @@ async def test_kill(
     bkill_path.write_text(
         f"#!/bin/sh\necho '{bkill_stdout}'\n"
         f"echo '{bkill_stderr}' >&2\n"
+        f"echo $@ > 'bkill_args'\n"
         f"exit {bkill_returncode}",
         encoding="utf-8",
     )
@@ -184,4 +185,7 @@ async def test_kill(
     if expected_logged_error:
         assert expected_logged_error in caplog.text
     else:
-        assert iens_to_kill not in driver._iens2jobid
+        assert (
+            mocked_iens2jobid[iens_to_kill]
+            == Path("bkill_args").read_text(encoding="utf-8").strip()
+        )


### PR DESCRIPTION
The driver will never retry killing but if it does not succeed the error messages are logged.

Killing twice will give a logged error if the first is successful.

**Issue**
Adds to  #7186 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
