### PR TITLE
Enable Scheduler for LSF Queue by default

### DIFF
--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class FeatureScheduler:
     _DEFAULTS = {
         "LOCAL": True,
-        "LSF": False,
+        "LSF": True,
         "SLURM": False,
         "TORQUE": True,
     }

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -180,6 +180,7 @@ def test_run_mocked_lsf_queue():
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--disable-monitor",
+        "--disable-scheduler",
         "poly.ert",
     )
     log = Path("bsub_log").read_text(encoding="utf-8")


### PR DESCRIPTION
**Issue**
Resolves #7187 


**Approach**
Enable LSF by default setting the defaults.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
