### PR TITLE
Make PBS tests more tolerant for SIGTERM variants

### DIFF
--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -79,12 +79,12 @@ async def test_submit_something_that_fails(driver, tmp_path):
 async def test_kill(driver):
     aborted_called = False
 
-    expected_returncode = 1
+    expected_returncodes = [1]
     if isinstance(driver, OpenPBSDriver):
-        expected_returncode = 256 + signal.SIGTERM
+        expected_returncodes = [128 + signal.SIGTERM, 256 + signal.SIGTERM]
 
     if isinstance(driver, LocalDriver):
-        expected_returncode = -signal.SIGTERM
+        expected_returncodes = [-signal.SIGTERM]
 
     async def started(iens):
         nonlocal driver
@@ -92,7 +92,7 @@ async def test_kill(driver):
 
     async def finished(iens, returncode, aborted):
         assert iens == 0
-        assert returncode == expected_returncode
+        assert returncode in expected_returncodes
         assert aborted is True
 
         nonlocal aborted_called


### PR DESCRIPTION
At least on RHEL8 and Python 3.11 the return code from PBS has been observed to be 128 + SIGTERM while at least on RHEL7/Python 3.8 it is 256 + SIGTERM.

We should accept both variants in tests.

**Issue**
Resolves one of the errors in 
https://github.com/equinor/komodo-releases/actions/runs/8278263613/job/22650241966


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
