### PR TITLE
Install only optional requirements for release testing 

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -12,7 +12,7 @@ copy_test_files () {
 }
 
 install_test_dependencies () {
-    pip install ".[dev]"
+    python script/install_requirements -k dev
 }
 
 run_ert_with_opm () {

--- a/script/install_requirements
+++ b/script/install_requirements
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Generate requirements.txt files from pyproject.toml."""
+
+import sys
+import argparse
+import subprocess
+
+from pathlib import Path
+
+try:  # standard module since Python 3.11
+    import tomllib as toml
+except ImportError:
+    try:  # available for older Python via pip
+        import tomli as toml
+    except ImportError:
+        sys.exit("`tomli` required: `pip install tomli`")
+
+
+def parse() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-k",
+        "--keys",
+        nargs='*',
+        type=str,
+        default=["dev", "test"],
+        help="Keys from optional-dependencies section exported in requirements file",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse()
+
+    script_pth = Path(__file__)
+    repo_dir = script_pth.parent.parent
+
+    req_fname = Path("requirements.txt")
+    pyproject = toml.loads((repo_dir / "pyproject.toml").read_text())
+    optional_dependencies = pyproject["project"]["optional-dependencies"]
+
+    req = []
+    for key in args.keys:
+        if key in optional_dependencies:
+            req += optional_dependencies[key]
+
+    req_fname.write_text("\n".join(req) + "\n")
+
+    # Install the requirements
+    subprocess.run(["pip", "install", "-r", f"{req_fname.name}"])
+
+    # Remove the file
+    req_fname.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/install_requirements
+++ b/script/install_requirements
@@ -4,6 +4,7 @@
 import sys
 import argparse
 import subprocess
+import json
 
 from pathlib import Path
 
@@ -31,11 +32,16 @@ def parse() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def get_packages():
+    res = subprocess.run(["pip", "list", "--format", "json"], capture_output=True)
+    return {package["name"]: package["version"] for package in json.loads(res.stdout)}
+
 def main():
     args = parse()
 
     script_pth = Path(__file__)
     repo_dir = script_pth.parent.parent
+    import time
 
     req_fname = Path("requirements.txt")
     pyproject = toml.loads((repo_dir / "pyproject.toml").read_text())
@@ -48,8 +54,32 @@ def main():
 
     req_fname.write_text("\n".join(req) + "\n")
 
+    # List of packages before installing dependencies
+    backup_pkgs = get_packages()
+
     # Install the requirements
     subprocess.run(["pip", "install", "-r", f"{req_fname.name}"])
+
+    # List of packages after installing dependencies
+    new_pkgs = get_packages()
+
+    changes = []
+    for package, version in backup_pkgs.items():
+        if new_pkgs[package] != version:
+            changes.append(f"{package}: {version} => {new_pkgs[package]}")
+
+    package_added = []
+    for package, version in new_pkgs.items():
+        if package not in backup_pkgs:
+            package_added.append(f"{package}=={version}")
+
+    if changes:
+        changes = ["Unexpected packages changed:"] + changes
+        sys.exit("\n".join(changes))
+
+    if package_added:
+        print("Added packages:")
+        print("\n".join(package_added))
 
     # Remove the file
     req_fname.unlink(missing_ok=True)


### PR DESCRIPTION
**Issue**
We would like to only install the optional requirements from ert and not the package when testing against a release this will test what is already installed in the release without modifying the current environment:

Resolves https://github.com/equinor/komodo-releases/issues/5305


**Approach**
* Extract optional dependencies from `pyproject.toml`
* Install the extracted dependencies using pip
* Check package versions are not modified by installing the optional(testing) dependencies



(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
