### PR TITLE
Consider start iteration on ES-MDA restart

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -166,14 +166,16 @@ class ExperimentPanel(QWidget):
         """Get the experiment name as provided by the user. Defaults to run mode if not set."""
         return self.get_experiment_arguments().experiment_name
 
-    def run_experiment(self) -> None:
-        args = self.get_experiment_arguments()
+    def run_experiment(self):
+        args = self.getSimulationArguments()
+        is_restart_run = False
         if args.mode == ES_MDA_MODE:
             if args.restart_run:
                 message = (
                     "Are you sure you want to restart from ensemble"
                     f" '{self._notifier.current_ensemble_name}'?"
                 )
+                is_restart_run = True
             else:
                 message = (
                     "Are you sure you want to use "
@@ -218,6 +220,9 @@ class ExperimentPanel(QWidget):
             QApplication.restoreOverrideCursor()
 
             delete_runpath_checkbox = None
+
+            if is_restart_run:
+                model.set_start_iteration(self._notifier.current_ensemble.iteration + 1)
 
             if not abort and model.check_if_runpath_exists():
                 msg_box = QMessageBox(self)

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -618,7 +618,7 @@ class BaseRunModel:
         number_of_iterations = self._simulation_arguments.num_iterations
         active_mask = self._simulation_arguments.active_realizations
         active_realizations = [i for i in range(len(active_mask)) if active_mask[i]]
-        for iteration in range(start_iteration, number_of_iterations):
+        for iteration in range(start_iteration, start_iteration + number_of_iterations):
             run_paths.extend(self.run_paths.get_paths(active_realizations, iteration))
         return run_paths
 

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -138,7 +138,9 @@ class MultipleDataAssimilation(BaseRunModel):
             )
             self._evaluate_and_postprocess(prior_context, evaluator_server_config)
         enumerated_weights = list(enumerate(weights))
-        weights_to_run = enumerated_weights[prior.iteration :]
+        starting_iteration = prior.iteration + 1
+        self._simulation_arguments.start_iteration = starting_iteration
+        weights_to_run = enumerated_weights[max(starting_iteration - 1, 0) :]
 
         for iteration, weight in weights_to_run:
             is_first_iteration = iteration == 0
@@ -194,6 +196,9 @@ class MultipleDataAssimilation(BaseRunModel):
         self.setPhase(iteration_count + 1, "Experiment completed.")
 
         return prior_context
+
+    def set_start_iteration(self, start_iteration: int) -> None:
+        self._simulation_arguments.start_iteration = start_iteration
 
     def update(
         self,


### PR DESCRIPTION
**Issue**
Resolves [#7633](https://github.com/equinor/ert/issues/7633)


**Approach**
Removed `start_iteration` from all run-models except `ES-MDA` as it only makes sense here.
If restart-run, I set `start_iteration` to the prior's iteration number plus one.
This means that no "Delete-run path" dialog will show when doing the steps described in #7633 :

**To reproduce**
Steps to reproduce the behaviour:
1. Create a new experiment in Manage experiments
2. Sample parameters in said experiment
3. Run experiment (Evaluate ensemble)
4. Run ES-MDA by checking the `Restart run` and restarting from the ensemble we created in 1.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
