### PR TITLE
Ignore stderr for parsing bsub output

### DIFF
--- a/src/clib/lib/job_queue/lsf_driver.cpp
+++ b/src/clib/lib/job_queue/lsf_driver.cpp
@@ -335,7 +335,7 @@ static int lsf_driver_submit_shell_job(lsf_driver_type *driver,
         spawn_blocking(driver->rsh_cmd, 2, (const char **)argv, tmp_file, NULL);
     } else if (driver->submit_method == LSF_SUBMIT_LOCAL_SHELL) {
         logger->debug("Submitting: {}\n", joined_argv);
-        spawn_blocking(remote_argv, tmp_file, tmp_file);
+        spawn_blocking(remote_argv, tmp_file, nullptr);
     }
 
     for (int i = 0; i < LSF_ARGV_SIZE; i++) {


### PR DESCRIPTION
backports https://github.com/equinor/ert/pull/7673


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
