### PR TITLE
Have lsf_driver specify SIGKILL when bkilling

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -735,15 +735,24 @@ void lsf_driver_kill_job(void *_driver, void *_job) {
         char **argv = (char **)calloc(2, sizeof *argv);
         CHECK_ALLOC(argv);
         argv[0] = driver->remote_lsf_server;
-        argv[1] = saprintf("%s %s", driver->bkill_cmd, job->lsf_jobnr_char);
+        argv[1] = saprintf("%s %s %s", driver->bkill_cmd, "-s SIGKILL",
+                           job->lsf_jobnr_char);
 
         spawn_blocking(driver->rsh_cmd, 2, (const char **)argv, NULL, NULL);
 
         free(argv[1]);
         free(argv);
     } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
-        spawn_blocking(driver->bkill_cmd, 1,
-                       (const char **)&job->lsf_jobnr_char, NULL, NULL);
+        char **argv = (char **)calloc(3, sizeof *argv);
+        CHECK_ALLOC(argv);
+        argv[0] = saprintf("%s", "-s");
+        argv[1] = saprintf("%s", "SIGKILL");
+        argv[2] = saprintf("%s", job->lsf_jobnr_char);
+        spawn_blocking(driver->bkill_cmd, 3, (const char **)argv, NULL, NULL);
+        free(argv[0]);
+        free(argv[1]);
+        free(argv[2]);
+        free(argv);
     }
 }
 

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -190,6 +190,8 @@ class LsfDriver(Driver):
         logger.debug(f"Killing realization {iens} with LSF-id {job_id}")
         process = await asyncio.create_subprocess_exec(
             self._bkill_cmd,
+            "-s",
+            "SIGKILL",
             job_id,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -188,6 +188,7 @@ async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
         await driver.submit(0, "sleep")
 
 
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "mocked_iens2jobid, iens_to_kill, bkill_returncode, bkill_stdout, bkill_stderr, expected_logged_error",
     [
@@ -273,16 +274,13 @@ async def test_kill(
     bkill_path.chmod(bkill_path.stat().st_mode | stat.S_IEXEC)
 
     driver = LsfDriver()
-
     driver._iens2jobid = mocked_iens2jobid
     await driver.kill(iens_to_kill)
     if expected_logged_error:
         assert expected_logged_error in caplog.text
     else:
-        assert (
-            mocked_iens2jobid[iens_to_kill]
-            == Path("bkill_args").read_text(encoding="utf-8").strip()
-        )
+        bkill_args = Path("bkill_args").read_text(encoding="utf-8").strip()
+        assert f"-s SIGKILL {mocked_iens2jobid[iens_to_kill]}" in bkill_args
 
 
 @given(st.text())


### PR DESCRIPTION
This commit makes the lsf_driver use bkill with the SIGKILL signal instead of the default SIGINT.

**Issue**
Resolves #7443  


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
