### PR TITLE
Refactor RunDialog and remove indeterminate flag

### DIFF
--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -141,10 +141,6 @@ class Monitor:
             )
 
     def _print_progress(self, event: SnapshotUpdateEvent) -> None:
-        if event.indeterminate:
-            # indeterminate, no progress to be shown
-            return
-
         current_phase = min(event.total_phases, event.current_phase + 1)
         if self._start_time is not None:
             elapsed = datetime.now() - self._start_time

--- a/src/ert/ensemble_evaluator/event.py
+++ b/src/ert/ensemble_evaluator/event.py
@@ -10,7 +10,6 @@ class _UpdateEvent:
     current_phase: int
     total_phases: int
     progress: float
-    indeterminate: bool
     iteration: int
 
 

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -13,7 +13,7 @@ class ProgressProxyModel(QAbstractItemModel):
     ) -> None:
         QAbstractItemModel.__init__(self, parent)
         self._source_model: QAbstractItemModel = source_model
-        self._progress: Optional[Dict[Union[str, dict], int]] = None
+        self._progress: Optional[Dict[str, Union[dict, int]]] = None
         self._connect()
 
     def _connect(self) -> None:

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -35,13 +35,7 @@ from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets.message_box import ErtMessageBox
 from ert.gui.model.job_list import JobListProxyModel
 from ert.gui.model.progress_proxy import ProgressProxyModel
