### PR TITLE
Mute transitions from PBS

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -231,7 +231,7 @@ class OpenPBSDriver(Driver):
 
     async def _process_job_update(self, job_id: str, job: AnyJob) -> None:
         significant_transitions = {"Q": ["R", "F"], "R": ["F"]}
-        muted_transitions = {"H": ["Q", "E"], "Q": ["E"], "R": ["E"]}
+        muted_transitions = {"H": ["Q", "E"], "Q": ["H", "E"], "R": ["E"]}
         if job_id not in self._jobs:
             return
 
@@ -241,7 +241,7 @@ class OpenPBSDriver(Driver):
             return
         if not new_state in significant_transitions[old_state]:
             if not new_state in muted_transitions[old_state]:
-                logger.warning(
+                logger.debug(
                     "Ignoring transition from "
                     f"{old_state} to {new_state} in {iens=} {job_id=}"
                 )


### PR DESCRIPTION
Avoiding WARNING as logs from INFO and above are kept centrally.

**Issue**
Resolves #7326 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
