### PR TITLE
Allow adjustable size for job overview header

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -5,9 +5,15 @@ from pathlib import Path
 from queue import SimpleQueue
 from typing import Optional
 
-from PyQt5.QtGui import QMouseEvent
 from qtpy.QtCore import QModelIndex, QSize, Qt, QThread, QTimer, Signal, Slot
-from qtpy.QtGui import QCloseEvent, QKeyEvent, QMovie, QTextCursor, QTextOption
+from qtpy.QtGui import (
+    QCloseEvent,
+    QKeyEvent,
+    QMouseEvent,
+    QMovie,
+    QTextCursor,
+    QTextOption,
+)
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QDialog,
@@ -81,7 +87,17 @@ class JobOverview(QTableView):
 
         horizontal_header = self.horizontalHeader()
         assert horizontal_header is not None
-        horizontal_header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+
+        for section in range(horizontal_header.count()):
+            horizontal_header.resizeSection(section, 140)
+            # Only last section should be stretch
+            horizontal_header.setSectionResizeMode(
+                section,
+                QHeaderView.Stretch
+                if section == horizontal_header.count() - 1
+                else QHeaderView.Interactive,
+            )
+
         vertical_header = self.verticalHeader()
         assert vertical_header is not None
         vertical_header.setMinimumWidth(20)
@@ -193,7 +209,6 @@ class RunDialog(QDialog):
         self._snapshot_model.rowsInserted.connect(self.on_snapshot_new_iteration)
 
         self._job_label = QLabel(self)
-
         self._job_overview = JobOverview(self._snapshot_model, self)
 
         self.running_time = QLabel("")


### PR DESCRIPTION
UI now provides adjustable horizontal header in job overview.
All sections have a reasonable default size, and allows interactive change of size.
The last section is set to stretch to fit the viewport.

Resolves #1638

Screenshot shows adjusted header.

![Screenshot 2024-07-03 at 15 50 01](https://github.com/equinor/ert/assets/114403625/020df21e-71df-4eb8-9d66-fcdddca8d1f6)



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
