### PR TITLE
Propagate debug logs from callbacks

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -126,7 +126,7 @@ loggers:
     level: INFO
     propagate: yes
   ert.callbacks:
-    level: INFO
+    level: DEBUG
     propagate: yes
   ert.scheduler:
     level: DEBUG


### PR DESCRIPTION
**Issue**
The log statements in callbacks.py was degraded to debug in a previous PR, but it makes a lot of sense to propagate this to the user log files, as it can often tell them what went wrong.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
