### PR TITLE
Remove poly integration test on PBS

### DIFF
--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -27,19 +27,6 @@ def queue_name_config():
     return ""
 
 
-@pytest.mark.integration_test
-@pytest.mark.usefixtures("copy_poly_case")
-def test_openpbs_driver_with_poly_example(queue_name_config):
-    with open("poly.ert", mode="a+", encoding="utf-8") as f:
-        f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
-        f.write(queue_name_config)
-    run_cli(
-        ENSEMBLE_EXPERIMENT_MODE,
-        "--enable-scheduler",
-        "poly.ert",
-    )
-
-
 async def mock_failure(message, *args, **kwargs):
     raise RuntimeError(message)
 


### PR DESCRIPTION
When tested through Komodo, this will not work as it requires the environment and the runpath to be on a shared disk, which the komodo setup currently does not facilitate.

Komodo testing will still effectively run this integration test through bigpoly.

**Issue**
Resolves #7524 

**Approach**
Drop this test. It is not tested for LSF, that is the reason this test file "passes" onprem.

If test is to be run, it requires some more infrastructure in place from Komodo. The easiest way in Komodo to have this pass is to let all komodo integration test run with everything on a shared disk, which will hamper test performance for all tests.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
