### PR TITLE
Support (in new PBS driver) and deprecate JOB_PREFIX

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -44,6 +44,14 @@ deprecated_keywords_list = [
         for kw in ["DEFINE", "DATA_KW"]
     ],
     DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message=(
+            "JOB_PREFIX as QUEUE_OPTION to the TORQUE system is deprecated. "
+            "Please add your prefix to JOBNAME instead."
+        ),
+        check=lambda line: "JOB_PREFIX" in line,
+    ),
+    DeprecationInfo(
         keyword="ANALYSIS_SET_VAR",
         message=partial(
             lambda line: f"The {line[1]} keyword was removed in 2017 and has no "

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -24,6 +24,7 @@ def create_driver(config: QueueConfig) -> Driver:
         return OpenPBSDriver(
             queue_name=queue_config.get("QUEUE"),
             memory_per_job=queue_config.get("MEMORY_PER_JOB"),
+            job_prefix=queue_config.get("JOB_PREFIX"),
         )
     elif config.queue_system == QueueSystem.LSF:
         queue_config = {

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -44,12 +44,17 @@ class OpenPBSDriver(Driver):
     """Driver targetting OpenPBS (https://github.com/openpbs/openpbs) / PBS Pro"""
 
     def __init__(
-        self, *, queue_name: Optional[str] = None, memory_per_job: Optional[str] = None
+        self,
+        *,
+        queue_name: Optional[str] = None,
+        memory_per_job: Optional[str] = None,
+        job_prefix: Optional[str] = None,
     ) -> None:
         super().__init__()
 
         self._queue_name = queue_name
         self._memory_per_job = memory_per_job
+        self._job_prefix = job_prefix
 
         self._jobs: MutableMapping[str, Tuple[int, JobState]] = {}
         self._iens2jobid: MutableMapping[int, str] = {}
@@ -74,11 +79,12 @@ class OpenPBSDriver(Driver):
         resource_string = self._resource_string()
         arg_resource_string = ["-l", resource_string] if resource_string else []
 
+        name_prefix = self._job_prefix or ""
         qsub_with_args: List[str] = [
             "qsub",
             "-koe",  # Discard stdout/stderr of job
             "-rn",  # Don't restart on failure
-            f"-N{name}",  # Set name of job
+            f"-N{name_prefix}{name}",  # Set name of job
             *arg_queue_name,
             *arg_resource_string,
             "--",

--- a/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -226,3 +226,15 @@ def test_that_suggester_gives_schedule_prediciton_migration(tmp_path):
         "The 'SCHEDULE_PREDICTION_FILE' config keyword has been removed" in s
         for s in suggestions
     )
+
+
+def test_that_suggester_gives_job_prefix_migration(tmp_path):
+    (tmp_path / "config.ert").write_text(
+        "NUM_REALIZATIONS 1\nQUEUE_OPTION TORQUE JOB_PREFIX foo\n"
+    )
+    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
+
+    assert any(
+        "JOB_PREFIX as QUEUE_OPTION to the TORQUE system is deprecated" in str(s)
+        for s in suggestions
+    )

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -40,3 +40,17 @@ async def test_no_validation_of_memory_per_job():
     driver = OpenPBSDriver(memory_per_job="a_lot")
     await driver.submit(0, "sleep")
     assert " -l mem=a_lot " in Path("captured_qsub_args").read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_job_name():
+    driver = OpenPBSDriver()
+    await driver.submit(0, "sleep", name="sleepy")
+    assert " -Nsleepy " in Path("captured_qsub_args").read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_job_name_with_prefix():
+    driver = OpenPBSDriver(job_prefix="pre_")
+    await driver.submit(0, "sleep", name="sleepy")
+    assert " -Npre_sleepy " in Path("captured_qsub_args").read_text(encoding="utf-8")


### PR DESCRIPTION
JOB_PREFIX is not mentioned in the docs and no usage is known in the logs. It should also be redundant.

**Issue**
Solve 50% of #7235 


**Approach**
Port behaviour from C-driver (torque_driver.cpp) to OpenPBS driver but also deprecate it for both drivers (C-version and Python version) in the config parser.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
