### PR TITLE
Ensure WAITING state is set on resubmissions

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -89,6 +89,7 @@ class Job:
         return 0
 
     async def _submit_and_run_once(self, sem: asyncio.BoundedSemaphore) -> None:
+        await self._send(State.WAITING)
         await sem.acquire()
         timeout_task: Optional[asyncio.Task[None]] = None
 

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -66,7 +66,7 @@ async def test_happy_path(
 
     assert mock_ws_task.done()
 
-    first_expected_queue_event_type = "SUBMITTED" if using_scheduler else "WAITING"
+    first_expected_queue_event_type = "WAITING"
 
     for received_event, expected_type, expected_queue_event_type in zip(
         [mock_ws_task.result()[0], mock_ws_task.result()[-1]],

--- a/tests/unit_tests/scheduler/test_job.py
+++ b/tests/unit_tests/scheduler/test_job.py
@@ -75,7 +75,8 @@ async def test_submitted_job_is_cancelled(realization, mock_event):
     await job_task
 
     await assert_scheduler_events(
-        scheduler, [State.SUBMITTING, State.PENDING, State.ABORTING, State.ABORTED]
+        scheduler,
+        [State.WAITING, State.SUBMITTING, State.PENDING, State.ABORTING, State.ABORTED],
     )
     scheduler.driver.kill.assert_called_with(job.iens)
     scheduler.driver.kill.assert_called_once()
@@ -142,7 +143,7 @@ async def test_job_run_sends_expected_events(
 
     await assert_scheduler_events(
         scheduler,
-        [State.SUBMITTING, State.PENDING, State.RUNNING] * max_submit
+        [State.WAITING, State.SUBMITTING, State.PENDING, State.RUNNING] * max_submit
         + [expected_final_event],
     )
     scheduler.driver.submit.assert_called_with(

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -583,7 +583,7 @@ async def test_scheduler_publishes_to_websocket(
     await websocket_server_task
     assert [
         json.loads(event)["data"]["queue_event_type"] for event in events_received
-    ] == ["SUBMITTED", "PENDING", "RUNNING", "SUCCESS"]
+    ] == ["WAITING", "SUBMITTED", "PENDING", "RUNNING", "SUCCESS"]
 
     assert (
         sch._events.empty()


### PR DESCRIPTION
Upon resubmissions, this state did not get set, as it before was only set in __init__, with the result that the GUI showed wrong state (RUNNING) before the realization was submitted.

**Issue**
Resolves #8079 


**Approach**
📯 

Screenshot shows that the realizations that failed in the first run are reset to Waiting (blue border):
![image](https://github.com/equinor/ert/assets/306834/7f9e0ed1-1f20-456d-91de-4d918af04f21)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
