### PR TITLE
Rename get_all_ensembles_not_running

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -130,12 +130,7 @@ class PlotApi:
 
         return list(all_keys.values())
 
-    def get_all_ensembles_not_running(self) -> List[PlotCaseObject]:
-        """Returns a list of all ensembles that are not running. For each ensemble a dict with
-        info about the ensemble is returned"""
-        # Currently, the ensemble information from the storage API does not contain any
-        # hint if a ensemble is running or not for now we return all the ensembles, running or
-        # not.
+    def get_all_ensembles(self) -> List[PlotCaseObject]:
         return self._get_all_ensembles()
 
     def data_for_key(self, ensemble_name: str, key: str) -> pd.DataFrame:

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -145,7 +145,7 @@ class PlotWindow(QMainWindow):
 
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         try:
-            ensembles = self._api.get_all_ensembles_not_running()
+            ensembles = self._api.get_all_ensembles()
         except (RequestError, TimeoutError) as e:
             logger.exception(e)
             open_error_dialog("Request failed", str(e))

--- a/tests/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/unit_tests/gui/tools/plot/test_plot_api.py
@@ -46,11 +46,9 @@ def test_key_def_structure(api):
 
 
 def test_case_structure(api):
-    ensembles = [ensemble.name for ensemble in api.get_all_ensembles_not_running()]
+    ensembles = [ensemble.name for ensemble in api.get_all_ensembles()]
     hidden_case = [
-        ensemble.name
-        for ensemble in api.get_all_ensembles_not_running()
-        if ensemble.hidden
+        ensemble.name for ensemble in api.get_all_ensembles() if ensemble.hidden
     ]
     expected = ["ensemble_1", ".ensemble_2", "default_0", "default_1"]
 


### PR DESCRIPTION
It returns all ensembles whether they are running or not.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
