### PR TITLE
Speed up snapshot index

### DIFF
--- a/src/ert/gui/model/node.py
+++ b/src/ert/gui/model/node.py
@@ -40,12 +40,14 @@ class _Node(ABC):
 class RootNode(_Node):
     parent: None = field(default=None, init=False)
     children: dict[str, IterNode] = field(default_factory=dict)
+    children_list: list[IterNode] = field(default_factory=list)
     max_memory_usage: Optional[int] = None
 
     def add_child(self, node: _Node) -> None:
         node = cast(IterNode, node)
         node.parent = self
         self.children[node.id_] = node
+        self.children_list.append(node)
 
 
 @dataclass
@@ -59,11 +61,13 @@ class IterNode(_Node):
     parent: Optional[RootNode] = None
     data: IterNodeData = field(default_factory=IterNodeData)
     children: dict[str, RealNode] = field(default_factory=dict)
+    children_list: list[RealNode] = field(default_factory=list)
 
     def add_child(self, node: _Node) -> None:
         node = cast(RealNode, node)
         node.parent = self
         self.children[node.id_] = node
+        self.children_list.append(node)
 
 
 @dataclass
@@ -83,11 +87,13 @@ class RealNode(_Node):
     parent: Optional[IterNode] = None
     data: RealNodeData = field(default_factory=RealNodeData)
     children: dict[str, ForwardModelStepNode] = field(default_factory=dict)
+    children_list: list[ForwardModelStepNode] = field(default_factory=list)
 
     def add_child(self, node: _Node) -> None:
         node = cast(ForwardModelStepNode, node)
         node.parent = self
         self.children[node.id_] = node
+        self.children_list.append(node)
 
 
 @dataclass

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -491,7 +491,7 @@ class SnapshotModel(QAbstractItemModel):
 
         parent_item = self.root if not parent.isValid() else parent.internalPointer()
         try:
-            child_item = list(parent_item.children.values())[row]
+            child_item = parent_item.children_list[row]
         except KeyError:
             return QModelIndex()
         else:

--- a/tests/unit_tests/gui/model/test_job_list.py
+++ b/tests/unit_tests/gui/model/test_job_list.py
@@ -35,11 +35,11 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
         model, reporting_mode
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "1")
 
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "0")
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "1")
 
     qtmodeltester.check(model, force_py=True)
 
@@ -56,7 +56,7 @@ def test_changes(full_snapshot):
         model, reporting_mode
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
     assert model.index(0, _id_to_col(ids.STATUS)).data() == FORWARD_MODEL_STATE_START
 
     partial = PartialSnapshot(full_snapshot)
@@ -71,7 +71,7 @@ def test_changes(full_snapshot):
             end_time=end_time,
         ),
     )
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "0")
     assert (
         model.index(0, _id_to_col(DURATION), QModelIndex()).data() == "1 day, 1:00:00"
     )
@@ -95,7 +95,7 @@ def test_duration(mock_datetime, timezone, full_snapshot):
         model, reporting_mode
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
     assert (
         model.index(0, _id_to_col(ids.STATUS), QModelIndex()).data()
         == FORWARD_MODEL_STATE_START
@@ -122,7 +122,7 @@ def test_duration(mock_datetime, timezone, full_snapshot):
             start_time=start_time,
         ),
     )
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "0")
     assert (
         model.index(2, _id_to_col(DURATION), QModelIndex()).data() == "1 day, 1:12:11"
     )
@@ -139,15 +139,15 @@ def test_no_cross_talk(full_snapshot):
     reporting_mode = qt_api.QtTest.QAbstractItemModelTester.FailureReportingMode.Warning
     qt_api.QtTest.QAbstractItemModelTester(model, reporting_mode)  # noqa: F841
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "1")
 
     # Test that changes to iter=1 does not bleed into iter=0
     partial = PartialSnapshot(full_snapshot)
     partial.update_forward_model(
         "0", "0", forward_model=ForwardModel(status=FORWARD_MODEL_STATE_FAILURE)
     )
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "1")
     assert (
         model.index(0, _id_to_col(ids.STATUS), QModelIndex()).data()
         == FORWARD_MODEL_STATE_START

--- a/tests/unit_tests/gui/model/test_real_list.py
+++ b/tests/unit_tests/gui/model/test_real_list.py
@@ -22,12 +22,12 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
         model, reporting_mode
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "1")
 
     partial = partial_snapshot(full_snapshot)
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "0")
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "1")
 
     qtmodeltester.check(model, force_py=True)
 
