### PR TITLE
Retry bsub when output is empty

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -264,6 +264,7 @@ class LsfDriver(Driver):
         logger.debug(f"Submitting to LSF with command {shlex.join(bsub_with_args)}")
         process_success, process_message = await self._execute_with_retry(
             bsub_with_args,
+            retry_on_empty_stdout=True,
             retry_codes=(FLAKY_SSH_RETURNCODE,),
             retries=self._bsub_retries,
             retry_interval=self._sleep_time_between_cmd_retries,

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -552,6 +552,7 @@ async def test_that_bsub_will_retry_and_fail(
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [
+        (0, "void"),
         (FLAKY_SSH_RETURNCODE, ""),
     ],
 )


### PR DESCRIPTION
Exit code 0 and empty bsub is proven to happen in the wild. Assume it is a retriable error condition. Log the occurence as a warning and then retry.

**Issue**
Resolves #8089 


**Approach**
Log and retry


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
