### PR TITLE
Make sure that scheduler send all events when jobs are finished

### DIFF
--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -576,6 +576,7 @@ async def test_scheduler_publishes_to_websocket(
         driver, [realization], ee_uri=f"ws://127.0.0.1:{unused_tcp_port}"
     )
     await sch.execute()
+
     # publisher_done is set only if CLOSE_PUBLISHER_SENTINEL was received
     assert sch._publisher_done.is_set()
 
@@ -588,6 +589,29 @@ async def test_scheduler_publishes_to_websocket(
     assert (
         sch._events.empty()
     ), "Schedulers internal event queue must be empty before finish"
+
+
+async def test_scheduler_finish_when_evaluator_quits_prematurely(
+    mock_driver, realization, unused_tcp_port, caplog
+):
+    set_when_done = asyncio.Event()
+
+    websocket_server_task = asyncio.create_task(
+        _mock_ws(set_when_done, None, unused_tcp_port)
+    )
+
+    driver = mock_driver()
+    sch = scheduler.Scheduler(
+        driver, [realization], ee_uri=f"ws://127.0.0.1:{unused_tcp_port}"
+    )
+    scheduler._queue_timeout = 0.1
+    set_when_done.set()
+    await sch.execute()
+
+    await websocket_server_task
+
+    assert sch._events.qsize() == 6  # we expect 5 events + the sentinel object
+    assert "6 items left unprocessed in the queue!" in caplog.text
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
**Issue**
Improves symptoms of https://github.com/equinor/ert/issues/8105


**Approach**
We include scheduler._events.join() and SENTINEL object to make
sure that the events left in the qeueu will be proccessed once the
jobs are done. To makes sure we won't wait for the queue and
SENTINEL indefinitely this introduces self._queue_timeout attribute.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
