### PR TITLE
Use concurrency to cancel existing workflow jobs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,10 +1,15 @@
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     name: Check all workflow files
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Download actionlint

--- a/.github/workflows/annotate_cpp.yml
+++ b/.github/workflows/annotate_cpp.yml
@@ -2,6 +2,10 @@ name: Annotate Cpp
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   annotate-cpp:
     strategy:
@@ -9,6 +13,7 @@ jobs:
         os: ['ubuntu-latest']
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
   benchmark:
     name: Run pytest-benchmark benchmark example
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -3,8 +3,8 @@ on:
     inputs:
       python-version:
         type: string
-jobs:
 
+jobs:
   build-wheels:
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -5,8 +5,8 @@ on:
         type: string
       os:
         type: string
-jobs:
 
+jobs:
   build-wheels:
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,6 +12,10 @@ env:
   ERT_SHOW_BACKTRACE: 1
   ECL_SKIP_SIGNAL: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-test-cmake:
     name: Run C++ tests and coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,10 @@ on:
    tags: "*"
  pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   python-test-coverage:
     name: Python Coverage

--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -12,6 +12,10 @@ permissions:
     # contents permission to update benchmark contents in gh-pages branch
     contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   benchmark:
     name: Run pytest-benchmark dark storage

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -8,9 +8,13 @@ on:
    tags: "*"
  pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   python-doctest:
-    name:
+    name: Set up Python ${{ matrix.python-version }}
     timeout-minutes: 40
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -8,8 +8,8 @@ on:
  pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   ERT_SHOW_BACKTRACE: 1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,6 +7,10 @@ on:
      - 'version-**'
  pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-style:
     timeout-minutes: 15

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -7,12 +7,12 @@ on:
         type: string
       test-type:
         type: string
-jobs:
 
+jobs:
   tests-ert:
     name: Run ert tests
     runs-on: ${{ inputs.os }}
-
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -5,6 +5,7 @@ on:
         type: string
       python-version:
         type: string
+
 jobs:
   test-poly-on-slurm:
     name: Run ert tests

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -7,6 +7,10 @@ name: Test Semeio
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-semeio:
     name: Test Semeio

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -7,6 +7,10 @@ on:
      - 'version-**'
  pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   type-checking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using concurrency groups to avoid unwanted congestion on subsequent commits.
Also set timeouts to 60 minutes where no timeout was provided.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
