### PR TITLE
Rename Job.__call__ to job.run in scheduler

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -125,7 +125,7 @@ class Job:
                 timeout_task.cancel()
             sem.release()
 
-    async def __call__(
+    async def run(
         self, start: asyncio.Event, sem: asyncio.BoundedSemaphore, max_submit: int = 2
     ) -> None:
         self._requested_max_submit = max_submit

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -277,7 +277,7 @@ class Scheduler:
         sem = asyncio.BoundedSemaphore(self._max_running or len(self._jobs))
         for iens, job in self._jobs.items():
             self._job_tasks[iens] = asyncio.create_task(
-                job(start, sem, self._max_submit), name=f"job-{iens}_task"
+                job.run(start, sem, self._max_submit), name=f"job-{iens}_task"
             )
 
         start.set()


### PR DESCRIPTION
**Issue**
Resolves #7591 


**Approach**
The commit in this PR renames Job.__call__ to job.run in scheduler.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
