### PR TITLE
Simplify PlotLimits

### DIFF
--- a/src/ert/gui/plottery/plot_config.py
+++ b/src/ert/gui/plottery/plot_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+from copy import copy
 from typing import Any, List, Optional
 
 from ert.gui.plottery import PlotLimits, PlotStyle
@@ -234,13 +235,11 @@ class PlotConfig:
 
     @property
     def limits(self) -> PlotLimits:
-        limits = PlotLimits()
-        limits.copyLimitsFrom(self._limits)
-        return limits
+        return copy(self._limits)
 
     @limits.setter
     def limits(self, value: PlotLimits) -> None:
-        self._limits.copyLimitsFrom(value)
+        self._limits = copy(value)
 
     def copyConfigFrom(self, other: "PlotConfig") -> None:
         self._default_style.copyStyleFrom(other._default_style, copy_enabled_state=True)
@@ -287,7 +286,7 @@ class PlotConfig:
         self._x_label = other._x_label
         self._y_label = other._y_label
 
-        self._limits.copyLimitsFrom(other._limits)
+        self._limits = copy(other._limits)
 
         if other._title is not None:
             self._title = other._title

--- a/src/ert/gui/plottery/plot_context.py
+++ b/src/ert/gui/plottery/plot_context.py
@@ -15,13 +15,11 @@ class PlotContext:
     INDEX_AXIS = "INDEX"
     COUNT_AXIS = "COUNT"
     DENSITY_AXIS = "DENSITY"
-    DEPTH_AXIS = "DEPTH"
     AXIS_TYPES = [
         UNKNOWN_AXIS,
         COUNT_AXIS,
         DATE_AXIS,
         DENSITY_AXIS,
-        DEPTH_AXIS,
         INDEX_AXIS,
         VALUE_AXIS,
     ]

--- a/src/ert/gui/plottery/plot_limits.py
+++ b/src/ert/gui/plottery/plot_limits.py
@@ -11,7 +11,6 @@ class PlotLimits:
     index_limits: Tuple[Optional[int], Optional[int]] = (None, None)
     count_limits: Tuple[Optional[int], Optional[int]] = (None, None)
     density_limits: Tuple[Optional[Num], Optional[Num]] = (None, None)
-    depth_limits: Tuple[Optional[Num], Optional[Num]] = (None, None)
     date_limits: Tuple[Optional[date], Optional[date]] = (None, None)
 
     @property
@@ -77,22 +76,6 @@ class PlotLimits:
     @density_maximum.setter
     def density_maximum(self, value: Optional[Num]) -> None:
         self.density_limits = (self.density_limits[0], value)
-
-    @property
-    def depth_minimum(self) -> Optional[Num]:
-        return self.depth_limits[0]
-
-    @depth_minimum.setter
-    def depth_minimum(self, value: Optional[Num]) -> None:
-        self.depth_limits = (value, self.depth_limits[1])
-
-    @property
-    def depth_maximum(self) -> Optional[Num]:
-        return self.depth_limits[1]
-
-    @depth_maximum.setter
-    def depth_maximum(self, value: Optional[Num]) -> None:
-        self.depth_limits = (self.depth_limits[0], value)
 
     @property
     def date_minimum(self) -> Optional[date]:

--- a/src/ert/gui/plottery/plot_limits.py
+++ b/src/ert/gui/plottery/plot_limits.py
@@ -1,115 +1,111 @@
-import datetime
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional, Tuple, Union
+
+Num = Union[float, int]
 
 
-class limit_property:
-    def __init__(self, attribute_name, types, minimum=None, maximum=None):
-        super().__init__()
-        self._types = types
-        self._maximum = maximum
-        self._minimum = minimum
-        self._attribute_name = attribute_name
-
-    def __get__(self, instance, owner):
-        if not hasattr(instance, f"_{self._attribute_name}"):
-            setattr(instance, f"_{self._attribute_name}", None)
-        return getattr(instance, f"_{self._attribute_name}")
-
-    def __set__(self, instance, value):
-        if value is not None:
-            if not isinstance(value, self._types):
-                raise TypeError(
-                    f"Value not (one) of type(s): {self._types}: {repr(value)}"
-                )
-            if self._minimum is not None and value < self._minimum:
-                raise ValueError(
-                    f"Value can not be less than {self._minimum:f}: "
-                    f"{value:f} < {self._minimum:f}"
-                )
-            if self._maximum is not None and value > self._maximum:
-                raise ValueError(
-                    f"Value can not be larger than {self._maximum:f}: "
-                    f"{value:f} > {self._maximum:f}"
-                )
-
-        setattr(instance, f"_{self._attribute_name}", value)
-
-
-class limits_property:
-    def __init__(self, minimum_attribute_name, maximum_attribute_name):
-        super().__init__()
-        self._minimum_attribute_name = minimum_attribute_name
-        self._maximum_attribute_name = maximum_attribute_name
-
-    def __get__(self, instance, owner):
-        return getattr(instance, f"{self._minimum_attribute_name}"), getattr(
-            instance, f"{self._maximum_attribute_name}"
-        )
-
-    def __set__(self, instance, value):
-        setattr(instance, f"_{self._minimum_attribute_name}", value[0])
-        setattr(instance, f"_{self._maximum_attribute_name}", value[1])
-
-
+@dataclass
 class PlotLimits:
