### PR TITLE
Change which lines are ignored in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [report]
-exclude_lines =
-    pragma: no cover
+exclude_also =
+    ; Don't complain about code for type checking only
     if TYPE_CHECKING:
+    ; Don't complain about overload type specifications, they aren't run:
+    @(typing\.)?overload


### PR DESCRIPTION
coverage.py can now be configured with the[ "exclude_also" keyword](https://coverage.readthedocs.io/en/latest/excluding.html) which is a nice simplification.

Since we are changing this anyways, I added two more excluded code blocks:

* abstract methods which should never be executed;
* plugin specifications which also should never be executed.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
