### PR TITLE
Add a test for opening empty storage

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -374,6 +374,7 @@ class LocalStorage(BaseMode):
 
 def _storage_version(path: Path) -> Optional[int]:
     if not path.exists():
+        logger.warning(f"Unknown storage version in '{path}'")
         return None
     try:
         with open(path / "index.json", encoding="utf-8") as f:

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -511,3 +511,29 @@ class StatefulStorageTest(RuleBasedStateMachine):
 
 
 TestStorage = StatefulStorageTest.TestCase
+
+
+def test_open_storage_write_with_empty_directory(tmp_path, caplog):
+    with open_storage(tmp_path / "storage", mode="w") as storage:
+        _ = storage.create_experiment()
+        assert len(list(storage.experiments)) == 1
+
+    assert len(caplog.messages) == 1
+    assert "Unknown storage version in" in caplog.messages[0]
+
+    caplog.clear()
+
+    with open_storage(tmp_path / "storage", mode="w") as storage:
+        _ = storage.create_experiment()
+        assert len(list(storage.experiments)) == 1
+
+    storage.refresh()
+    assert len(list(storage.experiments)) == 0
+
+    assert len(caplog.messages) == 0
+
+
+def test_open_storage_read_with_empty_directory(tmp_path, caplog):
+    with open_storage(tmp_path / "storage", mode="r"):
+        assert len(caplog.messages) == 1
+        assert "Unknown storage version in" in caplog.messages[0]


### PR DESCRIPTION
**Issue**
Resolves #7045 


**Approach**
There are no errors in the log anymore when opening an empty storage. 

Added a test to test this behavior

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
