### PR TITLE
Add support for KEEP_QSUB_OUTPUT for OpenPBSDriver

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -23,6 +23,7 @@ def create_driver(config: QueueConfig) -> Driver:
         }
         return OpenPBSDriver(
             queue_name=queue_config.get("QUEUE"),
+            keep_qsub_output=queue_config.get("KEEP_QSUB_OUTPUT", "0"),
             memory_per_job=queue_config.get("MEMORY_PER_JOB"),
             num_nodes=int(queue_config.get("NUM_NODES", 1)),
             num_cpus_per_node=int(queue_config.get("NUM_CPUS_PER_NODE", 1)),

--- a/tests/integration_tests/scheduler/bin/qsub
+++ b/tests/integration_tests/scheduler/bin/qsub
@@ -3,7 +3,7 @@ set -e
 
 name="STDIN"
 
-while getopts "N:r:k:l:" opt
+while getopts "N:r:l:o:e:" opt
 do
     case "$opt" in
         N)
@@ -11,7 +11,9 @@ do
             ;;
         r)
             ;;
-        k)
+        o)
+            ;;
+        e)
             ;;
         l)
             ;;
@@ -28,6 +30,7 @@ jobid="test${RANDOM}.localhost"
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
 echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
+
 
 bash "$(dirname $0)/runner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &
 disown


### PR DESCRIPTION
This is implemented differently compared to the legacy driver, which injects the '-k' option to 'qsub'. Controlling using ~~-j oe and~~ -o and -e seems more stable

**Issue**
Resolves #7233 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
