### PR TITLE
Make StorageService constructor match base

### DIFF
--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -242,7 +242,7 @@ class BaseService:
 
     def __init__(
         self,
-        exec_args: Sequence[str],
+        exec_args: Sequence[str] = tuple(),
         timeout: int = 120,
         conn_info: ConnInfo = None,
         project: Optional[str] = None,
@@ -294,7 +294,7 @@ class BaseService:
         while t < timeout:
             if (path / name).exists():
                 with (path / name).open() as f:
-                    return cls([], conn_info=json.load(f), project=str(path))
+                    return cls(tuple(), conn_info=json.load(f), project=str(path))
 
             sleep(1)
             t += 1

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-from os import PathLike
-from typing import Any, Optional, Tuple
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 import httpx
 import requests
@@ -16,19 +15,21 @@ class StorageService(BaseService):
 
     def __init__(
         self,
-        project: Optional[PathLike[str]] = None,
+        exec_args: Sequence[str] = tuple(),
+        timeout: int = 120,
+        conn_info: Union[Mapping[str, Any], Exception, None] = None,
+        project: Optional[str] = None,
         verbose: bool = False,
-        *args: Any,
-        **kwargs: Any,
     ):
         self._url: Optional[str] = None
 
         exec_args = local_exec_args("storage")
+
         exec_args.extend(["--project", str(project)])
         if verbose:
             exec_args.append("--verbose")
 
-        super().__init__(exec_args, *args, **kwargs)
+        super().__init__(exec_args, timeout, conn_info, project)
 
     def fetch_auth(self) -> Tuple[str, Any]:
         """

--- a/tests/unit_tests/services/test_storage_service.py
+++ b/tests/unit_tests/services/test_storage_service.py
@@ -1,15 +1,17 @@
 import json
 import os
+import socket
 
-from ert.services import _storage_main
+from ert.services import StorageService
+from ert.services._storage_main import _create_connection_info
 from ert.shared import port_handler
 
 
-def test_create_connection_string(monkeypatch):
+def test_create_connection_string():
     authtoken = "very_secret_token"
     _, _, sock = port_handler.find_available_port()
 
-    _storage_main._create_connection_info(sock, authtoken)
+    _create_connection_info(sock, authtoken)
 
     assert "ERT_STORAGE_CONNECTION_STRING" in os.environ
     connection_string = json.loads(os.environ["ERT_STORAGE_CONNECTION_STRING"])
@@ -18,3 +20,29 @@ def test_create_connection_string(monkeypatch):
     assert len(connection_string["urls"]) == 3
 
     del os.environ["ERT_STORAGE_CONNECTION_STRING"]
+
+
+def test_that_service_can_be_started_with_existing_conn_info_json(tmp_path):
+    """
+    This is a regression test for a bug with the following reproduction steps:
+
+        1. run `ert gui snake_oil.ert` with an old version of ert
+        2. kill that process, meaning `storage_service_server.json` is not cleaned up.
+        3. run `ert gui snake_oil.ert` with latest version of ert, which
+           may crash due to braking changes with respects to the file.
+    """
+    connection_info = {
+        "urls": [
+            f"http://{host}:51839"
+            for host in (
+                "127.0.0.1",
+                socket.gethostname(),
+                socket.getfqdn(),
+            )
+        ],
+        "authtoken": "dummytoken",
+    }
+
+    with open(tmp_path / "storage_server.json", mode="w") as f:
+        json.dump(connection_info, f)
+    StorageService.connect(project=tmp_path)


### PR DESCRIPTION
Fixes a bug where if json file is present, `StorageService.__init__` is called with unexpected arguments.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
