### PR TITLE
Fix test_small_time_mismatches_are_ignored

### DIFF
--- a/tests/integration_tests/test_observation_times.py
+++ b/tests/integration_tests/test_observation_times.py
@@ -114,7 +114,6 @@ def test_small_time_mismatches_are_ignored(
         with redirect_stderr(stderr):
             run_cli(
                 ES_MDA_MODE,
-                "--disable-monitor",
                 str(tmp_path / "config.ert"),
                 "--weights=0,1",
             )


### PR DESCRIPTION
**Issue**
In https://github.com/equinor/ert/pull/7552 `--disable-monitor` was added to many test cases.

However, `test_small_time_mismatches_are_ignored` depends on "Experiment completed" being written to stderr which does not happen if `--disable-monitor`.

Can be checked by running this reproducing example:
```
@reproduce_failure('6.100.1', b'AXicY2Bh4WBkZuZkY+WU4OVnEBQWZxYXYxcWFuMXYODgYpXkZGZhZ+NkSJrIIcAiwCHCJsbAwMzIAAQKDDDQAKEYGZhZWBnFmRiZOLk5uTi4RDmZJBihMkCQBgLpDKhaoYAbZIrpfzBgArIPcPc91eOt/4+uDgw4GQBdhRFl')
```

**Approach**
Add back `--disable-monitor`.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
