### PR TITLE
Remove builder pattern for Realization objects

### DIFF
--- a/src/ert/ensemble_evaluator/__init__.py
+++ b/src/ert/ensemble_evaluator/__init__.py
@@ -3,7 +3,6 @@ from ._builder import (
     EnsembleBuilder,
     ForwardModelStep,
     Realization,
-    RealizationBuilder,
 )
 from .config import EvaluatorServerConfig
 from .evaluator import EnsembleEvaluator
@@ -22,7 +21,6 @@ __all__ = (
     "Monitor",
     "PartialSnapshot",
     "Realization",
-    "RealizationBuilder",
     "Snapshot",
     "SnapshotUpdateEvent",
 )

--- a/src/ert/ensemble_evaluator/_builder/__init__.py
+++ b/src/ert/ensemble_evaluator/_builder/__init__.py
@@ -1,11 +1,10 @@
 from ._ensemble import Ensemble
 from ._ensemble_builder import EnsembleBuilder
-from ._realization import ForwardModelStep, Realization, RealizationBuilder
+from ._realization import ForwardModelStep, Realization
 
 __all__ = (
     "Ensemble",
     "EnsembleBuilder",
     "ForwardModelStep",
     "Realization",
-    "RealizationBuilder",
 )

--- a/src/ert/ensemble_evaluator/_builder/_realization.py
+++ b/src/ert/ensemble_evaluator/_builder/_realization.py
@@ -1,16 +1,10 @@
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Sequence
-
-from typing_extensions import Self
 
 from ert.config.forward_model_step import ForwardModelStep
 
 if TYPE_CHECKING:
     from ert.run_arg import RunArg
-SOURCE_TEMPLATE_REAL = "/real/{iens}"
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -22,68 +16,3 @@ class Realization:
     run_arg: "RunArg"
     num_cpu: int
     job_script: str
-
-
-class RealizationBuilder:
-    def __init__(self) -> None:
-        self._active: Optional[bool] = None
-        self._iens: Optional[int] = None
-        self._parent_source: Optional[str] = None
-        self._forward_model_steps: Sequence[ForwardModelStep] = []
-        self._max_runtime: Optional[int] = None
-        self._run_arg: Optional["RunArg"] = None
-        self._num_cpu: Optional[int] = None
-        self._job_script: Optional[str] = None
-
-    def active(self, active: bool) -> Self:
-        self._active = active
-        return self
-
-    def set_forward_models(self, forward_models: Sequence[ForwardModelStep]) -> Self:
-        self._forward_model_steps = forward_models
-        return self
-
-    def set_iens(self, iens: int) -> Self:
-        self._iens = iens
-        return self
-
-    def set_max_runtime(self, max_runtime: Optional[int]) -> Self:
-        self._max_runtime = max_runtime
-        return self
-
-    def set_run_arg(self, run_arg: "RunArg") -> Self:
-        self._run_arg = run_arg
-        return self
-
-    def set_num_cpu(self, num_cpu: int) -> Self:
-        self._num_cpu = num_cpu
-        return self
-
-    def set_job_script(self, job_script: str) -> Self:
-        self._job_script = job_script
-        return self
-
-    def build(self) -> Realization:
-        if not self._iens:
-            # assume this is being used as a forward model, thus should be 0
-            self._iens = 0
-
-        assert self._active is not None
-
-        if self._active:
-            assert self._run_arg is not None
-            assert self._num_cpu is not None
-            assert self._job_script is not None
-            # Mypy is not able to pick up these asserts due
-            # to the condition on self._active, thus we still
-            # need to ignore typing errors below
-
-        return Realization(
-            self._iens,
-            self._forward_model_steps,
-            self._active,
-            self._max_runtime,
-            self._run_arg,  # type: ignore
-            self._num_cpu,  # type: ignore
-            self._job_script,  # type: ignore
-        )

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -38,7 +38,7 @@ from ert.ensemble_evaluator import (
     EnsembleEvaluator,
     EvaluatorServerConfig,
     Monitor,
-    RealizationBuilder,
+    Realization,
 )
 from ert.ensemble_evaluator.event import (
     EndEvent,
@@ -566,15 +566,17 @@ class BaseRunModel:
         )
 
         for iens, run_arg in enumerate(run_context):
-            active = run_context.is_active(iens)
-            real = RealizationBuilder().set_iens(iens).active(active)
-            if active:
-                real.set_forward_models(self.ert_config.forward_model_steps)
-                real.set_max_runtime(self.ert_config.analysis_config.max_runtime)
-                real.set_run_arg(run_arg)
-                real.set_num_cpu(self.ert_config.preferred_num_cpu)
-                real.set_job_script(self.ert_config.queue_config.job_script)
-            builder.add_realization(real)
+            builder.add_realization(
+                Realization(
+                    active=run_context.is_active(iens),
+                    iens=iens,
+                    forward_models=self.ert_config.forward_model_steps,
+                    max_runtime=self.ert_config.analysis_config.max_runtime,
+                    run_arg=run_arg,
+                    num_cpu=self.ert_config.preferred_num_cpu,
+                    job_script=self.ert_config.queue_config.job_script,
+                )
+            )
         return builder.set_id(str(uuid.uuid1()).split("-", maxsplit=1)[0]).build()
 
     @property

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -124,15 +124,14 @@ def make_ensemble_builder(queue_config):
                     )
 
                 builder.add_realization(
-                    ert.ensemble_evaluator.RealizationBuilder()
-                    .active(True)
-                    .set_iens(iens)
-                    .set_forward_models(forward_model_list)
-                    .set_job_script("job_dispatch.py")
-                    .set_max_runtime(10)
-                    .set_num_cpu(1)
-                    .set_run_arg(
-                        RunArg(
+                    ert.ensemble_evaluator.Realization(
+                        active=True,
+                        iens=iens,
+                        forward_models=forward_model_list,
+                        job_script="job_dispatch.py",
+                        max_runtime=10,
+                        num_cpu=1,
+                        run_arg=RunArg(
                             str(iens),
                             MagicMock(spec=Ensemble),
                             iens,

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_builder.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_builder.py
@@ -5,7 +5,7 @@ import pytest
 from ert.config import ForwardModelStep, QueueConfig, QueueSystem
 from ert.ensemble_evaluator._builder import (
     EnsembleBuilder,
-    RealizationBuilder,
+    Realization,
 )
 
 
@@ -16,14 +16,15 @@ def test_build_ensemble(active_real):
         EnsembleBuilder()
         .set_legacy_dependencies(QueueConfig(queue_system=QueueSystem.LOCAL), False, 0)
         .add_realization(
-            RealizationBuilder()
-            .set_iens(2)
-            .set_run_arg(MagicMock())
-            .set_num_cpu(1)
-            .set_max_runtime(0)
-            .set_job_script("job_script")
-            .set_forward_models([ForwardModelStep("echo_command", "")])
-            .active(active_real)
+            Realization(
+                iens=2,
+                run_arg=MagicMock(),
+                num_cpu=1,
+                max_runtime=0,
+                job_script="job_script",
+                forward_models=[ForwardModelStep("echo_command", "")],
+                active=active_real,
+            )
         )
         .set_id("1")
     )


### PR DESCRIPTION
base_run_can make finished realization objects directly.

**Issue**
Resolves #8202 

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
