### PR TITLE
Return none if the parser does not provide scheduler_feature

### DIFF
--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -73,4 +73,6 @@ class FeatureScheduler:
 
     @staticmethod
     def _get_from_args(args: Namespace) -> Optional[bool]:
-        return args.feature_scheduler
+        if hasattr(args, "feature_scheduler"):
+            return args.feature_scheduler
+        return None


### PR DESCRIPTION
**Issue**
Resolves #7557 


**Approach**
Return none if the parser does not provide scheduler_feature

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
