### PR TITLE
Implement OpenPBS queue option`QSTAT_OPTIONS`

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -202,4 +202,11 @@ deprecated_keywords_list = [
         "up on hanging backend (TORQUE/PBS) when submitting jobs or job status querying.",
         check=lambda line: "QUEUE_QUERY_TIMEOUT" in line,
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="QSTAT_OPTIONS as QUEUE_OPTION to the TORQUE system will be ignored "
+        "when using the scheduler, and it is not recommended to use this QUEUE_OPTION. "
+        "It has been used in the past to supply options to the qstat command.",
+        check=lambda line: "QSTAT_OPTIONS" in line,
+    ),
 ]


### PR DESCRIPTION
**Issue**
Resolves #7747


**Approach**
Implement OpenPBS queue option`QSTAT_OPTIONS`

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
