### PR TITLE
Add missing space in ConfigWarning msg

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -108,7 +108,7 @@ class ErtConfig:
             # https://github.com/equinor/ert/issues/6974
             ConfigWarning.ert_context_warn(
                 "Setting ECLBASE without using SUMMARY, SUMMARY_OBSERVATION, "
-                "or HISTORY_OBSERVATION most likely causes the forward model to fail."
+                "or HISTORY_OBSERVATION most likely causes the forward model to fail. "
                 "To silence this warning just add 'SUMMARY *' to your config file.",
             )
         self.observations: Dict[str, xr.Dataset] = self.enkf_obs.datasets


### PR DESCRIPTION
**Issue**
Resolves missing space in log message:

`...forward model to fail.To silence this...`