### PR TITLE
Have scheduler lsf driver dump bhist summary to runpath

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -71,6 +71,7 @@ class Driver(ABC):
         retry_interval: float = 1.0,
         driverlogger: Optional[logging.Logger] = None,
         exit_on_msgs: Iterable[str] = (),
+        log_to_debug: Optional[bool] = True,
     ) -> Tuple[bool, str]:
         _logger = driverlogger or logging.getLogger(__name__)
         error_message: Optional[str] = None
@@ -91,9 +92,10 @@ class Driver(ABC):
                 f'error: "{stderr.decode(errors="ignore").strip() or "<empty>"}"'
             )
             if process.returncode == 0:
-                _logger.debug(
-                    f'Command "{shlex.join(cmd_with_args)}" succeeded with {outputs}'
-                )
+                if log_to_debug:
+                    _logger.debug(
+                        f'Command "{shlex.join(cmd_with_args)}" succeeded with {outputs}'
+                    )
                 return True, stdout.decode(errors="ignore").strip()
             if exit_on_msgs and any(
                 exit_on_msg in stderr.decode(errors="ignore")
@@ -103,9 +105,10 @@ class Driver(ABC):
             elif process.returncode in retry_codes:
                 error_message = outputs
             elif process.returncode in accept_codes:
-                _logger.debug(
-                    f'Command "{shlex.join(cmd_with_args)}" succeeded with {outputs}'
-                )
+                if log_to_debug:
+                    _logger.debug(
+                        f'Command "{shlex.join(cmd_with_args)}" succeeded with {outputs}'
+                    )
                 return True, stderr.decode(errors="ignore").strip()
             else:
                 error_message = (

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -145,6 +145,14 @@ def mock_bsub(request, tmp_path):
 
 
 @pytest.fixture
+def mock_bhist(tmp_path):
+    script_path = tmp_path / "mock_bhist"
+    script_path.write_text("#!/bin/sh\necho 'No matching job found'")
+
+    os.chmod(script_path, 0o755)
+
+
+@pytest.fixture
 def copy_lsf_poly_case(copy_poly_case, tmp_path):
     # Overwriting the "poly.ert" config file in tmpdir runpath
     # with our own customized config with at least sets queue option to LSF and
@@ -156,6 +164,7 @@ def copy_lsf_poly_case(copy_poly_case, tmp_path):
         "QUEUE_OPTION LSF MAX_RUNNING 10\n",
         f"QUEUE_OPTION LSF BJOBS_CMD {tmp_path}/mock_bjobs\n",
         f"QUEUE_OPTION LSF BSUB_CMD {tmp_path}/mock_bsub\n",
+        f"QUEUE_OPTION LSF BHIST_CMD {tmp_path}/mock_bhist\n",
         "RUNPATH poly_out/realization-<IENS>/iter-<ITER>\n",
         "OBS_CONFIG observations\n",
         "NUM_REALIZATIONS 10\n",
@@ -173,6 +182,7 @@ def copy_lsf_poly_case(copy_poly_case, tmp_path):
     "copy_lsf_poly_case",
     "mock_bsub",
     "mock_bjobs",
+    "mock_bhist",
     "mock_start_server",
 )
 @pytest.mark.integration_test

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -6,6 +6,7 @@ from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 from textwrap import dedent
 from typing import Collection, List, Optional, get_args
+from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given
@@ -94,6 +95,9 @@ async def test_events_produced_from_jobstate_updates(
     mocked_bjobs = tmp_path / "bjobs"
     mocked_bjobs.write_text(f"#!/bin/sh\necho '{exit_code}'")
     mocked_bjobs.chmod(mocked_bjobs.stat().st_mode | stat.S_IEXEC)
+    mocked_bhist = tmp_path / "bhist"
+    mocked_bhist.write_text("#!/bin/sh\necho 'foo'")
+    mocked_bhist.chmod(mocked_bhist.stat().st_mode | stat.S_IEXEC)
 
     started = any(
         state in jobstate_sequence
@@ -112,18 +116,21 @@ async def test_events_produced_from_jobstate_updates(
         ]
     )
 
-    driver = LsfDriver(bjobs_cmd=mocked_bjobs)
+    driver = LsfDriver(bjobs_cmd=mocked_bjobs, bhist_cmd=mocked_bhist)
 
-    async def mocked_submit(self, iens, *_args, **_kwargs):
+    async def mocked_submit(self, iens, name, *_args, **_kwargs):
         """A mocked submit is speedier than going through a command on disk"""
         self._jobs["1"] = JobData(
             iens=iens,
             job_state=QueuedJob(job_state="PEND"),
             submitted_timestamp=time.time(),
+            runpath=os.getcwd(),
+            name=name,
         )
         self._iens2jobid[iens] = "1"
 
     driver.submit = mocked_submit.__get__(driver)
+    driver._dump_bhist_job_summary_to_runpath = AsyncMock()
     await driver.submit(0, "_")
 
     # Replicate the behaviour of multiple calls to poll()
@@ -468,6 +475,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
     bjobs_path.write_text(f"#!/bin/sh\n{bjobs_script}")
     bjobs_path.chmod(bjobs_path.stat().st_mode | stat.S_IEXEC)
     driver = LsfDriver()
+    driver._log_bhist_job_summary = AsyncMock()
     with expectation:
         await driver.submit(0, "sleep")
         await asyncio.wait_for(poll(driver, {0}), timeout=1)


### PR DESCRIPTION
**Issue**
Resolves #7694


**Approach**
The commit in this PR has the lsf_driver dump the output of `bhist -l <JOB_ID>` to runpath.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
