### PR TITLE
Have integration tests running towards cluster set job names

### DIFF
--- a/tests/integration_tests/scheduler/bin/bjobs.py
+++ b/tests/integration_tests/scheduler/bin/bjobs.py
@@ -31,6 +31,7 @@ def get_parser() -> argparse.ArgumentParser:
         description="Mocked LSF bjobs command reading state from filesystem"
     )
     parser.add_argument("jobs", type=str, nargs="*")
+    parser.add_argument("-w", action="store_true")
     return parser
 
 

--- a/tests/integration_tests/scheduler/conftest.py
+++ b/tests/integration_tests/scheduler/conftest.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def mock_bin(monkeypatch, tmp_path):
     bin_path = Path(__file__).parent / "bin"
@@ -11,3 +13,8 @@ def mock_bin(monkeypatch, tmp_path):
     monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
     monkeypatch.setenv("PYTEST_TMP_PATH", str(tmp_path))
     monkeypatch.setenv("PYTHON", sys.executable)
+
+
+@pytest.fixture
+def job_name(request) -> str:
+    return request.node.name.split("[")[0]


### PR DESCRIPTION
**Issue**
Resolves #7727 


**Approach**
The commit in this PR makes the integration tests for the scheduler drivers use the test names as job names when doing `driver.submit`, making it easier to debug.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
