### PR TITLE
Limit MacOS testing to python 3.12, skipping 3.10 and 3.11

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup_python
         with:
+          # pin this to maintain comparable benchmark results
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -155,11 +155,9 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
-        python-version: [ '3.8', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.12' ]
         os: [ 'macos-13', 'macos-latest-xlarge' ]
         exclude:
-          - os: 'macos-13'
-            python-version: '3.10'
           - os: 'macos-latest-xlarge'
             python-version: '3.8'
     uses: ./.github/workflows/test_ert.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-13', 'macos-latest-xlarge']
+        os: ['ubuntu-latest', 'macos-latest-xlarge']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Test doctest
       run: |
-        # dark storage assumes it is a started service so cannot be excuded
+        # dark storage assumes it is a started service so cannot be excluded
         # by pytest blindly
         pytest --doctest-modules --cov=ert --cov-report=xml:cov.xml src/ --ignore src/ert/dark_storage
 

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   python-doctest:
-    name: Set up Python ${{ matrix.python-version }}
+    name: Set up Python
     timeout-minutes: 40
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.11', '3.12']
         os: [ubuntu-latest, macos-13, macos-latest-xlarge]
         exclude:
-        - python-version: '3.10'
-          os: ubuntu-latest
-        - python-version: '3.10'
+        - python-version: '3.11'
           os: macos-13
+        - python-version: '3.11'
+          os: macos-latest-xlarge
         - python-version: '3.8'
           os: macos-latest-xlarge
 


### PR DESCRIPTION
Adjusted after test-table was adjusted.
https://github.com/equinor/ert/pull/7204#issuecomment-1953179760

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
