### PR TITLE
Replace use of TypedDict with dataclasses in observation parser

### DIFF
--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -388,7 +388,7 @@ def ert_config_values(draw, use_eclbase=booleans):
     need_eclbase = any(
         (isinstance(val, (HistoryObservation, SummaryObservation)) for val in obs)
     )
-    use_eclbase = draw(use_eclbase) if not need_eclbase else st.just(True)
+    use_eclbase = draw(use_eclbase) if not need_eclbase else True
     dates = _observation_dates(obs, first_date)
     time_diffs = [d - first_date for d in dates]
     time_diff_floats = [diff.total_seconds() / (3600 * 24) for diff in time_diffs]

--- a/tests/unit_tests/config/parsing/test_observations_parser.py
+++ b/tests/unit_tests/config/parsing/test_observations_parser.py
@@ -6,8 +6,12 @@ import pytest
 from hypothesis import given
 
 from ert.config.parsing.observations_parser import (
+    GenObsValues,
+    HistoryValues,
     ObservationConfigError,
     ObservationType,
+    Segment,
+    SummaryValues,
     _parse_content,
     _validate_conf_content,
     observations_parser,
@@ -153,61 +157,56 @@ def test_validate(file_contents):
         ),
     ) == [
         (
-            ObservationType.HISTORY,
             "FOPR",
-            {"ERROR_MODE": "RELMIN", "ERROR": 0.1, "ERROR_MIN": 0.1, "SEGMENT": []},
+            HistoryValues(ERROR_MODE="RELMIN", ERROR=0.1, ERROR_MIN=0.1, SEGMENT=[]),
         ),
         (
-            ObservationType.SUMMARY,
             "WOPR_OP1_9",
-            {
-                "ERROR_MODE": "ABS",
-                "ERROR": 0.05,
-                "ERROR_MIN": 0.1,
-                "KEY": "WOPR:OP1",
-                "VALUE": 0.1,
-                "DATE": "2010-03-31",
-            },
+            SummaryValues(
+                ERROR_MODE="ABS",
+                ERROR=0.05,
+                ERROR_MIN=0.1,
+                KEY="WOPR:OP1",
+                VALUE=0.1,
+                DATE="2010-03-31",
+            ),
         ),
         (
-            ObservationType.GENERAL,
             "WPR_DIFF_1",
-            {
-                "DATA": "SNAKE_OIL_WPR_DIFF",
-                "INDEX_LIST": "400,800,1200,1800",
-                "DATE": "2015-06-13",
-                "OBS_FILE": "wpr_diff_obs.txt",
-            },
+            GenObsValues(
+                DATA="SNAKE_OIL_WPR_DIFF",
+                INDEX_LIST="400,800,1200,1800",
+                DATE="2015-06-13",
+                OBS_FILE="wpr_diff_obs.txt",
+            ),
         ),
         (
-            ObservationType.GENERAL,
             "WPR_DIFF_2",
-            {
-                "DATA": "SNAKE_OIL_WPR_DIFF",
-                "INDEX_FILE": "wpr_diff_idx.txt",
-                "DATE": "2015-06-13",
-                "OBS_FILE": "wpr_diff_obs.txt",
-            },
+            GenObsValues(
+                DATA="SNAKE_OIL_WPR_DIFF",
+                INDEX_FILE="wpr_diff_idx.txt",
+                DATE="2015-06-13",
+                OBS_FILE="wpr_diff_obs.txt",
+            ),
         ),
         (
-            ObservationType.HISTORY,
             "FWPR",
-            {
-                "ERROR_MODE": "RELMIN",
-                "ERROR": 0.1,
-                "ERROR_MIN": 0.1,
-                "SEGMENT": [
+            HistoryValues(
+                ERROR_MODE="RELMIN",
+                ERROR=0.1,
+                ERROR_MIN=0.1,
+                SEGMENT=[
                     (
                         "SEG",
-                        {
-                            "START": 1,
-                            "STOP": 0,
-                            "ERROR_MODE": "RELMIN",
-                            "ERROR": 0.25,
-                            "ERROR_MIN": 0.1,
-                        },
+                        Segment(
+                            START=1,
+                            STOP=0,
+                            ERROR_MODE="RELMIN",
+                            ERROR=0.25,
+                            ERROR_MIN=0.1,
+                        ),
                     )
                 ],
-            },
+            ),
         ),
     ]


### PR DESCRIPTION
Replace usage of TypedDict with dataclasses in observation parser

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
