### PR TITLE
Support NUM_NODES and NUM_CPUS_PER_NODE in OpenPBS driver

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -24,6 +24,8 @@ def create_driver(config: QueueConfig) -> Driver:
         return OpenPBSDriver(
             queue_name=queue_config.get("QUEUE"),
             memory_per_job=queue_config.get("MEMORY_PER_JOB"),
+            num_nodes=int(queue_config.get("NUM_NODES", 1)),
+            num_cpus_per_node=int(queue_config.get("NUM_CPUS_PER_NODE", 1)),
             job_prefix=queue_config.get("JOB_PREFIX"),
         )
     elif config.queue_system == QueueSystem.LSF:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -49,12 +49,16 @@ class OpenPBSDriver(Driver):
         *,
         queue_name: Optional[str] = None,
         memory_per_job: Optional[str] = None,
+        num_nodes: Optional[int] = None,
+        num_cpus_per_node: Optional[int] = None,
         job_prefix: Optional[str] = None,
     ) -> None:
         super().__init__()
 
         self._queue_name = queue_name
         self._memory_per_job = memory_per_job
+        self._num_nodes: Optional[int] = num_nodes
+        self._num_cpus_per_node: Optional[int] = num_cpus_per_node
         self._job_prefix = job_prefix
 
         self._jobs: MutableMapping[str, Tuple[int, JobState]] = {}
@@ -62,8 +66,12 @@ class OpenPBSDriver(Driver):
 
     def _resource_string(self) -> str:
         resource_specifiers: List[str] = []
+        if self._num_nodes is not None:
+            resource_specifiers += [f"nodes={self._num_nodes}"]
+        if self._num_cpus_per_node is not None:
+            resource_specifiers += [f"ppn={self._num_cpus_per_node}"]
         if self._memory_per_job is not None:
-            resource_specifiers += ["mem=" + self._memory_per_job]
+            resource_specifiers += [f"mem={self._memory_per_job}"]
         return ":".join(resource_specifiers)
 
     async def submit(

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -1,7 +1,8 @@
 import os
+import shlex
 import stat
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import pytest
 from hypothesis import given
@@ -59,6 +60,11 @@ async def test_events_produced_from_jobstate_updates(jobstate_sequence: List[str
         assert "1" not in driver._jobs
 
 
+words = st.text(
+    min_size=0, max_size=8, alphabet=st.characters(min_codepoint=65, max_codepoint=90)
+)
+
+
 @pytest.fixture
 def capturing_qsub(monkeypatch, tmp_path):
     os.chdir(tmp_path)
@@ -70,6 +76,18 @@ def capturing_qsub(monkeypatch, tmp_path):
         "#!/bin/sh\necho $@ > captured_qsub_args; echo '1'", encoding="utf-8"
     )
     qsub_path.chmod(qsub_path.stat().st_mode | stat.S_IEXEC)
+
+
+def parse_resource_string(qsub_args: str) -> Dict[str, str]:
+    if " -l " not in qsub_args:
+        return {}
+    args = shlex.split(qsub_args)
+    resource_string = args[args.index("-l") + 1]
+    resources = {}
+    for key_value in resource_string.split(":"):
+        key, value = key_value.split("=")
+        resources[key] = value
+    return resources
 
 
 @pytest.mark.usefixtures("capturing_qsub")
@@ -106,3 +124,66 @@ async def test_job_name_with_prefix():
     driver = OpenPBSDriver(job_prefix="pre_")
     await driver.submit(0, "sleep", name="sleepy")
     assert " -Npre_sleepy " in Path("captured_qsub_args").read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_num_nodes():
+    driver = OpenPBSDriver(num_nodes=2)
+    await driver.submit(0, "sleep")
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert resources["nodes"] == "2"
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_num_nodes_default():
+    # This is the driver default, Ert can fancy a different default
+    driver = OpenPBSDriver()
+    await driver.submit(0, "sleep")
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert "nodes" not in resources
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_num_cpus_per_node():
+    driver = OpenPBSDriver(num_cpus_per_node=2)
+    await driver.submit(0, "sleep")
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert resources["ppn"] == "2"
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_num_cpus_per_node_default():
+    driver = OpenPBSDriver()
+    await driver.submit(0, "sleep")
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert "ppn" not in resources
+
+
+@given(words, st.integers(min_value=0), st.integers(min_value=0))
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_full_resource_string(memory_per_job, num_nodes, num_cpus_per_node):
+    driver = OpenPBSDriver(
+        memory_per_job=memory_per_job if memory_per_job else None,
+        num_nodes=num_nodes if num_nodes > 0 else None,
+        num_cpus_per_node=num_cpus_per_node if num_cpus_per_node > 0 else None,
+    )
+    await driver.submit(0, "sleep")
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert resources.get("mem", "") == memory_per_job
+    assert resources.get("nodes", "0") == str(num_nodes)
+    assert resources.get("ppn", "0") == str(num_cpus_per_node)
+    # "0" here is a test implementation detail, not related to driver
+
+    assert len(resources) == sum(
+        [bool(memory_per_job), bool(num_cpus_per_node), bool(num_nodes)]
+    ), "Unknown resources injected in resource string"


### PR DESCRIPTION
**Issue**
Resolves #7232 

**Approach**
Just do it.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
