### PR TITLE
Add positive_int validation schema for NUM_CPU and MAX_SUBMIT

### DIFF
--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -7,6 +7,7 @@ from .config_schema_item import (
     float_keyword,
     int_keyword,
     path_keyword,
+    positive_int_keyword,
     single_arg_keyword,
     string_keyword,
 )
@@ -278,8 +279,8 @@ class ConfigSchemaDict(SchemaItemDict):
 def init_site_config_schema() -> ConfigSchemaDict:
     schema = ConfigSchemaDict()
     for item in [
-        int_keyword(ConfigKeys.MAX_SUBMIT),
-        int_keyword(ConfigKeys.NUM_CPU),
+        positive_int_keyword(ConfigKeys.MAX_SUBMIT),
+        positive_int_keyword(ConfigKeys.NUM_CPU),
         queue_system_keyword(True),
         queue_option_keyword(),
         job_script_keyword(),
@@ -342,8 +343,8 @@ def init_user_config_schema() -> ConfigSchemaDict:
         single_arg_keyword(ConfigKeys.GEN_KW_EXPORT_NAME),
         history_source_keyword(),
         path_keyword(ConfigKeys.RUNPATH_FILE),
-        int_keyword(ConfigKeys.MAX_SUBMIT),
-        int_keyword(ConfigKeys.NUM_CPU),
+        positive_int_keyword(ConfigKeys.MAX_SUBMIT),
+        positive_int_keyword(ConfigKeys.NUM_CPU),
         queue_system_keyword(False),
         queue_option_keyword(),
         job_script_keyword(),

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -92,6 +92,21 @@ class SchemaItem:
                     f"{self.kw!r} must have a boolean value as argument {index + 1!r}",
                     token,
                 )
+        if val_type == SchemaItemType.POSITIVE_INT:
+            try:
+                val = int(token)
+            except ValueError as e:
+                raise ConfigValidationError.with_context(
+                    f"{self.kw!r} must have an integer value as argument {index + 1!r}",
+                    token,
+                ) from e
+            if val > 0:
+                return ContextInt(val, token, keyword)
+            else:
+                raise ConfigValidationError.with_context(
+                    f"{self.kw!r} must have a positive integer value as argument {index + 1!r}",
+                    token,
+                )
         if val_type == SchemaItemType.INT:
             try:
                 return ContextInt(int(token), token, keyword)
@@ -242,6 +257,10 @@ def float_keyword(keyword: str) -> SchemaItem:
 
 def int_keyword(keyword: str) -> SchemaItem:
     return SchemaItem(kw=keyword, type_map=[SchemaItemType.INT])
+
+
+def positive_int_keyword(keyword: str) -> SchemaItem:
+    return SchemaItem(kw=keyword, type_map=[SchemaItemType.POSITIVE_INT])
 
 
 def string_keyword(keyword: str) -> SchemaItem:

--- a/src/ert/config/parsing/schema_item_type.py
+++ b/src/ert/config/parsing/schema_item_type.py
@@ -4,6 +4,7 @@ from ert.enum_shim import StrEnum
 class SchemaItemType(StrEnum):
     STRING = "STRING"
     INT = "INT"
+    POSITIVE_INT = "POSITIVE_INT"
     FLOAT = "FLOAT"
     PATH = "PATH"
     EXISTING_PATH = "EXISTING_PATH"

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -104,6 +104,10 @@ class Scheduler:
         self.completed_jobs: asyncio.Queue[int] = asyncio.Queue()
 
         self._cancelled = False
+        if max_submit < 0:
+            raise ValueError(
+                "max_submit needs to be a positive number. The zero value can be used internally for testing purposes only!"
+            )
         self._max_submit = max_submit
         self._max_running = max_running
 

--- a/tests/unit_tests/config/test_num_cpu.py
+++ b/tests/unit_tests/config/test_num_cpu.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from ert.config import ErtConfig
+from ert.config import ConfigValidationError, ErtConfig
 from ert.config.parsing import ConfigKeys
 
 
@@ -55,3 +55,20 @@ PARALLEL
     }
     ert_config = ErtConfig.from_dict(config_dict)
     assert ert_config.preferred_num_cpu == data_file_num_cpu
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "num_cpu_value, error_msg",
+    [
+        (-1, "must have a positive integer value as argument"),
+        (0, "must have a positive integer value as argument"),
+        (1.5, "must have an integer value as argument"),
+    ],
+)
+def test_wrong_num_cpu_raises_validation_error(num_cpu_value, error_msg):
+    with open("file.ert", mode="w", encoding="utf-8") as f:
+        f.write(f"{ConfigKeys.NUM_REALIZATIONS} 1\n")
+        f.write(f"{ConfigKeys.NUM_CPU} {num_cpu_value}\n")
+    with pytest.raises(ConfigValidationError, match=error_msg):
+        ErtConfig.from_file("file.ert")

--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -272,3 +272,20 @@ def test_multiple_max_submit_keywords(tmp_path):
     config_path.write_text("NUM_REALIZATIONS 1\nMAX_SUBMIT 10\nMAX_SUBMIT 42\n")
     config = ErtConfig.from_file(config_path)
     assert config.queue_config.max_submit == 42
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "max_submit_value, error_msg",
+    [
+        (-1, "must have a positive integer value as argument"),
+        (0, "must have a positive integer value as argument"),
+        (1.5, "must have an integer value as argument"),
+    ],
+)
+def test_wrong_max_submit_raises_validation_error(max_submit_value, error_msg):
+    with open("file.ert", mode="w", encoding="utf-8") as f:
+        f.write("NUM_REALIZATIONS 1\n")
+        f.write(f"MAX_SUBMIT {max_submit_value}\n")
+    with pytest.raises(ConfigValidationError, match=error_msg):
+        ErtConfig.from_file("file.ert")


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/7294
Resolves https://github.com/equinor/ert/issues/8078


**Approach**
Implement positive_int validation

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
