### PR TITLE
Ignore SIGNAL_OFFSET in assering exit_code from LSF

### DIFF
--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -275,8 +275,10 @@ async def test_kill_before_submit_is_finished(
         SIGTERM = 15
         assert iens == 0
         # If the kill is issued before the job really starts, you will not
-        # get SIGTERM but rather LSF_FAILED_JOB. We should accept both.
-        assert returncode in (SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
+        # get SIGTERM but rather LSF_FAILED_JOB. Whether SIGNAL_OFFSET is
+        # added or not depends on various shell configurations and is a
+        # detail we do not want to track.
+        assert returncode in (SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
 
     await poll(driver, {0}, finished=finished)
     assert "ERROR" not in str(caplog.text)


### PR DESCRIPTION
You are not guaranteed that LSF will always add SIGNAL_OFFSET (128) to the exit code from the job, it depends at least on shell types (csh vs bash) and you can also have a mix of these when bash encapsulates csh. This is not something we want to track.

**Issue**
Resolves #8142 

**Approach**
Bending over.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
