### PR TITLE
Fix copyablelabel not crashing when there is no clipboard

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -2,13 +2,20 @@ from os import path
 
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
+from qtpy.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+)
 
 # Get the absolute path of the directory that contains the current script
 current_dir = path.dirname(path.abspath(__file__))
 
 
-def escape_string(string):
+def escape_string(string: str) -> str:
     """
     Designed to replace/escape invalid html characters for
     correct display in Qt QWidgets
@@ -22,7 +29,7 @@ def escape_string(string):
     return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def unescape_string(string):
+def unescape_string(string: str) -> str:
     """
     Designed to transform an escaped string within a Qt widget
     into an unescaped string.
@@ -60,18 +67,18 @@ class CopyableLabel(QHBoxLayout):
     """CopyableLabel shows a string that is copyable via
     selection or clicking of a copy button"""
 
-    def __init__(self, text) -> None:
+    def __init__(self, text: str) -> None:
         super().__init__()
 
         self.label = QLabel(f"<b>{escape_string(text)}</b>")
-        self.label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         self.copy_button = QPushButton("")
         self.copy_button.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
         self.copy_button.setIcon(QIcon("img:copy.svg"))
         self.restore_timer = QTimer(self)
 
-        def restore_text():
+        def restore_text() -> None:
             self.copy_button.setIcon(QIcon("img:copy.svg"))
 
         self.restore_timer.timeout.connect(restore_text)
@@ -79,7 +86,17 @@ class CopyableLabel(QHBoxLayout):
         def copy_text() -> None:
             text = strip_run_path_magic_keywords(unescape_string(self.label.text()))
 
-            QApplication.clipboard().setText(text)
+            clipboard = QApplication.clipboard()
+            if clipboard:
+                clipboard.setText(text)
+            else:
+                QMessageBox.critical(
+                    None,
+                    "Error",
+                    "Cannot copy text to clipboard because your system does not have a clipboard",
+                    QMessageBox.Ok,
+                )
+
             self.copy_button.setIcon(QIcon("img:check.svg"))
 
             self.restore_timer.start(1000)
@@ -87,4 +104,4 @@ class CopyableLabel(QHBoxLayout):
         self.copy_button.clicked.connect(copy_text)
 
         self.addWidget(self.label)
-        self.addWidget(self.copy_button, alignment=Qt.AlignLeft)
+        self.addWidget(self.copy_button, alignment=Qt.AlignmentFlag.AlignLeft)


### PR DESCRIPTION
Some nonstandard graphical systems and many non-graphical systems may not have a clipboard causing QApplication.clipboard() to return None

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
