### PR TITLE
Add config test for num_cpu vs torque queue options

### DIFF
--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -133,6 +133,8 @@ def valid_queue_values(option_name, queue_system):
     elif option_name in queue_positive_number_options[queue_system]:
         return small_floats.map(str)
     elif option_name in queue_positive_int_options[queue_system]:
+        if option_name in ["NUM_NODES", "NUM_CPUS_PER_NODE"]:
+            return st.just("1")
         return positives.map(str)
     elif option_name in queue_bool_options[queue_system]:
         return booleans.map(str)
@@ -287,7 +289,7 @@ class ErtConfigValues:
             ConfigKeys.FIELD: self.field,
             ConfigKeys.GEN_DATA: self.gen_data,
             ConfigKeys.MAX_SUBMIT: self.max_submit,
-            ConfigKeys.NUM_CPU: self.num_cpu,
+            ConfigKeys.NUM_CPU: 1,
             ConfigKeys.QUEUE_SYSTEM: self.queue_system,
             ConfigKeys.QUEUE_OPTION: self.queue_option,
             ConfigKeys.ANALYSIS_SET_VAR: self.analysis_set_var,

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from hypothesis import assume, given, settings
+from hypothesis import strategies as st
 
 from ert.config import AnalysisConfig, ConfigValidationError, ErtConfig, HookRuntime
 from ert.config.ert_config import site_config_location
@@ -598,6 +599,56 @@ def test_queue_config_max_running_invalid_values(max_running_value, expected_err
         QUEUE_OPTION LOCAL MAX_RUNNING {max_running_value}
         """
     )
+    with open(test_config_file_name, "w", encoding="utf-8") as fh:
+        fh.write(test_config_contents)
+    if expected_error:
+        with pytest.raises(
+            expected_exception=ConfigValidationError,
+            match=expected_error,
+        ):
+            ErtConfig.from_file(test_config_file_name)
+    else:
+        ErtConfig.from_file(test_config_file_name)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@given(st.integers(min_value=0), st.integers(min_value=0), st.integers(min_value=0))
+def test_num_cpu_vs_torque_queue_cpu_configuration(
+    num_cpu_int, num_nodes_int, num_cpus_per_node_int
+):
+
+    # Only strictly positive ints are valid configuration values,
+    # zero values are used to represent the "not configured" scenario:
+    num_cpu = str(num_cpu_int) if num_cpu_int > 0 else ""
+    num_nodes = str(num_nodes_int) if num_nodes_int > 0 else ""
+    num_cpus_per_node = str(num_cpus_per_node_int) if num_cpus_per_node_int > 0 else ""
+
+    expected_error = (
+        "product .* must be equal"
+        if (num_cpu_int or 1) != (num_nodes_int or 1) * (num_cpus_per_node_int or 1)
+        else None
+    )
+
+    test_config_file_base = "test"
+    test_config_file_name = f"{test_config_file_base}.ert"
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS 1
+        DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>-<DATE>
+        RUNPATH <STORAGE>/runpath/realization-<IENS>/iter-<ITER>
+        ENSPATH <STORAGE>/ensemble
+        QUEUE_SYSTEM TORQUE
+        """
+    )
+    if num_cpu:
+        test_config_contents += f"NUM_CPU {num_cpu}\n"
+    if num_nodes:
+        test_config_contents += f"QUEUE_OPTION TORQUE NUM_NODES {num_nodes}\n"
+    if num_cpus_per_node:
+        test_config_contents += (
+            f"QUEUE_OPTION TORQUE NUM_CPUS_PER_NODE {num_cpus_per_node}\n"
+        )
+
     with open(test_config_file_name, "w", encoding="utf-8") as fh:
         fh.write(test_config_contents)
     if expected_error:


### PR DESCRIPTION
**Issue**
Resolves #7265 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
