### PR TITLE
Fix logic error in unify_responses

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -1294,7 +1294,8 @@ class LocalEnsemble(BaseMode):
         if key is None:
             for response_key in self.experiment.response_configuration:
                 self.unify_responses(response_key)
-                key = response_key
+
+            return None
 
         gen_data_keys = {
             k


### PR DESCRIPTION
If the key is None the function shall call itself for all response config keys, but not re-execute the logic on the last key