### PR TITLE
Allow pre-commit to run without failure in CI after merge

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run style check
       if: ${{ always() }}
       run: |
-        pre-commit run --all-files --show-diff-on-failure
+        SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
**Issue**
Resolves failing CI after every merge.


**Approach**
Read the docs https://pre-commit.com/#advanced-features



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
