### PR TITLE
Refactor gui node to use dataclasses

### DIFF
--- a/src/ert/gui/model/node.py
+++ b/src/ert/gui/model/node.py
@@ -1,5 +1,13 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Dict, Optional
+from typing import Any, Optional
+
+from qtpy.QtGui import QColor
+
+from ert.ensemble_evaluator.snapshot import ForwardModel
 
 
 class NodeType(Enum):
@@ -9,28 +17,126 @@ class NodeType(Enum):
     JOB = auto()
 
 
-class Node:
-    def __init__(self, id_: int, data: Dict, type_: NodeType) -> None:
-        self.parent: Optional[Node] = None
-        self.data: Dict = data
-        self.children: Dict[int, Node] = {}
-        self.id = id_
-        self.type = type_
+@dataclass
+class _Node(ABC):
+    id_: int
+    data: dict[Any, Any] = field(default_factory=dict)
+    parent: Optional[RootNode | IterNode | RealNode] = None
+    children: dict[int, IterNode | RealNode | ForwardModelStepNode] = field(
+        default_factory=dict
+    )
 
     def __repr__(self) -> str:
         parent = "no " if self.parent is None else ""
         children = "no " if len(self.children) == 0 else f"{len(self.children)} "
-        return f"Node<{self.type}>@{self.id} with {parent}parent and {children}children"
+        return f"Node<{type(self).__name__}>@{self.id_} with {parent}parent and {children}children"
 
-    def add_child(self, node: "Node", node_id: Optional[int] = None) -> None:
-        node.parent = self
-        if node_id is None:
-            node_id = node.id
-        self.children[node_id] = node
+    @abstractmethod
+    def add_child(
+        self,
+        node: IterNode | RealNode | ForwardModelStepNode,
+        node_id: Optional[int] = None,
+    ) -> None:
+        pass
 
     def row(self) -> int:
         if "index" in self.data:
             return int(self.data["index"])
         if self.parent:
-            return list(self.parent.children.keys()).index(self.id)
+            return list(self.parent.children.keys()).index(self.id_)
         raise ValueError(f"{self} had no parent")
+
+
+@dataclass
+class RootNodeData:
+    current_memory_usage: Optional[int] = None
+    max_memory_usage: Optional[int] = None
+
+
+@dataclass
+class RootNode(_Node):
+    parent: None = field(default=None, init=False)
+    children: dict[int, IterNode] = field(default_factory=dict)
+    data: RootNodeData = field(default_factory=RootNodeData)
+
+    def add_child(self, node: IterNode, node_id: Optional[int] = None) -> None:
+        node.parent = self
+        if node_id is None:
+            node_id = node.id_
+        self.children[node_id] = node
+
+
+@dataclass
+class IterNodeData:
+    index: Optional[str] = None
+    status: Optional[str] = None
+    sorted_realization_ids: list[str] = field(default_factory=list)
+    sorted_forward_model_step_ids_by_realization_id: dict[str, list[str]] = field(
+        default_factory=dict
+    )
+    current_memory_usage: Optional[int] = None
+    max_memory_usage: Optional[int] = None
+
+
+@dataclass
+class IterNode(_Node):
+    parent: RootNode
+    data: IterNodeData
+    children: dict[int, RealNode] = field(default_factory=dict)
+
+    def add_child(self, node: RealNode, node_id: Optional[int] = None) -> None:
+        node.parent = self
+        if node_id is None:
+            node_id = node.id_
+        self.children[node_id] = node
+
+    def row(self) -> int:
+        if self.data.index is not None:
+            return int(self.data.index)
+        if self.parent:
+            return list(self.parent.children.keys()).index(self.id_)
+        raise ValueError(f"{self} had no parent")
+
+
+@dataclass
+class RealNodeData:
+    index: Optional[str] = None
+    status: Optional[str] = None
+    active: Optional[bool] = False
+    forward_model_step_status_color_by_id: dict[str, QColor] = field(
+        default_factory=dict
+    )
+    real_status_color: Optional[str] = None
+    current_memory_usage: Optional[int] = None
+    max_memory_usage: Optional[int] = None
+
+
+@dataclass
+class RealNode(_Node):
+    parent: IterNode
+    data: RealNodeData
+    children: dict[int, ForwardModelStepNode] = field(default_factory=dict)
+
+    def add_child(
+        self, node: ForwardModelStepNode, node_id: Optional[int] = None
+    ) -> None:
+        node.parent = self
+        if node_id is None:
+            node_id = node.id_
+        self.children[node_id] = node
+
+    def row(self) -> int:
+        if self.data.index is not None:
+            return int(self.data.index)
+        if self.parent:
+            return list(self.parent.children.keys()).index(self.id_)
+        raise ValueError(f"{self} had no parent")
+
+
+@dataclass
+class ForwardModelStepNode(_Node):
+    parent: RealNode
+    data: ForwardModel
+
+    def add_child(self, *args, **kwargs):
+        pass

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -229,7 +229,7 @@ class RunDialog(QDialog):
             index = self._snapshot_model.index(start, 0, parent)
             iter_row = start
             self._iteration_progress_label.setText(
-                f"Progress for iteration {index.internalPointer().id}"
+                f"Progress for iteration {index.internalPointer().id_}"
             )
 
             widget = RealizationWidget(iter_row)
