### PR TITLE
Dynamically load ert.gui in workflows

### DIFF
--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -6,10 +6,6 @@ from qtpy.QtWidgets import QCheckBox
 
 from ert import LibresFacade
 from ert.config import CancelPluginException, ErtPlugin
-from ert.gui.ertwidgets.customdialog import CustomDialog
-from ert.gui.ertwidgets.listeditbox import ListEditBox
-from ert.gui.ertwidgets.models.path_model import PathModel
-from ert.gui.ertwidgets.pathchooser import PathChooser
 
 
 def loadDesignMatrix(filename) -> pandas.DataFrame:
@@ -162,6 +158,11 @@ class CSVExportJob(ErtPlugin):
         return export_info
 
     def getArguments(self, parent=None):
+        from ert.gui.ertwidgets.customdialog import CustomDialog
+        from ert.gui.ertwidgets.listeditbox import ListEditBox
+        from ert.gui.ertwidgets.models.path_model import PathModel
+        from ert.gui.ertwidgets.pathchooser import PathChooser
+
         description = "The CSV export requires some information before it starts:"
         dialog = CustomDialog("CSV Export", description, parent)
 

--- a/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/shared/share/ert/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -7,10 +7,6 @@ import pandas as pd
 from PyQt5.QtWidgets import QCheckBox
 
 from ert.config import CancelPluginException, ErtPlugin
-from ert.gui.ertwidgets.customdialog import CustomDialog
-from ert.gui.ertwidgets.listeditbox import ListEditBox
-from ert.gui.ertwidgets.models.path_model import PathModel
-from ert.gui.ertwidgets.pathchooser import PathChooser
 
 
 def load_args(filename, column_names=None):
@@ -232,6 +228,11 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         return export_info
 
     def getArguments(self, parent=None):
+        from ert.gui.ertwidgets.customdialog import CustomDialog
+        from ert.gui.ertwidgets.listeditbox import ListEditBox
+        from ert.gui.ertwidgets.models.path_model import PathModel
+        from ert.gui.ertwidgets.pathchooser import PathChooser
+
         description = (
             "The GEN_DATA RFT CSV export requires some information before it starts:"
         )


### PR DESCRIPTION
ert.gui modifies matplotlib backend so loading these workflows would make `ErtConfig.from_file` change matplotlib settings.

Resolves #4791


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

