### PR TITLE
Solve deprecation warning from datetime on UTC

### DIFF
--- a/tests/integration_tests/scheduler/bin/bjobs.py
+++ b/tests/integration_tests/scheduler/bin/bjobs.py
@@ -1,6 +1,6 @@
 import argparse
+import datetime
 import os
-from datetime import datetime
 from pathlib import Path
 from typing import List, Literal, Optional
 
@@ -37,7 +37,9 @@ def get_parser() -> argparse.ArgumentParser:
 def bjobs_formatter(jobstats: List[Job]) -> str:
     string = "JOBID USER     STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME\n"
     for job in jobstats:
-        submit_time = datetime.utcfromtimestamp((job.submit_time))
+        submit_time = datetime.datetime.fromtimestamp(
+            job.submit_time, datetime.timezone.utc
+        )
         string += (
             f"{str(job.job_id):<5s} {job.user_name:<8s} "
             f"{job.job_state:<4s} {job.queue:<8} "


### PR DESCRIPTION
**Issue**
```
Python 3.12.1 (main, Dec  7 2023, 20:45:44) [Clang 15.0.0 (clang-1500.0.40.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.datetime.utcfromtimestamp(0)
<stdin>:1: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
datetime.datetime(1970, 1, 1, 0, 0)
```


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
