### PR TITLE
Add out-of-memory detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ platforms = ["all"]
 addopts = "-ra --strict-markers"
 markers = [
     "integration_test",
+    "out_of_memory",
     "quick_only",
     "requires_eclipse",
     "requires_lsf",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,6 +255,12 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
     parser.addoption(
+        "--runoom",
+        action="store_true",
+        default=False,
+        help="Run Out-of-memory (OOM) test, ensure you are alone on your machine before running",
+    )
+    parser.addoption(
         "--eclipse-simulator",
         action="store_true",
         default=False,
@@ -344,6 +350,15 @@ def pytest_collection_modifyitems(config, items):
                 "--eclipse-simulator"
             ):
                 item.add_marker(pytest.mark.skip("Requires eclipse"))
+
+    if not config.getoption("--runoom"):
+        skip_oom = pytest.mark.skip(
+            "Skipping out-of-memory (oom) test, add --runoom to "
+            "include. Ensure the test will not affect others"
+        )
+        for item in items:
+            if "out_of_memory" in item.keywords:
+                item.add_marker(skip_oom)
 
 
 def _run_snake_oil(source_root):

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -36,6 +36,45 @@ def test_bad_config_error_message(tmp_path):
         run_cli(TEST_RUN_MODE, "--disable-monitor", str(tmp_path / "test.ert"))
 
 
+@pytest.mark.out_of_memory
+@pytest.mark.timeout(600)
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_oom_kills_are_reported():
+    """This test will do a local test run that will run a job that consumes all
+    memory until it is killed by the operating system. The test will assert
+    that Ert is able to pick up what happen and present the cause (oom-killer)
+    to the user).
+
+    This test is not run by default, but requires --runoom supplied on the
+    command line to pytest, as it will take a long time and make the system
+    partially unresponsive for all logged in users (more swap will make the
+    time of unresponsiveness longer)."""
+
+    print(os.getcwd())
+
+    poly_lines = Path("poly.ert").read_text(encoding="utf-8")
+    poly_lines += "\nINSTALL_JOB memory_hog MEMORY_HOG\nSIMULATION_JOB memory_hog"
+    Path("poly.ert").write_text(poly_lines, encoding="utf-8")
+
+    Path("MEMORY_HOG").write_text("EXECUTABLE memory_hog.sh", encoding="utf-8")
+    Path("memory_hog.sh").write_text(
+        dedent("""#!/bin/sh
+    perl -wE 'my @xs; for (1..2**20) { push @xs, q{a} x 2**20 }; say scalar @xs;'
+    """),
+        encoding="utf-8",
+    )
+    os.chmod("memory_hog.sh", 0o0755)
+    with pytest.raises(
+        ErtCliError,
+        match="Realization.*0 failed.*memory_hog.*was killed due to out-of-memory",
+    ):
+        run_cli(
+            "test_run",
+            "--disable-monitor",
+            "poly.ert",
+        )
+
+
 @pytest.mark.parametrize(
     "mode",
     [


### PR DESCRIPTION
Whenever a realization fails the output of dmesg is checked to see if there are any signs of known pids having been killed by the operating system

**Issue**
Resolves #7797 


**Approach**
Simple string searches in `dmesg` output.

![image](https://github.com/equinor/ert/assets/306834/627270ea-1aaf-433c-98f5-fcb93af7c79e)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
