### PR TITLE
Add use_tmpdir to tests that pollute cwd when running pytest

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -138,13 +138,14 @@ async def test_lsf_driver_masks_returncode(
     await poll(driver, {0}, finished=finished)
 
 
-async def test_submit_with_resource_requirement(tmp_path, job_name):
+@pytest.mark.usefixtures("use_tmpdir")
+async def test_submit_with_resource_requirement(job_name):
     resource_requirement = "select[cs && x86_64Linux]"
     driver = LsfDriver(resource_requirement=resource_requirement)
-    await driver.submit(0, "sh", "-c", f"echo test>{tmp_path}/test", name=job_name)
+    await driver.submit(0, "sh", "-c", "echo test>test", name=job_name)
     await poll(driver, {0})
 
-    assert (tmp_path / "test").read_text(encoding="utf-8") == "test\n"
+    assert Path("test").read_text(encoding="utf-8") == "test\n"
 
 
 async def test_polling_bhist_fallback(not_found_bjobs, caplog, job_name):

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -113,6 +113,7 @@ def test_date_parsing_in_observations(datestring, errors):
             ErtConfig.from_file("config.ert")
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_using_summary_observations_without_eclbase_shows_user_error():
     config_text = dedent(
         """


### PR DESCRIPTION
**Issue**
some tests leave files in working dir when running pytests.

**Approach**
add use_tmpdir to prevent this

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
