### PR TITLE
Make batching task finite by adding CLOSE_EVENT_SENTINEL

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -190,7 +190,7 @@ class LegacyEnsemble:
     async def evaluate(
         self,
         config: EvaluatorServerConfig,
-        scheduler_queue: Optional[asyncio.Queue[CloudEvent]] = None,
+        scheduler_queue: Optional[asyncio.Queue[Any]] = None,
         manifest_queue: Optional[asyncio.Queue[CloudEvent]] = None,
     ) -> None:
         self._config = config
@@ -220,7 +220,7 @@ class LegacyEnsemble:
         self,
         cloudevent_unary_send: Callable[[CloudEvent], Awaitable[None]],
         experiment_id: Optional[str] = None,
-        scheduler_queue: Optional[asyncio.Queue[CloudEvent]] = None,
+        scheduler_queue: Optional[asyncio.Queue[Any]] = None,
         manifest_queue: Optional[asyncio.Queue[CloudEvent]] = None,
     ) -> None:
         """

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -75,7 +75,7 @@ class Scheduler:
         driver: Driver,
         realizations: Optional[Sequence[Realization]] = None,
         manifest_queue: Optional[asyncio.Queue[CloudEvent]] = None,
-        ensemble_evaluator_queue: Optional[asyncio.Queue[CloudEvent]] = None,
+        ensemble_evaluator_queue: Optional[asyncio.Queue[Any]] = None,
         *,
         max_submit: int = 1,
         max_running: int = 1,

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -62,7 +62,9 @@ def queue_config_fixture():
 
 @pytest.fixture
 def make_ensemble(queue_config):
-    def _make_ensemble_builder(monkeypatch, tmpdir, num_reals, num_jobs, job_sleep=0):
+    def _make_ensemble_builder(
+        monkeypatch, tmpdir, num_reals, num_jobs, job_sleep=0, max_runtime=10
+    ):
         async def load_successful(_):
             return (LoadStatus.LOAD_SUCCESSFUL, "")
 
@@ -118,7 +120,7 @@ def make_ensemble(queue_config):
                         iens=iens,
                         forward_models=forward_model_list,
                         job_script="job_dispatch.py",
-                        max_runtime=10,
+                        max_runtime=max_runtime,
                         num_cpu=1,
                         run_arg=RunArg(
                             str(iens),


### PR DESCRIPTION
**Issue**
~~Resolves https://github.com/equinor/ert/issues/8359~~
Resolves #8070 


**Approach**
That error might be due to the last batch of events not being processed. Therefore adding SENTINEL object.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
