### PR TITLE
Get lsf jobid at the right time

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -178,9 +178,9 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
     num_cpu = 2
     driver = LsfDriver(num_cpu=num_cpu)
     await driver.submit(0, "sh", "-c", "echo test>test", name=job_name)
+    job_id = driver._iens2jobid[0]
     await poll(driver, {0})
 
-    job_id = driver._iens2jobid[0]
     process = await asyncio.create_subprocess_exec(
         "bhist",
         job_id,


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8067


**Approach**
Move the fetch code for jobid directly after driver.submit.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
