### PR TITLE
Remove timout on setup steps for Run ert tests github workflow

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -22,7 +22,6 @@ jobs:
 
     - uses: actions/setup-python@v5
       id: setup_python
-      timeout-minutes: 5
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
@@ -35,12 +34,10 @@ jobs:
 
     - name: Get wheels
       uses: actions/download-artifact@v4
-      timeout-minutes: 5
       with:
         name: ${{ inputs.os }} Python ${{ inputs.python-version }} wheel
 
     - name: Install wheel
-      timeout-minutes: 5
       run: |
         find . -name "*.whl" -exec pip install "{}[dev]" \;
 


### PR DESCRIPTION
The install wheel step has been seen to timeout on macos since it takes long to build wheels for tables on mac. Since we have a overall timeout on 60 min for the run ert test workflow it seems unnecessary to limit the individual setup steps.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
