### PR TITLE
Use macOS-14 runners for ert

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,12 +122,25 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        os: [ 'macos-13', 'macos-latest-xlarge' ]
+        # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+        os: [ 'macos-13', 'macos-14', 'macos-14-large']
         exclude:
-          - os: 'macos-latest-xlarge'
+          - os: 'macos-14'
             python-version: '3.8'
-          - os: 'macos-latest-xlarge'
+          - os: 'macos-14'
             python-version: '3.9'
+          - os: 'macos-14'
+            python-version: '3.10'
+          - os: 'macos-14-large'
+            python-version: '3.8'
+          - os: 'macos-14-large'
+            python-version: '3.9'
+          - os: 'macos-14-large'
+            python-version: '3.10'
+          - os: 'macos-13'
+            python-version: '3.11'
+          - os: 'macos-13'
+            python-version: '3.12'
 
     uses: ./.github/workflows/build-wheels-macos.yml
     with:
@@ -180,10 +193,15 @@ jobs:
       matrix:
         test-type: [ 'integration-tests', 'unit-tests', 'gui-test' ]
         python-version: [ '3.8', '3.12' ]
-        os: [ 'macos-13', 'macos-latest-xlarge' ]
+        os: [ 'macos-13', 'macos-14', 'macos-14-large']
         exclude:
-          - os: 'macos-latest-xlarge'
+          - os: 'macos-14'
             python-version: '3.8'
+          - os: 'macos-14-large'
+            python-version: '3.8'
+          - os: 'macos-13'
+            python-version: '3.12'
+
     uses: ./.github/workflows/test_ert.yml
     with:
       os: ${{ matrix.os }}

--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -41,7 +41,6 @@ def queue_name_config():
 def test_that_openpbs_driver_ignores_qstat_flakiness(
     text_to_ignore, caplog, capsys, create_mock_flaky_qstat
 ):
-
     create_mock_flaky_qstat(text_to_ignore)
     with open("poly.ert", mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 1")


### PR DESCRIPTION
Building tags
| OS | Arch | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 |
|----|----|----|----|----|----|----|
| macOS-14 | arm64 | ❌ | ❌ | ❌ | ✅  | ✅  | 
| macOS-14-large | x86_64 | ❌ | ❌ | ❌ | ✅  | ✅ |
| macOS-13 | x86_64 | ✅  | ✅ | ✅ | ❌ | ❌ |

Testing tags

| OS | Arch | 3.8 | 3.12 |
|----|----|----|----|
| macOS-14 | arm64 | ❌ |  ✅  | 
| macOS-14-large | x86_64 | ❌ | ✅ |
| macOS-13 | x86_64 | ✅  | ❌ |

Works fine on macOS-14
https://github.com/equinor/ert/actions/runs/8600062307


Use tag `macos-latest` when doing regular build and test for PR's since we have some included minutes for those specific runners.
Eventually (12 week window or so) these will not point at macos-12, but macos-14.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
