### PR TITLE
Remove extra character from the output message

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -95,8 +95,8 @@ async def test_lsf_can_retrieve_stdout_and_stderr(
     stderr_txt = Path(f"{job_name}.LSF-stderr").read_text(encoding="utf-8").strip()
     stdout_txt = Path(f"{job_name}.LSF-stdout").read_text(encoding="utf-8").strip()
 
-    assert stderr_txt[-min(tail_chars_to_read, num_written_characters) + 1 :] in message
-    assert stdout_txt[-min(tail_chars_to_read, num_written_characters) + 1 :] in message
+    assert stderr_txt[-min(tail_chars_to_read, num_written_characters) + 2 :] in message
+    assert stdout_txt[-min(tail_chars_to_read, num_written_characters) + 2 :] in message
 
 
 async def test_lsf_cannot_retrieve_stdout_and_stderr(tmp_path, job_name):


### PR DESCRIPTION
**Issue**
Apparently, there is an extra character produced by LSF server added to stdout and therefore we need to shift the expected output by 1.


**Approach**
+1 -> +2

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
