### PR TITLE
Let jobs failing in LSF be resubmitted

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -29,11 +29,11 @@ from typing import (
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
-from ert.scheduler.driver import SIGNAL_OFFSET, Driver
+from ert.scheduler.driver import Driver
 from ert.scheduler.event import Event, FinishedEvent, StartedEvent
 
 _POLL_PERIOD = 2.0  # seconds
-LSF_FAILED_JOB = SIGNAL_OFFSET + 65  # first non signal returncode
+LSF_FAILED_JOB = 65  # first non signal returncode
 """Return code we use when lsf reports failed jobs"""
 
 logger = logging.getLogger(__name__)

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -13,6 +13,7 @@ from hypothesis import strategies as st
 from tests.utils import poll
 
 from ert.scheduler import LsfDriver
+from ert.scheduler.driver import SIGNAL_OFFSET
 from ert.scheduler.lsf_driver import (
     BSUB_FLAKY_SSH,
     LSF_FAILED_JOB,
@@ -116,6 +117,9 @@ async def test_events_produced_from_jobstate_updates(jobstate_sequence: List[str
     elif started is True and not finished_success and finished_failure:
         assert len(events) <= 2  # The StartedEvent is not required
         assert events[-1] == FinishedEvent(iens=0, returncode=LSF_FAILED_JOB)
+        assert (
+            events[-1].returncode < SIGNAL_OFFSET
+        ), "returncode larger than SIGNAL_OFFSET will trigger cancellation"
         assert "1" not in driver._jobs
 
 


### PR DESCRIPTION
If the return_code is larger than SIGNAL_OFFSET the associated job_task will be cancelled, and the job cannot be resubmitted.

This change will incur that if users kill their realizations manually with bkill, ert will resubmit them.

**Issue**
Resolves #7657 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
