### PR TITLE
Add --disable-monitor to Ert client runs in integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,6 +365,7 @@ def _run_snake_oil(source_root):
         parser,
         [
             ENSEMBLE_EXPERIMENT_MODE,
+            "--disable-monitor",
             "--current-case",
             "default_0",
             "snake_oil.ert",

--- a/tests/integration_tests/analysis/test_adaptive_localization.py
+++ b/tests/integration_tests/analysis/test_adaptive_localization.py
@@ -17,6 +17,7 @@ def run_cli_ES_with_case(poly_config):
     posterior_sample_name = "posterior_sample" + "_" + config_name
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "--current-case",
         prior_sample_name,
         "--target-case",

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -56,6 +56,7 @@ def obs():
 def test_that_posterior_has_lower_variance_than_prior():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "--current-case",
         "default",
         "--target-case",
@@ -130,6 +131,7 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert():
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "snake_oil_surface.ert",
         "--target-case",
         "es_udpate",
@@ -173,6 +175,7 @@ def test_update_multiple_param():
     """
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "snake_oil.ert",
         "--target-case",
         "posterior",
@@ -461,6 +464,7 @@ def test_that_update_works_with_failed_realizations():
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "poly.ert",
         "--target-case",
         "posterior",

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -183,6 +183,7 @@ def test_run_mocked_lsf_queue(request, using_scheduler):
         )
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
+        "--disable-monitor",
         "poly.ert",
     )
     log = Path("bsub_log").read_text(encoding="utf-8")

--- a/tests/integration_tests/shared/share/test_shell.py
+++ b/tests/integration_tests/shared/share/test_shell.py
@@ -37,7 +37,7 @@ FORWARD_MODEL DELETE_DIRECTORY(<DIRECTORY>=mydir)
         with open("file.txt", "w", encoding="utf-8") as file_h:
             file_h.write("something")
 
-        run_cli("test_run", ert_config_fname)
+        run_cli("test_run", "--disable-monitor", ert_config_fname)
 
         with open("realization-0/iter-0/moved.txt", encoding="utf-8") as output_file:
             assert output_file.read() == "something"

--- a/tests/integration_tests/storage/test_field_parameter.py
+++ b/tests/integration_tests/storage/test_field_parameter.py
@@ -105,6 +105,7 @@ if __name__ == "__main__":
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
+            "--disable-monitor",
             "--current-case",
             "prior",
             "--target-case",
@@ -235,6 +236,7 @@ if __name__ == "__main__":
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
+            "--disable-monitor",
             "--current-case",
             "prior",
             "--target-case",

--- a/tests/integration_tests/storage/test_parameter_sample_types.py
+++ b/tests/integration_tests/storage/test_parameter_sample_types.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
+            "--disable-monitor",
             "--current-case",
             "prior",
             "--target-case",
@@ -270,6 +271,7 @@ if __name__ == "__main__":
 def run_poly():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
+        "--disable-monitor",
         "--current-case",
         "prior",
         "--target-case",

--- a/tests/integration_tests/test_observation_times.py
+++ b/tests/integration_tests/test_observation_times.py
@@ -114,6 +114,7 @@ def test_small_time_mismatches_are_ignored(
         with redirect_stderr(stderr):
             run_cli(
                 ES_MDA_MODE,
+                "--disable-monitor",
                 str(tmp_path / "config.ert"),
                 "--weights=0,1",
             )
@@ -122,6 +123,7 @@ def test_small_time_mismatches_are_ignored(
         with pytest.raises(ErtCliError, match="No active observations"):
             run_cli(
                 ES_MDA_MODE,
+                "--disable-monitor",
                 str(tmp_path / "config.ert"),
                 "--weights=0,1",
             )

--- a/tests/integration_tests/test_parameter_example.py
+++ b/tests/integration_tests/test_parameter_example.py
@@ -368,7 +368,7 @@ def test_parameter_example(
         smspec.to_file("ECLBASE.SMSPEC")
         unsmry.to_file("ECLBASE.UNSMRY")
 
-        run_cli(ENSEMBLE_EXPERIMENT_MODE, "config.ert")
+        run_cli(ENSEMBLE_EXPERIMENT_MODE, "--disable-monitor", "config.ert")
 
         mask = np.logical_not(
             np.array(io_source.actnum).reshape(io_source.dims, order="F")

--- a/tests/performance_tests/conftest.py
+++ b/tests/performance_tests/conftest.py
@@ -83,6 +83,7 @@ def template_config(request, source_root, tmp_path_factory):
                 parser,
                 [
                     ENSEMBLE_EXPERIMENT_MODE,
+                    "--disable-monitor",
                     "poly.ert",
                 ],
             )

--- a/tests/unit_tests/dark_storage/conftest.py
+++ b/tests/unit_tests/dark_storage/conftest.py
@@ -32,6 +32,7 @@ def poly_example_tmp_dir_shared(
             parser,
             [
                 ENSEMBLE_SMOOTHER_MODE,
+                "--disable-monitor",
                 "--current-case",
                 "alpha",
                 "--target-case",


### PR DESCRIPTION
This reduces the amount of lines printed to stdout while running through the test-suite.

**Issue**
Resolves  lengthy output when running `pytest -s`

**Approach**
Add command line option to ert command line client.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
