### PR TITLE
Fix Python3.12 deprecation warning in async_utils.py

### DIFF
--- a/src/ert/async_utils.py
+++ b/src/ert/async_utils.py
@@ -19,7 +19,7 @@ def new_event_loop() -> asyncio.AbstractEventLoop:
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        return asyncio.get_event_loop()
+        return asyncio.get_running_loop()
     except RuntimeError:
         asyncio.set_event_loop(new_event_loop())
         return asyncio.get_event_loop()


### PR DESCRIPTION
**Issue**
Python3.12 has a deprecation warning in async_utils.py which might actually be a bug.
We expect `asyncio.get_event_loop()` to raise a `RuntimeError` if there is not an event loop in the thread, but this is actually the behavior of `asyncio.get_running_loop()` instead. 
The consequence of this is that the code in the `except`-block is never executed, and the new loop does not have a task factory with our custom done/debug callbacks from b2b2e48. 

**Approach**
The commit in this PR fixes the `DeprecationWarning: There is no current event loop` warning for Python3.12 in the `get_event_loop` function in `async_utils.py`. Prior to this commit, the function used `asyncio.get_event_loop()` which creates a new event loop directly. `asyncio.get_running_loop()` does however raise a RuntimeError when there is no event loop, which is what we want.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
