### PR TITLE
Rename EnsembleEvaluator._stop and remove async keyword

### DIFF
--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -78,7 +78,7 @@ async def evaluator_to_use_fixture(make_ee_config):
     run_task = asyncio.create_task(evaluator.run_and_get_successful_realizations())
     await evaluator._server_started.wait()
     yield evaluator
-    await evaluator._stop()
+    evaluator.stop()
     await run_task
 
 

--- a/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -23,7 +23,7 @@ def evaluator_to_use():
         try:
             yield evaluator
         finally:
-            await evaluator._stop()
+            evaluator.stop()
             await run_task
 
     return run_evaluator


### PR DESCRIPTION
**Issue**
This renames `EnsembleEvaluator._stop` to `EnsembleEvaluator.stop`. `stop()` is part of the pubic API. Additionally, it removes async keyword as the function does not need to be async now. The same goes for the `_signal_cancel`.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
