### PR TITLE
Do not cancel the returncode in scheduler

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -130,7 +130,7 @@ class Job:
         for attempt in range(max_submit):
             await self._submit_and_run_once(sem)
 
-            if self.returncode.cancelled():
+            if self.returncode.cancelled() or self._scheduler._cancelled:
                 break
 
             if self.returncode.result() == 0:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -32,7 +32,7 @@ from ert.job_queue.queue import (
     EVTYPE_ENSEMBLE_CANCELLED,
     EVTYPE_ENSEMBLE_STOPPED,
 )
-from ert.scheduler.driver import SIGNAL_OFFSET, Driver
+from ert.scheduler.driver import Driver
 from ert.scheduler.event import FinishedEvent
 from ert.scheduler.job import Job
 from ert.scheduler.job import State as JobState
@@ -305,11 +305,12 @@ class Scheduler:
             # Any event implies the job has at least started
             job.started.set()
 
-            if isinstance(event, FinishedEvent):
-                if event.returncode >= SIGNAL_OFFSET:
-                    job.returncode.cancel()
-                else:
-                    job.returncode.set_result(event.returncode)
+            if (
+                isinstance(event, FinishedEvent)
+                and not self._cancelled
+                and not job.returncode.cancelled()
+            ):
+                job.returncode.set_result(event.returncode)
 
     def _update_jobs_json(self, iens: int, runpath: str) -> None:
         cert_path = f"{runpath}/{CERT_FILE}"

--- a/tests/unit_tests/scheduler/conftest.py
+++ b/tests/unit_tests/scheduler/conftest.py
@@ -1,10 +1,8 @@
 import asyncio
-import signal
 from typing import Any, Coroutine, Literal
 
 import pytest
 
-from ert.scheduler.driver import SIGNAL_OFFSET
 from ert.scheduler.local_driver import LocalDriver
 
 
@@ -45,7 +43,7 @@ class MockDriver(LocalDriver):
                 await self._mock_kill(iens)
             else:
                 await self._mock_kill()
-        return signal.SIGTERM + SIGNAL_OFFSET
+        return 1
 
 
 @pytest.fixture

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -13,7 +13,6 @@ from hypothesis import strategies as st
 from tests.utils import poll
 
 from ert.scheduler import LsfDriver
-from ert.scheduler.driver import SIGNAL_OFFSET
 from ert.scheduler.lsf_driver import (
     BSUB_FLAKY_SSH,
     LSF_FAILED_JOB,
@@ -117,9 +116,6 @@ async def test_events_produced_from_jobstate_updates(jobstate_sequence: List[str
     elif started is True and not finished_success and finished_failure:
         assert len(events) <= 2  # The StartedEvent is not required
         assert events[-1] == FinishedEvent(iens=0, returncode=LSF_FAILED_JOB)
-        assert (
-            events[-1].returncode < SIGNAL_OFFSET
-        ), "returncode larger than SIGNAL_OFFSET will trigger cancellation"
         assert "1" not in driver._jobs
 
 


### PR DESCRIPTION
Cancellation based on return_code can lead to jobs being able to circumvent resubmission based on return code. This is not functionality we want.

**Issue**
Resolves #7689 


**Approach**
just-do-it

This does not change any resubmission behaviour from before and after this PR on local driver or LSF driver, so this is not a bug fix.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
