### PR TITLE
Implemented exit codes in lsf driver

### DIFF
--- a/tests/integration_tests/scheduler/bin/bhist.py
+++ b/tests/integration_tests/scheduler/bin/bhist.py
@@ -28,6 +28,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Mocked LSF bhist command reading state from filesystem"
     )
+    parser.add_argument("-n", type=int, default=None)
+    parser.add_argument("-l", action="store_true")
     parser.add_argument("jobs", type=str, nargs="*")
     return parser
 

--- a/tests/integration_tests/scheduler/bin/bjobs.py
+++ b/tests/integration_tests/scheduler/bin/bjobs.py
@@ -30,6 +30,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Mocked LSF bjobs command reading state from filesystem"
     )
+    parser.add_argument("-o", type=str, default=None)
+    parser.add_argument("-noheader", action="store_true")
     parser.add_argument("jobs", type=str, nargs="*")
     parser.add_argument("-w", action="store_true")
     return parser
@@ -58,6 +60,12 @@ def main() -> None:
     args = get_parser().parse_args()
 
     jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
+
+    # this is for the bjobs call looking for exit code
+    if args.o is not None:
+        returncode = read(jobs_path / f"{args.jobs[0]}.returncode")
+        print(returncode)
+        return
 
     jobs_output: List[Job] = []
     for job in args.jobs:

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -2,10 +2,9 @@
 job=$1
 
 function handle_sigterm {
-    # Torque uses (256 + SIGNAL) as the returncode
-    # Fix this to whatever LSF does..
+    # LSF uses (128 + SIGNAL) as the returncode
     # SIGTERM=15
-    echo "1" > "${job}.returncode"
+    echo "143" > "${job}.returncode"
     echo ""
     kill $child_pid
     exit 1

--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -6,7 +6,7 @@ import pytest
 
 from ert.scheduler.driver import SIGNAL_OFFSET, Driver
 from ert.scheduler.local_driver import LocalDriver
-from ert.scheduler.lsf_driver import LSF_FAILED_JOB, LsfDriver
+from ert.scheduler.lsf_driver import LsfDriver
 from ert.scheduler.openpbs_driver import OpenPBSDriver
 from tests.utils import poll
 
@@ -60,15 +60,10 @@ async def test_submit_something_that_fails(driver: Driver, tmp_path, job_name):
     finished_called = False
 
     expected_returncode = 42
-    if isinstance(driver, LsfDriver):
-        expected_returncode = LSF_FAILED_JOB
 
     async def finished(iens, returncode):
         assert iens == 0
         assert returncode == expected_returncode
-
-        if isinstance(driver, LsfDriver):
-            assert returncode != 0
 
         nonlocal finished_called
         finished_called = True
@@ -90,8 +85,8 @@ async def test_kill(driver: Driver, tmp_path, request):
     os.chdir(tmp_path)
     aborted_called = False
     expected_returncodes = [
-        LSF_FAILED_JOB,
         SIGNAL_OFFSET + signal.SIGTERM,
+        SIGNAL_OFFSET + signal.SIGINT,
         256 + signal.SIGKILL,
         256 + signal.SIGTERM,
     ]


### PR DESCRIPTION
**Issue**
Resolves #7497 


**Approach**
read exit codes from bjobs with bhist as fallback.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
