### PR TITLE
Remove start experiment prompt

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -192,7 +192,6 @@ class ExperimentPanel(QWidget):
             return
 
         QApplication.restoreOverrideCursor()
-        delete_runpath = False
         if model.check_if_runpath_exists():
             msg_box = QMessageBox(self)
             msg_box.setObjectName("RUN_PATH_WARNING_BOX")
@@ -227,30 +226,26 @@ class ExperimentPanel(QWidget):
             if msg_box_res == QMessageBox.No:
                 return
 
-            delete_runpath = (
-                delete_runpath_checkbox is not None
-                and delete_runpath_checkbox.checkState() == Qt.CheckState.Checked
-            )
-        if delete_runpath:
-            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-            try:
-                model.rm_run_path()
-            except OSError as e:
+            if delete_runpath_checkbox.checkState() == Qt.CheckState.Checked:
+                QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+                try:
+                    model.rm_run_path()
+                except OSError as e:
+                    QApplication.restoreOverrideCursor()
+                    msg_box = QMessageBox(self)
+                    msg_box.setObjectName("RUN_PATH_ERROR_BOX")
+                    msg_box.setIcon(QMessageBox.Warning)
+                    msg_box.setText("ERT could not delete the existing runpath")
+                    msg_box.setInformativeText(
+                        (f"{e}\n\n" "Continue without deleting the runpath?")
+                    )
+                    msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+                    msg_box.setDefaultButton(QMessageBox.No)
+                    msg_box.setWindowModality(Qt.WindowModality.ApplicationModal)
+                    msg_box_res = msg_box.exec()
+                    if msg_box_res == QMessageBox.No:
+                        return
                 QApplication.restoreOverrideCursor()
-                msg_box = QMessageBox(self)
-                msg_box.setObjectName("RUN_PATH_ERROR_BOX")
-                msg_box.setIcon(QMessageBox.Warning)
-                msg_box.setText("ERT could not delete the existing runpath")
-                msg_box.setInformativeText(
-                    (f"{e}\n\n" "Continue without deleting the runpath?")
-                )
-                msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
-                msg_box.setDefaultButton(QMessageBox.No)
-                msg_box.setWindowModality(Qt.WindowModality.ApplicationModal)
-                msg_box_res = msg_box.exec()
-                if msg_box_res == QMessageBox.No:
-                    return
-            QApplication.restoreOverrideCursor()
 
         dialog = RunDialog(
             self._config_file,

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -287,10 +287,6 @@ def run_experiment_fixture(request):
         run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
 
         def handle_dialog():
-            qtbot.mouseClick(
-                wait_for_child(gui, qtbot, QMessageBox).buttons()[0], Qt.LeftButton
-            )
-
             QTimer.singleShot(
                 500,
                 lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False),

--- a/tests/unit_tests/gui/test_restart_esmda.py
+++ b/tests/unit_tests/gui/test_restart_esmda.py
@@ -1,5 +1,5 @@
-from qtpy.QtCore import Qt, QTimer
-from qtpy.QtWidgets import QCheckBox, QComboBox, QDialogButtonBox, QMessageBox, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QCheckBox, QComboBox, QWidget
 
 from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.simulation.run_dialog import RunDialog
@@ -26,17 +26,8 @@ def test_restart_esmda(ensemble_experiment_has_run_no_failure, qtbot):
     restart_checkbox.click()
     assert restart_checkbox.isChecked()
 
-    def handle_dialog():
-        qtbot.waitUntil(lambda: gui.findChild(QMessageBox) is not None)
-        confirm_restart_dialog = gui.findChild(QMessageBox)
-        assert isinstance(confirm_restart_dialog, QMessageBox)
-        dialog_buttons = confirm_restart_dialog.findChild(QDialogButtonBox).buttons()
-        yes_button = [b for b in dialog_buttons if "Yes" in b.text()][0]
-        qtbot.mouseClick(yes_button, Qt.LeftButton)
-
     es_mda_panel._ensemble_selector.setCurrentText("iter-0")
     assert es_mda_panel._ensemble_selector.selected_ensemble.name == "iter-0"
-    QTimer.singleShot(500, handle_dialog)
     run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
     qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)


### PR DESCRIPTION
**Issue**
Resolves #6346

Not sure this extra dialog box is worth it, as we now validate the model, and we never overwrite ensembles (which was the case when this extra pop up was originally created). If we run in an existing run path, we still caution the user.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
