### PR TITLE
Fix flaky test test_memory_profile_in_running_events

### DIFF
--- a/tests/unit_tests/forward_model_runner/test_job.py
+++ b/tests/unit_tests/forward_model_runner/test_job.py
@@ -132,9 +132,9 @@ def test_memory_profile_in_running_events():
     ).all(), f"Emitted memory usage not increasing, got {emitted_rss_values[:-3]=}"
 
     assert (
-        np.diff(np.array(emitted_rss_values[3:])).max() < 3 * 1024 * 1024
+        np.diff(np.array(emitted_rss_values[7:])).max() < 3 * 1024 * 1024
         # Avoid the first steps, which includes the Python interpreters memory usage
-    ), f"Memory increased too sharply, missing a measurement? Got {emitted_rss_values[3:]=}"
+    ), f"Memory increased too sharply, missing a measurement? Got {emitted_rss_values[7:]=}"
 
     if sys.platform.startswith("darwin"):
         # No oom_score on MacOS


### PR DESCRIPTION
**Issue**
Resolves #8368 


**Approach**
This improves the observed flakiness by discarding more of the initial memory readings.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
