### PR TITLE
Fix incorrect AlignBottom enum

### DIFF
--- a/src/ert/gui/tools/plugins/process_job_dialog.py
+++ b/src/ert/gui/tools/plugins/process_job_dialog.py
@@ -53,7 +53,7 @@ class ProcessJobDialog(QDialog):
         widget_layout.addWidget(processing_animation)
 
         self.processing_label = QLabel(f"Processing job: '{title}'")
-        widget_layout.addWidget(self.processing_label, Qt.AlignBottom)
+        widget_layout.addWidget(self.processing_label, Qt.AlignmentFlag.AlignBottom)
 
         widget.setLayout(widget_layout)
 

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -85,7 +85,7 @@ class RunWorkflowWidget(QWidget):
         processing_label = QLabel(
             f"Processing workflow '{self.getCurrentWorkflowName()}'"
         )
-        layout.addWidget(processing_label, Qt.Alignment.AlignBottom)
+        layout.addWidget(processing_label, Qt.AlignmentFlag.AlignBottom)
 
         widget.setLayout(layout)
 


### PR DESCRIPTION
The membership of AlignBottom was incorrectly set to `Qt.Alignment` leading to the following error:
```
  File ".../ert/gui/tools/workflows/run_workflow_widget.py", line 113, in startWorkflow
    "Running workflow", self.createSpinWidget(), self
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File .../ert/gui/tools/workflows/run_workflow_widget.py", line 88, in createSpinWidget
    layout.addWidget(processing_label, Qt.Alignment.AlignBottom)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'Alignment' has no attribute 'AlignBottom'
```