### PR TITLE
Display possible error when removing existing runpath

### DIFF
--- a/tests/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from pytestqt.qtbot import QtBot
@@ -20,7 +20,12 @@ from ert.services.storage_service import StorageService
 from ert.storage import open_storage
 
 
-def handle_run_path_dialog(gui: ErtMainWindow, qtbot: QtBot, delete_run_path: bool):
+def handle_run_path_dialog(
+    gui: ErtMainWindow,
+    qtbot: QtBot,
+    delete_run_path: bool = True,
+    expect_error: bool = False,
+):
     mb = gui.findChild(QMessageBox, "RUN_PATH_WARNING_BOX")
 
     if mb is not None:
@@ -31,6 +36,71 @@ def handle_run_path_dialog(gui: ErtMainWindow, qtbot: QtBot, delete_run_path: bo
             qtbot.mouseClick(mb.checkBox(), Qt.LeftButton)
 
         qtbot.mouseClick(mb.buttons()[0], Qt.LeftButton)
+        if expect_error:
+            QTimer.singleShot(1000, lambda: handle_run_path_error_dialog(gui, qtbot))
+
+
+def handle_run_path_error_dialog(gui: ErtMainWindow, qtbot: QtBot):
+    mb = gui.findChild(QMessageBox, "RUN_PATH_ERROR_BOX")
+
+    if mb is not None:
+        assert mb
+        assert isinstance(mb, QMessageBox)
+        # Continue without deleting the runpath
+        qtbot.mouseClick(mb.buttons()[0], Qt.LeftButton)
+
+
+@pytest.mark.usefixtures("using_scheduler")
+def test_run_path_deleted_error(
+    snake_oil_case_storage: ErtConfig, qtbot: QtBot, mocker
+):
+    snake_oil_case = snake_oil_case_storage
+    args_mock = Mock()
+    args_mock.config = "snake_oil.ert"
+
+    with StorageService.init_service(
+        project=os.path.abspath(snake_oil_case.ens_path),
+    ), open_storage(snake_oil_case.ens_path, mode="w") as storage:
+        gui = _setup_main_window(
+            EnKFMain(snake_oil_case), args_mock, GUILogHandler(), storage
+        )
+        simulation_panel = gui.findChild(SimulationPanel)
+
+        assert isinstance(simulation_panel, SimulationPanel)
+        simulation_mode_combo = simulation_panel.findChild(QComboBox)
+        assert isinstance(simulation_mode_combo, QComboBox)
+        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+        simulation_settings = gui.findChild(EnsembleExperimentPanel)
+        simulation_settings._name_field.setText("new_experiment_name")
+
+        # Click start simulation and agree to the message
+        start_simulation = simulation_panel.findChild(QWidget, name="start_simulation")
+        assert start_simulation
+        assert isinstance(start_simulation, QToolButton)
+
+        # Add something to the runpath
+        run_path = Path(
+            snake_oil_case.model_config.runpath_format_string.replace(
+                "<IENS>", "0"
+            ).replace("<ITER>", "0")
+        )
+        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+            dummy_file.close()
+
+        QTimer.singleShot(
+            1000, lambda: handle_run_path_dialog(gui, qtbot, expect_error=True)
+        )
+        with patch("shutil.rmtree", side_effect=PermissionError("Not allowed!")):
+            qtbot.mouseClick(start_simulation, Qt.LeftButton)
+
+            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+        run_dialog = gui.findChild(RunDialog)
+        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
+        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+        qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
+
+        assert os.path.exists(run_path / dummy_file.name)
 
 
 @pytest.mark.usefixtures("using_scheduler")


### PR DESCRIPTION
**Issue**
Resolves #7541 


**Approach**
Display error dialog with error msg and allow user to continue without deleting the runpath.


(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/equinor/ert/assets/4508053/7f91501b-f9ef-4102-b697-b1b8073eb543)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
