### PR TITLE
Fix incorrect lsf_driver integration test

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -121,7 +121,7 @@ async def test_lsf_driver_masks_returncode(
 
 
 async def test_submit_with_resource_requirement(tmp_path):
-    resource_requirement = "rusage=[mem=20MB]"
+    resource_requirement = "select[cs && x86_64Linux]"
     driver = LsfDriver(resource_requirement=resource_requirement)
     await driver.submit(0, "sh", "-c", f"echo test>{tmp_path}/test")
     await poll(driver, {0})

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -135,9 +135,9 @@ async def test_submit_with_default_queue():
 
 @pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_with_resource_requirement():
-    driver = LsfDriver(resource_requirement="rusage[mem=512MB:swp=1GB]")
+    driver = LsfDriver(resource_requirement="select[cs && x86_64Linux]")
     await driver.submit(0, "sleep")
-    assert "-R rusage[mem=512MB:swp=1GB]" in Path("captured_bsub_args").read_text(
+    assert "-R select[cs && x86_64Linux]" in Path("captured_bsub_args").read_text(
         encoding="utf-8"
     )
 

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -520,7 +520,7 @@ def test_scheduler_create_lsf_driver():
     bkill_cmd = "foo_bkill_cmd"
     bjobs_cmd = "bar_bjobs_cmd"
     bhist_cmd = "com_bjobs_cmd"
-    lsf_resource = "rusage[mem=512MB:swp=1GB]"
+    lsf_resource = "select[cs && x86_64Linux]"
     queue_config_dict = {
         "QUEUE_SYSTEM": "LSF",
         "QUEUE_OPTION": [


### PR DESCRIPTION
**Issue**
Resolves #7550 


**Approach**
This commit fixes the invald resource requirement in /tests/integration_tests/scheduler/test_lsf_driver.py::test_submit_with_resource_requirement


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
