### PR TITLE
Remove timeouts for LSF integration tests

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -44,7 +44,6 @@ async def poll(driver: Driver, expected: Set[int], *, started=None, finished=Non
         poll_task.cancel()
 
 
-@pytest.mark.timeout(5)
 @pytest.mark.integration_test
 async def test_submit(tmp_path):
     driver = LsfDriver()
@@ -71,7 +70,6 @@ async def test_submit_something_that_fails():
     assert finished_called
 
 
-@pytest.mark.timeout(5)
 async def test_kill():
     driver = LsfDriver()
     aborted_called = False


### PR DESCRIPTION
**Issue**
Resolves #7316  (maybe)


**Approach**
Remove the offending timeout. If the test is really hanging, another timeout will occur.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
