### PR TITLE
Fix memory being reported without units in GUI

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -414,10 +414,10 @@ class SnapshotModel(QAbstractItemModel):
         if role == Qt.DisplayRole:
             _, data_name = COLUMNS[NodeType.REAL][index.column()]
             if data_name in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
-                data = node.data.get(ids.DATA)
-                _bytes = data.get(data_name) if data else None
+                data = node.data
+                _bytes: Optional[str] = data.get(data_name) if data else None
                 if _bytes:
-                    return byte_with_unit(_bytes)
+                    return byte_with_unit(float(_bytes))
 
             if data_name in [ids.STDOUT, ids.STDERR]:
                 return "OPEN" if node.data.get(data_name) else QVariant()

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -495,7 +495,7 @@ def test_run_dialog_memory_usage_showing(
         current_memory_value = widget._job_model.data(
             current_memory_column_proxy_index, Qt.DisplayRole
         )
-        assert current_memory_value == "50000"
+        assert current_memory_value == "50.00 kB"
 
         max_memory_column_proxy_index = widget._job_model.index(
             job_number, max_memory_column_index
@@ -503,7 +503,7 @@ def test_run_dialog_memory_usage_showing(
         max_memory_value = widget._job_model.data(
             max_memory_column_proxy_index, Qt.DisplayRole
         )
-        assert max_memory_value == "60000"
+        assert max_memory_value == "60.00 kB"
 
 
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config", "using_scheduler")


### PR DESCRIPTION
**Issue**
Resolves #7636 

**Approach**
Memory will now be reported in with suitable units.
![image](https://github.com/equinor/ert/assets/107626001/a58499ed-8a70-45ed-8b33-e65a02b79993)


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
