### PR TITLE
Test that pbs driver ignores qstat flakiness

### DIFF
--- a/tests/integration_tests/scheduler/bin/qstat.py
+++ b/tests/integration_tests/scheduler/bin/qstat.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 QSTAT_HEADER = (
-    "Job id            Name             User              Time Use S Queue\n"
-    "----------------  ---------------- ----------------  -------- - -----\n"
+    "Job id                         Name            User             Time Use S Queue\n"
+    "-----------------------------  --------------- ---------------  -------- - ---------------\n"
 )
 
 

--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -1,5 +1,6 @@
 import os
 from functools import partial
+from pathlib import Path
 
 import pytest
 
@@ -25,6 +26,35 @@ def queue_name_config():
     if queue_name := os.getenv("_ERT_TESTS_DEFAULT_QUEUE_NAME"):
         return f"\nQUEUE_OPTION TORQUE QUEUE {queue_name}"
     return ""
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("copy_poly_case")
+@pytest.mark.parametrize(
+    "text_to_ignore",
+    [
+        "pbs_iff: cannot connect to host\npbs_iff: all reserved ports in use",
+        "qstat: Invalid credential",
+    ],
+)
+def test_that_openpbs_driver_ignores_qstat_flakiness(
+    text_to_ignore, caplog, capsys, create_mock_flaky_qstat
+):
+
+    create_mock_flaky_qstat(text_to_ignore)
+    with open("poly.ert", mode="a+", encoding="utf-8") as f:
+        f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 1")
+    run_cli(
+        ENSEMBLE_EXPERIMENT_MODE,
+        "--enable-scheduler",
+        "poly.ert",
+    )
+    assert Path("counter_file").exists()
+    assert int(Path("counter_file").read_text(encoding="utf-8")) >= 3
+    assert text_to_ignore not in capsys.readouterr().out
+    assert text_to_ignore not in capsys.readouterr().err
+    assert text_to_ignore not in caplog.text
 
 
 async def mock_failure(message, *args, **kwargs):


### PR DESCRIPTION
**Issue**
Resolves #7357 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
