### PR TITLE
Avoid using abspath for commands

### DIFF
--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -129,6 +129,7 @@ class SchemaItem:
             return ContextString(path, token, keyword)
         if val_type == SchemaItemType.EXECUTABLE:
             absolute_path: Optional[str]
+            is_command = False
             if not os.path.isabs(token):
                 # Try relative
                 absolute_path = os.path.abspath(os.path.join(cwd, token))
@@ -136,6 +137,7 @@ class SchemaItem:
                 absolute_path = token
             if not os.path.exists(absolute_path):
                 absolute_path = shutil.which(token)
+                is_command = True
 
             if absolute_path is None:
                 raise ConfigValidationError.with_context(
@@ -157,7 +159,9 @@ class SchemaItem:
                 raise ConfigValidationError.with_context(
                     f"File not executable: {context}", token
                 )
-            return ContextString(absolute_path, token, keyword)
+            return ContextString(
+                str(token) if is_command else absolute_path, token, keyword
+            )
         if isinstance(val_type, SchemaItemType):
             return ContextString(str(token), token, keyword)
         if isinstance(val_type, EnumType):


### PR DESCRIPTION
If the user specifies a command we would like to avoid hardcoding the path to it in case job_dispatch.py runs in a different environment.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
