### PR TITLE
Make sure to not cancel the job when job is done

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -126,13 +126,15 @@ class Scheduler:
 
     async def _cancel_job_tasks(self) -> None:
         for task in self._job_tasks.values():
-            task.cancel()
-        with suppress(asyncio.TimeoutError):
-            await asyncio.wait(
-                self._job_tasks.values(),
-                timeout=1.0,
-                return_when=asyncio.ALL_COMPLETED,
-            )
+            if not task.done():
+                task.cancel()
+        _, pending = await asyncio.wait(
+            self._job_tasks.values(),
+            timeout=1.0,
+            return_when=asyncio.ALL_COMPLETED,
+        )
+        for task in pending:
+            logger.error(f"Task {task.get_name()} was not killed properly!")
 
     async def _update_avg_job_runtime(self) -> None:
         while True:
@@ -283,11 +285,11 @@ class Scheduler:
             await self.driver.finish()
             for scheduling_task in scheduling_tasks:
                 scheduling_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await asyncio.wait(
-                    scheduling_tasks,
-                    return_when=asyncio.ALL_COMPLETED,
-                )
+            # We discard exceptions when cancelling the scheduling tasks
+            await asyncio.gather(
+                *scheduling_tasks,
+                return_exceptions=True,
+            )
 
         if self._cancelled:
             logger.debug("scheduler cancelled, stopping jobs...")


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/7634


**Approach**
Make sure to not cancel the job when job is done

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
