### PR TITLE
Add log-file for ert.async_utils

### DIFF
--- a/src/ert/async_utils.py
+++ b/src/ert/async_utils.py
@@ -74,6 +74,10 @@ def _done_callback(task: asyncio.Task[_T_co]) -> None:
         if (exc := task.exception()) is None:
             return
 
-        logger.error(f"Exception occurred during {task.get_name()}", exc_info=exc)
+        print(
+            # We would like to raise the exception, but it will not bring down
+            # ERTs main thread, so resort to printing to the terminal
+            f'Exception "{exc}" occured, check log files for details.'
+        )
     except asyncio.CancelledError:
         pass

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -130,7 +130,10 @@ loggers:
     level: DEBUG
     handlers: [jobqueue_file]
     propagate: yes
-
+  ert.async_utils:
+    level: DEBUG
+    handlers: [asyncio_file]
+    propagate: yes
 
 root:
   level: DEBUG


### PR DESCRIPTION
This will make logger statements from this module
go somewhere else than dev/null. Also print
a message to the screen in case of emergency as we are not able to fully take down Ert.

**Issue**
Partially resolves #7142 but does not take down Ert.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
