### PR TITLE
Solve and enforce ruff-unused-variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,6 @@ ignore = ["PLW2901",  # redefined-loop-name
           "PLC2701",  # import-private-name
           "PLR6201",  # literal-membership
           "PLR0914",  # too-many-locals
-          "F841",  # unused-variable
           "PLR6301",  # no-self-use
           "PLW1641",  # eq-without-hash
           "PLR0904",  # too-many-public-methods

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -150,7 +150,7 @@ class PathChooser(QWidget):
 
     def contentsChanged(self) -> None:
         """Called whenever the path is changed."""
-        path_is_valid, message = self.isPathValid(self.getPath())
+        path_is_valid, _ = self.isPathValid(self.getPath())
 
         if not self._editing and path_is_valid:
             self._model.setPath(self.getPath())

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 import webbrowser
 from signal import SIG_DFL, SIGINT, signal
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+from typing import Optional, Tuple, cast
 
 if sys.version_info >= (3, 9):
     from importlib.resources import files
@@ -44,9 +44,6 @@ from ert.storage.local_storage import local_storage_set_ert_config
 from .suggestor import Suggestor
 from .summarypanel import SummaryPanel
 
-if TYPE_CHECKING:
-    from ert.config import ParameterConfig
-
 
 def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) -> int:
     # Replace Python's exception handler for SIGINT with the system default.
@@ -64,9 +61,7 @@ def run_gui(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
     app.setWindowIcon(QIcon("img:ert_icon.svg"))
 
     with add_gui_log_handler() as log_handler:
-        window, ens_path, ensemble_size, parameter_config = _start_initial_gui_window(
-            args, log_handler, plugin_manager
-        )
+        window, ens_path = _start_initial_gui_window(args, log_handler, plugin_manager)
 
         def show_window() -> int:
             window.show()
@@ -89,7 +84,7 @@ def _start_initial_gui_window(
     args: Namespace,
     log_handler: GUILogHandler,
     plugin_manager: Optional[ErtPluginManager] = None,
-) -> Tuple[QWidget, Optional[str], Optional[int], Optional[List[ParameterConfig]]]:
+) -> Tuple[QWidget, Optional[str]]:
     # Create logger inside function to make sure all handlers have been added to
     # the root-logger.
     logger = logging.getLogger(__name__)
@@ -136,8 +131,6 @@ def _start_initial_gui_window(
                         else {}
                     ),
                 ),
