### PR TITLE
Let bkill retry on ssh failures

### DIFF
--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -14,7 +14,7 @@ from tests.utils import poll
 
 from ert.scheduler import LsfDriver
 from ert.scheduler.lsf_driver import (
-    BSUB_FLAKY_SSH,
+    FLAKY_SSH_RETURNCODE,
     LSF_FAILED_JOB,
     FinishedEvent,
     FinishedJobFailure,
@@ -243,15 +243,6 @@ async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
         pytest.param(
             {"1": "11"},
             "1",
-            0,
-            "",
-            "wrong_on_stderr",
-            "wrong_on_stderr",
-            id="artifical_bkill_stderr_giving_logged_error",
-        ),
-        pytest.param(
-            {"1": "11"},
-            "1",
             1,
             "",
             "wrong_on_stderr",
@@ -459,7 +450,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [
-        (BSUB_FLAKY_SSH, ""),
+        (FLAKY_SSH_RETURNCODE, ""),
         (199, "Not recognized"),
     ],
 )
@@ -488,7 +479,7 @@ async def test_that_bsub_will_retry_and_fail(
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [
-        (BSUB_FLAKY_SSH, ""),
+        (FLAKY_SSH_RETURNCODE, ""),
     ],
 )
 async def test_that_bsub_will_retry_and_succeed(


### PR DESCRIPTION
**Issue**
Resolves lack of retry on known SSH failures for bkill


**Approach**
Use the drivers function execute_with_retry.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
