### PR TITLE
Ensure group is escaped in glob

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import glob
 import json
 import logging
 import os
@@ -699,7 +700,9 @@ class LocalEnsemble(BaseMode):
                     return xr.combine_nested(
                         [
                             xr.open_dataset(p)
-                            for p in self._path.glob(f"realization-*/{group}.nc")
+                            for p in self._path.glob(
+                                f"realization-*/{glob.escape(group)}.nc"
+                            )
                         ],
                         concat_dim="realizations",
                     )
@@ -1262,7 +1265,9 @@ class LocalEnsemble(BaseMode):
             combined_ds_path = self._path / f"{group}.nc"
             has_existing_combined = os.path.exists(combined_ds_path)
 
-            paths = sorted(self.mount_point.glob(f"realization-*/{group}.nc"))
+            paths = sorted(
+                self.mount_point.glob(f"realization-*/{glob.escape(group)}.nc")
+            )
 
             if len(paths) > 0:
                 new_combined = xr.combine_nested(
@@ -1317,7 +1322,9 @@ class LocalEnsemble(BaseMode):
             files_to_remove = []
             to_concat = []
             for group in gen_data_keys:
-                paths = sorted(self.mount_point.glob(f"realization-*/{group}.nc"))
+                paths = sorted(
+                    self.mount_point.glob(f"realization-*/{glob.escape(group)}.nc")
+                )
 
                 if len(paths) > 0:
                     ds_for_group = xr.concat(

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -15,6 +15,7 @@ import xarray as xr
 from hypothesis import assume
 from hypothesis.extra.numpy import arrays
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule
+from xarray.testing import assert_allclose
 
 from ert.config import (
     Field,
@@ -402,7 +403,6 @@ observations = st.builds(
                 min_size=1,
             ),
         ),
-        max_size=3,
     ).filter(_ensure_unique_obs_names),
 )
 
@@ -644,9 +644,9 @@ class StatefulStorageTest(RuleBasedStateMachine):
             list(storage_experiment.response_configuration.values())
             == model_experiment.responses
         )
-        assert model_experiment.observations == pytest.approx(
-            storage_experiment.observations
-        )
+        for obskey, obs in model_experiment.observations.items():
+            assert obskey in storage_experiment.observations
+            assert_allclose(obs, storage_experiment.observations[obskey])
 
     @rule(model_ensemble=ensembles)
     def get_ensemble(self, model_ensemble: Ensemble):


### PR DESCRIPTION
Fixes an issue where glob was not escaped in storage. Also, increases the size of test data generation in `test_local_storage.py` reverting the change made in https://github.com/equinor/ert/commit/58fa26453a3149b0cfe607700d02d333768cb1aa

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