-                None,
-                None,
                 None,
             )
     config_warnings = [
@@ -191,15 +184,11 @@ def _start_initial_gui_window(
         return (
             suggestor,
             ert_config.ens_path,
-            ert_config.model_config.num_realizations,
-            ert_config.ensemble_config.parameter_configuration,
         )
     else:
         return (
             _main_window,
             ert_config.ens_path,
-            ert_config.model_config.num_realizations,
-            ert_config.ensemble_config.parameter_configuration,
         )
 
 

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -156,7 +156,7 @@ class PlotWidget(QWidget):
             )
             self._canvas.draw()
         except Exception as e:
-            exc_type, exc_value, exc_tb = sys.exc_info()
+            exc_type, _, exc_tb = sys.exc_info()
             sys.stderr.write("-" * 80 + "\n")
             traceback.print_tb(exc_tb)
             if exc_type is not None:

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -92,7 +92,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self._current_iteration_label = "Pre processing update..."
         self.run_workflows(HookRuntime.PRE_UPDATE, self._storage, prior_storage)
         try:
-            smoother_snapshot, self.sies_smoother = iterative_smoother_update(
+            _, self.sies_smoother = iterative_smoother_update(
                 prior_storage,
                 posterior_storage,
                 self.sies_smoother,

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -105,7 +105,7 @@ def _open_main_window(
 ) -> Generator[Tuple[ErtMainWindow, Storage, ErtConfig], None, None]:
     args_mock = Mock()
     args_mock.config = str(path)
-    with ErtPluginContext() as plugin_context:
+    with ErtPluginContext():
         config = ErtConfig.with_plugins().from_file(path)
         with open_storage(
             config.ens_path, mode="w"

--- a/tests/unit_tests/shared/test_port_handler.py
+++ b/tests/unit_tests/shared/test_port_handler.py
@@ -58,7 +58,7 @@ def test_find_available_port(unused_tcp_port):
 
 def test_find_available_port_forced(unused_tcp_port):
     custom_range = range(unused_tcp_port, unused_tcp_port)
-    host, port, sock = port_handler.find_available_port(
+    _, port, sock = port_handler.find_available_port(
         custom_range=custom_range, custom_host="127.0.0.1"
     )
     assert port == unused_tcp_port
@@ -134,7 +134,7 @@ def _simulate_server(host, port, sock: socket.socket):
             self.port = port
             sock.listen()
             ready_event.set()
-            conn, addr = sock.accept()
+            conn, _ = sock.accept()
             with contextlib.suppress(Exception):
                 self.data = conn.recv(1024).decode()
                 conn.sendall(b"Who's there?")
@@ -335,7 +335,7 @@ def test_reuse_active_live_nok_nok(unused_tcp_port):
         )
 
     with pytest.raises(port_handler.NoPortsInRangeException):
-        _, port, sock = port_handler.find_available_port(
+        _, port, _ = port_handler.find_available_port(
             custom_range=custom_range,
             custom_host="127.0.0.1",
             will_close_then_reopen_socket=True,
@@ -365,13 +365,13 @@ def test_def_active_live_nok_nok(unused_tcp_port):
 
     # Immediately trying to bind to the same port fails...
     with pytest.raises(port_handler.NoPortsInRangeException):
-        host, port, sock = port_handler.find_available_port(
+        host, port, _ = port_handler.find_available_port(
             custom_range=custom_range, custom_host="127.0.0.1"
         )
 
     # ... also using will_close_then_reopen_socket=True
     with pytest.raises(port_handler.NoPortsInRangeException):
-        host, port, sock = port_handler.find_available_port(
+        host, port, _ = port_handler.find_available_port(
             custom_range=custom_range,
             custom_host="127.0.0.1",
             will_close_then_reopen_socket=True,
@@ -453,14 +453,14 @@ def test_def_active_close_linux_nok_nok(unused_tcp_port):
 
     # Immediately trying to bind to the same port fails
     with pytest.raises(port_handler.NoPortsInRangeException):
-        host, port, sock = port_handler.find_available_port(
+        host, port, _ = port_handler.find_available_port(
             custom_range=custom_range, custom_host="127.0.0.1"
         )
 
     # On Linux, setting will_close_then_reopen_socket=True in subsequent calls do
     # NOT allow reusing the port in this case
     with pytest.raises(port_handler.NoPortsInRangeException):
-        host, port, sock = port_handler.find_available_port(
+        host, port, _ = port_handler.find_available_port(
             custom_range=custom_range,
             custom_host="127.0.0.1",
             will_close_then_reopen_socket=True,

--- a/tests/unit_tests/test_enkf_main.py
+++ b/tests/unit_tests/test_enkf_main.py
@@ -16,7 +16,6 @@ from ert.run_arg import create_run_arguments
     ],
 )
 def test_create_run_args(prior_ensemble, config_dict, run_paths):
-    iteration = 0
     ensemble_size = 10
     config = ErtConfig.from_dict(config_dict)
 
@@ -38,7 +37,6 @@ def test_create_run_args(prior_ensemble, config_dict, run_paths):
 
 
 def test_create_run_args_separate_base_and_name(prior_ensemble, run_paths):
-    iteration = 0
     ensemble_size = 10
     config = ErtConfig.from_dict({"JOBNAME": "name<IENS>", "ECLBASE": "base<IENS>"})
     run_args = create_run_arguments(


### PR DESCRIPTION
**Issue**
Resolves unused variables in the source.


**Approach**
Replace with `_` to indicate to code readers that something is not to be used.

For the gui function, change the return statement to not return unusused stuff. The function is internal to the file.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
