### PR TITLE
Remove start sync event from scheduler job.__call__

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -125,11 +125,8 @@ class Job:
                 timeout_task.cancel()
             sem.release()
 
-    async def run(
-        self, start: asyncio.Event, sem: asyncio.BoundedSemaphore, max_submit: int = 2
-    ) -> None:
+    async def run(self, sem: asyncio.BoundedSemaphore, max_submit: int = 2) -> None:
         self._requested_max_submit = max_submit
-        await start.wait()
         for attempt in range(max_submit):
             await self._submit_and_run_once(sem)
 

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -273,14 +273,11 @@ class Scheduler:
             )
             scheduling_tasks.append(asyncio.create_task(self._update_avg_job_runtime()))
 
-        start = asyncio.Event()
         sem = asyncio.BoundedSemaphore(self._max_running or len(self._jobs))
         for iens, job in self._jobs.items():
             self._job_tasks[iens] = asyncio.create_task(
-                job.run(start, sem, self._max_submit), name=f"job-{iens}_task"
+                job.run(sem, self._max_submit), name=f"job-{iens}_task"
             )
-
-        start.set()
 
         try:
             await self._monitor_and_handle_tasks(scheduling_tasks)

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -113,7 +113,7 @@ async def test_job_run_sends_expected_events(
     job.started.set()
 
     job_run_task = asyncio.create_task(
-        job.run(job.started, asyncio.Semaphore(), max_submit=max_submit)
+        job.run(asyncio.Semaphore(), max_submit=max_submit)
     )
 
     for attempt in range(max_submit):


### PR DESCRIPTION
**Issue**
Resolves #7413 


**Approach**
The scheduler job has a synchronization event (`start = asyncio.Event()`) with the purpose of executing job-group start,  and was passed as a parameter to `job.__call__`. It does not seems to be that necessary in the end as `asyncio.BoundedSemaphore` will handle job execution regardless. This commit removes this redundant event.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