-    value_minimum = limit_property("value_minimum", (float, int))
-    """ :type: float """
-    value_maximum = limit_property("value_maximum", (float, int))
-    """ :type: float """
-    value_limits = limits_property("value_minimum", "value_maximum")
-    """ :type: (float, float) """
+    value_limits: Tuple[Optional[Num], Optional[Num]] = (None, None)
+    index_limits: Tuple[Optional[int], Optional[int]] = (None, None)
+    count_limits: Tuple[Optional[int], Optional[int]] = (None, None)
+    density_limits: Tuple[Optional[Num], Optional[Num]] = (None, None)
+    depth_limits: Tuple[Optional[Num], Optional[Num]] = (None, None)
+    date_limits: Tuple[Optional[date], Optional[date]] = (None, None)
 
-    index_minimum = limit_property("index_minimum", int, minimum=0)
-    """ :type: int """
-    index_maximum = limit_property("index_maximum", int, minimum=0)
-    """ :type: int """
-    index_limits = limits_property("index_minimum", "index_maximum")
-    """ :type: (int, int) """
+    @property
+    def value_minimum(self) -> Optional[Num]:
+        return self.value_limits[0]
 
-    count_minimum = limit_property("count_minimum", int, minimum=0)
-    """ :type: int """
-    count_maximum = limit_property("count_maximum", int, minimum=0)
-    """ :type: int """
-    count_limits = limits_property("count_minimum", "count_maximum")
-    """ :type: (int, int) """
+    @value_minimum.setter
+    def value_minimum(self, value: Optional[Num]) -> None:
+        self.value_limits = (value, self.value_limits[1])
 
-    density_minimum = limit_property("density_minimum", (float, int), minimum=0.0)
-    """ :type: float """
-    density_maximum = limit_property("density_maximum", (float, int), minimum=0.0)
-    """ :type: float """
-    density_limits = limits_property("density_minimum", "density_maximum")
-    """ :type: (float, float) """
+    @property
+    def value_maximum(self) -> Optional[Num]:
+        return self.value_limits[1]
 
-    depth_minimum = limit_property("depth_minimum", (float, int), minimum=0.0)
-    """ :type: float """
-    depth_maximum = limit_property("depth_maximum", (float, int), minimum=0.0)
-    """ :type: float """
-    depth_limits = limits_property("depth_minimum", "depth_maximum")
-    """ :type: tuple[float, float] """
+    @value_maximum.setter
+    def value_maximum(self, value: Optional[Num]) -> None:
+        self.value_limits = (self.value_limits[0], value)
 
-    date_minimum = limit_property("date_minimum", (datetime.date, datetime.datetime))
-    """ :type: datetime.datetime or datetime.date """
-    date_maximum = limit_property("date_maximum", (datetime.date, datetime.datetime))
-    """ :type: datetime.datetime or datetime.date """
-    date_limits = limits_property("date_minimum", "date_maximum")
-    """ :type: tuple[datetime.datetime|datetime.date,
-    datetime.datetime|datetime.date] """
+    @property
+    def count_minimum(self) -> Optional[int]:
+        return self.count_limits[0]
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, PlotLimits):
-            return False
-        equality = self.value_limits == other.value_limits
-        equality = equality and self.index_limits == other.index_limits
-        equality = equality and self.count_limits == other.count_limits
-        equality = equality and self.depth_limits == other.depth_limits
-        equality = equality and self.date_limits == other.date_limits
-        equality = equality and self.density_limits == other.density_limits
+    @count_minimum.setter
+    def count_minimum(self, value: Optional[int]) -> None:
+        self.count_limits = (value, self.count_limits[1])
 
-        return equality
+    @property
+    def count_maximum(self) -> Optional[int]:
+        return self.count_limits[1]
 
