### PR TITLE
Reflect failed realizations after ert restart

### DIFF
--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -47,6 +47,7 @@ class EvaluateEnsemblePanel(SimulationConfigPanel):
         self._active_realizations_field.setValidator(
             RangeStringArgument(ensemble_size),
         )
+        self._realizations_from_fs()
         layout.addRow("Active realizations", self._active_realizations_field)
 
         self.setLayout(layout)
@@ -55,6 +56,7 @@ class EvaluateEnsemblePanel(SimulationConfigPanel):
             self.simulationConfigurationChanged
         )
         self._ensemble_selector.ensemble_populated.connect(self._realizations_from_fs)
+        self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
 
     def isConfigurationValid(self):
         return self._active_realizations_field.isValid()
@@ -65,11 +67,3 @@ class EvaluateEnsemblePanel(SimulationConfigPanel):
             ensemble_name=self._ensemble_selector.currentText(),
             realizations=self._active_realizations_field.text(),
         )
-
-    def _realizations_from_fs(self):
-        ensemble = str(self._ensemble_selector.currentText())
-        if ensemble:
-            mask = self.notifier.storage.get_ensemble_by_name(
-                ensemble
-            ).get_realization_mask_with_parameters()
-            self._active_realizations_field.model.setValueFromMask(mask)

--- a/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/iterated_ensemble_smoother_panel.py
@@ -48,8 +48,8 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         self._name_field.setMinimumWidth(250)
         layout.addRow("Experiment name:", self._name_field)
 
-        ensemble_selector = EnsembleSelector(notifier)
-        layout.addRow("Current ensemble:", ensemble_selector)
+        self._ensemble_selector = EnsembleSelector(notifier)
+        layout.addRow("Current ensemble:", self._ensemble_selector)
 
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
@@ -91,6 +91,7 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
             self._active_realizations_model, "config/simulation/active_realizations"
         )
         self._active_realizations_field.setValidator(RangeStringArgument(ensemble_size))
+        self._realizations_from_fs()
         layout.addRow("Active realizations", self._active_realizations_field)
 
         self._iterated_target_ensemble_format_field.getValidationSupport().validationChanged.connect(  # noqa
@@ -99,6 +100,9 @@ class IteratedEnsembleSmootherPanel(SimulationConfigPanel):
         self._active_realizations_field.getValidationSupport().validationChanged.connect(  # noqa
             self.simulationConfigurationChanged
         )
+
+        self._ensemble_selector.ensemble_populated.connect(self._realizations_from_fs)
+        self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
 
         self.setLayout(layout)
 

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -86,6 +86,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
             self._active_realizations_model, "config/simulation/active_realizations"
         )
         self._active_realizations_field.setValidator(RangeStringArgument(ensemble_size))
+        self._ensemble_selector = EnsembleSelector(notifier)
+        self._realizations_from_fs()
         layout.addRow("Active realizations:", self._active_realizations_field)
 
         self._restart_box = QCheckBox("")
@@ -94,8 +96,8 @@ class MultipleDataAssimilationPanel(SimulationConfigPanel):
         self._restart_box.setEnabled(False)
         layout.addRow("Restart run:", self._restart_box)
 
-        self._ensemble_selector = EnsembleSelector(notifier)
         self._ensemble_selector.ensemble_populated.connect(self.restart_run_toggled)
+        self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
         layout.addRow("Restart from:", self._ensemble_selector)
 
         self._target_ensemble_format_field.getValidationSupport().validationChanged.connect(  # noqa

--- a/src/ert/gui/simulation/simulation_config_panel.py
+++ b/src/ert/gui/simulation/simulation_config_panel.py
@@ -22,3 +22,11 @@ class SimulationConfigPanel(QWidget):
     @staticmethod
     def getSimulationArguments() -> Dict[str, Any]:
         return {}
+
+    def _realizations_from_fs(self):
+        ensemble = str(self._ensemble_selector.currentText())
+        if ensemble:
+            mask = self.notifier.storage.get_ensemble_by_name(
+                ensemble
+            ).get_realization_mask_with_parameters()
+            self._active_realizations_field.model.setValueFromMask(mask)


### PR DESCRIPTION
**Issue**
Resolves #7505 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
