### PR TITLE
Let mocked bkill support specific kill signal

### DIFF
--- a/tests/integration_tests/scheduler/bin/bkill.py
+++ b/tests/integration_tests/scheduler/bin/bkill.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Kill jobs")
+    parser.add_argument(
+        "-s", "--signal", type=str, help="Which signal to send", default="SIGKILL"
+    )
     parser.add_argument("jobids", type=str, nargs="+")
     return parser
 
@@ -15,7 +18,7 @@ def main() -> None:
     args = get_parser().parse_args()
 
     jobdir = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
-    killsignal = signal.SIGTERM
+    killsignal = getattr(signal, args.signal)
     for jobid in args.jobids:
         pidfile = jobdir / f"{jobid}.pid"
         if not pidfile.exists():

--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -79,6 +79,7 @@ async def test_submit_something_that_fails(driver, tmp_path):
     assert finished_called
 
 
+@pytest.mark.timeout(50)
 async def test_kill(driver, tmp_path):
     os.chdir(tmp_path)
     aborted_called = False


### PR DESCRIPTION
The tests sent a -s option to the mock that failed the mock. Another error (missing timeout) let the kill test pass when it should not.

**Issue**
Resolves #7598 


**Approach**
Add timeout to fail the test, then fix the mock and pass the test.

(since the LSF driver does not return the correct return code, the assert on return code did not otherwise fail the test as it would for PBS driver)

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