@@ -43,20 +43,20 @@ def test_change_iter(full_snapshot):
         model, reporting_mode
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
 
     assert (
         model.index(0, 0, QModelIndex()).data(NodeRole).data.status
         == REALIZATION_STATE_RUNNING
     )
 
-    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
+    source_model._add_snapshot(SnapshotModel.prerender(full_snapshot), "1")
 
     model.setIter(1)
 
     partial = partial_snapshot(full_snapshot)
     partial._realization_states["0"].update({"status": REALIZATION_STATE_FINISHED})
-    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
+    source_model._add_partial_snapshot(SnapshotModel.prerender(partial), "1")
 
     assert (
         model.index(0, 0, QModelIndex()).data(NodeRole).data.status

--- a/tests/unit_tests/gui/model/test_snapshot.py
+++ b/tests/unit_tests/gui/model/test_snapshot.py
@@ -16,12 +16,12 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
         model, reporting_mode
     )
 
-    model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
-    model._add_snapshot(SnapshotModel.prerender(full_snapshot), 1)
+    model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
+    model._add_snapshot(SnapshotModel.prerender(full_snapshot), "1")
 
     partial = partial_snapshot(SnapshotModel.prerender(full_snapshot))
-    model._add_partial_snapshot(SnapshotModel.prerender(partial), 0)
-    model._add_partial_snapshot(SnapshotModel.prerender(partial), 1)
+    model._add_partial_snapshot(SnapshotModel.prerender(partial), "0")
+    model._add_partial_snapshot(SnapshotModel.prerender(partial), "1")
 
     qtmodeltester.check(model, force_py=True)
 
@@ -29,7 +29,7 @@ def test_using_qt_model_tester(qtmodeltester, full_snapshot):
 def test_realization_sort_order(full_snapshot):
     model = SnapshotModel()
 
-    model._add_snapshot(SnapshotModel.prerender(full_snapshot), 0)
+    model._add_snapshot(SnapshotModel.prerender(full_snapshot), "0")
 
     for i in range(0, 100):
         iter_index = model.index(i, 0, model.index(0, 0, QModelIndex()))
@@ -41,7 +41,7 @@ def test_realization_sort_order(full_snapshot):
 
 def test_realization_state_is_queue_finalized_state(fail_snapshot):
     model = SnapshotModel()
-    model._add_snapshot(SnapshotModel.prerender(fail_snapshot), 0)
+    model._add_snapshot(SnapshotModel.prerender(fail_snapshot), "0")
     first_real = model.index(0, 0, model.index(0, 0))
 
     queue_color = model.data(first_real, RealStatusColorHint)

--- a/tests/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/unit_tests/gui/simulation/view/test_realization.py
@@ -28,7 +28,7 @@ def test_delegate_drawing_count(small_snapshot, qtbot):
 
     with qtbot.waitActive(widget, timeout=30000):
         model = SnapshotModel()
-        model._add_snapshot(SnapshotModel.prerender(small_snapshot), it)
+        model._add_snapshot(SnapshotModel.prerender(small_snapshot), str(it))
 
         widget.setSnapshotModel(model)
 
@@ -55,7 +55,7 @@ def test_selection_success(large_snapshot, qtbot):
     qtbot.addWidget(widget)
 
     model = SnapshotModel()
-    model._add_snapshot(SnapshotModel.prerender(large_snapshot), it)
+    model._add_snapshot(SnapshotModel.prerender(large_snapshot), str(it))
 
     widget.setSnapshotModel(model)
 

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -77,10 +77,12 @@ def test_that_the_manual_analysis_tool_works(ensemble_experiment_has_run, qtbot)
 
     assert isinstance(manage_tool, ManageExperimentsTool)
     experiments_panel = manage_tool._manage_experiments_panel
+    assert experiments_panel
 
     # In the "create new case" tab, it should now contain "iter-1"
     experiments_panel.setCurrentIndex(0)
     current_tab = experiments_panel.currentWidget()
+    assert current_tab
     assert current_tab.objectName() == "create_new_ensemble_tab"
     storage_widget = get_child(current_tab, StorageWidget)
     tree_view = get_child(storage_widget, QTreeView)


### PR DESCRIPTION
snapshot index gets called very often. making a list of the dict and then indexing it is slow.

**Approach**
Add a list with all the children that is faster to index

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
