### PR TITLE
Improve output from test_smoother_snapshot_alpha

### DIFF
--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -169,7 +169,7 @@ def _ensemble_experiment_run(
                     dedent(
                         """\
                         #!/usr/bin/env python3
-                        import numpy as np
+                        import os
                         import sys
                         import json
 
@@ -181,7 +181,7 @@ def _ensemble_experiment_run(
                             return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
 
                         if __name__ == "__main__":
-                            if np.random.random(1) > 0.5:
+                            if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:
                                 sys.exit(1)
                             coeffs = _load_coeffs("parameters.json")
                             output = [_evaluate(coeffs, x) for x in range(10)]

--- a/tests/unit_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/unit_tests/gui/test_restart_no_responses_and_parameters.py
@@ -36,10 +36,10 @@ def _open_main_window(
             dedent(
                 """\
                 #!/usr/bin/env python3
-                import random
+                import os
 
                 if __name__ == "__main__":
-                    if random.random() > 0.5:
+                    if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:
                         raise ValueError()
                 """
             )


### PR DESCRIPTION
Using xfail creates an error message in the test log. This is quite confusing and we have had several instances of reporting false positives. This change uses pytest.raises which does not produce any false positive output.

Also, makes gui tests more predictable by avoiding a random chance of no realizations failing where the tests expect at least one failure.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release
