### PR TITLE
Refactor Lsf driver to use dataclasses

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -11,6 +11,7 @@ import stat
 import subprocess
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     Dict,
@@ -21,12 +22,11 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Type,
     Union,
+    cast,
     get_args,
 )
-
-from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 from ert.scheduler.driver import SIGNAL_OFFSET, Driver
 from ert.scheduler.event import Event, FinishedEvent, StartedEvent
@@ -42,34 +42,49 @@ JobState = Literal[
 ]
 
 
-class IgnoredJobstates(BaseModel):
+@dataclass(frozen=True)
+class IgnoredJobstates:
     job_state: Literal["UNKWN"]
 
 
-class FinishedJobSuccess(BaseModel):
+@dataclass(frozen=True)
+class FinishedJobSuccess:
     job_state: Literal["DONE", "PDONE"]
 
 
-class FinishedJobFailure(BaseModel):
+@dataclass(frozen=True)
+class FinishedJobFailure:
     job_state: Literal["EXIT", "ZOMBI"]
 
 
-class QueuedJob(BaseModel):
+@dataclass(frozen=True)
+class QueuedJob:
     job_state: Literal["PEND"]
 
 
-class RunningJob(BaseModel):
+@dataclass(frozen=True)
+class RunningJob:
     job_state: Literal["RUN", "SSUSP", "USUSP", "PSUSP"]
 
 
