### PR TITLE
Fix default in _iterative_case_format

### DIFF
--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -187,7 +187,6 @@ def _setup_multiple_data_assimilation(
     args: Namespace,
     update_settings: UpdateSettings,
 ) -> MultipleDataAssimilation:
-
     restart_run, prior_ensemble = _determine_restart_info(args)
 
     return MultipleDataAssimilation(
@@ -263,8 +262,7 @@ def _iterative_case_format(config: ErtConfig, args: Namespace) -> str:
     return (
         args.target_case
         or config.analysis_config.case_format
-        or f"{getattr(args, 'current_case', None)}_%d"
-        or "default_%d"
+        or f"{getattr(args, 'current_case', None) or 'default'}_%d"
     )
 
 


### PR DESCRIPTION
a7682a733a82f4a5f17c2e74f14b378e93d36520 introduced an unintended change where the case format could become "None_%d".


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
