### PR TITLE
Add blue color and underscore to STDOUT and STDERR in job view

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -347,12 +347,14 @@ class SnapshotModel(QAbstractItemModel):
         return self.createIndex(parent_item.row(), 0, parent_item)
 
     @override
-    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+    def data(
+        self, index: QModelIndex, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
+    ) -> Any:
         if not index.isValid():
             return QVariant()
 
-        if role == Qt.TextAlignmentRole:
-            return Qt.AlignCenter
+        if role == Qt.ItemDataRole.TextAlignmentRole:
+            return Qt.AlignmentFlag.AlignCenter
 
         node: Union[RootNode, IterNode, RealNode, ForwardModelStepNode] = (
             index.internalPointer()
@@ -372,22 +374,30 @@ class SnapshotModel(QAbstractItemModel):
         if isinstance(node, RealNode):
             return self._real_data(index, node, role)
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             if index.column() == 0:
                 return f"{type(node).__name__}:{node.id_}"
             if index.column() == 1:
                 return f"{node.data.status}"
 
-        if role in (Qt.StatusTipRole, Qt.WhatsThisRole, Qt.ToolTipRole):
+        if role in (
+            Qt.ItemDataRole.StatusTipRole,
+            Qt.ItemDataRole.WhatsThisRole,
+            Qt.ItemDataRole.ToolTipRole,
+        ):
             return ""
 
-        if role == Qt.SizeHintRole:
+        if role == Qt.ItemDataRole.SizeHintRole:
             return QSize()
 
-        if role == Qt.FontRole:
+        if role == Qt.ItemDataRole.FontRole:
             return QFont()
 
-        if role in (Qt.BackgroundRole, Qt.ForegroundRole, Qt.DecorationRole):
+        if role in (
+            Qt.ItemDataRole.BackgroundRole,
+            Qt.ItemDataRole.ForegroundRole,
+            Qt.ItemDataRole.DecorationRole,
+        ):
             return QColor()
 
         return QVariant()
@@ -422,13 +432,27 @@ class SnapshotModel(QAbstractItemModel):
         return QVariant()
 
     @staticmethod
-    def _job_data(index: QModelIndex, node: ForwardModelStepNode, role: int):
+    def _job_data(
+        index: QModelIndex, node: ForwardModelStepNode, role: Qt.ItemDataRole
+    ):
         node_id = str(node.id_)
 
-        if role == Qt.BackgroundRole:
+        if role == Qt.ItemDataRole.FontRole:
+            data_name = COLUMNS[NodeType.REAL][index.column()]
+            if data_name in [ids.STDOUT, ids.STDERR]:
+                font = QFont()
+                font.setUnderline(True)
+                return font
+
+        if role == Qt.ItemDataRole.ForegroundRole:
+            data_name = COLUMNS[NodeType.REAL][index.column()]
+            if data_name in [ids.STDOUT, ids.STDERR]:
+                return QColor(Qt.GlobalColor.blue)
+
+        if role == Qt.ItemDataRole.BackgroundRole:
             return node.parent.data.forward_model_step_status_color_by_id[node_id]
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             data_name = COLUMNS[NodeType.REAL][index.column()]
             if data_name in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
                 data = node.data
@@ -463,7 +487,7 @@ class SnapshotModel(QAbstractItemModel):
         if role == IterNum:
             return node.parent.parent.id_
 
-        if role == Qt.ToolTipRole:
+        if role == Qt.ItemDataRole.ToolTipRole:
             data_name = COLUMNS[NodeType.REAL][index.column()]
             data = None
             if data_name == ids.ERROR:

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -396,8 +396,8 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(qtbot: QtBot, sto
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
         run_dialog = gui.findChild(RunDialog)
         qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-        job_view = run_dialog._job_view
-        qtbot.waitUntil(job_view.isVisible, timeout=20000)
+        job_overview = run_dialog._job_overview
+        qtbot.waitUntil(job_overview.isVisible, timeout=20000)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
 
         realization_widget = run_dialog.findChild(RealizationWidget)
@@ -412,8 +412,9 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(qtbot: QtBot, sto
                 Qt.LeftButton,
                 pos=click_pos,
             )
-        click_pos = job_view.visualRect(run_dialog._job_model.index(0, 4)).center()
-        qtbot.mouseClick(job_view.viewport(), Qt.LeftButton, pos=click_pos)
+
+        click_pos = job_overview.visualRect(job_overview.model().index(0, 4)).center()
+        qtbot.mouseClick(job_overview.viewport(), Qt.LeftButton, pos=click_pos)
 
         qtbot.waitUntil(run_dialog.findChild(FileDialog).isVisible, timeout=3000)
 
@@ -516,7 +517,7 @@ def test_run_dialog_memory_usage_showing(
     assert type(realization_box) == RealizationWidget
     # Click the first realization box
     qtbot.mouseClick(realization_box, Qt.LeftButton)
-    job_model = run_dialog._job_view.model()
+    job_model = run_dialog._job_overview.model()
     assert job_model._real == 0
 
     job_number = 0


### PR DESCRIPTION
**Issue**
Resolves #4371 



**Approach**
Adding qt buttons to the job list is non trivial and would require a larger rewrite. This solution is simpler while adding some feedback to the user that these columns are clickable.

![image](https://github.com/equinor/ert/assets/30144033/cbe75e3a-8662-42be-bc9e-30a1508d87f1)










- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
