### PR TITLE
Make sure to log Realization status after completed run as info

### DIFF
--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -81,7 +81,7 @@ class LocalDriver(Driver):
         returncode = 0
         try:
             returncode = await self._wait(proc)
-            logger.debug(f"Realization {iens} finished with {returncode=}")
+            logger.info(f"Realization {iens} finished with {returncode=}")
         except asyncio.CancelledError:
             returncode = await self._kill(proc)
         finally:

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -399,14 +399,12 @@ class LsfDriver(Driver):
             logger.debug(f"Realization {iens} is running")
             event = StartedEvent(iens=iens)
         elif isinstance(new_state, FinishedJobFailure):
-            logger.debug(
-                f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) failed"
-            )
+            logger.info(f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) failed")
             exit_code = await self._get_exit_code(job_id)
             event = FinishedEvent(iens=iens, returncode=exit_code)
 
         elif isinstance(new_state, FinishedJobSuccess):
-            logger.debug(
+            logger.info(
                 f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) succeeded"
             )
             event = FinishedEvent(iens=iens, returncode=0)

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -290,7 +290,7 @@ class LsfDriver(Driver):
 
     async def kill(self, iens: int) -> None:
         if iens not in self._iens2jobid:
-            logger.error(f"LSF kill failed due to missing jobid for realization {iens}")
+            logger.info(f"LSF kill failed due to missing jobid for realization {iens}")
             return
 
         job_id = self._iens2jobid[iens]

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -225,7 +225,7 @@ class OpenPBSDriver(Driver):
             return
 
         if iens not in self._iens2jobid:
-            logger.error(f"PBS kill failed due to missing jobid for realization {iens}")
+            logger.info(f"PBS kill failed due to missing jobid for realization {iens}")
             return
 
         job_id = self._iens2jobid[iens]

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -330,11 +330,11 @@ class OpenPBSDriver(Driver):
             )
 
             if new_state.returncode != 0:
-                logger.debug(
+                logger.info(
                     f"Realization {iens} (PBS-id: {self._iens2jobid[iens]}) failed"
                 )
             else:
-                logger.debug(
+                logger.info(
                     f"Realization {iens} (PBS-id: {self._iens2jobid[iens]}) succeeded"
                 )
             self._finished_iens.add(iens)

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import stat
 import time
@@ -370,6 +371,7 @@ async def test_kill(
     expected_logged_error,
     caplog,
 ):
+    caplog.set_level(logging.INFO)
     monkeypatch.chdir(tmp_path)
     bin_path = Path("bin")
     bin_path.mkdir()


### PR DESCRIPTION
**Issue**
Resolves #8071 


**Approach**
Use logger.info to get the state into fmu-logs

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
