### PR TITLE
Allow larger columns for treeview in manage experiments

### DIFF
--- a/src/ert/gui/ertwidgets/storage_widget.py
+++ b/src/ert/gui/ertwidgets/storage_widget.py
@@ -62,8 +62,7 @@ class StorageWidget(QWidget):
         self._notifier = notifier
         self._ert_config = ert_config
         self._ensemble_size = ensemble_size
-        self.setMinimumWidth(450)
-        self.setMaximumWidth(450)
+        self.setMinimumWidth(700)
 
         self._tree_view = QTreeView(self)
         storage_model = StorageModel(self._notifier.storage)
@@ -85,7 +84,8 @@ class StorageWidget(QWidget):
         selection_model = QItemSelectionModel(proxy_model)
         self._tree_view.setSelectionModel(selection_model)
         self._tree_view.selectionModel().currentChanged.connect(self._currentChanged)
-        self._tree_view.setColumnWidth(0, 200)
+        self._tree_view.setColumnWidth(0, 350)
+        self._tree_view.setColumnWidth(1, 150)
 
         self._create_experiment_button = AddWidget(self._addItem)
 


### PR DESCRIPTION
**Issue**
Resolves #7947 

Adjusted limitations on columns and widget width.

![Screenshot 2024-05-22 at 15 29 25](https://github.com/equinor/ert/assets/114403625/7451eda2-c8ec-4e76-a41c-df14b5b88665)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
