### PR TITLE
Hardcode `-x` qstat option in `torque_driver.cpp`

### DIFF
--- a/src/clib/lib/job_queue/torque_driver.cpp
+++ b/src/clib/lib/job_queue/torque_driver.cpp
@@ -682,9 +682,9 @@ torque_driver_get_qstat_status(torque_driver_type *driver,
     close(fd);
     job_status_type status = JOB_QUEUE_STATUS_FAILURE;
 
-    /* "qstat -f" means "full"/"long" output
+    /* "qstat -fx" means "full"/"long" output including moved/finished jobs
      * (multiple lines of output pr. job)  */
-    std::array argv{"-f", (const char *)driver->qstat_opts, jobnr_char};
+    std::array argv{"-fx", (const char *)driver->qstat_opts, jobnr_char};
 
     /* The qstat command might fail intermittently for acceptable reasons,
        retry a couple of times with exponential sleep. ERT pings qstat

--- a/tests/unit_tests/job_queue/test_job_queue_node_torque.py
+++ b/tests/unit_tests/job_queue/test_job_queue_node_torque.py
@@ -185,7 +185,7 @@ def test_run_torque_job(
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "user_qstat_option, expected_options",
-    [("", "-f 10001"), ("-x", "-f -x 10001"), ("-f", "-f -f 10001")],
+    [("", "-fx 10001"), ("-x", "-fx -x 10001"), ("-f", "-fx -f 10001")],
 )
 def test_that_torque_driver_passes_options_to_qstat(
     temp_working_directory,


### PR DESCRIPTION
**Approach**
This commit makes the legacy torque driver better match the scheduler OpenPBSDriver.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