-    def copyLimitsFrom(self, other: "PlotLimits") -> None:
-        self.value_limits = other.value_limits
-        self.density_limits = other.density_limits
-        self.depth_limits = other.depth_limits
-        self.index_limits = other.index_limits
-        self.date_limits = other.date_limits
-        self.count_limits = other.count_limits
+    @count_maximum.setter
+    def count_maximum(self, value: Optional[int]) -> None:
+        self.count_limits = (self.count_limits[0], value)
+
+    @property
+    def index_minimum(self) -> Optional[int]:
+        return self.index_limits[0]
+
+    @index_minimum.setter
+    def index_minimum(self, value: Optional[int]) -> None:
+        self.index_limits = (value, self.index_limits[1])
+
+    @property
+    def index_maximum(self) -> Optional[int]:
+        return self.index_limits[1]
+
+    @index_maximum.setter
+    def index_maximum(self, value: Optional[int]) -> None:
+        self.index_limits = (self.index_limits[0], value)
+
+    @property
+    def density_minimum(self) -> Optional[Num]:
+        return self.density_limits[0]
+
+    @density_minimum.setter
+    def density_minimum(self, value: Optional[Num]) -> None:
+        self.density_limits = (value, self.density_limits[1])
+
+    @property
+    def density_maximum(self) -> Optional[Num]:
+        return self.density_limits[1]
+
+    @density_maximum.setter
+    def density_maximum(self, value: Optional[Num]) -> None:
+        self.density_limits = (self.density_limits[0], value)
+
+    @property
+    def depth_minimum(self) -> Optional[Num]:
+        return self.depth_limits[0]
+
+    @depth_minimum.setter
+    def depth_minimum(self, value: Optional[Num]) -> None:
+        self.depth_limits = (value, self.depth_limits[1])
+
+    @property
+    def depth_maximum(self) -> Optional[Num]:
+        return self.depth_limits[1]
+
+    @depth_maximum.setter
+    def depth_maximum(self, value: Optional[Num]) -> None:
+        self.depth_limits = (self.depth_limits[0], value)
+
+    @property
+    def date_minimum(self) -> Optional[date]:
+        return self.date_limits[0]
+
+    @date_minimum.setter
+    def date_minimum(self, value: Optional[date]) -> None:
+        self.date_limits = (value, self.date_limits[1])
+
+    @property
+    def date_maximum(self) -> Optional[date]:
+        return self.date_limits[1]
+
+    @date_maximum.setter
+    def date_maximum(self, value: Optional[date]) -> None:
+        self.date_limits = (self.date_limits[0], value)

--- a/src/ert/gui/plottery/plots/plot_tools.py
+++ b/src/ert/gui/plottery/plots/plot_tools.py
@@ -35,8 +35,6 @@ class PlotTools:
             return limits.date_limits
         elif axis_name == plot_context.DENSITY_AXIS:
             return limits.density_limits
-        elif axis_name == plot_context.DEPTH_AXIS:
-            return limits.depth_limits
         elif axis_name == plot_context.INDEX_AXIS:
             return limits.index_limits
 
@@ -55,8 +53,6 @@ class PlotTools:
             return limits.date_limits
         elif axis_name == plot_context.DENSITY_AXIS:
             return limits.density_limits
-        elif axis_name == plot_context.DEPTH_AXIS:
-            return limits.depth_limits
         elif axis_name == plot_context.INDEX_AXIS:
             return limits.index_limits
 

--- a/src/ert/gui/tools/plot/customize/limits_customization_view.py
+++ b/src/ert/gui/tools/plot/customize/limits_customization_view.py
@@ -38,7 +38,6 @@ class LimitsStack(StackedInput):
     FLOAT_AXIS = [
         PlotContext.VALUE_AXIS,
         PlotContext.DENSITY_AXIS,
-        PlotContext.DEPTH_AXIS,
     ]
     INT_AXIS = [PlotContext.INDEX_AXIS, PlotContext.COUNT_AXIS]
     NUMBER_AXIS = FLOAT_AXIS + INT_AXIS
