### PR TITLE
Backports to ert==10.1

### DIFF
--- a/src/ert/ensemble_evaluator/_builder/_legacy.py
+++ b/src/ert/ensemble_evaluator/_builder/_legacy.py
@@ -204,7 +204,9 @@ class LegacyEnsemble(Ensemble):
                     ee_cert=self._config.cert,
                     ee_token=self._config.token,
                 )
-                scheduler_logger.info("Experiment ran on ORCHESTRATOR: scheduler")
+                scheduler_logger.info(
+                    f"Experiment ran on ORCHESTRATOR: scheduler on {self._queue_config.queue_system} queue"
+                )
             else:
                 queue = JobQueue(
                     self._queue_config,
@@ -215,7 +217,9 @@ class LegacyEnsemble(Ensemble):
                     ee_token=self._config.token,
                     on_timeout=on_timeout,
                 )
-                scheduler_logger.info("Experiment ran on ORCHESTRATOR: job_queue")
+                scheduler_logger.info(
+                    f"Experiment ran on ORCHESTRATOR: job_queue on {self._queue_config.queue_system}"
+                )
             self._job_queue = queue
 
             await cloudevent_unary_send(

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -491,8 +491,8 @@ class BaseRunModel:
             event_logger.debug("connecting to new monitor...")
             async with Monitor(ee_config.get_connection_info()) as monitor:
                 event_logger.debug("connected")
-                async for event in monitor.track():
-                    if event["type"] in (
+                async for event in monitor.track(heartbeat_interval=0.1):
+                    if event is not None and event["type"] in (
                         EVTYPE_EE_SNAPSHOT,
                         EVTYPE_EE_SNAPSHOT_UPDATE,
                     ):
@@ -512,7 +512,7 @@ class BaseRunModel:
                             )
                             # Allow track() to emit an EndEvent.
                             return False
-                    elif event["type"] == EVTYPE_EE_TERMINATED:
+                    elif event is not None and event["type"] == EVTYPE_EE_TERMINATED:
                         event_logger.debug("got terminator event")
 
                     if not self._end_queue.empty():

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -18,6 +18,7 @@ class Driver(ABC):
 
     def __init__(self, **kwargs: Dict[str, str]) -> None:
         self._event_queue: Optional[asyncio.Queue[Event]] = None
+        self._job_error_message_by_iens: Dict[int, str] = {}
 
     @property
     def event_queue(self) -> asyncio.Queue[Event]:
@@ -60,6 +61,12 @@ class Driver(ABC):
     @abstractmethod
     async def finish(self) -> None:
         """make sure that all the jobs / realizations are complete."""
+
+    def read_stdout_and_stderr_files(
+        self, runpath: str, job_name: str, num_characters_to_read_from_end: int = 300
+    ) -> str:
+        """Each driver should provide some output in case of failure."""
+        return ""
 
     @staticmethod
     async def _execute_with_retry(

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -187,6 +187,13 @@ class Job:
             f"\n\t{self._callback_status_msg}"
         )
 
+        if msg := self.driver._job_error_message_by_iens.get(self.iens, ""):
+            error_msg += f"\nDriver reported: {msg}"
+
+        error_msg += self.driver.read_stdout_and_stderr_files(
+            self.real.run_arg.runpath, self.real.run_arg.job_name
+        )
+
         self.real.run_arg.ensemble_storage.set_failure(
             self.real.run_arg.iens, RealizationStorageState.LOAD_FAILURE, error_msg
         )

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -70,7 +70,9 @@ class LocalDriver(Driver):
         except FileNotFoundError as err:
             # /bin/sh uses returncode 127 for FileNotFound, so copy that
             # behaviour.
-            logger.error(f"Realization {iens} failed with {err}")
+            msg = f"Realization {iens} failed with {err}"
+            logger.error(msg)
+            self._job_error_message_by_iens[iens] = msg
             await self._dispatch_finished_event(iens, 127)
             return
 

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -255,6 +255,7 @@ class LsfDriver(Driver):
             [str(self._bsub_cmd)]
             + arg_queue_name
             + ["-o", str(runpath / (name + ".LSF-stdout"))]
+            + ["-e", str(runpath / (name + ".LSF-stderr"))]
             + self._build_resource_requirement_arg()
             + ["-J", name, str(script_path), str(runpath)]
         )

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -211,6 +211,7 @@ class OpenPBSDriver(Driver):
             driverlogger=logger,
         )
         if not process_success:
