### PR TITLE
Make sure only the main thread sets a new signal handler

### DIFF
--- a/src/_ert/threading.py
+++ b/src/_ert/threading.py
@@ -68,4 +68,5 @@ def _handler(signum: int, frametype: FrameType | None) -> None:
     raise current_exception
 
 
-signal.signal(signal.SIGUSR1, _handler)
+if threading.current_thread() is threading.main_thread():
+    signal.signal(signal.SIGUSR1, _handler)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/everest/issues/2227


**Approach**
Make sure only the main thread sets a new signal handler

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
