### PR TITLE
Reverse ensemble order for plotting

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -39,7 +39,7 @@ class EnsembleSelectListWidget(QListWidget):
 
     def __init__(self, ensembles):
         super().__init__()
-        self._ensembles = ensembles
+        self._ensembles = reversed(ensembles)
         self.setObjectName("ensemble_selector")
 
         for i, ensemble in enumerate(self._ensembles):


### PR DESCRIPTION
Response to user opinion:

> User opinion here: I would always opt to arrange the plots so that the latest iteration is on top. We expect to see lower variability as we progress through the iterations, and we are typically more interested in observing the behavior of the posterior. The idea is to have a plot where we see how the posterior converges closer to the observed data compared to the priors, which are usually more spread out in the background of the posterior curves. 

ref.
https://equinor.slack.com/archives/C01MCMWD075/p1713877068266489

![Screenshot 2024-04-24 at 14 26 00](https://github.com/equinor/ert/assets/114403625/4bdec330-7a80-479c-825a-96e7aad640da)



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
