### PR TITLE
Avoid import outside top-level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ ignore = ["PLW2901",  # redefined-loop-name
           "PLR6104",  # non-augmented-assignment
           "PLR6301",  # no-self-use
           "PLW1641",  # eq-without-hash
-          "PLC0415",  # import-outside-toplevel
           "PLR0904",  # too-many-public-methods
           "PLR1702",  # too-many-nested-blocks
           "PLW3201",  # bad-dunder-method-name

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -184,7 +184,8 @@ def valid_port_range(user_input: str) -> range:
 
 
 def run_gui_wrapper(args: Namespace, ert_plugin_manager: ErtPluginManager) -> None:
-    from ert.gui.main import run_gui
+    # Importing ert.gui on-demand saves ~0.5 seconds off `from ert import __main__`
+    from ert.gui.main import run_gui  # noqa: PLC0415
 
     run_gui(args, ert_plugin_manager)
 

--- a/src/ert/plugins/hook_implementations/workflows/export_misfit_data.py
+++ b/src/ert/plugins/hook_implementations/workflows/export_misfit_data.py
@@ -30,7 +30,7 @@ class ExportMisfitDataJob(ErtScript):
 
         realizations = ensemble.get_realization_list_with_responses()
 
-        from ert import LibresFacade
+        from ert import LibresFacade  # noqa: PLC0415 (circular import)
 
         facade = LibresFacade(ert_config)
         misfit = facade.load_all_misfit_data(ensemble)

--- a/src/ert/resources/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/resources/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -161,7 +161,12 @@ class CSVExportJob(ErtPlugin):
         return export_info
 
     def getArguments(self, parent, ert_config, storage):
-        from ert.gui.ertwidgets import CustomDialog, ListEditBox, PathChooser, PathModel
+        from ert.gui.ertwidgets import (  # noqa: PLC0415
+            CustomDialog,
+            ListEditBox,
+            PathChooser,
+            PathModel,
+        )
 
         description = "The CSV export requires some information before it starts:"
         dialog = CustomDialog("CSV Export", description, parent)

--- a/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -231,8 +231,13 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         return export_info
 
     def getArguments(self, parent, storage):
-        from ert.gui.ertwidgets import CustomDialog, ListEditBox, PathChooser
-        from ert.gui.ertwidgets.models.path_model import PathModel
+        # Importing ert.gui on-demand saves ~0.5 seconds off `from ert import __main__`
+        from ert.gui.ertwidgets import (  # noqa: PLC0415
+            CustomDialog,
+            ListEditBox,
+            PathChooser,
+        )
+        from ert.gui.ertwidgets.models.path_model import PathModel  # noqa: PLC0415
 
         description = (
             "The GEN_DATA RFT CSV export requires some information before it starts:"


### PR DESCRIPTION
Keeping as exception at one spot due to circular dependency and one spot due to measurable time-loss to do top-level import.

Ignoring the issue in script/build, this file is being deleted soon.

**Issue**
Resolves ruff PLC0415


**Approach**
fix/add exception/comment.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
