### PR TITLE
Solve py312 warning on pkgutil.get_loader

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1,8 +1,8 @@
 # mypy: ignore-errors
 import copy
+import importlib
 import logging
 import os
-import pkgutil
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -19,7 +19,6 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    cast,
     overload,
 )
 
@@ -59,7 +58,7 @@ from .workflow import Workflow
 from .workflow_job import ErtScriptLoadFailure, WorkflowJob
 
 if TYPE_CHECKING:
-    from importlib.abc import FileLoader
+    pass
 
 
 logger = logging.getLogger(__name__)
@@ -68,8 +67,10 @@ logger = logging.getLogger(__name__)
 def site_config_location() -> str:
     if "ERT_SITE_CONFIG" in os.environ:
         return os.environ["ERT_SITE_CONFIG"]
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    return path.dirname(ert_shared_loader.get_filename()) + "/share/ert/site-config"
+    return str(
+        Path(importlib.util.find_spec("ert.shared").origin).parent
+        / "share/ert/site-config"
+    )
 
 
 @dataclass

--- a/src/ert/shared/hook_implementations/jobs.py
+++ b/src/ert/shared/hook_implementations/jobs.py
@@ -1,20 +1,21 @@
+import importlib.util
 import os
-import pkgutil
-from os.path import dirname
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from pathlib import Path
+from typing import Dict, List, Optional
 
 from jinja2 import Template
 
 from ert.shared.plugins.plugin_manager import hook_implementation
 from ert.shared.plugins.plugin_response import plugin_response
 
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
-
 
 def _resolve_ert_share_path() -> str:
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    return dirname(ert_shared_loader.get_filename()) + "/share/ert"
+    spec = importlib.util.find_spec("ert.shared")
+    assert spec, "Could not find ert.shared in import path"
+    assert spec.has_location
+    spec_origin = spec.origin
+    assert spec_origin
+    return str(Path(spec_origin).parent / "share/ert")
 
 
 def _get_jobs_from_directories(directories: List[str]) -> Dict[str, str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,15 @@
 import fileinput
+import importlib
 import json
 import logging
 import os
-import pkgutil
 import resource
 import shutil
 import stat
 import sys
 from argparse import ArgumentParser
-from os.path import dirname
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 from qtpy.QtWidgets import QApplication
@@ -39,9 +37,6 @@ from ert.shared.feature_toggling import FeatureScheduler
 from ert.storage import open_storage
 
 from .utils import SOURCE_DIR
-
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
 
 st.register_type_strategy(Path, st.builds(Path, st.text().map(lambda x: "/tmp/" + x)))
 
@@ -97,8 +92,9 @@ def fixture_source_root():
 def class_source_root(request, source_root):
     request.cls.SOURCE_ROOT = source_root
     request.cls.TESTDATA_ROOT = source_root / "test-data"
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    request.cls.SHARE_ROOT = dirname(ert_shared_loader.get_filename()) + "/share"
+    request.cls.SHARE_ROOT = str(
+        Path(importlib.util.find_spec("ert.shared").origin).parent / "share"
+    )
     yield
 
 

--- a/tests/unit_tests/shared/share/test_forward_models.py
+++ b/tests/unit_tests/shared/share/test_forward_models.py
@@ -1,10 +1,6 @@
+import importlib
 import os
-import pkgutil
-from os.path import dirname
-from typing import TYPE_CHECKING, cast
-
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
+from pathlib import Path
 
 
 def extract_executable(filename):
@@ -21,8 +17,10 @@ def file_exist_and_is_executable(file_path):
 
 
 def test_validate_scripts():
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    fm_path = dirname(ert_shared_loader.get_filename()) + "/share/ert/forward-models"
+    fm_path = (
+        Path(importlib.util.find_spec("ert.shared").origin).parent
+        / "share/ert/forward-models"
+    )
     for fm_dir in os.listdir(fm_path):
         fm_dir = os.path.join(fm_path, fm_dir)
         # get all sub-folder in forward-models

--- a/tests/unit_tests/shared/share/test_rms.py
+++ b/tests/unit_tests/shared/share/test_rms.py
@@ -1,12 +1,11 @@
+import importlib.util
 import json
 import os
-import pkgutil
 import shutil
 import stat
 import subprocess
 import sys
-from os.path import dirname
-from typing import TYPE_CHECKING, cast
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -14,10 +13,6 @@ import pytest
 from tests.utils import SOURCE_DIR
 
 from ._import_from_location import import_from_location
-
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
-
 
 # import rms.py from ert/forward-models/res/script
 # package-data path which. These are kept out of the ert package to avoid the
@@ -54,9 +49,8 @@ $@
 """
 
 
-def _get_ert_shared_dir():
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    return dirname(ert_shared_loader.get_filename())
+def _get_ert_shared_dir() -> str:
+    return str(Path(importlib.util.find_spec("ert.shared").origin).parent)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/shared/share/test_templating.py
+++ b/tests/unit_tests/shared/share/test_templating.py
@@ -1,9 +1,8 @@
+import importlib
 import json
 import os
-import pkgutil
 import subprocess
-from os.path import dirname
-from typing import TYPE_CHECKING, cast
+from pathlib import Path
 
 import jinja2
 import pytest
@@ -11,10 +10,6 @@ import pytest
 from tests.utils import SOURCE_DIR
 
 from ._import_from_location import import_from_location
-
-if TYPE_CHECKING:
-    from importlib.abc import FileLoader
-
 
 # import template_render.py from ert/forward-models/templating/script
 # package-data path which. These are kept out of the ert package to avoid the
@@ -224,10 +219,9 @@ def test_template_executable():
         "--template_file template "
         "--input_files other.json"
     )
-    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
-    template_render_exec = (
-        dirname(ert_shared_loader.get_filename())
-        + "/share/ert/forward-models/templating/script/template_render.py"
+    template_render_exec = str(
+        Path(importlib.util.find_spec("ert.shared").origin).parent
+        / "share/ert/forward-models/templating/script/template_render.py"
     )
 
     subprocess.call(template_render_exec + params, shell=True, stdout=subprocess.PIPE)


### PR DESCRIPTION
Using importlib instead

**Issue**
```
tests/unit_tests/shared/share/test_shell.py::test_shell_script_jobs_names
  /Users/HAVB/venv/3.12-arm64/lib/python3.12/site-packages/ert/config/ert_config.py:71: DeprecationWarning: 'pkgutil.get_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead
    ert_shared_loader = cast("FileLoader", pkgutil.get_loader("ert.shared"))
```

**Approach**
Use `importlib.util.find_spec`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
