### PR TITLE
Fix summary reading being too slow in case of many summary keys to match against

### DIFF
--- a/tests/unit_tests/config/test_read_summary.py
+++ b/tests/unit_tests/config/test_read_summary.py
@@ -486,3 +486,20 @@ def test_that_ambiguous_case_restart_raises_an_informative_error(
         match="Ambiguous reference to unified summary",
     ):
         read_summary(str(tmp_path / "test"), ["*"])
+
+
+@given(summaries())
+def test_that_length_of_fetch_keys_does_not_reduce_performance(
+    tmp_path_factory, summary
+):
+    """With a compiled regex this takes seconds to run, and with
+    a naive implementation it will take almost an hour.
+    """
+    tmp_path = tmp_path_factory.mktemp("summary")
+    smspec, unsmry = summary
+    unsmry.to_file(tmp_path / "TEST.UNSMRY")
+    smspec.to_file(tmp_path / "TEST.SMSPEC")
+    fetch_keys = [str(i) for i in range(100000)]
+    (_, keys, time_map, _) = read_summary(str(tmp_path / "TEST"), fetch_keys)
+    assert all(k in fetch_keys for k in keys)
+    assert len(time_map) == len(unsmry.steps)


### PR DESCRIPTION
Resolves [#7262](https://github.com/equinor/ert/issues/7262)

looping over a fnmatch is too slow, especially after converting the fnmatch from c to python. Compiling a regex once is much faster, see the included test.

I ran the following test and the result of the new function seems to be identical to the old function.
```python
from hypothesis import given, settings
from fnmatch import fnmatch, translate
import re
import hypothesis.strategies as st


def _fetch_keys_to_matcher(fetch_keys):
    if not fetch_keys:
        return lambda _: False
    regex = re.compile("|".join(translate(key) for key in fetch_keys))
    return lambda s: regex.fullmatch(s) is not None


def _should_load_summary_key(data_key, user_set_keys):
    return any(fnmatch(data_key, key) for key in user_set_keys)


@settings(max_examples=10000)
@given(st.lists(st.text()), st.text())
def test_are_the_same(fetch_keys, key):
    assert _fetch_keys_to_matcher(fetch_keys)(key) == _should_load_summary_key(
        key, fetch_keys
    )

```

I took some benchmarks using random but realistic fetch_keys and keys.

![image](https://github.com/equinor/ert/assets/32731672/29a45293-99e0-49e3-9ee5-b92826279f0d)

![image](https://github.com/equinor/ert/assets/32731672/4cb527bd-2268-48ec-b565-7ba8d2731a14)


The new algorithm can sometimes perform worse when the size of `fetch_keys` is close to or smaller than the number of keys, but the old algorithm is regularly worse as the number of keys grow.
