### PR TITLE
Fix an issue where the about_panel didn't work

### DIFF
--- a/src/ert/gui/about_dialog.py
+++ b/src/ert/gui/about_dialog.py
@@ -22,9 +22,12 @@ class AboutDialog(QDialog):
         self.setModal(True)
         self.setFixedSize(QSize(600, 480))
         self.setWindowFlags(
-            self.windowFlags() & ~Qt.WindowFlags.WindowContextHelpButtonHint
+            self.windowFlags()
+            & ~Qt.WindowFlags(Qt.WindowType.WindowContextHelpButtonHint)
         )
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowFlags.WindowCloseButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowFlags(Qt.WindowType.WindowCloseButtonHint)
+        )
 
         main_layout = QVBoxLayout()
 
@@ -45,7 +48,7 @@ class AboutDialog(QDialog):
         info_layout = QVBoxLayout()
 
         ert = QLabel()
-        ert.setAlignment(Qt.Alignment.AlignHCenter)
+        ert.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
         title_font = QFont()
         title_font.setPointSize(40)
@@ -55,13 +58,13 @@ class AboutDialog(QDialog):
         info_layout.addWidget(ert)
         info_layout.addStretch(1)
         ert_title = QLabel()
-        ert_title.setAlignment(Qt.Alignment.AlignHCenter)
+        ert_title.setAlignment(Qt.AlignmentFlag.AlignHCenter)
         ert_title.setText("Ensemble based Reservoir Tool")
         info_layout.addWidget(ert_title)
 
         version = QLabel()
 
-        version.setAlignment(Qt.Alignment.AlignHCenter)
+        version.setAlignment(Qt.AlignmentFlag.AlignHCenter)
         version.setText(f"ert version:{ert_gui.__version__}")
         info_layout.addWidget(version)
 


### PR DESCRIPTION
The about panel would not open due to changes made in c649826e5393a55243ae4326a7e43f0ee25a4ea2

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
