### PR TITLE
Deprecate unused lsf options

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1596,7 +1596,7 @@ in :ref:`queue-system-chapter`. In brief, the queue systems have the following o
 
 * :ref:`LOCAL <local-queue>` — no queue options.
 * :ref:`LSF <lsf-systems>` — ``LSF_SERVER``, ``LSF_QUEUE``, ``LSF_RESOURCE``,
-  ``LFS_RSH_COMMAND``, ``LSF_LOGIN_SHELL``, ``BSUB_CMD``, ``BJOBS_CMD``, ``BKILL_CMD``,
+  ``BSUB_CMD``, ``BJOBS_CMD``, ``BKILL_CMD``,
   ``BHIST_CMD``, ``BJOBS_TIMEOUT``, ``SUBMIT_SLEEP``, ``PROJECT_CODE``, ``EXCLUDE_HOST``,
   ``MAX_RUNNING``
 * :ref:`TORQUE <pbs-systems>` — ``QSUB_CMD``, ``QSTAT_CMD``, ``QDEL_CMD``,

--- a/docs/reference/configuration/queue.rst
+++ b/docs/reference/configuration/queue.rst
@@ -188,24 +188,6 @@ The following is a list of available LSF configuration options:
 
     QUEUE_OPTION LSF LSF_RESOURCE rusage[mem=512MB:swp=1GB]
 
-.. _lsf_rsh_cmd:
-.. topic:: LSF_RSH_CMD
-
-  This option sets the remote shell command, which defaults to ``/usr/bin/ssh``.
-  To use another command, pass the full path::
-
-    QUEUE_OPTION LSF LSF_RSH_CMD /opt/bin/ssh
-
-.. _lsf_login_shell:
-.. topic:: LSF_LOGIN_SHELL
-
-  Equates to the ``-L`` parameter of e.g. ``bsub``.
-  Useful if you need to force the ``bsub`` command to use e.g. ``/bin/csh``.
-  `Docs <https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/lsf_command_ref/bsub.__l.1.html>`__
-  For example::
-
-    QUEUE_OPTION LSF LSF_LOGIN_SHELL /bin/csh
-
 .. _project_code:
 .. topic:: PROJECT_CODE
 

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -177,4 +177,20 @@ deprecated_keywords_list = [
         "for the Ensemble Smoother update algorithm. "
         "Please use ENKF_ALPHA and STD_CUTOFF keywords instead.",
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="LSF_LOGIN_SHELL as QUEUE_OPTION to the LSF system will be removed in "
+        "the future, and it is not recommended to use this QUEUE_OPTION. "
+        "It has been used in the past to force the bsub command to use a "
+        "specific shell. The current ERT default is to use local shell.",
+        check=lambda line: "LSF_LOGIN_SHELL" in line,
+    ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="LSF_RSH_CMD as QUEUE_OPTION to the LSF system will be removed in "
+        "the future, and it is not recommended to use this QUEUE_OPTION. "
+        "It has been used in the past to set the remote shell command. "
+        "The ERT default is to use /usr/bin/ssh.",
+        check=lambda line: "LSF_RSH_CMD" in line,
+    ),
 ]

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -38,7 +38,7 @@ class SchemaItem:
     # A list of item's which must also be set (if this item is set). (can be NULL)
     required_children: List[str] = Field(default_factory=list)
     # Information about the deprecation if deprecated
-    deprecation_info: Optional[DeprecationInfo] = None
+    deprecation_info: List[DeprecationInfo] = Field(default_factory=list)
     # if positive, arguments after this count will be concatenated with a " " between
     join_after: Optional[PositiveInt] = None
     # if true, will accumulate many values set for key, otherwise each entry will
@@ -54,7 +54,7 @@ class SchemaItem:
     def deprecated_dummy_keyword(cls, info: DeprecationInfo) -> "SchemaItem":
         return SchemaItem(
             kw=info.keyword,
-            deprecation_info=info,
+            deprecation_info=[info],
             required_set=False,
             argc_min=0,
             argc_max=None,

--- a/src/ert/config/parsing/schema_dict.py
+++ b/src/ert/config/parsing/schema_dict.py
@@ -59,7 +59,7 @@ class SchemaItemDict(_UserDict):
             if info.keyword not in self:
                 self[info.keyword] = SchemaItem.deprecated_dummy_keyword(info)
             else:
-                self[info.keyword].deprecation_info = info
+                self[info.keyword].deprecation_info.append(info)
 
     @no_type_check
     def search_for_deprecated_keyword_usages(
@@ -69,13 +69,14 @@ class SchemaItemDict(_UserDict):
     ) -> None:
         detected_deprecations = []
 
-        def push_deprecation(info: DeprecationInfo, line: List[ContextString]):
-            if info.check is None or (callable(info.check) and info.check(line)):
-                detected_deprecations.append((info, line))
+        def push_deprecation(infos: List[DeprecationInfo], line: List[ContextString]):
+            for info in infos:
+                if info.check is None or (callable(info.check) and info.check(line)):
+                    detected_deprecations.append((info, line))
 
         for kw, v in config_dict.items():
             schema_info = self.get(kw)
-            if schema_info is not None and schema_info.deprecation_info is not None:
+            if schema_info is not None and len(schema_info.deprecation_info) > 0:
                 if v is None:
                     # Edge case: Happens if
                     # a keyword is specified in the schema and takes N args

--- a/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -230,11 +230,15 @@ def test_that_suggester_gives_schedule_prediciton_migration(tmp_path):
 
 def test_that_suggester_gives_job_prefix_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
-        "NUM_REALIZATIONS 1\nQUEUE_OPTION TORQUE JOB_PREFIX foo\n"
+        "NUM_REALIZATIONS 1\nQUEUE_OPTION TORQUE JOB_PREFIX foo\nQUEUE_OPTION LSF LSF_RSH_CMD foo\n"
     )
     suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
 
     assert any(
         "JOB_PREFIX as QUEUE_OPTION to the TORQUE system is deprecated" in str(s)
+        for s in suggestions
+    )
+    assert any(
+        "LSF_RSH_CMD as QUEUE_OPTION to the LSF system will be removed" in str(s)
         for s in suggestions
     )


### PR DESCRIPTION
**Issue**
Resolves #7203 

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
