### PR TITLE
Fix signature of overrides from QAbstractItemModel

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,9 +39,14 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 ignore_errors = True
 
-[mypy-ert.gui.model.*]
+[mypy-ert.gui.model.node]
 ignore_missing_imports = True
 ignore_errors = True
+
+[mypy-ert.gui.model.snapshot]
+ignore_missing_imports = True
+ignore_errors = True
+
 
 [mypy-ert.gui.simulation.*]
 ignore_missing_imports = True

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -173,7 +173,8 @@ class StorageModel(QAbstractItemModel):
     def columnCount(self, parent: QModelIndex = default_index) -> int:
         return _NUM_COLUMNS
 
-    def rowCount(self, parent: QModelIndex) -> int:
+    @override
+    def rowCount(self, parent: QModelIndex = default_index) -> int:
         if parent.isValid():
             if isinstance(parent.internalPointer(), RealizationModel):
                 return 0

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -29,8 +29,6 @@ _COLUMN_TEXT = {
     2: "Type",
 }
 
-default_index = QModelIndex()
-
 
 class RealizationModel:
     def __init__(self, realization: int, parent: Any) -> None:
@@ -170,11 +168,13 @@ class StorageModel(QAbstractItemModel):
             self._children.append(ex)
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         return _NUM_COLUMNS
 
     @override
-    def rowCount(self, parent: QModelIndex = default_index) -> int:
+    def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             if isinstance(parent.internalPointer(), RealizationModel):
                 return 0
@@ -187,8 +187,8 @@ class StorageModel(QAbstractItemModel):
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
-        if not child.isValid():
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
+        if child is None or not child.isValid():
             return QModelIndex()
 
         child_item = child.internalPointer()
@@ -220,8 +220,10 @@ class StorageModel(QAbstractItemModel):
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
+        if parent is None:
+            parent = QModelIndex()
         parentItem = parent.internalPointer() if parent.isValid() else self
         try:
             childItem = parentItem._children[row]

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -212,7 +212,10 @@ class StorageModel(QAbstractItemModel):
 
         return index.internalPointer().data(index, role)
 
-    def index(self, row: int, column: int, parent: QModelIndex) -> QModelIndex:
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         parentItem = parent.internalPointer() if parent.isValid() else self
         try:
             childItem = parentItem._children[row]

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -10,6 +10,7 @@ from qtpy.QtCore import (
     Slot,
 )
 from qtpy.QtWidgets import QApplication
+from typing_extensions import override
 
 from ert.storage import Ensemble, Experiment, Storage
 
@@ -26,6 +27,8 @@ _COLUMN_TEXT = {
     1: "Created at",
     2: "Type",
 }
+
+default_index = QModelIndex()
 
 
 class RealizationModel:
@@ -165,8 +168,8 @@ class StorageModel(QAbstractItemModel):
 
             self._children.append(ex)
 
-    @staticmethod
-    def columnCount(parent: QModelIndex) -> int:
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         return _NUM_COLUMNS
 
     def rowCount(self, parent: QModelIndex) -> int:

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -199,8 +199,13 @@ class StorageModel(QAbstractItemModel):
 
         return self.createIndex(parentItem.row(), 0, parentItem)
 
-    @staticmethod
-    def headerData(section: int, orientation: int, role: int) -> Any:
+    @override
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
         if role != Qt.ItemDataRole.DisplayRole:
             return None
 

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -206,8 +206,8 @@ class StorageModel(QAbstractItemModel):
 
         return _COLUMN_TEXT[_Column(section)]
 
-    @staticmethod
-    def data(index: QModelIndex, role=Qt.ItemDataRole.DisplayRole) -> Any:
+    @override
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         if not index.isValid():
             return None
 

--- a/src/ert/gui/ertwidgets/models/storage_model.py
+++ b/src/ert/gui/ertwidgets/models/storage_model.py
@@ -1,11 +1,12 @@
 from enum import IntEnum
-from typing import Any, List
+from typing import Any, List, Optional, overload
 from uuid import UUID
 
 import humanize
 from qtpy.QtCore import (
     QAbstractItemModel,
     QModelIndex,
+    QObject,
     Qt,
     Slot,
 )
