### PR TITLE
Set default pytest timeout of 240s

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -11,7 +11,6 @@ jobs:
 
   tests-ert:
     name: Run ert tests
-    timeout-minutes: 30
     runs-on: ${{ inputs.os }}
 
     steps:
@@ -23,6 +22,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       id: setup_python
+      timeout-minutes: 5
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
@@ -32,22 +32,22 @@ jobs:
 
     - name: Get wheels
       uses: actions/download-artifact@v3
+      timeout-minutes: 5
       with:
         name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
 
     - name: Install wheel
+      timeout-minutes: 5
       run: |
         find . -name "*.whl" -exec pip install "{}[dev]" \;
 
     - name: Test GUI
       if: inputs.test-type == 'gui-test'
-      timeout-minutes: 30
       run: |
         pytest tests --junit-xml=junit.xml -sv --mpl -m "requires_window_manager" --benchmark-disable
 
     - name: Unit Test
       if: inputs.test-type == 'unit-tests'
-      timeout-minutes: 15
       run: |
         pytest tests --junit-xml=junit.xml -n4 --show-capture=stderr -sv -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ markers = [
 ]
 log_cli = "false"
 asyncio_mode = "auto"
+timeout = 360
 
 [tool.black]
 include = '(\.pyi?|\.ipynb|\.py\.j2)$'


### PR DESCRIPTION
**Issue**
Resolves #7217 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
