### PR TITLE
Refactor realization delegate

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -404,25 +404,20 @@ class SnapshotModel(QAbstractItemModel):
     @staticmethod
     def _real_data(_index: QModelIndex, node: RealNode, role: int):
         if role == RealJobColorHint:
-            selected_color = COLOR_UNKNOWN
-            color_index = finished_count = 0
+            finished_count = 0
             total_count = len(node.data.forward_model_step_status_color_by_id.values())
+            current_job = ""
 
             for color in node.data.forward_model_step_status_color_by_id.values():
-                current_index = COLOR_IMPORTANCE_LIST.index(color)
-
-                if current_index == 1:
+                if color == COLOR_FINISHED:
                     finished_count += 1
+                elif color == COLOR_RUNNING:
+                    for fm in node.children.values():
+                        if fm.data.status == state.FORWARD_MODEL_STATE_RUNNING:
+                            current_job = fm.data.name
 
-                if current_index > color_index:
-                    selected_color = color
-                    color_index = current_index
-
-            # if queue is failed or finished, we have a finalized state
-            if node.data.real_status_color in [COLOR_FINISHED, COLOR_FAILED]:
-                selected_color = node.data.real_status_color
-
-            return selected_color, finished_count, total_count
+            queue_color = node.data.real_status_color
+            return queue_color, finished_count, total_count, current_job
         if role == RealLabelHint:
             return node.id_
         if role == RealIens:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -25,7 +25,6 @@ from ert.shared.status.utils import byte_with_unit
 
 logger = logging.getLogger(__name__)
 
-
 NodeRole = Qt.UserRole + 1
 RealJobColorHint = Qt.UserRole + 2
 RealStatusColorHint = Qt.UserRole + 3
