### PR TITLE
Set default exit code to 1 in LocalDriver

### DIFF
--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -55,7 +55,11 @@ class LocalDriver(Driver):
             raise err
 
     async def finish(self) -> None:
-        await asyncio.gather(*self._tasks.values())
+        results = await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error(f"Exception in LocalDriver: {result}")
+                raise result
         logger.info("All realization tasks finished")
 
     async def _run(self, iens: int, executable: str, /, *args: str) -> None:
@@ -79,7 +83,7 @@ class LocalDriver(Driver):
 
         await self.event_queue.put(StartedEvent(iens=iens))
 
-        returncode = 0
+        returncode = 1
         try:
             returncode = await self._wait(proc)
             logger.info(f"Realization {iens} finished with {returncode=}")

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -356,8 +356,8 @@ class Scheduler:
 
         try:
             await self._monitor_and_handle_tasks(scheduling_tasks)
-        finally:
             await self.driver.finish()
+        finally:
             for scheduling_task in scheduling_tasks:
                 scheduling_task.cancel()
             # We discard exceptions when cancelling the scheduling tasks


### PR DESCRIPTION
**Issue**
~~Resolves https://github.com/equinor/ert/issues/8208~~
Resolves https://github.com/equinor/ert/issues/8220


**Approach**


- [x] write test

We set default exit code to 1 in LocalDriver
Since the exceptions are handled only in the driver.finish, this has
caused realizations to be flagged as completed ragardless.
Additionally this moves driver finish to try section in monitoring the jobs in order to allow for background tasks to finish if exception happens.
Add test that job state is failed when exception occurs


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
