### PR TITLE
Avoid imports from job_queue

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -30,11 +30,10 @@ from websockets.client import connect
 
 from _ert.async_utils import get_running_loop
 from ert.constant_filenames import CERT_FILE
-from ert.event_type_constants import EVTYPE_FORWARD_MODEL_CHECKSUM
-from ert.job_queue.queue import (
-    CLOSE_PUBLISHER_SENTINEL,
+from ert.event_type_constants import (
     EVTYPE_ENSEMBLE_CANCELLED,
     EVTYPE_ENSEMBLE_STOPPED,
+    EVTYPE_FORWARD_MODEL_CHECKSUM,
 )
 from ert.serialization import evaluator_unmarshaller
 
@@ -47,6 +46,8 @@ if TYPE_CHECKING:
     from ert.ensemble_evaluator import Realization
 
 logger = logging.getLogger(__name__)
+
+CLOSE_PUBLISHER_SENTINEL = object()
 
 
 @dataclass


### PR DESCRIPTION
job_queue module is going away soon.

**Issue**
Resolves #8246 

**Approach**
do-it


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
