### PR TITLE
Change default MAX_SUBMIT to 1

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -1519,8 +1519,9 @@ MAX_SUBMIT
 ----------
 .. _max_submit:
 
-How many times the queue system should retry a simulation.
-Default is 2.
+How many times a realization can be submitted to the queue system in case of
+realization failures. Default is 1, meaning there will be no resubmission upon
+failures.
 
 
 Advanced keywords

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -46,7 +46,7 @@ VALID_QUEUE_OPTIONS: Dict[Any, List[str]] = {
 @dataclass
 class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
-    max_submit: int = 2
+    max_submit: int = 1
     submit_sleep: float = 0.0
     queue_system: QueueSystem = QueueSystem.LOCAL
     queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = field(
@@ -63,7 +63,7 @@ class QueueConfig:
             "JOB_SCRIPT", shutil.which("job_dispatch.py") or "job_dispatch.py"
         )
         job_script = job_script or "job_dispatch.py"
-        max_submit: int = config_dict.get("MAX_SUBMIT", 2)
+        max_submit: int = config_dict.get("MAX_SUBMIT", 1)
         submit_sleep: float = config_dict.get("SUBMIT_SLEEP", 0.0)
         queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = defaultdict(list)
         for queue_system, option_name, *values in config_dict.get("QUEUE_OPTION", []):

--- a/src/ert/job_queue/job_queue_node.py
+++ b/src/ert/job_queue/job_queue_node.py
@@ -329,7 +329,7 @@ class JobQueueNode(BaseCClass):  # type: ignore
         _kill(self, driver)
         self._tried_killing += 1
 
-    def run(self, driver: "Driver", pool_sema: Semaphore, max_submit: int = 2) -> None:
+    def run(self, driver: "Driver", pool_sema: Semaphore, max_submit: int = 1) -> None:
         # Prevent multiple threads working on the same object
         self.wait_for()
         # Do not start if already kill signal is sent

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -769,7 +769,7 @@ def test_failing_job_cli_error_message():
         poly_script.writelines(["    raise RuntimeError('Argh')"])
 
     expected_substrings = [
-        "Realization: 0 failed after reaching max submit (2)",
+        "Realization: 0 failed after reaching max submit (1)",
         "job poly_eval failed",
         "Process exited with status code 1",
         "Traceback",

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -633,7 +633,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
         label = error_dialog.label_text.text()
         assert "ERT experiment failed" in label
         expected_substrings = [
-            "Realization: 0 failed after reaching max submit (2)",
+            "Realization: 0 failed after reaching max submit (1)",
             "job poly_eval failed",
             "Process exited with status code 1",
             "Traceback",


### PR DESCRIPTION
We do not want resubmission to happen by default for realizations that fail. Forward model setups may or may not be compatible with resubmissions, and flakyness should not be assumed by default.

**Issue**
Resolves no issue, but is in line with default configured behaviour for onprem users.


**Approach**
:doit:



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
