### PR TITLE
Move get_machine_name to public API

### DIFF
--- a/src/ert/shared/__init__.py
+++ b/src/ert/shared/__init__.py
@@ -7,5 +7,6 @@ except ImportError:
 from ert.shared.hook_implementations.jobs import (
     _resolve_ert_share_path as ert_share_path,
 )
+from ert.shared.port_handler import get_machine_name
 
-__all__ = ["ert_share_path", "__version__"]
+__all__ = ["ert_share_path", "get_machine_name", "__version__"]

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
@@ -1,4 +1,4 @@
-from ert.ensemble_evaluator.config import EvaluatorServerConfig, get_machine_name
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 
 
 def test_load_config(unused_tcp_port):
@@ -35,39 +35,3 @@ def test_load_config(unused_tcp_port):
     assert sock is not None
     assert not sock._closed
     sock.close()
-
-
-def test_that_get_machine_name_is_predictive(mocker):
-    """For ip addresses with multiple PTR records we must ensure
-    that get_machine_name() is predictive to avoid mismatch for SSL certificates.
-
-    The order DNS servers respond to reverse DNS lookups for such hosts is not
-    defined."""
-
-    # GIVEN that reverse DNS resolution results in two names (in random order):
-    ptr_records = ["barfoo01.internaldomain.barf.", "foobar01.equinor.com."]
-
-    # It is important that get_machine_name() is predictive for each
-    # invocation, not how it attains predictiveness. Currently the PTR records
-    # are sorted and the first element is returned, but that should be regarded
-    # as an implementation detail.
-    expected_resolved_name = ptr_records[0].rstrip(".")
-
-    # Avoid possibility of flakyness in code paths not relevant
-    # for this test:
-    mocker.patch("socket.gethostname", return_value=None)
-    mocker.patch("socket.gethostbyname", return_value=None)
-    mocker.patch("dns.reversename.from_address", return_value=None)
-
-    # This call is what this test wants to test:
-    mocker.patch("dns.resolver.resolve", return_value=ptr_records)
-
-    # ASSERT the returned name
-    assert get_machine_name() == expected_resolved_name
-
-    # Shuffle the the list and try again:
-    ptr_records.reverse()
-    mocker.patch("dns.resolver.resolve", return_value=ptr_records)
-
-    # ASSERT that we still get the same name
-    assert get_machine_name() == expected_resolved_name


### PR DESCRIPTION
As this function is used outside of ert, it should not be hidden below ensemble_evalutor.config.

port_handler.py serves as a placeholder for the code, but the function but exposed and should be used as ert.shared.get_machine.name()

**Issue**
Resolves #7888 


**Approach**
🚚 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
