### PR TITLE
Fix documentation for LSF memory booking

### DIFF
--- a/docs/reference/configuration/queue.rst
+++ b/docs/reference/configuration/queue.rst
@@ -183,10 +183,13 @@ The following is a list of available LSF configuration options:
   LSF uses resource requirements to select hosts for remote execution and
   job execution. Resource requirement strings can be simple (applying to the
   entire job) or compound (applying to the specified number of slots).
+  The value passed does not use units and depends on the cluster's configuration,
+  so follow up with cluster administrator to find out what the set unit is.
   `Docs. <https://www.ibm.com/support/knowledgecenter/SSWRJV_10.1.0/lsf_admin/res_req_strings_about.html>`__
-  Passed as the ``-R`` option to ``bsub``. For example::
+  Passed as the ``-R`` option to ``bsub``. For example, this will
+  request approximately 15 gigabytes when the default unit is megabytes::
 
-    QUEUE_OPTION LSF LSF_RESOURCE rusage[mem=512MB:swp=1GB]
+    QUEUE_OPTION LSF LSF_RESOURCE rusage[mem=15000]
 
 .. _project_code:
 .. topic:: PROJECT_CODE


### PR DESCRIPTION
**Issue**
Resolves #7651 


**Approach**
The commit in this PR updates the documentation for the LSF queue option `LSF_RESOURCE`. The old example used units in the resource string, but that is not supported by LSF9. The default unit is KB, so all memory requests will use that.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
