### PR TITLE
Avoid calling kill() on each submit in LocalDriver

### DIFF
--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -572,15 +572,3 @@ def test_scheduler_create_openpbs_driver():
     assert driver._num_cpus_per_node == num_cpus_per_node
     assert driver._cluster_label == cluster_label
     assert driver._job_prefix == job_prefix
-
-
-@pytest.mark.timeout(15)
-async def test_that_driver_kill_exceptions_from_job_call_are_propagated(
-    mock_driver, realization
-):
-    driver = mock_driver()
-    driver.kill = partial(mock_failure, "Driver kill failed")
-    sch = scheduler.Scheduler(driver, [realization])
-
-    with pytest.raises(RuntimeError, match=r"Driver kill failed"):
-        await sch.execute()


### PR DESCRIPTION
This cleanup seems redundant, and will give wrong logs.

Also removes a test that relies on kill() being called upon
each submit, which we should not rely on.


**Issue**
Resolves suspicios kill call.


**Approach**
✂️ 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
