### PR TITLE
Move duplicate ev_types to ert/event_type_constants.py

### DIFF
--- a/src/ert/ensemble_evaluator/identifiers.py
+++ b/src/ert/ensemble_evaluator/identifiers.py
@@ -1,3 +1,17 @@
+from ert.event_type_constants import (
+    EVTYPE_ENSEMBLE_CANCELLED,
+    EVTYPE_ENSEMBLE_FAILED,
+    EVTYPE_ENSEMBLE_STARTED,
+    EVTYPE_ENSEMBLE_STOPPED,
+    EVTYPE_REALIZATION_FAILURE,
+    EVTYPE_REALIZATION_PENDING,
+    EVTYPE_REALIZATION_RUNNING,
+    EVTYPE_REALIZATION_SUCCESS,
+    EVTYPE_REALIZATION_TIMEOUT,
+    EVTYPE_REALIZATION_UNKNOWN,
+    EVTYPE_REALIZATION_WAITING,
+)
+
 ACTIVE = "active"
 CURRENT_MEMORY_USAGE = "current_memory_usage"
 DATA = "data"
@@ -16,14 +30,6 @@ STATUS = "status"
 STDERR = "stderr"
 STDOUT = "stdout"
 STEPS = "steps"
-
-EVTYPE_REALIZATION_FAILURE = "com.equinor.ert.realization.failure"
-EVTYPE_REALIZATION_PENDING = "com.equinor.ert.realization.pending"
-EVTYPE_REALIZATION_RUNNING = "com.equinor.ert.realization.running"
-EVTYPE_REALIZATION_SUCCESS = "com.equinor.ert.realization.success"
-EVTYPE_REALIZATION_UNKNOWN = "com.equinor.ert.realization.unknown"
-EVTYPE_REALIZATION_WAITING = "com.equinor.ert.realization.waiting"
-EVTYPE_REALIZATION_TIMEOUT = "com.equinor.ert.realization.timeout"
 
 EVTYPE_FORWARD_MODEL_START = "com.equinor.ert.forward_model_job.start"
 EVTYPE_FORWARD_MODEL_RUNNING = "com.equinor.ert.forward_model_job.running"
@@ -56,10 +62,6 @@ EVTYPE_EE_TERMINATED = "com.equinor.ert.ee.terminated"
 EVTYPE_EE_USER_CANCEL = "com.equinor.ert.ee.user_cancel"
 EVTYPE_EE_USER_DONE = "com.equinor.ert.ee.user_done"
 
-EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
-EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
-EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"
-EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.failed"
 
 EVGROUP_ENSEMBLE = {
     EVTYPE_ENSEMBLE_STARTED,

--- a/src/ert/event_type_constants.py
+++ b/src/ert/event_type_constants.py
@@ -1,0 +1,12 @@
+EVTYPE_REALIZATION_FAILURE = "com.equinor.ert.realization.failure"
+EVTYPE_REALIZATION_PENDING = "com.equinor.ert.realization.pending"
+EVTYPE_REALIZATION_RUNNING = "com.equinor.ert.realization.running"
+EVTYPE_REALIZATION_SUCCESS = "com.equinor.ert.realization.success"
+EVTYPE_REALIZATION_UNKNOWN = "com.equinor.ert.realization.unknown"
+EVTYPE_REALIZATION_WAITING = "com.equinor.ert.realization.waiting"
+EVTYPE_REALIZATION_TIMEOUT = "com.equinor.ert.realization.timeout"
+
+EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
+EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
+EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"
+EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.failed"

--- a/src/ert/job_queue/queue.py
+++ b/src/ert/job_queue/queue.py
@@ -22,6 +22,17 @@ from websockets.exceptions import ConnectionClosed
 
 from ert.config import QueueConfig
 from ert.constant_filenames import CERT_FILE, JOBS_FILE
+from ert.event_type_constants import (
+    EVTYPE_ENSEMBLE_CANCELLED,
+    EVTYPE_ENSEMBLE_FAILED,
+    EVTYPE_ENSEMBLE_STOPPED,
+    EVTYPE_REALIZATION_FAILURE,
+    EVTYPE_REALIZATION_PENDING,
+    EVTYPE_REALIZATION_RUNNING,
+    EVTYPE_REALIZATION_SUCCESS,
+    EVTYPE_REALIZATION_UNKNOWN,
+    EVTYPE_REALIZATION_WAITING,
+)
 from ert.job_queue.job_queue_node import JobQueueNode
 from ert.job_queue.job_status import JobStatus
 from ert.job_queue.queue_differ import QueueDiffer
@@ -45,17 +56,6 @@ CONCURRENT_INTERNALIZATION = 1
 """How many realizations allowed to be concurrently internalized using
 threads."""
 
-EVTYPE_REALIZATION_FAILURE = "com.equinor.ert.realization.failure"
-EVTYPE_REALIZATION_PENDING = "com.equinor.ert.realization.pending"
-EVTYPE_REALIZATION_RUNNING = "com.equinor.ert.realization.running"
-EVTYPE_REALIZATION_SUCCESS = "com.equinor.ert.realization.success"
-EVTYPE_REALIZATION_UNKNOWN = "com.equinor.ert.realization.unknown"
-EVTYPE_REALIZATION_WAITING = "com.equinor.ert.realization.waiting"
-EVTYPE_REALIZATION_TIMEOUT = "com.equinor.ert.realization.timeout"
-EVTYPE_ENSEMBLE_STARTED = "com.equinor.ert.ensemble.started"
-EVTYPE_ENSEMBLE_STOPPED = "com.equinor.ert.ensemble.stopped"
-EVTYPE_ENSEMBLE_CANCELLED = "com.equinor.ert.ensemble.cancelled"
-EVTYPE_ENSEMBLE_FAILED = "com.equinor.ert.ensemble.failed"
 
 _queue_state_to_event_type_map = {
     "NOT_ACTIVE": EVTYPE_REALIZATION_WAITING,


### PR DESCRIPTION
**Issue**
Resolves #6457 


**Approach**
The commit in this PR moves duplicate event type constants found in `job_queue/queue.py` and `ensemble_evaluator/identifiers.py` into a common module `ert/event_type_constants.py`

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
