### PR TITLE
Revert "Enable Scheduler for LSF Queue by default"

### DIFF
--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class FeatureScheduler:
     _DEFAULTS = {
         "LOCAL": True,
-        "LSF": True,
+        "LSF": False,
         "SLURM": False,
         "TORQUE": True,
     }

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -180,7 +180,6 @@ def test_run_mocked_lsf_queue():
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--disable-monitor",
-        "--disable-scheduler",
         "poly.ert",
     )
     log = Path("bsub_log").read_text(encoding="utf-8")


### PR DESCRIPTION
This reverts commit 2e48eeead5d321a50c5dd188e6fcd9bb3d4c511c.

**Issue**
After the several experiments, Scheduler is still WIP and thus we need to revert enabling it by default.