### PR TITLE
Fix external_ert_script does not fail on error

### DIFF
--- a/docs/reference/workflows/configuring_jobs.rst
+++ b/docs/reference/workflows/configuring_jobs.rst
@@ -64,7 +64,19 @@ For example, if a job is defined as follows:
     EXECUTABLE script.sh
     STOP_ON_FAIL TRUE                   -- Tell the job to stop ert on failure
 
-STOP_ON_FAIL can also be specified within the internal (python) or external (executable) job script.
+Shell scripts (Bash) must, in addition to having `STOP_ON_FAIL TRUE` in ert config, set the "exit immediately" flag (`set -e`) for the error to propagate. Otherwise, even if errors occur within the script, it will still be "successful".
+
+::
+    set -e
+
+For example, this bash external job script will stop on failure
+
+::
+    #!/usr/bin/env bash
+    set -e
+    ekho 'Hello World' # misspelled command fails
+
+
 For example, this internal job script will stop on failure
 
 ::
@@ -76,15 +88,6 @@ For example, this internal job script will stop on failure
         def run(self):
             assert False, "failure"
     """
-
-As will external .sh executables if they contain the line STOP_ON_FAIL=TRUE:
-
-::
-
-    #!/bin/bash
-    STOP_ON_FAIL=True #
-    ekho helo wordl
-
 
 Configuring the arguments
 -------------------------

--- a/src/ert/config/external_ert_script.py
+++ b/src/ert/config/external_ert_script.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import codecs
-import os
-import stat
 import sys
-import tempfile
-from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -24,39 +20,22 @@ class ExternalErtScript(ErtScript):
         self.__job: Optional[Popen[bytes]] = None
 
     def run(self, *args: Any) -> None:
-        script_content = (
-            Path(self.__executable).read_text(encoding="utf-8").splitlines()
-        )
-        tmp_script_path: Optional[str] = None
-        if self.__executable[-2:] == "sh":
-            script_content.insert(1, "set -e")
-        try:
-            with tempfile.NamedTemporaryFile(
-                mode="w+", encoding="utf-8", delete=False
-            ) as tmp_file:
-                tmp_file.write("\n".join(script_content))
-                tmp_file.flush()
-                tmp_script_path = tmp_file.name
-            os.chmod(tmp_script_path, os.stat(tmp_script_path).st_mode | stat.S_IEXEC)
-            command = [tmp_script_path]
-            command.extend([str(arg) for arg in args])
+        command = [self.__executable]
+        command.extend([str(arg) for arg in args])
 
-            # we take care to terminate the process in cancel()
-            self.__job = Popen(command, stdout=PIPE, stderr=PIPE)
+        # we take care to terminate the process in cancel()
+        self.__job = Popen(command, stdout=PIPE, stderr=PIPE)
 
-            # The job will complete before stdout and stderr is returned
-            stdoutdata, stderrdata = self.__job.communicate()
+        # The job will complete before stdout and stderr is returned
+        stdoutdata, stderrdata = self.__job.communicate()
 
-            self._stdoutdata = codecs.decode(stdoutdata, "utf8", "replace")
-            self._stderrdata = codecs.decode(stderrdata, "utf8", "replace")
+        self._stdoutdata = codecs.decode(stdoutdata, "utf8", "replace")
+        self._stderrdata = codecs.decode(stderrdata, "utf8", "replace")
 
-            sys.stdout.write(self._stdoutdata)
+        sys.stdout.write(self._stdoutdata)
 
-            if self.__job.returncode != 0:
-                raise RuntimeError(self._stderrdata)
-        finally:
-            if tmp_script_path is not None:
-                os.remove(tmp_script_path)
+        if self.__job.returncode != 0:
+            raise RuntimeError(self._stderrdata)
 
     def cancel(self) -> Any:
         super().cancel()

--- a/src/ert/config/external_ert_script.py
+++ b/src/ert/config/external_ert_script.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import codecs
+import os
+import stat
 import sys
+import tempfile
+from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -20,22 +24,39 @@ class ExternalErtScript(ErtScript):
         self.__job: Optional[Popen[bytes]] = None
 
     def run(self, *args: Any) -> None:
-        command = [self.__executable]
-        command.extend([str(arg) for arg in args])
+        script_content = (
+            Path(self.__executable).read_text(encoding="utf-8").splitlines()
+        )
+        tmp_script_path: Optional[str] = None
+        if self.__executable[-2:] == "sh":
+            script_content.insert(1, "set -e")
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+", encoding="utf-8", delete=False
+            ) as tmp_file:
+                tmp_file.write("\n".join(script_content))
+                tmp_file.flush()
+                tmp_script_path = tmp_file.name
+            os.chmod(tmp_script_path, os.stat(tmp_script_path).st_mode | stat.S_IEXEC)
+            command = [tmp_script_path]
+            command.extend([str(arg) for arg in args])
 
-        # we take care to terminate the process in cancel()
-        self.__job = Popen(command, stdout=PIPE, stderr=PIPE)
+            # we take care to terminate the process in cancel()
+            self.__job = Popen(command, stdout=PIPE, stderr=PIPE)
 
-        # The job will complete before stdout and stderr is returned
-        stdoutdata, stderrdata = self.__job.communicate()
+            # The job will complete before stdout and stderr is returned
+            stdoutdata, stderrdata = self.__job.communicate()
 
-        self._stdoutdata = codecs.decode(stdoutdata, "utf8", "replace")
-        self._stderrdata = codecs.decode(stderrdata, "utf8", "replace")
+            self._stdoutdata = codecs.decode(stdoutdata, "utf8", "replace")
+            self._stderrdata = codecs.decode(stderrdata, "utf8", "replace")
 
-        sys.stdout.write(self._stdoutdata)
+            sys.stdout.write(self._stdoutdata)
 
-        if self.__job.returncode != 0:
-            raise RuntimeError(self._stderrdata)
+            if self.__job.returncode != 0:
+                raise RuntimeError(self._stderrdata)
+        finally:
+            if tmp_script_path is not None:
+                os.remove(tmp_script_path)
 
     def cancel(self) -> Any:
         super().cancel()

--- a/src/ert/job_queue/workflow_runner.py
+++ b/src/ert/job_queue/workflow_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from concurrent import futures
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -60,20 +59,6 @@ class WorkflowJobRunner:
 
             if self.job.stop_on_fail is not None:
                 self.stop_on_fail = self.job.stop_on_fail
-            elif self.job.executable is not None and os.path.isfile(
-                self.job.executable
-            ):
-                try:
-                    with open(self.job.executable, encoding="utf-8") as executable:
-                        lines = executable.readlines()
-                        if any(
-                            line.lower().replace(" ", "").replace("\n", "")
-                            == "stop_on_fail=true"
-                            for line in lines
-                        ):
-                            self.stop_on_fail = True
-                except Exception:  # pylint: disable=broad-exception-caught
-                    self.stop_on_fail = False
 
         else:
             raise UserWarning("Unknown script type!")

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -298,11 +298,17 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
         assert lines[3].strip() == "fourth:foo"
 
 
+@pytest.mark.timeout(30)
 @pytest.mark.usefixtures("copy_poly_case", "using_scheduler")
 @pytest.mark.parametrize(
-    ("job_src", "script_name", "script_src", "expect_stopped"),
+    (
+        "workflow_job_config_content",
+        "file_extension",
+        "script_content",
+        "expect_stopped",
+    ),
     [
-        (
+        pytest.param(
             dedent(
                 """
                     STOP_ON_FAIL True
