### PR TITLE
Update ruff config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,9 @@ write_to = "src/ert/shared/version.py"
 
 [tool.ruff]
 src = ["src"]
+line-length = 88
+
+[tool.ruff.lint]
 select = [
   "W",   # pycodestyle
   "I",   # isort
@@ -174,7 +177,6 @@ select = [
   "F",   # pyflakes
   "PL",  # pylint
 ]
-line-length = 88
 ignore = ["PLW2901", # redefined-loop-name
           "PLR2004", # magic-value-comparison
           "PLR0915", # too-many-statements
@@ -183,11 +185,11 @@ ignore = ["PLW2901", # redefined-loop-name
           "PLR0911",  # too-many-return-statements
 ]
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "tests/*" = [
 "PLW0603" # global-statement
 ]
 "src/ert/dark_storage/json_schema/__init__.py" = ["F401"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 20


### PR DESCRIPTION
Following up recommendation from ruff itself:
warning: The top-level linter settings are deprecated in favour of their counterparts in the  section. Please update the following options in :
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'pylint' -> 'lint.pylint'
  - 'extend-per-file-ignores' -> 'lint.extend-per-file-ignores'

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
