### PR TITLE
Cache result of row in _Node

### DIFF
--- a/src/ert/gui/model/node.py
+++ b/src/ert/gui/model/node.py
@@ -16,6 +16,7 @@ class _Node(ABC):
     children: dict[int, IterNode | RealNode | ForwardModelStepNode] = field(
         default_factory=dict
     )
+    _index: Optional[int] = None
 
     def __repr__(self) -> str:
         parent = "no " if self.parent is None else ""
@@ -30,9 +31,12 @@ class _Node(ABC):
         pass
 
     def row(self) -> int:
-        if self.parent:
-            return list(self.parent.children.keys()).index(self.id_)
-        raise ValueError(f"{self} had no parent")
+        if not self._index:
+            if self.parent:
+                self._index = list(self.parent.children.keys()).index(self.id_)
+            else:
+                raise ValueError(f"{self} had no parent")
+        return self._index
 
 
 @dataclass


### PR DESCRIPTION
row() used a significant amount of time when profiling

**Approach**
cache result of row

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