@@ -310,16 +316,17 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                     EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script.sh",
+            "sh",
             dedent(
-                """
+                """\
                     #!/bin/bash
                     ekho helo wordl
                 """
             ),
             True,
+            id="external_bash_script__stop_on_fail_enabled_in_config",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     STOP_ON_FAIL False
@@ -327,33 +334,35 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                     EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script.sh",
+            "sh",
             dedent(
-                """
+                """\
                     #!/bin/bash
                     ekho helo wordl
                 """
             ),
             False,
+            id="external_bash_script__stop_on_fail_disabled_in_config",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     INTERNAL False
                     EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script.sh",
+            "sh",
             dedent(
-                """
+                """\
                     #!/bin/bash
                     STOP_ON_FAIL=False
                     ekho helo wordl
                 """
             ),
             False,
+            id="external_bash_script__stop_on_fail_disabled_in_script",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     STOP_ON_FAIL True
@@ -361,17 +370,18 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                     EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script.sh",
+            "sh",
             dedent(
-                """
+                """\
                     #!/bin/bash
                     ekho helo wordl
                     STOP_ON_FAIL=False
                 """
             ),
             True,
+            id="external_bash_script__stop_on_fail_enabled_in_config_disabled_in_script",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                    STOP_ON_FAIL False
@@ -379,83 +389,93 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                    EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script.sh",
+            "sh",
             dedent(
-                """
-                   #!/bin/bash
+                """\
+                    #!/bin/bash
                    ekho helo wordl
                    STOP_ON_FAIL=TRUE
                """
             ),
             False,
+            id="external_bash_script__stop_on_fail_disabled_in_config_enabled_in_script",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     INTERNAL False
-                    EXECUTABLE failing_script_w_stop.sh
+                    EXECUTABLE failing_script.sh
                 """
             ),
