### PR TITLE
Deprecate slurm queue option MEMORY_PER_CPU

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -236,4 +236,10 @@ deprecated_keywords_list = [
         "the future. Replace by REALIZATION_MEMORY.",
         check=lambda line: "MEMORY" in line,
     ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="MEMORY_PER_CPU as QUEUE_OPTION to SLURM is deprecated and will be removed in "
+        "the future. Use REALIZATION_MEMORY instead.",
+        check=lambda line: "MEMORY_PER_CPU" in line,
+    ),
 ]


### PR DESCRIPTION
**Issue**
Resolves #8199 


**Approach**
Add slurm queue option MEMORY_PER_CPU to list in config_schema_deprecations.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
