### PR TITLE
Use correct plural form for zero

### DIFF
--- a/src/ert/gui/ertwidgets/summarypanel.py
+++ b/src/ert/gui/ertwidgets/summarypanel.py
@@ -80,8 +80,11 @@ class SummaryPanel(QFrame):
         summary = ErtSummary(self.ert.ert_config)
 
         forward_model_list = summary.getForwardModels()
+        plural_s = ""
+        if not len(forward_model_list) or len(forward_model_list) > 1:
+            plural_s = "s"
         text = SummaryTemplate(
-            f"Forward model ({len(forward_model_list):,} step{'s' if len(forward_model_list) > 1 else ''})"
+            f"Forward model ({len(forward_model_list):,} step{plural_s})"
         )
         for fm_name, fm_count in self._runlength_encode_list(forward_model_list):
             if fm_count == 1:


### PR DESCRIPTION
If there are no forward_model_steps, we should write '0 steps', not '0 step'

**Issue**
Resolves remainder of  #7911


**Approach**
Fix.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
