### PR TITLE
Plot first observation as default if found

### DIFF
--- a/src/ert/gui/ertwidgets/storage_info_widget.py
+++ b/src/ert/gui/ertwidgets/storage_info_widget.py
@@ -284,6 +284,13 @@ class _EnsembleWidget(QWidget):
 
                 self._observations_tree_widget.sortItems(0, Qt.SortOrder.AscendingOrder)
 
+            for i in range(self._observations_tree_widget.topLevelItemCount()):
+                if self._observations_tree_widget.topLevelItem(i).childCount() > 0:
+                    self._observations_tree_widget.setCurrentItem(
+                        self._observations_tree_widget.topLevelItem(i).child(0)
+                    )
+                    break
+
     @Slot(Ensemble)
     def setEnsemble(self, ensemble: Ensemble) -> None:
         self._ensemble = ensemble


### PR DESCRIPTION
**Issue**
Resolves #7946 

When opening the plotter tab now, the first item is selected by default.

![Screenshot 2024-05-22 at 14 36 13](https://github.com/equinor/ert/assets/114403625/0c031f2f-192a-4428-a7f7-c1db32a3bd4c)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
