### PR TITLE
Initialize ensemble config last

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -194,11 +194,6 @@ class ErtConfig:
         if errors:
             raise ConfigValidationError.from_collected(errors)
 
-        try:
-            ensemble_config = EnsembleConfig.from_dict(config_dict=config_dict)
-        except ConfigValidationError as err:
-            errors.append(err)
-
         workflow_jobs = {}
         workflows = {}
         hooked_workflows = {}
@@ -241,6 +236,11 @@ class ErtConfig:
 
         try:
             analysis_config = AnalysisConfig.from_dict(config_dict)
+        except ConfigValidationError as err:
+            errors.append(err)
+
+        try:
+            ensemble_config = EnsembleConfig.from_dict(config_dict=config_dict)
         except ConfigValidationError as err:
             errors.append(err)
 


### PR DESCRIPTION
**Issue**
Small change towards https://github.com/equinor/ert/issues/8034 , `EnsembleConfig` has some dependencies on `ModelConfig` and others, moving its initialization to be after the others opens up for it to require elements from preceding configs without introducing a circular dependency between the things
