### PR TITLE
Avoid unused varibles in test_slurm_driver

### DIFF
--- a/tests/integration_tests/scheduler/test_slurm_driver.py
+++ b/tests/integration_tests/scheduler/test_slurm_driver.py
@@ -50,7 +50,7 @@ async def test_slurm_dumps_stderr_to_file(tmp_path, job_name):
 
 def generate_random_text(size):
     letters = string.ascii_letters
-    return "".join(random.choice(letters) for i in range(size))
+    return "".join(random.choice(letters) for _ in range(size))
 
 
 @pytest.mark.parametrize("tail_chars_to_read", [(5), (50), (500), (700)])
@@ -78,7 +78,7 @@ async def test_slurm_can_retrieve_stdout_and_stderr(
 
 
 @pytest.mark.integration_test
-async def test_submit_to_named_queue(tmp_path, caplog, job_name):
+async def test_submit_to_named_queue(tmp_path, job_name):
     """If the environment variable _ERT_TEST_ALTERNATIVE_QUEUE is defined
     a job will be attempted submitted to that queue.
 


### PR DESCRIPTION
**Issue**
Resolves editor complaints.

**Approach**
✂️ 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
