### PR TITLE
Mitigate flakyness in test_slurm_driver

### DIFF
--- a/tests/integration_tests/scheduler/test_slurm_driver.py
+++ b/tests/integration_tests/scheduler/test_slurm_driver.py
@@ -121,6 +121,7 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
     assert Path("test").read_text(encoding="utf-8") == "test\n"
 
 
+@pytest.mark.flaky(reruns=3)
 async def test_kill_before_submit_is_finished(
     tmp_path, monkeypatch, caplog, pytestconfig
 ):
@@ -128,8 +129,8 @@ async def test_kill_before_submit_is_finished(
 
     if pytestconfig.getoption("slurm"):
         # Allow more time when tested on a real compute cluster to avoid false positives.
-        job_kill_window = 10
-        test_grace_time = 20
+        job_kill_window = 5
+        test_grace_time = 10
     elif sys.platform.startswith("darwin"):
         # Mitigate flakiness on low-power test nodes
         job_kill_window = 5


### PR DESCRIPTION
The flakyness was easily reproducible with --count=100 -n 16, but after adding reruns the flakyness cannot be reproduced, so assuming reruns is sufficient (this was with mocked Slurm system, not with the --slurm option to pytest).

Since we have added reruns, we can reduce the job_kill_window when doing real integration tests also.

**Issue**
Resolves #8260 


**Approach**
`pytest.mark.flaky(reruns=3)`


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
