### PR TITLE
Plot items support reorder and have visual indicators

### DIFF
--- a/src/ert/gui/resources/gui/img/swap_vertical.svg
+++ b/src/ert/gui/resources/gui/img/swap_vertical.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 6.99 9 3l4 3.99h-3V14H8V6.99H5ZM16 10v7.01h3L15 21l-4-3.99h3V10h2Z"/></svg>

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -40,8 +40,7 @@ from ert.gui.suggestor._suggestor_message import SuggestorMessage
 from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_ensemble_selection_widget import (
-    EnsembleSelectCheckButton,
-    EnsembleSelectionWidget,
+    EnsembleSelectListWidget,
 )
 from ert.gui.tools.plot.plot_window import PlotApi, PlotWindow
 from ert.run_models import SingleTestRun
@@ -51,7 +50,6 @@ from ert.shared.plugins.plugin_manager import ErtPluginManager
 from .conftest import (
     add_experiment_manually,
     get_child,
-    get_children,
     load_results_manually,
     wait_for_child,
     with_manage_tool,
@@ -403,16 +401,15 @@ def test_that_the_plot_window_contains_the_expected_elements(
     # Then the plot window opens
     plot_window = wait_for_child(gui, qtbot, PlotWindow)
     data_types = get_child(plot_window, DataTypeKeysWidget)
-    case_selection = get_child(plot_window, EnsembleSelectionWidget)
-    assert isinstance(case_selection, EnsembleSelectionWidget)
-    toggle_buttons = get_children(
-        case_selection, EnsembleSelectCheckButton, "ensemble_selector"
+
+    case_selection = get_child(
+        plot_window, EnsembleSelectListWidget, "ensemble_selector"
     )
 
     # Assert that the Case selection widget contains the expected ensembles
     ensemble_names = []
-    for toggle_button in toggle_buttons:
-        ensemble_names.append(toggle_button.text())
+    for index in range(case_selection.count()):
+        ensemble_names.append(case_selection.item(index).text())
 
     assert sorted(ensemble_names) == expected_ensembles
 
@@ -718,12 +715,11 @@ def test_that_gui_plotter_works_when_no_data(qtbot, storage, monkeypatch):
         qtbot.addWidget(gui)
         gui.tools["Create plot"].trigger()
         plot_window = wait_for_child(gui, qtbot, PlotWindow)
-        case_selection = get_child(plot_window, EnsembleSelectionWidget)
-        assert isinstance(case_selection, EnsembleSelectionWidget)
-        toggle_buttons = get_children(
-            case_selection, EnsembleSelectCheckButton, "ensemble_selector"
-        )
-        assert len(toggle_buttons) == 0
+
+        ensemble_plot_names = get_child(
+            plot_window, EnsembleSelectListWidget, "ensemble_selector"
+        ).get_checked_ensemble_plot_names()
+        assert len(ensemble_plot_names) == 0
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
Resolves #7606 

Replace plot selection buttons with qlistwidget items
Add swap icon from Equinor Design System
Items are now dragable, and cursor changes to reflect click/drag
Plotting and colors are still dependant on order top-down

![Screenshot 2024-04-11 at 13 07 41](https://github.com/equinor/ert/assets/114403625/f5d7c8f8-7550-4ba5-affa-ac0b7fec6fe2)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
