### PR TITLE
Fix bug in LSF driver resource manipulation

### DIFF
--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -610,7 +610,7 @@ async def test_that_bsub_will_retry_and_succeed(
             "select[location=='cloud']",
             ["linrgs12-foo", "linrgs13-bar"],
             "select[location=='cloud' && hname!='linrgs12-foo' && hname!='linrgs13-bar']",
-            id="multiple_selects",
+            id="existing_select",
         ),
         pytest.param(
             None,
@@ -629,6 +629,24 @@ async def test_that_bsub_will_retry_and_succeed(
             [""],
             "select[location=='cloud']",
             id="select_in_resource_requirement_and_empty_string_in_excluded_hosts",
+        ),
+        pytest.param(
+            "select[location=='cloud'] rusage[mem=7000]",
+            [""],
+            "select[location=='cloud'] rusage[mem=7000]",
+            id="select_and_rusage_in_resource_requirement_empty_excluded_hosts",
+        ),
+        pytest.param(
+            "select[location=='cloud'] rusage[mem=7000]",
+            ["rogue_host"],
+            "select[location=='cloud' && hname!='rogue_host'] rusage[mem=7000]",
+            id="select_and_rusage_in_resource_requirement_one_excluded_hosts",
+        ),
+        pytest.param(
+            "rusage[mem=7000] select[location=='cloud']",
+            ["rogue_host"],
+            "rusage[mem=7000] select[location=='cloud' && hname!='rogue_host']",
+            id="rusage_and_select_resource_requirement_one_excluded_hosts",
         ),
     ],
 )


### PR DESCRIPTION
If both select and rusage was part of the existing resource string, and some hosts were attempted excluded, the previous code would inject the exclusion string at the wrong spot, failing to locate the correct end of the select statement.

Added tests that triggers the original bug.

**Issue**
Resolves #8255 


**Approach**
Use regexp parsing


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