@@ -180,11 +181,16 @@ class StorageModel(QAbstractItemModel):
         else:
             return len(self._children)
 
-    def parent(self, index: QModelIndex) -> QModelIndex:
-        if not index.isValid():
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+        if not child.isValid():
             return QModelIndex()
 
-        child_item = index.internalPointer()
+        child_item = child.internalPointer()
         parentItem = child_item._parent
 
         if parentItem == self:

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -73,7 +73,8 @@ class JobListProxyModel(QAbstractProxyModel):
         source_parent = self.mapToSource(start).parent()
         return source_parent
 
-    def setSourceModel(self, sourceModel: QAbstractItemModel) -> None:
+    @override
+    def setSourceModel(self, sourceModel: Optional[QAbstractItemModel]) -> None:
         if not sourceModel:
             raise ValueError("need source model")
         self.beginResetModel()

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -83,8 +83,13 @@ class JobListProxyModel(QAbstractProxyModel):
         self._connect()
         self.endResetModel()
 
-    @staticmethod
-    def headerData(section: int, orientation: Qt.Orientation, role: Qt.UserRole) -> Any:
+    @override
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
         if role != Qt.DisplayRole:
             return QVariant()
         if orientation == Qt.Horizontal:

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -21,8 +21,6 @@ from ert.gui.model.snapshot import (
     NodeRole,
 )
 
