### PR TITLE
Remove step_id from forward_model_runner Init message

### DIFF
--- a/src/_ert_forward_model_runner/reporting/message.py
+++ b/src/_ert_forward_model_runner/reporting/message.py
@@ -85,7 +85,6 @@ class Init(Message):
         ert_pid,
         ens_id=None,
         real_id=None,
-        step_id=None,
         experiment_id=None,
     ):
         super().__init__()
@@ -95,7 +94,6 @@ class Init(Message):
         self.experiment_id = experiment_id
         self.ens_id = ens_id
         self.real_id = real_id
-        self.step_id = step_id
 
 
 class Finish(Message):


### PR DESCRIPTION
**Issue**
Resolves #7805


**Approach**
Remove step_id from forward_model_runner Init message.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