@@ -52,10 +51,6 @@ class LimitsStack(StackedInput):
         self.addInput(PlotContext.DATE_AXIS, CustomDateEdit())
         self.addInput(
             PlotContext.DENSITY_AXIS,
-            self.createDoubleLineEdit(minimum=0, placeholder="Default value"),
-        )
-        self.addInput(
-            PlotContext.DEPTH_AXIS,
             self.createDoubleLineEdit(minimum=0, placeholder="Default value"),
         )
         self.addInput(
@@ -169,11 +164,6 @@ class LimitsWidget:
         self._y_minimum_stack.setValue(PlotContext.DATE_AXIS, limits.date_minimum)
         self._y_maximum_stack.setValue(PlotContext.DATE_AXIS, limits.date_maximum)
 
-        self._x_minimum_stack.setValue(PlotContext.DEPTH_AXIS, limits.depth_minimum)
-        self._x_maximum_stack.setValue(PlotContext.DEPTH_AXIS, limits.depth_maximum)
-        self._y_minimum_stack.setValue(PlotContext.DEPTH_AXIS, limits.depth_minimum)
-        self._y_maximum_stack.setValue(PlotContext.DEPTH_AXIS, limits.depth_maximum)
-
         self._x_minimum_stack.setValue(PlotContext.DENSITY_AXIS, limits.density_minimum)
         self._x_maximum_stack.setValue(PlotContext.DENSITY_AXIS, limits.density_maximum)
         self._y_minimum_stack.setValue(PlotContext.DENSITY_AXIS, limits.density_minimum)
@@ -210,8 +200,6 @@ class LimitsWidget:
             self._limits.count_limits = minimum, maximum
         elif axis_name == PlotContext.DENSITY_AXIS:
             self._limits.density_limits = minimum, maximum
-        elif axis_name == PlotContext.DEPTH_AXIS:
-            self._limits.depth_limits = minimum, maximum
         elif axis_name == PlotContext.DATE_AXIS:
             self._limits.date_limits = minimum, maximum
         elif axis_name == PlotContext.INDEX_AXIS:

--- a/src/ert/gui/tools/plot/customize/limits_customization_view.py
+++ b/src/ert/gui/tools/plot/customize/limits_customization_view.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtGui import QDoubleValidator, QIntValidator
@@ -154,13 +155,11 @@ class LimitsWidget:
     @property
     def limits(self) -> PlotLimits:
         self._updateLimits()
-        limits = PlotLimits()
-        limits.copyLimitsFrom(self._limits)
-        return limits
+        return copy(self._limits)
 
     @limits.setter
     def limits(self, value: PlotLimits) -> None:
-        self._limits.copyLimitsFrom(value)
+        self._limits = copy(value)
         self._updateWidgets()
 
     def _updateWidgets(self) -> None:

--- a/tests/unit_tests/gui/plottery/test_plot_limits.py
+++ b/tests/unit_tests/gui/plottery/test_plot_limits.py
@@ -1,6 +1,5 @@
 import datetime
-
-import pytest
+from copy import copy
 
 from ert.gui.plottery import PlotLimits
 
@@ -36,31 +35,12 @@ def test_plot_limits():
     plot_limits = PlotLimits()
     limit_names = ["value", "index", "count", "density", "depth", "date"]
 
-    non_numbers = [
-        "string",
-        datetime.date(2001, 1, 1),
-        "3.0",
-        "1e-5",
-        "-5.5",
-        "-.5",
-    ]
-
     positive_floats = [1.0, 1.5, 3.1415, 1e10, 5.2e-7]
     negative_floats = [-1.0, -1.5, -3.1415, -1e10, -5.2e-7]
     positive_ints = [1, 5, 1000]
     negative_ints = [-1, -5, -1000]
 
-    non_dates = ["string", "3.4", "2001-01-01", datetime.time()]
-    dates = [datetime.date(2001, 1, 1), datetime.datetime(2010, 3, 3)]
-
-    setter_should_fail_values = {
-        "value": non_numbers + dates,
-        "index": non_numbers + positive_floats + negative_floats + dates,
-        "depth": non_numbers + negative_floats + negative_ints + negative_ints,
-        "count": non_numbers + negative_ints + negative_floats + positive_floats,
-        "density": non_numbers + negative_floats + negative_ints,
-        "date": non_dates,
-    }
+    dates = [datetime.date(2001, 1, 1), datetime.date(2010, 3, 3)]
 
     setter_should_succeed_values = {
         "value": positive_floats + negative_floats + positive_ints + negative_ints,
@@ -79,18 +59,6 @@ def test_plot_limits():
         setattr(plot_limits, f"{attribute_name}_minimum", None)
         setattr(plot_limits, f"{attribute_name}_maximum", None)
         setattr(plot_limits, f"{attribute_name}_limits", (None, None))
-
-        with pytest.raises(TypeError):
-            setattr(plot_limits, f"{attribute_name}_limits", None)
-
-        for value in setter_should_fail_values[attribute_name]:
-            with pytest.raises((TypeError, ValueError)):
-                setattr(plot_limits, f"{attribute_name}_minimum", value)
-
-            with pytest.raises((TypeError, ValueError)):
-                setattr(plot_limits, f"{attribute_name}_maximum", value)
-
-            assert getattr(plot_limits, f"{attribute_name}_limits") == (None, None)
 
         for value in setter_should_succeed_values[attribute_name]:
             setattr(plot_limits, f"{attribute_name}_minimum", value)
@@ -115,11 +83,12 @@ def test_copy_plot_limits():
     plot_limits.count_limits = 5, 6
     plot_limits.depth_limits = 7, 8
     plot_limits.density_limits = 9, 10
-    plot_limits.date_limits = datetime.date(1999, 1, 1), datetime.date(1999, 12, 31)
+    plot_limits.date_limits = (
+        datetime.date(1999, 1, 1),
+        datetime.date(1999, 12, 31),
+    )
 
-    copy_of_plot_limits = PlotLimits()
-
-    copy_of_plot_limits.copyLimitsFrom(plot_limits)
+    copy_of_plot_limits = copy(plot_limits)
 
     assert copy_of_plot_limits == plot_limits
 

--- a/tests/unit_tests/gui/plottery/test_plot_limits.py
+++ b/tests/unit_tests/gui/plottery/test_plot_limits.py
@@ -22,10 +22,6 @@ def test_plot_limits_construction():
     assert plot_limits.density_maximum is None
     assert plot_limits.density_limits == (None, None)
 
-    assert plot_limits.depth_minimum is None
-    assert plot_limits.depth_maximum is None
-    assert plot_limits.depth_limits == (None, None)
-
     assert plot_limits.date_minimum is None
     assert plot_limits.date_maximum is None
     assert plot_limits.date_limits == (None, None)
@@ -33,7 +29,7 @@ def test_plot_limits_construction():
 
 def test_plot_limits():
     plot_limits = PlotLimits()
-    limit_names = ["value", "index", "count", "density", "depth", "date"]
+    limit_names = ["value", "index", "count", "density", "date"]
 
     positive_floats = [1.0, 1.5, 3.1415, 1e10, 5.2e-7]
     negative_floats = [-1.0, -1.5, -3.1415, -1e10, -5.2e-7]
@@ -45,7 +41,6 @@ def test_plot_limits():
     setter_should_succeed_values = {
         "value": positive_floats + negative_floats + positive_ints + negative_ints,
         "index": positive_ints,
-        "depth": positive_floats + positive_ints,
         "count": positive_ints,
         "density": positive_floats + positive_ints,
         "date": dates,
@@ -81,7 +76,6 @@ def test_copy_plot_limits():
     plot_limits.value_limits = 1, 2
     plot_limits.index_limits = 3, 4
     plot_limits.count_limits = 5, 6
-    plot_limits.depth_limits = 7, 8
     plot_limits.density_limits = 9, 10
     plot_limits.date_limits = (
         datetime.date(1999, 1, 1),
@@ -95,7 +89,6 @@ def test_copy_plot_limits():
     assert copy_of_plot_limits.value_limits == (1, 2)
     assert copy_of_plot_limits.index_limits == (3, 4)
     assert copy_of_plot_limits.count_limits == (5, 6)
-    assert copy_of_plot_limits.depth_limits == (7, 8)
     assert copy_of_plot_limits.density_limits == (9, 10)
     assert copy_of_plot_limits.date_limits == (
         datetime.date(1999, 1, 1),

--- a/tests/unit_tests/gui/plottery/test_plot_style.py
+++ b/tests/unit_tests/gui/plottery/test_plot_style.py
@@ -80,7 +80,6 @@ def test_plot_config():
 
     limits = PlotLimits()
     limits.count_limits = 1, 2
-    limits.depth_limits = 3, 4
     limits.density_limits = 5, 6
     limits.date_limits = datetime.date(2005, 2, 5), datetime.date(2006, 2, 6)
     limits.index_limits = 7, 8


### PR DESCRIPTION
The PlotLimits class implements runtime typechecking in a very magical way. The type checking isn't really used for anything so it is more useful to implement it in a such a way that it can be type checked by mypy.

All functionality of the "undostack" setting the plotlimits in the custmization panel seems to still work as expected:

![image](https://github.com/equinor/ert/assets/32731672/96ea5b38-f314-4d46-a81a-89bf68d65bbb)

The DEPTH_AXIS seems to be unused, and index axis makes the corresponding customization field not accept "-" so the minimum is enforced by the text field:

![image](https://github.com/equinor/ert/assets/32731672/b5777848-9873-4133-8193-42003f10027f)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
