### PR TITLE
Remove -s from pytest in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test GUI
       if: matrix.test-type == 'gui-tests'
       run: |
-        pytest tests/ --cov=ert -m "requires_window_manager" --cov-report=xml:cov.xml -s -vv
+        pytest tests/ --cov=ert -m "requires_window_manager" --cov-report=xml:cov.xml -v
 
     - name: Test Integration
       if: matrix.test-type == 'integration-tests'

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -47,17 +47,17 @@ jobs:
     - name: Test GUI
       if: inputs.test-type == 'gui-test'
       run: |
-        pytest tests --junit-xml=junit.xml -sv --mpl -m "requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -v --mpl -m "requires_window_manager" --benchmark-disable
 
     - name: Unit Test
       if: inputs.test-type == 'unit-tests'
       run: |
-        pytest tests --junit-xml=junit.xml -n logical --show-capture=stderr -sv -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
+        pytest tests --junit-xml=junit.xml -n logical --show-capture=stderr -v -m "not integration_test and not requires_window_manager" --benchmark-disable --dist loadgroup
 
     - name: Integration Test
       if: inputs.test-type == 'integration-tests'
       run: |
-        pytest tests --junit-xml=junit.xml -n logical --show-capture=stderr -sv -m "integration_test and not requires_window_manager" --benchmark-disable
+        pytest tests --junit-xml=junit.xml -n logical --show-capture=stderr -v -m "integration_test and not requires_window_manager" --benchmark-disable
 
     - name: Test for a clean repository
       run: |

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -59,7 +59,7 @@ start_tests () {
 
     # Using presence of "bsub" in PATH to detect onprem vs azure
     if which bsub >/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
-        pytest -sv --lsf --basetemp="$basetemp" integration_tests/scheduler/test_lsf_driver.py && \
+        pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler/test_lsf_driver.py && \
         rm -rf "$basetemp"
     fi
     popd


### PR DESCRIPTION
`pytest-xdist` is incompatible with `-s`, and the output from successful tests isn't interesting.

Ref: https://github.com/pytest-dev/pytest-xdist/blob/017cc72b7090dc4bb7e7ad3d0caab024feb977a8/docs/known-limitations.rst#output-stdout-and-stderr-from-workers