### PR TITLE
Implement LSF_RESOURCE and EXCLUDE_HOST queue option

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -39,6 +39,7 @@ def create_driver(config: QueueConfig) -> Driver:
             bkill_cmd=queue_config.get("BKILL_CMD"),
             bjobs_cmd=queue_config.get("BJOBS_CMD"),
             queue_name=queue_config.get("LSF_QUEUE"),
+            resource_requirement=queue_config.get("LSF_RESOURCE"),
         )
     else:
         raise NotImplementedError("Only LOCAL, TORQUE and LSF drivers are implemented")

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -38,6 +38,7 @@ def create_driver(config: QueueConfig) -> Driver:
             bsub_cmd=queue_config.get("BSUB_CMD"),
             bkill_cmd=queue_config.get("BKILL_CMD"),
             bjobs_cmd=queue_config.get("BJOBS_CMD"),
+            exclude_hosts=queue_config.get("EXCLUDE_HOST", "").split(","),
             queue_name=queue_config.get("LSF_QUEUE"),
             resource_requirement=queue_config.get("LSF_RESOURCE"),
         )

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -16,6 +16,7 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Sequence,
     Tuple,
     Union,
     get_args,
@@ -96,9 +97,39 @@ def parse_bjobs(bjobs_output: str) -> Dict[str, Dict[str, Dict[str, str]]]:
     return {"jobs": data}
 
 
+def parse_resource_requirement_string(
+    exclude_hosts: Sequence[str], resource_requirement: str
+) -> str:
+    resource_requirements = []
+    if len(exclude_hosts or []) > 0:
+        select_list = [f"hname!='{host_name}'" for host_name in exclude_hosts]
+        exclude_hosts_string = " && ".join(select_list)
+        if resource_requirement:
+            if "select[" in resource_requirement:
+                # We split string into (before) "bla[..] bla[..] select[xxx_"
+                # and (after) "... bla[..] bla[..]". (we replaced one ']' with ' ')
+                # Then we make final string:  before + &&excludes] + after
+                end_index = resource_requirement.rindex("]")
+                first_part = resource_requirement[:end_index]
+                second_part = resource_requirement[end_index:]
+                resource_requirements.append(
+                    f"{first_part} && {exclude_hosts_string}{second_part}"
+                )
+            else:
+                resource_requirements.append(resource_requirement)
+                resource_requirements.append(f"select[{exclude_hosts_string}]")
+        else:
+            resource_requirements.append(f"select[{exclude_hosts_string}]")
+
+    elif resource_requirement:
+        resource_requirements.append(resource_requirement)
+    return " ".join(resource_requirements)
+
+
 class LsfDriver(Driver):
     def __init__(
         self,
+        exclude_hosts: Optional[Sequence[str]] = None,
         queue_name: Optional[str] = None,
         resource_requirement: Optional[str] = None,
         bsub_cmd: Optional[str] = None,
@@ -107,6 +138,7 @@ class LsfDriver(Driver):
     ) -> None:
         super().__init__()
 
+        self._exclude_hosts = list(exclude_hosts) if exclude_hosts else []
         self._queue_name = queue_name
         self._resource_requirement = resource_requirement or ""
 
@@ -154,9 +186,7 @@ class LsfDriver(Driver):
             script_path = Path(script_handle.name)
         assert script_path is not None
         script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
-        arg_resource_requirement = (
-            ["-R", self._resource_requirement] if self._resource_requirement else []
-        )
+        arg_resource_requirement = self._get_resource_requirement_arg()
 
         bsub_with_args: List[str] = (
             [str(self._bsub_cmd)]
@@ -185,6 +215,16 @@ class LsfDriver(Driver):
         )
         self._jobs[job_id] = (iens, QueuedJob(job_state="PEND"))
         self._iens2jobid[iens] = job_id
