### PR TITLE
Ensure no duplicate keys in SummaryConfig

### DIFF
--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -26,6 +26,7 @@ class SummaryConfig(ResponseConfig):
     def __post_init__(self) -> None:
         if isinstance(self.refcase, list):
             self.refcase = {datetime.fromisoformat(val) for val in self.refcase}
+        self.keys = sorted(set(self.keys))
         if len(self.keys) < 1:
             raise ValueError("SummaryConfig must be given at least one key")
 

--- a/tests/integration_tests/test_storage_migration.py
+++ b/tests/integration_tests/test_storage_migration.py
@@ -53,9 +53,6 @@ def test_that_storage_matches(tmp_path, source_root, snapshot, monkeypatch):
 
             # We need to normalize some irrelevant details:
             experiment.response_configuration["summary"].refcase = {}
-            experiment.response_configuration["summary"].keys = sorted(
-                set(experiment.response_configuration["summary"].keys)
-            )
             experiment.parameter_configuration["PORO"].mask_file = ""
 
             snapshot.assert_match(

--- a/tests/unit_tests/config/test_summary_config.py
+++ b/tests/unit_tests/config/test_summary_config.py
@@ -25,3 +25,10 @@ def test_rading_empty_summaries_raises(wopr_summary):
     unsmry.to_file("CASE.UNSMRY")
     with pytest.raises(ValueError, match="Did not find any summary values"):
         SummaryConfig("summary", "CASE", ["WWCT:OP1"], None).read_from_file(".", 0)
+
+
+def test_summary_config_normalizes_list_of_keys():
+    assert SummaryConfig("summary", "CASE", ["FOPR", "WOPR", "WOPR"]).keys == [
+        "FOPR",
+        "WOPR",
+    ]

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -174,7 +174,7 @@ response_configs = st.lists(
             input_file=st.text(
                 alphabet=st.characters(min_codepoint=65, max_codepoint=90)
             ),
-            keys=st.lists(summary_keys, max_size=3, min_size=1),
+            keys=summary_keys,
             refcase=st.just(None),
         ),
     ),


### PR DESCRIPTION
In a77ee9ca669cce6c75c6ddd448997ee313b9f677 , it became possible to have duplicate keys in the SummaryConfig. This can degrade performance of summary loading.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
