### PR TITLE
Have bkill not retry on error Job already finished

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -70,6 +70,7 @@ class Driver(ABC):
         retries: int = 1,
         retry_interval: float = 1.0,
         driverlogger: Optional[logging.Logger] = None,
+        exit_on_msgs: Iterable[str] = (),
     ) -> Tuple[bool, str]:
         _logger = driverlogger or logging.getLogger(__name__)
         error_message: Optional[str] = None
@@ -86,6 +87,11 @@ class Driver(ABC):
             assert process.returncode is not None
             if process.returncode == 0:
                 return True, stdout.decode(errors="ignore").strip()
+            if exit_on_msgs and any(
+                exit_on_msg in stderr.decode(errors="ignore")
+                for exit_on_msg in exit_on_msgs
+            ):
+                return True, stderr.decode(errors="ignore").strip()
             elif process.returncode in retry_codes:
                 error_message = stderr.decode(errors="ignore").strip()
             elif process.returncode in accept_codes:

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -80,6 +80,7 @@ _STATE_ORDER: dict[type[BaseModel], int] = {
 
 LSF_INFO_JSON_FILENAME = "lsf_info.json"
 FLAKY_SSH_RETURNCODE = 255
+JOB_ALREADY_FINISHED_BKILL_MSG = "Job has already finished"
 
 
 class _Stat(BaseModel):
@@ -278,11 +279,13 @@ class LsfDriver(Driver):
             "SIGTERM",
             job_id,
         ]
+
         process_success, process_message = await self._execute_with_retry(
             bkill_with_args,
             retry_codes=(FLAKY_SSH_RETURNCODE,),
             retries=3,
             retry_interval=self._sleep_time_between_cmd_retries,
+            exit_on_msgs=(JOB_ALREADY_FINISHED_BKILL_MSG),
         )
         subprocess.Popen(
             f"sleep {self._sleep_time_between_bkills}; {self._bkill_cmd} -s SIGKILL {job_id}",
@@ -295,6 +298,9 @@ class LsfDriver(Driver):
         if not re.match(
             f"Job <{job_id}> is being (terminated|signaled)", process_message
         ):
+            if JOB_ALREADY_FINISHED_BKILL_MSG in process_message:
+                logger.debug(f"LSF kill failed with message: {process_message}")
+                return
             logger.error(f"LSF kill failed with message: {process_message}")
 
     async def poll(self) -> None:

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -249,6 +249,15 @@ async def test_faulty_bsub(monkeypatch, tmp_path, bsub_script, expectation):
             "wrong_on_stderr",
             id="artifical_bkill_stderr_and_returncode_giving_logged_error",
         ),
+        pytest.param(
+            {"1": "11"},
+            "1",
+            255,
+            "",
+            "Job <11>: Job has already finished",
+            "",
+            id="job_already_finished",
+        ),
     ],
 )
 async def test_kill(


### PR DESCRIPTION
**Issue**
Resolves #7676


**Approach**
Have bkill not retry on error Job already finished

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
