### PR TITLE
Fix hanging cli integration test

### DIFF
--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 import xtgeo
 
+import _ert.threading
 import ert.shared
 from _ert.threading import ErtThreadError
 from ert import LibresFacade, ensemble_evaluator
@@ -476,8 +477,10 @@ def test_that_stop_on_fail_workflow_jobs_stop_ert(
     file_extension,
     script_content,
     expect_stopped,
+    monkeypatch,
 ):
     script_name = f"failing_script.{file_extension}"
+    monkeypatch.setattr(_ert.threading, "_can_raise", False)
 
     with open("failing_job", "w", encoding="utf-8") as f:
         f.write(workflow_job_config_content)


### PR DESCRIPTION
**Issue**
Resolves #7596 


**Approach**
This commit fixes `tests/integration_tests/test_cli.py::test_that_stop_on_workflow_jobs_stop_ert` hanging after finishing tests. It seems like ErtThread with exceptions had some issues with pytest in this case, but it was fixed by monkeypatching `_ert_threading.can_raise = False`


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
