### PR TITLE
Let LSF driver fall back to bhist for not-found jobs in bjobs

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -38,6 +38,7 @@ def create_driver(config: QueueConfig) -> Driver:
             bsub_cmd=queue_config.get("BSUB_CMD"),
             bkill_cmd=queue_config.get("BKILL_CMD"),
             bjobs_cmd=queue_config.get("BJOBS_CMD"),
+            bhist_cmd=queue_config.get("BHIST_CMD"),
             exclude_hosts=queue_config.get("EXCLUDE_HOST", "").split(","),
             queue_name=queue_config.get("LSF_QUEUE"),
             resource_requirement=queue_config.get("LSF_RESOURCE"),

--- a/tests/integration_tests/scheduler/bin/bhist
+++ b/tests/integration_tests/scheduler/bin/bhist
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "${PYTHON:-$(which python3)}" "$(dirname $0)/bhist.py" "$@"

--- a/tests/integration_tests/scheduler/bin/bhist.py
+++ b/tests/integration_tests/scheduler/bin/bhist.py
@@ -1,0 +1,96 @@
+import argparse
+import os
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Job(BaseModel):
+    job_id: str
+    user: str = "username"
+    job_name: str = "d u m m y"  # can be up to 4094 chars
+    pend: int = 0
+    psusp: int = 0
+    run: int = 0
+    ususp: int = 0
+    ssusp: int = 0
+    unkwn: int = 0
+    total: int = 0
+
+
+class SQueueOutput(BaseModel):
+    jobs: List[Job]
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Mocked LSF bhist command reading state from filesystem"
+    )
+    parser.add_argument("jobs", type=str, nargs="*")
+    return parser
+
+
+def bhist_formatter(jobstats: List[Job]) -> str:
+    string = "Summary of time in seconds spent in various states:\n"
+    string += "JOBID   USER    JOB_NAME  PEND    PSUSP   RUN     USUSP   SSUSP   UNKWN   TOTAL\n"
+    for job in jobstats:
+        string += (
+            f"{str(job.job_id):7.7s} {job.user:7.7s} "
+            f"{job.job_name:9.9s} {str(job.pend):7.7s} "
+            f"{str(job.psusp):7.7s} {str(job.run):7.7s} "
+            f"{str(job.ususp):7.7s} {str(job.ssusp):7.7s} "
+            f"{str(job.unkwn):7.7s} {str(job.total):7.7s}\n"
+        )
+    return string
+
+
+def read(path: Path, default: Optional[str] = None) -> Optional[str]:
+    return path.read_text().strip() if path.exists() else default
+
+
+def main() -> None:
+    args = get_parser().parse_args()
+
+    jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
+
+    jobs_output: List[Job] = []
+    for job in args.jobs:
+        job_name: str = read(jobs_path / f"{job}.name") or "_"
+        assert job_name is not None
+
+        submit_time_millis: int = int(
+            os.path.getctime(jobs_path / f"{job}.name") * 1000
+        )
+        pending_time_millis = int(read(jobs_path / "pendingtimemillis") or 0)
+        run_start_time_millis: int = submit_time_millis + pending_time_millis
+        end_time_millis: int = int(time.time() * 1000)
+        if (jobs_path / f"{job}.returncode").exists():
+            print("bhist says job is done")
+            end_time_millis = int(
+                os.path.getctime(jobs_path / f"{job}.returncode") * 1000
+            )
+            print(f"run: {end_time_millis - run_start_time_millis}")
+        pend: int = min(
+            run_start_time_millis - submit_time_millis,
+            int(time.time() * 1000) - submit_time_millis,
+        )
+
+        jobs_output.append(
+            Job(
+                **{
+                    "job_id": job,
+                    "user": "dummyuser",
+                    "job_name": job_name,
+                    "pend": pend,
+                    "run": max(0, end_time_millis - run_start_time_millis),
+                    "total": end_time_millis - submit_time_millis,
+                }
+            )
+        )
+    print(bhist_formatter(jobs_output))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -519,14 +519,17 @@ def test_scheduler_create_lsf_driver():
     bsub_cmd = "bar_bsub_cmd"
     bkill_cmd = "foo_bkill_cmd"
     bjobs_cmd = "bar_bjobs_cmd"
+    bhist_cmd = "com_bjobs_cmd"
     lsf_resource = "rusage[mem=512MB:swp=1GB]"
     exclude_host = "host1,host2"
+
     queue_config_dict = {
         "QUEUE_SYSTEM": "LSF",
         "QUEUE_OPTION": [
             ("LSF", "BSUB_CMD", bsub_cmd),
             ("LSF", "BKILL_CMD", bkill_cmd),
             ("LSF", "BJOBS_CMD", bjobs_cmd),
+            ("LSF", "BHIST_CMD", bhist_cmd),
             ("LSF", "EXCLUDE_HOST", exclude_host),
             ("LSF", "LSF_QUEUE", queue_name),
             ("LSF", "LSF_RESOURCE", lsf_resource),
@@ -537,6 +540,7 @@ def test_scheduler_create_lsf_driver():
     assert str(driver._bsub_cmd) == bsub_cmd
     assert str(driver._bkill_cmd) == bkill_cmd
     assert str(driver._bjobs_cmd) == bjobs_cmd
+    assert str(driver._bhist_cmd) == bhist_cmd
     assert driver._exclude_hosts == exclude_host.split(",")
     assert driver._queue_name == queue_name
     assert driver._resource_requirement == lsf_resource

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -137,3 +137,4 @@ async def poll(driver: Driver, expected: set[int], *, started=None, finished=Non
                     break
     finally:
         poll_task.cancel()
+        await driver.finish()


### PR DESCRIPTION
**Issue**
Resolves #7208 


**Approach**
Replicate the functionality of the C-driver, but with a different approach. We rely that the polling will 
happen repeatedly and will only provide JobStates from bhist polling when bhist has been polled earlier.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
