### PR TITLE
Have OpenPBS driver use qstat -E option

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -244,6 +244,7 @@ class OpenPBSDriver(Driver):
                     "qstat",
                     "-x",
                     "-w",  # wide format
+                    "-E",  # group job ids
                     *self._non_finished_job_ids,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/tests/integration_tests/scheduler/bin/qstat.py
+++ b/tests/integration_tests/scheduler/bin/qstat.py
@@ -24,6 +24,7 @@ def parse_args() -> Namespace:
     ap.add_argument("-F", default="")
     ap.add_argument("jobs", nargs="*")
     ap.add_argument("-w", action="store_true")
+    ap.add_argument("-E", action="store_true")
     return ap.parse_args()
 
 

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -278,9 +278,7 @@ async def test_faulty_qstat(monkeypatch, tmp_path, qstat_script, started_expecte
             was_started = True
 
     with contextlib.suppress(asyncio.TimeoutError):
-        await asyncio.wait_for(
-            poll(driver, expected=set(), started=started), timeout=0.5
-        )
+        await asyncio.wait_for(poll(driver, expected=set(), started=started), timeout=1)
 
     assert was_started == started_expected
 


### PR DESCRIPTION
**Issue**
Resolves [#5453](https://github.com/equinor/komodo-releases/issues/5453)


**Approach**
The commit in this PR might solve the issue by having qstat be more performant. The -E option groups the job ids together, so instead of one connection per job; they will all be executed in the same one.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
