### PR TITLE
Catch XML errors when logging error file

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -288,7 +288,14 @@ class Job:
 def log_info_from_exit_file(exit_file_path: Path) -> None:
     if not exit_file_path.exists():
         return
-    exit_file = etree.parse(exit_file_path)
+    try:
+        exit_file = etree.parse(exit_file_path)
+    except etree.XMLSyntaxError:
+        raw_xml_contents = exit_file_path.read_text(encoding="utf-8", errors="ignore")
+        logger.error(
+            f"job failed with invalid XML ERROR file, contents '{raw_xml_contents}'"
+        )
+        return
     filecontents: List[str] = []
     for element in ["job", "reason", "stderr_file", "stderr"]:
         filecontents.append(str(exit_file.findtext(element)))


### PR DESCRIPTION
It is not critical that this ERROR file is valid XML, it just means the user parsing the log must decipher XML manually.

**Issue**
Resolves #8231 

**Approach**
catch exception and log.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
