### PR TITLE
Increase tolerance in truncated_normal test

### DIFF
--- a/tests/unit_tests/config/test_transfer_functions.py
+++ b/tests/unit_tests/config/test_transfer_functions.py
@@ -60,7 +60,7 @@ def test_that_truncated_normal_stays_within_bounds(x, arg):
 )
 def test_that_truncated_normal_is_monotonic(x1x2, arg):
     x1, x2 = x1x2
-    assume((x2 - x1) > abs(arg[0] / 1e14) + 1e-14)  # tolerance relative to mean
+    assume((x2 - x1) > abs(arg[0] / 1e13) + 1e-13)  # tolerance relative to mean
     result1 = TransferFunction.trans_truncated_normal(x1, arg)
     result2 = TransferFunction.trans_truncated_normal(x2, arg)
     # Results should be different unless clamped


### PR DESCRIPTION
The test failed due to too low tolerance in https://github.com/equinor/ert/actions/runs/8784412078/job/24102745261

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
