### PR TITLE
Enable ruff preview checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,12 +176,33 @@ select = [
   "F",   # pyflakes
   "PL",  # pylint
 ]
+preview = true
 ignore = ["PLW2901", # redefined-loop-name
           "PLR2004", # magic-value-comparison
           "PLR0915", # too-many-statements
           "PLR0912", # too-many-branches
           "PLR5501", # collapsible-else-if
-          "PLR0911",  # too-many-return-statements
+          "PLR0911", # too-many-return-statements
+          "PLC2701", # import-private-name
+          "PLR6201", # literal-membership
+          "PLR0914", # too-many-locals
+          "F841", # unused-variable
+          "PLW1514", # unspecified-encoding
+          "PLR6104", # non-augmented-assignment
+          "PLR6301", # no-self-use
+          "PLW1641", # eq-without-hash
+          "PLC0415", # import-outside-toplevel
+          "PLR0904", # too-many-public-methods
+          "PLR1702", # too-many-nested-blocks
+          "SIM103", # needless-bool
+          "PLW3201", # bad-dunder-method-name
+          "PLR1704", # redefined-argument-from-local
+          "PLC1901", # compare-to-empty-string
+          "SIM300", # yoda-conditions
+          "PLW0128", # redeclared-assigned-name
+          "PLW0108", # unnecessary-lambda
+          "PLR1730", # if-stmt-min-max
+          "PLC2801", # unnecessary-dunder-call
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
This extends the number of checks to pass for the ruff linter considerably, by including rules that are currently only marked for preview in ruff. These rules are in preview due to the automatic fix not being ready, but it does not mean that the rule is not valid.

All existing issues found by enabling this are currently marked as exceptions, to be solved one by one. At least, enabling this at least ensure that no new issues can be introduced unknowingly into the code base

**Issue**
Resolves #7377 


**Approach**
➕ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
