### PR TITLE
Remove ValueError causing issue with storage v4

### DIFF
--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -26,8 +26,6 @@ class SummaryConfig(ResponseConfig):
     def __post_init__(self) -> None:
         if isinstance(self.refcase, list):
             self.refcase = {datetime.fromisoformat(val) for val in self.refcase}
-        if len(self.keys) < 1:
-            raise ValueError("SummaryConfig must be given at least one key")
 
     def read_from_file(self, run_path: str, iens: int) -> xr.Dataset:
         filename = self.input_file.replace("<IENS>", str(iens))


### PR DESCRIPTION
This fixes the problem of empty summary configs still being in storage. It should not cause an empty summary being loaded due to https://github.com/equinor/ert/blob/d1b15b546bd868cd636eb655f9226110e39bcf6f/src/ert/callbacks.py#L51-L54.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
