### PR TITLE
Let ERT be able to stop experiment when all realizations are pending

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -491,8 +491,8 @@ class BaseRunModel:
             event_logger.debug("connecting to new monitor...")
             async with Monitor(ee_config.get_connection_info()) as monitor:
                 event_logger.debug("connected")
-                async for event in monitor.track():
-                    if event["type"] in (
+                async for event in monitor.track(heartbeat_interval=0.1):
+                    if event is not None and event["type"] in (
                         EVTYPE_EE_SNAPSHOT,
                         EVTYPE_EE_SNAPSHOT_UPDATE,
                     ):
@@ -512,7 +512,7 @@ class BaseRunModel:
                             )
                             # Allow track() to emit an EndEvent.
                             return False
-                    elif event["type"] == EVTYPE_EE_TERMINATED:
+                    elif event is not None and event["type"] == EVTYPE_EE_TERMINATED:
                         event_logger.debug("got terminator event")
 
                     if not self._end_queue.empty():


### PR DESCRIPTION
This allows the base_run_model to also being able to check regularly if there are other tasks at hand, like terminating the experiment.

**Issue**
Resolves #7871 


**Approach**
Add heartbeat to `monitor.track()`

Add a test to certify that `monitor.track()` is able to emit `None` events, aka "heartbeats". A better test would be to test that `BaseRunmodel.run_monitor()` would be able to exit at any time, but that looks like a big task. If `run_monitor()` is changed not to request hearbeats, the original bug would reappear but this test will not catch it.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
