### PR TITLE
Bugfix: unswap key_index and obs_name

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -66,8 +66,8 @@ class ObservationsAndResponsesData:
 
     def to_long_dataframe(self) -> pd.DataFrame:
         cols = [
-            "key_index",
             "name",
+            "key_index",
             "OBS",
             "STD",
             *range(self._observations_and_responses.shape[1] - 4),
@@ -83,14 +83,14 @@ class ObservationsAndResponsesData:
         Extracts a ndarray with the shape (num_obs,).
         Each cell holds the observation primary key.
         """
-        return self._observations_and_responses[:, 0].astype(str)
+        return self._observations_and_responses[:, 1].astype(str)
 
     def observation_keys(self) -> npt.NDArray[np.str_]:
         """
         Extracts a ndarray with the shape (num_obs,).
         Each cell holds the observation name.
         """
-        return self._observations_and_responses[:, 1].astype(str)
+        return self._observations_and_responses[:, 0].astype(str)
 
     def errors(self) -> npt.NDArray[np.float_]:
         """
@@ -1216,8 +1216,8 @@ class LocalEnsemble(BaseMode):
 
                     combined_np_long = np.concatenate(
                         [
-                            key_index_1d,
                             obs_names_1d,
+                            key_index_1d,
                             obs_vals_1d,
                             std_vals_1d,
                             response_vals_per_real,
@@ -1236,7 +1236,7 @@ class LocalEnsemble(BaseMode):
 
         # Ensure sorting by obs_name->key_index
         long_np = np.concatenate(long_nps)
-        sorted_long_np = long_np[np.lexsort((long_np[:, 0], long_np[:, 1]))]
+        sorted_long_np = long_np[np.lexsort((long_np[:, 1], long_np[:, 0]))]
 
         return ObservationsAndResponsesData(sorted_long_np)
 

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -70,7 +70,7 @@ def test_that_observations_and_responses_is_always_ordered(poly_template):
             prior_ens.experiment.observation_keys
         )
         np_ds = ds._observations_and_responses
-        assert np.all(np_ds[np.lexsort((np_ds[:, 0], np_ds[:, 1]))] == np_ds)
+        assert np.all(np_ds[np.lexsort((np_ds[:, 1], np_ds[:, 0]))] == np_ds)
 
 
 def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:


### PR DESCRIPTION
fixes oopsie. This effectively swapped the `obs_name` and `key_index` columns, which again set the ordering of the observations to be by `key_index`->`obs_name` when it really should be `obs_name`->`key_index`. It does not make the update step invalid, but it does alter the snapshots.