### PR TITLE
Account for cases when the summary data is empty.

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -61,7 +61,7 @@ def data_for_key(
             "summary", tuple(ensemble.get_realization_list_with_responses("summary"))
         )
         summary_keys = summary_data["name"].values
-    except ValueError:
+    except (ValueError, KeyError):
         summary_data = xr.Dataset()
         summary_keys = np.array([], dtype=str)
 

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -295,7 +295,7 @@ class LocalEnsemble(BaseMode):
                 tuple(self.get_realization_list_with_responses("summary")),
             )
             return sorted(summary_data["name"].values)
-        except ValueError:
+        except (ValueError, KeyError):
             return []
 
     def _get_gen_data_config(self, key: str) -> GenDataConfig:


### PR DESCRIPTION
**Issue**
Resolves #7356 


**Approach**
Catch also KeyError when checking summary_data["name"].values

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
