### PR TITLE
Simplify openpbs job states

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -20,7 +20,6 @@ from typing import (
     Type,
     Union,
     cast,
-    get_args,
     get_type_hints,
 )
 
@@ -30,7 +29,7 @@ from .event import Event, FinishedEvent, StartedEvent
 logger = logging.getLogger(__name__)
 
 _POLL_PERIOD = 2.0  # seconds
-JobState = Literal[
+JOB_STATES = [
     "B",  # Begun
     "E",  # Exiting with or without errors
     "F",  # Finished (completed, failed or deleted)
@@ -119,7 +118,7 @@ def parse_qstat(qstat_output: str) -> Dict[str, Dict[str, str]]:
             continue
         tokens = line.split(maxsplit=6)
         if len(tokens) >= 5 and tokens[0] and tokens[5]:
-            if tokens[4] not in get_args(JobState):
+            if tokens[4] not in JOB_STATES:
                 logger.error(
                     f"Unknown state {tokens[4]} obtained from "
                     f"PBS for jobid {tokens[0]}, ignored."

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -16,6 +16,7 @@ from tests.utils import poll
 
 from ert.scheduler import OpenPBSDriver
 from ert.scheduler.openpbs_driver import (
+    JOB_STATES,
     QDEL_JOB_HAS_FINISHED,
     QDEL_REQUEST_INVALID,
     QSUB_CONNECTION_REFUSED,
@@ -23,7 +24,6 @@ from ert.scheduler.openpbs_driver import (
     QSUB_PREMATURE_END_OF_MESSAGE,
     FinishedEvent,
     FinishedJob,
-    JobState,
     QueuedJob,
     RunningJob,
     StartedEvent,
@@ -32,7 +32,7 @@ from ert.scheduler.openpbs_driver import (
 )
 
 
-@given(st.lists(st.sampled_from(JobState.__args__)))
+@given(st.lists(st.sampled_from(JOB_STATES)))
 async def test_events_produced_from_jobstate_updates(jobstate_sequence: List[str]):
     # Determine what to expect from the sequence:
     started = False


### PR DESCRIPTION
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
