### PR TITLE
[Backport] Display possible error when removing existing runpath

### DIFF
--- a/src/ert/gui/simulation/simulation_panel.py
+++ b/src/ert/gui/simulation/simulation_panel.py
@@ -248,15 +248,31 @@ class SimulationPanel(QWidget):
             ):
                 abort = True
 
-            if not abort:
-                if (
-                    delete_runpath_checkbox is not None
-                    and delete_runpath_checkbox.checkState() == Qt.Checked
-                ):
-                    QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            delete_runpath = (
+                delete_runpath_checkbox is not None
+                and delete_runpath_checkbox.checkState() == Qt.Checked
+            )
+            if not abort and delete_runpath:
+                QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+                try:
                     model.rm_run_path()
+                except OSError as e:
                     QApplication.restoreOverrideCursor()
+                    msg_box = QMessageBox(self)
+                    msg_box.setObjectName("RUN_PATH_ERROR_BOX")
+                    msg_box.setIcon(QMessageBox.Warning)
+                    msg_box.setText("ERT could not delete the existing runpath")
+                    msg_box.setInformativeText(
+                        (f"{e}\n\n" "Continue without deleting the runpath?")
+                    )
+                    msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+                    msg_box.setDefaultButton(QMessageBox.No)
+                    msg_box.setWindowModality(Qt.ApplicationModal)
+                    msg_box_res = msg_box.exec()
+                    abort = msg_box_res == QMessageBox.No
+                QApplication.restoreOverrideCursor()
 
+            if not abort:
                 dialog = RunDialog(
                     self._config_file, model, self._notifier, self.parent()
                 )


### PR DESCRIPTION
Allow the user to continue without deleting the runpath.

**Issue**
Resolves #7541


(Screenshot of new behaviour in GUI if applicable)
![image](https://github.com/equinor/ert/assets/4508053/57c0f9f6-a60e-404f-b274-81ac39da3045)



- [ ] PR title captures the intent of the changes and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
