### PR TITLE
Simplify simulation arguments to run models

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -387,20 +387,18 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         alternative_option="--current-ensemble",
         dest="current_ensemble",
         default="default",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --current-ensemble instead.",
+        help="Deprecated: This argument is deprecated and has no effect.",
     )
     ensemble_smoother_parser.add_argument(
         "--current-ensemble",
         type=valid_name,
         default="default",
-        help="Name of the ensemble where the results for the experiment "
-        "using the prior parameters will be stored.",
+        help="This argument is deprecated and has no effect.",
     )
     ensemble_smoother_parser.add_argument(
         "--target-case",
-        type=valid_name,
-        default="posterior",
+        type=valid_name_format,
+        default="iter-%d",
         action=DeprecatedAction,
         alternative_option="--target-ensemble",
         dest="target_ensemble",
@@ -409,8 +407,8 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     )
     ensemble_smoother_parser.add_argument(
         "--target-ensemble",
-        type=valid_name,
-        default="posterior",
+        type=valid_name_format,
+        default="iter-%d",
         dest="target_ensemble",
         help="Name of the ensemble where the results for the "
         "updated parameters will be stored.",

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -92,7 +92,7 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
             status_queue,
         )
     except ValueError as e:
-        raise ErtCliError(e) from e
+        raise ErtCliError(f"{args.mode} was not valid, failed with: {e}") from e
 
     if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
         args.port_range = range(49152, 51819)

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -26,7 +26,6 @@ class Arguments:
     mode: str
     target_ensemble: str
     realizations: str
-    current_ensemble: str
     experiment_name: str
 
 
