### PR TITLE
Faster date parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers=[
 dynamic = ["version"]
 dependencies=[
     "aiohttp",
+    "backports-datetime_fromisoformat",
     "cloudevents>=1.6.0",
     "cloudpickle",
     "cryptography",
@@ -51,7 +52,6 @@ dependencies=[
     "humanize",
     "importlib_resources;python_version <= '3.8'",
     "iterative_ensemble_smoother>=0.2.6",
-    "typing_extensions>=4.5",
     "jinja2",
     "lark",
     "lxml",
@@ -77,6 +77,7 @@ dependencies=[
     "tables<3.9;python_version == '3.8'",
     "tabulate",
     "tqdm>=4.62.0",
+    "typing_extensions>=4.5",
     "uvicorn >= 0.17.0",
     "websockets",
     "xarray",

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -1,7 +1,7 @@
-import datetime
 import re
 import typing
 from collections import defaultdict
+from datetime import datetime
 from typing import (
     Any,
     DefaultDict,
@@ -73,12 +73,12 @@ _ENSEMBLE_TYPE_EVENT_TO_STATUS = {
 
 
 def convert_iso8601_to_datetime(
-    timestamp: Union[datetime.datetime, str],
-) -> datetime.datetime:
-    if isinstance(timestamp, datetime.datetime):
+    timestamp: Union[datetime, str],
+) -> datetime:
+    if isinstance(timestamp, datetime):
         return timestamp
 
-    return datetime.datetime.fromisoformat(timestamp)
+    return datetime.fromisoformat(timestamp)
 
 
 RealId = str
@@ -100,7 +100,7 @@ class PartialSnapshot:
     def __init__(self, snapshot: Optional["Snapshot"] = None) -> None:
         self._realization_states: Dict[
             str,
-            Dict[str, Union[bool, datetime.datetime, str, Dict[str, "ForwardModel"]]],
+            Dict[str, Union[bool, datetime, str, Dict[str, "ForwardModel"]]],
         ] = defaultdict(dict)
         """A shallow dictionary of realization states. The key is a string with
         realization number, pointing to a dict with keys active (bool),
@@ -136,8 +136,8 @@ class PartialSnapshot:
         self,
         real_id: str,
         status: str,
-        start_time: Optional[datetime.datetime] = None,
-        end_time: Optional[datetime.datetime] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
     ) -> "PartialSnapshot":
         self._realization_states[real_id].update(
             _filter_nones(
@@ -419,8 +419,8 @@ class Snapshot:
 
 class ForwardModel(TypedDict, total=False):
     status: Optional[str]
-    start_time: Optional[datetime.datetime]
-    end_time: Optional[datetime.datetime]
+    start_time: Optional[datetime]
+    end_time: Optional[datetime]
     index: Optional[str]
     current_memory_usage: Optional[str]
     max_memory_usage: Optional[str]
@@ -433,8 +433,8 @@ class ForwardModel(TypedDict, total=False):
 class RealizationSnapshot(BaseModel):
     status: Optional[str] = None
     active: Optional[bool] = None
-    start_time: Optional[datetime.datetime] = None
-    end_time: Optional[datetime.datetime] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
     forward_models: Dict[str, ForwardModel] = {}
 
 
@@ -452,8 +452,8 @@ class SnapshotBuilder(BaseModel):
         self,
         real_ids: Sequence[str],
         status: Optional[str],
-        start_time: Optional[datetime.datetime] = None,
-        end_time: Optional[datetime.datetime] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
     ) -> Snapshot:
         top = SnapshotDict(status=status, metadata=self.metadata)
         for r_id in real_ids:
@@ -474,8 +474,8 @@ class SnapshotBuilder(BaseModel):
         status: Optional[str],
         current_memory_usage: Optional[str] = None,
         max_memory_usage: Optional[str] = None,
-        start_time: Optional[datetime.datetime] = None,
-        end_time: Optional[datetime.datetime] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
     ) -> "SnapshotBuilder":

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -14,14 +14,16 @@ from typing import (
     Union,
 )
 
+from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
 from cloudevents.http import CloudEvent
-from dateutil.parser import parse
 from pydantic import BaseModel
 from qtpy.QtGui import QColor
 from typing_extensions import TypedDict
 
 from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
+
+MonkeyPatch.patch_fromisoformat()
 
 _regexp_pattern = r"(?<=/{token}/)[^/]+"
 
@@ -76,7 +78,7 @@ def convert_iso8601_to_datetime(
     if isinstance(timestamp, datetime.datetime):
         return timestamp
 
-    return parse(timestamp)
+    return datetime.datetime.fromisoformat(timestamp)
 
 
 RealId = str

--- a/src/ert/serialization/_evaluator.py
+++ b/src/ert/serialization/_evaluator.py
@@ -1,5 +1,5 @@
-import datetime
 import json
+from datetime import date, datetime
 from typing import Any
 
 from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
@@ -9,7 +9,7 @@ MonkeyPatch.patch_fromisoformat()
 
 class _EvaluatorEncoder(json.JSONEncoder):
     def default(self, o: Any) -> Any:
-        if isinstance(o, (datetime.date, datetime.datetime)):
+        if isinstance(o, (date, datetime)):
             return {"__type__": "isoformat8601", "value": o.isoformat()}
         return json.JSONEncoder.default(self, o)
 
@@ -28,7 +28,7 @@ def _object_hook(obj: Any) -> Any:
         return obj
 
     if obj["__type__"] == "isoformat8601":
-        return datetime.datetime.fromisoformat(obj["value"])
+        return datetime.fromisoformat(obj["value"])
 
     return obj
 

--- a/src/ert/serialization/_evaluator.py
+++ b/src/ert/serialization/_evaluator.py
@@ -2,7 +2,9 @@ import datetime
 import json
 from typing import Any
 
-from dateutil import parser
+from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
+
+MonkeyPatch.patch_fromisoformat()
 
 
 class _EvaluatorEncoder(json.JSONEncoder):
@@ -26,7 +28,7 @@ def _object_hook(obj: Any) -> Any:
         return obj
 
     if obj["__type__"] == "isoformat8601":
-        return parser.parse(obj["value"])
+        return datetime.datetime.fromisoformat(obj["value"])
 
     return obj
 


### PR DESCRIPTION
datetime parsing while unpacking json in cloudevents is *very* slow currently.

**Approach**
Replaced datetime parsing library with a new one that is included in python 3.11. Using backport package for older python versions. The new one should be a bit more than two orders of magnitude faster.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
