### PR TITLE
Fix num_cpu LSF integration test

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -183,13 +183,17 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
 
     process = await asyncio.create_subprocess_exec(
         "bhist",
+        "-l",
         job_id,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, _ = await process.communicate()
-    matches = re.search(".*([0-9]+) Processors Requested", stdout.decode())
-    assert matches and matches[1] == num_cpu
+    stdout, stderr = await process.communicate()
+    stdout_no_whitespaces = re.sub(r"\s+", "", stdout.decode())
+    matches = re.search(r".*([0-9]+)ProcessorsRequested.*", stdout_no_whitespaces)
+    assert matches and matches[1] == str(
+        num_cpu
+    ), f"Could not verify processor allocation from stdout: {stdout}, stderr: {stderr}"
 
     assert Path("test").read_text(encoding="utf-8") == "test\n"
 


### PR DESCRIPTION
Contained three bugs:
* Missing -l
* int vs string comparison for num_cpu
* stdout from bhist has line breaks and whitespace indentation at random places

**Issue**
Resolves nightly test failure.


**Approach**
just-do-it


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