@@ -63,6 +62,9 @@ COLUMNS: Dict[NodeType, Sequence[str]] = {
 COLOR_WAITING: Final[QColor] = QColor(*state.COLOR_WAITING)
 COLOR_PENDING: Final[QColor] = QColor(*state.COLOR_PENDING)
 COLOR_RUNNING: Final[QColor] = QColor(*state.COLOR_RUNNING)
+COLOR_UNKNOWN: Final[QColor] = QColor(*state.COLOR_UNKNOWN)
+COLOR_FINISHED: Final[QColor] = QColor(*state.COLOR_FINISHED)
+COLOR_FAILED: Final[QColor] = QColor(*state.COLOR_FAILED)
 
 _QCOLORS = {
     state.COLOR_WAITING: QColor(*state.COLOR_WAITING),
@@ -73,6 +75,14 @@ _QCOLORS = {
     state.COLOR_FINISHED: QColor(*state.COLOR_FINISHED),
     state.COLOR_NOT_ACTIVE: QColor(*state.COLOR_NOT_ACTIVE),
 }
+
+COLOR_IMPORTANCE_LIST = [
+    QColor(*state.COLOR_UNKNOWN),
+    QColor(*state.COLOR_FINISHED),
+    QColor(*state.COLOR_PENDING),
+    QColor(*state.COLOR_RUNNING),
+    QColor(*state.COLOR_FAILED),
+]
 
 
 def _estimate_duration(
@@ -394,37 +404,25 @@ class SnapshotModel(QAbstractItemModel):
     @staticmethod
     def _real_data(_index: QModelIndex, node: RealNode, role: int):
         if role == RealJobColorHint:
-            colors: List[QColor] = []
+            selected_color = COLOR_UNKNOWN
+            color_index = finished_count = 0
+            total_count = len(node.data.forward_model_step_status_color_by_id.values())
 
-            is_running = False
+            for color in node.data.forward_model_step_status_color_by_id.values():
+                current_index = COLOR_IMPORTANCE_LIST.index(color)
 
-            if (
-                COLOR_RUNNING
-                in node.data.forward_model_step_status_color_by_id.values()
-            ):
-                is_running = True
+                if current_index == 1:
+                    finished_count += 1
 
-            for (
-                forward_model_id
-            ) in node.parent.data.sorted_forward_model_step_ids_by_realization_id[
-                str(node.id_)
-            ]:
-                # if queue system status is WAIT, jobs should indicate WAIT
-                if (
-                    node.data.forward_model_step_status_color_by_id[forward_model_id]
-                    == COLOR_PENDING
-                    and node.data.real_status_color == COLOR_WAITING
-                    and not is_running
-                ):
-                    colors.append(COLOR_WAITING)
-                else:
-                    colors.append(
-                        node.data.forward_model_step_status_color_by_id[
-                            forward_model_id
-                        ]
-                    )
+                if current_index > color_index:
+                    selected_color = color
+                    color_index = current_index
 
-            return colors
+            # if queue is failed or finished, we have a finalized state
+            if node.data.real_status_color in [COLOR_FINISHED, COLOR_FAILED]:
+                selected_color = node.data.real_status_color
+
+            return selected_color, finished_count, total_count
         if role == RealLabelHint:
             return node.id_
         if role == RealIens:
@@ -447,23 +445,7 @@ class SnapshotModel(QAbstractItemModel):
         node_id = str(node.id_)
 
         if role == Qt.BackgroundRole:
-            real = node.parent
-
-            if (
-                COLOR_RUNNING
-                in real.data.forward_model_step_status_color_by_id.values()
-            ):
-                return real.data.forward_model_step_status_color_by_id[node_id]
-
-            # if queue system status is WAIT, jobs should indicate WAIT
-            if (
-                real.data.forward_model_step_status_color_by_id[node_id]
-                == COLOR_PENDING
-                and real.data.real_status_color == COLOR_WAITING
-            ):
-                return COLOR_WAITING
-
-            return real.data.forward_model_step_status_color_by_id[node_id]
+            return node.parent.data.forward_model_step_status_color_by_id[node_id]
 
         if role == Qt.DisplayRole:
             data_name = COLUMNS[NodeType.REAL][index.column()]
@@ -487,21 +469,6 @@ class SnapshotModel(QAbstractItemModel):
                 delta -= datetime.timedelta(microseconds=delta.microseconds)
                 return str(delta)
 
-            real = node.parent
-            if (
-                COLOR_RUNNING
-                in real.data.forward_model_step_status_color_by_id.values()
-            ):
-                return node.data.get(data_name)
-
-            # if queue system status is WAIT, jobs should indicate WAIT
-            if (
-                data_name in [ids.STATUS]
-                and real.data.real_status_color == COLOR_WAITING
-                and real.data.forward_model_step_status_color_by_id[node_id]
-                == COLOR_PENDING
-            ):
-                return str("Waiting")
             return node.data.get(data_name)
 
         if role == FileRole:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -59,12 +59,7 @@ COLUMNS: Dict[NodeType, Sequence[str]] = {
     NodeType.JOB: [],
 }
 
-COLOR_WAITING: Final[QColor] = QColor(*state.COLOR_WAITING)
-COLOR_PENDING: Final[QColor] = QColor(*state.COLOR_PENDING)
-COLOR_RUNNING: Final[QColor] = QColor(*state.COLOR_RUNNING)
-COLOR_UNKNOWN: Final[QColor] = QColor(*state.COLOR_UNKNOWN)
 COLOR_FINISHED: Final[QColor] = QColor(*state.COLOR_FINISHED)
-COLOR_FAILED: Final[QColor] = QColor(*state.COLOR_FAILED)
 
 _QCOLORS = {
     state.COLOR_WAITING: QColor(*state.COLOR_WAITING),
@@ -75,14 +70,6 @@ _QCOLORS = {
     state.COLOR_FINISHED: QColor(*state.COLOR_FINISHED),
     state.COLOR_NOT_ACTIVE: QColor(*state.COLOR_NOT_ACTIVE),
 }
-
-COLOR_IMPORTANCE_LIST = [
-    QColor(*state.COLOR_UNKNOWN),
-    QColor(*state.COLOR_FINISHED),
-    QColor(*state.COLOR_PENDING),
-    QColor(*state.COLOR_RUNNING),
-    QColor(*state.COLOR_FAILED),
-]
 
 
 def _estimate_duration(

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -406,18 +406,13 @@ class SnapshotModel(QAbstractItemModel):
         if role == RealJobColorHint:
             finished_count = 0
             total_count = len(node.data.forward_model_step_status_color_by_id.values())
-            current_job = ""
 
             for color in node.data.forward_model_step_status_color_by_id.values():
                 if color == COLOR_FINISHED:
                     finished_count += 1
-                elif color == COLOR_RUNNING:
-                    for fm in node.children.values():
-                        if fm.data.status == state.FORWARD_MODEL_STATE_RUNNING:
-                            current_job = fm.data.name
 
             queue_color = node.data.real_status_color
-            return queue_color, finished_count, total_count, current_job
+            return queue_color, finished_count, total_count
         if role == RealLabelHint:
             return node.id_
         if role == RealIens:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -404,12 +404,12 @@ class SnapshotModel(QAbstractItemModel):
     @staticmethod
     def _real_data(_index: QModelIndex, node: RealNode, role: int):
         if role == RealJobColorHint:
-            finished_count = 0
-            total_count = len(node.data.forward_model_step_status_color_by_id.values())
-
-            for color in node.data.forward_model_step_status_color_by_id.values():
-                if color == COLOR_FINISHED:
-                    finished_count += 1
+            total_count = len(node.data.forward_model_step_status_color_by_id)
+            finished_count = sum(
+                1
+                for color in node.data.forward_model_step_status_color_by_id.values()
+                if color == COLOR_FINISHED
+            )
 
             queue_color = node.data.real_status_color
             return queue_color, finished_count, total_count

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -1,5 +1,4 @@
-import math
-from typing import Any, Final, Optional, Tuple
+from typing import Any, Optional
 
 from qtpy.QtCore import (
     QAbstractItemModel,
@@ -7,12 +6,11 @@ from qtpy.QtCore import (
     QModelIndex,
     QObject,
     QPoint,
-    QRect,
     QSize,
     Qt,
     Signal,
 )
-from qtpy.QtGui import QColor, QColorConstants, QImage, QPainter, QPen
+from qtpy.QtGui import QColor, QColorConstants, QPainter
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QListView,
@@ -73,10 +71,10 @@ class RealizationWidget(QWidget):
 
 
 class RealizationDelegate(QStyledItemDelegate):
-    def __init__(self, width: int, height: int, parent: QObject) -> None:
+    def __init__(self, size: QSize, parent: QObject) -> None:
         super().__init__(parent)
         self._size = size
-        self.parent().installEventFilter(self)
+        parent.installEventFilter(self)
         self.adjustment_point_for_job_rect_margin = QPoint(-20, -20)
 
     def paint(
@@ -135,8 +133,8 @@ class RealizationDelegate(QStyledItemDelegate):
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         return self._size
 
-    def eventFilter(self, object: Optional[QObject], event: Optional[QEvent]) -> bool:
-        if event.type() == QEvent.Type.ToolTip:  # type: ignore
+    def eventFilter(self, object: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.ToolTip:
             mouse_pos = event.pos() + self.adjustment_point_for_job_rect_margin  # type: ignore
             parent: RealizationWidget = self.parent()  # type: ignore
             view = parent._real_view

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -88,7 +88,7 @@ class RealizationDelegate(QStyledItemDelegate):
         if painter is None:
             return
         text = index.data(RealLabelHint)
-        selected_color, finished_count, total_count, current_job = tuple(
+        selected_color, finished_count, total_count = tuple(
             index.data(RealJobColorHint)
         )
 
@@ -125,13 +125,7 @@ class RealizationDelegate(QStyledItemDelegate):
         painter.drawEllipse(adjusted_rect)
         pen = QPen(QColorConstants.Black)
         painter.setPen(pen)
-
-        if 0 < percentage_done < 100 and current_job:
-            painter.drawText(option.rect, Qt.AlignCenter, current_job[0:6])
-            adj_rect = option.rect.adjusted(0, 20, 0, 0)
-            painter.drawText(adj_rect, Qt.AlignHCenter, text)
-        else:
-            painter.drawText(adjusted_rect, Qt.AlignCenter, text)
+        painter.drawText(adjusted_rect, Qt.AlignCenter, text)
 
         painter.restore()
 

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -92,22 +92,17 @@ class RealizationDelegate(QStyledItemDelegate):
             index.data(RealJobColorHint)
         )
 
-        progress_color = QColor(50, 173, 230)
-
         painter.save()
         painter.setRenderHint(QPainter.TextAntialiasing, True)
         painter.setRenderHint(QPainter.Antialiasing, True)
+        progress_color = QColor(50, 173, 230)
 
-        if option.state & QStyle.State_Selected:
-            selected_color = selected_color.lighter(125)
-
-        percentage_done = int(
-            (finished_count * 100.0) / (total_count if total_count > 0 else 1)
+        percentage_done = (
+            100 if total_count < 1 else int((finished_count * 100.0) / total_count)
         )
-
-        adjusted_rect = option.rect.adjusted(2, 2, -2, -2)
         progressed_step = -int(percentage_done * 57.6)
 
+        adjusted_rect = option.rect.adjusted(2, 2, -2, -2)
         painter.setBrush(QColor(QColorConstants.LightGray).lighter(120))
         painter.drawEllipse(adjusted_rect)
 
@@ -119,13 +114,21 @@ class RealizationDelegate(QStyledItemDelegate):
                 painter.setBrush(progress_color)
             painter.drawEllipse(adjusted_rect)
 
-        painter.setBrush(selected_color)
+        if option.state & QStyle.State_Selected:
+            selected_color = selected_color.lighter(125)
 
+        painter.setBrush(selected_color)
         adjusted_rect = option.rect.adjusted(7, 7, -7, -7)
         painter.drawEllipse(adjusted_rect)
-        pen = QPen(QColorConstants.Black)
-        painter.setPen(pen)
-        painter.drawText(adjusted_rect, Qt.AlignCenter, text)
+
+        font = painter.font()
+        font.setBold(True)
+        painter.setFont(font)
+
+        adj_rect = option.rect.adjusted(0, 20, 0, 0)
+        painter.drawText(adj_rect, Qt.AlignHCenter, text)
+        adj_rect = option.rect.adjusted(0, 45, 0, 0)
+        painter.drawText(adj_rect, Qt.AlignHCenter, f"{finished_count} / {total_count}")
 
         painter.restore()
 

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -34,7 +34,7 @@ class RealizationWidget(QWidget):
         super().__init__(parent)
 
         self._iter = _it
-        self._delegate_size = QSize(100, 100)
+        self._delegate_size = QSize(90, 90)
 
         self._real_view = QListView(self)
         self._real_view.setViewMode(QListView.IconMode)
@@ -88,7 +88,7 @@ class RealizationDelegate(QStyledItemDelegate):
         if painter is None:
             return
         text = index.data(RealLabelHint)
-        selected_color, finished_count, total_count = tuple(
+        selected_color, finished_count, total_count, current_job = tuple(
             index.data(RealJobColorHint)
         )
 
@@ -99,45 +99,36 @@ class RealizationDelegate(QStyledItemDelegate):
         if option.state & QStyle.State_Selected:
             selected_color = selected_color.lighter(125)
 
-        painter.setBrush(selected_color)
         percentage_done = int(
             (finished_count * 100.0) / (total_count if total_count > 0 else 1)
         )
 
         adjusted_rect = option.rect.adjusted(2, 2, -2, -2)
-
-        first_step = -int(percentage_done * 57.6)
+        progressed_step = -int(percentage_done * 57.6)
 
         painter.setBrush(QColor(QColorConstants.LightGray).lighter(120))
         painter.drawEllipse(adjusted_rect)
 
-        # progress_color = QColorConstants.Blue
-        # progress_color = progress_color.lighter(150)
-
-        pcolor = QColor(5, 183, 250)
-
-        painter.setBrush(pcolor)
-        # painter.setBrush(selected_color)
-
-        if percentage_done != 0:
-            if percentage_done != 100:
-                painter.drawPie(adjusted_rect, int(5760 / 4), first_step)
-            else:
-                painter.drawEllipse(adjusted_rect)
+        if 0 < percentage_done < 100:
+            painter.setBrush(QColor(5, 183, 250))
+            painter.drawPie(adjusted_rect, 1440, progressed_step)
+        else:
+            painter.drawEllipse(adjusted_rect)
 
         painter.setBrush(selected_color)
-        # painter.setBrush(QColorConstants.White)
 
-        adjusted_rect = option.rect.adjusted(10, 10, -10, -10)
+        adjusted_rect = option.rect.adjusted(7, 7, -7, -7)
         painter.drawEllipse(adjusted_rect)
+        pen = QPen(QColorConstants.Black)
+        painter.setPen(pen)
 
-        painter.setBrush(selected_color)
+        if 0 < percentage_done < 100 and current_job:
+            painter.drawText(option.rect, Qt.AlignCenter, current_job[0:6])
+            adj_rect = option.rect.adjusted(0, 20, 0, 0)
+            painter.drawText(adj_rect, Qt.AlignHCenter, text)
+        else:
+            painter.drawText(adjusted_rect, Qt.AlignCenter, text)
 
-        painter.setPen(QPen(QColorConstants.Black))
-
-        painter.drawText(option.rect, Qt.AlignCenter, f"{percentage_done} %")
-        adj_rect = option.rect.adjusted(0, 20, 0, 0)
-        painter.drawText(adj_rect, Qt.AlignHCenter, text)
         painter.restore()
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -92,6 +92,8 @@ class RealizationDelegate(QStyledItemDelegate):
             index.data(RealJobColorHint)
         )
 
+        progress_color = QColor(50, 173, 230)
+
         painter.save()
         painter.setRenderHint(QPainter.TextAntialiasing, True)
         painter.setRenderHint(QPainter.Antialiasing, True)
@@ -110,9 +112,11 @@ class RealizationDelegate(QStyledItemDelegate):
         painter.drawEllipse(adjusted_rect)
 
         if 0 < percentage_done < 100:
-            painter.setBrush(QColor(5, 183, 250))
+            painter.setBrush(progress_color)
             painter.drawPie(adjusted_rect, 1440, progressed_step)
         else:
+            if percentage_done == 100:
+                painter.setBrush(progress_color)
             painter.drawEllipse(adjusted_rect)
 
         painter.setBrush(selected_color)

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -102,7 +102,9 @@ class RealizationDelegate(QStyledItemDelegate):
         painter.drawRect(option.rect)
 
         painter.setPen(QPen(QColorConstants.Black))
-        percentage_done = int((finished_count * 100.0) / total_count)
+        percentage_done = int(
+            (finished_count * 100.0) / (total_count if total_count > 0 else 1)
+        )
         painter.drawText(option.rect, Qt.AlignCenter, f"{percentage_done} %")
         adj_rect = option.rect.adjusted(2, 1, 0, 0)
         painter.drawText(adj_rect, Qt.AlignTop, text)

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -112,7 +112,7 @@ class RealizationDelegate(QStyledItemDelegate):
                 painter.setBrush(progress_color)
             painter.drawEllipse(adjusted_rect)
 
-        if option.state & QStyle.State_Selected:
+        if option.state & QStyle.StateFlag.State_Selected:
             selected_color = selected_color.lighter(125)
 
         painter.setBrush(selected_color)
@@ -124,17 +124,19 @@ class RealizationDelegate(QStyledItemDelegate):
         painter.setFont(font)
 
         adj_rect = option.rect.adjusted(0, 20, 0, 0)
-        painter.drawText(adj_rect, Qt.AlignHCenter, text)
+        painter.drawText(adj_rect, Qt.AlignmentFlag.AlignHCenter, text)
         adj_rect = option.rect.adjusted(0, 45, 0, 0)
-        painter.drawText(adj_rect, Qt.AlignHCenter, f"{finished_count} / {total_count}")
+        painter.drawText(
+            adj_rect, Qt.AlignmentFlag.AlignHCenter, f"{finished_count} / {total_count}"
+        )
 
         painter.restore()
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         return self._size
 
-    def eventFilter(self, object: QObject, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.ToolTip:
+    def eventFilter(self, object: Optional[QObject], event: Optional[QEvent]) -> bool:
+        if event.type() == QEvent.Type.ToolTip:  # type: ignore
             mouse_pos = event.pos() + self.adjustment_point_for_job_rect_margin  # type: ignore
             parent: RealizationWidget = self.parent()  # type: ignore
             view = parent._real_view

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -34,7 +34,7 @@ class RealizationWidget(QWidget):
         super().__init__(parent)
 
         self._iter = _it
-        self._delegate_size = QSize(70, 70)
+        self._delegate_size = QSize(100, 100)
 
         self._real_view = QListView(self)
         self._real_view.setViewMode(QListView.IconMode)
@@ -94,20 +94,50 @@ class RealizationDelegate(QStyledItemDelegate):
 
         painter.save()
         painter.setRenderHint(QPainter.TextAntialiasing, True)
+        painter.setRenderHint(QPainter.Antialiasing, True)
 
         if option.state & QStyle.State_Selected:
             selected_color = selected_color.lighter(125)
 
         painter.setBrush(selected_color)
-        painter.drawRect(option.rect)
-
-        painter.setPen(QPen(QColorConstants.Black))
         percentage_done = int(
             (finished_count * 100.0) / (total_count if total_count > 0 else 1)
         )
+
+        adjusted_rect = option.rect.adjusted(2, 2, -2, -2)
+
+        first_step = -int(percentage_done * 57.6)
+
+        painter.setBrush(QColor(QColorConstants.LightGray).lighter(120))
+        painter.drawEllipse(adjusted_rect)
+
+        # progress_color = QColorConstants.Blue
+        # progress_color = progress_color.lighter(150)
+
+        pcolor = QColor(5, 183, 250)
+
+        painter.setBrush(pcolor)
+        # painter.setBrush(selected_color)
+
+        if percentage_done != 0:
+            if percentage_done != 100:
+                painter.drawPie(adjusted_rect, int(5760 / 4), first_step)
+            else:
+                painter.drawEllipse(adjusted_rect)
+
+        painter.setBrush(selected_color)
+        # painter.setBrush(QColorConstants.White)
+
+        adjusted_rect = option.rect.adjusted(10, 10, -10, -10)
+        painter.drawEllipse(adjusted_rect)
+
+        painter.setBrush(selected_color)
+
+        painter.setPen(QPen(QColorConstants.Black))
+
         painter.drawText(option.rect, Qt.AlignCenter, f"{percentage_done} %")
-        adj_rect = option.rect.adjusted(2, 1, 0, 0)
-        painter.drawText(adj_rect, Qt.AlignTop, text)
+        adj_rect = option.rect.adjusted(0, 20, 0, 0)
+        painter.drawText(adj_rect, Qt.AlignHCenter, text)
         painter.restore()
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -29,9 +29,9 @@ from ert.ensemble_evaluator.snapshot import (
 from ert.ensemble_evaluator.state import (
     ENSEMBLE_STATE_STARTED,
     FORWARD_MODEL_STATE_START,
+    REALIZATION_STATE_FAILED,
     REALIZATION_STATE_RUNNING,
     REALIZATION_STATE_UNKNOWN,
-    REALIZATION_STATE_WAITING,
 )
 from ert.gui.ertwidgets import ClosableDialog
 from ert.gui.ertwidgets.create_experiment_dialog import CreateExperimentDialog
@@ -380,9 +380,9 @@ def full_snapshot() -> Snapshot:
 
 
 @pytest.fixture()
-def waiting_snapshot() -> Snapshot:
+def fail_snapshot() -> Snapshot:
     real = RealizationSnapshot(
-        status=REALIZATION_STATE_WAITING,
+        status=REALIZATION_STATE_FAILED,
         active=True,
         forward_models={
             "0": ForwardModel(
@@ -396,19 +396,7 @@ def waiting_snapshot() -> Snapshot:
                 stderr="std_err_file",
                 current_memory_usage="123",
                 max_memory_usage="312",
-            ),
-            "1": ForwardModel(
-                start_time=dt.now(),
-                end_time=None,
-                name="poly_postval",
-                index="1",
-                status=FORWARD_MODEL_STATE_START,
-                error="error",
-                stdout="std_out_file",
-                stderr="std_err_file",
-                current_memory_usage="123",
-                max_memory_usage="312",
-            ),
+            )
         },
     )
     snapshot = SnapshotDict(

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -1,4 +1,3 @@
-import pytest
 from pytestqt.qt_compat import qt_api
 from qtpy.QtCore import QModelIndex
 from qtpy.QtGui import QColor
@@ -6,12 +5,7 @@ from qtpy.QtGui import QColor
 from ert.ensemble_evaluator.snapshot import ForwardModel, PartialSnapshot
 from ert.ensemble_evaluator.state import (
     COLOR_FAILED,
-    COLOR_PENDING,
-    COLOR_RUNNING,
-    FORWARD_MODEL_STATE_FAILURE,
     FORWARD_MODEL_STATE_FINISHED,
-    FORWARD_MODEL_STATE_RUNNING,
-    FORWARD_MODEL_STATE_START,
 )
 from ert.gui.model.snapshot import RealJobColorHint, RealStatusColorHint, SnapshotModel
 
@@ -49,7 +43,7 @@ def test_realization_sort_order(full_snapshot):
         )
 
 
-def test_realization_state_is_overridden_by_queue_finalized_state(fail_snapshot):
+def test_realization_state_is_queue_finalized_state(fail_snapshot):
     model = SnapshotModel()
     model._add_snapshot(SnapshotModel.prerender(fail_snapshot), 0)
 
@@ -67,49 +61,3 @@ def test_realization_state_is_overridden_by_queue_finalized_state(fail_snapshot)
     assert color == QColor(*COLOR_FAILED)
     assert done_count == 1
     assert full_count == 1
-
-
-@pytest.mark.parametrize(
-    "first_state, second_state, expected_color",
-    [
-        (
-            FORWARD_MODEL_STATE_FINISHED,
-            FORWARD_MODEL_STATE_START,
-            QColor(*COLOR_PENDING),
-        ),
-        (
-            FORWARD_MODEL_STATE_FINISHED,
-            FORWARD_MODEL_STATE_RUNNING,
-            QColor(*COLOR_RUNNING),
-        ),
-        (
-            FORWARD_MODEL_STATE_FINISHED,
-            FORWARD_MODEL_STATE_FAILURE,
-            QColor(*COLOR_FAILED),
-        ),
-        (
-            FORWARD_MODEL_STATE_RUNNING,
-            FORWARD_MODEL_STATE_START,
-            QColor(*COLOR_RUNNING),
-        ),
-        (
-            FORWARD_MODEL_STATE_FAILURE,
-            FORWARD_MODEL_STATE_START,
-            QColor(*COLOR_FAILED),
-        ),
-    ],
-)
-def test_display_color_changes_to_more_important_state(
-    first_state, second_state, expected_color, full_snapshot
-):
-    model = SnapshotModel()
-    model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
-
-    partial = PartialSnapshot(full_snapshot)
-    partial.update_forward_model("0", "0", ForwardModel(status=first_state))
-    partial.update_forward_model("0", "1", ForwardModel(status=second_state))
-    model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
-    first_real = model.index(0, 0, model.index(0, 0))
-
-    color, _, _ = model.data(first_real, RealJobColorHint)
-    assert color == expected_color

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -63,7 +63,7 @@ def test_realization_state_is_overridden_by_queue_finalized_state(fail_snapshot)
 
     queue_color = model.data(first_real, RealStatusColorHint)
     assert queue_color == QColor(*COLOR_FAILED)
-    color, done_count, full_count, _ = model.data(first_real, RealJobColorHint)
+    color, done_count, full_count = model.data(first_real, RealJobColorHint)
     assert color == QColor(*COLOR_FAILED)
     assert done_count == 1
     assert full_count == 1
@@ -111,5 +111,5 @@ def test_display_color_changes_to_more_important_state(
     model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
     first_real = model.index(0, 0, model.index(0, 0))
 
-    color, _, _, _ = model.data(first_real, RealJobColorHint)
+    color, _, _ = model.data(first_real, RealJobColorHint)
     assert color == expected_color

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -3,10 +3,7 @@ from qtpy.QtCore import QModelIndex
 from qtpy.QtGui import QColor
 
 from ert.ensemble_evaluator.snapshot import ForwardModel, PartialSnapshot
-from ert.ensemble_evaluator.state import (
-    COLOR_FAILED,
-    FORWARD_MODEL_STATE_FINISHED,
-)
+from ert.ensemble_evaluator.state import COLOR_FAILED, FORWARD_MODEL_STATE_FINISHED
 from ert.gui.model.snapshot import RealJobColorHint, RealStatusColorHint, SnapshotModel
 
 from .gui_models_utils import partial_snapshot

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -63,7 +63,7 @@ def test_realization_state_is_overridden_by_queue_finalized_state(fail_snapshot)
 
     queue_color = model.data(first_real, RealStatusColorHint)
     assert queue_color == QColor(*COLOR_FAILED)
-    color, done_count, full_count = model.data(first_real, RealJobColorHint)
+    color, done_count, full_count, _ = model.data(first_real, RealJobColorHint)
     assert color == QColor(*COLOR_FAILED)
     assert done_count == 1
     assert full_count == 1
@@ -111,5 +111,5 @@ def test_display_color_changes_to_more_important_state(
     model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
     first_real = model.index(0, 0, model.index(0, 0))
 
-    color, _, _ = model.data(first_real, RealJobColorHint)
+    color, _, _, _ = model.data(first_real, RealJobColorHint)
     assert color == expected_color


### PR DESCRIPTION
Resolves #8185 

⚠️ I will squash everything into one commit.

There was a decision to test out another variant;
- Color inside circle is the QUEUE colour
- Progress outside the circle reflect percentage of finished forward model steps

Update:

![Screenshot 2024-06-24 at 15 42 45](https://github.com/equinor/ert/assets/114403625/9a52319a-1fae-4d71-bd8b-5ea502af40d9)

![Screenshot 2024-06-24 at 15 42 48](https://github.com/equinor/ert/assets/114403625/81003aa0-af1c-410b-8268-d4ff7032bc82)

-----------------------------------------

Now the colour is solely based on the active forward model step, with the only exception being that the queue status is either set to FINISHED or FAILED. When those statuses are met, that overrides whatever colour is picked from the forward model steps.


No selection
![Screenshot 2024-06-19 at 13 03 29](https://github.com/equinor/ert/assets/114403625/f0aca207-6adc-4986-8d2c-7220321dd3f2)

With selection
![Screenshot 2024-06-19 at 13 05 42](https://github.com/equinor/ert/assets/114403625/3e24b1c8-7351-4dca-b82d-b2c5cabac89e)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
