### PR TITLE
Add SIGKILL to possible returncodes from kill

### DIFF
--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -85,6 +85,7 @@ async def test_kill(driver, tmp_path):
     expected_returncodes = [
         LSF_FAILED_JOB,
         SIGNAL_OFFSET + signal.SIGTERM,
+        256 + signal.SIGKILL,
         256 + signal.SIGTERM,
     ]
 


### PR DESCRIPTION
Observed on PBS

**Issue**
Resolves failure observation from nightly testing:
```
E       assert 265 in [193, 143, 271]
```

https://github.com/equinor/komodo-releases/actions/runs/8585204221/job/23526657740

**Approach**
➕ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
