### PR TITLE
Improve LSFDriver.kill and logging for scheduler

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -135,11 +135,11 @@ class Scheduler:
                 task.cancel()
         _, pending = await asyncio.wait(
             self._job_tasks.values(),
-            timeout=15.0,
+            timeout=30.0,
             return_when=asyncio.ALL_COMPLETED,
         )
         for task in pending:
-            logger.error(f"Task {task.get_name()} was not killed properly!")
+            logger.debug(f"Task {task.get_name()} was not killed properly!")
 
     async def _update_avg_job_runtime(self) -> None:
         while True:

--- a/tests/integration_tests/scheduler/bin/bkill.py
+++ b/tests/integration_tests/scheduler/bin/bkill.py
@@ -24,6 +24,7 @@ def main() -> None:
         if not pidfile.exists():
             sys.exit(1)
         pid = int(pidfile.read_text(encoding="utf-8").strip())
+        print(f"Job <{jobid}> is being terminated")
         os.kill(pid, killsignal)
         pidfile.unlink()
 

--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -38,8 +38,8 @@ echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
 
-[ -z $stdout] && stdout="/dev/null"
-[ -z $stderr] && stderr="/dev/null"
+[ -z $stdout ] && stdout="/dev/null"
+[ -z $stderr ] && stderr="/dev/null"
 
 bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>$stderr &
 disown

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-job=$1
+job=$1  # NB: Includes full path
 
 function handle_sigterm {
     # LSF uses (128 + SIGNAL) as the returncode
     # SIGTERM=15
     echo "143" > "${job}.returncode"
-    echo ""
-    kill $child_pid
+    for grandchild in $(pgrep -P $child_pid); do
+        kill -s SIGTERM $grandchild
+    done
+    kill -s SIGTERM $child_pid
     exit 1
 }
 

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -183,13 +183,17 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
 
     process = await asyncio.create_subprocess_exec(
         "bhist",
+        "-l",
         job_id,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, _ = await process.communicate()
-    matches = re.search(".*([0-9]+) Processors Requested", stdout.decode())
-    assert matches and matches[1] == num_cpu
+    stdout, stderr = await process.communicate()
+    stdout_no_whitespaces = re.sub(r"\s+", "", stdout.decode())
+    matches = re.search(r".*([0-9]+)ProcessorsRequested.*", stdout_no_whitespaces)
+    assert matches and matches[1] == str(
+        num_cpu
+    ), f"Could not verify processor allocation from stdout: {stdout}, stderr: {stderr}"
 
     assert Path("test").read_text(encoding="utf-8") == "test\n"
 

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -312,7 +312,7 @@ async def test_faulty_bsub_produces_error_log(monkeypatch, tmp_path):
             1,
             "",
             "",
-            "LSF kill failed due to missing",
+            "not submitted properly",
             id="internal_ert_error",
         ),
         pytest.param(
@@ -382,6 +382,9 @@ async def test_kill(
     driver = LsfDriver()
     driver._iens2jobid = mocked_iens2jobid
     driver._sleep_time_between_bkills = 0
+
+    # Needed because we are not submitting anything in this test
+    driver._submit_locks[iens_to_kill] = asyncio.Lock()
 
     await driver.kill(iens_to_kill)
 
@@ -788,6 +791,7 @@ async def test_kill_does_not_log_error_on_accepted_bkill_outputs(
 
     async def mock_submit(*args, **kwargs):
         driver._iens2jobid[0] = "1"
+        driver._submit_locks[0] = asyncio.Lock()
 
     driver.submit = mock_submit
     await driver.submit(0, "sh", "-c", f"echo test>{tmp_path}/test")
@@ -820,3 +824,10 @@ def test_filter_job_ids_on_submission_time(time_submitted_modifier, expected_res
         )
     }
     assert filter_job_ids_on_submission_time(jobs, submitted_before) == expected_result
+
+
+async def test_kill_before_submit_logs_error(caplog):
+    driver = LsfDriver()
+    await driver.kill(0)
+    assert "ERROR" in caplog.text
+    assert "realization 0 has never been submitted" in caplog.text


### PR DESCRIPTION
The goal of this backport is the improve flakyness of integration tests around LSFDriver.kill. Mainly, we fix a bug when the job is not running yet, but driver.kill wants to kill it.
