### PR TITLE
Reduce timeout in order to speed up tests

### DIFF
--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -453,7 +453,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
     driver = LsfDriver()
     with expectation:
         await driver.submit(0, "sleep")
-        await asyncio.wait_for(poll(driver, {0}), timeout=5)
+        await asyncio.wait_for(poll(driver, {0}), timeout=1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For the test id's that are expected to timeout (5 of them), the test runtime will indeed be the timeout. 0.2 has been proven to be too small (the initial commit) for MacOS runners. 5 seconds is proven to be sufficient, but is probably overkill. Try 1 second as a middle ground.

**Issue**
Resolves 25 seconds to run one test function (reduced to 5 seconds).

**Approach**
Shorten timeout


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
