### PR TITLE
Add test of about dialog

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -113,6 +113,7 @@ class ErtMainWindow(QMainWindow):
         show_about = help_menu.addAction("About")
         assert show_about is not None
         show_about.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
+        show_about.setObjectName("about_action")
         show_about.triggered.connect(self.__showAboutMessage)
 
     def __saveSettings(self) -> None:


### PR DESCRIPTION
Added a small test of the about dialog


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release
