### PR TITLE
Simplify how we call and parse bjobs

### DIFF
--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -176,11 +176,7 @@ def copy_lsf_poly_case(copy_poly_case, tmp_path):
     "mock_start_server",
 )
 @pytest.mark.integration_test
-def test_run_mocked_lsf_queue(request, using_scheduler):
-    if "fail" in request.node.name and using_scheduler:
-        pytest.skip(
-            "Python LSF driver does not support general resubmission on bsub errors"
-        )
+def test_run_mocked_lsf_queue():
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--disable-monitor",

--- a/tests/integration_tests/scheduler/bin/bjobs.py
+++ b/tests/integration_tests/scheduler/bin/bjobs.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import os
 from pathlib import Path
 from typing import List, Literal, Optional
@@ -13,13 +12,7 @@ JobState = Literal[
 
 class Job(BaseModel):
     job_id: str
-    name: str
     job_state: JobState
-    user_name: str = "username"
-    queue: str = "normal"
-    from_host: str = "localhost"
-    exec_host: str = "localhost"
-    submit_time: int = 0
 
 
 class SQueueOutput(BaseModel):
@@ -38,18 +31,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def bjobs_formatter(jobstats: List[Job]) -> str:
-    string = "JOBID USER     STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME\n"
-    for job in jobstats:
-        submit_time = datetime.datetime.fromtimestamp(
-            job.submit_time, datetime.timezone.utc
-        )
-        string += (
-            f"{str(job.job_id):<5s} {job.user_name:<8s} "
-            f"{job.job_state:<4s} {job.queue:<8} "
-            f"{job.from_host:<11s} {job.exec_host:<11s} {job.name:<8s} "
-            f"{submit_time}\n"
-        )
-    return string
+    return "".join([f"{job.job_id}^{job.job_state}\n" for job in jobstats])
 
 
 def read(path: Path, default: Optional[str] = None) -> Optional[str]:
@@ -62,16 +44,13 @@ def main() -> None:
     jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
 
     # this is for the bjobs call looking for exit code
-    if args.o is not None:
+    if args.o.strip() == "exit_code":
         returncode = read(jobs_path / f"{args.jobs[0]}.returncode")
         print(returncode)
         return
 
     jobs_output: List[Job] = []
     for job in args.jobs:
-        name: str = read(jobs_path / f"{job}.name") or "_"
-        assert name is not None
-
         pid = read(jobs_path / f"{job}.pid")
         returncode = read(jobs_path / f"{job}.returncode")
 
@@ -86,7 +65,6 @@ def main() -> None:
             Job(
                 **{
                     "job_id": job,
-                    "name": name,
                     "job_state": state,
                 }
             )

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import os
@@ -75,22 +74,6 @@ async def test_lsf_info_file_in_runpath(explicit_runpath, tmp_path, job_name):
     assert json.loads(
         (effective_runpath / "lsf_info.json").read_text(encoding="utf-8")
     ).keys() == {"job_id"}
-
-
-async def test_job_name(tmp_path, job_name):
-    os.chdir(tmp_path)
-    driver = LsfDriver()
-    iens: int = 0
-    await driver.submit(iens, "sh", "-c", "sleep 99", name=job_name)
-    jobid = driver._iens2jobid[iens]
-    bjobs_process = await asyncio.create_subprocess_exec(
-        "bjobs",
-        "-w",
-        jobid,
-        stdout=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await bjobs_process.communicate()
-    assert job_name in stdout.decode()
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
Use the -o option to specify which columns we are interested in. Add the -noheader option to remove the header from output.


**Approach**
Specifying output when calling bjobs to make the lsf driver logic a bit simpler.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
