### PR TITLE
Make qt error message for plot fail resizable+selectable

### DIFF
--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -33,8 +33,6 @@ from .listeditbox import ListEditBox  # noqa
 from .customdialog import CustomDialog  # noqa
 from .summarypanel import SummaryPanel  # noqa
 from .pathchooser import PathChooser  # noqa
-from .models import TextModel
+from .models import TextModel  # noqa
 
-__all__ = [
-    "TextModel",
-]
+__all__ = ["TextModel"]


### PR DESCRIPTION
QMessageBox is per definition not resizable (possible but PITA to achieve), so using QDialog+modal instead

This (resizable, selectable & with copy button)
![Mar-06-2024 11-43-02](https://github.com/equinor/ert/assets/11595637/fa54b088-af17-450f-a002-f2a0474a6b03)



Instead of this
![Screenshot 2024-03-06 at 09 12 32](https://github.com/equinor/ert/assets/11595637/d59cb7df-fd70-4b8a-856e-999ba41bb212)

