### PR TITLE
Rename async_utils get_event_loop() to get_running_loop()

### DIFF
--- a/src/ert/async_utils.py
+++ b/src/ert/async_utils.py
@@ -17,7 +17,7 @@ def new_event_loop() -> asyncio.AbstractEventLoop:
     return loop
 
 
-def get_event_loop() -> asyncio.AbstractEventLoop:
+def get_running_loop() -> asyncio.AbstractEventLoop:
     try:
         return asyncio.get_running_loop()
     except RuntimeError:

--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -19,7 +19,7 @@ from typing import (
 from cloudevents.http.event import CloudEvent
 
 from _ert.threading import ErtThread
-from ert.async_utils import get_event_loop, new_event_loop
+from ert.async_utils import get_running_loop, new_event_loop
 from ert.ensemble_evaluator import identifiers
 from ert.job_queue import JobQueue
 from ert.scheduler import Scheduler, create_driver
@@ -102,7 +102,7 @@ class LegacyEnsemble(Ensemble):
                 assert self._config  # mypy
                 await cloudevent_unary_send(timeout_cloudevent)
 
-        send_timeout_future = get_event_loop().create_task(send_timeout_message())
+        send_timeout_future = get_running_loop().create_task(send_timeout_message())
 
         return on_timeout, send_timeout_future
 
@@ -110,7 +110,7 @@ class LegacyEnsemble(Ensemble):
         if not config:
             raise ValueError("no config for evaluator")
         self._config = config
-        get_event_loop().run_until_complete(
+        get_running_loop().run_until_complete(
             wait_for_evaluator(
                 base_url=self._config.url,
                 token=self._config.token,
@@ -149,7 +149,7 @@ class LegacyEnsemble(Ensemble):
                 cert=self._config.cert,
             ),
         )
-        get_event_loop().run_until_complete(
+        get_running_loop().run_until_complete(
             self._evaluate_inner(
                 cloudevent_unary_send=getattr(self, ce_unary_send_method_name)
             )

--- a/src/ert/ensemble_evaluator/evaluator_tracker.py
+++ b/src/ert/ensemble_evaluator/evaluator_tracker.py
@@ -10,7 +10,7 @@ from aiohttp import ClientError
 from websockets.exceptions import ConnectionClosedError
 
 from _ert.threading import ErtThread
-from ert.async_utils import get_event_loop, new_event_loop
+from ert.async_utils import get_running_loop, new_event_loop
 from ert.ensemble_evaluator.identifiers import (
     EVTYPE_EE_SNAPSHOT,
     EVTYPE_EE_SNAPSHOT_UPDATE,
@@ -220,7 +220,7 @@ class EvaluatorTracker:
         #
         try:
             logger.debug("requesting termination...")
-            get_event_loop().run_until_complete(
+            get_running_loop().run_until_complete(
                 wait_for_evaluator(
                     base_url=self._ee_con_info.url,
                     token=self._ee_con_info.token,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from hypothesis import strategies as st
 from qtpy.QtCore import QDir
 
 from ert.__main__ import ert_parser
-from ert.async_utils import get_event_loop
+from ert.async_utils import get_running_loop
 from ert.cli import ENSEMBLE_EXPERIMENT_MODE
 from ert.cli.main import run_cli
 from ert.config import ErtConfig
@@ -303,7 +303,7 @@ def using_scheduler(request, monkeypatch):
     if should_enable_scheduler:
         # Flaky - the new scheduler needs an event loop, which might not be initialized yet.
         #  This might be a bug in python 3.8, but it does not occur locally.
-        _ = get_event_loop()
+        _ = get_running_loop()
 
     monkeypatch.setenv("ERT_FEATURE_SCHEDULER", "1" if should_enable_scheduler else "0")
     monkeypatch.setattr(FeatureScheduler, "_value", should_enable_scheduler)

--- a/tests/performance_tests/test_dark_storage_performance.py
+++ b/tests/performance_tests/test_dark_storage_performance.py
@@ -4,7 +4,7 @@ from typing import Awaitable, TypeVar
 import pandas as pd
 import pytest
 
-from ert.async_utils import get_event_loop
+from ert.async_utils import get_running_loop
 from ert.config import ErtConfig
 from ert.dark_storage.endpoints import ensembles, experiments, records
 from ert.enkf_main import EnKFMain
@@ -15,7 +15,7 @@ T = TypeVar("T")
 
 
 def run_in_loop(coro: Awaitable[T]) -> T:
-    return get_event_loop().run_until_complete(coro)
+    return get_running_loop().run_until_complete(coro)
 
 
 def get_single_record_csv(storage, ensemble_id1, keyword, poly_ran):

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -4,7 +4,7 @@ import pytest
 from cloudevents.http import from_json
 from websockets.server import serve
 
-from ert.async_utils import get_event_loop
+from ert.async_utils import get_running_loop
 from ert.ensemble_evaluator._wait_for_evaluator import wait_for_evaluator
 from ert.job_queue import JobQueue
 from ert.scheduler import Scheduler, create_driver
@@ -43,8 +43,8 @@ async def test_happy_path(
     host = "localhost"
     url = f"ws://{host}:{unused_tcp_port}"
 
-    done = get_event_loop().create_future()
-    mock_ws_task = get_event_loop().create_task(mock_ws(host, unused_tcp_port, done))
+    done = get_running_loop().create_future()
+    mock_ws_task = get_running_loop().create_task(mock_ws(host, unused_tcp_port, done))
     await wait_for_evaluator(base_url=url, timeout=5)
 
     ensemble = make_ensemble_builder(monkeypatch, tmpdir, 1, 1).build()


### PR DESCRIPTION
**Approach**
The asyncio.utils `get_event_loop()` function has been updated and now uses `asyncio.get_running_loop` instead of `asyncio.get_event_loop`, so this commit changes the function name to reflect this change.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
