### PR TITLE
Reduce flakyness in test_observation_times

### DIFF
--- a/tests/integration_tests/test_observation_times.py
+++ b/tests/integration_tests/test_observation_times.py
@@ -113,12 +113,14 @@ def test_small_time_mismatches_are_ignored(
         stderr = StringIO()
         with redirect_stderr(stderr):
             run_cli(
-                ES_MDA_MODE,
                 "--disable-monitor",
+                ES_MDA_MODE,
                 str(tmp_path / "config.ert"),
                 "--weights=0,1",
             )
-        assert "Experiment completed" in stderr.getvalue()
+        assert (
+            not stderr.getvalue()
+        ), "There should be no errors when mismatches are small"
     else:
         with pytest.raises(ErtCliError, match="No active observations"):
             run_cli(


### PR DESCRIPTION
The commit adding --disable-monitor b5a72e3e1572471b927d64c0146fc739283c900c made this test fail in case it ended in the 'less than one second' if-branch.

**Issue**
Resolves partly the flakyness of test_observation_times. There is still residual flakyness as in #7587


**Approach**
Change the assert to the actual output when --disable-monitoring is in use.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