-from ert.gui.model.snapshot import (
-    COLUMNS,
-    FileRole,
-    IterNum,
-    RealIens,
-    SnapshotModel,
-)
+from ert.gui.model.snapshot import COLUMNS, FileRole, IterNum, RealIens, SnapshotModel
 from ert.gui.tools.file import FileDialog
 from ert.gui.tools.plot.plot_tool import PlotTool
 from ert.run_models import (
@@ -112,7 +106,7 @@ class RunDialog(QDialog):
 
         self._progress_view = ProgressView(self)
         self._progress_view.setModel(progress_proxy_model)
-        self._progress_view.setIndeterminate(True)
+        self._progress_view.set_active_progress(False)
 
         legend_view = LegendView(self)
         legend_view.setModel(progress_proxy_model)
@@ -356,12 +350,7 @@ class RunDialog(QDialog):
         self.kill_button.setHidden(True)
         self.restart_button.setVisible(self._run_model.has_failed_realizations())
         self.restart_button.setEnabled(self._run_model.support_restart)
-        self._total_progress_bar.setValue(100)
-        self._total_progress_label.setText(
-            _TOTAL_PROGRESS_TEMPLATE.format(
-                total_progress=100, phase_name=self._run_model.getPhaseName()
-            )
-        )
+        self.update_total_progress(1.0, self._run_model.getPhaseName())
         self._notifier.set_is_simulation_running(False)
         if failed:
             self.fail_msg_box = ErtMessageBox(
@@ -393,14 +382,14 @@ class RunDialog(QDialog):
         elif isinstance(event, FullSnapshotEvent):
             if event.snapshot is not None:
                 self._snapshot_model._add_snapshot(event.snapshot, event.iteration)
-            self._progress_view.setIndeterminate(event.indeterminate)
+            self._progress_view.set_active_progress()
             self.update_total_progress(event.progress, event.phase_name)
         elif isinstance(event, SnapshotUpdateEvent):
             if event.partial_snapshot is not None:
                 self._snapshot_model._add_partial_snapshot(
                     event.partial_snapshot, event.iteration
                 )
-            self._progress_view.setIndeterminate(event.indeterminate)
+            self._progress_view.set_active_progress()
             self.update_total_progress(event.progress, event.phase_name)
         elif isinstance(event, RunModelUpdateBeginEvent):
             iteration = event.iteration

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -394,29 +394,14 @@ class RunDialog(QDialog):
             if event.snapshot is not None:
                 self._snapshot_model._add_snapshot(event.snapshot, event.iteration)
             self._progress_view.setIndeterminate(event.indeterminate)
-            progress = int(event.progress * 100)
-            self.validate_percentage_range(progress)
-            self._total_progress_bar.setValue(progress)
-            self._total_progress_label.setText(
-                _TOTAL_PROGRESS_TEMPLATE.format(
-                    total_progress=progress, phase_name=event.phase_name
-                )
-            )
+            self.update_total_progress(event.progress, event.phase_name)
         elif isinstance(event, SnapshotUpdateEvent):
             if event.partial_snapshot is not None:
                 self._snapshot_model._add_partial_snapshot(
                     event.partial_snapshot, event.iteration
                 )
             self._progress_view.setIndeterminate(event.indeterminate)
-            progress = int(event.progress * 100)
-            self.validate_percentage_range(progress)
-            self._total_progress_bar.setValue(progress)
-            self._total_progress_label.setText(
-                _TOTAL_PROGRESS_TEMPLATE.format(
-                    total_progress=progress, phase_name=event.phase_name
-                )
-            )
-
+            self.update_total_progress(event.progress, event.phase_name)
         elif isinstance(event, RunModelUpdateBeginEvent):
             iteration = event.iteration
             widget = UpdateWidget(iteration)
@@ -460,11 +445,17 @@ class RunDialog(QDialog):
                 return widget
         return None
 
-    @staticmethod
-    def validate_percentage_range(progress: int) -> None:
-        if not 0 <= progress <= 100:
+    def update_total_progress(self, progress_value: float, phase_name: str) -> None:
+        progress = int(progress_value * 100)
+        if not (0 <= progress <= 100):
             logger = logging.getLogger(__name__)
             logger.warning(f"Total progress bar exceeds [0-100] range: {progress}")
+        self._total_progress_bar.setValue(progress)
+        self._total_progress_label.setText(
+            _TOTAL_PROGRESS_TEMPLATE.format(
+                total_progress=progress, phase_name=phase_name
+            )
+        )
 
     def restart_failed_realizations(self) -> None:
         msg = QMessageBox(self)

--- a/src/ert/gui/simulation/view/legend.py
+++ b/src/ert/gui/simulation/view/legend.py
@@ -27,11 +27,8 @@ class LegendDelegate(QStyledItemDelegate):
     @staticmethod
     def paint(painter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         data = index.data(ProgressRole)
-        nr_reals = 0
-        status = {}
-        if data:
-            nr_reals = data["nr_reals"]
-            status = data["status"]
+        nr_reals = data["nr_reals"] if data else 0
+        status = data["status"] if data else {}
 
         painter.save()
         painter.setRenderHint(QPainter.Antialiasing, True)
@@ -43,27 +40,19 @@ class LegendDelegate(QStyledItemDelegate):
         )
 
         total_states = len(REAL_STATE_TO_COLOR.items())
-        d = math.ceil(option.rect.width() / total_states)
-        x_pos = 0
+        delta = math.ceil(option.rect.width() / total_states)
+        x_offset = 0
+        y = option.rect.y() + 5
+        h = option.rect.height()
+        w = delta - 25
+
         for state, color_ref in REAL_STATE_TO_COLOR.items():
-            state_progress = status.get(state, 0)
-
-            x = x_pos
-            y = option.rect.y()
-            w = d
-            h = option.rect.height()
-            margin = 5
-
+            x = x_offset
             painter.setBrush(QColor(*color_ref))
-            painter.drawRect(x, y + margin, 20, 20)
-            painter.drawText(
-                x + 25,
-                y + margin,
-                w - 25,
-                h,
-                Qt.AlignLeft,
-                f"{state} ({state_progress}/{nr_reals})",
-            )
-            x_pos += d
+            painter.drawRect(x, y, 20, 20)
+            state_progress = status.get(state, 0)
+            text = f"{state} ({state_progress}/{nr_reals})"
+            painter.drawText(x + 25, y, w, h, Qt.AlignLeft, text)
+            x_offset += delta
 
         painter.restore()

--- a/src/ert/gui/simulation/view/progress.py
+++ b/src/ert/gui/simulation/view/progress.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 
-from qtpy.QtCore import QModelIndex, QSize, Qt, Slot
+from qtpy.QtCore import QModelIndex, QSize, Qt
 from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (
     QProgressBar,
@@ -45,10 +45,9 @@ class ProgressView(QWidget):
     def setModel(self, model) -> None:
         self._progress_tree_view.setModel(model)
 
-    @Slot(bool)
-    def setIndeterminate(self, enable: bool) -> None:
-        self._progress_bar.setVisible(enable)
-        self._progress_tree_view.setVisible(not enable)
+    def set_active_progress(self, enable: bool = True) -> None:
+        self._progress_bar.setVisible(not enable)
+        self._progress_tree_view.setVisible(enable)
 
 
 class ProgressDelegate(QStyledItemDelegate):

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -53,7 +53,7 @@ class EnsembleExperiment(BaseRunModel):
         self,
         evaluator_server_config: EvaluatorServerConfig,
     ) -> RunContext:
-        self.setPhaseName(self.run_message(), indeterminate=False)
+        self.setPhaseName(self.run_message())
         experiment = self._storage.create_experiment(
             name=self.simulation_arguments.experiment_name,
             parameters=self.ert_config.ensemble_config.parameter_configuration,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -66,7 +66,7 @@ class EnsembleSmoother(BaseRunModel):
 
         log_msg = "Running ES"
         logger.info(log_msg)
-        self.setPhaseName(log_msg, indeterminate=True)
+        self.setPhaseName(log_msg)
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,
             observations=self.ert_config.observations.datasets,

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -51,7 +51,7 @@ class EvaluateEnsemble(BaseRunModel):
         self,
         evaluator_server_config: EvaluatorServerConfig,
     ) -> RunContext:
-        self.setPhaseName("Running evaluate experiment...", indeterminate=False)
+        self.setPhaseName("Running evaluate experiment...")
 
         ensemble_id = self.simulation_arguments.current_ensemble
         ensemble_uuid = UUID(ensemble_id)

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -82,9 +82,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         iteration: int,
         initial_mask: npt.NDArray[np.bool_],
     ) -> None:
-        self.setPhaseName("Analyzing...", indeterminate=True)
-
-        self.setPhaseName("Pre processing update...", indeterminate=True)
+        self.setPhaseName("Pre processing update...")
         self.ert.runWorkflows(HookRuntime.PRE_UPDATE, self._storage, prior_storage)
         try:
             smoother_snapshot, self.sies_smoother = iterative_smoother_update(
@@ -107,7 +105,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 f"Update algorithm failed with the following error: {e}"
             ) from e
 
-        self.setPhaseName("Post processing update...", indeterminate=True)
+        self.setPhaseName("Post processing update...")
         self.ert.runWorkflows(HookRuntime.POST_UPDATE, self._storage, posterior_storage)
 
     def run_experiment(
@@ -126,7 +124,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
             f'iteration{"s" if (iteration_count != 1) else ""}.'
         )
         logger.info(log_msg)
-        self.setPhaseName(log_msg, indeterminate=True)
+        self.setPhaseName(log_msg)
 
         target_ensemble_format = self._simulation_arguments.target_ensemble
         experiment = self._storage.create_experiment(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -80,7 +80,7 @@ class MultipleDataAssimilation(BaseRunModel):
 
         log_msg = f"Running ES-MDA with normalized weights {weights}"
         logger.info(log_msg)
-        self.setPhaseName(log_msg, indeterminate=True)
+        self.setPhaseName(log_msg)
 
         restart_run = self._simulation_arguments.restart_run
         target_ensemble_format = self._simulation_arguments.target_ensemble
@@ -189,7 +189,7 @@ class MultipleDataAssimilation(BaseRunModel):
             self._evaluate_and_postprocess(posterior_context, evaluator_server_config)
             prior_context = posterior_context
 
-        self.setPhaseName("Post processing...", indeterminate=True)
+        self.setPhaseName("Post processing...")
 
         self.setPhase(iteration_count + 1, "Experiment completed.")
 
@@ -204,7 +204,7 @@ class MultipleDataAssimilation(BaseRunModel):
         next_iteration = prior_context.iteration + 1
 
         phase_string = f"Analyzing iteration: {next_iteration} with weight {weight}"
-        self.setPhase(self.currentPhase() + 1, phase_string, indeterminate=True)
+        self.setPhase(self.currentPhase() + 1, phase_string)
         try:
             return smoother_update(
                 prior_context.ensemble,

--- a/tests/unit_tests/cli/test_cli_monitor.py
+++ b/tests/unit_tests/cli/test_cli_monitor.py
@@ -71,7 +71,6 @@ def test_print_progress():
         current_phase=0,
         total_phases=2,
         progress=0.5,
-        indeterminate=False,
         iteration=0,
     )
 

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -126,7 +126,6 @@ def test_large_snapshot(
             total_phases=1,
             progress=0.5,
             iteration=0,
-            indeterminate=False,
         ),
         FullSnapshotEvent(
             snapshot=large_snapshot,
@@ -135,7 +134,6 @@ def test_large_snapshot(
             total_phases=1,
             progress=0.5,
             iteration=1,
-            indeterminate=False,
         ),
         EndEvent(failed=False, failed_msg=""),
     ]
@@ -178,7 +176,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.25,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -191,7 +188,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.5,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 EndEvent(failed=False, failed_msg=""),
             ],
@@ -218,7 +214,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.25,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -231,7 +226,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.5,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 EndEvent(failed=False, failed_msg=""),
             ],
