### PR TITLE
Backports to ert==10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies=[
     "lark",
     "lxml",
     "matplotlib",
-    "netCDF4",
+    "netCDF4!=1.7.1",
     "numpy<2",
     "packaging",
     "pandas",

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -149,7 +149,7 @@ class PartialSnapshot:
         return {}
 
     @property
-    def reals(self) -> Mapping[str, "RealizationSnapshot"]:
+    def reals(self) -> Dict[str, "RealizationSnapshot"]:
         return {
             real_id: RealizationSnapshot(**real_data)
             for real_id, real_data in self._realization_states.items()

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -44,7 +44,7 @@ handlers:
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
   websocketsfile:
-    level: DEBUG
+    level: INFO
     formatter: simple_with_threading
     filename: websockets-log.txt
     (): ert.logging.TimestampedFileHandler

--- a/src/ert/shared/feature_toggling.py
+++ b/src/ert/shared/feature_toggling.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class FeatureScheduler:
     _DEFAULTS = {
         "LOCAL": True,
-        "LSF": False,
+        "LSF": True,
         "SLURM": False,
         "TORQUE": True,
     }

--- a/tests/integration_tests/job_queue/test_lsf_driver.py
+++ b/tests/integration_tests/job_queue/test_lsf_driver.py
@@ -180,6 +180,7 @@ def test_run_mocked_lsf_queue():
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
         "--disable-monitor",
+        "--disable-scheduler",
         "poly.ert",
     )
     log = Path("bsub_log").read_text(encoding="utf-8")

--- a/tests/integration_tests/scheduler/test_lsf_driver.py
+++ b/tests/integration_tests/scheduler/test_lsf_driver.py
@@ -275,8 +275,10 @@ async def test_kill_before_submit_is_finished(
         SIGTERM = 15
         assert iens == 0
         # If the kill is issued before the job really starts, you will not
-        # get SIGTERM but rather LSF_FAILED_JOB. We should accept both.
-        assert returncode in (SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
+        # get SIGTERM but rather LSF_FAILED_JOB. Whether SIGNAL_OFFSET is
+        # added or not depends on various shell configurations and is a
+        # detail we do not want to track.
+        assert returncode in (SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
 
     await poll(driver, {0}, finished=finished)
     assert "ERROR" not in str(caplog.text)


### PR DESCRIPTION
**Issue**
The main goal is to re-enable scheduler


**Approach**
In addition, it fixes flaky `test_kill_before_submit_is_finished` and decrease the amount of logs coming from websockets by setting to log level to info.
