### PR TITLE
Iterate ensembles to look for history to plot

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -204,26 +204,29 @@ class PlotApi:
             }
             return pd.DataFrame(data_struct).T
 
-    def history_data(self, key, ensemble=None) -> pd.DataFrame:
+    def history_data(self, key, ensembles: Optional[List[str]]) -> pd.DataFrame:
         """Returns a pandas DataFrame with the data points for the history for a
         given data key, if any.  The row index is the index/date and the column
         index is the key."""
+        if ensembles:
+            for ensemble in ensembles:
+                if ":" in key:
+                    head, tail = key.split(":", 2)
+                    history_key = f"{head}H:{tail}"
+                else:
+                    history_key = f"{key}H"
 
-        if ":" in key:
-            head, tail = key.split(":", 2)
-            history_key = f"{head}H:{tail}"
-        else:
-            history_key = f"{key}H"
+                df = self.data_for_key(ensemble, history_key)
 
-        df = self.data_for_key(ensemble, history_key)
-
-        if not df.empty:
-            df = df.T
-            # Drop columns with equal data
-            duplicate_cols = [
-                cc[0] for cc in combi(df.columns, r=2) if (df[cc[0]] == df[cc[1]]).all()
-            ]
-            return df.drop(columns=duplicate_cols)
+                if not df.empty:
+                    df = df.T
+                    # Drop columns with equal data
+                    duplicate_cols = [
+                        cc[0]
+                        for cc in combi(df.columns, r=2)
+                        if (df[cc[0]] == df[cc[1]]).all()
+                    ]
+                    return df.drop(columns=duplicate_cols)
 
         return pd.DataFrame()
 

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -223,15 +223,17 @@ class PlotWindow(QMainWindow):
             plot_config = PlotConfig.createCopy(self._plot_customizer.getPlotConfig())
             plot_context = PlotContext(plot_config, ensembles, key, layer)
 
-            ensemble = plot_context.ensembles()[0] if plot_context.ensembles() else None
-
             # Check if key is a history key.
             # If it is it already has the data it needs
             if str(key).endswith("H") or "H:" in str(key):
                 plot_context.history_data = DataFrame()
             else:
                 try:
-                    plot_context.history_data = self._api.history_data(key, ensemble)
+                    plot_context.history_data = self._api.history_data(
+                        key,
+                        plot_context.ensembles(),
+                    )
+
                 except (RequestError, TimeoutError) as e:
                     logger.exception(e)
                     open_error_dialog("Request failed", f"{e}")

--- a/tests/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/unit_tests/gui/tools/plot/test_plot_api.py
@@ -99,10 +99,22 @@ def test_all_data_type_keys(api):
 
 
 def test_load_history_data(api):
-    df = api.history_data(ensemble="default_0", key="FOPR")
+    df = api.history_data(ensembles=["default_0"], key="FOPR")
     assert_frame_equal(
         df, pd.DataFrame({1: [0.2, 0.2, 1.2], 3: [1.0, 1.1, 1.2], 4: [1.0, 1.1, 1.3]})
     )
+
+
+def test_load_history_data_searches_until_history_found(api):
+    df = api.history_data(ensembles=["no-history", "default_0"], key="FOPR")
+    assert_frame_equal(
+        df, pd.DataFrame({1: [0.2, 0.2, 1.2], 3: [1.0, 1.1, 1.2], 4: [1.0, 1.1, 1.3]})
+    )
+
+
+def test_load_history_data_returns_empty_frame_if_no_history(api):
+    df = api.history_data(ensembles=["no-history", "still-no-history"], key="FOPR")
+    assert_frame_equal(df, pd.DataFrame())
 
 
 def test_plot_api_request_errors_all_data_type_keys(api, mocker):


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/7803

Iterate ensembles to plot, looking for history.

Changing the order should produce history results in both cases:
![Screenshot 2024-05-02 at 13 15 13](https://github.com/equinor/ert/assets/114403625/62426cf3-9728-4bf1-8b0d-8519702aed12)
![Screenshot 2024-05-02 at 13 15 03](https://github.com/equinor/ert/assets/114403625/56ad7cb9-f12d-4901-bd57-1a488309c035)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
