### PR TITLE
Increase memory limit to 130MB in test_field_param_memory

### DIFF
--- a/tests/integration_tests/storage/test_parameter_sample_types.py
+++ b/tests/integration_tests/storage/test_parameter_sample_types.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
 
 
 @pytest.mark.integration_test
-@pytest.mark.limit_memory("110 MB")
+@pytest.mark.limit_memory("130 MB")
 @pytest.mark.flaky(reruns=5)
 def test_field_param_memory(tmpdir):
     with tmpdir.as_cwd():


### PR DESCRIPTION
After we changed from flaky to pytest_rerunfailures this test started failing. It appears that when using flaky the test was passing even though the memory reported was well above the memory limit. This increase in memory limit aims to reflect this. Should be noted that the test was only failing on RHEL7, it passed on RHEL8 but only on the second attempt.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
