### PR TITLE
Reduce flakiness in memory profiling

### DIFF
--- a/tests/unit_tests/forward_model_runner/test_job.py
+++ b/tests/unit_tests/forward_model_runner/test_job.py
@@ -85,6 +85,7 @@ def test_memory_usage_counts_grandchildren():
     assert max_seens[1] < max_seens[2]
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.usefixtures("use_tmpdir")
 def test_memory_profile_in_running_events():
     scriptname = "increasing_memory.py"
@@ -96,10 +97,10 @@ def test_memory_profile_in_running_events():
             import time
             somelist = []
 
-            for _ in range(20):
+            for _ in range(10):
                 # 1 Mb allocated pr iteration
                 somelist.append(b' ' * 1024 * 1024)
-                time.sleep(0.02)"""
+                time.sleep(0.1)"""
             )
         )
     executable = os.path.realpath(scriptname)


### PR DESCRIPTION
Spending some extra time (increased from 0.4s to 2s test time) to allow for profiling to happen.

**Issue**
Resolves https://github.com/equinor/komodo-releases/issues/5751


**Approach**
Spend more time.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
