### PR TITLE
Make ErtThread signal and re-raising opt-in

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -14,6 +14,7 @@ import yaml
 from resdata import set_abort_handler
 
 import ert.shared
+from _ert.threading import set_signal_handler
 from ert.cli import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -536,6 +537,9 @@ def main() -> None:
 
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     locale.setlocale(locale.LC_NUMERIC, "C")
+
+    # Have ErtThread re-raise uncaught exceptions on main thread
+    set_signal_handler()
 
     args = ert_parser(None, sys.argv[1:])
 

--- a/src/ert/gui/tools/plugins/plugin_runner.py
+++ b/src/ert/gui/tools/plugins/plugin_runner.py
@@ -1,5 +1,4 @@
 import time
-from functools import partial
 from typing import TYPE_CHECKING
 
 from _ert.threading import ErtThread
@@ -34,18 +33,22 @@ class PluginRunner:
 
             dialog.cancelConfirmed.connect(self.cancel)
 
-            run_function = partial(self.__runWorkflowJob, plugin, arguments)
-
-            workflow_job_thread = ErtThread(name="ert_gui_workflow_job_thread")
-            workflow_job_thread.daemon = True
-            workflow_job_thread.run = run_function
+            workflow_job_thread = ErtThread(
+                name="ert_gui_workflow_job_thread",
+                target=self.__runWorkflowJob,
+                args=(plugin, arguments),
+                daemon=True,
+                should_raise=False,
+            )
             workflow_job_thread.start()
 
-            poll_function = partial(self.__pollRunner, dialog)
-
-            self.poll_thread = ErtThread(name="ert_gui_workflow_job_poll_thread")
-            self.poll_thread.daemon = True
-            self.poll_thread.run = poll_function
+            self.poll_thread = ErtThread(
+                name="ert_gui_workflow_job_poll_thread",
+                target=self.__pollRunner,
+                args=(dialog,),
+                daemon=True,
+                should_raise=False,
+            )
             self.poll_thread.start()
 
             dialog.show()

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -115,9 +115,12 @@ class RunWorkflowWidget(QWidget):
         )
         self._running_workflow_dialog.closeButtonPressed.connect(self.cancelWorkflow)
 
-        workflow_thread = ErtThread(name="ert_gui_workflow_thread")
-        workflow_thread.daemon = True
-        workflow_thread.run = self.runWorkflow
+        workflow_thread = ErtThread(
+            name="ert_gui_workflow_thread",
+            target=self.runWorkflow,
+            daemon=True,
+            should_raise=False,
+        )
 
         workflow = self.ert.ert_config.workflows[self.getCurrentWorkflowName()]
         self._workflow_runner = WorkflowRunner(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from os.path import dirname
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
+from _ert.threading import set_signal_handler
+
 if sys.version_info >= (3, 9):
     from importlib.resources import files
 else:
@@ -50,7 +52,7 @@ def log_check():
 @pytest.fixture(scope="session", autouse=True)
 def _reraise_thread_exceptions_on_main_thread():
     """Allow `ert.shared.threading.ErtThread` to re-raise exceptions on main thread"""
-    os.environ["_ERT_THREAD_RAISE"] = "1"
+    set_signal_handler()
 
 
 @pytest.fixture


### PR DESCRIPTION
This commit does the following:
1. Adds a function `set_signal_handler` that must be called before re-raising works
2. Adds a kwarg `should_raise` that must be True for re-raising to work
3. Workflow jobs don't reraise, only log