### PR TITLE
Have OpenPBS driver use qstat -w option

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -304,7 +304,6 @@ class OpenPBSDriver(Driver):
                     "qstat",
                     "-fx",
                     "-Fjson",
-                    "-w",  # wide format
                     *self._finished_job_ids,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/tests/integration_tests/scheduler/bin/qstat.py
+++ b/tests/integration_tests/scheduler/bin/qstat.py
@@ -67,14 +67,10 @@ def main() -> None:
             user = "mock"
             time = "00:00:00"
             queue = "mocked"
-            if args.w:
-                print(
-                    f"{job:30.30}  {name:15.15} {user:15.15}  {time:8.8} {state:1.1} {queue:5.5}"
-                )
-            else:
-                print(
-                    f"{job:16.16}  {name:16.16} {name:16.16}  {time:8.8} {state:1.1} {queue:5.5}"
-                )
+
+            print(
+                f"{job:30.30}  {name:15.15} {user:15.15}  {time:8.8} {state:1.1} {queue:5.5}"
+            )
 
     if args.F == "json":
         print(json.dumps({"Jobs": jobs_output}))

--- a/tests/integration_tests/scheduler/bin/qstat.py
+++ b/tests/integration_tests/scheduler/bin/qstat.py
@@ -23,7 +23,7 @@ def parse_args() -> Namespace:
     ap.add_argument("-x", action="store_true", required=True)
     ap.add_argument("-F", default="")
     ap.add_argument("jobs", nargs="*")
-
+    ap.add_argument("-w", action="store_true")
     return ap.parse_args()
 
 
@@ -67,9 +67,14 @@ def main() -> None:
             user = "mock"
             time = "00:00:00"
             queue = "mocked"
-            print(
-                f"{job:16.16}  {name:16.16} {user:16.16}  {time:8.8} {state:1.1} {queue:5.5}"
-            )
+            if args.w:
+                print(
+                    f"{job:30.30}  {name:15.15} {user:15.15}  {time:8.8} {state:1.1} {queue:5.5}"
+                )
+            else:
+                print(
+                    f"{job:16.16}  {name:16.16} {name:16.16}  {time:8.8} {state:1.1} {queue:5.5}"
+                )
 
     if args.F == "json":
         print(json.dumps({"Jobs": jobs_output}))


### PR DESCRIPTION
**Issue**
Resolves #7404 
Using the -w option removes the need for the _expand_truncated_jobids method, as the job id is not truncated anymore. 

**Approach**
Added the -w flag in both the driver and the mocked qstat script.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
