### PR TITLE
Fix exclude host lsf queue option

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -39,6 +39,7 @@ def create_driver(config: QueueConfig) -> Driver:
             bkill_cmd=queue_config.get("BKILL_CMD"),
             bjobs_cmd=queue_config.get("BJOBS_CMD"),
             bhist_cmd=queue_config.get("BHIST_CMD"),
+            exclude_hosts=queue_config.get("EXCLUDE_HOST"),
             queue_name=queue_config.get("LSF_QUEUE"),
             resource_requirement=queue_config.get("LSF_RESOURCE"),
         )

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -521,6 +521,7 @@ def test_scheduler_create_lsf_driver():
     bjobs_cmd = "bar_bjobs_cmd"
     bhist_cmd = "com_bjobs_cmd"
     lsf_resource = "select[cs && x86_64Linux]"
+    exclude_host = "host1,host2"
     queue_config_dict = {
         "QUEUE_SYSTEM": "LSF",
         "QUEUE_OPTION": [
@@ -530,6 +531,7 @@ def test_scheduler_create_lsf_driver():
             ("LSF", "BHIST_CMD", bhist_cmd),
             ("LSF", "LSF_QUEUE", queue_name),
             ("LSF", "LSF_RESOURCE", lsf_resource),
+            ("LSF", "EXCLUDE_HOST", exclude_host),
         ],
     }
     queue_config = QueueConfig.from_dict(queue_config_dict)
@@ -540,6 +542,7 @@ def test_scheduler_create_lsf_driver():
     assert str(driver._bhist_cmd) == bhist_cmd
     assert driver._queue_name == queue_name
     assert driver._resource_requirement == lsf_resource
+    assert driver._exclude_hosts == ["host1", "host2"]
 
 
 def test_scheduler_create_openpbs_driver():


### PR DESCRIPTION
This commit fixes exclude_host lsf queue option using empty string as default instead of None.

**Issue**
Resolves #7539 
Resolves #7345


**Approach**
The problem was that when you do "".split(), you get a list with one item. We then iterated over this list, and built a resource string containing hname!="<THE_EMPTY_STRING>".

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
