### PR TITLE
Improve scheduler driver logging to always include exit code, stdout, stderr

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -315,13 +315,13 @@ class LsfDriver(Driver):
             stderr=subprocess.DEVNULL,
         )
 
-        if not re.match(
+        if not re.search(
             f"Job <{job_id}> is being (terminated|signaled)", process_message
         ):
             if JOB_ALREADY_FINISHED_BKILL_MSG in process_message:
-                logger.debug(f"LSF kill failed with message: {process_message}")
+                logger.debug(f"LSF kill failed with: {process_message}")
                 return
-            logger.error(f"LSF kill failed with message: {process_message}")
+            logger.error(f"LSF kill failed with: {process_message}")
 
     async def poll(self) -> None:
         while True:

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -493,9 +493,9 @@ async def test_that_bsub_will_retry_and_fail(
     driver._bsub_retries = 2
     driver._sleep_time_between_cmd_retries = 0.2
     match_str = (
-        f"failed after 2 retries with error {error_msg}"
+        f'failed after 2 retries with exit code {exit_code}.*error: "{error_msg if error_msg else "<empty>"}"'
         if exit_code != 199
-        else "failed with exit code 199 and error message: Not recognized"
+        else 'failed with exit code 199.*error: "Not recognized"'
     )
     with pytest.raises(RuntimeError, match=match_str):
         await driver.submit(0, "sleep 10")

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -279,9 +279,7 @@ async def test_faulty_qstat(monkeypatch, tmp_path, qstat_script, started_expecte
             was_started = True
 
     with contextlib.suppress(asyncio.TimeoutError):
-        await asyncio.wait_for(
-            poll(driver, expected=set(), started=started), timeout=0.5
-        )
+        await asyncio.wait_for(poll(driver, expected=set(), started=started), timeout=1)
 
     assert was_started == started_expected
 
@@ -343,9 +341,9 @@ async def test_that_qsub_will_retry_and_fail(
     driver._num_pbs_cmd_retries = 2
     driver._sleep_time_between_cmd_retries = 0.2
     match_str = (
-        f"failed after 2 retries with error {error_msg}"
+        f'failed after 2 retries with exit code {exit_code}.*error: "{error_msg}"'
         if exit_code != 199
-        else "failed with exit code 199 and error message: Not recognized"
+        else 'failed with exit code 199.*error: "Not recognized"'
     )
     with pytest.raises(RuntimeError, match=match_str):
         await driver.submit(0, "sleep 10")


### PR DESCRIPTION
**Issue**
Resolves #7691 


**Approach**
^

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