@@ -262,7 +256,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.25,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -281,7 +274,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.5,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -299,7 +291,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.5,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 EndEvent(failed=False, failed_msg=""),
             ],
@@ -324,7 +315,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.25,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 FullSnapshotEvent(
                     snapshot=(
@@ -342,7 +332,6 @@ def test_large_snapshot(
                     total_phases=1,
                     progress=0.5,
                     iteration=1,
-                    indeterminate=False,
                 ),
                 EndEvent(failed=False, failed_msg=""),
             ],
@@ -438,7 +427,6 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(qtbot: QtBot, sto
                     total_phases=1,
                     progress=0.25,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -458,7 +446,6 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(qtbot: QtBot, sto
                     total_phases=1,
                     progress=0.5,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 SnapshotUpdateEvent(
                     partial_snapshot=PartialSnapshot(
@@ -478,7 +465,6 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(qtbot: QtBot, sto
                     total_phases=1,
                     progress=1,
                     iteration=0,
-                    indeterminate=False,
                 ),
                 EndEvent(failed=False, failed_msg=""),
             ],


### PR DESCRIPTION
The concept of `indeterminate` was probably to switch between the waiting-for-updates-progress-bar, and showing the actual progress bar when there was a proper state.
The current implementation never switches back after the first update, so we decided to remove it for now.
Retained current behaviour.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
