### PR TITLE
WIP: Refactor job stopping

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -110,11 +110,14 @@ class Job:
             await self.started.wait()
             print("awaiting started.wait, done!")
             self._start_time = time.time()
+            print(self.returncode)
 
             if not self.returncode.done():
                 await self._send(State.RUNNING)
                 if self.real.max_runtime is not None and self.real.max_runtime > 0:
                     timeout_task = asyncio.create_task(self._max_runtime_task())
+            else:
+                print("returncode was done before we started")
 
             await self.returncode
 
@@ -209,6 +212,7 @@ class Job:
         log_info_from_exit_file(Path(self.real.run_arg.runpath) / ERROR_file)
 
     async def _send(self, state: State) -> None:
+        print(f"_sending {state}")
         self.state = state
         if state == State.FAILED:
             await self._handle_failure()

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -305,6 +305,7 @@ class Scheduler:
             job = self._jobs[event.iens]
 
             # Any event implies the job has at least started
+            print(f"job started when {event=}? {job.started=}")
             job.started.set()
 
             if isinstance(event, FinishedEvent):
@@ -312,6 +313,7 @@ class Scheduler:
                 #    with suppress(asyncio.InvalidStateError):
                 #        job.returncode.set_result(999)
                 # else:
+                print("got finishedevent")
                 if not job.returncode.done():
                     job.returncode.set_result(event.returncode)
 


### PR DESCRIPTION
**Issue**
Resolves #7658 


**Approach**
Refactor  how jobs are stopped. They are not any longer cancelled, instead the returncode is set to a sentinel value.

It does pass tests yet, it is problematic how we ensure that State.RUNNING is sent in _submit_and_run_once. Might leave the approach due to that.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
