### PR TITLE
Make sure not to close the evaluator _ws_thread when done is not set yet

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -145,7 +145,6 @@ class EnsembleEvaluator:
             )
             send_future.result()
             self._loop.call_soon_threadsafe(self._stop)
-            self._ws_stopped_event.wait()
 
     def _failed_handler(self, events: List[CloudEvent]) -> None:
         if self.ensemble.status not in (
@@ -423,7 +422,6 @@ class EnsembleEvaluator:
         else:
             logger.debug("Stopping current ensemble")
             self._loop.call_soon_threadsafe(self._stop)
-            self._ws_stopped_event.wait()
 
     def join(self) -> None:
         self._ws_thread.join()

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -123,6 +123,8 @@ class Job:
         finally:
             if timeout_task and not timeout_task.done():
                 timeout_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await timeout_task
             sem.release()
 
     async def run(self, sem: asyncio.BoundedSemaphore, max_submit: int = 2) -> None:
@@ -224,6 +226,9 @@ class Job:
                 "queue_event_type": status,
             },
         )
+        if self._scheduler._publisher_done.is_set():
+            logger.error("PUBLISHER is CLOSED ALREADY!!!!!!!!!!!!!!**********")
+            print("PUBLISHER is CLOSED ALREADY!!!!!!!!!!!!!!**********")
         await self._scheduler._events.put(to_json(event))
 
 

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -206,6 +206,7 @@ class Scheduler:
                         event = await self._events.get()
                     if event == CLOSE_PUBLISHER_SENTINEL:
                         self._publisher_done.set()
+                        self._events.task_done()
                         return
                     await conn.send(event)
                     event = None


### PR DESCRIPTION
**Issue**
(Maybe) Resolves https://github.com/equinor/ert/issues/7642


**Approach**
Make sure to wait until done is set.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
