### PR TITLE
Use Trusted publishing for PyPi

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,6 +210,8 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build-test-cmake, test-linux, test-mac, docs-ert]
+    permissions:
+      id-token: write
 
     # If this is a tagged release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -227,5 +229,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
**Issue**
Ert does not use Trusted publishing for PyPi


**Approach**
Enable trusted publishing on PyPi and modify workflow

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [x] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
