### PR TITLE
Only get reals and forward models once from partial update

### DIFF
--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -176,7 +176,7 @@ class PartialSnapshot:
         return {}
 
     @property
-    def reals(self) -> Mapping[str, "RealizationSnapshot"]:
+    def reals(self) -> Dict[str, "RealizationSnapshot"]:
         return {
             real_id: RealizationSnapshot(**real_data)
             for real_id, real_data in self._realization_states.items()

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 
 from ert.ensemble_evaluator import PartialSnapshot, Snapshot, state
 from ert.ensemble_evaluator import identifiers as ids
-from ert.ensemble_evaluator.snapshot import SnapshotMetadata
+from ert.ensemble_evaluator.snapshot import RealizationSnapshot, SnapshotMetadata
 from ert.gui.model.node import (
     ForwardModelStepNode,
     IterNode,
@@ -169,7 +169,8 @@ class SnapshotModel(QAbstractItemModel):
             return
 
         job_infos = partial.get_all_forward_models()
-        if not partial.reals and not job_infos:
+        reals = partial.reals
+        if not reals and not job_infos:
             logger.debug(f"no realizations in partial for iter {iter_}")
             return
 
@@ -186,9 +187,12 @@ class SnapshotModel(QAbstractItemModel):
 
             reals_changed: List[int] = []
 
-            for real_id in partial.get_real_ids():
+            for idx in job_infos:
+                real_id = idx[0]
+                if real_id not in reals:
+                    reals[real_id] = RealizationSnapshot()
+            for real_id, real in reals.items():
                 real_node = iter_node.children[real_id]
-                real = partial.get_real(real_id)
                 if real and real.status:
                     real_node.data.status = real.status
                 for real_forward_model_id, color in (
@@ -208,7 +212,7 @@ class SnapshotModel(QAbstractItemModel):
             for (
                 real_id,
                 forward_model_id,
-            ), job in partial.get_all_forward_models().items():
+            ), job in job_infos.items():
                 real_node = iter_node.children[real_id]
                 job_node = real_node.children[forward_model_id]
 

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from collections import defaultdict
 from contextlib import ExitStack
-from typing import Any, Dict, Final, List, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Dict, Final, List, Optional, Sequence, Union, overload
 
 from dateutil import tz
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, QSize, Qt, QVariant
@@ -207,7 +207,7 @@ class SnapshotModel(QAbstractItemModel):
                     ]
                 reals_changed.append(real_node.row())
 
-            jobs_changed_by_real: Mapping[str, Sequence[int]] = defaultdict(list)
+            jobs_changed_by_real: Dict[str, List[int]] = defaultdict(list)
 
             for (
                 real_id,


### PR DESCRIPTION
**Issue**
add_partial_snapshot in SnapshotModel is slow...


**Approach**
Remove superfluous calls to PartialSnapshot

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
