### PR TITLE
Improve readability of stateful storage test

### DIFF
--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -275,6 +275,24 @@ class StatefulStorageTest(RuleBasedStateMachine):
     (the model).
 
     see https://hypothesis.readthedocs.io/en/latest/stateful.html
+
+    When the test fails, you get a printout like this:
+
+    .. code-block:: text
+
+        state = StatefulStorageTest()
+        v1 = state.create_grid(egrid=EGrid(...))
+        v2 = state.create_field_list(fields=[...])
+        v3 = state.create_experiment(obs=EnkfObs(...), parameters=[...], responses=[...])
+        v4 = state.create_ensemble(ensemble_size=1, model_experiment=v3)
+        v5 = state.create_ensemble_from_prior(prior=v4)
+        state.get_ensemble(model_ensemble=v5)
+        state.teardown()
+
+    This describes which rules are run (like create_experiment which corresponds to
+    the same action storage api endpoint: self.storage.create_experiment), and which
+    parameters are applied (e.g. v1 is in the grid bundle and is created by the rule
+    state.create_grid).
     """
 
     def __init__(self):

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -228,9 +228,11 @@ observations = st.builds(
     ),
 )
 
+small_ints = st.integers(min_value=1, max_value=10)
+
 
 @st.composite
-def fields(draw, egrid) -> List[Field]:
+def fields(draw, egrid, num_fields=small_ints) -> List[Field]:
     grid_file, grid = egrid
     nx, ny, nz = grid.shape
     return [
@@ -246,7 +248,7 @@ def fields(draw, egrid) -> List[Field]:
                 output_file=st.just(Path(f"field{i}.roff")),
             )
         )
-        for i in range(10)
+        for i in range(draw(num_fields))
     ]
 
 


### PR DESCRIPTION
Tried to document the storage test better.

Also made the number of fields variable which makes for better shrinking and faster execution.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
