### PR TITLE
Solve race condition in lsf_driver for job_ids

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -274,9 +274,10 @@ class LsfDriver(Driver):
             if not self._jobs.keys():
                 await asyncio.sleep(self._poll_period)
                 continue
+            current_jobids = list(self._jobs.keys())
             process = await asyncio.create_subprocess_exec(
                 self._bjobs_cmd,
-                *self._jobs.keys(),
+                *current_jobids,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -290,7 +291,7 @@ class LsfDriver(Driver):
                 )
             bjobs_states = _Stat(**parse_bjobs(stdout.decode(errors="ignore")))
 
-            if missing_in_bjobs_output := set(self._jobs) - set(
+            if missing_in_bjobs_output := set(current_jobids) - set(
                 bjobs_states.jobs.keys()
             ):
                 logger.debug(f"bhist is used for job ids: {missing_in_bjobs_output}")


### PR DESCRIPTION
It is possible for self._jobs to be changed throughout the poll() function, we must be sure to compare to the original set before we employ the bhist fallback

**Issue**
Resolves #7574 

**Approach**
Copy the list used for later comparison.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
