### PR TITLE
Fix integration tests with real LSF cluster

### DIFF
--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -47,6 +47,7 @@ def driver(request, pytestconfig, monkeypatch, tmp_path):
 
 @pytest.mark.integration_test
 async def test_submit(driver, tmp_path):
+    os.chdir(tmp_path)
     await driver.submit(0, "sh", "-c", f"echo test > {tmp_path}/test")
     await poll(driver, {0})
 
@@ -54,6 +55,7 @@ async def test_submit(driver, tmp_path):
 
 
 async def test_submit_something_that_fails(driver, tmp_path):
+    os.chdir(tmp_path)
     finished_called = False
 
     expected_returncode = 42
@@ -76,7 +78,8 @@ async def test_submit_something_that_fails(driver, tmp_path):
     assert finished_called
 
 
-async def test_kill(driver):
+async def test_kill(driver, tmp_path):
+    os.chdir(tmp_path)
     aborted_called = False
 
     expected_returncodes = [1]

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -21,6 +21,7 @@ def mock_lsf(pytestconfig, monkeypatch, tmp_path):
 
 @pytest.mark.parametrize("explicit_runpath", [(True), (False)])
 async def test_lsf_info_file_in_runpath(explicit_runpath, tmp_path):
+    os.chdir(tmp_path)
     driver = LsfDriver()
     (tmp_path / "some_runpath").mkdir()
     os.chdir(tmp_path)
@@ -41,7 +42,8 @@ async def test_lsf_info_file_in_runpath(explicit_runpath, tmp_path):
     ).keys() == {"job_id"}
 
 
-async def test_job_name():
+async def test_job_name(tmp_path):
+    os.chdir(tmp_path)
     driver = LsfDriver()
     iens: int = 0
     await driver.submit(iens, "sh", "-c", "sleep 99", name="my_job")
@@ -80,12 +82,15 @@ async def test_submit_to_named_queue(tmp_path, caplog):
         ([256, 0]),  # return codes are 8 bit.
     ],
 )
-async def test_lsf_driver_masks_returncode(actual_returncode, returncode_that_ert_sees):
+async def test_lsf_driver_masks_returncode(
+    actual_returncode, returncode_that_ert_sees, tmp_path
+):
     """actual_returncode is the returncode from job_dispatch.py (or whatever is submitted)
 
     The LSF driver is not picking up this returncode, it will only look at the
     status the job obtains through bjobs, which is success/failure.
     """
+    os.chdir(tmp_path)
     driver = LsfDriver()
 
     async def finished(iens, returncode, aborted):


### PR DESCRIPTION
The LSF driver writes its job script to disk and sends that script path to the LSF cluster through bsub. If the job script is not on a shared disk the job will fail silently.

**Issue**
Resolves #7449


**Approach**
`os.chdir()`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
