### PR TITLE
Add generic driver test for num_cpu

### DIFF
--- a/tests/integration_tests/scheduler/bin/bsub
+++ b/tests/integration_tests/scheduler/bin/bsub
@@ -19,6 +19,7 @@ do
             queue=$OPTARG
             ;;
         n)
+            num_cpu=$OPTARG
             ;;
         R)
             resource_requirement=$OPTARG
@@ -32,11 +33,15 @@ shift $((OPTIND-1))
 
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid="${RANDOM}"
+job_env_file="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.env"
 
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
 echo $@ > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
 echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
+touch $job_env_file
+
+[ -n $num_cpu ] && echo "export LSB_MAX_NUM_PROCESSORS=$num_cpu" >> $job_env_file
 
 [ -z $stdout ] && stdout="/dev/null"
 [ -z $stderr ] && stderr="/dev/null"

--- a/tests/integration_tests/scheduler/bin/lsfrunner
+++ b/tests/integration_tests/scheduler/bin/lsfrunner
@@ -15,7 +15,8 @@ function handle_sigterm {
 trap handle_sigterm SIGTERM
 
 echo "$$" > "${job}.pid"
-bash "${job}.script" > "${job}.stdout" 2> "${job}.stderr" &
+source "${job}.env"
+bash "${job}.script" > "${job}.stdout" 2> "${job}.stderr"  &
 child_pid=$!
 wait $child_pid
 

--- a/tests/integration_tests/scheduler/bin/qsub
+++ b/tests/integration_tests/scheduler/bin/qsub
@@ -16,6 +16,7 @@ do
         e)
             ;;
         l)
+            resource=$OPTARG
             ;;
         *)
             echo "Unprocessed option ${opt}"
@@ -26,11 +27,18 @@ shift $((OPTIND-1))
 
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid="test${RANDOM}.localhost"
+job_env_file="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.env"
 
 mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
 cat <&0 > "${jobdir}/${jobid}.script"
 echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
+touch $job_env_file
 
+echo $resource >> $job_env_file
+num_cpu=$(echo $resource | sed 's/.*ncpus=\([[:digit:]]*\).*/\1/')
+
+[ -n $num_cpu ] && echo "export OMP_NUM_THREADS=$num_cpu" >> $job_env_file
+[ -n $num_cpu ] && echo "export NCPUS=$num_cpu" >> $job_env_file
 
 bash "$(dirname $0)/runner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &
 disown

--- a/tests/integration_tests/scheduler/bin/runner
+++ b/tests/integration_tests/scheduler/bin/runner
@@ -14,6 +14,7 @@ function handle_sigterm {
 trap handle_sigterm SIGTERM
 
 echo "$$" > "${job}.pid"
+source "${job}.env"
 bash "${job}.script" > "${job}.stdout" 2> "${job}.stderr" &
 child_pid=$!
 wait $child_pid

--- a/tests/integration_tests/scheduler/bin/sbatch.py
+++ b/tests/integration_tests/scheduler/bin/sbatch.py
@@ -32,6 +32,16 @@ def main() -> None:
     (jobdir / "mock_jobs").mkdir(parents=True, exist_ok=True)
     (jobdir / "mock_jobs" / f"{jobid}.script").write_text(args.script, encoding="utf-8")
     (jobdir / "mock_jobs" / f"{jobid}.name").write_text(args.job_name, encoding="utf-8")
+    env_file = jobdir / "mock_jobs" / f"{jobid}.env"
+
+    if args.ntasks:
+        env_file.write_text(
+            f"export SLURM_JOB_CPUS_PER_NODE={args.ntasks}\n"
+            f"export SLURM_CPUS_ON_NODE={args.ntasks}",
+            encoding="utf-8",
+        )
+    else:
+        env_file.touch()
 
     subprocess.Popen(
         [str(Path(__file__).parent / "runner"), f"{jobdir}/mock_jobs/{jobid}"],


### PR DESCRIPTION
Test all drivers that there are remnants in the compute environment from the number of cpus requested.

**Issue**
Resolves #8195 


**Approach**
do-it.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
