### PR TITLE
Update tooltip text for plot ensemble selector

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -56,7 +56,7 @@ class EnsembleSelectListWidget(QListWidget):
         self.setItemDelegate(CustomItemDelegate())
         self.itemClicked.connect(self.slot_toggle_plot)
         self.setToolTip(
-            "Select/deselect [1,5] or reorder plots\nOrder determines draw order and color"
+            "Toggle up to 5 plots or reorder by drag & drop\nOrder determines draw order and color"
         )
 
     def get_checked_ensembles(self) -> List[EnsembleObject]:


### PR DESCRIPTION
Minor clarification on functionality.

User request:

_When hoovering one get some info saying one can reorder, but it would be nice to extend the text to emphasize that it is done "by drag and drop"._


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
