### PR TITLE
Set max_submit to 1 in job.py

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -128,7 +128,7 @@ class Job:
                 timeout_task.cancel()
             sem.release()
 
-    async def run(self, sem: asyncio.BoundedSemaphore, max_submit: int = 2) -> None:
+    async def run(self, sem: asyncio.BoundedSemaphore, max_submit: int = 1) -> None:
         self._requested_max_submit = max_submit
         for attempt in range(max_submit):
             await self._submit_and_run_once(sem)


### PR DESCRIPTION
This has been changed from 2 to 1 in all (?) other places in Ert already, so this particular place has just been forgotten.

**Issue**
*payback*



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
