### PR TITLE
Deprecate NUM_NODES and NUM_CPUS_PER_NODE in Torque/OpenPBS driver

### DIFF
--- a/docs/reference/configuration/queue.rst
+++ b/docs/reference/configuration/queue.rst
@@ -292,23 +292,12 @@ The following is a list of all queue-specific configuration options:
 .. _torque_nodes_cpus:
 .. topic:: NUM_NODES, NUM_CPUS_PER_NODE
 
-  When using TORQUE/PBS systems, you can specify how many nodes a single job should
-  use, and how many CPUs per node. These options are called ``NUM_NODES`` and
-  ``NUM_CPUS_PER_NODE``. The default setup in ERT will use one node and
-  one CPU.
+  The support for running a job over multiple nodes is deprecated in Ert,
+  but was previously accomplished by setting NUM_NODES to a number larger
+  than 1.
 
-  If the numbers specified is higher than supported by the cluster (e.g. use 32
-  CPUs, but no node has more than 16), the job will not start.
-
-  If you wish to increase this number, the program running will usually also
-  have to be told to correspondingly use more processing units (e.g. for
-  ECLIPSE, use the keyword ``PARALLEL``).
-
-  The following should allow 3 × 8 = 24 CPUs for processing realizations::
-
-    QUEUE_SYSTEM TORQUE
-    QUEUE_OPTION TORQUE NUM_NODES 3
-    QUEUE_OPTION TORQUE NUM_CPUS_PER_NODE 8
+  NUM_CPUS_PER_NODE is deprecated, instead please use NUM_CPU to specify the
+  number of CPU cores to reserve on a single compute node.
 
 .. _torque_memory_per_job:
 .. topic:: MEMORY_PER_JOB

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -212,4 +212,16 @@ deprecated_keywords_list = [
         "the future. Please remove the configuration line.",
         check=lambda line: "LSF_SERVER" in line,
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="NUM_CPUS_PER_NODE as QUEUE_OPTION to Torque is deprecated and will removed in "
+        "the future. Replace by NUM_CPU.",
+        check=lambda line: "NUM_CPUS_PER_NODE" in line,
+    ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="NUM_NODES as QUEUE_OPTION to Torque is deprecated and will removed in "
+        "the future. Replace by NUM_CPU on a single compute node.",
+        check=lambda line: "NUM_NODES" in line,
+    ),
 ]

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -196,17 +196,14 @@ deprecated_keywords_list = [
     ),
     DeprecationInfo(
         keyword="QUEUE_OPTION",
-        message="QUEUE_QUERY_TIMEOUT as QUEUE_OPTION to the TORQUE system will be ignored "
-        "when using the scheduler, and it is not recommended to use this QUEUE_OPTION. "
-        "It has been used in the past to set the time ERT will wait before giving "
-        "up on hanging backend (TORQUE/PBS) when submitting jobs or job status querying.",
+        message="QUEUE_QUERY_TIMEOUT as QUEUE_OPTION is ignored. "
+        "Please remove the line.",
         check=lambda line: "QUEUE_QUERY_TIMEOUT" in line,
     ),
     DeprecationInfo(
         keyword="QUEUE_OPTION",
-        message="QSTAT_OPTIONS as QUEUE_OPTION to the TORQUE system will be ignored "
-        "when using the scheduler, and it is not recommended to use this QUEUE_OPTION. "
-        "It has been used in the past to supply options to the qstat command.",
+        message="QSTAT_OPTIONS as QUEUE_OPTION to the TORQUE is ignored. "
+        "Please remove the line.",
         check=lambda line: "QSTAT_OPTIONS" in line,
     ),
     DeprecationInfo(

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -158,6 +158,9 @@ def _check_num_cpu_requirement(
     torque_options = _option_list_to_dict(queue_system_options)
     num_nodes_str = torque_options.get("NUM_NODES", [""])[-1]
     num_cpus_per_node_str = torque_options.get("NUM_CPUS_PER_NODE", [""])[-1]
+    if not num_nodes_str and not num_cpus_per_node_str:
+        # NUM_CPU will take precedence when deprecated options are not set
+        return
     num_nodes = int(num_nodes_str) if num_nodes_str else 1
     num_cpus_per_node = int(num_cpus_per_node_str) if num_cpus_per_node_str else 1
     if num_cpu != num_nodes * num_cpus_per_node:

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from ert.config.parsing.queue_system import QueueSystem
 from ert.scheduler.driver import Driver
@@ -21,6 +21,8 @@ def create_driver(config: QueueConfig) -> Driver:
             key: value
             for key, value in config.queue_options.get(QueueSystem.TORQUE, [])
         }
+        num_nodes: Optional[str] = queue_config.get("NUM_NODES")
+        num_cpus_per_node: Optional[str] = queue_config.get("NUM_CPUS_PER_NODE")
         return OpenPBSDriver(
             qsub_cmd=queue_config.get("QSUB_CMD"),
             qstat_cmd=queue_config.get("QSTAT_CMD"),
@@ -28,8 +30,8 @@ def create_driver(config: QueueConfig) -> Driver:
             queue_name=queue_config.get("QUEUE"),
             keep_qsub_output=queue_config.get("KEEP_QSUB_OUTPUT", "0"),
             memory_per_job=queue_config.get("MEMORY_PER_JOB"),
-            num_nodes=int(queue_config.get("NUM_NODES", 1)),
-            num_cpus_per_node=int(queue_config.get("NUM_CPUS_PER_NODE", 1)),
+            num_nodes=int(num_nodes) if num_nodes else None,
+            num_cpus_per_node=int(num_cpus_per_node) if num_cpus_per_node else None,
             cluster_label=queue_config.get("CLUSTER_LABEL"),
             job_prefix=queue_config.get("JOB_PREFIX"),
         )

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -623,11 +623,14 @@ def test_num_cpu_vs_torque_queue_cpu_configuration(
     num_nodes = str(num_nodes_int) if num_nodes_int > 0 else ""
     num_cpus_per_node = str(num_cpus_per_node_int) if num_cpus_per_node_int > 0 else ""
 
-    expected_error = (
-        "product .* must be equal"
-        if (num_cpu_int or 1) != (num_nodes_int or 1) * (num_cpus_per_node_int or 1)
-        else None
-    )
+    if num_nodes or num_cpus_per_node:
+        expected_error = (
+            "product .* must be equal"
+            if (num_cpu_int or 1) != (num_nodes_int or 1) * (num_cpus_per_node_int or 1)
+            else None
+        )
+    else:
+        expected_error = None
 
     test_config_file_base = "test"
     test_config_file_name = f"{test_config_file_base}.ert"

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -179,7 +179,7 @@ async def test_num_nodes_default():
 @pytest.mark.usefixtures("capturing_qsub")
 async def test_num_cpus_per_node():
     driver = OpenPBSDriver(num_cpus_per_node=2)
-    await driver.submit(0, "sleep")
+    await driver.submit(0, "sleep", num_cpu=2)
     resources = parse_resource_string(
         Path("captured_qsub_args").read_text(encoding="utf-8")
     )
@@ -284,24 +284,58 @@ async def test_faulty_qstat(monkeypatch, tmp_path, qstat_script, started_expecte
     assert was_started == started_expected
 
 
+@given(words, st.integers(min_value=1), words)
+@pytest.mark.usefixtures("capturing_qsub")
+async def test_full_resource_string(memory_per_job, num_cpu, cluster_label):
+    driver = OpenPBSDriver(
+        memory_per_job=memory_per_job if memory_per_job else None,
+        cluster_label=cluster_label if cluster_label else None,
+    )
+    await driver.submit(0, "sleep", num_cpu=num_cpu)
+    resources = parse_resource_string(
+        Path("captured_qsub_args").read_text(encoding="utf-8")
+    )
+    assert resources.get("mem", "") == memory_per_job
+    assert resources.get("select", "1") == "1"
+    assert resources.get("ncpus", "1") == str(num_cpu)
+
+    if cluster_label:
+        # cluster_label is not a key-value thing in the resource list,
+        # the parser in this test handles that specially
+        assert resources.get(cluster_label) == "_present_"
+
+    assert len(resources) == sum(
+        [
+            bool(memory_per_job),
+            num_cpu > 1,
+            bool(cluster_label),
+        ]
+    ), "Unknown or missing resources in resource string"
+
+
 @given(words, st.integers(min_value=0), st.integers(min_value=0), words)
 @pytest.mark.usefixtures("capturing_qsub")
-async def test_full_resource_string(
+async def test_full_resource_string_deprecated_options(
     memory_per_job, num_nodes, num_cpus_per_node, cluster_label
 ):
+    """Test deprecated queue options to the driver.
+
+    Remove this test function altogether when NUM_CPUS_PER_NODE and NUM_NODES
+    support is removed"""
     driver = OpenPBSDriver(
         memory_per_job=memory_per_job if memory_per_job else None,
         num_nodes=num_nodes if num_nodes > 0 else None,
         num_cpus_per_node=num_cpus_per_node if num_cpus_per_node > 0 else None,
         cluster_label=cluster_label if cluster_label else None,
     )
-    await driver.submit(0, "sleep")
+    num_cpu = (num_nodes or 1) * (num_cpus_per_node or 1)
+    await driver.submit(0, "sleep", num_cpu=num_cpu)
     resources = parse_resource_string(
         Path("captured_qsub_args").read_text(encoding="utf-8")
     )
     assert resources.get("mem", "") == memory_per_job
     assert resources.get("select", "0") == str(num_nodes)
-    assert resources.get("ncpus", "0") == str(num_cpus_per_node)
+    assert resources.get("ncpus", "1") == str(num_cpu)
     # "0" here is a test implementation detail, not related to driver
     if cluster_label:
         # cluster_label is not a key-value thing in the resource list,
@@ -311,11 +345,11 @@ async def test_full_resource_string(
     assert len(resources) == sum(
         [
             bool(memory_per_job),
-            bool(num_cpus_per_node),
+            num_cpu > 1,
             bool(num_nodes),
             bool(cluster_label),
         ]
-    ), "Unknown resources injected in resource string"
+    ), "Unknown or missing resources in resource string"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #8088 


**Approach**
✂️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
