### PR TITLE
Increase responsiveness of run dialog under heavy load

### DIFF
--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -15,6 +15,7 @@ from ert.ensemble_evaluator import (
     Snapshot,
     SnapshotUpdateEvent,
 )
+from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator.state import (
     ALL_REALIZATION_STATES,
     COLOR_FAILED,
@@ -109,9 +110,10 @@ class Monitor:
         for snapshot in self._snapshots.values():
             for real in snapshot.reals.values():
                 for job in real.forward_models.values():
-                    if job.status == FORWARD_MODEL_STATE_FAILURE:
-                        result = failed_jobs.get(job.error, 0)
-                        failed_jobs[job.error] = result + 1
+                    if job.get(ids.STATUS) == FORWARD_MODEL_STATE_FAILURE:
+                        err = job.get(ids.ERROR)
+                        result = failed_jobs.get(err, 0)
+                        failed_jobs[err] = result + 1
         for error, number_of_jobs in failed_jobs.items():
             print(f"{number_of_jobs} jobs failed due to the error: {error}")
 

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -27,6 +27,7 @@ from websockets.legacy.server import WebSocketServerProtocol
 
 from _ert.async_utils import new_event_loop
 from _ert.threading import ErtThread
+from ert.ensemble_evaluator import identifiers as ids
 from ert.serialization import evaluator_marshaller, evaluator_unmarshaller
 
 from ._builder import Ensemble
@@ -136,7 +137,7 @@ class EnsembleEvaluator:
             with self._snapshot_mutex:
                 max_memory_usage = -1
                 for job in self.ensemble.snapshot.get_all_forward_models().values():
-                    memory_usage = job.max_memory_usage or "-1"
+                    memory_usage = job[ids.MAX_MEMORY_USAGE] or "-1"
                     max_memory_usage = max(int(memory_usage), max_memory_usage)
                 logger.info(
                     f"Ensemble ran with maximum memory usage for a single realization job: {max_memory_usage}"

--- a/src/ert/ensemble_evaluator/identifiers.py
+++ b/src/ert/ensemble_evaluator/identifiers.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from ert.event_type_constants import (
     EVTYPE_ENSEMBLE_CANCELLED,
     EVTYPE_ENSEMBLE_FAILED,
@@ -12,33 +14,33 @@ from ert.event_type_constants import (
     EVTYPE_REALIZATION_WAITING,
 )
 
-ACTIVE = "active"
-CURRENT_MEMORY_USAGE = "current_memory_usage"
-DATA = "data"
-END_TIME = "end_time"
-ERROR = "error"
-ERROR_MSG = "error_msg"
-ERROR_FILE = "error_file"
-INDEX = "index"
-JOBS = "jobs"
-MAX_MEMORY_USAGE = "max_memory_usage"
-METADATA = "metadata"
-NAME = "name"
-REALS = "reals"
-START_TIME = "start_time"
-STATUS = "status"
-STDERR = "stderr"
-STDOUT = "stdout"
-STEPS = "steps"
+ACTIVE: Final = "active"
+CURRENT_MEMORY_USAGE: Final = "current_memory_usage"
+DATA: Final = "data"
+END_TIME: Final = "end_time"
+ERROR: Final = "error"
+ERROR_MSG: Final = "error_msg"
+ERROR_FILE: Final = "error_file"
+INDEX: Final = "index"
+JOBS: Final = "jobs"
+MAX_MEMORY_USAGE: Final = "max_memory_usage"
+METADATA: Final = "metadata"
+NAME: Final = "name"
+REALS: Final = "reals"
+START_TIME: Final = "start_time"
+STATUS: Final = "status"
+STDERR: Final = "stderr"
+STDOUT: Final = "stdout"
+STEPS: Final = "steps"
 
-EVTYPE_FORWARD_MODEL_START = "com.equinor.ert.forward_model_job.start"
-EVTYPE_FORWARD_MODEL_RUNNING = "com.equinor.ert.forward_model_job.running"
-EVTYPE_FORWARD_MODEL_SUCCESS = "com.equinor.ert.forward_model_job.success"
-EVTYPE_FORWARD_MODEL_FAILURE = "com.equinor.ert.forward_model_job.failure"
-EVTYPE_FORWARD_MODEL_CHECKSUM = "com.equinor.ert.forward_model_job.checksum"
+EVTYPE_FORWARD_MODEL_START: Final = "com.equinor.ert.forward_model_job.start"
+EVTYPE_FORWARD_MODEL_RUNNING: Final = "com.equinor.ert.forward_model_job.running"
+EVTYPE_FORWARD_MODEL_SUCCESS: Final = "com.equinor.ert.forward_model_job.success"
+EVTYPE_FORWARD_MODEL_FAILURE: Final = "com.equinor.ert.forward_model_job.failure"
+EVTYPE_FORWARD_MODEL_CHECKSUM: Final = "com.equinor.ert.forward_model_job.checksum"
 
 
-EVGROUP_REALIZATION = {
+EVGROUP_REALIZATION: Final = {
     EVTYPE_REALIZATION_FAILURE,
     EVTYPE_REALIZATION_PENDING,
     EVTYPE_REALIZATION_RUNNING,
@@ -48,7 +50,7 @@ EVGROUP_REALIZATION = {
     EVTYPE_REALIZATION_TIMEOUT,
 }
 
-EVGROUP_FORWARD_MODEL = {
+EVGROUP_FORWARD_MODEL: Final = {
     EVTYPE_FORWARD_MODEL_START,
     EVTYPE_FORWARD_MODEL_RUNNING,
     EVTYPE_FORWARD_MODEL_SUCCESS,
@@ -57,14 +59,14 @@ EVGROUP_FORWARD_MODEL = {
 
 EVGROUP_FM_ALL = EVGROUP_REALIZATION | EVGROUP_FORWARD_MODEL
 
-EVTYPE_EE_SNAPSHOT = "com.equinor.ert.ee.snapshot"
-EVTYPE_EE_SNAPSHOT_UPDATE = "com.equinor.ert.ee.snapshot_update"
-EVTYPE_EE_TERMINATED = "com.equinor.ert.ee.terminated"
-EVTYPE_EE_USER_CANCEL = "com.equinor.ert.ee.user_cancel"
-EVTYPE_EE_USER_DONE = "com.equinor.ert.ee.user_done"
+EVTYPE_EE_SNAPSHOT: Final = "com.equinor.ert.ee.snapshot"
+EVTYPE_EE_SNAPSHOT_UPDATE: Final = "com.equinor.ert.ee.snapshot_update"
+EVTYPE_EE_TERMINATED: Final = "com.equinor.ert.ee.terminated"
+EVTYPE_EE_USER_CANCEL: Final = "com.equinor.ert.ee.user_cancel"
+EVTYPE_EE_USER_DONE: Final = "com.equinor.ert.ee.user_done"
 
 
-EVGROUP_ENSEMBLE = {
+EVGROUP_ENSEMBLE: Final = {
     EVTYPE_ENSEMBLE_STARTED,
     EVTYPE_ENSEMBLE_STOPPED,
     EVTYPE_ENSEMBLE_CANCELLED,

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -53,8 +53,10 @@ async def test_restarted_jobs_do_not_have_error_msgs(evaluator):
 
         def is_completed_snapshot(snapshot: Snapshot) -> bool:
             try:
-                assert snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_FAILURE
-                assert snapshot.get_job("0", "0").error == "error"
+                assert (
+                    snapshot.get_job("0", "0")["status"] == FORWARD_MODEL_STATE_FAILURE
+                )
+                assert snapshot.get_job("0", "0")["error"] == "error"
                 return True
             except AssertionError:
                 return False
@@ -87,8 +89,10 @@ async def test_restarted_jobs_do_not_have_error_msgs(evaluator):
         def check_if_final_snapshot_is_complete(snapshot: Snapshot) -> bool:
             try:
                 assert snapshot.status == ENSEMBLE_STATE_UNKNOWN
-                assert snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_FINISHED
-                assert not snapshot.get_job("0", "0").error
+                assert (
+                    snapshot.get_job("0", "0")["status"] == FORWARD_MODEL_STATE_FINISHED
+                )
+                assert not snapshot.get_job("0", "0")["error"]
                 return True
             except AssertionError:
                 return False
@@ -153,9 +157,15 @@ async def test_new_monitor_can_pick_up_where_we_left_off(evaluator):
 
         def check_if_all_fm_running(snapshot: Snapshot) -> bool:
             try:
-                assert snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_RUNNING
-                assert snapshot.get_job("1", "0").status == FORWARD_MODEL_STATE_RUNNING
-                assert snapshot.get_job("1", "1").status == FORWARD_MODEL_STATE_RUNNING
+                assert (
+                    snapshot.get_job("0", "0")["status"] == FORWARD_MODEL_STATE_RUNNING
+                )
+                assert (
+                    snapshot.get_job("1", "0")["status"] == FORWARD_MODEL_STATE_RUNNING
+                )
+                assert (
+                    snapshot.get_job("1", "1")["status"] == FORWARD_MODEL_STATE_RUNNING
+                )
                 return True
             except AssertionError:
                 return False
@@ -199,13 +209,16 @@ async def test_new_monitor_can_pick_up_where_we_left_off(evaluator):
         try:
             assert final_snapshot.status == ENSEMBLE_STATE_UNKNOWN
             assert (
-                final_snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_RUNNING
+                final_snapshot.get_job("0", "0")["status"]
+                == FORWARD_MODEL_STATE_RUNNING
             )
             assert (
-                final_snapshot.get_job("1", "0").status == FORWARD_MODEL_STATE_FINISHED
+                final_snapshot.get_job("1", "0")["status"]
+                == FORWARD_MODEL_STATE_FINISHED
             )
             assert (
-                final_snapshot.get_job("1", "1").status == FORWARD_MODEL_STATE_FAILURE
+                final_snapshot.get_job("1", "1")["status"]
+                == FORWARD_MODEL_STATE_FAILURE
             )
             return True
         except AssertionError:
@@ -287,9 +300,9 @@ async def test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_e
             )
             evt = await events.__anext__()
             snapshot = Snapshot(evt.data)
-            assert snapshot.get_job("1", "0").status == FORWARD_MODEL_STATE_FINISHED
-            assert snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_RUNNING
-            assert snapshot.get_job("1", "1").status == FORWARD_MODEL_STATE_FAILURE
+            assert snapshot.get_job("1", "0")["status"] == FORWARD_MODEL_STATE_FINISHED
+            assert snapshot.get_job("0", "0")["status"] == FORWARD_MODEL_STATE_RUNNING
+            assert snapshot.get_job("1", "1")["status"] == FORWARD_MODEL_STATE_FAILURE
 
         # a second monitor connects
         async with Monitor(evaluator._config.get_connection_info()) as monitor2:
@@ -298,9 +311,9 @@ async def test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_e
             assert full_snapshot_event["type"] == identifiers.EVTYPE_EE_SNAPSHOT
             snapshot = Snapshot(full_snapshot_event.data)
             assert snapshot.status == ENSEMBLE_STATE_UNKNOWN
-            assert snapshot.get_job("1", "0").status == FORWARD_MODEL_STATE_FINISHED
-            assert snapshot.get_job("0", "0").status == FORWARD_MODEL_STATE_RUNNING
-            assert snapshot.get_job("1", "1").status == FORWARD_MODEL_STATE_FAILURE
+            assert snapshot.get_job("1", "0")["status"] == FORWARD_MODEL_STATE_FINISHED
+            assert snapshot.get_job("0", "0")["status"] == FORWARD_MODEL_STATE_RUNNING
+            assert snapshot.get_job("1", "1")["status"] == FORWARD_MODEL_STATE_FAILURE
 
             # one monitor requests that server exit
             await monitor.signal_cancel()

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -91,7 +91,10 @@ def test_run_and_cancel_legacy_ensemble(
                         if cancel:
                             await mon.signal_cancel()
                             cancel = False
-                        if event["type"] == identifiers.EVTYPE_EE_TERMINATED:
+                        if (
+                            event is not None
+                            and event["type"] == identifiers.EVTYPE_EE_TERMINATED
+                        ):
                             terminated_event = True
             return terminated_event
 

--- a/tests/unit_tests/ensemble_evaluator/test_snapshot.py
+++ b/tests/unit_tests/ensemble_evaluator/test_snapshot.py
@@ -65,7 +65,9 @@ def test_snapshot_merge(snapshot: Snapshot):
         name="forward_model1",
     )
 
-    assert snapshot.get_job(real_id="9", forward_model_id="0").status == "Running"
+    assert (
+        snapshot.get_job(real_id="9", forward_model_id="0").get("status") == "Running"
+    )
     assert snapshot.get_job(real_id="9", forward_model_id="0") == ForwardModel(
         status="Running",
         index="0",


### PR DESCRIPTION
The pydantic version is causing our GUI to freeze for several seconds on heavy updates. 

**Approach**
Using TypedDict eliminates most of the freeze duration.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
