### PR TITLE
Avoid race condition in simulation_context

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -109,6 +110,8 @@ class Scheduler:
         self._cancelled = True
         for task in self._tasks.values():
             task.cancel()
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(task, timeout=0.1)
 
     async def _update_avg_job_runtime(self) -> None:
         while True:


### PR DESCRIPTION
Tasks need time to clean up after cancellation
but might also fail during this cleanup.

**Issue**
Resolves #7309


**Approach**
`asyncio.waitfor()`

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
