### PR TITLE
Let LSFDriver pick num_cpu from the realization object

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -48,7 +48,6 @@ class QueueConfig:
     job_script: str = shutil.which("job_dispatch.py") or "job_dispatch.py"
     max_submit: int = 1
     submit_sleep: float = 0.0
-    num_cpu: int = 1
     queue_system: QueueSystem = QueueSystem.LOCAL
     queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = field(
         default_factory=dict
@@ -66,7 +65,6 @@ class QueueConfig:
         job_script = job_script or "job_dispatch.py"
         max_submit: int = config_dict.get("MAX_SUBMIT", 1)
         submit_sleep: float = config_dict.get("SUBMIT_SLEEP", 0.0)
-        num_cpu: int = config_dict.get("NUM_CPU", 1)
         queue_options: Dict[QueueSystem, List[Tuple[str, str]]] = defaultdict(list)
         for queue_system, option_name, *values in config_dict.get("QUEUE_OPTION", []):
             if option_name not in VALID_QUEUE_OPTIONS[queue_system]:
@@ -110,7 +108,6 @@ class QueueConfig:
             job_script,
             max_submit,
             submit_sleep,
-            num_cpu,
             selected_queue_system,
             queue_options,
         )
@@ -120,7 +117,6 @@ class QueueConfig:
             self.job_script,
             self.max_submit,
             self.submit_sleep,
-            self.num_cpu,
             QueueSystem.LOCAL,
             self.queue_options,
         )

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -44,7 +44,6 @@ def create_driver(config: QueueConfig) -> Driver:
             bhist_cmd=queue_config.get("BHIST_CMD"),
             exclude_hosts=queue_config.get("EXCLUDE_HOST"),
             queue_name=queue_config.get("LSF_QUEUE"),
-            num_cpu=config.num_cpu,
             resource_requirement=queue_config.get("LSF_RESOURCE"),
         )
     else:

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -35,6 +35,7 @@ class Driver(ABC):
         *args: str,
         name: str = "dummy",
         runpath: Optional[Path] = None,
+        num_cpu: Optional[int] = 1,
     ) -> None:
         """Submit a program to execute on the cluster.
 
@@ -44,6 +45,7 @@ class Driver(ABC):
           args: List of arguments to send to the program.
           cwd: Working directory.
           name: Name of job as submitted to compute cluster
+          num_cpu: Number of CPU-cores to allocate
         """
 
     @abstractmethod

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -100,6 +100,7 @@ class Job:
                 self.real.iens,
                 self.real.job_script,
                 self.real.run_arg.runpath,
+                num_cpu=self.real.num_cpu,
                 name=self.real.run_arg.job_name,
                 runpath=Path(self.real.run_arg.runpath),
             )

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -32,6 +32,7 @@ class LocalDriver(Driver):
         *args: str,
         name: str = "dummy",
         runpath: Optional[Path] = None,
+        num_cpu: Optional[int] = 1,
     ) -> None:
         self._tasks[iens] = asyncio.create_task(self._run(iens, executable, *args))
         with suppress(KeyError):

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -186,7 +186,6 @@ class LsfDriver(Driver):
         self,
         queue_name: Optional[str] = None,
         resource_requirement: Optional[str] = None,
-        num_cpu: int = 1,
         exclude_hosts: Optional[str] = None,
         bsub_cmd: Optional[str] = None,
         bjobs_cmd: Optional[str] = None,
@@ -196,7 +195,6 @@ class LsfDriver(Driver):
         super().__init__()
         self._queue_name = queue_name
         self._resource_requirement = resource_requirement
-        self._num_cpu = num_cpu
         self._exclude_hosts = [
             host.strip() for host in (exclude_hosts.split(",") if exclude_hosts else [])
         ]
@@ -227,6 +225,7 @@ class LsfDriver(Driver):
         *args: str,
         name: str = "dummy",
         runpath: Optional[Path] = None,
+        num_cpu: Optional[int] = 1,
     ) -> None:
         if runpath is None:
             runpath = Path.cwd()
@@ -257,7 +256,7 @@ class LsfDriver(Driver):
             + arg_queue_name
             + ["-o", str(runpath / (name + ".LSF-stdout"))]
             + ["-e", str(runpath / (name + ".LSF-stderr"))]
-            + ["-n", str(self._num_cpu)]
+            + ["-n", str(num_cpu)]
             + self._build_resource_requirement_arg()
             + ["-J", name, str(script_path), str(runpath)]
         )

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -173,6 +173,7 @@ class OpenPBSDriver(Driver):
         *args: str,
         name: str = "dummy",
         runpath: Optional[Path] = None,
+        num_cpu: Optional[int] = 1,
     ) -> None:
         if runpath is None:
             runpath = Path.cwd()

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -176,8 +176,8 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
         return
 
     num_cpu = 2
-    driver = LsfDriver(num_cpu=num_cpu)
-    await driver.submit(0, "sh", "-c", "echo test>test", name=job_name)
+    driver = LsfDriver()
+    await driver.submit(0, "sh", "-c", "echo test>test", name=job_name, num_cpu=num_cpu)
     job_id = driver._iens2jobid[0]
     await poll(driver, {0})
 

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -151,5 +151,6 @@ async def test_job_run_sends_expected_events(
         realization.run_arg.runpath,
         name=realization.run_arg.job_name,
         runpath=Path(realization.run_arg.runpath),
+        num_cpu=realization.num_cpu,
     )
     assert scheduler.driver.submit.call_count == max_submit

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -215,8 +215,8 @@ async def test_submit_with_resource_requirement():
 
 @pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_with_num_cpu():
-    driver = LsfDriver(num_cpu=4)
-    await driver.submit(0, "sleep")
+    driver = LsfDriver()
+    await driver.submit(0, "sleep", num_cpu=4)
     assert "-n 4" in Path("captured_bsub_args").read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
**Issue**
Resolves #8095 


**Approach**
Use the Realization object which is pre-populated with the correct cpu count.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
