### PR TITLE
Only build & test using macos runners for tags

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest-xlarge']
+        os: ['ubuntu-latest']
 
     runs-on: ${{ matrix.os }}
 
@@ -107,6 +107,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   build-mac:
+    if: github.ref_type == 'tag' # only build for mac when tags
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +151,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   test-mac:
+    if: github.ref_type == 'tag' # only test for mac when tags
     needs: [build-mac]
     strategy:
       fail-fast: false

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -21,14 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.11', '3.12']
-        os: [ubuntu-latest, macos-13, macos-latest-xlarge]
-        exclude:
-        - python-version: '3.11'
-          os: macos-13
-        - python-version: '3.11'
-          os: macos-latest-xlarge
-        - python-version: '3.8'
-          os: macos-latest-xlarge
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Mitigation efforts after we learned of the pricing and usage of the GitHub macOS-runners.