### PR TITLE
Log when max_runtime kicks in

### DIFF
--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -233,8 +233,8 @@ class JobQueueNode(BaseCClass):  # type: ignore
         # check before we log.
         if self._tried_killing == 1:
             logger.error(
-                f"MAX_RUNTIME reached in run path {self.run_path}. Runtime: "
-                f"{self.runtime} (max runtime: {self._max_runtime})"
+                f"Realization {self.run_arg.iens} stopped due to "
+                f"MAX_RUNTIME={self._max_runtime} seconds. "
             )
         elif self._tried_killing % 100 == 0:
             logger.warning(

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -176,7 +176,9 @@ class Job:
         )
         assert self._scheduler._events is not None
         await self._scheduler._events.put(to_json(timeout_event))
-
+        logger.error(
+            f"Realization {self.iens} stopped due to MAX_RUNTIME={self.real.max_runtime} seconds"
+        )
         self.returncode.cancel()  # Triggers CancelledError
 
     async def _handle_failure(self) -> None:

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -198,7 +198,7 @@ async def test_that_max_submit_is_not_reached_on_success(realization, mock_drive
 
 
 @pytest.mark.timeout(10)
-async def test_max_runtime(realization, mock_driver):
+async def test_max_runtime(realization, mock_driver, caplog):
     wait_started = asyncio.Event()
 
     async def wait():
@@ -219,6 +219,8 @@ async def test_max_runtime(realization, mock_driver):
         if from_json(event)["type"] == "com.equinor.ert.realization.timeout":
             timeouteventfound = True
     assert timeouteventfound
+
+    assert "Realization 0 stopped due to MAX_RUNTIME=1 seconds" in caplog.text
 
 
 @pytest.mark.parametrize("max_running", [0, 1, 2, 10])


### PR DESCRIPTION
Redoing for the scheduler what job_queue already does. The log message is slightly altered compared to jobqueue.

**Issue**
Resolves #7226 

**Approach**
🗒️ 

See https://github.com/equinor/ert/blob/main/src/ert/job_queue/job_queue_node.py#L230C3-L243C14 for old logging code.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
