### PR TITLE
Only log INFO messages from websockets

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -44,7 +44,7 @@ handlers:
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
   websocketsfile:
-    level: DEBUG
+    level: INFO
     formatter: simple_with_threading
     filename: websockets-log.txt
     (): ert.logging.TimestampedFileHandler


### PR DESCRIPTION
**Issue**
Resolves #8161 
Resolves speed issue for Ert, according to @JHolba excessive time is spent by websocket.serve() due to logging.

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
