### PR TITLE
Fix misleading logging statement

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -299,7 +299,7 @@ class Scheduler:
             )
 
         if self._cancelled:
-            logger.debug("scheduler cancelled, stopping jobs...")
+            logger.debug("Scheduler has been cancelled, jobs are stopped.")
             return EVTYPE_ENSEMBLE_CANCELLED
 
         return EVTYPE_ENSEMBLE_STOPPED


### PR DESCRIPTION
This log statement happens after all jobs have been stopped, so it should reflect what has happened correctly.

**Issue**
Resolves the error in the last line of this log sequence:

2024-05-14 09:21:14,959 - ert.scheduler.scheduler - LegacyEnsemble - INFO - Cancelling all jobs
2024-05-14 09:21:14,960 - ert.scheduler.openpbs_driver - LegacyEnsemble - DEBUG - Killing realization 0 with PBS-id 759247.s034-lcam
2024-05-14 09:21:15,090 - ert.scheduler.openpbs_driver - LegacyEnsemble - DEBUG - Killing realization 14 with PBS-id 759258.s034-lcam
2024-05-14 09:21:15,119 - ert.scheduler.openpbs_driver - LegacyEnsemble - DEBUG - Command "/opt/pbs/bin/qdel 759247.s034-lcam" succeeded with exit code 0, output: "<empty>", and error: "<empty>"
2024-05-14 09:21:15,124 - ert.scheduler.openpbs_driver - LegacyEnsemble - DEBUG - Command "/opt/pbs/bin/qdel 759248.s034-lcam" succeeded with exit code 0, output: "<empty>", and error: "<empty>"
2024-05-14 09:21:15,287 - ert.scheduler.openpbs_driver - LegacyEnsemble - DEBUG - Command "/opt/pbs/bin/qdel 759258.s034-lcam" succeeded with exit code 0, output: "<empty>", and error: "<empty>"
2024-05-14 09:21:15,290 - ert.scheduler.scheduler - LegacyEnsemble - DEBUG - scheduler cancelled, stopping jobs...


**Approach**
:fix:


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
