### PR TITLE
Raise error if no gen kws specified

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -385,6 +385,12 @@ class ErtConfig:
     ) -> List[Union[ErrorInfo, ConfigValidationError]]:
         errors = []
 
+        gen_kws = config_dict.get("GEN_KW", [])
+        for gen_kw in gen_kws:
+            file_path = Path(gen_kw[1])
+            if file_path.stat().st_size == 0:
+                raise ConfigValidationError(f"No parameters specified in {file_path}")
+
         if ConfigKeys.SUMMARY in config_dict and ConfigKeys.ECLBASE not in config_dict:
             errors.append(
                 ErrorInfo(

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -1613,3 +1613,21 @@ def test_using_relative_path_to_eclbase_sets_jobname_to_basename(tmp_path):
         ErtConfig.from_file(str(config_file)).model_config.jobname_format_string
         == "eclbase_<IENS>"
     )
+
+
+def test_that_empty_params_file_gives_reasonable_error(tmpdir):
+    with tmpdir.as_cwd():
+        config = """
+        NUM_REALIZATIONS 1
+        GEN_KW COEFFS coeffs_priors
+        """
+
+        with open("config.ert", mode="w", encoding="utf-8") as fh:
+            fh.writelines(config)
+
+        # Create an empty file named 'coeffs_priors'
+        with open("coeffs_priors", mode="w", encoding="utf-8") as fh:
+            pass
+
+        with pytest.raises(ConfigValidationError, match="No parameters specified in"):
+            ErtConfig.from_file("config.ert")

--- a/tests/unit_tests/config/test_gen_kw_config.py
+++ b/tests/unit_tests/config/test_gen_kw_config.py
@@ -494,12 +494,12 @@ def test_gen_kw_objects_equal(tmpdir):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_pred_special_suggested_removal():
-    with open("empty_file.txt", "a", encoding="utf-8") as f:
-        f.write("")
+    with open("coeff_priors.txt", "a", encoding="utf-8") as f:
+        f.write("a NORMAL 0 1")
     with open("config.ert", "a", encoding="utf-8") as f:
         f.write(
             "NUM_REALIZATIONS 1\n"
-            "GEN_KW PRED empty_file.txt empty_file.txt empty_file.txt\n"
+            "GEN_KW PRED coeff_priors.txt coeff_priors.txt coeff_priors.txt\n"
         )
     with pytest.warns(
         ConfigWarning,


### PR DESCRIPTION
**Issue**
Resolves #7937 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
