### PR TITLE
Change cwd to tmpdir in some tests currently polluting working dir

### DIFF
--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -39,8 +39,8 @@ def nonempty_string_without_whitespace():
 
 @pytest.fixture
 def capturing_bsub(monkeypatch, tmp_path):
-    os.chdir(tmp_path)
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bsub_path = bin_path / "bsub"
@@ -186,7 +186,8 @@ async def test_submit_with_resource_requirement():
     ],
 )
 async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bsub_path = bin_path / "bsub"
@@ -268,8 +269,8 @@ async def test_kill(
     expected_logged_error,
     caplog,
 ):
-    os.chdir(tmp_path)
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bkill_path = bin_path / "bkill"
@@ -437,7 +438,8 @@ BJOBS_HEADER = (
     ],
 )
 async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bsub_path = bin_path / "bsub"
@@ -462,8 +464,8 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
 async def test_that_bsub_will_retry_and_fail(
     monkeypatch, tmp_path, exit_code, error_msg
 ):
-    os.chdir(tmp_path)
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bsub_path = bin_path / "bsub"
@@ -490,8 +492,8 @@ async def test_that_bsub_will_retry_and_fail(
 async def test_that_bsub_will_retry_and_succeed(
     monkeypatch, tmp_path, exit_code, error_msg
 ):
-    os.chdir(tmp_path)
-    bin_path = tmp_path / "bin"
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("bin")
     bin_path.mkdir()
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     bsub_path = bin_path / "bsub"


### PR DESCRIPTION
**Issue**
some files are created in your working directory when running pytest


**Approach**
change working directory in the test using monkeypatch

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
