### PR TITLE
Increase timeout for cluster integration tests

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -67,7 +67,7 @@ start_tests () {
     # Using presence of "bsub" in PATH to detect onprem vs azure
     if which bsub >/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
         export _ERT_TESTS_ALTERNATIVE_QUEUE=short
-        pytest -v --lsf --basetemp="$basetemp" integration_tests/scheduler
+        pytest --timeout=3600 -v --lsf --basetemp="$basetemp" integration_tests/scheduler
         rm -rf "$basetemp" || true
     fi
     if ! which bsub 2>/dev/null && basetemp=$(mktemp -d -p ~/pytest-tmp); then
@@ -77,7 +77,7 @@ start_tests () {
         else
             export _ERT_TESTS_DEFAULT_QUEUE_NAME=permanent_8
         fi
-        pytest -v --openpbs --basetemp="$basetemp" integration_tests/scheduler
+        pytest --timeout=3600 -v --openpbs --basetemp="$basetemp" integration_tests/scheduler
         rm -rf "$basetemp" || true
     fi
     popd

--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -79,7 +79,6 @@ async def test_submit_something_that_fails(driver, tmp_path):
     assert finished_called
 
 
-@pytest.mark.timeout(50)
 async def test_kill(driver, tmp_path):
     os.chdir(tmp_path)
     aborted_called = False


### PR DESCRIPTION
The default timeout at 10 minutes can be too low if the compute cluster has low availability of compute resources, as the time spent waiting in the queue for a compute job is counted. Increasing the timeout to 1 hour only when running the tests against the real compute cluster.

The timeout for the test_kill had to be removed, as that test can also suffer the same problem. Note that this can then hide a bug for the LSF driver as the driver cannot distuingish between  which will happen when the job is not killed and the exit code when it is killed.

**Issue**
Resolves #7595 


**Approach**
➕ 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
