### PR TITLE
Remove unneeded lsf_server checks in queue_config

### DIFF
--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -92,7 +92,7 @@ def test_that_invalid_memory_pr_job_raises_validation_error(memory_with_unit_str
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "queue_system, queue_system_option",
-    [("LSF", "LSF_SERVER"), ("SLURM", "SQUEUE"), ("TORQUE", "QUEUE")],
+    [("LSF", "LSF_QUEUE"), ("SLURM", "SQUEUE"), ("TORQUE", "QUEUE")],
 )
 def test_that_overwriting_QUEUE_OPTIONS_warns(
     tmp_path, monkeypatch, queue_system, queue_system_option, caplog
@@ -123,30 +123,10 @@ def test_that_overwriting_QUEUE_OPTIONS_warns(
     ) not in caplog.text
 
 
-@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
-def test_undefined_LSF_SERVER_environment_variable_raises_validation_error():
-    filename = "config.ert"
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1\n")
-        f.write("QUEUE_SYSTEM LSF\n")
-        f.write("QUEUE_OPTION LSF LSF_SERVER $MY_SERVER\n")
-    with pytest.raises(
-        ConfigValidationError,
-        match=(
-            r"Invalid server name specified for QUEUE_OPTION LSF LSF_SERVER: "
-            r"\$MY_SERVER. Server name is currently an undefined environment variable."
-            r" The LSF_SERVER keyword is usually provided by the site-configuration"
-            r" file, beware that you are effectively replacing the default value"
-            r" provided."
-        ),
-    ):
-        ErtConfig.from_file(filename)
-
-
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "queue_system, queue_system_option",
-    [("LSF", "LSF_SERVER"), ("SLURM", "SQUEUE")],
+    [("LSF", "LSF_QUEUE"), ("SLURM", "SQUEUE")],
 )
 def test_initializing_empty_config_queue_options_resets_to_default_value(
     queue_system, queue_system_option


### PR DESCRIPTION
Removes the check for some earlier behavior regarding lsf server.



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
