### PR TITLE
Fixed issues with termination in run_dialog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ Repository = "https://github.com/equinor/ert"
 [project.optional-dependencies]
 dev = [
     "furo",
-    "hypothesis",
+    "hypothesis<6.100.6",
     "jsonpath_ng",
     "jupyter",
     "jupytext",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies=[
     "tqdm>=4.62.0",
     "uvicorn >= 0.17.0",
     "websockets",
-    "xarray",
+    "xarray<2024.5.0",
     "xtgeo >= 3.3.0",
 ]
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -53,6 +53,7 @@ _TOTAL_PROGRESS_TEMPLATE = "Total progress {total_progress}% — {phase_name}"
 class RunDialog(QDialog):
     simulation_done = Signal(bool, str)
     on_run_model_event = Signal(object)
+    _RUN_TIME_POLL_RATE = 1000
 
     def __init__(
         self,
@@ -293,7 +294,7 @@ class RunDialog(QDialog):
         self.simulation_done.connect(worker.stop)
         worker_thread.started.connect(worker.consume_and_emit)
 
-        self._ticker.start(1000)
+        self._ticker.start(self._RUN_TIME_POLL_RATE)
         self._worker_thread.start()
         simulation_thread.start()
         self._notifier.set_is_simulation_running(True)

--- a/tests/performance_tests/test_snapshot.py
+++ b/tests/performance_tests/test_snapshot.py
@@ -19,7 +19,10 @@ from ..unit_tests.gui.conftest import (  # noqa: F401
     large_snapshot,
 )
 from ..unit_tests.gui.simulation.test_run_dialog import (  # noqa: F401
-    run_model_mock,
+    event_queue,
+    notifier,
+    run_dialog,
+    run_model,
     test_large_snapshot,
 )
 
@@ -44,19 +47,20 @@ def test_snapshot_handling_of_forward_model_events(
     )
 
 
-@pytest.mark.skip("Seems like this test kills github workers")
 def test_gui_snapshot(
     benchmark,
     large_snapshot,  # noqa: F811
     qtbot,
-    run_model_mock,  # noqa: F811
+    run_dialog,  # noqa: F811
+    event_queue,  # noqa: F811
 ):
     infinite_timeout = 100000
     benchmark(
         test_large_snapshot,
         large_snapshot,
         qtbot,
-        run_model_mock,
+        run_dialog,
+        event_queue,
         timeout_per_iter=infinite_timeout,
     )
 

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -51,7 +51,7 @@ def notifier():
 def run_dialog(qtbot: QtBot, run_model, event_queue, notifier):
     run_dialog = RunDialog("mock.ert", run_model, event_queue, notifier)
     qtbot.addWidget(run_dialog)
-    yield run_dialog
+    return run_dialog
 
 
 def test_that_done_button_is_not_hidden_when_the_end_event_is_given(
@@ -109,7 +109,11 @@ def test_run_dialog_polls_run_model_for_runtime(
 
 
 def test_large_snapshot(
-    large_snapshot, qtbot: QtBot, run_dialog, event_queue, timeout_per_iter=5000
+    large_snapshot,
+    qtbot: QtBot,
+    run_dialog: RunDialog,
+    event_queue,
+    timeout_per_iter=5000,
 ):
     events = [
         FullSnapshotEvent(


### PR DESCRIPTION
Fixed an issue where worker_thread may not have been correctly cleaned up leading to flaky tests.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
