### PR TITLE
Backport: Fix summary reading being too slow in case of many summary keys to match against

### DIFF
--- a/tests/unit_tests/config/test_read_summary.py
+++ b/tests/unit_tests/config/test_read_summary.py
@@ -483,3 +483,20 @@ def test_that_ambiguous_case_restart_raises_an_informative_error(
         match="Ambiguous reference to unified summary",
     ):
         read_summary(str(tmp_path / "test"), ["*"])
+
+
+@given(summaries())
+def test_that_length_of_fetch_keys_does_not_reduce_performance(
+    tmp_path_factory, summary
+):
+    """With a compiled regex this takes seconds to run, and with
+    a naive implementation it will take almost an hour.
+    """
+    tmp_path = tmp_path_factory.mktemp("summary")
+    smspec, unsmry = summary
+    unsmry.to_file(tmp_path / "TEST.UNSMRY")
+    smspec.to_file(tmp_path / "TEST.SMSPEC")
+    fetch_keys = [str(i) for i in range(100000)]
+    (_, keys, time_map, _) = read_summary(str(tmp_path / "TEST"), fetch_keys)
+    assert all(k in fetch_keys for k in keys)
+    assert len(time_map) == len(unsmry.steps)


### PR DESCRIPTION
looping over a fnmatch was simply too slow

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