-AnyJob = Annotated[
-    Union[
-        FinishedJobSuccess, FinishedJobFailure, QueuedJob, RunningJob, IgnoredJobstates
-    ],
-    Field(discriminator="job_state"),
+_JOBSTATE_MAP = {
+    "EXIT": FinishedJobFailure,
+    "DONE": FinishedJobSuccess,
+    "PEND": QueuedJob,
+    "RUN": RunningJob,
+    "ZOMBI": FinishedJobFailure,
+    "PDONE": FinishedJobSuccess,
+    "SSUSP": RunningJob,
+    "USUSP": RunningJob,
+    "PSUSP": RunningJob,
+    "UNKWN": IgnoredJobstates,
+}
+
+AnyJob = Union[
+    FinishedJobSuccess, FinishedJobFailure, QueuedJob, RunningJob, IgnoredJobstates
 ]
 
-_STATE_ORDER: dict[type[BaseModel], int] = {
+_STATE_ORDER: dict[Type[AnyJob], int] = {
     IgnoredJobstates: -1,
     QueuedJob: 0,
     RunningJob: 1,
@@ -82,18 +97,22 @@ FLAKY_SSH_RETURNCODE = 255
 JOB_ALREADY_FINISHED_BKILL_MSG = "Job has already finished"
 
 
-class _Stat(BaseModel):
-    jobs: Mapping[str, AnyJob]
+def _parse_jobs_dict(jobs: Mapping[str, JobState]) -> dict[str, AnyJob]:
+    parsed_jobs_dict: dict[str, AnyJob] = {}
+    for job_id, job_state in jobs.items():
+        parsed_jobs_dict[job_id] = _JOBSTATE_MAP[job_state](job_state)
+    return parsed_jobs_dict
 
 
-class JobData(BaseModel):
+@dataclass
+class JobData:
     iens: int
     job_state: AnyJob
     submitted_timestamp: float
 
 
-def parse_bjobs(bjobs_output: str) -> Dict[str, Dict[str, Dict[str, str]]]:
-    data: Dict[str, Dict[str, str]] = {}
+def parse_bjobs(bjobs_output: str) -> Dict[str, JobState]:
+    data: Dict[str, JobState] = {}
     for line in bjobs_output.splitlines():
         tokens = line.split(sep="^")
         if len(tokens) == 2:
@@ -104,8 +123,8 @@ def parse_bjobs(bjobs_output: str) -> Dict[str, Dict[str, Dict[str, str]]]:
                     f"LSF for jobid {job_id}, ignored."
                 )
                 continue
-            data[job_id] = {"job_state": job_state}
-    return {"jobs": data}
+            data[job_id] = cast(JobState, job_state)
+    return data
 
 
 def build_resource_requirement_string(
@@ -346,9 +365,9 @@ class LsfDriver(Driver):
                 logger.warning(
                     f"bjobs gave returncode {process.returncode} and error {stderr.decode()}"
                 )
-            bjobs_states = _Stat(**parse_bjobs(stdout.decode(errors="ignore")))
+            bjobs_states = _parse_jobs_dict(parse_bjobs(stdout.decode(errors="ignore")))
 
-            job_ids_found_in_bjobs_output = set(bjobs_states.jobs.keys())
+            job_ids_found_in_bjobs_output = set(bjobs_states.keys())
             if (
                 missing_in_bjobs_output := filter_job_ids_on_submission_time(
                     self._jobs, submitted_before=time.time() - self._poll_period
@@ -358,16 +377,16 @@ class LsfDriver(Driver):
                 logger.debug(f"bhist is used for job ids: {missing_in_bjobs_output}")
                 bhist_states = await self._poll_once_by_bhist(missing_in_bjobs_output)
                 missing_in_bhist_and_bjobs = missing_in_bjobs_output - set(
-                    bhist_states.jobs.keys()
+                    bhist_states.keys()
                 )
             else:
-                bhist_states = _Stat(**{"jobs": {}})
+                bhist_states = {}
                 missing_in_bhist_and_bjobs = set()
 
             for job_id, job in itertools.chain(
-                bjobs_states.jobs.items(), bhist_states.jobs.items()
+                bjobs_states.items(), bhist_states.items()
             ):
-                await self._process_job_update(job_id, job)
+                await self._process_job_update(job_id, new_state=job)
 
             if missing_in_bhist_and_bjobs and self._bhist_cache is not None:
                 logger.debug(
@@ -378,7 +397,6 @@ class LsfDriver(Driver):
     async def _process_job_update(self, job_id: str, new_state: AnyJob) -> None:
         if job_id not in self._jobs:
             return
-
         old_state = self._jobs[job_id].job_state
         iens = self._jobs[job_id].iens
         if isinstance(new_state, IgnoredJobstates):
@@ -463,9 +481,11 @@ class LsfDriver(Driver):
         )
         logger.info(f"Output from bhist -l: {process_message}")
 
-    async def _poll_once_by_bhist(self, missing_job_ids: Iterable[str]) -> _Stat:
+    async def _poll_once_by_bhist(
+        self, missing_job_ids: Iterable[str]
+    ) -> Dict[str, AnyJob]:
         if time.time() - self._bhist_cache_timestamp < self._bhist_required_cache_age:
-            return _Stat(**{"jobs": {}})
+            return {}
 
         process = await asyncio.create_subprocess_exec(
             self._bhist_cmd,
@@ -480,16 +500,16 @@ class LsfDriver(Driver):
                 f"output{stdout.decode(errors='ignore').strip()} "
                 f"and error {stderr.decode(errors='ignore').strip()}"
             )
-            return _Stat(**{"jobs": {}})
+            return {}
 
         data: Dict[str, Dict[str, int]] = parse_bhist(stdout.decode())
 
         if not self._bhist_cache:
             # Boot-strapping. We can't give any data until we have run again.
             self._bhist_cache = data
-            return _Stat(**{"jobs": {}})
+            return {}
 
-        jobs = {}
+        jobs: dict[str, JobState] = {}
         for job_id, job_stat in data.items():
             if job_id not in self._bhist_cache:
                 continue
@@ -499,20 +519,20 @@ class LsfDriver(Driver):
                 and job_stat["running_seconds"]
                 == self._bhist_cache[job_id]["running_seconds"]
             ):
-                jobs[job_id] = {"job_state": "DONE"}  # or EXIT, we can't tell
+                jobs[job_id] = cast(JobState, "DONE")  # or EXIT, we can't tell
             elif (
                 job_stat["running_seconds"]
                 > self._bhist_cache[job_id]["running_seconds"]
             ):
-                jobs[job_id] = {"job_state": "RUN"}
+                jobs[job_id] = cast(JobState, "RUN")
             elif (
                 job_stat["pending_seconds"]
                 > self._bhist_cache[job_id]["pending_seconds"]
             ):
-                jobs[job_id] = {"job_state": "PEND"}
+                jobs[job_id] = cast(JobState, "PEND")
         self._bhist_cache = data
         self._bhist_cache_timestamp = time.time()
-        return _Stat(**{"jobs": jobs})
+        return _parse_jobs_dict(jobs)
 
     def _build_resource_requirement_arg(self) -> List[str]:
         resource_requirement_string = build_resource_requirement_string(

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -5,7 +5,7 @@ import time
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 from textwrap import dedent
-from typing import Collection, List, Optional, get_args
+from typing import Collection, List, Optional, get_args, get_type_hints
 from unittest.mock import AsyncMock
 
 import pytest
@@ -25,7 +25,7 @@ from ert.scheduler.lsf_driver import (
     QueuedJob,
     RunningJob,
     StartedEvent,
-    _Stat,
+    _parse_jobs_dict,
     build_resource_requirement_string,
     filter_job_ids_on_submission_time,
     parse_bhist,
@@ -101,31 +101,25 @@ async def test_events_produced_from_jobstate_updates(
 
     started = any(
         state in jobstate_sequence
-        for state in RunningJob.model_json_schema()["properties"]["job_state"]["enum"]
+        for state in get_type_hints(RunningJob)["job_state"].__args__
     )
     finished_success = any(
         state in jobstate_sequence
-        for state in FinishedJobSuccess.model_json_schema()["properties"]["job_state"][
-            "enum"
-        ]
+        for state in get_type_hints(FinishedJobSuccess)["job_state"].__args__
     )
     finished_failure = any(
         state in jobstate_sequence
-        for state in FinishedJobFailure.model_json_schema()["properties"]["job_state"][
-            "enum"
-        ]
+        for state in get_type_hints(FinishedJobFailure)["job_state"].__args__
     )
 
     driver = LsfDriver(bjobs_cmd=mocked_bjobs, bhist_cmd=mocked_bhist)
 
-    async def mocked_submit(self, iens, name, *_args, **_kwargs):
+    async def mocked_submit(self: LsfDriver, iens, name, *_args, **_kwargs):
         """A mocked submit is speedier than going through a command on disk"""
         self._jobs["1"] = JobData(
             iens=iens,
             job_state=QueuedJob(job_state="PEND"),
             submitted_timestamp=time.time(),
-            runpath=os.getcwd(),
-            name=name,
         )
         self._iens2jobid[iens] = "1"
 
@@ -135,7 +129,7 @@ async def test_events_produced_from_jobstate_updates(
 
     # Replicate the behaviour of multiple calls to poll()
     for statestr in jobstate_sequence:
-        jobstate = _Stat(**{"jobs": {"1": {"job_state": statestr}}}).jobs["1"]
+        jobstate = _parse_jobs_dict({"1": statestr})["1"]
         await driver._process_job_update("1", jobstate)
 
     events = []
@@ -380,7 +374,7 @@ async def test_kill(
 
 @given(st.text())
 def test_parse_bjobs_gives_empty_result_on_random_input(some_text):
-    assert parse_bjobs(some_text) == {"jobs": {}}
+    assert parse_bjobs(some_text) == {}
 
 
 @pytest.mark.parametrize(
@@ -388,19 +382,19 @@ def test_parse_bjobs_gives_empty_result_on_random_input(some_text):
     [
         pytest.param(
             "1^RUN",
-            {"1": {"job_state": "RUN"}},
+            {"1": "RUN"},
             id="basic",
         ),
-        pytest.param("1^DONE", {"1": {"job_state": "DONE"}}, id="done"),
+        pytest.param("1^DONE", {"1": "DONE"}, id="done"),
         pytest.param(
             "1^DONE\n2^RUN",
-            {"1": {"job_state": "DONE"}, "2": {"job_state": "RUN"}},
+            {"1": "DONE", "2": "RUN"},
             id="two_jobs",
         ),
     ],
 )
 def test_parse_bjobs_happy_path(bjobs_output, expected):
-    assert parse_bjobs(bjobs_output) == {"jobs": expected}
+    assert parse_bjobs(bjobs_output) == expected
 
 
 @given(
@@ -409,14 +403,12 @@ def test_parse_bjobs_happy_path(bjobs_output, expected):
     st.from_type(JobState),
 )
 def test_parse_bjobs(job_id, username, job_state):
-    assert parse_bjobs(f"{job_id}^{job_state}") == {
-        "jobs": {str(job_id): {"job_state": job_state}}
-    }
+    assert parse_bjobs(f"{job_id}^{job_state}") == {str(job_id): job_state}
 
 
 @given(nonempty_string_without_whitespace().filter(lambda x: x not in valid_jobstates))
 def test_parse_bjobs_invalid_state_is_ignored(random_state):
-    assert parse_bjobs(f"1^{random_state}") == {"jobs": {}}
+    assert parse_bjobs(f"1^{random_state}") == {}
 
 
 def test_parse_bjobs_invalid_state_is_logged(caplog):
@@ -654,7 +646,7 @@ async def test_parse_bhist(bhist_output, expected):
     assert parse_bhist(bhist_output) == expected
 
 
-empty_states = _Stat(**{"jobs": {}})
+empty_states = _parse_jobs_dict({})
 
 
 @pytest.mark.parametrize(
@@ -665,37 +657,37 @@ empty_states = _Stat(**{"jobs": {}})
         pytest.param(
             "1 x x 0 x 0",
             "1 x x 0 x 0",
-            _Stat(**{"jobs": {"1": {"job_state": "DONE"}}}),
+            _parse_jobs_dict({"1": "DONE"}),
             id="short-job-finished",  # required_cache_age is zero in this test
         ),
         pytest.param(
             "1 x x 1 x 0",
             "1 x x 2 x 0",
-            _Stat(**{"jobs": {"1": {"job_state": "PEND"}}}),
+            _parse_jobs_dict({"1": "PEND"}),
             id="job-is-pending",
         ),
         pytest.param(
             "1 x x 1 x 0",
             "1 x x 1 x 1",
-            _Stat(**{"jobs": {"1": {"job_state": "RUN"}}}),
+            _parse_jobs_dict({"1": "RUN"}),
             id="job-is-running",
         ),
         pytest.param(
             "1 x x 1 x 0\n",
             "1 x x 1 x 1\n2 x x 0 x 0",
-            _Stat(**{"jobs": {"1": {"job_state": "RUN"}}}),
+            _parse_jobs_dict({"1": "RUN"}),
             id="partial_cache",
         ),
         pytest.param(
             "1 x x 1 x 0\n2 x x 0 x 0",
             "1 x x 1 x 1\n2 x x 0 x 0",
-            _Stat(**{"jobs": {"1": {"job_state": "RUN"}, "2": {"job_state": "DONE"}}}),
+            _parse_jobs_dict({"1": "RUN", "2": "DONE"}),
             id="two-jobs",
         ),
         pytest.param(
             "1 x x 1 x 0\n2 x x 0 x 0",
             "2 x x 0 x 0",
-            _Stat(**{"jobs": {"2": {"job_state": "DONE"}}}),
+            _parse_jobs_dict({"2": "DONE"}),
             id="job-exited-from-cache",
         ),
     ],
@@ -725,7 +717,7 @@ async def test_poll_once_by_bhist(
         pytest.param(10, empty_states, id="no_output_for_fresh_cache"),
         pytest.param(
             0,
-            _Stat(**{"jobs": {"1": {"job_state": "DONE"}}}),
+            _parse_jobs_dict({"1": "DONE"}),
             id="cache_is_old_enough",
         ),
     ],


### PR DESCRIPTION
**Issue**
Resolves #7879 


**Approach**
The commit in this PR  refactors lsf driver from using pydantic classes to dataclasses, as pydantic was overkill for our usage.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
