### PR TITLE
Remove fixture marks that has no effect

### DIFF
--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -61,7 +61,6 @@ def with_manage_tool(gui, qtbot: QtBot, callback) -> None:
     manage_tool.trigger()
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 @pytest.fixture(name="opened_main_window", scope="module")
 def opened_main_window_fixture(source_root, tmpdir_factory) -> ErtMainWindow:
     with pytest.MonkeyPatch.context() as mp:
@@ -130,14 +129,12 @@ def opened_main_window_clean(source_root, tmpdir):
             yield gui
 
 
-@pytest.mark.usefixtures("use_tmpdir, opened_main_window")
 @pytest.fixture(scope="module")
 def esmda_has_run(run_experiment):
     # Runs a default ES-MDA run
     run_experiment(MultipleDataAssimilation)
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 @pytest.fixture(name="run_experiment", scope="module")
 def run_experiment_fixture(request, opened_main_window):
     def func(experiment_mode):
@@ -193,7 +190,6 @@ def run_experiment_fixture(request, opened_main_window):
     return func
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 @pytest.fixture(scope="module")
 def ensemble_experiment_has_run(opened_main_window, run_experiment, request):
     gui = opened_main_window


### PR DESCRIPTION
See https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

**Issue**
Resolves these warnings in komodo testing:
```
=============================== warnings summary ===============================
unit_tests/gui/conftest.py:66: 16 warnings
  /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root/tests/unit_tests/gui/conftest.py:66: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    def opened_main_window_fixture(source_root, tmpdir_factory) -> ErtMainWindow:

unit_tests/gui/conftest.py:135: 16 warnings
  /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root/tests/unit_tests/gui/conftest.py:135: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    def esmda_has_run(run_experiment):

unit_tests/gui/conftest.py:142: 16 warnings
  /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root/tests/unit_tests/gui/conftest.py:142: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    def run_experiment_fixture(request, opened_main_window):

unit_tests/gui/conftest.py:198: 16 warnings
  /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root/tests/unit_tests/gui/conftest.py:198: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    def ensemble_experiment_has_run(opened_main_window, run_experiment, request):


```

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