+
+    def _get_resource_requirement_arg(self) -> List[str]:
+        parsed_resource_requirement_string = parse_resource_requirement_string(
+            self._exclude_hosts, self._resource_requirement
+        )
+        return (
+            ["-R", parsed_resource_requirement_string]
+            if parsed_resource_requirement_string
+            else []
+        )
 
     async def kill(self, iens: int) -> None:
         if iens not in self._iens2jobid:

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -100,6 +100,7 @@ class LsfDriver(Driver):
     def __init__(
         self,
         queue_name: Optional[str] = None,
+        resource_requirement: Optional[str] = None,
         bsub_cmd: Optional[str] = None,
         bjobs_cmd: Optional[str] = None,
         bkill_cmd: Optional[str] = None,
@@ -107,6 +108,7 @@ class LsfDriver(Driver):
         super().__init__()
 
         self._queue_name = queue_name
+        self._resource_requirement = resource_requirement or ""
 
         self._bsub_cmd = Path(bsub_cmd or shutil.which("bsub") or "bsub")
         self._bjobs_cmd = Path(bjobs_cmd or shutil.which("bjobs") or "bjobs")
@@ -152,10 +154,14 @@ class LsfDriver(Driver):
             script_path = Path(script_handle.name)
         assert script_path is not None
         script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
+        arg_resource_requirement = (
+            ["-R", self._resource_requirement] if self._resource_requirement else []
+        )
 
         bsub_with_args: List[str] = (
             [str(self._bsub_cmd)]
             + arg_queue_name
+            + arg_resource_requirement
             + ["-J", name, str(script_path), str(runpath)]
         )
         logger.debug(f"Submitting to LSF with command {shlex.join(bsub_with_args)}")

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,7 +3,7 @@ set -e
 
 name="STDIN"
 
-while getopts "J:q:" opt
+while getopts "J:q:R:" opt
 do
     case "$opt" in
         J)
@@ -11,6 +11,9 @@ do
             ;;
         q)
             queue=$OPTARG
+            ;;
+        R)
+            resource_requirement=$OPTARG
             ;;
         *)
             echo "Unprocessed option ${opt}"
@@ -25,6 +28,7 @@ jobid="${RANDOM}"
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
 echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
+echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
 
 bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &
 disown

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -100,3 +100,12 @@ async def test_lsf_driver_masks_returncode(
 
     await driver.submit(0, "sh", "-c", f"exit {actual_returncode}")
     await poll(driver, {0}, finished=finished)
+
+
+async def test_submit_with_resource_requirement(tmp_path):
+    resource_requirement = "rusage=[mem=20MB]"
+    driver = LsfDriver(resource_requirement=resource_requirement)
+    await driver.submit(0, "sh", "-c", f"echo test>{tmp_path}/test")
+    await poll(driver, {0})
+
+    assert (tmp_path / "test").read_text(encoding="utf-8") == "test\n"

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -23,6 +23,7 @@ from ert.scheduler.lsf_driver import (
     StartedEvent,
     _Stat,
     parse_bjobs,
+    parse_resource_requirement_string,
 )
 
 valid_jobstates: Collection[str] = list(get_args(JobState))
@@ -136,7 +137,7 @@ async def test_submit_with_default_queue():
 async def test_submit_with_resource_requirement():
     driver = LsfDriver(resource_requirement="rusage[mem=512MB:swp=1GB]")
     await driver.submit(0, "sleep")
-    assert "-R 'rusage[mem=512MB:swp=1GB]'" in Path("captured_bsub_args").read_text(
+    assert "-R rusage[mem=512MB:swp=1GB]" in Path("captured_bsub_args").read_text(
         encoding="utf-8"
     )
 
@@ -488,3 +489,40 @@ async def test_that_bsub_will_retry_and_succeed(
     driver._bsub_retries = 2
     driver._sleep_time_between_cmd_retries = 0.2
     await driver.submit(0, "sleep 10")
+
+
+@pytest.mark.parametrize(
+    "resource_requirement, exclude_hosts, expected_string",
+    [
+        pytest.param(None, None, "", id="None input"),
+        pytest.param(
+            "rusage[mem=512MB:swp=1GB]",
+            [],
+            "rusage[mem=512MB:swp=1GB]",
+            id="resource_requirement_without_select_and_no_excluded_hosts",
+        ),
+        pytest.param(
+            None,
+            ["linrgs12-foo", "linrgs13-bar"],
+            "select[hname!='linrgs12-foo' && hname!='linrgs13-bar']",
+            id="excluded_hosts",
+        ),
+        pytest.param(
+            "rusage[mem=512MB:swp=1GB]",
+            ["linrgs12-foo"],
+            "rusage[mem=512MB:swp=1GB] select[hname!='linrgs12-foo']",
+            id="resource_requirement_and_excluded_hosts",
+        ),
+        pytest.param(
+            "select[location=='cloud']",
+            ["linrgs12-foo", "linrgs13-bar"],
+            "select[location=='cloud' && hname!='linrgs12-foo' && hname!='linrgs13-bar']",
+            id="multiple_selects",
+        ),
+    ],
+)
+def test_parse_resource_requirement_string(
+    resource_requirement: str, exclude_hosts: List[str], expected_string: str
+):
+    result_str = parse_resource_requirement_string(exclude_hosts, resource_requirement)
+    assert result_str == expected_string

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -132,6 +132,15 @@ async def test_submit_with_default_queue():
     assert "-q" not in Path("captured_bsub_args").read_text(encoding="utf-8")
 
 
+@pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_with_resource_requirement():
+    driver = LsfDriver(resource_requirement="rusage[mem=512MB:swp=1GB]")
+    await driver.submit(0, "sleep")
+    assert "-R 'rusage[mem=512MB:swp=1GB]'" in Path("captured_bsub_args").read_text(
+        encoding="utf-8"
+    )
+
+
 @pytest.mark.parametrize(
     "bsub_script, expectation",
     [

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -519,7 +519,7 @@ def test_scheduler_create_lsf_driver():
     bsub_cmd = "bar_bsub_cmd"
     bkill_cmd = "foo_bkill_cmd"
     bjobs_cmd = "bar_bjobs_cmd"
-
+    lsf_resource = "rusage[mem=512MB:swp=1GB]"
     queue_config_dict = {
         "QUEUE_SYSTEM": "LSF",
         "QUEUE_OPTION": [
@@ -527,6 +527,7 @@ def test_scheduler_create_lsf_driver():
             ("LSF", "BKILL_CMD", bkill_cmd),
             ("LSF", "BJOBS_CMD", bjobs_cmd),
             ("LSF", "LSF_QUEUE", queue_name),
+            ("LSF", "LSF_RESOURCE", lsf_resource),
         ],
     }
     queue_config = QueueConfig.from_dict(queue_config_dict)
@@ -535,6 +536,7 @@ def test_scheduler_create_lsf_driver():
     assert str(driver._bkill_cmd) == bkill_cmd
     assert str(driver._bjobs_cmd) == bjobs_cmd
     assert driver._queue_name == queue_name
+    assert driver._resource_requirement == lsf_resource
 
 
 def test_scheduler_create_openpbs_driver():

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -520,12 +520,14 @@ def test_scheduler_create_lsf_driver():
     bkill_cmd = "foo_bkill_cmd"
     bjobs_cmd = "bar_bjobs_cmd"
     lsf_resource = "rusage[mem=512MB:swp=1GB]"
+    exclude_host = "host1,host2"
     queue_config_dict = {
         "QUEUE_SYSTEM": "LSF",
         "QUEUE_OPTION": [
             ("LSF", "BSUB_CMD", bsub_cmd),
             ("LSF", "BKILL_CMD", bkill_cmd),
             ("LSF", "BJOBS_CMD", bjobs_cmd),
+            ("LSF", "EXCLUDE_HOST", exclude_host),
             ("LSF", "LSF_QUEUE", queue_name),
             ("LSF", "LSF_RESOURCE", lsf_resource),
         ],
@@ -535,6 +537,7 @@ def test_scheduler_create_lsf_driver():
     assert str(driver._bsub_cmd) == bsub_cmd
     assert str(driver._bkill_cmd) == bkill_cmd
     assert str(driver._bjobs_cmd) == bjobs_cmd
+    assert driver._exclude_hosts == exclude_host.split(",")
     assert driver._queue_name == queue_name
     assert driver._resource_requirement == lsf_resource
 


### PR DESCRIPTION
**Issue**
Resolves #7345 


**Approach**
This PR makes scheduler lsf_driver use QUEUE_OPTION LSF_RESOURCE as qsub resource_request option.
It also adds the EXCLUDE_HOST queue option for LSF, as they were closely related in the legacy C driver.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
