### PR TITLE
Remove unwanted warning when user is setting ECLBASE and no summary data

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -108,14 +108,7 @@ class ErtConfig:
             else os.getcwd()
         )
         self.enkf_obs: EnkfObs = self._create_observations()
-        if self.ensemble_config.eclbase is not None and len(self.summary_keys) == 0:
-            # There is a bug with storing empty responses so we have
-            # to warn that the forward model fails in this case
-            # https://github.com/equinor/ert/issues/6974
-            ConfigWarning.ert_context_warn(
-                "Setting ECLBASE without using SUMMARY, SUMMARY_OBSERVATION, "
-                "or HISTORY_OBSERVATION. No summary values will be loaded",
-            )
+
         if len(self.summary_keys) != 0:
             self.ensemble_config.addNode(self._create_summary_config())
         self.observations: Dict[str, xr.Dataset] = self.enkf_obs.datasets

--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -553,9 +553,6 @@ def config_generators(draw, use_eclbase=booleans):
         "ignore", message=".*input contained no data.*", category=UserWarning
     )
     filterwarnings(
-        "ignore", message=".*Setting ECLBASE without using.*", category=UserWarning
-    )
-    filterwarnings(
         "ignore", message=".*overflow encountered in.*", category=RuntimeWarning
     )
     filterwarnings(

--- a/tests/unit_tests/test_enkf_main.py
+++ b/tests/unit_tests/test_enkf_main.py
@@ -7,9 +7,6 @@ from ert.config import ErtConfig
 from ert.enkf_main import create_run_path, ensemble_context, sample_prior
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Setting ECLBASE without using.*:ert.config.ConfigWarning"
-)
 @pytest.mark.parametrize(
     "config_dict",
     [
@@ -47,9 +44,6 @@ def test_create_run_context(prior_ensemble, config_dict):
     assert substitutions.get("<ECLBASE>") == "name<IENS>"
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Setting ECLBASE without using.*:ert.config.ConfigWarning"
-)
 def test_create_run_context_separate_base_and_name(prior_ensemble):
     iteration = 0
     ensemble_size = 10

--- a/tests/unit_tests/test_load_forward_model.py
+++ b/tests/unit_tests/test_load_forward_model.py
@@ -86,9 +86,6 @@ def test_load_forward_model(snake_oil_default_storage):
         ]  # Check that status is as expected
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Setting ECLBASE without using.*:ert.config.ConfigWarning"
-)
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "summary_configuration, expected",

--- a/tests/unit_tests/test_run_path_creation.py
+++ b/tests/unit_tests/test_run_path_creation.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
-from warnings import filterwarnings
 
 import pytest
 
@@ -11,13 +10,6 @@ from ert.enkf_main import create_run_path, ensemble_context, sample_prior
 from ert.run_context import RunContext
 from ert.runpaths import Runpaths
 from ert.storage import Storage
-
-
-@pytest.fixture(autouse=True)
-def filter_configwarning():
-    filterwarnings(
-        "ignore", message="Setting ECLBASE without using.*", category=UserWarning
-    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
**Issue**
Resolves #7513


**Approach**
Remvoe the warning.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
