### PR TITLE
Test only deterministic realization fails

### DIFF
--- a/tests/unit_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/unit_tests/gui/test_restart_ensemble_experiment.py
@@ -82,7 +82,7 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
 
     qtbot.mouseClick(run_dialog.show_details_button, Qt.MouseButton.LeftButton)
 
-    qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=200000)
+    qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=20000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
     # Assert that the number of boxes in the detailed view is
@@ -116,7 +116,7 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     write_poly_eval(failing_reals=failing_reals_second_try)
     qtbot.mouseClick(run_dialog.restart_button, Qt.MouseButton.LeftButton)
 
-    qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=200000)
+    qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=20000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
     # Assert that the number of boxes in the detailed view is
@@ -145,7 +145,7 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     write_poly_eval(failing_reals=failing_reals_third_try)
     qtbot.mouseClick(run_dialog.restart_button, Qt.MouseButton.LeftButton)
 
-    qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
+    qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
     # Assert that the number of boxes in the detailed view is


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8300

Can be inspected with `pytest --show-gui tests/unit_tests/gui/test_restart_ensemble_experiment.py -k test_restart_failed_realizations`

<img width="1202" alt="Screenshot 2024-07-05 at 12 35 26" src="https://github.com/equinor/ert/assets/11595637/51ea47bb-77ae-43a8-a104-662d8cfe6a3a">
<img width="1200" alt="Screenshot 2024-07-05 at 12 35 37" src="https://github.com/equinor/ert/assets/11595637/22992c1b-aabf-4468-8c29-2f7f01b5b121">
<img width="1205" alt="Screenshot 2024-07-05 at 12 35 49" src="https://github.com/equinor/ert/assets/11595637/715095dc-48f1-498f-b078-018db25fa980">

