### PR TITLE
Backport fixes to version-10.1 branch

### DIFF
--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -7,6 +7,7 @@ from .config_schema_item import (
     float_keyword,
     int_keyword,
     path_keyword,
+    positive_int_keyword,
     single_arg_keyword,
     string_keyword,
 )
@@ -278,8 +279,8 @@ class ConfigSchemaDict(SchemaItemDict):
 def init_site_config_schema() -> ConfigSchemaDict:
     schema = ConfigSchemaDict()
     for item in [
-        int_keyword(ConfigKeys.MAX_SUBMIT),
-        int_keyword(ConfigKeys.NUM_CPU),
+        positive_int_keyword(ConfigKeys.MAX_SUBMIT),
+        positive_int_keyword(ConfigKeys.NUM_CPU),
         queue_system_keyword(True),
         queue_option_keyword(),
         job_script_keyword(),
@@ -342,8 +343,8 @@ def init_user_config_schema() -> ConfigSchemaDict:
         single_arg_keyword(ConfigKeys.GEN_KW_EXPORT_NAME),
         history_source_keyword(),
         path_keyword(ConfigKeys.RUNPATH_FILE),
-        int_keyword(ConfigKeys.MAX_SUBMIT),
-        int_keyword(ConfigKeys.NUM_CPU),
+        positive_int_keyword(ConfigKeys.MAX_SUBMIT),
+        positive_int_keyword(ConfigKeys.NUM_CPU),
         queue_system_keyword(False),
         queue_option_keyword(),
         job_script_keyword(),

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -92,6 +92,21 @@ class SchemaItem:
                     f"{self.kw!r} must have a boolean value as argument {index + 1!r}",
                     token,
                 )
+        if val_type == SchemaItemType.POSITIVE_INT:
+            try:
+                val = int(token)
+            except ValueError as e:
+                raise ConfigValidationError.with_context(
+                    f"{self.kw!r} must have an integer value as argument {index + 1!r}",
+                    token,
+                ) from e
+            if val > 0:
+                return ContextInt(val, token, keyword)
+            else:
+                raise ConfigValidationError.with_context(
+                    f"{self.kw!r} must have a positive integer value as argument {index + 1!r}",
+                    token,
+                )
         if val_type == SchemaItemType.INT:
             try:
                 return ContextInt(int(token), token, keyword)
@@ -242,6 +257,10 @@ def float_keyword(keyword: str) -> SchemaItem:
 
 def int_keyword(keyword: str) -> SchemaItem:
     return SchemaItem(kw=keyword, type_map=[SchemaItemType.INT])
+
+
+def positive_int_keyword(keyword: str) -> SchemaItem:
+    return SchemaItem(kw=keyword, type_map=[SchemaItemType.POSITIVE_INT])
 
 
 def string_keyword(keyword: str) -> SchemaItem:

--- a/src/ert/config/parsing/schema_item_type.py
+++ b/src/ert/config/parsing/schema_item_type.py
@@ -4,6 +4,7 @@ from ert.enum_shim import StrEnum
 class SchemaItemType(StrEnum):
     STRING = "STRING"
     INT = "INT"
+    POSITIVE_INT = "POSITIVE_INT"
     FLOAT = "FLOAT"
     PATH = "PATH"
     EXISTING_PATH = "EXISTING_PATH"

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -81,7 +81,7 @@ class LocalDriver(Driver):
         returncode = 0
         try:
             returncode = await self._wait(proc)
-            logger.debug(f"Realization {iens} finished with {returncode=}")
+            logger.info(f"Realization {iens} finished with {returncode=}")
         except asyncio.CancelledError:
             returncode = await self._kill(proc)
         finally:

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -291,7 +291,7 @@ class LsfDriver(Driver):
 
     async def kill(self, iens: int) -> None:
         if iens not in self._iens2jobid:
-            logger.error(f"LSF kill failed due to missing jobid for realization {iens}")
+            logger.info(f"LSF kill failed due to missing jobid for realization {iens}")
             return
 
         job_id = self._iens2jobid[iens]
@@ -400,14 +400,12 @@ class LsfDriver(Driver):
             logger.debug(f"Realization {iens} is running")
             event = StartedEvent(iens=iens)
         elif isinstance(new_state, FinishedJobFailure):
-            logger.debug(
-                f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) failed"
-            )
+            logger.info(f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) failed")
             exit_code = await self._get_exit_code(job_id)
             event = FinishedEvent(iens=iens, returncode=exit_code)
 
         elif isinstance(new_state, FinishedJobSuccess):
