### PR TITLE
Backports to ert-10.1

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -209,4 +209,10 @@ deprecated_keywords_list = [
         "It has been used in the past to supply options to the qstat command.",
         check=lambda line: "QSTAT_OPTIONS" in line,
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="LSF_SERVER as QUEUE_OPTION is not needed and will be removed in "
+        "the future. Please remove the configuration line.",
+        check=lambda line: "LSF_SERVER" in line,
+    ),
 ]

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -58,6 +58,7 @@ class SchemaItem:
             required_set=False,
             argc_min=0,
             argc_max=None,
+            multi_occurrence=True,
         )
 
     def token_to_value_with_context(

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -122,6 +122,7 @@ class Scheduler:
 
     async def cancel_all_jobs(self) -> None:
         self._cancelled = True
+        logger.info("Cancelling all jobs")
         await self._cancel_job_tasks()
 
     async def _cancel_job_tasks(self) -> None:
@@ -156,6 +157,12 @@ class Scheduler:
                         > long_running_factor * self._average_job_runtime
                         and not task.done()
                     ):
+                        logger.info(
+                            f"Stopping realization {iens} as its running duration "
+                            f"{self._jobs[iens].running_duration}s is longer than "
+                            f"the factor {long_running_factor} multiplied with the "
+                            f"average runtime {self._average_job_runtime}s."
+                        )
                         task.cancel()
                         with suppress(asyncio.CancelledError):
                             await task

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class FeatureScheduler:
     _DEFAULTS = {
         "LOCAL": True,
-        "LSF": False,
+        "LSF": True,
         "SLURM": False,
         "TORQUE": True,
     }

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -180,6 +180,7 @@ def test_run_mocked_lsf_queue():
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--disable-monitor",
+        "--disable-scheduler",
         "poly.ert",
     )
     log = Path("bsub_log").read_text(encoding="utf-8")

--- a/tests/integration_tests/test_storage_migration.py
+++ b/tests/integration_tests/test_storage_migration.py
@@ -138,7 +138,7 @@ def test_that_storage_matches(
             tuple(ensemble.get_realization_list_with_responses("summary")),
         )
         snapshot.assert_match(
-            summary_data.to_dataframe().astype(np.float32).transform(np.sort).to_csv(),
+            summary_data.to_dataframe().transform(np.sort).to_csv(),
             "summary_data",
         )
         snapshot.assert_match_dir(

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -169,7 +169,7 @@ def _ensemble_experiment_run(
                     dedent(
                         """\
                         #!/usr/bin/env python3
-                        import numpy as np
+                        import os
                         import sys
                         import json
 
@@ -181,7 +181,7 @@ def _ensemble_experiment_run(
                             return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
 
                         if __name__ == "__main__":
-                            if np.random.random(1) > 0.5:
+                            if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:
                                 sys.exit(1)
                             coeffs = _load_coeffs("parameters.json")
                             output = [_evaluate(coeffs, x) for x in range(10)]

--- a/tests/unit_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/unit_tests/gui/test_restart_no_responses_and_parameters.py
@@ -36,10 +36,10 @@ def _open_main_window(
             dedent(
                 """\
                 #!/usr/bin/env python3
-                import random
+                import os
 
                 if __name__ == "__main__":
-                    if random.random() > 0.5:
+                    if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:
                         raise ValueError()
                 """
             )


### PR DESCRIPTION
**Issue**
The main goal of this backport is to enable scheduler by default on LSF.


**Approach**
It includes the following commits:
bc0a18f2768e1a80c869318d7cd8bcf3b1565f6a
0fbed388a872ad7e7018eefb39a3bb6f862ea897
baf32e1803d93facb523353f837f029874b84630
ed904475a67dbb28088c2e03a357fb75093d7d1a
5d0450b1f90d8da0503cd8c5ddeb64378fa91264
82cabbc0153818b30030ea75215b06c0cf214c49

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
