### PR TITLE
Fix test_search_bar running onprem and azure.

### DIFF
--- a/tests/unit_tests/gui/ertwidgets/test_search_bar.py
+++ b/tests/unit_tests/gui/ertwidgets/test_search_bar.py
@@ -1,6 +1,7 @@
 import pytest
+from pytestqt.qtbot import QtBot
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QApplication, QPlainTextEdit
+from qtpy.QtWidgets import QPlainTextEdit
 
 from ert.gui.tools.search_bar import SearchBar
 
@@ -26,8 +27,7 @@ from ert.gui.tools.search_bar import SearchBar
         pytest.param("Testing search functionality.", "", id="Empty selection"),
     ],
 )
-def test_search_bar(text, search):
-    _ = QApplication([])
+def test_search_bar(text, search, qtbot: QtBot):
     text_box = QPlainTextEdit()
     text_box.setPlainText(text)
     search_bar = SearchBar(text_box)


### PR DESCRIPTION
**Issue**
Bleeding tests on azure and onprem are failing for the test `test_search_bar`. 




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