-            logger.debug(
+            logger.info(
                 f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) succeeded"
             )
             event = FinishedEvent(iens=iens, returncode=0)

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -264,6 +264,7 @@ class LsfDriver(Driver):
         logger.debug(f"Submitting to LSF with command {shlex.join(bsub_with_args)}")
         process_success, process_message = await self._execute_with_retry(
             bsub_with_args,
+            retry_on_empty_stdout=True,
             retry_codes=(FLAKY_SSH_RETURNCODE,),
             retries=self._bsub_retries,
             retry_interval=self._sleep_time_between_cmd_retries,
@@ -441,6 +442,7 @@ class LsfDriver(Driver):
             retry_codes=(FLAKY_SSH_RETURNCODE,),
             retries=3,
             retry_interval=self._sleep_time_between_cmd_retries,
+            log_to_debug=False,
         )
 
         if success:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -225,7 +225,7 @@ class OpenPBSDriver(Driver):
             return
 
         if iens not in self._iens2jobid:
-            logger.error(f"PBS kill failed due to missing jobid for realization {iens}")
+            logger.info(f"PBS kill failed due to missing jobid for realization {iens}")
             return
 
         job_id = self._iens2jobid[iens]
@@ -330,11 +330,11 @@ class OpenPBSDriver(Driver):
             )
 
             if new_state.returncode != 0:
-                logger.debug(
+                logger.info(
                     f"Realization {iens} (PBS-id: {self._iens2jobid[iens]}) failed"
                 )
             else:
-                logger.debug(
+                logger.info(
                     f"Realization {iens} (PBS-id: {self._iens2jobid[iens]}) succeeded"
                 )
             self._finished_iens.add(iens)

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -104,6 +104,10 @@ class Scheduler:
         self.completed_jobs: asyncio.Queue[int] = asyncio.Queue()
 
         self._cancelled = False
+        if max_submit < 0:
+            raise ValueError(
+                "max_submit needs to be a positive number. The zero value can be used internally for testing purposes only!"
+            )
         self._max_submit = max_submit
         self._max_running = max_running
 

--- a/tests/unit_tests/config/test_num_cpu.py
+++ b/tests/unit_tests/config/test_num_cpu.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from ert.config import ErtConfig
+from ert.config import ConfigValidationError, ErtConfig
 from ert.config.parsing import ConfigKeys
 
 
@@ -55,3 +55,20 @@ PARALLEL
     }
     ert_config = ErtConfig.from_dict(config_dict)
     assert ert_config.preferred_num_cpu == data_file_num_cpu
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "num_cpu_value, error_msg",
+    [
+        (-1, "must have a positive integer value as argument"),
+        (0, "must have a positive integer value as argument"),
+        (1.5, "must have an integer value as argument"),
+    ],
+)
+def test_wrong_num_cpu_raises_validation_error(num_cpu_value, error_msg):
+    with open("file.ert", mode="w", encoding="utf-8") as f:
+        f.write(f"{ConfigKeys.NUM_REALIZATIONS} 1\n")
+        f.write(f"{ConfigKeys.NUM_CPU} {num_cpu_value}\n")
+    with pytest.raises(ConfigValidationError, match=error_msg):
+        ErtConfig.from_file("file.ert")

--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -308,3 +308,20 @@ def test_multiple_max_submit_keywords(tmp_path):
     config_path.write_text("NUM_REALIZATIONS 1\nMAX_SUBMIT 10\nMAX_SUBMIT 42\n")
     config = ErtConfig.from_file(config_path)
     assert config.queue_config.max_submit == 42
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "max_submit_value, error_msg",
+    [
+        (-1, "must have a positive integer value as argument"),
+        (0, "must have a positive integer value as argument"),
+        (1.5, "must have an integer value as argument"),
+    ],
+)
+def test_wrong_max_submit_raises_validation_error(max_submit_value, error_msg):
+    with open("file.ert", mode="w", encoding="utf-8") as f:
+        f.write("NUM_REALIZATIONS 1\n")
+        f.write(f"MAX_SUBMIT {max_submit_value}\n")
+    with pytest.raises(ConfigValidationError, match=error_msg):
+        ErtConfig.from_file("file.ert")

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import stat
 import time
@@ -363,6 +364,7 @@ async def test_kill(
     expected_logged_error,
     caplog,
 ):
+    caplog.set_level(logging.INFO)
     monkeypatch.chdir(tmp_path)
     bin_path = Path("bin")
     bin_path.mkdir()

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -544,6 +544,7 @@ async def test_that_bsub_will_retry_and_fail(
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [
+        (0, "void"),
         (FLAKY_SSH_RETURNCODE, ""),
     ],
 )


### PR DESCRIPTION
Add positive_int validation schema for NUM_CPU and MAX_SUBMIT 2434ff8380378fd3daa86ea637a66d8cee5ebd7f
Retry bsub when output is empty] 9e9bc71772212141e354d4a051136f39969a09be
Make sure to log Realization status after completed run as info 3e03e02a2a3f2024be1431f68949a40c88151ff3
