### PR TITLE
Use job script on disk for LSF driver and use stdin for PBS

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -59,8 +59,13 @@ start_tests () {
 
     # Using presence of "bsub" in PATH to detect onprem vs azure
     if which bsub >/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
-        pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler/test_lsf_driver.py && \
-        rm -rf "$basetemp"
+        pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler && \
+            rm -rf "$basetemp"
+    fi
+    if ! which bsub 2>/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
+        export _ERT_TESTS_DEFAULT_QUEUE_NAME=permanent
+        pytest -v --openpbs --basetemp="$basetemp" integration_tests/scheduler && \
+            rm -rf "$basetemp"
     fi
     popd
 

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Dict, Optional
 
 from ert.scheduler.event import Event
@@ -27,7 +28,7 @@ class Driver(ABC):
         /,
         *args: str,
         name: str = "dummy",
-        runpath: Optional[str] = None,
+        runpath: Optional[Path] = None,
     ) -> None:
         """Submit a program to execute on the cluster.
 

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -100,7 +100,7 @@ class Job:
                 self.real.job_script,
                 self.real.run_arg.runpath,
                 name=self.real.run_arg.job_name,
-                runpath=self.real.run_arg.runpath,
+                runpath=Path(self.real.run_arg.runpath),
             )
 
             await self._send(State.PENDING)

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 from asyncio.subprocess import Process
+from pathlib import Path
 from typing import MutableMapping, Optional
 
 from ert.scheduler.driver import Driver
@@ -23,7 +24,7 @@ class LocalDriver(Driver):
         /,
         *args: str,
         name: str = "dummy",
-        runpath: Optional[str] = None,
+        runpath: Optional[Path] = None,
     ) -> None:
         await self.kill(iens)
         self._tasks[iens] = asyncio.create_task(self._run(iens, executable, *args))

--- a/tests/integration_tests/scheduler/bin/qsub
+++ b/tests/integration_tests/scheduler/bin/qsub
@@ -28,7 +28,7 @@ jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid="test${RANDOM}.localhost"
 
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
-echo $@ > "${jobdir}/${jobid}.script"
+cat <&0 > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 
 

--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -1,4 +1,6 @@
+import os
 import signal
+import sys
 
 import pytest
 
@@ -12,32 +14,43 @@ from .conftest import mock_bin
 @pytest.fixture(params=[LsfDriver, OpenPBSDriver])
 def driver(request, pytestconfig, monkeypatch, tmp_path):
     class_ = request.param
+    queue_name = None
 
     # It's not possible to dynamically choose a pytest fixture in a fixture, so
     # we copy some code here
     if class_ is OpenPBSDriver and pytestconfig.getoption("openpbs"):
         # User provided --openpbs, which means we should use the actual OpenPBS
         # cluster without mocking anything.
-        pass
+        if str(tmp_path).startswith("/tmp"):
+            print(
+                "Please use --basetemp option to pytest, PBS tests needs a shared disk"
+            )
+            sys.exit(1)
+        queue_name = os.getenv("_ERT_TESTS_DEFAULT_QUEUE_NAME")
     elif class_ is LsfDriver and pytestconfig.getoption("lsf"):
         # User provided --lsf, which means we should use the actual LSF
         # cluster without mocking anything.""
-        pass
+        if str(tmp_path).startswith("/tmp"):
+            print(
+                "Please use --basetemp option to pytest, "
+                "the real LSF cluster needs a shared disk"
+            )
+            sys.exit(1)
     else:
         mock_bin(monkeypatch, tmp_path)
 
-    return class_()
+    return class_(queue_name=queue_name)
 
 
 @pytest.mark.integration_test
 async def test_submit(driver, tmp_path):
-    await driver.submit(0, f"echo test > {tmp_path}/test")
+    await driver.submit(0, "sh", "-c", f"echo test > {tmp_path}/test")
     await poll(driver, {0})
 
     assert (tmp_path / "test").read_text(encoding="utf-8") == "test\n"
 
 
-async def test_submit_something_that_fails(driver):
+async def test_submit_something_that_fails(driver, tmp_path):
     finished_called = False
 
     expected_returncode = 42
@@ -54,7 +67,7 @@ async def test_submit_something_that_fails(driver):
         nonlocal finished_called
         finished_called = True
 
-    await driver.submit(0, f"exit {expected_returncode}")
+    await driver.submit(0, "sh", "-c", f"exit {expected_returncode}", runpath=tmp_path)
     await poll(driver, {0}, finished=finished)
 
     assert finished_called

--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -19,12 +20,19 @@ def mock_openpbs(pytestconfig, monkeypatch, tmp_path):
     mock_bin(monkeypatch, tmp_path)
 
 
-@pytest.mark.timeout(30)
+@pytest.fixture()
+def queue_name_config():
+    if queue_name := os.getenv("_ERT_TESTS_DEFAULT_QUEUE_NAME"):
+        return f"\nQUEUE_OPTION TORQUE QUEUE {queue_name}"
+    return ""
+
+
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("copy_poly_case")
-def test_openpbs_driver_with_poly_example():
+def test_openpbs_driver_with_poly_example(queue_name_config):
     with open("poly.ert", mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
+        f.write(queue_name_config)
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--enable-scheduler",
@@ -36,17 +44,17 @@ async def mock_failure(message, *args, **kwargs):
     raise RuntimeError(message)
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("copy_poly_case")
 def test_openpbs_driver_with_poly_example_failing_submit_fails_ert_and_propagates_exception_to_user(
-    monkeypatch, caplog
+    monkeypatch, caplog, queue_name_config
 ):
     monkeypatch.setattr(
         OpenPBSDriver, "submit", partial(mock_failure, "Submit job failed")
     )
     with open("poly.ert", mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
+        f.write(queue_name_config)
     with pytest.raises(ErtCliError):
         run_cli(
             ENSEMBLE_EXPERIMENT_MODE,
@@ -56,17 +64,17 @@ def test_openpbs_driver_with_poly_example_failing_submit_fails_ert_and_propagate
     assert "RuntimeError: Submit job failed" in caplog.text
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("copy_poly_case")
 def test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_exception_to_user(
-    monkeypatch, caplog
+    monkeypatch, caplog, queue_name_config
 ):
     monkeypatch.setattr(
         OpenPBSDriver, "poll", partial(mock_failure, "Status polling failed")
     )
     with open("poly.ert", mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
+        f.write(queue_name_config)
     with pytest.raises(ErtCliError):
         run_cli(
             ENSEMBLE_EXPERIMENT_MODE,

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import shutil
+from pathlib import Path
 from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
@@ -138,6 +139,6 @@ async def test_call(
         realization.job_script,
         realization.run_arg.runpath,
         name=realization.run_arg.job_name,
-        runpath=realization.run_arg.runpath,
+        runpath=Path(realization.run_arg.runpath),
     )
     assert scheduler.driver.submit.call_count == max_submit

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -120,7 +120,7 @@ def parse_resource_string(qsub_args: str) -> Dict[str, str]:
 async def test_memory_per_job():
     driver = OpenPBSDriver(memory_per_job="10gb")
     await driver.submit(0, "sleep")
-    assert " -l mem=10gb " in Path("captured_qsub_args").read_text(encoding="utf-8")
+    assert " -l mem=10gb" in Path("captured_qsub_args").read_text(encoding="utf-8")
 
 
 @pytest.mark.usefixtures("capturing_qsub")
@@ -135,7 +135,7 @@ async def test_no_validation_of_memory_per_job():
     # Validation will happen during config parsing
     driver = OpenPBSDriver(memory_per_job="a_lot")
     await driver.submit(0, "sleep")
-    assert " -l mem=a_lot " in Path("captured_qsub_args").read_text(encoding="utf-8")
+    assert " -l mem=a_lot" in Path("captured_qsub_args").read_text(encoding="utf-8")
 
 
 @pytest.mark.usefixtures("capturing_qsub")
@@ -197,7 +197,7 @@ async def test_num_cpus_per_node_default():
 async def test_cluster_label():
     driver = OpenPBSDriver(cluster_label="foobar")
     await driver.submit(0, "sleep")
-    assert "-l foobar " in Path("captured_qsub_args").read_text(encoding="utf-8")
+    assert "-l foobar" in Path("captured_qsub_args").read_text(encoding="utf-8")
 
 
 QSTAT_HEADER = (
@@ -464,6 +464,6 @@ async def test_keep_qsub_output(
     if expectedkeep:
         assert "dev/null" not in Path("captured_qsub_args").read_text(encoding="utf-8")
     else:
-        assert " -o /dev/null -e /dev/null " in Path("captured_qsub_args").read_text(
+        assert " -o /dev/null -e /dev/null" in Path("captured_qsub_args").read_text(
             encoding="utf-8"
         )


### PR DESCRIPTION
Let PBS and LSF make explicit job scripts for test robustness 

For OpenPBS the explicit job script only exists in memory and
is provided to qsub via stdin.

For LSF, the bsub command seemingly cannot read stdin, and the
job script is placed on runpath with a unique filename that
will be left behind.

This enables more complex jobs (e.g. redirection) submitted to the
drivers submit() function.

Align Python LSF driver with C-driver in supplying the runpath as the
last argument. This is needed to pass a legacy test. Note that legacy
LSF and legacy Torque drivers differ in this behaviour, the latter does
not supply runpath.

The type of the runpath object supplied is changed from str to
pathlib.Path

**Issue**
Resolves #7327 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
