### PR TITLE
Fix `_get_oom_score_for_processtree(...)` not ignoring `ProcessLookup…

### DIFF
--- a/src/_ert_forward_model_runner/job.py
+++ b/src/_ert_forward_model_runner/job.py
@@ -316,7 +316,9 @@ def _get_oom_score_for_processtree(process: Process) -> Optional[int]:
         oom_score = int(
             Path(f"/proc/{process.pid}/oom_score").read_text(encoding="utf-8")
         )
-    with contextlib.suppress(NoSuchProcess, AccessDenied, ZombieProcess):
+    with contextlib.suppress(
+        NoSuchProcess, AccessDenied, ZombieProcess, ProcessLookupError
+    ):
         for child in process.children(recursive=True):
             with contextlib.suppress(ValueError, FileNotFoundError):
                 oom_score_child = int(


### PR DESCRIPTION
…Error` in `_ert_forward_model_runner/job.py`

**Issue**
Resolves #7930 


**Approach**
Add `ProcessLookupError` to suppress list.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
