### PR TITLE
Fix GUI RunDialog not expanding details header

### DIFF
--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -88,15 +88,9 @@ class JobListProxyModel(QAbstractProxyModel):
             return section
         return QVariant()
 
-    def columnCount(self, parent=None) -> int:
-        if parent is None:
-            parent = QModelIndex()
-        if parent.isValid():
-            return 0
-        source_index = self._get_source_parent_index()
-        if not source_index.isValid():
-            return 0
-        return self.sourceModel().columnCount(source_index)
+    @staticmethod
+    def columnCount(parent: QModelIndex = None):
+        return len(COLUMNS[NodeType.REAL])
 
     def rowCount(self, parent=None) -> int:
         if parent is None:

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -114,6 +114,10 @@ class RunDialog(QDialog):
         self._job_view.setSelectionMode(QAbstractItemView.SingleSelection)
         self._job_view.clicked.connect(self._job_clicked)
         self._job_view.setModel(self._job_model)
+        self._job_view.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch
+        )
+        self._job_view.verticalHeader().setMinimumWidth(20)
 
         self.running_time = QLabel("")
 
@@ -248,8 +252,6 @@ class RunDialog(QDialog):
         self._job_label.setText(
             f"Realization id {index.data(RealIens)} in iteration {index.data(IterNum)}"
         )
-
-        self._job_view.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
 
     def closeEvent(self, QCloseEvent):
         if self._run_model.isFinished():


### PR DESCRIPTION
**Issue**
Resolves #6995


**Approach**
The commit in this PR
 fixes an issue where the RunDialog show details section
would not expand the header to fill the width, without having a
realization set.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/equinor/ert/assets/107626001/265df5ad-3c51-4c99-8502-fb2923f28227)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
