### PR TITLE
Fix LSF drivers ability to send to non-default queue

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -59,6 +59,7 @@ start_tests () {
 
     # Using presence of "bsub" in PATH to detect onprem vs azure
     if which bsub >/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
+        export _ERT_TESTS_ALTERNATIVE_QUEUE=short
         pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler
         rm -rf "$basetemp"
     fi

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -168,7 +168,7 @@ class LsfDriver(Driver):
         if not process_success:
             raise RuntimeError(process_message)
 
-        match = re.search("Job <([0-9]+)> is submitted to .+ queue", process_message)
+        match = re.search("Job <([0-9]+)> is submitted to .*queue", process_message)
         if match is None:
             raise RuntimeError(f"Could not understand '{process_message}' from bsub")
         job_id = match[1]

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,11 +3,14 @@ set -e
 
 name="STDIN"
 
-while getopts "J:" opt
+while getopts "J:q:" opt
 do
     case "$opt" in
         J)
             name=$OPTARG
+            ;;
+        q)
+            queue=$OPTARG
             ;;
         *)
             echo "Unprocessed option ${opt}"

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -55,6 +55,21 @@ async def test_job_name():
     assert "my_job" in stdout.decode()
 
 
+@pytest.mark.integration_test
+async def test_submit_to_named_queue(tmp_path, caplog):
+    """If the environment variable _ERT_TEST_ALTERNATIVE_QUEUE is defined
+    a job will be attempted submitted to that queue.
+
+    As Ert does not keep track of which queue a job is executed in, we can only
+    test for success for the job."""
+    os.chdir(tmp_path)
+    driver = LsfDriver(queue_name=os.getenv("_ERT_TESTS_ALTERNATIVE_QUEUE"))
+    await driver.submit(0, "sh", "-c", f"echo test > {tmp_path}/test")
+    await poll(driver, {0})
+
+    assert (tmp_path / "test").read_text(encoding="utf-8") == "test\n"
+
+
 @pytest.mark.parametrize(
     "actual_returncode, returncode_that_ert_sees",
     [


### PR DESCRIPTION
The Python LSF driver had a bug in a regexp causing it to crash if one tried to use a queue other than the default.

**Issue**
Resolves #7465 


**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
