### PR TITLE
Run LSF and PBS integration tests during Komodo tests

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -57,6 +57,8 @@ start_tests () {
 
     which bsub 2>/dev/null && \
         pytest -v --lsf --basetemp=~/.pytest-tmp integration_tests/scheduler/test_lsf_driver.py
+
+    export PBS_QUEUE=permanent
     which bsub 2>/dev/null || \
         pytest -v --openpbs --basetemp=~/.pytest-tmp integration_tests/scheduler/test_openpbs_driver.py
 }

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -54,4 +54,9 @@ start_tests () {
     popd
 
     run_ert_with_opm
+
+    which bsub 2>/dev/null && \
+        pytest -v --lsf --basetemp=~/.pytest-tmp integration_tests/scheduler/test_lsf_driver.py
+    which bsub 2>/dev/null || \
+        pytest -v --openpbs --basetemp=~/.pytest-tmp integration_tests/scheduler/test_openpbs_driver.py
 }

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -71,7 +71,6 @@ async def test_submit_something_that_fails():
     assert finished_called
 
 
-@pytest.mark.timeout(5)
 async def test_kill():
     driver = LsfDriver()
     aborted_called = False
@@ -116,7 +115,7 @@ async def test_lsf_info_file_in_runpath(runpath_supplied, tmp_path):
 async def test_job_name():
     driver = LsfDriver()
     iens: int = 0
-    await driver.submit(iens, "sleep 99", name="my_job_name")
+    await driver.submit(iens, "sleep 99", name="my_job")
     jobid = driver._iens2jobid[iens]
     bjobs_process = await asyncio.create_subprocess_exec(
         "bjobs",
@@ -124,7 +123,7 @@ async def test_job_name():
         stdout=asyncio.subprocess.PIPE,
     )
     stdout, _ = await bjobs_process.communicate()
-    assert "my_job_name" in stdout.decode()
+    assert "my_job" in stdout.decode()
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -49,7 +49,7 @@ async def poll(driver: Driver, expected: Set[int], *, started=None, finished=Non
 
 @pytest.mark.integration_test
 async def test_submit(tmp_path):
-    driver = OpenPBSDriver()
+    driver = OpenPBSDriver(queue_name=os.getenv("PBS_QUEUE"))
     await driver.submit(0, f"echo test > {tmp_path}/test")
     await poll(driver, {0})
 
@@ -58,7 +58,7 @@ async def test_submit(tmp_path):
 
 @pytest.mark.integration_test
 async def test_returncode():
-    driver = OpenPBSDriver()
+    driver = OpenPBSDriver(queue_name=os.getenv("PBS_QUEUE"))
     finished_called = False
 
     async def finished(iens, returncode, aborted):
@@ -76,7 +76,7 @@ async def test_returncode():
 
 @pytest.mark.integration_test
 async def test_kill():
-    driver = OpenPBSDriver()
+    driver = OpenPBSDriver(queue_name=os.getenv("PBS_QUEUE"))
     aborted_called = False
 
     async def started(iens):


### PR DESCRIPTION
**Issue**
Resolves #7317 

**Approach**
Use  --basetmp option to pytest.

Tune tests to make them work (remove too short timeout, and do not use long job name as long job names are truncated in bjobs output)

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
