### PR TITLE
Increase timeout for testing of faulty bjobs

### DIFF
--- a/tests/integration_tests/scheduler/test_openpbs_driver.py
+++ b/tests/integration_tests/scheduler/test_openpbs_driver.py
@@ -41,7 +41,6 @@ def queue_name_config():
 def test_that_openpbs_driver_ignores_qstat_flakiness(
     text_to_ignore, caplog, capsys, create_mock_flaky_qstat
 ):
-
     create_mock_flaky_qstat(text_to_ignore)
     with open("poly.ert", mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 1")

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -449,7 +449,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
     driver = LsfDriver()
     with expectation:
         await driver.submit(0, "sleep")
-        await asyncio.wait_for(poll(driver, {0}), timeout=0.2)
+        await asyncio.wait_for(poll(driver, {0}), timeout=5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The existing timeout at 0.2 is too small on MacOS when pytest is run concurrently with -n auto

**Issue**
Resolves partly flaky Mac tests.

**Approach**
➕ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
