### PR TITLE
Revert "Add validation for FIELD parameter name"

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -688,7 +688,7 @@ Field parameters (e.g. porosity, permeability or Gaussian Random Fields from APS
         FIELD  ID  PARAMETER  <OUTPUT_FILE>  INIT_FILES:/path/%d  FORWARD_INIT:True  INIT_TRANSFORM:FUNC  OUTPUT_TRANSFORM:FUNC  MIN:X  MAX:Y
 
 - **ID**
-  String identifier with maximum 8 characters that must match the name of the parameter specified in ``INIT_FILES``. The 8 characters limitation is due to Eclipse where keywords are limited to max 8 characters.
+  String identifier with maximum 8 characters that must match the name of the parameter specified in ``INIT_FILES``.
 
 - **PARAMETER**
   Legacy from when ERT supported EnKF and needed to handle dynamic fields like pressure and saturations.

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -110,14 +110,6 @@ class Field(ParameterConfig):
                 )
             )
 
-        if len(name) > 8:
-            errors.append(
-                ConfigValidationError.with_context(
-                    f"FIELD parameter_name '{name}' is too long. Eclipse keywords are limited to max 8 characters",
-                    config_list,
-                )
-            )
-
         if errors:
             raise ConfigValidationError.from_collected(errors)
         assert file_format is not None

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -533,7 +533,7 @@ def test_and_benchmark_adaptive_localization_with_fields(
     obs = obs.expand_dims({"obs_name": ["OBSERVATION"]})
     obs = obs.expand_dims({"name": ["RESPONSE"]})
 
-    param_group = "PARA_FLD"
+    param_group = "PARAM_FIELD"
 
     config = Field.from_config_list(
         "MY_EGRID.EGRID",
@@ -673,7 +673,7 @@ def test_temporary_parameter_storage_with_inactive_fields(
     num_grid_cells = 40
     layers = 5
     ensemble_size = 5
-    param_group = "PARA_FLD"
+    param_group = "PARAM_FIELD"
     shape = Shape(num_grid_cells, num_grid_cells, layers)
 
     grid = xtgeo.create_box_grid(dimension=(shape.nx, shape.ny, shape.nz))

--- a/tests/unit_tests/config/config_dict_generator.py
+++ b/tests/unit_tests/config/config_dict_generator.py
@@ -452,8 +452,7 @@ def ert_config_values(draw, use_eclbase=booleans):
             gen_kw_export_name=st.just("gen-kw-export-name-" + draw(file_names)),
             field=small_list(
                 st.tuples(
-                    ##
-                    st.just(draw(words)),
+                    st.builds(lambda w: "FIELD-" + w, words),
                     st.just("PARAMETER"),
                     field_output_names(),
                     st.builds(lambda x: f"FORWARD_INIT:{x}", booleans),

--- a/tests/unit_tests/config/test_field.py
+++ b/tests/unit_tests/config/test_field.py
@@ -210,13 +210,3 @@ def test_invalid_argument_gives_a_user_error_message(
         _ = parse_field_line(
             f"FIELD f parameter out.roff INIT_FILES:file.init {invalid_argument}"
         )
-
-
-def test_field_parameter_name_max_length(parse_field_line):
-    with pytest.raises(
-        ConfigValidationError,
-        match="FIELD parameter_name 'very_long_parameter_name' is too long. Eclipse keywords are limited to max 8 characters",
-    ):
-        _ = parse_field_line(
-            "FIELD very_long_parameter_name PARAMETER permx.grdecl INIT_FILES:fields/perms%d.grdecl"
-        )


### PR DESCRIPTION
This reverts commit 892f91e327eabc5356689d51d11c6c21262924fd.

Not everyone is using Eclipse.
For example, Intersert does not have a limitation of 8 characters.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
