### PR TITLE
Avoid "qstat -f" for non-finished jobs in PBS

### DIFF
--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -15,7 +15,7 @@ def mock_openpbs(pytestconfig, monkeypatch, tmp_path):
     mock_bin(monkeypatch, tmp_path)
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(30)
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("copy_poly_case")
 def test_openpbs_driver_with_poly_example():

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -328,7 +328,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
     bsub_path.chmod(bsub_path.stat().st_mode | stat.S_IEXEC)
     bjobs_path = bin_path / "bjobs"
     bjobs_path.write_text(f"#!/bin/sh\n{bjobs_script}")
-    bjobs_path.chmod(bsub_path.stat().st_mode | stat.S_IEXEC)
+    bjobs_path.chmod(bjobs_path.stat().st_mode | stat.S_IEXEC)
     driver = LsfDriver()
     with expectation:
         await driver.submit(0, "sleep")


### PR DESCRIPTION
qstat -f (f for "full format") is a heavy operation for the PBS cluster, and we only use it to obtain the Exit status for the job.

This will change the polling into using qstat -f only for jobs that are already marked as finished, through polling with the default qstat output.

**Issue**
Resolves #7368 


**Approach**
see commit




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
