### PR TITLE
Fix OpenPBS driver logging error when killing failed jobs

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -131,6 +131,7 @@ class OpenPBSDriver(Driver):
         self._iens2jobid: MutableMapping[int, str] = {}
         self._non_finished_job_ids: Set[str] = set()
         self._finished_job_ids: Set[str] = set()
+        self._finished_iens: Set[int] = set()
 
         self._resources = self._resource_strings()
 
@@ -210,6 +211,9 @@ class OpenPBSDriver(Driver):
         self._non_finished_job_ids.add(job_id_)
 
     async def kill(self, iens: int) -> None:
+        if iens in self._finished_iens:
+            return
+
         if iens not in self._iens2jobid:
             logger.error(f"PBS kill failed due to missing jobid for realization {iens}")
             return
@@ -323,6 +327,7 @@ class OpenPBSDriver(Driver):
                 logger.debug(
                     f"Realization {iens} (PBS-id: {self._iens2jobid[iens]}) succeeded"
                 )
+            self._finished_iens.add(iens)
             del self._jobs[job_id]
             del self._iens2jobid[iens]
             self._finished_job_ids.remove(job_id)


### PR DESCRIPTION
**Issue**
Resolves #7560 


**Approach**
This commit fixes the bug where OpenPBS driver would log `PBS kill failed due to missing jobid for realization` when killing jobs that had already finished with a failure.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
