### PR TITLE
Ignore failed test-summary

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -66,6 +66,7 @@ jobs:
         test -z "$(git status --porcelain | sed '/ert.*.whl$\\|\\/block_storage$/d')"
 
     - uses: test-summary/action@v2
+      continue-on-error: true
       with:
         paths: junit.xml
       if: always()


### PR DESCRIPTION
test-summary will fail if junit.xml does not exist, which happens when the tests time out. Since this is only for pretty output, we ignore such errors.
