### PR TITLE
Fix test_unexpected_close

### DIFF
--- a/tests/unit_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/unit_tests/ensemble_evaluator/test_monitor.py
@@ -64,9 +64,11 @@ async def test_unexpected_close(unused_tcp_port):
     )
 
     set_when_done = asyncio.Event()
+    socket_closed = asyncio.Event()
 
     async def mock_ws_event_handler(websocket):
         await websocket.close()
+        socket_closed.set()
 
     websocket_server_task = asyncio.create_task(
         _mock_ws(set_when_done, mock_ws_event_handler, ee_con_info)
@@ -76,6 +78,7 @@ async def test_unexpected_close(unused_tcp_port):
         # but no attempt on resubmitting
         # since connection closed via websocket.close
         with pytest.raises(ConnectionClosedOK):
+            await socket_closed.wait()
             await monitor.signal_done()
 
     set_when_done.set()


### PR DESCRIPTION
The test failed on macos due to missing exception.

Closes #8124

**Approach**
Wait for socket to be closed before signaling done from monitor

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
