### PR TITLE
Fix dark storage performance benchmark

### DIFF
--- a/.github/workflows/dark_storage_benchmark.yml
+++ b/.github/workflows/dark_storage_benchmark.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           pip install matplotlib
           dev/dark_storage_performance_benchmark/process_benchmark_result.py
+          rm -rf benchmark.svg
           dev/dark_storage_performance_benchmark/plot_benchmark_result.py
           git config --global user.name "Dark Storage Benchmarking Workflow"
           git config --global user.email ""


### PR DESCRIPTION
This commit should fix the issue where labels are appended to the benchmark.svg file instead of overwriting it. This might have causes the bug where old labels were not replaced by new ones.