### PR TITLE
Allow cleanup rm commands to fail

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -61,7 +61,7 @@ start_tests () {
     if which bsub >/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
         export _ERT_TESTS_ALTERNATIVE_QUEUE=short
         pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler
-        rm -rf "$basetemp"
+        rm -rf "$basetemp" || true
     fi
     if ! which bsub 2>/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
         export PATH=$PATH:/opt/pbs/bin
@@ -71,7 +71,7 @@ start_tests () {
             export _ERT_TESTS_DEFAULT_QUEUE_NAME=permanent_8
         fi
         pytest -v --openpbs --basetemp="$basetemp" integration_tests/scheduler
-        rm -rf "$basetemp"
+        rm -rf "$basetemp" || true
     fi
     popd
 


### PR DESCRIPTION
These rm commands operate on a NFS share, and removal on NFS shares occasionally fail due to some lock files or similar being hard to remove.

**Issue**
Resolves https://github.com/equinor/komodo-releases/actions/runs/8319390417/job/22763654808


**Approach**
Wipe problem under the carpet 🧹 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
