### PR TITLE
Fix ensemble selector counting list items wrongly

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -40,12 +40,14 @@ class EnsembleSelectListWidget(QListWidget):
     def __init__(self, ensembles):
         super().__init__()
         self._ensembles = reversed(ensembles)
+        self._ensemble_count = 0
         self.setObjectName("ensemble_selector")
 
         for i, ensemble in enumerate(self._ensembles):
             it = QListWidgetItem(ensemble)
             it.setData(Qt.ItemDataRole.UserRole, i == 0)
             self.addItem(it)
+            self._ensemble_count += 1
 
         self.viewport().setMouseTracking(True)
         self.setDragDropMode(QAbstractItemView.InternalMove)
@@ -58,7 +60,7 @@ class EnsembleSelectListWidget(QListWidget):
     def get_checked_ensemble_plot_names(self) -> List[str]:
         return [
             self.item(index).text()
-            for index in range(self.count())
+            for index in range(self._ensemble_count)
             if self.item(index).data(Qt.ItemDataRole.UserRole)
         ]
 
@@ -76,7 +78,6 @@ class EnsembleSelectListWidget(QListWidget):
     def slot_toggle_plot(self, item: QListWidgetItem):
         count = len(self.get_checked_ensemble_plot_names())
         selected = item.data(Qt.ItemDataRole.UserRole)
-
         if selected and count > self.MINIMUM_SELECTED:
             item.setData(Qt.ItemDataRole.UserRole, False)
         elif not selected and count < self.MAXIMUM_SELECTED:


### PR DESCRIPTION
**Issue**
Resolves #7943

**Approach**
The `QListWidget` internal count increases temporarily when the last item is dragged and dropped underneath itself. This only happens at the bottom for some reason, and when it does, the internal count() function yields off by one.
To avoid using the item-count from the this list, we use the ensemble_count instead, which always has the correct number of items available, and never changes.

Will backport once approved.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
