### PR TITLE
Remove current memory usage from run details view

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -372,12 +372,11 @@ class RunDialog(QDialog):
         runtime = self._run_model.get_runtime()
         self.running_time.setText(format_running_time(runtime))
 
-        current_memory_usage = self._snapshot_model.root.data.current_memory_usage
         maximum_memory_usage = self._snapshot_model.root.data.max_memory_usage
 
-        if current_memory_usage and maximum_memory_usage:
+        if maximum_memory_usage:
             self.memory_usage.setText(
-                f"Memory Usage: [Current: {byte_with_unit(current_memory_usage)}, Max: {byte_with_unit(maximum_memory_usage)}]"
+                f"Maximal realization memory usage: {byte_with_unit(maximum_memory_usage)}"
             )
 
     @Slot(object)


### PR DESCRIPTION
Also adds the string 'realization' to the displayed string to remind that this is not about the usage of the Ert mother process.

Current memory usage quickly becomes a very random uninteresting number when realization eventually get staggered in time. Maximum is the only thing that really matters.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
