### PR TITLE
Fix small GUI error in create_experiment

### DIFF
--- a/src/ert/gui/ertwidgets/create_experiment_dialog.py
+++ b/src/ert/gui/ertwidgets/create_experiment_dialog.py
@@ -30,14 +30,13 @@ class CreateExperimentDialog(QDialog):
         QDialog.__init__(self, parent=parent)
         self.setModal(True)
         self.setWindowTitle(title)
-        self.setFixedSize(400, 100)
+        self.setFixedSize(450, 120)
 
         layout = QGridLayout()
 
         experiment_label = QLabel("Experiment name:")
         self._experiment_edit = StringBox(
-            TextModel(""),
-            placeholder_text="My experiment",
+            TextModel(""), placeholder_text="My experiment", minimum_width=200
         )
         self._experiment_edit.setValidator(
             NotInStorage(notifier.storage, "experiments")
@@ -45,6 +44,7 @@ class CreateExperimentDialog(QDialog):
 
         ensemble_label = QLabel("Ensemble name:")
         self._ensemble_edit = QLineEdit()
+        self._ensemble_edit.setMinimumWidth(200)
         self._ensemble_edit.setPlaceholderText("My ensemble")
 
         buttons = QDialogButtonBox(

--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -23,6 +23,7 @@ class StringBox(QLineEdit):
         default_string: str = "",
         continuous_update: bool = False,
         placeholder_text: str = "",
+        minimum_width: int = 250,
     ):
         """
         :type model: ert.gui.ertwidgets.models.valuemodel.ValueModel
@@ -31,7 +32,7 @@ class StringBox(QLineEdit):
         :type continuous_update: bool
         """
         QLineEdit.__init__(self)
-        self.setMinimumWidth(250)
+        self.setMinimumWidth(minimum_width)
         self._validation = ValidationSupport(self)
         self._validator: Optional[ArgumentDefinition] = None
         self._model = model


### PR DESCRIPTION
**Issue**
Before:
![image](https://github.com/equinor/ert/assets/30144033/011fcf6e-81e5-4fbb-a454-987474ee2912)

After:
<img width="461" alt="image" src="https://github.com/equinor/ert/assets/30144033/c208f05d-d2a3-40ef-8b0c-9c2396b565f4">


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