+            self._job_error_message_by_iens[iens] = process_message
             raise RuntimeError(process_message)
 
         job_id_ = process_message

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,11 +3,14 @@ set -e
 
 name="STDIN"
 
-while getopts "o:J:q:R:" opt
+while getopts "o:e:J:q:R:" opt
 do
     case "$opt" in
         o)
             stdout=$OPTARG
+            ;;
+        e)
+            stderr=$OPTARG
             ;;
         J)
             name=$OPTARG
@@ -34,8 +37,9 @@ echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
 
 [ -z $stdout] && stdout="/dev/null"
+[ -z $stderr] && stderr="/dev/null"
 
-bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>/dev/null &
+bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>$stderr &
 disown
 
 echo "Job <$jobid> is submitted to default queue <normal>."

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -23,3 +23,5 @@ echo "Subject: Job $job:"
 echo "[..skipped in mock..]"
 echo "The output (if any) follows:"
 cat ${job}.stdout
+
+cat ${job}.stderr >&2

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -92,15 +92,11 @@ async def test_lsf_can_retrieve_stdout_and_stderr(
         num_characters_to_read_from_end=tail_chars_to_read,
     )
 
-    if tail_chars_to_read > num_written_characters:
-        assert f"LSF-stderr:\n{_err}" in message
-        # we get some extra echos after LSF-out
-        assert f"{_out}" in message
-    else:
-        assert f"LSF-stderr:\n{_err}" not in message
-        assert f"LSF-stderr:\n{_err[-tail_chars_to_read+1:]}" in message
-        assert f"LSF-stdout:\n{_out}" not in message
-        assert f"LSF-stdout:\n{_out[-tail_chars_to_read+1:]}" in message
+    stderr_txt = Path(f"{job_name}.LSF-stderr").read_text(encoding="utf-8").strip()
+    stdout_txt = Path(f"{job_name}.LSF-stdout").read_text(encoding="utf-8").strip()
+
+    assert stderr_txt[-min(tail_chars_to_read, num_written_characters) + 1 :] in message
+    assert stdout_txt[-min(tail_chars_to_read, num_written_characters) + 1 :] in message
 
 
 async def test_lsf_cannot_retrieve_stdout_and_stderr(tmp_path, job_name):

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -109,6 +109,12 @@ async def test_job_run_sends_expected_events(
         lambda _: LoadResult(forward_model_ok_result, ""),
     )
     scheduler = create_scheduler()
+    monkeypatch.setattr(
+        scheduler.driver,
+        "read_stdout_and_stderr_files",
+        lambda *args: "",
+    )
+
     scheduler.job.forward_model_ok = MagicMock()
     scheduler.job.forward_model_ok.return_value = LoadResult(
         forward_model_ok_result, ""

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -187,6 +187,16 @@ async def test_submit_sets_stdout():
 
 
 @pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_sets_stderr():
+    driver = LsfDriver()
+    await driver.submit(0, "sleep", name="myjobname")
+    expected_stdout_file = Path(os.getcwd()) / "myjobname.LSF-stderr"
+    assert f"-e {expected_stdout_file}" in Path("captured_bsub_args").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_with_resource_requirement():
     driver = LsfDriver(resource_requirement="select[cs && x86_64Linux]")
     await driver.submit(0, "sleep")


### PR DESCRIPTION
**Issue**
The main reason of the backport is to provide more logging for users when using the LSF queue system.
This includes the following commits:
11196173684c072e31437f50f0df614869721f4c
0a55f0a194b6f3cf1aa1de46ffe6ca8bfc5167d2
9f9307b7eec9e7db8ed38218c37aad6570ab097f
59d9933a856f2f9a921e66c139667d429833d151
13975dbbc479a02262262c97cf3e4a8898e96958


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