@@ -94,8 +93,7 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
     def get_experiment_arguments(self) -> Arguments:
         arguments = Arguments(
             mode=ENSEMBLE_SMOOTHER_MODE,
-            current_ensemble=self._ensemble_format_model.getValue() % 0,
-            target_ensemble=self._ensemble_format_model.getValue() % 1,
+            target_ensemble=self._ensemble_format_model.getValue(),
             realizations=self._active_realizations_field.text(),
             experiment_name=(
                 self._name_field.text()

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -158,18 +158,16 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             self.weights_valid = False
 
             if self._relative_iteration_weights_box.isValid():
-                weights = MultipleDataAssimilation.parseWeights(
-                    relative_iteration_weights_model.getValue()
-                )
-                normalized_weights = MultipleDataAssimilation.normalizeWeights(weights)
-                normalized_weights_model.setValue(
-                    ", ".join(f"{x:.2f}" for x in normalized_weights)
-                )
-
-                if not weights:
-                    normalized_weights_model.setValue("The weights are invalid!")
-                else:
+                try:
+                    normalized_weights = MultipleDataAssimilation.parse_weights(
+                        relative_iteration_weights_model.getValue()
+                    )
+                    normalized_weights_model.setValue(
+                        ", ".join(f"{x:.2f}" for x in normalized_weights)
+                    )
                     self.weights_valid = True
+                except ValueError:
+                    normalized_weights_model.setValue("The weights are invalid!")
             else:
                 normalized_weights_model.setValue("The weights are invalid!")
 

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -283,14 +283,6 @@ class BaseRunModel:
             # If all realisations fail
             return [True] * len(self._initial_realizations_mask)
 
-    def _count_successful_realizations(self) -> int:
-        """
-        Counts the realizations completed in the previous ensemble run
-        :return:
-        """
-        completed = self._completed_realizations_mask
-        return completed.count(True)
-
     def set_env_key(self, key: str, value: str) -> None:
         """
         Will set an environment variable that will be available until the

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -581,8 +581,7 @@ class BaseRunModel:
     def paths(self) -> List[str]:
         run_paths = []
         number_of_iterations = self.number_of_iterations
-        active_mask = self.active_realizations
-        active_realizations = [i for i in range(len(active_mask)) if active_mask[i]]
+        active_realizations = np.where(self.active_realizations)[0]
         for iteration in range(self.start_iteration, number_of_iterations):
             run_paths.extend(self.run_paths.get_paths(active_realizations, iteration))
         return run_paths
@@ -603,11 +602,7 @@ class BaseRunModel:
                 shutil.rmtree(run_path)
 
     def validate(self) -> None:
-        active_mask = self.active_realizations
-        active_realizations_count = len(
-            [i for i in range(len(active_mask)) if active_mask[i]]
-        )
-
+        active_realizations_count = self.active_realizations.count(True)
         min_realization_count = self.minimum_required_realizations
 
         if active_realizations_count < min_realization_count:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -175,7 +175,6 @@ class BaseRunModel:
         self.facade = LibresFacade(self.ert_config)
         self._storage = storage
         self._simulation_arguments = simulation_arguments
-        self.reset()
         self._context_env_keys: List[str] = []
         self.random_seed: int = _seed_sequence(simulation_arguments.random_seed)
         self.rng = np.random.default_rng(self.random_seed)

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -582,7 +582,9 @@ class BaseRunModel:
         run_paths = []
         number_of_iterations = self.number_of_iterations
         active_realizations = np.where(self.active_realizations)[0]
-        for iteration in range(self.start_iteration, number_of_iterations):
+        for iteration in range(
+            self.start_iteration, self.start_iteration + number_of_iterations
+        ):
             run_paths.extend(self.run_paths.get_paths(active_realizations, iteration))
         return run_paths
 

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -196,7 +196,6 @@ class BaseRunModel:
         self.minimum_required_realizations = (
             simulation_arguments.minimum_required_realizations
         )
-        self.prev_successful_realizations: int = 0
         self.active_realizations = copy.copy(simulation_arguments.active_realizations)
         self.number_of_iterations = number_of_iterations
         self.start_iteration = start_iteration
@@ -267,7 +266,6 @@ class BaseRunModel:
     def restart(self) -> None:
         active_realizations = self._create_mask_from_failed_realizations()
         self.active_realizations = active_realizations
-        self.prev_successful_realizations += self._count_successful_realizations()
 
     def has_failed_realizations(self) -> bool:
         return any(self._create_mask_from_failed_realizations())

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -80,7 +80,7 @@ event_logger = logging.getLogger("ert.event_log")
 if TYPE_CHECKING:
     from ert.config import QueueConfig
     from ert.ensemble_evaluator import Ensemble as EEEnsemble
-    from ert.run_models.run_arguments import RunArgumentsType
+    from ert.run_models.run_arguments import SimulationArguments
 
 StatusEvents = Union[
     FullSnapshotEvent,
@@ -136,7 +136,7 @@ def captured_logs(
 class BaseRunModel:
     def __init__(
         self,
-        simulation_arguments: RunArgumentsType,
+        simulation_arguments: SimulationArguments,
         config: ErtConfig,
         storage: Storage,
         queue_config: QueueConfig,
@@ -185,11 +185,6 @@ class BaseRunModel:
             filename=str(config.runpath_file),
             substitution_list=self.substitution_list,
         )
-        if hasattr(self._simulation_arguments, "current_ensemble"):
-            current_ensemble = self._simulation_arguments.current_ensemble
-            if current_ensemble is not None:
-                self.run_paths.set_ert_ensemble(current_ensemble)
-
         self._iter_snapshot: Dict[int, Snapshot] = {}
         self._status_queue = status_queue
         self._end_queue: SimpleQueue[str] = SimpleQueue()
@@ -240,7 +235,7 @@ class BaseRunModel:
         return self._queue_config.queue_system
 
     @property
-    def simulation_arguments(self) -> RunArgumentsType:
+    def simulation_arguments(self) -> SimulationArguments:
         return self._simulation_arguments
 
     @property

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -176,8 +176,6 @@ class BaseRunModel:
         self._storage = storage
         self._simulation_arguments = simulation_arguments
         self.reset()
-        # mapping from iteration number to ensemble id
-        self._iter_map: Dict[int, str] = {}
         self._context_env_keys: List[str] = []
         self.random_seed: int = _seed_sequence(simulation_arguments.random_seed)
         self.rng = np.random.default_rng(self.random_seed)

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -63,7 +63,7 @@ class EnsembleExperiment(BaseRunModel):
         )
         ensemble = self._storage.create_ensemble(
             experiment,
-            name=self._simulation_arguments.current_ensemble,
+            name=self._simulation_arguments.ensemble_name,
             ensemble_size=self._simulation_arguments.ensemble_size,
         )
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -72,9 +72,7 @@ class EnsembleExperiment(BaseRunModel):
         prior_context = RunContext(
             ensemble=ensemble,
             runpaths=self.run_paths,
-            initial_mask=np.array(
-                self._simulation_arguments.active_realizations, dtype=bool
-            ),
+            initial_mask=np.array(self.active_realizations, dtype=bool),
         )
         sample_prior(
             prior_context.ensemble,
@@ -100,7 +98,7 @@ class EnsembleExperiment(BaseRunModel):
         return "Ensemble experiment"
 
     def check_if_runpath_exists(self) -> bool:
-        active_mask = self._simulation_arguments.active_realizations
+        active_mask = self.active_realizations
         active_realizations = [i for i in range(len(active_mask)) if active_mask[i]]
         run_paths = self.run_paths.get_paths(active_realizations, 0)
         return any(Path(run_path).exists() for run_path in run_paths)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -59,11 +59,6 @@ class EnsembleSmoother(BaseRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:
-        self.checkHaveSufficientRealizations(
-            self._simulation_arguments.active_realizations.count(True),
-            self._simulation_arguments.minimum_required_realizations,
-        )
-
         log_msg = "Running ES"
         logger.info(log_msg)
         self.setPhaseName(log_msg)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -62,6 +62,7 @@ class EnsembleSmoother(BaseRunModel):
         log_msg = "Running ES"
         logger.info(log_msg)
         self.setPhaseName(log_msg)
+        ensemble_format = self._simulation_arguments.target_ensemble
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,
             observations=self.ert_config.observations.datasets,
@@ -71,11 +72,10 @@ class EnsembleSmoother(BaseRunModel):
         )
 
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
-        prior_name = self._simulation_arguments.current_ensemble
         prior = self._storage.create_ensemble(
             experiment,
             ensemble_size=self._simulation_arguments.ensemble_size,
-            name=prior_name,
+            name=ensemble_format % 0,
         )
         self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
         prior_context = RunContext(
@@ -114,13 +114,12 @@ class EnsembleSmoother(BaseRunModel):
                 msg="Creating posterior ensemble..",
             )
         )
-        target_ensemble_format = self._simulation_arguments.target_ensemble
         posterior_context = RunContext(
             ensemble=self._storage.create_ensemble(
                 experiment,
                 ensemble_size=prior.ensemble_size,
                 iteration=1,
-                name=target_ensemble_format,
+                name=ensemble_format % 1,
                 prior_ensemble=prior,
             ),
             runpaths=self.run_paths,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -45,6 +45,7 @@ class EnsembleSmoother(BaseRunModel):
             queue_config,
             status_queue,
             phase_count=2,
+            number_of_iterations=2,
         )
         self.es_settings = es_settings
         self.update_settings = update_settings
@@ -62,7 +63,7 @@ class EnsembleSmoother(BaseRunModel):
         log_msg = "Running ES"
         logger.info(log_msg)
         self.setPhaseName(log_msg)
-        ensemble_format = self._simulation_arguments.target_ensemble
+        ensemble_format = self.simulation_arguments.target_ensemble
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,
             observations=self.ert_config.observations.datasets,
@@ -81,9 +82,7 @@ class EnsembleSmoother(BaseRunModel):
         prior_context = RunContext(
             ensemble=prior,
             runpaths=self.run_paths,
-            initial_mask=np.array(
-                self._simulation_arguments.active_realizations, dtype=bool
-            ),
+            initial_mask=np.array(self.active_realizations, dtype=bool),
             iteration=0,
         )
 

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -65,9 +65,7 @@ class EvaluateEnsemble(BaseRunModel):
         prior_context = RunContext(
             ensemble=ensemble,
             runpaths=self.run_paths,
-            initial_mask=np.array(
-                self._simulation_arguments.active_realizations, dtype=bool
-            ),
+            initial_mask=np.array(self.active_realizations, dtype=bool),
             iteration=ensemble.iteration,
         )
 

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -53,7 +53,7 @@ class EvaluateEnsemble(BaseRunModel):
     ) -> RunContext:
         self.setPhaseName("Running evaluate experiment...")
 
-        ensemble_id = self.simulation_arguments.current_ensemble
+        ensemble_id = self.simulation_arguments.ensemble_id
         ensemble_uuid = UUID(ensemble_id)
         ensemble = self._storage.get_ensemble(ensemble_uuid)
         assert isinstance(ensemble, Ensemble)

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -111,10 +111,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:
-        self.checkHaveSufficientRealizations(
-            self._simulation_arguments.active_realizations.count(True),
-            self._simulation_arguments.minimum_required_realizations,
-        )
         iteration_count = self.simulation_arguments.num_iterations
         phase_count = iteration_count + 1
         self.setPhaseCount(phase_count)

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -43,14 +43,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
         update_settings: UpdateSettings,
         status_queue: SimpleQueue[StatusEvents],
     ):
-        super().__init__(
-            simulation_arguments,
-            config,
-            storage,
-            queue_config,
-            status_queue,
-            phase_count=2,
-        )
         self.support_restart = False
         self.analysis_config = analysis_config
         self.update_settings = update_settings
@@ -60,6 +52,16 @@ class IteratedEnsembleSmoother(BaseRunModel):
             min_steplength=analysis_config.ies_min_steplength,
             max_steplength=analysis_config.ies_max_steplength,
             halflife=analysis_config.ies_dec_steplength,
+        )
+
+        super().__init__(
+            simulation_arguments,
+            config,
+            storage,
+            queue_config,
+            status_queue,
+            phase_count=2,
+            number_of_iterations=simulation_arguments.number_of_iterations,
         )
 
         # Initialize sies_smoother to None
@@ -111,7 +113,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:
-        iteration_count = self.simulation_arguments.num_iterations
+        iteration_count = self.number_of_iterations
         phase_count = iteration_count + 1
         self.setPhaseCount(phase_count)
 
@@ -138,9 +140,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
 
-        initial_mask = np.array(
-            self._simulation_arguments.active_realizations, dtype=bool
-        )
+        initial_mask = np.array(self.active_realizations, dtype=bool)
         prior_context = RunContext(
             ensemble=prior,
             runpaths=self.run_paths,

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -91,7 +91,7 @@ def _setup_single_test_run(
     return SingleTestRun(
         SingleTestRunArguments(
             random_seed=config.random_seed,
-            current_ensemble=args.current_ensemble,
+            ensemble_name=args.current_ensemble,
             minimum_required_realizations=1,
             ensemble_size=1,
             stop_long_running=config.analysis_config.stop_long_running,
@@ -126,7 +126,7 @@ def _setup_ensemble_experiment(
         EnsembleExperimentRunArguments(
             random_seed=config.random_seed,
             active_realizations=active_realizations.tolist(),
-            current_ensemble=args.current_ensemble,
+            ensemble_name=args.current_ensemble,
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,
             stop_long_running=config.analysis_config.stop_long_running,
@@ -160,7 +160,7 @@ def _setup_evaluate_ensemble(
         EvaluateEnsembleRunArguments(
             random_seed=config.random_seed,
             active_realizations=active_realizations.tolist(),
-            current_ensemble=args.ensemble_id,
+            ensemble_id=args.ensemble_id,
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,
             stop_long_running=config.analysis_config.stop_long_running,
@@ -186,7 +186,6 @@ def _setup_ensemble_smoother(
             active_realizations=_realizations(
                 args, config.model_config.num_realizations
             ).tolist(),
-            current_ensemble=args.current_ensemble,
             target_ensemble=args.target_ensemble,
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -96,6 +96,7 @@ def _setup_single_test_run(
             ensemble_size=1,
             stop_long_running=config.analysis_config.stop_long_running,
             experiment_name=args.experiment_name,
+            active_realizations=[True],
         ),
         config,
         storage,
@@ -239,6 +240,9 @@ def _setup_multiple_data_assimilation(
             weights=args.weights,
             restart_run=restart_run,
             prior_ensemble_id=prior_ensemble,
+            starting_iteration=storage.get_ensemble(prior_ensemble).iteration + 1
+            if restart_run
+            else 0,
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,
             stop_long_running=config.analysis_config.stop_long_running,
@@ -267,7 +271,7 @@ def _setup_iterative_ensemble_smoother(
                 args, config.model_config.num_realizations
             ).tolist(),
             target_ensemble=_iterative_ensemble_format(config, args),
-            num_iterations=_num_iterations(config, args),
+            number_of_iterations=_num_iterations(config, args),
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,
             num_retries_per_iter=config.analysis_config.num_retries_per_iter,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -48,6 +48,14 @@ class MultipleDataAssimilation(BaseRunModel):
         self.weights = self.parse_weights(simulation_arguments.weights)
         self.es_settings = es_settings
         self.update_settings = update_settings
+        if simulation_arguments.starting_iteration == 0:
+            # If a regular run we also need to account for the prior
+            number_of_iterations = len(self.weights) + 1
+        else:
+            number_of_iterations = len(
+                self.weights[simulation_arguments.starting_iteration - 1 :]
+            )
+
         super().__init__(
             simulation_arguments,
             config,
@@ -55,7 +63,7 @@ class MultipleDataAssimilation(BaseRunModel):
             queue_config,
             status_queue,
             phase_count=2,
-            number_of_iterations=len(self.weights),
+            number_of_iterations=number_of_iterations,
             start_iteration=simulation_arguments.starting_iteration,
         )
 

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -60,10 +60,6 @@ class MultipleDataAssimilation(BaseRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig
     ) -> RunContext:
-        self.checkHaveSufficientRealizations(
-            self._simulation_arguments.active_realizations.count(True),
-            self._simulation_arguments.minimum_required_realizations,
-        )
         weights = self.parseWeights(self._simulation_arguments.weights)
 
         if not weights:

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -86,9 +86,6 @@ class MultipleDataAssimilation(BaseRunModel):
                     initial_mask=np.array(self.active_realizations, dtype=bool),
                     iteration=prior.iteration,
                 )
-                self.prev_successful_realizations = (
-                    prior.get_realization_mask_without_failure().sum()
-                )
                 if self.start_iteration != prior.iteration + 1:
                     raise ValueError(
                         f"Experiment misconfigured, got starting iteration: {self.start_iteration},"

--- a/src/ert/run_models/run_arguments.py
+++ b/src/ert/run_models/run_arguments.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional
 
 
 @dataclass
@@ -9,6 +9,7 @@ class SimulationArguments:
     ensemble_size: int
     stop_long_running: bool
     experiment_name: Optional[str]
+    active_realizations: List[bool]
 
 
 @dataclass
@@ -16,83 +17,41 @@ class SingleTestRunArguments(SimulationArguments):
     ensemble_name: str = "prior"
     ensemble_type: str = "Single test"
 
-    def __post_init__(self) -> None:
-        self.num_iterations = 1
-        self.prev_successful_realizations = 0
-        self.iter_num = 0
-        self.active_realizations = [True]
-
 
 @dataclass
 class EnsembleExperimentRunArguments(SimulationArguments):
-    active_realizations: List[bool]
     experiment_name: str
     ensemble_name: str = "prior"
     ensemble_type: str = "Ensemble experiment"
 
-    def __post_init__(self) -> None:
-        self.num_iterations = 1
-        self.prev_successful_realizations = 0
-        self.iter_num = 0
-
 
 @dataclass
 class EvaluateEnsembleRunArguments(SimulationArguments):
-    active_realizations: List[bool]
     ensemble_id: str
     ensemble_type: str = "Evaluate ensemble"
-
-    def __post_init__(self) -> None:
-        self.target_ensemble = None
-        self.iter_num = 0
-        self.prev_successful_realizations = 0
-        self.num_iterations = 1
 
 
 @dataclass
 class ESRunArguments(SimulationArguments):
-    active_realizations: List[bool]
     target_ensemble: str
     ensemble_type: str = "ES"
-
-    num_iterations: int = 1
-    prev_successful_realizations: int = 0
 
 
 # pylint: disable=R0902
 @dataclass
 class ESMDARunArguments(SimulationArguments):
-    active_realizations: List[bool]
     target_ensemble: str
     weights: str
     restart_run: bool
     prior_ensemble_id: str
+    starting_iteration: int
     ensemble_type: str = "ES_MDA"
-    start_iteration: int = 0
-    prev_successful_realizations: int = 0
     current_ensemble = None
-
-    def __post_init__(self) -> None:
-        self.num_iterations: int = len(self.weights)
 
 
 @dataclass
 class SIESRunArguments(SimulationArguments):
-    active_realizations: List[bool]
     target_ensemble: str
-    num_iterations: int
     num_retries_per_iter: int
-
+    number_of_iterations: int = 3
     ensemble_type: str = "IES"
-    iter_num = 0
-    prev_successful_realizations = 0
-
-
-RunArgumentsType = Union[
-    SingleTestRunArguments,
-    EnsembleExperimentRunArguments,
-    EvaluateEnsembleRunArguments,
-    ESRunArguments,
-    ESMDARunArguments,
-    SIESRunArguments,
-]

--- a/src/ert/run_models/run_arguments.py
+++ b/src/ert/run_models/run_arguments.py
@@ -13,8 +13,7 @@ class SimulationArguments:
 
 @dataclass
 class SingleTestRunArguments(SimulationArguments):
-    current_ensemble: str = "prior"
-    target_ensemble: Optional[str] = None
+    ensemble_name: str = "prior"
     ensemble_type: str = "Single test"
 
     def __post_init__(self) -> None:
@@ -28,8 +27,7 @@ class SingleTestRunArguments(SimulationArguments):
 class EnsembleExperimentRunArguments(SimulationArguments):
     active_realizations: List[bool]
     experiment_name: str
-    current_ensemble: str = "prior"
-    target_ensemble: Optional[str] = None
+    ensemble_name: str = "prior"
     ensemble_type: str = "Ensemble experiment"
 
     def __post_init__(self) -> None:
@@ -41,7 +39,7 @@ class EnsembleExperimentRunArguments(SimulationArguments):
 @dataclass
 class EvaluateEnsembleRunArguments(SimulationArguments):
     active_realizations: List[bool]
-    current_ensemble: str
+    ensemble_id: str
     ensemble_type: str = "Evaluate ensemble"
 
     def __post_init__(self) -> None:
@@ -54,7 +52,6 @@ class EvaluateEnsembleRunArguments(SimulationArguments):
 @dataclass
 class ESRunArguments(SimulationArguments):
     active_realizations: List[bool]
-    current_ensemble: str
     target_ensemble: str
     ensemble_type: str = "ES"
 
@@ -86,7 +83,6 @@ class SIESRunArguments(SimulationArguments):
     num_iterations: int
     num_retries_per_iter: int
 
-    current_ensemble = None
     ensemble_type: str = "IES"
     iter_num = 0
     prev_successful_realizations = 0

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from typing_extensions import override
 
 from ert.config import ErtConfig
-from ert.run_models import EnsembleExperiment, ErtRunError
+from ert.run_models import EnsembleExperiment
 
 if TYPE_CHECKING:
     from queue import SimpleQueue
@@ -28,14 +28,6 @@ class SingleTestRun(EnsembleExperiment):
         super().__init__(
             simulation_arguments, config, storage, local_queue_config, status_queue
         )
-
-    @staticmethod
-    def checkHaveSufficientRealizations(
-        num_successful_realizations: int, _: int
-    ) -> None:
-        # Should only have one successful realization
-        if num_successful_realizations != 1:
-            raise ErtRunError("Experiment failed!")
 
     @override
     @classmethod

--- a/src/ert/runpaths.py
+++ b/src/ert/runpaths.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Union
 
 from ert.substitution_list import SubstitutionList
 
@@ -44,7 +44,7 @@ class Runpaths:
         self._substitution_list["<ERT-CASE>"] = ensemble_name
         self._substitution_list["<ERTCASE>"] = ensemble_name
 
-    def get_paths(self, realizations: List[int], iteration: int) -> List[str]:
+    def get_paths(self, realizations: Iterable[int], iteration: int) -> List[str]:
         return [
             self._substitution_list.substitute_real_iter(
                 self._runpath_format, realization, iteration

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -30,7 +30,7 @@ from .ensure_correct_xr_coordinate_order import ensure_correct_coordinate_order
 if TYPE_CHECKING:
     from ert.config.parameter_config import ParameterConfig
     from ert.run_models.run_arguments import (
-        RunArgumentsType,
+        SimulationArguments,
     )
     from ert.storage.local_ensemble import LocalEnsemble
     from ert.storage.local_storage import LocalStorage
@@ -102,7 +102,7 @@ class LocalExperiment(BaseMode):
         parameters: Optional[List[ParameterConfig]] = None,
         responses: Optional[List[ResponseConfig]] = None,
         observations: Optional[Dict[str, xr.Dataset]] = None,
-        simulation_arguments: Optional[RunArgumentsType] = None,
+        simulation_arguments: Optional[SimulationArguments] = None,
         name: Optional[str] = None,
     ) -> LocalExperiment:
         """
@@ -122,7 +122,7 @@ class LocalExperiment(BaseMode):
             List of response configurations.
         observations : dict of str: xr.Dataset, optional
             Observations dictionary.
-        simulation_arguments : RunArgumentsType, optional
+        simulation_arguments : SimulationArguments, optional
             Simulation arguments for the experiment.
         name : str, optional
             Experiment name. Defaults to current date if None.

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -37,7 +37,7 @@ from ert.storage.realization_storage_state import RealizationStorageState
 
 if TYPE_CHECKING:
     from ert.config import ParameterConfig, ResponseConfig
-    from ert.run_models.run_arguments import RunArgumentsType
+    from ert.run_models.run_arguments import SimulationArguments
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ class LocalStorage(BaseMode):
 
         return self._experiments[uuid]
 
-    def get_ensemble(self, uuid: UUID) -> LocalEnsemble:
+    def get_ensemble(self, uuid: Union[UUID, str]) -> LocalEnsemble:
         """
         Retrieves an ensemble by UUID.
 
@@ -160,7 +160,8 @@ class LocalStorage(BaseMode):
         local_ensemble : LocalEnsemble
             The ensemble associated with the given UUID.
         """
-
+        if isinstance(uuid, str):
+            uuid = UUID(uuid)
         return self._ensembles[uuid]
 
     def get_ensemble_by_name(self, name: str) -> LocalEnsemble:
@@ -297,7 +298,7 @@ class LocalStorage(BaseMode):
         parameters: Optional[List[ParameterConfig]] = None,
         responses: Optional[List[ResponseConfig]] = None,
         observations: Optional[Dict[str, xr.Dataset]] = None,
-        simulation_arguments: Optional[RunArgumentsType] = None,
+        simulation_arguments: Optional[SimulationArguments] = None,
         name: Optional[str] = None,
     ) -> LocalExperiment:
         """
@@ -311,7 +312,7 @@ class LocalStorage(BaseMode):
             The responses for the experiment.
         observations : dict of str to Dataset, optional
             The observations for the experiment.
-        simulation_arguments : RunArgumentsType, optional
+        simulation_arguments : SimulationArguments, optional
             The simulation arguments for the experiment.
         name : str, optional
             The name of the experiment.

--- a/tests/integration_tests/analysis/test_adaptive_localization.py
+++ b/tests/integration_tests/analysis/test_adaptive_localization.py
@@ -12,16 +12,9 @@ from tests.integration_tests.run_cli import run_cli
 
 
 def run_cli_ES_with_case(poly_config):
-    config_name = poly_config.split(".")[0]
-    prior_sample_name = "prior_sample" + "_" + config_name
-    posterior_sample_name = "posterior_sample" + "_" + config_name
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
-        "--current-case",
-        prior_sample_name,
-        "--target-case",
-        posterior_sample_name,
         "--realizations",
         "1-50",
         poly_config,
@@ -30,8 +23,8 @@ def run_cli_ES_with_case(poly_config):
     )
     storage_path = ErtConfig.from_file(poly_config).ens_path
     with open_storage(storage_path) as storage:
-        prior_ensemble = storage.get_ensemble_by_name(prior_sample_name)
-        posterior_ensemble = storage.get_ensemble_by_name(posterior_sample_name)
+        prior_ensemble = storage.get_ensemble_by_name("iter-0")
+        posterior_ensemble = storage.get_ensemble_by_name("iter-1")
     return prior_ensemble, posterior_ensemble
 
 

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -68,19 +68,15 @@ def test_that_posterior_has_lower_variance_than_prior():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
-        "--current-case",
-        "default",
-        "--target-case",
-        "target",
         "--realizations",
         "1-50",
         "poly.ert",
     )
     facade = LibresFacade.from_config_file("poly.ert")
     with open_storage(facade.enspath) as storage:
-        prior_ensemble = storage.get_ensemble_by_name("default")
+        prior_ensemble = storage.get_ensemble_by_name("iter-0")
         df_default = prior_ensemble.load_all_gen_kw_data()
-        posterior_ensemble = storage.get_ensemble_by_name("target")
+        posterior_ensemble = storage.get_ensemble_by_name("iter-1")
         df_target = posterior_ensemble.load_all_gen_kw_data()
 
         # The std for the ensemble should decrease
@@ -144,16 +140,14 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert():
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
         "snake_oil_surface.ert",
-        "--target-case",
-        "es_udpate",
     )
 
     ert_config = ErtConfig.from_file("snake_oil_surface.ert")
 
     storage = open_storage(ert_config.ens_path)
 
-    ens_prior = storage.get_ensemble_by_name("default")
-    ens_posterior = storage.get_ensemble_by_name("es_udpate")
+    ens_prior = storage.get_ensemble_by_name("iter-0")
+    ens_posterior = storage.get_ensemble_by_name("iter-1")
 
     # Check that surfaces defined in INIT_FILES are not changed by ERT
     surf_prior = ens_prior.load_parameters("TOP", list(range(ensemble_size)))["values"]
@@ -184,15 +178,13 @@ def test_update_multiple_param():
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
         "snake_oil.ert",
-        "--target-case",
-        "posterior",
     )
 
     ert_config = ErtConfig.from_file("snake_oil.ert")
 
     storage = open_storage(ert_config.ens_path)
-    prior_ensemble = storage.get_ensemble_by_name("default")
-    posterior_ensemble = storage.get_ensemble_by_name("posterior")
+    prior_ensemble = storage.get_ensemble_by_name("iter-0")
+    posterior_ensemble = storage.get_ensemble_by_name("iter-1")
 
     prior_array = _all_parameters(prior_ensemble, list(range(10)))
     posterior_array = _all_parameters(posterior_ensemble, list(range(10)))
@@ -482,15 +474,13 @@ def test_that_update_works_with_failed_realizations():
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
         "poly.ert",
-        "--target-case",
-        "posterior",
     )
 
     ert_config = ErtConfig.from_file("poly.ert")
 
     with open_storage(ert_config.ens_path) as storage:
-        prior = storage.get_ensemble_by_name("default")
-        posterior = storage.get_ensemble_by_name("posterior")
+        prior = storage.get_ensemble_by_name("iter-0")
+        posterior = storage.get_ensemble_by_name("iter-1")
 
         assert all(
             posterior.get_ensemble_state()[idx]

--- a/tests/integration_tests/status/test_tracking_integration.py
+++ b/tests/integration_tests/status/test_tracking_integration.py
@@ -111,8 +111,6 @@ def check_expression(original, path_expression, expected, msg_start):
             "",
             [
                 ENSEMBLE_SMOOTHER_MODE,
-                "--target-case",
-                "poly_runpath_file",
                 "--realizations",
                 "0,1",
                 "poly.ert",
@@ -128,8 +126,6 @@ def check_expression(original, path_expression, expected, msg_start):
             '    import os\n    if os.getcwd().split("/")[-2].split("-")[1] == "0": sys.exit(1)',  # noqa 501
             [
                 ENSEMBLE_SMOOTHER_MODE,
-                "--target-case",
-                "poly_runpath_file",
                 "--realizations",
                 "0,1",
                 "poly.ert",

--- a/tests/integration_tests/storage/test_field_parameter.py
+++ b/tests/integration_tests/storage/test_field_parameter.py
@@ -106,16 +106,12 @@ if __name__ == "__main__":
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
             "--disable-monitor",
-            "--current-case",
-            "prior",
-            "--target-case",
-            "smoother_update",
             "config.ert",
         )
         config = ErtConfig.from_file("config.ert")
         with open_storage(config.ens_path, mode="w") as storage:
-            prior = storage.get_ensemble_by_name("prior")
-            posterior = storage.get_ensemble_by_name("smoother_update")
+            prior = storage.get_ensemble_by_name("iter-0")
+            posterior = storage.get_ensemble_by_name("iter-1")
 
             prior_result = prior.load_parameters("MY_PARAM", list(range(5)))["values"]
             assert len(prior_result.x) == NCOL
@@ -237,16 +233,12 @@ if __name__ == "__main__":
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
             "--disable-monitor",
-            "--current-case",
-            "prior",
-            "--target-case",
-            "smoother_update",
             "config.ert",
         )
         config = ErtConfig.from_file("config.ert")
         with open_storage(config.ens_path) as storage:
-            prior = storage.get_ensemble_by_name("prior")
-            posterior = storage.get_ensemble_by_name("smoother_update")
+            prior = storage.get_ensemble_by_name("iter-0")
+            posterior = storage.get_ensemble_by_name("iter-1")
 
             prior_result = prior.load_parameters("MY_PARAM", list(range(realizations)))[
                 "values"

--- a/tests/integration_tests/storage/test_parameter_sample_types.py
+++ b/tests/integration_tests/storage/test_parameter_sample_types.py
@@ -120,15 +120,11 @@ if __name__ == "__main__":
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
             "--disable-monitor",
-            "--current-case",
-            "prior",
-            "--target-case",
-            "smoother_update",
             "config.ert",
         )
         with open_storage(tmpdir / "storage") as storage:
-            prior = storage.get_ensemble_by_name("prior")
-            posterior = storage.get_ensemble_by_name("smoother_update")
+            prior = storage.get_ensemble_by_name("iter-0")
+            posterior = storage.get_ensemble_by_name("iter-1")
             prior_param = (
                 prior.load_parameters("MY_PARAM", list(range(5)))["values"]
                 .values.reshape(5, 2 * 3)
@@ -271,9 +267,5 @@ def run_poly():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
-        "--current-case",
-        "prior",
-        "--target-case",
-        "smoother_update",
         "config.ert",
     )

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -137,10 +137,7 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
 def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
     with pytest.raises(
         ErtCliError,
-        match=(
-            "Operation halted: ES-MDA requires weights to proceed. "
-            "Please provide appropriate weights and try again."
-        ),
+        match="Invalid weights: 0",
     ):
         run_cli(
             ES_MDA_MODE,

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -129,7 +129,7 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
             "--disable-monitor",
             "poly-no-gen-kw.ert",
             "--target-case",
-            "testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d",
+            "testcase-%d",
         )
 
 
@@ -256,7 +256,7 @@ def test_that_the_model_raises_exception_if_active_less_than_minimum_realization
             "--realizations",
             "0-19",
             "--target-case",
-            "testcase" if mode is ENSEMBLE_SMOOTHER_MODE else "testcase-%d",
+            "testcase-%d",
         )
 
 
@@ -606,7 +606,7 @@ def test_ensemble_evaluator():
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
         "--target-case",
-        "poly_runpath_file",
+        "poly_runpath_file_%d",
         "--realizations",
         "1,2,4,8,16,32,64",
         "poly.ert",
@@ -650,7 +650,9 @@ def test_es_mda(snapshot):
 @pytest.mark.parametrize(
     "mode, target",
     [
-        pytest.param(ENSEMBLE_SMOOTHER_MODE, "target", id=f"{ENSEMBLE_SMOOTHER_MODE}"),
+        pytest.param(
+            ENSEMBLE_SMOOTHER_MODE, "target_%d", id=f"{ENSEMBLE_SMOOTHER_MODE}"
+        ),
         pytest.param(
             ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
             "iter-%d",
@@ -680,8 +682,6 @@ def test_ensemble_evaluator_disable_monitoring():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitoring",
-        "--target-case",
-        "poly_runpath_file",
         "--realizations",
         "1,2,4,8,16,32,64",
         "poly.ert",
@@ -869,13 +869,13 @@ def test_exclude_parameter_from_update():
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitor",
         "--target-case",
-        "iter-1",
+        "iter-%d",
         "--realizations",
         "0-5",
         "poly.ert",
     )
     with open_storage("storage", "r") as storage:
-        prior = storage.get_ensemble_by_name("default")
+        prior = storage.get_ensemble_by_name("iter-0")
         posterior = storage.get_ensemble_by_name("iter-1")
         assert prior.load_parameters(
             "ANOTHER_KW", tuple(range(5))

--- a/tests/unit_tests/all/test_main.py
+++ b/tests/unit_tests/all/test_main.py
@@ -90,27 +90,20 @@ def test_argparse_exec_ensemble_experiment_faulty_realizations():
         )
 
 
-def test_argparse_exec_ensemble_smoother_valid_case():
-    parsed = ert_parser(
-        None,
-        [ENSEMBLE_SMOOTHER_MODE, "--target-case", "some_case", "path/to/config.ert"],
-    )
-    assert parsed.mode == ENSEMBLE_SMOOTHER_MODE
-    assert parsed.target_ensemble == "some_case"
-    assert parsed.func.__name__ == "run_cli"
-
-
-def test_argparse_exec_iterative_ensemble_smoother_valid_case():
+@pytest.mark.parametrize(
+    "mode", [ITERATIVE_ENSEMBLE_SMOOTHER_MODE, ENSEMBLE_SMOOTHER_MODE]
+)
+def test_argparse_exec_smoother_valid_case(mode):
     parsed = ert_parser(
         None,
         [
-            ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
+            mode,
             "--target-case",
             "some_case_%d",
             "path/to/config.ert",
         ],
     )
-    assert parsed.mode == ITERATIVE_ENSEMBLE_SMOOTHER_MODE
+    assert parsed.mode == mode
     assert parsed.target_ensemble == "some_case_%d"
     assert parsed.func.__name__ == "run_cli"
 
@@ -156,23 +149,6 @@ def test_argparse_exec_workflow():
     parsed = ert_parser(None, [WORKFLOW_MODE, "workflow_name", "path/to/config.ert"])
     assert parsed.mode == WORKFLOW_MODE
     assert parsed.name == "workflow_name"
-    assert parsed.func.__name__ == "run_cli"
-
-
-def test_argparse_exec_ensemble_smoother_current_ensemble():
-    parsed = ert_parser(
-        None,
-        [
-            ENSEMBLE_SMOOTHER_MODE,
-            "--current-case",
-            "test_case",
-            "--target-case",
-            "test_case_smoother",
-            "path/to/config.ert",
-        ],
-    )
-    assert parsed.mode == ENSEMBLE_SMOOTHER_MODE
-    assert parsed.current_ensemble == "test_case"
     assert parsed.func.__name__ == "run_cli"
 
 

--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -94,6 +94,7 @@ def test_hook_call_order_es_mda(monkeypatch):
         ensemble_size=1,
         stop_long_running=False,
         experiment_name="no-name",
+        starting_iteration=0,
     )
     run_wfs_mock = MagicMock()
     monkeypatch.setattr(multiple_data_assimilation, "sample_prior", MagicMock())
@@ -138,7 +139,7 @@ def test_hook_call_order_iterative_ensemble_smoother(monkeypatch):
         random_seed=None,
         active_realizations=[True],
         target_ensemble="target_%d",
-        num_iterations=1,
+        number_of_iterations=1,
         num_retries_per_iter=1,
         minimum_required_realizations=0,
         ensemble_size=1,

--- a/tests/unit_tests/cli/test_model_hook_order.py
+++ b/tests/unit_tests/cli/test_model_hook_order.py
@@ -52,8 +52,7 @@ def test_hook_call_order_ensemble_smoother(monkeypatch):
     minimum_args = ESRunArguments(
         random_seed=None,
         active_realizations=[True],
-        current_ensemble="default",
-        target_ensemble="smooth",
+        target_ensemble="smooth_%d",
         minimum_required_realizations=0,
         ensemble_size=1,
         stop_long_running=False,

--- a/tests/unit_tests/cli/test_run_context.py
+++ b/tests/unit_tests/cli/test_run_context.py
@@ -26,6 +26,7 @@ def test_that_all_iterations_gets_correct_name_and_iteration_number(
         ensemble_size=1,
         stop_long_running=True,
         experiment_name="no-name",
+        starting_iteration=0,
     )
     ens_mock = MagicMock()
     ens_mock.iteration = 0

--- a/tests/unit_tests/dark_storage/conftest.py
+++ b/tests/unit_tests/dark_storage/conftest.py
@@ -33,10 +33,6 @@ def poly_example_tmp_dir_shared(
             [
                 ENSEMBLE_SMOOTHER_MODE,
                 "--disable-monitor",
-                "--current-case",
-                "alpha",
-                "--target-case",
-                "beta",
                 "--realizations",
                 "1,2,4",
                 "poly.ert",

--- a/tests/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/unit_tests/dark_storage/test_http_endpoints.py
@@ -28,7 +28,7 @@ def test_get_ensemble(poly_example_tmp_dir, dark_storage_client):
     ensemble_json = resp.json()
 
     assert ensemble_json["experiment_id"] == experiment_json[0]["id"]
-    assert ensemble_json["userdata"]["name"] in ("alpha", "beta")
+    assert ensemble_json["userdata"]["name"] in ("iter-0", "iter-1")
     assert ensemble_json["userdata"]["experiment_name"] == experiment_json[0]["name"]
 
 
@@ -45,7 +45,7 @@ def test_get_experiment_ensemble(poly_example_tmp_dir, dark_storage_client):
 
     assert len(ensembles_json) == 2
     assert ensembles_json[0]["experiment_id"] == experiment_json[0]["id"]
-    assert ensembles_json[0]["userdata"]["name"] in ("alpha", "beta")
+    assert ensembles_json[0]["userdata"]["name"] in ("iter-0", "iter-1")
 
 
 def test_get_responses_with_observations(poly_example_tmp_dir, dark_storage_client):
@@ -72,13 +72,13 @@ def test_get_response(poly_example_tmp_dir, dark_storage_client):
 
     # Make sure the order is correct
     resp: Response = dark_storage_client.get(f"/ensembles/{ensemble_id1}")
-    if resp.json()["userdata"]["name"] == "beta":
-        # First ensemble is 'beta', switch it so it is 'alpha'
+    if resp.json()["userdata"]["name"] == "iter-1":
+        # First ensemble is 'iter-1', switch it so it is 'iter-0'
         ensemble_id1, ensemble_id2 = ensemble_id2, ensemble_id1
 
     resp: Response = dark_storage_client.get(f"/ensembles/{ensemble_id1}")
     ensemble_json = resp.json()
-    assert ensemble_json["userdata"]["name"] == "alpha", (
+    assert ensemble_json["userdata"]["name"] == "iter-0", (
         f"\nexperiment_json: {json.dumps(experiment_json, indent=1)} \n\n"
         f"ensemble_json: {json.dumps(ensemble_json, indent=1)}"
     )
@@ -86,7 +86,7 @@ def test_get_response(poly_example_tmp_dir, dark_storage_client):
     resp: Response = dark_storage_client.get(f"/ensembles/{ensemble_id2}")
     ensemble_json2 = resp.json()
 
-    assert ensemble_json2["userdata"]["name"] == "beta", (
+    assert ensemble_json2["userdata"]["name"] == "iter-1", (
         f"\nexperiment_json: {json.dumps(experiment_json, indent=1)} \n\n"
         f"ensemble_json2: {json.dumps(ensemble_json2, indent=1)}"
     )

--- a/tests/unit_tests/run_models/test_base_run_model.py
+++ b/tests/unit_tests/run_models/test_base_run_model.py
@@ -77,8 +77,6 @@ def test_failed_realizations(initials, completed, any_failed, failures, base_arg
     brm._completed_realizations_mask = completed
 
     assert brm._create_mask_from_failed_realizations() == failures
-    assert brm._count_successful_realizations() == sum(completed)
-
     assert brm.has_failed_realizations() == any_failed
 
 

--- a/tests/unit_tests/run_models/test_base_run_model.py
+++ b/tests/unit_tests/run_models/test_base_run_model.py
@@ -143,7 +143,7 @@ def test_delete_run_path(run_path_format, active_realizations):
     simulation_arguments = EnsembleExperimentRunArguments(
         random_seed=None,
         active_realizations=active_realizations,
-        current_ensemble="Case_Name",
+        ensemble_name="Case_Name",
         target_ensemble=None,
         minimum_required_realizations=0,
         ensemble_size=1,

--- a/tests/unit_tests/run_models/test_ensemble_experiment.py
+++ b/tests/unit_tests/run_models/test_ensemble_experiment.py
@@ -26,7 +26,7 @@ def test_check_if_runpath_exists(
     simulation_arguments = EnsembleExperimentRunArguments(
         random_seed=None,
         active_realizations=active_mask,
-        current_ensemble=None,
+        ensemble_name=None,
         target_ensemble=None,
         minimum_required_realizations=0,
         ensemble_size=1,

--- a/tests/unit_tests/run_models/test_ensemble_experiment.py
+++ b/tests/unit_tests/run_models/test_ensemble_experiment.py
@@ -26,8 +26,7 @@ def test_check_if_runpath_exists(
     simulation_arguments = EnsembleExperimentRunArguments(
         random_seed=None,
         active_realizations=active_mask,
-        ensemble_name=None,
-        target_ensemble=None,
+        ensemble_name="Some_name",
         minimum_required_realizations=0,
         ensemble_size=1,
         stop_long_running=False,

--- a/tests/unit_tests/run_models/test_model_factory.py
+++ b/tests/unit_tests/run_models/test_model_factory.py
@@ -60,7 +60,7 @@ def test_setup_single_test_run(poly_case, storage):
         MagicMock(),
     )
     assert isinstance(model, SingleTestRun)
-    assert model.simulation_arguments.current_ensemble == "current-ensemble"
+    assert model.simulation_arguments.ensemble_id == "current-ensemble"
     assert model.simulation_arguments.target_ensemble is None
     assert model._storage == storage
     assert model.ert_config == poly_case
@@ -79,7 +79,7 @@ def test_setup_single_test_run_with_ensemble(poly_case, storage):
         MagicMock(),
     )
     assert isinstance(model, SingleTestRun)
-    assert model.simulation_arguments.current_ensemble == "current-ensemble"
+    assert model.simulation_arguments.ensemble_id == "current-ensemble"
     assert model.simulation_arguments.target_ensemble is None
     assert model._storage == storage
     assert model.ert_config == poly_case

--- a/tests/unit_tests/run_models/test_model_factory.py
+++ b/tests/unit_tests/run_models/test_model_factory.py
@@ -1,9 +1,12 @@
 import dataclasses
 from argparse import Namespace
 from unittest.mock import MagicMock
+from uuid import uuid1
 
 import pytest
 
+import ert
+from ert.config import ErtConfig
 from ert.libres_facade import LibresFacade
 from ert.run_models import (
     EnsembleExperiment,
@@ -166,3 +169,40 @@ def test_setup_iterative_ensemble_smoother(poly_case, storage):
     )
     assert model.simulation_arguments.number_of_iterations == 10
     assert poly_case.analysis_config.num_iterations == 10
+
+
+@pytest.mark.parametrize(
+    "restart_from_iteration, expected_path",
+    [
+        [0, ["realization-0/iter-1", "realization-0/iter-2", "realization-0/iter-3"]],
+        [1, ["realization-0/iter-2", "realization-0/iter-3"]],
+        [2, ["realization-0/iter-3"]],
+        [3, []],
+    ],
+)
+def test_multiple_data_assimilation_restart_paths(
+    tmp_path, monkeypatch, restart_from_iteration, expected_path
+):
+    monkeypatch.chdir(tmp_path)
+    args = Namespace(
+        realizations="0",
+        weights="6,4,2",
+        target_ensemble="restart_case_%d",
+        restart_run=True,
+        prior_ensemble_id=str(uuid1()),
+        experiment_name=None,
+    )
+    monkeypatch.setattr(
+        ert.run_models.base_run_model.BaseRunModel, "validate", MagicMock()
+    )
+    storage_mock = MagicMock()
+    ensemble_mock = MagicMock()
+    ensemble_mock.iteration = restart_from_iteration
+    config = ErtConfig()
+    storage_mock.get_ensemble.return_value = ensemble_mock
+    model = model_factory._setup_multiple_data_assimilation(
+        config, storage_mock, args, MagicMock(), MagicMock()
+    )
+    base_path = tmp_path / "simulations"
+    expected_path = [str(base_path / expected) for expected in expected_path]
+    assert model.paths == expected_path

--- a/tests/unit_tests/run_models/test_model_factory.py
+++ b/tests/unit_tests/run_models/test_model_factory.py
@@ -60,8 +60,6 @@ def test_setup_single_test_run(poly_case, storage):
         MagicMock(),
     )
     assert isinstance(model, SingleTestRun)
-    assert model.simulation_arguments.ensemble_id == "current-ensemble"
-    assert model.simulation_arguments.target_ensemble is None
     assert model._storage == storage
     assert model.ert_config == poly_case
 
@@ -79,8 +77,6 @@ def test_setup_single_test_run_with_ensemble(poly_case, storage):
         MagicMock(),
     )
     assert isinstance(model, SingleTestRun)
-    assert model.simulation_arguments.ensemble_id == "current-ensemble"
-    assert model.simulation_arguments.target_ensemble is None
     assert model._storage == storage
     assert model.ert_config == poly_case
 
@@ -117,10 +113,8 @@ def test_setup_ensemble_smoother(poly_case, storage):
         poly_case, storage, args, MagicMock(), MagicMock()
     )
     assert isinstance(model, EnsembleSmoother)
-    assert model.simulation_arguments.current_ensemble == "default"
-    assert model.simulation_arguments.target_ensemble == "test_case"
     assert (
-        model.simulation_arguments.active_realizations
+        model.active_realizations
         == [True] * 5 + [False] * 2 + [True] * 2 + [False] * 91
     )
 
@@ -133,6 +127,7 @@ def test_setup_multiple_data_assimilation(poly_case, storage):
         restart_run=False,
         prior_ensemble_id="b272fe09-83ac-4744-b667-9a0a5415420b",
         experiment_name=None,
+        starting_iteration=0,
     )
 
     model = model_factory._setup_multiple_data_assimilation(
@@ -141,7 +136,7 @@ def test_setup_multiple_data_assimilation(poly_case, storage):
     assert isinstance(model, MultipleDataAssimilation)
     assert model.simulation_arguments.weights == "6,4,2"
     assert (
-        model.simulation_arguments.active_realizations
+        model.active_realizations
         == [True] * 5 + [False] * 3 + [True] * 1 + [False] * 91
     )
     assert model.simulation_arguments.target_ensemble == "test_case_%d"
@@ -155,7 +150,6 @@ def test_setup_multiple_data_assimilation(poly_case, storage):
 def test_setup_iterative_ensemble_smoother(poly_case, storage):
     args = Namespace(
         realizations="0-4,7,8",
-        current_ensemble="default",
         target_ensemble="test_case_%d",
         num_iterations="10",
         experiment_name=None,
@@ -167,8 +161,8 @@ def test_setup_iterative_ensemble_smoother(poly_case, storage):
     assert isinstance(model, IteratedEnsembleSmoother)
     assert model.simulation_arguments.target_ensemble == "test_case_%d"
     assert (
-        model.simulation_arguments.active_realizations
+        model.active_realizations
         == [True] * 5 + [False] * 2 + [True] * 2 + [False] * 91
     )
-    assert model.simulation_arguments.num_iterations == 10
+    assert model.simulation_arguments.number_of_iterations == 10
     assert poly_case.analysis_config.num_iterations == 10

--- a/tests/unit_tests/run_models/test_multiple_data_assimilation.py
+++ b/tests/unit_tests/run_models/test_multiple_data_assimilation.py
@@ -4,29 +4,21 @@ import pytest
 from ert.run_models import MultipleDataAssimilation as mda
 
 
-def test_normalized_weights():
-    weights = mda.normalizeWeights([1])
-    assert weights == [1.0]
-
-    weights = mda.normalizeWeights([1, 1])
-    assert weights == [2.0, 2.0]
-
-    weights = np.array(mda.normalizeWeights([8, 4, 2, 1]))
+@pytest.mark.parametrize(
+    "weights, expected",
+    [
+        ("2, 2, 2, 2", [4] * 4),
+        ("1, 2, 4, ", [1.75, 3.5, 7.0]),
+        ("1, 0, 1, ", [2, 2]),
+        ("1.414213562373095, 1.414213562373095", [2, 2]),
+    ],
+)
+def test_weights(weights, expected):
+    weights = mda.parse_weights(weights)
+    assert weights == expected
     assert np.reciprocal(weights).sum() == 1.0
 
 
-def test_weights():
-    weights = mda.parseWeights("2, 2, 2, 2")
-    assert weights == [2, 2, 2, 2]
-
-    weights = mda.parseWeights("1, 2, 3, ")
-    assert weights == [1, 2, 3]
-
-    weights = mda.parseWeights("1, 0, 1")
-    assert weights == [1, 1]
-
-    weights = mda.parseWeights("1.414213562373095, 1.414213562373095")
-    assert weights == [1.414213562373095, 1.414213562373095]
-
+def test_invalid_weights():
     with pytest.raises(ValueError):
-        mda.parseWeights("2, error, 2, 2")
+        mda.parse_weights("2, error, 2, 2")


### PR DESCRIPTION
The intention here is to reduce the statefullness of the run models, by reducing the use of simulation arguments as holders of state, and internalizing state on the run models instead. Also to simplify the simulation arguments by removing a lot of unneeded properties.

This results in a breaking change for the cli, which aligns it with the GUI in terms of naming the ensembles in ensemble smoother.

Closes #7633 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [x] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
