### PR TITLE
Instruct LSF to dump stderr of submitted job to runpath

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -255,6 +255,7 @@ class LsfDriver(Driver):
             [str(self._bsub_cmd)]
             + arg_queue_name
             + ["-o", str(runpath / (name + ".LSF-stdout"))]
+            + ["-e", str(runpath / (name + ".LSF-stderr"))]
             + self._build_resource_requirement_arg()
             + ["-J", name, str(script_path), str(runpath)]
         )

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,11 +3,14 @@ set -e
 
 name="STDIN"
 
-while getopts "o:J:q:R:" opt
+while getopts "o:e:J:q:R:" opt
 do
     case "$opt" in
         o)
             stdout=$OPTARG
+            ;;
+        e)
+            stderr=$OPTARG
             ;;
         J)
             name=$OPTARG
@@ -34,8 +37,9 @@ echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
 
 [ -z $stdout] && stdout="/dev/null"
+[ -z $stderr] && stderr="/dev/null"
 
-bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>/dev/null &
+bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>$stderr &
 disown
 
 echo "Job <$jobid> is submitted to default queue <normal>."

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -23,3 +23,5 @@ echo "Subject: Job $job:"
 echo "[..skipped in mock..]"
 echo "The output (if any) follows:"
 cat ${job}.stdout
+
+cat ${job}.stderr >&2

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -52,6 +52,22 @@ async def test_lsf_stdout_file(tmp_path, job_name):
     assert "yay" in lsf_stdout
 
 
+async def test_lsf_dumps_stderr_to_file(tmp_path, job_name):
+    os.chdir(tmp_path)
+    driver = LsfDriver()
+    failure_message = "failURE"
+    await driver.submit(0, "sh", "-c", f"echo {failure_message} >&2", name=job_name)
+    await poll(driver, {0})
+    assert Path(
+        f"{job_name}.LSF-stderr"
+    ).exists(), "LSF system did not write stderr file"
+
+    assert (
+        Path(f"{job_name}.LSF-stderr").read_text(encoding="utf-8").strip()
+        == failure_message
+    )
+
+
 @pytest.mark.parametrize("explicit_runpath", [(True), (False)])
 async def test_lsf_info_file_in_runpath(explicit_runpath, tmp_path, job_name):
     os.chdir(tmp_path)

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -187,6 +187,16 @@ async def test_submit_sets_stdout():
 
 
 @pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_sets_stderr():
+    driver = LsfDriver()
+    await driver.submit(0, "sleep", name="myjobname")
+    expected_stdout_file = Path(os.getcwd()) / "myjobname.LSF-stderr"
+    assert f"-e {expected_stdout_file}" in Path("captured_bsub_args").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_with_resource_requirement():
     driver = LsfDriver(resource_requirement="select[cs && x86_64Linux]")
     await driver.submit(0, "sleep")


### PR DESCRIPTION
This information should not be lost, can be crucial for debugging

**Issue**
Related to #3502 

**Approach**
Use `bsub`s `-e` option.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
