### PR TITLE
Remove usages of Reader/Accessor alias

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -35,7 +35,7 @@ from .event import AnalysisEvent, AnalysisStatusEvent, AnalysisTimeEvent
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
 _logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class TempStorage(UserDict):  # type: ignore
 
 
 def _all_parameters(
-    ensemble: LocalEnsemble,
+    ensemble: Ensemble,
     iens_active_index: npt.NDArray[np.int_],
     param_groups: List[str],
 ) -> Optional[npt.NDArray[np.double]]:
@@ -163,7 +163,7 @@ def _all_parameters(
 
 
 def _save_temp_storage_to_disk(
-    ensemble: LocalEnsemble,
+    ensemble: Ensemble,
     temp_storage: TempStorage,
     iens_active_index: npt.NDArray[np.int_],
 ) -> None:
@@ -174,7 +174,7 @@ def _save_temp_storage_to_disk(
 
 
 def _create_temporary_parameter_storage(
-    ensemble: LocalEnsemble,
+    ensemble: Ensemble,
     iens_active_index: npt.NDArray[np.int_],
     param_group: str,
 ) -> TempStorage:
@@ -187,7 +187,7 @@ def _create_temporary_parameter_storage(
 
 
 def _get_obs_and_measure_data(
-    ensemble: LocalEnsemble,
+    ensemble: Ensemble,
     selected_observations: Iterable[str],
     iens_active_index: npt.NDArray[np.int_],
 ) -> Tuple[
@@ -235,7 +235,7 @@ def _get_obs_and_measure_data(
 
 
 def _load_observations_and_responses(
-    ensemble: LocalEnsemble,
+    ensemble: Ensemble,
     alpha: float,
     std_cutoff: float,
     global_std_scaling: float,
@@ -385,8 +385,8 @@ def _copy_unupdated_parameters(
     all_parameter_groups: Iterable[str],
     updated_parameter_groups: Iterable[str],
     iens_active_index: npt.NDArray[np.int_],
-    source_ensemble: LocalEnsemble,
-    target_ensemble: LocalEnsemble,
+    source_ensemble: Ensemble,
+    target_ensemble: Ensemble,
 ) -> None:
     """
     Copies parameter groups that have not been updated from a source ensemble to a target ensemble.
@@ -399,8 +399,8 @@ def _copy_unupdated_parameters(
     updated_parameter_groups (List[str]): A list of parameter groups that have already been updated.
     iens_active_index (npt.NDArray[np.int_]): An array of indices for the active realizations in the
                                               target ensemble.
-    source_ensemble (LocalEnsemble): The file system of the source ensemble, from which parameters are copied.
-    target_ensemble (LocalEnsemble): The file system of the target ensemble, to which parameters are saved.
+    source_ensemble (Ensemble): The file system of the source ensemble, from which parameters are copied.
+    target_ensemble (Ensemble): The file system of the target ensemble, to which parameters are saved.
 
     Returns:
     None: The function does not return any value but updates the target file system by copying over
@@ -428,8 +428,8 @@ def analysis_ES(
     global_scaling: float,
     smoother_snapshot: SmootherSnapshot,
     ens_mask: npt.NDArray[np.bool_],
-    source_ensemble: LocalEnsemble,
-    target_ensemble: LocalEnsemble,
+    source_ensemble: Ensemble,
+    target_ensemble: Ensemble,
     progress_callback: Callable[[AnalysisEvent], None],
     misfit_process: bool,
 ) -> None:
@@ -496,7 +496,6 @@ def analysis_ES(
         np.fill_diagonal(T, T.diagonal() + 1)
 
     for param_group in parameters:
-        source: LocalEnsemble
         source = source_ensemble
         temp_storage = _create_temporary_parameter_storage(
             source, iens_active_index, param_group
@@ -562,8 +561,8 @@ def analysis_IES(
     std_cutoff: float,
     smoother_snapshot: SmootherSnapshot,
     ens_mask: npt.NDArray[np.bool_],
-    source_ensemble: LocalEnsemble,
-    target_ensemble: LocalEnsemble,
+    source_ensemble: Ensemble,
+    target_ensemble: Ensemble,
     sies_smoother: Optional[ies.SIES],
     progress_callback: Callable[[AnalysisEvent], None],
     misfit_preprocessor: bool,
@@ -632,7 +631,7 @@ def analysis_IES(
     sies_smoother.W[:, masking_of_initial_parameters] = proposed_W
 
     for param_group in parameters:
-        source: LocalEnsemble = target_ensemble
+        source = target_ensemble
         try:
             target_ensemble.load_parameters(group=param_group, realizations=0)["values"]
         except Exception:
@@ -730,8 +729,8 @@ def _create_smoother_snapshot(
 
 
 def smoother_update(
-    prior_storage: LocalEnsemble,
-    posterior_storage: LocalEnsemble,
+    prior_storage: Ensemble,
+    posterior_storage: Ensemble,
     run_id: str,
     observations: Iterable[str],
     parameters: Iterable[str],
@@ -785,8 +784,8 @@ def smoother_update(
 
 
 def iterative_smoother_update(
-    prior_storage: LocalEnsemble,
-    posterior_storage: LocalEnsemble,
+    prior_storage: Ensemble,
+    posterior_storage: Ensemble,
     sies_smoother: Optional[ies.SIES],
     run_id: str,
     parameters: Iterable[str],

--- a/src/ert/cli/model_factory.py
+++ b/src/ert/cli/model_factory.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from ert.config import Workflow
     from ert.namespace import Namespace
-    from ert.storage import StorageAccessor
+    from ert.storage import Storage
 
 
 def _misfit_preprocessor(workflows: List[Workflow]) -> bool:
@@ -54,7 +54,7 @@ def _misfit_preprocessor(workflows: List[Workflow]) -> bool:
 
 def create_model(
     config: ErtConfig,
-    storage: StorageAccessor,
+    storage: Storage,
     args: Namespace,
 ) -> BaseRunModel:
     logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ def create_model(
 
 
 def _setup_single_test_run(
-    config: ErtConfig, storage: StorageAccessor, args: Namespace
+    config: ErtConfig, storage: Storage, args: Namespace
 ) -> SingleTestRun:
     return SingleTestRun(
         SingleTestRunArguments(
@@ -112,7 +112,7 @@ def _setup_single_test_run(
 
 
 def _setup_ensemble_experiment(
-    config: ErtConfig, storage: StorageAccessor, args: Namespace
+    config: ErtConfig, storage: Storage, args: Namespace
 ) -> EnsembleExperiment:
     min_realizations_count = config.analysis_config.minimum_required_realizations
     active_realizations = _realizations(args, config.model_config.num_realizations)
@@ -144,7 +144,7 @@ def _setup_ensemble_experiment(
 
 
 def _setup_evaluate_ensemble(
-    config: ErtConfig, storage: StorageAccessor, args: Namespace
+    config: ErtConfig, storage: Storage, args: Namespace
 ) -> EvaluateEnsemble:
     min_realizations_count = config.analysis_config.minimum_required_realizations
     active_realizations = _realizations(args, config.model_config.num_realizations)
@@ -175,7 +175,7 @@ def _setup_evaluate_ensemble(
 
 def _setup_ensemble_smoother(
     config: ErtConfig,
-    storage: StorageAccessor,
+    storage: Storage,
     args: Namespace,
     update_settings: UpdateSettings,
 ) -> EnsembleSmoother:
@@ -219,7 +219,7 @@ def _determine_restart_info(args: Namespace) -> Tuple[bool, str]:
 
 def _setup_multiple_data_assimilation(
     config: ErtConfig,
-    storage: StorageAccessor,
+    storage: Storage,
     args: Namespace,
     update_settings: UpdateSettings,
 ) -> MultipleDataAssimilation:
@@ -250,7 +250,7 @@ def _setup_multiple_data_assimilation(
 
 def _setup_iterative_ensemble_smoother(
     config: ErtConfig,
-    storage: StorageAccessor,
+    storage: Storage,
     args: Namespace,
     update_settings: UpdateSettings,
 ) -> IteratedEnsembleSmoother:

--- a/src/ert/cli/workflow.py
+++ b/src/ert/cli/workflow.py
@@ -7,12 +7,10 @@ from ert.job_queue import WorkflowRunner
 
 if TYPE_CHECKING:
     from ert.enkf_main import EnKFMain
-    from ert.storage import StorageAccessor
+    from ert.storage import Storage
 
 
-def execute_workflow(
-    ert: EnKFMain, storage: StorageAccessor, workflow_name: str
-) -> None:
+def execute_workflow(ert: EnKFMain, storage: Storage, workflow_name: str) -> None:
     logger = logging.getLogger(__name__)
     try:
         workflow = ert.ert_config.workflows[workflow_name]

--- a/src/ert/config/ert_script.py
+++ b/src/ert/config/ert_script.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type
 
 if TYPE_CHECKING:
     from ert.enkf_main import EnKFMain
-    from ert.storage import EnsembleAccessor, StorageAccessor
+    from ert.storage import Ensemble, Storage
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +22,8 @@ class ErtScript:
     def __init__(
         self,
         ert: EnKFMain,
-        storage: StorageAccessor,
-        ensemble: Optional[EnsembleAccessor] = None,
+        storage: Storage,
+        ensemble: Optional[Ensemble] = None,
     ) -> None:
         self.__ert = ert
         self.__storage = storage
@@ -55,15 +55,15 @@ class ErtScript:
         return self.__ert
 
     @property
-    def storage(self) -> StorageAccessor:
+    def storage(self) -> Storage:
         return self.__storage
 
     @property
-    def ensemble(self) -> Optional[EnsembleAccessor]:
+    def ensemble(self) -> Optional[Ensemble]:
         return self.__ensemble
 
     @ensemble.setter
-    def ensemble(self, ensemble: EnsembleAccessor) -> None:
+    def ensemble(self, ensemble: Ensemble) -> None:
         self.__ensemble = ensemble
 
     def isCancelled(self) -> bool:
@@ -130,7 +130,7 @@ class ErtScript:
     @staticmethod
     def loadScriptFromFile(
         path: str,
-    ) -> Callable[["EnKFMain", "StorageAccessor"], "ErtScript"]:
+    ) -> Callable[["EnKFMain", "Storage"], "ErtScript"]:
         module_name = f"ErtScriptModule_{ErtScript.__module_count}"
         ErtScript.__module_count += 1
 
@@ -151,7 +151,7 @@ class ErtScript:
     @staticmethod
     def __findErtScriptImplementations(
         module: ModuleType,
-    ) -> Callable[["EnKFMain", "StorageAccessor"], "ErtScript"]:
+    ) -> Callable[["EnKFMain", "Storage"], "ErtScript"]:
         result = []
         for _, member in inspect.getmembers(
             module,

--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -13,7 +13,7 @@ from .parameter_config import ParameterConfig
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
     Number = Union[int, float]
     DataType = Mapping[str, Union[Number, Mapping[str, Number]]]
@@ -71,7 +71,7 @@ class ExtParamConfig(ParameterConfig):
         raise NotImplementedError()
 
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: LocalEnsemble
+        self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> None:
         file_path = run_path / self.output_file
         Path.mkdir(file_path.parent, exist_ok=True, parents=True)
@@ -94,7 +94,7 @@ class ExtParamConfig(ParameterConfig):
 
     def save_parameters(
         self,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
         group: str,
         realization: int,
         data: npt.NDArray[np.float_],
@@ -102,7 +102,7 @@ class ExtParamConfig(ParameterConfig):
         raise NotImplementedError()
 
     def load_parameters(
-        self, ensemble: LocalEnsemble, group: str, realizations: npt.NDArray[np.int_]
+        self, ensemble: Ensemble, group: str, realizations: npt.NDArray[np.int_]
     ) -> Union[npt.NDArray[np.float_], xr.DataArray]:
         raise NotImplementedError()
 

--- a/src/ert/config/external_ert_script.py
+++ b/src/ert/config/external_ert_script.py
@@ -9,11 +9,11 @@ from .ert_script import ErtScript
 
 if TYPE_CHECKING:
     from ert.enkf_main import EnKFMain
-    from ert.storage import StorageAccessor
+    from ert.storage import Storage
 
 
 class ExternalErtScript(ErtScript):
-    def __init__(self, ert: EnKFMain, storage: StorageAccessor, executable: str):
+    def __init__(self, ert: EnKFMain, storage: Storage, executable: str):
         super().__init__(ert, storage, None)
 
         self.__executable = executable

--- a/src/ert/config/field_config.py
+++ b/src/ert/config/field_config.py
@@ -22,7 +22,7 @@ from .parsing import ConfigValidationError, ConfigWarning
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
 _logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class FieldConfig(ParameterConfig):
         return ds
 
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: LocalEnsemble
+        self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> None:
         t = time.perf_counter()
         file_out = run_path.joinpath(self.output_file)
@@ -181,7 +181,7 @@ class FieldConfig(ParameterConfig):
 
     def save_parameters(
         self,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
         group: str,
         realization: int,
         data: npt.NDArray[np.float_],
@@ -197,7 +197,7 @@ class FieldConfig(ParameterConfig):
         ensemble.save_parameters(group, realization, ds)
 
     def load_parameters(
-        self, ensemble: LocalEnsemble, group: str, realizations: npt.NDArray[np.int_]
+        self, ensemble: Ensemble, group: str, realizations: npt.NDArray[np.int_]
     ) -> Union[npt.NDArray[np.float_], xr.DataArray]:
         ds = ensemble.load_parameters(group, realizations)
         ensemble_size = len(ds.realizations)
@@ -209,9 +209,7 @@ class FieldConfig(ParameterConfig):
         )
         return da.T.to_numpy()
 
-    def _fetch_from_ensemble(
-        self, real_nr: int, ensemble: LocalEnsemble
-    ) -> xr.DataArray:
+    def _fetch_from_ensemble(self, real_nr: int, ensemble: Ensemble) -> xr.DataArray:
         da = ensemble.load_parameters(self.name, real_nr)["values"]
         assert isinstance(da, xr.DataArray)
         return da

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -32,7 +32,7 @@ from .parsing import ConfigValidationError, ConfigWarning, ErrorInfo
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
 _logger = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ class GenKwConfig(ParameterConfig):
         self,
         run_path: Path,
         real_nr: int,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
     ) -> Dict[str, Dict[str, float]]:
         array = ensemble.load_parameters(self.name, real_nr)["transformed_values"]
         assert isinstance(array, xr.DataArray)
@@ -280,7 +280,7 @@ class GenKwConfig(ParameterConfig):
 
     def save_parameters(
         self,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
         group: str,
         realization: int,
         data: npt.NDArray[np.float_],
@@ -298,7 +298,7 @@ class GenKwConfig(ParameterConfig):
         ensemble.save_parameters(group, realization, ds)
 
     def load_parameters(
-        self, ensemble: LocalEnsemble, group: str, realizations: npt.NDArray[np.int_]
+        self, ensemble: Ensemble, group: str, realizations: npt.NDArray[np.int_]
     ) -> Union[npt.NDArray[np.float_], xr.DataArray]:
         return ensemble.load_parameters(group, realizations)["values"].values.T
 

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -13,7 +13,7 @@ from ert.config._option_dict import option_dict
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
 
 class CustomDict(dict):  # type: ignore
@@ -77,7 +77,7 @@ class ParameterConfig(ABC):
 
     @abstractmethod
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: LocalEnsemble
+        self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> Optional[Dict[str, Dict[str, float]]]:
         """
         This function is responsible for converting the parameter
@@ -88,7 +88,7 @@ class ParameterConfig(ABC):
     @abstractmethod
     def save_parameters(
         self,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
         group: str,
         realization: int,
         data: npt.NDArray[np.float_],
@@ -99,7 +99,7 @@ class ParameterConfig(ABC):
 
     @abstractmethod
     def load_parameters(
-        self, ensemble: LocalEnsemble, group: str, realizations: npt.NDArray[np.int_]
+        self, ensemble: Ensemble, group: str, realizations: npt.NDArray[np.int_]
     ) -> Union[npt.NDArray[np.float_], xr.DataArray]:
         """
         Load the parameter from internal storage for the given ensemble

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -17,7 +17,7 @@ from .parsing import ConfigValidationError, ErrorInfo
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import LocalEnsemble
+    from ert.storage import Ensemble
 
 
 @dataclass
@@ -121,7 +121,7 @@ class SurfaceConfig(ParameterConfig):
         return da.to_dataset()
 
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: LocalEnsemble
+        self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> None:
         data = ensemble.load_parameters(self.name, real_nr)["values"]
 
@@ -143,7 +143,7 @@ class SurfaceConfig(ParameterConfig):
 
     def save_parameters(
         self,
-        ensemble: LocalEnsemble,
+        ensemble: Ensemble,
         group: str,
         realization: int,
         data: npt.NDArray[np.float_],
@@ -159,6 +159,6 @@ class SurfaceConfig(ParameterConfig):
         ensemble.save_parameters(group, realization, ds)
 
     def load_parameters(
-        self, ensemble: LocalEnsemble, group: str, realizations: npt.NDArray[np.int_]
+        self, ensemble: Ensemble, group: str, realizations: npt.NDArray[np.int_]
     ) -> Union[npt.NDArray[np.float_], xr.DataArray]:
         return ensemble.load_parameters(group, realizations)["values"]

--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -7,10 +7,10 @@ import pandas as pd
 import xarray as xr
 
 from ert.config import GenDataConfig, GenKwConfig
-from ert.storage import EnsembleReader, ExperimentReader, LocalEnsemble, StorageReader
+from ert.storage import Ensemble, Experiment, Storage
 
 
-def _ensemble_parameter_names(ensemble: LocalEnsemble) -> Iterator[str]:
+def _ensemble_parameter_names(ensemble: Ensemble) -> Iterator[str]:
     return (
         (
             f"LOG10_{config.name}:{keyword}"
@@ -23,22 +23,20 @@ def _ensemble_parameter_names(ensemble: LocalEnsemble) -> Iterator[str]:
     )
 
 
-def ensemble_parameters(
-    storage: StorageReader, ensemble_id: UUID
-) -> List[Dict[str, Any]]:
+def ensemble_parameters(storage: Storage, ensemble_id: UUID) -> List[Dict[str, Any]]:
     return [
         {"name": key, "userdata": {"data_origin": "GEN_KW"}, "labels": []}
         for key in _ensemble_parameter_names(storage.get_ensemble(ensemble_id))
     ]
 
 
-def get_response_names(ensemble: EnsembleReader) -> List[str]:
+def get_response_names(ensemble: Ensemble) -> List[str]:
     result = ensemble.get_summary_keyset()
     result.extend(sorted(gen_data_keys(ensemble), key=lambda k: k.lower()))
     return result
 
 
-def gen_data_keys(ensemble: LocalEnsemble) -> Iterator[str]:
+def gen_data_keys(ensemble: Ensemble) -> Iterator[str]:
     for k, v in ensemble.experiment.response_configuration.items():
         if isinstance(v, GenDataConfig):
             if v.report_steps is None:
@@ -49,7 +47,7 @@ def gen_data_keys(ensemble: LocalEnsemble) -> Iterator[str]:
 
 
 def data_for_key(
-    ensemble: EnsembleReader,
+    ensemble: Ensemble,
     key: str,
 ) -> pd.DataFrame:
     """Returns a pandas DataFrame with the datapoints for a given key for a
@@ -148,7 +146,7 @@ def data_for_key(
     return pd.DataFrame()
 
 
-def get_all_observations(experiment: ExperimentReader) -> List[Dict[str, Any]]:
+def get_all_observations(experiment: Experiment) -> List[Dict[str, Any]]:
     observations = []
     for key, dataset in experiment.observations.items():
         observation = {
@@ -167,7 +165,7 @@ def get_all_observations(experiment: ExperimentReader) -> List[Dict[str, Any]]:
 
 
 def get_observations_for_obs_keys(
-    ensemble: EnsembleReader, observation_keys: List[str]
+    ensemble: Ensemble, observation_keys: List[str]
 ) -> List[Dict[str, Any]]:
     observations = []
     experiment_observations = ensemble.experiment.observations
@@ -188,7 +186,7 @@ def get_observations_for_obs_keys(
     return observations
 
 
-def get_observation_name(ensemble: EnsembleReader, observation_keys: List[str]) -> str:
+def get_observation_name(ensemble: Ensemble, observation_keys: List[str]) -> str:
     observations_dict = ensemble.experiment.observations
     for key in observation_keys:
         observation = observations_dict[key]
@@ -199,7 +197,7 @@ def get_observation_name(ensemble: EnsembleReader, observation_keys: List[str]) 
 
 
 def get_observation_keys_for_response(
-    ensemble: EnsembleReader, response_key: str
+    ensemble: Ensemble, response_key: str
 ) -> List[str]:
     """
     Get all observation keys for given response key

--- a/src/ert/dark_storage/endpoints/compute/misfits.py
+++ b/src/ert/dark_storage/endpoints/compute/misfits.py
@@ -15,7 +15,7 @@ from ert.dark_storage.common import (
 )
 from ert.dark_storage.compute.misfits import calculate_misfits_from_pandas
 from ert.dark_storage.enkf import get_storage
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["misfits"])
 DEFAULT_STORAGEREADER = Depends(get_storage)
@@ -31,7 +31,7 @@ DEFAULT_STORAGEREADER = Depends(get_storage)
 )
 async def get_response_misfits(
     *,
-    storage: StorageReader = DEFAULT_STORAGEREADER,
+    storage: Storage = DEFAULT_STORAGEREADER,
     ensemble_id: UUID,
     response_name: str,
     realization_index: Optional[int] = None,

--- a/src/ert/dark_storage/endpoints/ensembles.py
+++ b/src/ert/dark_storage/endpoints/ensembles.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Body, Depends
 
 from ert.dark_storage import json_schema as js
 from ert.dark_storage.enkf import get_storage
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["ensemble"])
 DEFAULT_STORAGE = Depends(get_storage)
@@ -14,7 +14,7 @@ DEFAULT_BODY = Body(...)
 @router.get("/ensembles/{ensemble_id}", response_model=js.EnsembleOut)
 def get_ensemble(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     ensemble_id: UUID,
 ) -> js.EnsembleOut:
     ensemble = storage.get_ensemble(ensemble_id)

--- a/src/ert/dark_storage/endpoints/experiments.py
+++ b/src/ert/dark_storage/endpoints/experiments.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, Depends
 from ert.dark_storage import json_schema as js
 from ert.dark_storage.enkf import get_storage
 from ert.shared.storage.extraction import create_priors
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["experiment"])
 
@@ -17,7 +17,7 @@ DEFAULT_BODY = Body(...)
 @router.get("/experiments", response_model=List[js.ExperimentOut])
 def get_experiments(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
 ) -> List[js.ExperimentOut]:
     return [
         js.ExperimentOut(
@@ -34,7 +34,7 @@ def get_experiments(
 @router.get("/experiments/{experiment_id}", response_model=js.ExperimentOut)
 def get_experiment_by_id(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     experiment_id: UUID,
 ) -> js.ExperimentOut:
     experiment = storage.get_experiment(experiment_id)
@@ -52,7 +52,7 @@ def get_experiment_by_id(
 )
 def get_experiment_ensembles(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     experiment_id: UUID,
 ) -> List[js.EnsembleOut]:
     return [

--- a/src/ert/dark_storage/endpoints/observations.py
+++ b/src/ert/dark_storage/endpoints/observations.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, Depends
 from ert.dark_storage import json_schema as js
 from ert.dark_storage.common import get_all_observations
 from ert.dark_storage.enkf import get_storage
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["ensemble"])
 
@@ -18,7 +18,7 @@ DEFAULT_BODY = Body(...)
     "/experiments/{experiment_id}/observations", response_model=List[js.ObservationOut]
 )
 def get_observations(
-    *, storage: StorageReader = DEFAULT_STORAGE, experiment_id: UUID
+    *, storage: Storage = DEFAULT_STORAGE, experiment_id: UUID
 ) -> List[js.ObservationOut]:
     experiment = storage.get_experiment(experiment_id)
     return [

--- a/src/ert/dark_storage/endpoints/records.py
+++ b/src/ert/dark_storage/endpoints/records.py
@@ -17,7 +17,7 @@ from ert.dark_storage.common import (
     get_observations_for_obs_keys,
 )
 from ert.dark_storage.enkf import get_storage
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["record"])
 
@@ -30,7 +30,7 @@ DEFAULT_HEADER = Header("application/json")
 @router.get("/ensembles/{ensemble_id}/records/{response_name}/observations")
 async def get_record_observations(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     ensemble_id: UUID,
     response_name: str,
 ) -> List[js.ObservationOut]:
@@ -67,7 +67,7 @@ async def get_record_observations(
 )
 async def get_ensemble_record(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     name: str,
     ensemble_id: UUID,
     accept: Annotated[Union[str, None], Header()] = None,
@@ -94,7 +94,7 @@ async def get_ensemble_record(
 
 @router.get("/ensembles/{ensemble_id}/parameters", response_model=List[Dict[str, Any]])
 async def get_ensemble_parameters(
-    *, storage: StorageReader = DEFAULT_STORAGE, ensemble_id: UUID
+    *, storage: Storage = DEFAULT_STORAGE, ensemble_id: UUID
 ) -> List[Dict[str, Any]]:
     return ensemble_parameters(storage, ensemble_id)
 
@@ -104,7 +104,7 @@ async def get_ensemble_parameters(
 )
 def get_ensemble_responses(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     ensemble_id: UUID,
 ) -> Mapping[str, js.RecordOut]:
     response_map: Dict[str, js.RecordOut] = {}

--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -5,7 +5,7 @@ from fastapi.responses import Response
 
 from ert.dark_storage.common import data_for_key
 from ert.dark_storage.enkf import get_storage
-from ert.storage import StorageReader
+from ert.storage import Storage
 
 router = APIRouter(tags=["response"])
 
@@ -15,7 +15,7 @@ DEFAULT_STORAGE = Depends(get_storage)
 @router.get("/ensembles/{ensemble_id}/responses/{response_name}/data")
 async def get_ensemble_response_dataframe(
     *,
-    storage: StorageReader = DEFAULT_STORAGE,
+    storage: Storage = DEFAULT_STORAGE,
     ensemble_id: UUID,
     response_name: str,
 ) -> Response:

--- a/src/ert/dark_storage/enkf.py
+++ b/src/ert/dark_storage/enkf.py
@@ -6,17 +6,17 @@ from typing import Optional
 from fastapi import Depends
 
 from ert.dark_storage.security import security
-from ert.storage import StorageReader, open_storage
+from ert.storage import Storage, open_storage
 
 __all__ = ["get_storage"]
 
 
-_storage: Optional[StorageReader] = None
+_storage: Optional[Storage] = None
 
 DEFAULT_SECURITY = Depends(security)
 
 
-def get_storage() -> StorageReader:
+def get_storage() -> Storage:
     global _storage  # noqa: PLW0603e
     if _storage is None:
         return (_storage := open_storage(os.environ["ERT_STORAGE_ENS_PATH"]))

--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -17,7 +17,7 @@ import pandas as pd
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.storage import EnsembleReader
+    from ert.storage import Ensemble
 
 
 class ResponseError(Exception):
@@ -27,7 +27,7 @@ class ResponseError(Exception):
 class MeasuredData:
     def __init__(
         self,
-        ensemble: EnsembleReader,
+        ensemble: Ensemble,
         keys: Optional[List[str]] = None,
         index_lists: Optional[List[List[Union[int, datetime]]]] = None,
     ):
@@ -88,7 +88,7 @@ class MeasuredData:
 
     def _get_data(
         self,
-        ensemble: EnsembleReader,
+        ensemble: Ensemble,
         observation_keys: List[str],
     ) -> pd.DataFrame:
         """

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from .config import ErtConfig, HookRuntime
-    from .storage import EnsembleAccessor, EnsembleReader, StorageAccessor
+    from .storage import Ensemble, Storage
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def _generate_parameter_files(
     export_base_name: str,
     run_path: Path,
     iens: int,
-    fs: EnsembleReader,
+    fs: Ensemble,
     iteration: int,
 ) -> None:
     """
@@ -91,7 +91,7 @@ def _generate_parameter_files(
             `parameters` in `parameters.json`.
         run_path: Path to the runtime directory
         iens: Realisation index
-        fs: EnsembleReader from which to load parameter data
+        fs: Ensemble from which to load parameter data
     """
     exports: Dict[str, Dict[str, float]] = {}
 
@@ -136,15 +136,15 @@ class EnKFMain:
     def runWorkflows(
         self,
         runtime: HookRuntime,
-        storage: Optional[StorageAccessor] = None,
-        ensemble: Optional[EnsembleAccessor] = None,
+        storage: Optional[Storage] = None,
+        ensemble: Optional[Ensemble] = None,
     ) -> None:
         for workflow in self.ert_config.hooked_workflows[runtime]:
             WorkflowRunner(workflow, self, storage, ensemble).run_blocking()
 
 
 def sample_prior(
-    ensemble: EnsembleAccessor,
+    ensemble: Ensemble,
     active_realizations: Iterable[int],
     parameters: Optional[List[str]] = None,
     random_seed: Optional[int] = None,
@@ -239,7 +239,7 @@ def create_run_path(
 
 
 def ensemble_context(
-    case: EnsembleAccessor,
+    case: Ensemble,
     active_realizations: npt.NDArray[np.bool_],
     iteration: int,
     substitution_list: Optional[SubstitutionList],

--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from qtpy.QtCore import QObject, Signal, Slot
 
-from ert.storage import EnsembleReader, StorageReader
+from ert.storage import Ensemble, Storage
 
 
 class ErtNotifier(QObject):
@@ -13,7 +13,7 @@ class ErtNotifier(QObject):
     def __init__(self, config_file: str):
         QObject.__init__(self)
         self._config_file = config_file
-        self._storage: Optional[StorageReader] = None
+        self._storage: Optional[Storage] = None
         self._current_case = None
         self._is_simulation_running = False
 
@@ -22,7 +22,7 @@ class ErtNotifier(QObject):
         return self._storage is not None
 
     @property
-    def storage(self) -> StorageReader:
+    def storage(self) -> Storage:
         assert self.is_storage_available
         return self._storage
 
@@ -31,7 +31,7 @@ class ErtNotifier(QObject):
         return self._config_file
 
     @property
-    def current_case(self) -> Optional[EnsembleReader]:
+    def current_case(self) -> Optional[Ensemble]:
         if self._current_case is None and self._storage is not None:
             ensembles = list(self._storage.ensembles)
             if ensembles:
@@ -53,12 +53,12 @@ class ErtNotifier(QObject):
         self.ertChanged.emit()
 
     @Slot(object)
-    def set_storage(self, storage: StorageReader) -> None:
+    def set_storage(self, storage: Storage) -> None:
         self._storage = storage
         self.storage_changed.emit(storage)
 
     @Slot(object)
-    def set_current_case(self, case: Optional[EnsembleReader] = None) -> None:
+    def set_current_case(self, case: Optional[Ensemble] = None) -> None:
         self._current_case = case
         self.current_case_changed.emit(case)
 

--- a/src/ert/gui/ertwidgets/caselist.py
+++ b/src/ert/gui/ertwidgets/caselist.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (
 from ert.config import ErtConfig
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets.validateddialog import ValidatedDialog
-from ert.storage import StorageAccessor
+from ert.storage import Storage
 
 
 class AddWidget(QWidget):
@@ -75,7 +75,7 @@ class CaseList(QWidget):
         self.updateList()
 
     @property
-    def storage(self) -> StorageAccessor:
+    def storage(self) -> Storage:
         return self.notifier.storage
 
     def addItem(self):

--- a/src/ert/gui/ertwidgets/caseselector.py
+++ b/src/ert/gui/ertwidgets/caseselector.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import QComboBox
 from ert.gui.ertnotifier import ErtNotifier
 
 if TYPE_CHECKING:
-    from ert.storage import EnsembleReader
+    from ert.storage import Ensemble
 
 
 class CaseSelector(QComboBox):
@@ -66,7 +66,7 @@ class CaseSelector(QComboBox):
 
         self.case_populated.emit()
 
-    def _case_list(self) -> Iterable[EnsembleReader]:
+    def _case_list(self) -> Iterable[Ensemble]:
         if self._show_only_initialized:
             case_list = (
                 x
@@ -80,5 +80,5 @@ class CaseSelector(QComboBox):
     def _on_current_index_changed(self, index: int) -> None:
         self.notifier.set_current_case(self.itemData(index))
 
-    def _on_global_current_case_changed(self, data: Optional[EnsembleReader]) -> None:
+    def _on_global_current_case_changed(self, data: Optional[Ensemble]) -> None:
         self.setCurrentIndex(max(self.findData(data, Qt.ItemDataRole.UserRole), 0))

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -10,7 +10,7 @@ from qtpy.QtCore import (
 )
 from qtpy.QtWidgets import QApplication
 
-from ert.storage import EnsembleReader, ExperimentReader, StorageReader
+from ert.storage import Ensemble, Experiment, Storage
 
 
 class _Column(IntEnum):
@@ -30,7 +30,7 @@ _COLUMN_TEXT = {
 
 
 class Ensemble:
-    def __init__(self, ensemble: EnsembleReader, parent: Any):
+    def __init__(self, ensemble: Ensemble, parent: Any):
         self._parent = parent
         self._name = ensemble.name
         self._id = ensemble.id
@@ -61,7 +61,7 @@ class Ensemble:
 
 
 class Experiment:
-    def __init__(self, experiment: ExperimentReader, parent: Any):
+    def __init__(self, experiment: Experiment, parent: Any):
         self._parent = parent
         self._id = experiment.id
         self._name = experiment.name
@@ -98,14 +98,13 @@ class Experiment:
 
 
 class StorageModel(QAbstractItemModel):
-
-    def __init__(self, storage: StorageReader):
+    def __init__(self, storage: Storage):
         super().__init__(None)
         self._children: List[Experiment] = []
         self._load_storage(storage)
 
-    @Slot(StorageReader)
-    def reloadStorage(self, storage: StorageReader) -> None:
+    @Slot(Storage)
+    def reloadStorage(self, storage: Storage) -> None:
         self.beginResetModel()
         self._load_storage(storage)
         self.endResetModel()
@@ -117,7 +116,7 @@ class StorageModel(QAbstractItemModel):
         self._children.append(experiment)
         self.endInsertRows()
 
-    def _load_storage(self, storage: StorageReader) -> None:
+    def _load_storage(self, storage: Storage) -> None:
         self._children = []
         for experiment in storage.experiments:
             ex = Experiment(experiment, self)

--- a/src/ert/gui/tools/run_analysis/run_analysis_tool.py
+++ b/src/ert/gui/tools/run_analysis/run_analysis_tool.py
@@ -16,7 +16,7 @@ from ert.gui.ertwidgets.statusdialog import StatusDialog
 from ert.gui.tools import Tool
 from ert.gui.tools.run_analysis import RunAnalysisPanel
 from ert.run_models.event import RunModelEvent, RunModelStatusEvent, RunModelTimeEvent
-from ert.storage import EnsembleAccessor, EnsembleReader
+from ert.storage import Ensemble
 
 
 class Analyse(QObject):
@@ -33,8 +33,8 @@ class Analyse(QObject):
     def __init__(
         self,
         ert: EnKFMain,
-        target_fs: EnsembleAccessor,
-        source_fs: EnsembleReader,
+        target_fs: Ensemble,
+        source_fs: Ensemble,
     ):
         QObject.__init__(self)
         self._ert = ert
@@ -177,7 +177,7 @@ class RunAnalysisTool(Tool):
         else:
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
 
-    def _init_analyse(self, source_fs: EnsembleReader, target: str):
+    def _init_analyse(self, source_fs: Ensemble, target: str):
         target_fs = self.notifier.storage.create_ensemble(
             source_fs.experiment_id,
             name=target,

--- a/src/ert/job_queue/workflow_runner.py
+++ b/src/ert/job_queue/workflow_runner.py
@@ -12,7 +12,7 @@ from ert.config import ErtScript, ExternalErtScript, Workflow, WorkflowJob
 
 if TYPE_CHECKING:
     from ert.enkf_main import EnKFMain
-    from ert.storage import EnsembleAccessor, StorageAccessor
+    from ert.storage import Ensemble, Storage
 
 
 class WorkflowJobRunner:
@@ -25,8 +25,8 @@ class WorkflowJobRunner:
     def run(
         self,
         ert: Optional[EnKFMain] = None,
-        storage: Optional[StorageAccessor] = None,
-        ensemble: Optional[EnsembleAccessor] = None,
+        storage: Optional[Storage] = None,
+        ensemble: Optional[Ensemble] = None,
         arguments: Optional[List[Any]] = None,
     ) -> Any:
         if arguments is None:
@@ -130,8 +130,8 @@ class WorkflowRunner:
         self,
         workflow: Workflow,
         ert: Optional[EnKFMain] = None,
-        storage: Optional[StorageAccessor] = None,
-        ensemble: Optional[EnsembleAccessor] = None,
+        storage: Optional[Storage] = None,
+        ensemble: Optional[Ensemble] = None,
     ) -> None:
         self.__workflow = workflow
         self._ert = ert

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -33,7 +33,7 @@ from ert.data import MeasuredData
 from ert.data._measured_data import ObservationError, ResponseError
 from ert.load_status import LoadResult, LoadStatus
 from ert.shared.version import __version__
-from ert.storage import EnsembleReader
+from ert.storage import Ensemble
 
 from .analysis._es_update import UpdateSettings
 from .enkf_main import EnKFMain, ensemble_context
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
         WorkflowJob,
     )
     from ert.run_arg import RunArg
-    from ert.storage import EnsembleAccessor, StorageAccessor
+    from ert.storage import Ensemble, Storage
 
 
 def _load_realization(
@@ -80,8 +80,8 @@ class LibresFacade:
 
     def smoother_update(
         self,
-        prior_storage: EnsembleReader,
-        posterior_storage: EnsembleAccessor,
+        prior_storage: Ensemble,
+        posterior_storage: Ensemble,
         run_id: str,
         observations: Iterable[str],
         parameters: Iterable[str],
@@ -162,7 +162,7 @@ class LibresFacade:
 
     def load_from_forward_model(
         self,
-        ensemble: EnsembleAccessor,
+        ensemble: Ensemble,
         realisations: npt.NDArray[np.bool_],
         iteration: int,
     ) -> int:
@@ -270,7 +270,7 @@ class LibresFacade:
         else:
             return []
 
-    def load_all_misfit_data(self, ensemble: EnsembleReader) -> DataFrame:
+    def load_all_misfit_data(self, ensemble: Ensemble) -> DataFrame:
         """Loads all misfit data for a given ensemble.
 
         Retrieves all active realizations from the ensemble, and for each
@@ -350,8 +350,8 @@ class LibresFacade:
     def run_ertscript(  # type: ignore
         self,
         ertscript,
-        storage: StorageAccessor,
-        ensemble: EnsembleAccessor,
+        storage: Storage,
+        ensemble: Ensemble,
         *args: Optional[Any],
         **kwargs: Optional[Any],
     ) -> Any:

--- a/src/ert/run_arg.py
+++ b/src/ert/run_arg.py
@@ -4,13 +4,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from ert.storage import EnsembleAccessor
+    from ert.storage import Ensemble
 
 
 @dataclass
 class RunArg:
     run_id: str
-    ensemble_storage: EnsembleAccessor
+    ensemble_storage: Ensemble
     iens: int
     itr: int
     runpath: str

--- a/src/ert/run_context.py
+++ b/src/ert/run_context.py
@@ -12,12 +12,12 @@ from .runpaths import Runpaths
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from .storage import EnsembleAccessor
+    from .storage import Ensemble
 
 
 @dataclass
 class RunContext:
-    sim_fs: EnsembleAccessor
+    sim_fs: Ensemble
     runpaths: Runpaths
     initial_mask: npt.NDArray[np.bool_] = field(
         default_factory=lambda: np.array([], dtype=bool)

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -35,7 +35,7 @@ from ert.ensemble_evaluator import (
 from ert.libres_facade import LibresFacade
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
-from ert.storage import StorageAccessor
+from ert.storage import Storage
 
 from .event import (
     RunModelStatusEvent,
@@ -85,7 +85,7 @@ class BaseRunModel:
         self,
         simulation_arguments: RunArgumentsType,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
         phase_count: int = 1,
     ):

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -8,7 +8,7 @@ import numpy as np
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
-from ert.storage import StorageAccessor
+from ert.storage import Storage
 
 from .base_run_model import BaseRunModel
 
@@ -36,7 +36,7 @@ class EnsembleExperiment(BaseRunModel):
             EnsembleExperimentRunArguments,
         ],
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
     ):
         super().__init__(

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -12,7 +12,7 @@ from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESRunArguments
-from ert.storage import StorageAccessor
+from ert.storage import Storage
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
@@ -31,7 +31,7 @@ class EnsembleSmoother(BaseRunModel):
         self,
         simulation_arguments: ESRunArguments,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
         es_settings: ESSettings,
         update_settings: UpdateSettings,

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -7,7 +7,7 @@ import numpy as np
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import EvaluateEnsembleRunArguments
-from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage import Ensemble, Storage
 
 from . import BaseRunModel
 
@@ -30,7 +30,7 @@ class EvaluateEnsemble(BaseRunModel):
         self,
         simulation_arguments: EvaluateEnsembleRunArguments,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
     ):
         super().__init__(
@@ -47,7 +47,7 @@ class EvaluateEnsemble(BaseRunModel):
         self.setPhaseName("Running evaluate experiment...", indeterminate=False)
         ensemble_name = self.simulation_arguments.current_case
         ensemble = self._storage.get_ensemble_by_name(ensemble_name)
-        assert isinstance(ensemble, EnsembleAccessor)
+        assert isinstance(ensemble, Ensemble)
         experiment = ensemble.experiment
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
         self.set_env_key("_ERT_ENSEMBLE_ID", str(ensemble.id))

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -13,7 +13,7 @@ from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import SIESRunArguments
-from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage import Ensemble, Storage
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import IESSettings
@@ -36,7 +36,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self,
         simulation_arguments: SIESRunArguments,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
         analysis_config: IESSettings,
         update_settings: UpdateSettings,
@@ -73,8 +73,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
 
     def analyzeStep(
         self,
-        prior_storage: EnsembleAccessor,
-        posterior_storage: EnsembleAccessor,
+        prior_storage: Ensemble,
+        posterior_storage: Ensemble,
         ensemble_id: str,
         iteration: int,
         initial_mask: npt.NDArray[np.bool_],

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -12,7 +12,7 @@ from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_context import RunContext
 from ert.run_models.run_arguments import ESMDARunArguments
-from ert.storage import EnsembleAccessor, StorageAccessor
+from ert.storage import Ensemble, Storage
 
 from ..analysis._es_update import UpdateSettings
 from ..config.analysis_module import ESSettings
@@ -37,7 +37,7 @@ class MultipleDataAssimilation(BaseRunModel):
         self,
         simulation_arguments: ESMDARunArguments,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
         queue_config: QueueConfig,
         es_settings: ESSettings,
         update_settings: UpdateSettings,
@@ -90,7 +90,7 @@ class MultipleDataAssimilation(BaseRunModel):
                 experiment = prior.experiment
                 self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
                 self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
-                assert isinstance(prior, EnsembleAccessor)
+                assert isinstance(prior, Ensemble)
                 prior_context = RunContext(
                     sim_fs=prior,
                     runpaths=self.run_paths,

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -9,7 +9,7 @@ from ert.run_models import EnsembleExperiment, ErtRunError
 
 if TYPE_CHECKING:
     from ert.run_models.run_arguments import SingleTestRunArguments
-    from ert.storage import StorageAccessor
+    from ert.storage import Storage
 
 
 class SingleTestRun(EnsembleExperiment):
@@ -17,7 +17,7 @@ class SingleTestRun(EnsembleExperiment):
         self,
         simulation_arguments: SingleTestRunArguments,
         config: ErtConfig,
-        storage: StorageAccessor,
+        storage: Storage,
     ):
         local_queue_config = config.queue_config.create_local_copy()
         super().__init__(simulation_arguments, config, storage, local_queue_config)

--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, Mapping, Union
 
 from ert.config.gen_kw_config import GenKwConfig
-from ert.storage import ExperimentReader
+from ert.storage import Experiment
 
 logger = logging.getLogger()
 
@@ -24,7 +24,7 @@ _PRIOR_NAME_MAP = {
 
 
 def create_priors(
-    experiment: ExperimentReader,
+    experiment: Experiment,
 ) -> Mapping[str, Dict[str, Union[str, float]]]:
     priors_dict = {}
 

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -10,7 +10,7 @@ from ert.enkf_main import EnKFMain
 from .batch_simulator_context import BatchContext
 
 if TYPE_CHECKING:
-    from ert.storage import EnsembleAccessor, StorageAccessor
+    from ert.storage import Ensemble, Storage
 
 
 class BatchSimulator:
@@ -113,7 +113,7 @@ class BatchSimulator:
         self,
         sim_id: int,
         controls: Dict[str, Dict[str, Any]],
-        file_system: EnsembleAccessor,
+        file_system: Ensemble,
     ) -> None:
         def _check_suffix(
             ext_config: "ExtParamConfig",
@@ -169,7 +169,7 @@ class BatchSimulator:
         self,
         case_name: str,
         case_data: List[Tuple[int, Dict[str, Dict[str, Any]]]],
-        storage: StorageAccessor,
+        storage: Storage,
     ) -> BatchContext:
         """Start batch simulation, return a simulation context
 

--- a/src/ert/simulator/batch_simulator_context.py
+++ b/src/ert/simulator/batch_simulator_context.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.enkf_main import EnKFMain
-    from ert.storage import EnsembleAccessor
+    from ert.storage import Ensemble
 
 Status = namedtuple("Status", "waiting pending running complete failed")
 
@@ -28,7 +28,7 @@ class BatchContext(SimulationContext):
         self,
         result_keys: "Iterable[str]",
         ert: "EnKFMain",
-        fs: EnsembleAccessor,
+        fs: Ensemble,
         mask: npt.NDArray[np.bool_],
         itr: int,
         case_data: List[Tuple[Any, Any]],

--- a/src/ert/simulator/simulation_context.py
+++ b/src/ert/simulator/simulation_context.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from ert.enkf_main import EnKFMain
     from ert.run_arg import RunArg
-    from ert.storage import EnsembleAccessor
+    from ert.storage import Ensemble
 
 
 def _slug(entity: str) -> str:
@@ -86,7 +86,7 @@ class SimulationContext:
     def __init__(
         self,
         ert: "EnKFMain",
-        sim_fs: EnsembleAccessor,
+        sim_fs: Ensemble,
         mask: npt.NDArray[np.bool_],
         itr: int,
         case_data: List[Tuple[Any, Any]],
@@ -242,7 +242,7 @@ class SimulationContext:
             f"#success = {numSucc}, #failed = {numFail}, #waiting = {numWait})"
         )
 
-    def get_sim_fs(self) -> EnsembleAccessor:
+    def get_sim_fs(self) -> Ensemble:
         return self._run_context.sim_fs
 
     def stop(self) -> None:

--- a/tests/unit_tests/cli/test_run_context.py
+++ b/tests/unit_tests/cli/test_run_context.py
@@ -8,7 +8,7 @@ from ert.run_models import (
     multiple_data_assimilation,
 )
 from ert.run_models.run_arguments import ESMDARunArguments
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -54,7 +54,7 @@ def test_that_all_iterations_gets_correct_name_and_iteration_number(
     calls = set(
         (x.kwargs["sim_fs"].name, x.kwargs["iteration"])
         for x in context_mock.mock_calls
-        if "sim_fs" in x.kwargs and isinstance(x.kwargs["sim_fs"], EnsembleAccessor)
+        if "sim_fs" in x.kwargs and isinstance(x.kwargs["sim_fs"], Ensemble)
     )
     assert ("target_0", 0) in calls
     assert ("target_1", 1) in calls

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -13,7 +13,7 @@ from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.ensemble_evaluator.snapshot import SnapshotBuilder
 from ert.load_status import LoadStatus
 from ert.run_arg import RunArg
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 from .ensemble_evaluator_utils import TestEnsemble
 
@@ -130,7 +130,7 @@ def make_ensemble_builder(queue_config):
                     .set_run_arg(
                         RunArg(
                             str(iens),
-                            MagicMock(spec=EnsembleAccessor),
+                            MagicMock(spec=Ensemble),
                             iens,
                             0,
                             str(run_path),

--- a/tests/unit_tests/job_queue/test_job_queue.py
+++ b/tests/unit_tests/job_queue/test_job_queue.py
@@ -13,7 +13,7 @@ import pytest
 from ert.config import QueueConfig, QueueSystem
 from ert.job_queue import Driver, JobQueue, JobQueueNode, JobStatus
 from ert.run_arg import RunArg
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 
 def wait_for(
@@ -89,7 +89,7 @@ def create_local_queue(
             num_cpu=DUMMY_CONFIG["num_cpu"],
             run_arg=RunArg(
                 str(iens),
-                MagicMock(spec=EnsembleAccessor),
+                MagicMock(spec=Ensemble),
                 0,
                 0,
                 DUMMY_CONFIG["run_path"].format(iens),
@@ -412,7 +412,7 @@ def test_num_cpu_submitted_correctly_lsf(tmpdir, simple_script):
         num_cpu=4,
         run_arg=RunArg(
             str(job_id),
-            MagicMock(spec=EnsembleAccessor),
+            MagicMock(spec=Ensemble),
             0,
             0,
             os.path.realpath(DUMMY_CONFIG["run_path"].format(job_id)),

--- a/tests/unit_tests/job_queue/test_job_queue_node.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node.py
@@ -19,7 +19,7 @@ from ert.job_queue.job_status import JobStatus
 from ert.job_queue.submit_status import SubmitStatus
 from ert.job_queue.thread_status import ThreadStatus
 from ert.run_arg import RunArg
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 queue_systems = st.sampled_from(QueueSystem)
 job_status = st.sampled_from(JobStatus.enums())
@@ -36,7 +36,7 @@ def make_driver(queue_system: QueueSystem):
 drivers = st.builds(make_driver, queue_systems)
 
 job_script = "mock_job_script"
-mock_ensemble_storage = MagicMock(spec=EnsembleAccessor)
+mock_ensemble_storage = MagicMock(spec=Ensemble)
 
 runargs = st.builds(
     RunArg,

--- a/tests/unit_tests/job_queue/test_job_queue_node_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node_torque.py
@@ -10,7 +10,7 @@ import pytest
 from ert.config import QueueSystem
 from ert.job_queue import Driver, JobQueueNode, JobStatus
 from ert.run_arg import RunArg
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 
 @pytest.fixture(name="temp_working_directory")
@@ -121,7 +121,7 @@ def _build_jobqueuenode(job_script, dummy_config: JobConfig, job_id=0):
         num_cpu=1,
         run_arg=RunArg(
             str(job_id),
-            MagicMock(spec=EnsembleAccessor),
+            MagicMock(spec=Ensemble),
             0,
             0,
             os.path.realpath(dummy_config["run_path"].format(job_id)),

--- a/tests/unit_tests/storage/create_runpath.py
+++ b/tests/unit_tests/storage/create_runpath.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context, sample_prior
 from ert.libres_facade import LibresFacade
-from ert.storage import EnsembleAccessor
+from ert.storage import Ensemble
 
 
 def create_runpath(
@@ -11,10 +11,10 @@ def create_runpath(
     config,
     active_mask=None,
     *,
-    ensemble: Optional[EnsembleAccessor] = None,
+    ensemble: Optional[Ensemble] = None,
     iteration=0,
     random_seed: Optional[int] = 1234,
-) -> Tuple[ErtConfig, EnsembleAccessor]:
+) -> Tuple[ErtConfig, Ensemble]:
     active_mask = [True] if active_mask is None else active_mask
     ert_config = ErtConfig.from_file(config)
 

--- a/tests/unit_tests/test_run_path_creation.py
+++ b/tests/unit_tests/test_run_path_creation.py
@@ -10,7 +10,7 @@ from ert.config import ConfigValidationError, ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context, sample_prior
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
-from ert.storage import StorageAccessor
+from ert.storage import Storage
 
 
 @pytest.fixture(autouse=True)
@@ -469,7 +469,7 @@ def test_assert_export(prior_ensemble):
     )
 
 
-def _create_runpath(ert_config: ErtConfig, storage: StorageAccessor) -> RunContext:
+def _create_runpath(ert_config: ErtConfig, storage: Storage) -> RunContext:
     """
     Instantiate an ERT runpath. This will create the parameter coefficients.
     """


### PR DESCRIPTION
At one point there was a difference between Reader and Accessors. Now they are the same class, with aliasing kept for compatibility. This is the first step to remove the distinction in the Ert codebase.

The exact commands run were:
```sh
find src -type f -name "*.py" -exec sed -i "s,\(Storage\|Experiment\|Ensemble\)\(Reader\|Accessor\),\1,g" '{}' \;
find tests -type f -name "*.py" -exec sed -i "s,\(Storage\|Experiment\|Ensemble\)\(Reader\|Accessor\),\1,g" '{}' \;
```
...and excepting `src/ert/storage/__init__.py`