### PR TITLE
Backport comments fix in gen_kw_config to 10.1

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -132,7 +132,7 @@ class GenKwConfig(ParameterConfig):
         transfer_function_definitions: List[str] = []
         with open(parameter_file, "r", encoding="utf-8") as file:
             for item in file:
-                item = item.rsplit("--")[0]  # remove comments
+                item = item.split("--")[0]  # remove comments
                 if item.strip():  # only lines with content
                     transfer_function_definitions.append(item)
 

--- a/tests/unit_tests/config/test_gen_kw_config.py
+++ b/tests/unit_tests/config/test_gen_kw_config.py
@@ -497,6 +497,8 @@ def test_gen_kw_config_validation():
         f.write("\n\n")  # Two blank lines
         f.write("KEY2  UNIFORM 0 1\n")
         f.write("--KEY3  \n")
+        f.write("---KEY3  \n")
+        f.write("------------  \n")
         f.write("KEY3  UNIFORM 0 1\n")
 
     EnsembleConfig.from_dict(


### PR DESCRIPTION
Backport of minor fix to comments in gen_kw_config


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
