### PR TITLE
Implement OpenPBS queue options `QSUB_CMD`, `QSTAT_CMD`, `QDEL_CMD`

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -194,4 +194,12 @@ deprecated_keywords_list = [
         "The ERT default is to use /usr/bin/ssh.",
         check=lambda line: "LSF_RSH_CMD" in line,
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="QUEUE_QUERY_TIMEOUT as QUEUE_OPTION to the TORQUE system will be ignored "
+        "when using the scheduler, and it is not recommended to use this QUEUE_OPTION. "
+        "It has been used in the past to set the time ERT will wait before giving "
+        "up on hanging backend (TORQUE/PBS) when submitting jobs or job status querying.",
+        check=lambda line: "QUEUE_QUERY_TIMEOUT" in line,
+    ),
 ]

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -22,6 +22,9 @@ def create_driver(config: QueueConfig) -> Driver:
             for key, value in config.queue_options.get(QueueSystem.TORQUE, [])
         }
         return OpenPBSDriver(
+            qsub_cmd=queue_config.get("QSUB_CMD"),
+            qstat_cmd=queue_config.get("QSTAT_CMD"),
+            qdel_cmd=queue_config.get("QDEL_CMD"),
             queue_name=queue_config.get("QUEUE"),
             keep_qsub_output=queue_config.get("KEEP_QSUB_OUTPUT", "0"),
             memory_per_job=queue_config.get("MEMORY_PER_JOB"),

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -667,7 +667,9 @@ def test_scheduler_create_openpbs_driver():
     num_cpus_per_node = 1
     cluster_label = "bar_cluster_label"
     job_prefix = "foo_job_prefix"
-
+    qsub_cmd = "bar_qsub_cmd"
+    qdel_cmd = "foo_qdel_cmd"
+    qstat_cmd = "bar_qstat_cmd"
     queue_config_dict = {
         "QUEUE_SYSTEM": "TORQUE",
         "QUEUE_OPTION": [
@@ -678,6 +680,9 @@ def test_scheduler_create_openpbs_driver():
             ("TORQUE", "NUM_CPUS_PER_NODE", num_cpus_per_node),
             ("TORQUE", "CLUSTER_LABEL", cluster_label),
             ("TORQUE", "JOB_PREFIX", job_prefix),
+            ("TORQUE", "QSUB_CMD", qsub_cmd),
+            ("TORQUE", "QSTAT_CMD", qstat_cmd),
+            ("TORQUE", "QDEL_CMD", qdel_cmd),
         ],
     }
     queue_config = QueueConfig.from_dict(queue_config_dict)
@@ -689,3 +694,6 @@ def test_scheduler_create_openpbs_driver():
     assert driver._num_cpus_per_node == num_cpus_per_node
     assert driver._cluster_label == cluster_label
     assert driver._job_prefix == job_prefix
+    assert str(driver._qsub_cmd) == qsub_cmd
+    assert str(driver._qstat_cmd) == qstat_cmd
+    assert str(driver._qdel_cmd) == qdel_cmd


### PR DESCRIPTION
**Issue**
Resolves #7747 


**Approach**
Implement OpenPBS queue options `QSUB_CMD`, `QSTAT_CMD`, `QDEL_CMD`

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
