### PR TITLE
Increase qstat performance by adding -E option

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -238,7 +238,7 @@ class OpenPBSDriver(Driver):
             if self._non_finished_job_ids:
                 process = await asyncio.create_subprocess_exec(
                     "qstat",
-                    "-x",
+                    "-Ex",
                     "-w",  # wide format
                     *self._non_finished_job_ids,
                     stdout=asyncio.subprocess.PIPE,
@@ -266,7 +266,7 @@ class OpenPBSDriver(Driver):
             if self._finished_job_ids:
                 process = await asyncio.create_subprocess_exec(
                     "qstat",
-                    "-fx",
+                    "-Efx",
                     "-Fjson",
                     *self._finished_job_ids,
                     stdout=asyncio.subprocess.PIPE,

--- a/tests/integration_tests/scheduler/bin/qstat.py
+++ b/tests/integration_tests/scheduler/bin/qstat.py
@@ -24,6 +24,7 @@ def parse_args() -> Namespace:
     ap.add_argument("-F", default="")
     ap.add_argument("jobs", nargs="*")
     ap.add_argument("-w", action="store_true")
+    ap.add_argument("-E", action="store_true")
     return ap.parse_args()
 
 


### PR DESCRIPTION
Using the -E option causes qstat to group job status calls going to the same server together. This makes qstat orders of magnitude faster for calls with many job ids.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