@@ -237,7 +237,7 @@ class RunDialog(QDialog):
             widget.currentChanged.connect(self._select_real)
 
             self._tab_widget.addTab(
-                widget, f"Realizations for iteration {index.internalPointer().id}"
+                widget, f"Realizations for iteration {index.internalPointer().id_}"
             )
 
     @Slot(QModelIndex)
@@ -372,10 +372,8 @@ class RunDialog(QDialog):
         runtime = self._run_model.get_runtime()
         self.running_time.setText(format_running_time(runtime))
 
-        current_memory_usage = self._snapshot_model.root.data.get(
-            ids.CURRENT_MEMORY_USAGE
-        )
-        maximum_memory_usage = self._snapshot_model.root.data.get(ids.MAX_MEMORY_USAGE)
+        current_memory_usage = self._snapshot_model.root.data.current_memory_usage
+        maximum_memory_usage = self._snapshot_model.root.data.max_memory_usage
 
         if current_memory_usage and maximum_memory_usage:
             self.memory_usage.setText(

--- a/tests/unit_tests/gui/model/test_real_list.py
+++ b/tests/unit_tests/gui/model/test_real_list.py
@@ -46,7 +46,7 @@ def test_change_iter(full_snapshot):
     source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
 
     assert (
-        model.index(0, 0, QModelIndex()).data(NodeRole).data["status"]
+        model.index(0, 0, QModelIndex()).data(NodeRole).data.status
         == REALIZATION_STATE_UNKNOWN
     )
 
@@ -59,6 +59,6 @@ def test_change_iter(full_snapshot):
     source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
 
     assert (
-        model.index(0, 0, QModelIndex()).data(NodeRole).data["status"]
+        model.index(0, 0, QModelIndex()).data(NodeRole).data.status
         == REALIZATION_STATE_FINISHED
     )

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -39,7 +39,7 @@ def test_realization_sort_order(full_snapshot):
     for i in range(0, 100):
         iter_index = model.index(i, 0, model.index(0, 0, QModelIndex()))
 
-        assert str(i) == iter_index.internalPointer().id, print(
+        assert str(i) == iter_index.internalPointer().id_, print(
             i, iter_index.internalPointer()
         )
 

--- a/tests/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/unit_tests/gui/simulation/view/test_realization.py
@@ -2,7 +2,7 @@ from qtpy import QtCore
 from qtpy.QtCore import QModelIndex, QSize
 from qtpy.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 
-from ert.gui.model.node import Node
+from ert.gui.model.node import _Node
 from ert.gui.model.snapshot import SnapshotModel
 from ert.gui.simulation.view.realization import RealizationWidget
 
@@ -14,7 +14,7 @@ class MockDelegate(QStyledItemDelegate):
         self._max_id = 0
 
     def paint(self, painter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
-        self._max_id = max(int(index.internalPointer().id), self._max_id)
+        self._max_id = max(int(index.internalPointer().id_), self._max_id)
 
     def sizeHint(self, option, index) -> QSize:
         return self._size
@@ -72,7 +72,7 @@ def test_selection_success(large_snapshot, qtbot):
 
     def check_selection_cb(index):
         node = index.internalPointer()
-        return isinstance(node, Node) and str(node.id) == str(selection_id)
+        return isinstance(node, _Node) and str(node.id_) == str(selection_id)
 
     with qtbot.waitSignal(
         widget.currentChanged, timeout=30000, check_params_cb=check_selection_cb


### PR DESCRIPTION
**Issue**
Resolves #7382 


**Approach**
The commit in this PR refactors the nodes in GUI (RootNode, IterNode, RealNode, ForwardModelNode) to use explicit dataclasses for each type instead of having the type as a field.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
