### PR TITLE
Replace swap_vertical icon with reorder for plotter selection

### DIFF
--- a/src/ert/gui/resources/gui/img/reorder.svg
+++ b/src/ert/gui/resources/gui/img/reorder.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 7V5h18v2H3Zm0 4h18V9H3v2Zm18 4H3v-2h18v2Zm0 4H3v-2h18v2Z"/></svg>

--- a/src/ert/gui/resources/gui/img/swap_vertical.svg
+++ b/src/ert/gui/resources/gui/img/swap_vertical.svg
@@ -1,1 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 6.99 9 3l4 3.99h-3V14H8V6.99H5ZM16 10v7.01h3L15 21l-4-3.99h3V10h2Z"/></svg>

--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -88,7 +88,7 @@ class EnsembleSelectListWidget(QListWidget):
 class CustomItemDelegate(QStyledItemDelegate):
     def __init__(self):
         super().__init__()
-        self.swap_pixmap = QIcon("img:swap_vertical.svg").pixmap(QSize(20, 20))
+        self.swap_pixmap = QIcon("img:reorder.svg").pixmap(QSize(20, 20))
 
     def sizeHint(self, option, index):
         return QSize(-1, 30)
@@ -113,6 +113,6 @@ class CustomItemDelegate(QStyledItemDelegate):
         text_rect = rect.adjusted(4, 4, -4, -4)
         painter.drawText(text_rect, Qt.AlignHCenter, index.data())
 
-        cursor_x = option.rect.right() - self.swap_pixmap.width() - 5
+        cursor_x = option.rect.left() + self.swap_pixmap.width() - 14
         cursor_y = int(option.rect.center().y() - (self.swap_pixmap.height() / 2))
         painter.drawPixmap(cursor_x, cursor_y, self.swap_pixmap)


### PR DESCRIPTION
**Issue**
Resolves #7745

![Screenshot 2024-04-24 at 08 38 23](https://github.com/equinor/ert/assets/114403625/67203e88-16c0-4efd-8a9c-7d147848a4f7)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