-            "failing_script_w_stop.sh",
+            "sh",
             dedent(
-                """
+                """\
                     #!/bin/bash
                     ekho helo wordl
                     STOP_ON_FAIL=True
                 """
             ),
             True,
+            id="external_bash_script__stop_on_fail_enabled_in_script",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     INTERNAL True
-                    SCRIPT failing_ert_script.py
+                    SCRIPT failing_script.py
                 """
             ),
-            "failing_ert_script.py",
-            """
-from ert import ErtScript
-class AScript(ErtScript):
-    stop_on_fail = True
+            "py",
+            dedent(
+                """
+                    from ert import ErtScript
+                    class AScript(ErtScript):
+                        stop_on_fail = True
 
-    def run(self):
-        assert False, "failure"
-""",
+                        def run(self):
+                            assert False, "failure"
+                """
+            ),
             True,
+            id="internal_python_script__stop_on_fail_enabled_in_script",
         ),
-        (
+        pytest.param(
             dedent(
                 """
                     INTERNAL True
-                    SCRIPT failing_ert_script.py
+                    SCRIPT failing_script.py
                     STOP_ON_FAIL False
                 """
             ),
-            "failing_ert_script.py",
-            """
-from ert import ErtScript
-class AScript(ErtScript):
-    stop_on_fail = True
+            "py",
+            dedent(
+                """
+                    from ert import ErtScript
+                    class AScript(ErtScript):
+                        stop_on_fail = True
 
-    def run(self):
-        assert False, "failure"
-""",
+                        def run(self):
+                            assert False, "failure"
+                """
+            ),
             False,
+            id="internal_python_script__stop_on_failed_disabled_in_config_enabled_in_script",
         ),
     ],
 )
 def test_that_stop_on_fail_workflow_jobs_stop_ert(
-    job_src,
-    script_name,
-    script_src,
+    workflow_job_config_content,
+    file_extension,
+    script_content,
     expect_stopped,
 ):
+    script_name = f"failing_script.{file_extension}"
+
     with open("failing_job", "w", encoding="utf-8") as f:
-        f.write(job_src)
+        f.write(workflow_job_config_content)
 
     with open(script_name, "w", encoding="utf-8") as s:
-        s.write(script_src)
+        s.write(script_content)
 
     os.chmod(script_name, os.stat(script_name).st_mode | 0o111)
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -320,66 +320,12 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
             dedent(
                 """\
                     #!/bin/bash
+                    set -e
                     ekho helo wordl
                 """
             ),
             True,
