### PR TITLE
Add -o option to bsub for stdout from LSF

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -239,6 +239,7 @@ class LsfDriver(Driver):
         bsub_with_args: List[str] = (
             [str(self._bsub_cmd)]
             + arg_queue_name
+            + ["-o", str(runpath / (name + ".LSF-stdout"))]
             + self._build_resource_requirement_arg()
             + ["-J", name, str(script_path), str(runpath)]
         )

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,9 +3,12 @@ set -e
 
 name="STDIN"
 
-while getopts "J:q:R:" opt
+while getopts "o:J:q:R:" opt
 do
     case "$opt" in
+        o)
+            stdout=$OPTARG
+            ;;
         J)
             name=$OPTARG
             ;;
@@ -30,7 +33,9 @@ echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
 
-bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &
+[ -z $stdout] && stdout="/dev/null"
+
+bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>/dev/null &
 disown
 
 echo "Job <$jobid> is submitted to default queue <normal>."

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -19,3 +19,8 @@ child_pid=$!
 wait $child_pid
 
 echo "$?" > "${job}.returncode"
+echo "Sender: Mocked LSF system <$USER@$(hostname -s)"
+echo "Subject: Job $job:"
+echo "[..skipped in mock..]"
+echo "The output (if any) follows:"
+cat ${job}.stdout

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -134,6 +134,16 @@ async def test_submit_with_default_queue():
 
 
 @pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_sets_stdout():
+    driver = LsfDriver()
+    await driver.submit(0, "sleep", name="myjobname")
+    expected_stdout_file = Path(os.getcwd()) / "myjobname.LSF-stdout"
+    assert f"-o {expected_stdout_file}" in Path("captured_bsub_args").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_with_resource_requirement():
     driver = LsfDriver(resource_requirement="select[cs && x86_64Linux]")
     await driver.submit(0, "sleep")


### PR DESCRIPTION
**Issue**
Resolves #7695 

**Approach**
Replicate legacy driver.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