-default_index = QModelIndex()
-
 
 class JobListProxyModel(QAbstractProxyModel):
     """This proxy model presents two-dimensional views (row-column) of
@@ -104,10 +102,10 @@ class JobListProxyModel(QAbstractProxyModel):
         return QVariant()
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         return len(COLUMNS[NodeType.REAL])
 
-    def rowCount(self, parent: QModelIndex = default_index) -> int:
+    def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
@@ -115,19 +113,21 @@ class JobListProxyModel(QAbstractProxyModel):
         source_index = self._get_source_parent_index()
         if not source_index.isValid():
             return 0
-        return self.sourceModel().rowCount(source_index)
+        source_model = self.sourceModel()
+        assert source_model is not None
+        return source_model.rowCount(source_index)
 
     @overload
     def parent(self, child: QModelIndex) -> QModelIndex: ...
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
         return QModelIndex()
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -119,7 +119,10 @@ class JobListProxyModel(QAbstractProxyModel):
     def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
-    def index(self, row: int, column: int, parent=None) -> QModelIndex:
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, overload
 
 from qtpy.QtCore import (
     QAbstractItemModel,
@@ -111,8 +111,12 @@ class JobListProxyModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().rowCount(source_index)
 
-    @staticmethod
-    def parent(_index: QModelIndex):
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
     def index(self, row: int, column: int, parent=None) -> QModelIndex:

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -88,16 +88,16 @@ class JobListProxyModel(QAbstractProxyModel):
         orientation: Qt.Orientation,
         role: int = Qt.ItemDataRole.DisplayRole,
     ) -> Any:
-        if role != Qt.DisplayRole:
+        if role != Qt.ItemDataRole.DisplayRole:
             return QVariant()
-        if orientation == Qt.Horizontal:
+        if orientation == Qt.Orientation.Horizontal:
             header = COLUMNS[NodeType.REAL][section]
             if header in [ids.STDOUT, ids.STDERR]:
                 return header.upper()
             if header in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
                 header = header.replace("_", " ")
             return header.capitalize()
-        if orientation == Qt.Vertical:
+        if orientation == Qt.Orientation.Vertical:
             return section
         return QVariant()
 
@@ -140,6 +140,7 @@ class JobListProxyModel(QAbstractProxyModel):
         if not proxyIndex.isValid():
             return QModelIndex()
         source_model = self.sourceModel()
+        assert source_model is not None
         iter_index = source_model.index(self._iter, 0, QModelIndex())
         if not iter_index.isValid() or not source_model.hasChildren(iter_index):
             return QModelIndex()

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -101,7 +101,7 @@ class JobListProxyModel(QAbstractProxyModel):
     def columnCount(self, parent: QModelIndex = default_index) -> int:
         return len(COLUMNS[NodeType.REAL])
 
-    def rowCount(self, parent=None) -> int:
+    def rowCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import (
     QVariant,
     Slot,
 )
+from typing_extensions import override
 
 from ert.ensemble_evaluator import identifiers as ids
 from ert.gui.model.node import NodeType
@@ -19,6 +20,8 @@ from ert.gui.model.snapshot import (
     IsRealizationRole,
     NodeRole,
 )
+
+default_index = QModelIndex()
 
 
 class JobListProxyModel(QAbstractProxyModel):
@@ -94,8 +97,8 @@ class JobListProxyModel(QAbstractProxyModel):
             return section
         return QVariant()
 
-    @staticmethod
-    def columnCount(parent: QModelIndex = None):
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         return len(COLUMNS[NodeType.REAL])
 
     def rowCount(self, parent=None) -> int:

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -3,8 +3,11 @@ from typing import Dict, List, Optional, Union
 
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QSize, Qt, QVariant
 from qtpy.QtGui import QColor, QFont
+from typing_extensions import override
 
 from ert.gui.model.snapshot import IsEnsembleRole, ProgressRole, StatusRole
+
+default_index = QModelIndex()
 
 
 class ProgressProxyModel(QAbstractItemModel):
@@ -28,8 +31,8 @@ class ProgressProxyModel(QAbstractItemModel):
         if last_iter >= 0:
             self._recalculate_progress(last_iter)
 
-    @staticmethod
-    def columnCount(parent: QModelIndex = None) -> int:
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -65,8 +65,8 @@ class ProgressProxyModel(QAbstractItemModel):
     def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
-    @staticmethod
-    def hasChildren(parent: QModelIndex) -> bool:
+    @override
+    def hasChildren(self, parent: QModelIndex = default_index) -> bool:
         return not parent.isValid()
 
     @override

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -39,8 +39,8 @@ class ProgressProxyModel(QAbstractItemModel):
             return 0
         return 1
 
-    @staticmethod
-    def rowCount(parent: QModelIndex = None) -> int:
+    @override
+    def rowCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, overload
 
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, QSize, Qt, QVariant
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
 from qtpy.QtGui import QColor, QFont
 from typing_extensions import override
 
@@ -54,8 +54,12 @@ class ProgressProxyModel(QAbstractItemModel):
             return QModelIndex()
         return self.createIndex(row, column, None)
 
-    @staticmethod
-    def parent(_index: QModelIndex) -> QModelIndex:
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
     @staticmethod

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -10,11 +10,11 @@ from ert.gui.model.snapshot import IsEnsembleRole, ProgressRole, StatusRole
 
 class ProgressProxyModel(QAbstractItemModel):
     def __init__(
-        self, source_model: QAbstractItemModel, parent: QModelIndex = None
+        self, source_model: QAbstractItemModel, parent: Optional[QModelIndex] = None
     ) -> None:
         QAbstractItemModel.__init__(self, parent)
         self._source_model: QAbstractItemModel = source_model
-        self._progress: Optional[Dict[str, Union[dict, int]]] = None
+        self._progress: Optional[Dict[str, Union[dict[Any, Any], int]]] = None
         self._connect()
 
     def _connect(self) -> None:
@@ -74,31 +74,39 @@ class ProgressProxyModel(QAbstractItemModel):
         if not index.isValid():
             return QVariant()
 
-        if role == Qt.TextAlignmentRole:
-            return Qt.AlignCenter
+        if role == Qt.ItemDataRole.TextAlignmentRole:
+            return Qt.AlignmentFlag.AlignCenter
 
         if role == ProgressRole:
             return self._progress
 
-        if role in (Qt.StatusTipRole, Qt.WhatsThisRole, Qt.ToolTipRole):
+        if role in (
+            Qt.ItemDataRole.StatusTipRole,
+            Qt.ItemDataRole.WhatsThisRole,
+            Qt.ItemDataRole.ToolTipRole,
+        ):
             return ""
 
-        if role == Qt.SizeHintRole:
+        if role == Qt.ItemDataRole.SizeHintRole:
             return QSize(30, 30)
 
-        if role == Qt.FontRole:
+        if role == Qt.ItemDataRole.FontRole:
             return QFont()
 
-        if role in (Qt.BackgroundRole, Qt.ForegroundRole, Qt.DecorationRole):
+        if role in (
+            Qt.ItemDataRole.BackgroundRole,
+            Qt.ItemDataRole.ForegroundRole,
+            Qt.ItemDataRole.DecorationRole,
+        ):
             return QColor()
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return ""
 
         return QVariant()
 
     def _recalculate_progress(self, iter_: int) -> None:
-        status_counts = defaultdict(int)
+        status_counts: Dict[Any, int] = defaultdict(int)
         nr_reals: int = 0
         current_iter_index = self._source_model.index(iter_, 0, QModelIndex())
         if current_iter_index.internalPointer() is None:

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Union, overload
+from typing import Any, Dict, List, Optional, Union, overload
 
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
 from qtpy.QtGui import QColor, QFont
@@ -69,7 +69,8 @@ class ProgressProxyModel(QAbstractItemModel):
     def hasChildren(parent: QModelIndex) -> bool:
         return not parent.isValid()
 
-    def data(self, index: QModelIndex, role=Qt.DisplayRole) -> QVariant:
+    @override
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         if not index.isValid():
             return QVariant()
 

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -47,7 +47,10 @@ class ProgressProxyModel(QAbstractItemModel):
             return 0
         return 1
 
-    def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/progress_proxy.py
+++ b/src/ert/gui/model/progress_proxy.py
@@ -7,8 +7,6 @@ from typing_extensions import override
 
 from ert.gui.model.snapshot import IsEnsembleRole, ProgressRole, StatusRole
 
-default_index = QModelIndex()
-
 
 class ProgressProxyModel(QAbstractItemModel):
     def __init__(
@@ -32,7 +30,7 @@ class ProgressProxyModel(QAbstractItemModel):
             self._recalculate_progress(last_iter)
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
@@ -40,7 +38,7 @@ class ProgressProxyModel(QAbstractItemModel):
         return 1
 
     @override
-    def rowCount(self, parent: QModelIndex = default_index) -> int:
+    def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
@@ -49,7 +47,7 @@ class ProgressProxyModel(QAbstractItemModel):
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
@@ -62,11 +60,13 @@ class ProgressProxyModel(QAbstractItemModel):
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
         return QModelIndex()
 
     @override
-    def hasChildren(self, parent: QModelIndex = default_index) -> bool:
+    def hasChildren(self, parent: Optional[QModelIndex] = None) -> bool:
+        if parent is None:
+            return QModelIndex().isValid()
         return not parent.isValid()
 
     @override

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -62,7 +62,8 @@ class RealListModel(QAbstractProxyModel):
         source_model.modelAboutToBeReset.connect(self.modelAboutToBeReset)
         source_model.modelReset.connect(self.modelReset)
 
-    def setSourceModel(self, sourceModel: QAbstractItemModel) -> None:
+    @override
+    def setSourceModel(self, sourceModel: Optional[QAbstractItemModel]) -> None:
         if not sourceModel:
             raise ValueError("need source model")
         self.beginResetModel()

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -82,7 +82,7 @@ class RealListModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().columnCount(iter_index)
 
-    def rowCount(self, parent: QModelIndex = None) -> int:
+    def rowCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -8,8 +8,11 @@ from qtpy.QtCore import (
     Signal,
     Slot,
 )
+from typing_extensions import override
 
 from ert.gui.model.snapshot import IsEnsembleRole, IsRealizationRole, NodeRole
+
+default_index = QModelIndex()
 
 
 class RealListModel(QAbstractProxyModel):
@@ -68,7 +71,8 @@ class RealListModel(QAbstractProxyModel):
         self._connect()
         self.endResetModel()
 
-    def columnCount(self, parent: QModelIndex = None) -> int:
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -112,7 +112,8 @@ class RealListModel(QAbstractProxyModel):
         ret_index = self.createIndex(row, column, real_index.data(NodeRole))
         return ret_index
 
-    def hasChildren(self, parent: QModelIndex) -> bool:
+    @override
+    def hasChildren(self, parent: QModelIndex = default_index) -> bool:
         # Reimplemented, since in the source model, the realizations have
         # children (i.e. valid indices.). Realizations do not have children in
         # this model.

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -100,7 +100,10 @@ class RealListModel(QAbstractProxyModel):
     def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
-    def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -12,8 +12,6 @@ from typing_extensions import override
 
 from ert.gui.model.snapshot import IsEnsembleRole, IsRealizationRole, NodeRole
 
-default_index = QModelIndex()
-
 
 class RealListModel(QAbstractProxyModel):
     def __init__(
@@ -73,7 +71,7 @@ class RealListModel(QAbstractProxyModel):
         self.endResetModel()
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
@@ -83,7 +81,7 @@ class RealListModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().columnCount(iter_index)
 
-    def rowCount(self, parent: QModelIndex = default_index) -> int:
+    def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
@@ -98,12 +96,12 @@ class RealListModel(QAbstractProxyModel):
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
         return QModelIndex()
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
@@ -114,10 +112,12 @@ class RealListModel(QAbstractProxyModel):
         return ret_index
 
     @override
-    def hasChildren(self, parent: QModelIndex = default_index) -> bool:
+    def hasChildren(self, parent: Optional[QModelIndex] = None) -> bool:
         # Reimplemented, since in the source model, the realizations have
         # children (i.e. valid indices.). Realizations do not have children in
         # this model.
+        if parent is None:
+            parent = QModelIndex()
         if parent.isValid():
             return False
         return self.sourceModel().hasChildren(self.mapToSource(parent))

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -20,7 +20,7 @@ class RealListModel(QAbstractProxyModel):
         iter_: int,
     ) -> None:
         super().__init__(parent=parent)
-        self._iter = iter_
+        self._iter: int = iter_
 
     def get_iter(self) -> int:
         return self._iter
@@ -31,7 +31,7 @@ class RealListModel(QAbstractProxyModel):
     def setIter(self, iter_: int) -> None:
         self._disconnect()
         self.modelAboutToBeReset.emit()
-        self._iter: int = iter_
+        self._iter = iter_
         self.modelReset.emit()
         self._connect()
         self.iter_changed.emit(iter_)
@@ -76,20 +76,24 @@ class RealListModel(QAbstractProxyModel):
             parent = QModelIndex()
         if parent.isValid():
             return 0
-        iter_index = self.sourceModel().index(self._iter, 0, QModelIndex())
+        source_model = self.sourceModel()
+        assert source_model is not None
+        iter_index = source_model.index(self._iter, 0, QModelIndex())
         if not iter_index.isValid():
             return 0
-        return self.sourceModel().columnCount(iter_index)
+        return source_model.columnCount(iter_index)
 
     def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         if parent.isValid():
             return 0
-        iter_index = self.sourceModel().index(self._iter, 0, QModelIndex())
+        source_model = self.sourceModel()
+        assert source_model is not None
+        iter_index = source_model.index(self._iter, 0, QModelIndex())
         if not iter_index.isValid():
             return 0
-        return self.sourceModel().rowCount(iter_index)
+        return source_model.rowCount(iter_index)
 
     @overload
     def parent(self, child: QModelIndex) -> QModelIndex: ...
@@ -120,12 +124,15 @@ class RealListModel(QAbstractProxyModel):
             parent = QModelIndex()
         if parent.isValid():
             return False
-        return self.sourceModel().hasChildren(self.mapToSource(parent))
+        source_model = self.sourceModel()
+        assert source_model is not None
+        return source_model.hasChildren(self.mapToSource(parent))
 
     def mapToSource(self, proxyIndex: QModelIndex) -> QModelIndex:
         if not proxyIndex.isValid():
             return QModelIndex()
         sm = self.sourceModel()
+        assert sm is not None
         iter_index = sm.index(self._iter, 0, QModelIndex())
         if not iter_index.isValid() or not sm.hasChildren(iter_index):
             return QModelIndex()

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, overload
 
 from qtpy.QtCore import (
     QAbstractItemModel,
@@ -92,8 +92,12 @@ class RealListModel(QAbstractProxyModel):
             return 0
         return self.sourceModel().rowCount(iter_index)
 
-    @staticmethod
-    def parent(_index: QModelIndex):
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
     def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from collections import defaultdict
 from contextlib import ExitStack
-from typing import Dict, Final, List, Mapping, Optional, Sequence, Union
+from typing import Dict, Final, List, Mapping, Optional, Sequence, Union, overload
 
 from dateutil import tz
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
@@ -346,11 +346,16 @@ class SnapshotModel(QAbstractItemModel):
 
         return len(parent_item.children)
 
-    def parent(self, index: QModelIndex):
-        if not index.isValid():
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+        if not child.isValid():
             return QModelIndex()
 
-        parent_item = index.internalPointer().parent
+        parent_item = child.internalPointer().parent
         if parent_item == self.root:
             return QModelIndex()
 

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -547,7 +547,10 @@ class SnapshotModel(QAbstractItemModel):
 
         return QVariant()
 
-    def index(self, row: int, column: int, parent: QModelIndex = None) -> QModelIndex:
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()
         if not self.hasIndex(row, column, parent):

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -7,6 +7,7 @@ from typing import Dict, Final, List, Mapping, Optional, Sequence, Union
 from dateutil import tz
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
 from qtpy.QtGui import QColor, QFont
+from typing_extensions import override
 
 from ert.ensemble_evaluator import PartialSnapshot, Snapshot, state
 from ert.ensemble_evaluator import identifiers as ids
@@ -72,6 +73,8 @@ _QCOLORS = {
     state.COLOR_FINISHED: QColor(*state.COLOR_FINISHED),
     state.COLOR_NOT_ACTIVE: QColor(*state.COLOR_NOT_ACTIVE),
 }
+
+default_index = QModelIndex()
 
 
 def _estimate_duration(
@@ -315,8 +318,8 @@ class SnapshotModel(QAbstractItemModel):
         self.root.add_child(snapshot_tree, node_id=iter_)
         self.rowsInserted.emit(parent, snapshot_tree.row(), snapshot_tree.row())
 
-    @staticmethod
-    def columnCount(parent: QModelIndex = None):
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         if parent is None:
             parent = QModelIndex()
         parent_node = parent.internalPointer()

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -74,8 +74,6 @@ _QCOLORS = {
     state.COLOR_NOT_ACTIVE: QColor(*state.COLOR_NOT_ACTIVE),
 }
 
-default_index = QModelIndex()
-
 
 def _estimate_duration(
     start_time: datetime.datetime, end_time: Optional[datetime.datetime] = None
@@ -319,7 +317,7 @@ class SnapshotModel(QAbstractItemModel):
         self.rowsInserted.emit(parent, snapshot_tree.row(), snapshot_tree.row())
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         if parent is None:
             parent = QModelIndex()
         parent_node = parent.internalPointer()
@@ -336,7 +334,7 @@ class SnapshotModel(QAbstractItemModel):
                 count = len(COLUMNS[NodeType.JOB])
         return count
 
-    def rowCount(self, parent: QModelIndex = None):
+    def rowCount(self, parent: Optional[QModelIndex] = None):
         if parent is None:
             parent = QModelIndex()
         parent_item = self.root if not parent.isValid() else parent.internalPointer()
@@ -351,8 +349,8 @@ class SnapshotModel(QAbstractItemModel):
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
-        if not child.isValid():
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
+        if child is None or not child.isValid():
             return QModelIndex()
 
         parent_item = child.internalPointer().parent
@@ -550,7 +548,7 @@ class SnapshotModel(QAbstractItemModel):
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
         if parent is None:
             parent = QModelIndex()

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from collections import defaultdict
 from contextlib import ExitStack
-from typing import Dict, Final, List, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Dict, Final, List, Mapping, Optional, Sequence, Union, overload
 
 from dateutil import tz
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
@@ -361,7 +361,8 @@ class SnapshotModel(QAbstractItemModel):
 
         return self.createIndex(parent_item.row(), 0, parent_item)
 
-    def data(self, index: QModelIndex, role=Qt.DisplayRole):
+    @override
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         if not index.isValid():
             return QVariant()
 

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -33,7 +33,8 @@ class DataTypeKeysListModel(QAbstractItemModel):
     def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
-    def rowCount(self, parent=None, *args, **kwargs):
+    @override
+    def rowCount(self, parent: QModelIndex = default_index) -> int:
         return len(self._keys)
 
     @override

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -2,8 +2,11 @@ from typing import List, Optional
 
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
 from qtpy.QtGui import QColor, QIcon
+from typing_extensions import override
 
 from ert.gui.tools.plot.plot_api import PlotApiKeyDefinition
+
+default_index = QModelIndex()
 
 
 class DataTypeKeysListModel(QAbstractItemModel):
@@ -26,8 +29,8 @@ class DataTypeKeysListModel(QAbstractItemModel):
     def rowCount(self, parent=None, *args, **kwargs):
         return len(self._keys)
 
-    @staticmethod
-    def columnCount(QModelIndex_parent=None, *args, **kwargs):
+    @override
+    def columnCount(self, parent: QModelIndex = default_index) -> int:
         return 1
 
     def data(self, index, role=None):

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, overload
+from typing import Any, List, Optional, overload
 
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from qtpy.QtGui import QColor, QIcon
@@ -41,7 +41,8 @@ class DataTypeKeysListModel(QAbstractItemModel):
     def columnCount(self, parent: QModelIndex = default_index) -> int:
         return 1
 
-    def data(self, index, role=None):
+    @override
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         assert isinstance(index, QModelIndex)
 
         if index.isValid():

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -1,6 +1,6 @@
-from typing import List, Optional
+from typing import List, Optional, overload
 
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from qtpy.QtGui import QColor, QIcon
 from typing_extensions import override
 
@@ -22,8 +22,12 @@ class DataTypeKeysListModel(QAbstractItemModel):
     def index(self, row, column, parent=None, *args, **kwargs):
         return self.createIndex(row, column)
 
-    @staticmethod
-    def parent(index=None):
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+    @override
+    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
         return QModelIndex()
 
     def rowCount(self, parent=None, *args, **kwargs):

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -6,8 +6,6 @@ from typing_extensions import override
 
 from ert.gui.tools.plot.plot_api import PlotApiKeyDefinition
 
-default_index = QModelIndex()
-
 
 class DataTypeKeysListModel(QAbstractItemModel):
     DEFAULT_DATA_TYPE = QColor(255, 255, 255)
@@ -21,7 +19,7 @@ class DataTypeKeysListModel(QAbstractItemModel):
 
     @override
     def index(
-        self, row: int, column: int, parent: QModelIndex = default_index
+        self, row: int, column: int, parent: Optional[QModelIndex] = None
     ) -> QModelIndex:
         return self.createIndex(row, column)
 
@@ -30,15 +28,15 @@ class DataTypeKeysListModel(QAbstractItemModel):
     @overload
     def parent(self) -> Optional[QObject]: ...
     @override
-    def parent(self, child: QModelIndex = default_index) -> Optional[QObject]:
+    def parent(self, child: Optional[QModelIndex] = None) -> Optional[QObject]:
         return QModelIndex()
 
     @override
-    def rowCount(self, parent: QModelIndex = default_index) -> int:
+    def rowCount(self, parent: Optional[QModelIndex] = None) -> int:
         return len(self._keys)
 
     @override
-    def columnCount(self, parent: QModelIndex = default_index) -> int:
+    def columnCount(self, parent: Optional[QModelIndex] = None) -> int:
         return 1
 
     @override

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -19,7 +19,10 @@ class DataTypeKeysListModel(QAbstractItemModel):
         self._keys = keys
         self.__icon = QIcon("img:star_filled.svg")
 
-    def index(self, row, column, parent=None, *args, **kwargs):
+    @override
+    def index(
+        self, row: int, column: int, parent: QModelIndex = default_index
+    ) -> QModelIndex:
         return self.createIndex(row, column)
 
     @overload


### PR DESCRIPTION
To satisfy LSP it should have exactly the same signature as QAbstractItemModel.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
