### PR TITLE
Make SummaryConfig part of EnsembleConfig

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -150,11 +150,6 @@ class ErtConfig:
         if errors:
             raise ConfigValidationError.from_collected(errors)
 
-        try:
-            ensemble_config = EnsembleConfig.from_dict(config_dict=config_dict)
-        except ConfigValidationError as err:
-            errors.append(err)
-
         workflow_jobs = {}
         workflows = {}
         hooked_workflows = {}
@@ -170,6 +165,11 @@ class ErtConfig:
             substitution_list["<ECLBASE>"] = eclbase
         except ConfigValidationError as e:
             errors.append(e)
+
+        try:
+            ensemble_config = EnsembleConfig.from_dict(config_dict=config_dict)
+        except ConfigValidationError as err:
+            errors.append(err)
 
         try:
             workflow_jobs, workflows, hooked_workflows = cls._workflows_from_dict(


### PR DESCRIPTION
Towards making responses more generic, SummaryConfig is currently too entangled/dependent on other *config objects in the ert config