### PR TITLE
Fix LSF driver logging wrong message when killing

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -285,22 +285,26 @@ class LsfDriver(Driver):
             f"sleep {self._sleep_time_between_bkills}; {self._bkill_cmd} -s SIGKILL {job_id}",
             shell=True,
             start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         if process.returncode:
             logger.error(
                 f"LSF kill failed with returncode {process.returncode} "
-                f"and error message {stderr.decode(errors='ignore')}"
+                f"and stdout: {stdout.decode(errors='ignore').strip()}"
+                f"and stderr: {stderr.decode(errors='ignore').strip()}"
             )
             return
 
         if not re.match(
-            f"Job <{job_id}> is being terminated", stdout.decode(errors="ignore")
+            f"Job <{job_id}> is being (terminated|signaled)",
+            stdout.decode(errors="ignore"),
         ):
             logger.error(
                 "LSF kill failed with stdout: "
-                + stdout.decode(errors="ignore")
+                + stdout.decode(errors="ignore").strip()
                 + " and stderr: "
-                + stderr.decode(errors="ignore")
+                + stderr.decode(errors="ignore").strip()
             )
             return
 


### PR DESCRIPTION
**Issue**
Resolves #7664 


**Approach**
The commit in this PR fixes some minor logging issues in scheduler lsf driver:
* sigkill fire-and-forget process logged to terminal instead of devnull after sleeping 30s.
* stdout and stderr from bkill was missing `strip()` so logs were split over multiple lines.
* bkill can output `Job <id> is being signaled`, but it should not be interpreted as an error.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
