### PR TITLE
Have BKILL signal SIGKILL after SIGTERM

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import shutil
 import stat
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import (
@@ -115,6 +116,7 @@ class LsfDriver(Driver):
         self._jobs: MutableMapping[str, Tuple[int, AnyJob]] = {}
         self._iens2jobid: MutableMapping[int, str] = {}
         self._max_attempt: int = 100
+        self._sleep_time_between_bkills = 30
         self._sleep_time_between_cmd_retries = 3
         self._bsub_retries = 10
 
@@ -191,12 +193,17 @@ class LsfDriver(Driver):
         process = await asyncio.create_subprocess_exec(
             self._bkill_cmd,
             "-s",
-            "SIGKILL",
+            "SIGTERM",
             job_id,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await process.communicate()
+        _sigkill_process = subprocess.Popen(
+            f"sleep {self._sleep_time_between_bkills}; {self._bkill_cmd} -s SIGKILL {job_id}",
+            shell=True,
+            start_new_session=True,
+        )
         if process.returncode:
             logger.error(
                 f"LSF kill failed with returncode {process.returncode} "

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -267,7 +267,7 @@ async def test_kill(
     bkill_path.write_text(
         f"#!/bin/sh\necho '{bkill_stdout}'\n"
         f"echo '{bkill_stderr}' >&2\n"
-        f"echo $@ > 'bkill_args'\n"
+        f"echo $@ >> 'bkill_args'\n"
         f"exit {bkill_returncode}",
         encoding="utf-8",
     )
@@ -275,12 +275,25 @@ async def test_kill(
 
     driver = LsfDriver()
     driver._iens2jobid = mocked_iens2jobid
+    driver._sleep_time_between_bkills = 0
+
     await driver.kill(iens_to_kill)
+
+    async def wait_for_sigkill_in_file():
+        while True:
+            bkill_args_file_content = Path("bkill_args").read_text(encoding="utf-8")
+
+            if "-s SIGKILL" in bkill_args_file_content:
+                break
+            await asyncio.sleep(0.1)
+
     if expected_logged_error:
         assert expected_logged_error in caplog.text
     else:
-        bkill_args = Path("bkill_args").read_text(encoding="utf-8").strip()
-        assert f"-s SIGKILL {mocked_iens2jobid[iens_to_kill]}" in bkill_args
+        bkill_args = Path("bkill_args").read_text(encoding="utf-8").strip().split("\n")
+        assert f"-s SIGTERM {mocked_iens2jobid[iens_to_kill]}" in bkill_args
+
+        await asyncio.wait_for(wait_for_sigkill_in_file(), timeout=5)
 
 
 @given(st.text())


### PR DESCRIPTION
**Issue**
Resolves #7405 


**Approach**
This PR makes the LSF drivers spawn a new process to run `bkill -s SIGKILL` in a fire-and-forget manner.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
