### PR TITLE
Compare only obs dataset structure

### DIFF
--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -643,9 +643,9 @@ class StatefulStorageTest(RuleBasedStateMachine):
             list(storage_experiment.response_configuration.values())
             == model_experiment.responses
         )
-        assert model_experiment.observations == pytest.approx(
-            storage_experiment.observations
-        )
+
+        for ds_name, ds in model_experiment.observations.items():
+            assert ds.dims == storage_experiment.observations[ds_name].dims
 
     @rule(model_ensemble=ensembles)
     def get_ensemble(self, model_ensemble: Ensemble):


### PR DESCRIPTION
Speeds up slow running, sometimes hanging hypothesis test in `test_local_storage.py`. Note; `dims` holds the dimension names and lengths.

![Screenshot 2024-05-28 at 13 57 32](https://github.com/equinor/ert/assets/11595637/24719556-c2f1-4ac0-819e-3dbb88525d31)