-            id="external_bash_script__stop_on_fail_enabled_in_config",
-        ),
-        pytest.param(
-            dedent(
-                """
-                    STOP_ON_FAIL False
-                    INTERNAL False
-                    EXECUTABLE failing_script.sh
-                """
-            ),
-            "sh",
-            dedent(
-                """\
-                    #!/bin/bash
-                    ekho helo wordl
-                """
-            ),
-            False,
-            id="external_bash_script__stop_on_fail_disabled_in_config",
-        ),
-        pytest.param(
-            dedent(
-                """
-                    INTERNAL False
-                    EXECUTABLE failing_script.sh
-                """
-            ),
-            "sh",
-            dedent(
-                """\
-                    #!/bin/bash
-                    STOP_ON_FAIL=False
-                    ekho helo wordl
-                """
-            ),
-            False,
-            id="external_bash_script__stop_on_fail_disabled_in_script",
-        ),
-        pytest.param(
-            dedent(
-                """
-                    STOP_ON_FAIL True
-                    INTERNAL False
-                    EXECUTABLE failing_script.sh
-                """
-            ),
-            "sh",
-            dedent(
-                """\
-                    #!/bin/bash
-                    ekho helo wordl
-                    STOP_ON_FAIL=False
-                """
-            ),
-            True,
-            id="external_bash_script__stop_on_fail_enabled_in_config_disabled_in_script",
+            id="external_bash_script__stop_on_fail_enabled",
         ),
         pytest.param(
             dedent(
@@ -393,12 +339,12 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
             dedent(
                 """\
                    #!/bin/bash
+                   set -e
                    ekho helo wordl
-                   STOP_ON_FAIL=TRUE
                """
             ),
             False,
-            id="external_bash_script__stop_on_fail_disabled_in_config_enabled_in_script",
+            id="external_bash_script__stop_on_fail_disabled",
         ),
         pytest.param(
             dedent(
@@ -411,12 +357,12 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
             dedent(
                 """\
                     #!/bin/bash
+                    set -e
                     ekho helo wordl
-                    STOP_ON_FAIL=True
                 """
             ),
-            True,
-            id="external_bash_script__stop_on_fail_enabled_in_script",
+            False,
+            id="external_bash_script__stop_on_fail_disabled_by_default",
         ),
         pytest.param(
             dedent(
@@ -430,14 +376,13 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                 """
                     from ert import ErtScript
                     class AScript(ErtScript):
-                        stop_on_fail = True
 
                         def run(self):
                             assert False, "failure"
                 """
             ),
-            True,
-            id="internal_python_script__stop_on_fail_enabled_in_script",
+            False,
+            id="internal_python_script__stop_on_fail_disabled_by_default",
         ),
         pytest.param(
             dedent(
@@ -452,14 +397,13 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                 """
                     from ert import ErtScript
                     class AScript(ErtScript):
-                        stop_on_fail = True
 
                         def run(self):
                             assert False, "failure"
                 """
             ),
             False,
-            id="internal_python_script__stop_on_failed_disabled_in_config_enabled_in_script",
+            id="internal_python_script__stop_on_failed_disabled",
         ),
         pytest.param(
             dedent(
@@ -478,11 +422,52 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
                         def run(self):
                             assert False, "failure"
 
-                        stop_on_fail = False
                 """
             ),
             True,
-            id="external_python_script__stop_on_failed_enabled_in_config_disabled_in_script",
+            id="internal_python_script__stop_on_failed_enabled_in_config",
+        ),
+        pytest.param(
+            dedent(
+                """
+                    INTERNAL True
+                    SCRIPT failing_script.py
+                """
+            ),
+            "py",
+            dedent(
+                """
+                    from ert import ErtScript
+                    class AScript(ErtScript):
+                        stop_on_fail = True
+                        def run(self):
+                            assert False, "failure"
+
+                """
+            ),
+            True,
+            id="internal_python_script__stop_on_fail_enabled_in_script",
+        ),
+        pytest.param(
+            dedent(
+                """
+                    INTERNAL True
+                    SCRIPT failing_script.py
+                """
+            ),
+            "py",
+            dedent(
+                """
+                    from ert import ErtScript
+                    class AScript(ErtScript):
+                        stop_on_fail = False
+                        def run(self):
+                            assert False, "failure"
+
+                """
+            ),
+            False,
+            id="internal_python_script__stop_on_fail_disabled_in_script",
         ),
     ],
 )

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -392,7 +392,7 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
             "sh",
             dedent(
                 """\
-                    #!/bin/bash
+                   #!/bin/bash
                    ekho helo wordl
                    STOP_ON_FAIL=TRUE
                """
@@ -460,6 +460,29 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
             ),
             False,
             id="internal_python_script__stop_on_failed_disabled_in_config_enabled_in_script",
+        ),
+        pytest.param(
+            dedent(
+                """
+                    INTERNAL True
+                    SCRIPT failing_script.py
+                    STOP_ON_FAIL True
+                """
+            ),
+            "py",
+            dedent(
+                """
+                    from ert import ErtScript
+                    class AScript(ErtScript):
+
+                        def run(self):
+                            assert False, "failure"
+
+                        stop_on_fail = False
+                """
+            ),
+            True,
+            id="external_python_script__stop_on_failed_enabled_in_config_disabled_in_script",
         ),
     ],
 )


### PR DESCRIPTION
**Issue**
Resolves #7212


**Approach**
The script supplied by the user is now copies over to a temporary file, and we add the `set -e` flag to the line after the shebang to ensure it will stop on failure.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
