### PR TITLE
New LSF driver should allocate correct number of cpus

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -33,6 +33,7 @@ class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
     max_submit: int = 2
     submit_sleep: float = 0.0
+    num_cpu: int = 1
     queue_system: QueueSystem = QueueSystem.LOCAL
     queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = field(
         default_factory=dict
@@ -50,6 +51,7 @@ class QueueConfig:
         job_script = job_script or "job_dispatch.py"
         max_submit: int = config_dict.get("MAX_SUBMIT", 2)
         submit_sleep: float = config_dict.get("SUBMIT_SLEEP", 0.0)
+        num_cpu: int = config_dict.get("NUM_CPU", 1)
         queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = defaultdict(list)
         for queue_system, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             if option_name not in VALID_QUEUE_OPTIONS[queue_system]:
@@ -98,7 +100,12 @@ class QueueConfig:
                 queue_options[selected_queue_system],
             )
         return QueueConfig(
-            job_script, max_submit, submit_sleep, selected_queue_system, queue_options
+            job_script,
+            max_submit,
+            submit_sleep,
+            num_cpu,
+            selected_queue_system,
+            queue_options,
         )
 
     def create_local_copy(self) -> QueueConfig:
@@ -106,6 +113,7 @@ class QueueConfig:
             self.job_script,
             self.max_submit,
             self.submit_sleep,
+            self.num_cpu,
             QueueSystem.LOCAL,
             self.queue_options,
         )

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -44,6 +44,7 @@ def create_driver(config: QueueConfig) -> Driver:
             bhist_cmd=queue_config.get("BHIST_CMD"),
             exclude_hosts=queue_config.get("EXCLUDE_HOST"),
             queue_name=queue_config.get("LSF_QUEUE"),
+            num_cpu=config.num_cpu,
             resource_requirement=queue_config.get("LSF_RESOURCE"),
         )
     else:

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -186,6 +186,7 @@ class LsfDriver(Driver):
         self,
         queue_name: Optional[str] = None,
         resource_requirement: Optional[str] = None,
+        num_cpu: int = 1,
         exclude_hosts: Optional[str] = None,
         bsub_cmd: Optional[str] = None,
         bjobs_cmd: Optional[str] = None,
@@ -193,9 +194,9 @@ class LsfDriver(Driver):
         bhist_cmd: Optional[str] = None,
     ) -> None:
         super().__init__()
-
         self._queue_name = queue_name
         self._resource_requirement = resource_requirement
+        self._num_cpu = num_cpu
         self._exclude_hosts = [
             host.strip() for host in (exclude_hosts.split(",") if exclude_hosts else [])
         ]
@@ -256,6 +257,7 @@ class LsfDriver(Driver):
             + arg_queue_name
             + ["-o", str(runpath / (name + ".LSF-stdout"))]
             + ["-e", str(runpath / (name + ".LSF-stderr"))]
+            + ["-n", str(self._num_cpu)]
             + self._build_resource_requirement_arg()
             + ["-J", name, str(script_path), str(runpath)]
         )

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -3,7 +3,7 @@ set -e
 
 name="STDIN"
 
-while getopts "o:e:J:q:R:" opt
+while getopts "o:e:J:q:R:n:" opt
 do
     case "$opt" in
         o)
@@ -17,6 +17,8 @@ do
             ;;
         q)
             queue=$OPTARG
+            ;;
+        n)
             ;;
         R)
             resource_requirement=$OPTARG

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -206,6 +206,13 @@ async def test_submit_with_resource_requirement():
     assert "hname" not in Path("captured_bsub_args").read_text(encoding="utf-8")
 
 
+@pytest.mark.usefixtures("capturing_bsub")
+async def test_submit_with_num_cpu():
+    driver = LsfDriver(num_cpu=4)
+    await driver.submit(0, "sleep")
+    assert "-n 4" in Path("captured_bsub_args").read_text(encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     "bsub_script, expectation",
     [


### PR DESCRIPTION
This backports support for NUM_CPU into Scheduler/LSFDriver

The corresponding commit.

9e4c1448fca5a150811d460af11f0ccafd774dab
