### PR TITLE
Add validation for num_realizations > 1 for analysis modules

### DIFF
--- a/docs/reference/configuration/keywords.rst
+++ b/docs/reference/configuration/keywords.rst
@@ -91,7 +91,8 @@ NUM_REALIZATIONS
 
 This is the size of the ensemble, i.e. the number of
 realizations/members in the ensemble. All configs must contain this
-keyword.
+keyword. Bear in mind that experiments that require update step must contain
+at least 2 realizations.
 
 *Example:*
 

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -246,9 +246,9 @@ def _setup_multiple_data_assimilation(
             weights=args.weights,
             restart_run=restart_run,
             prior_ensemble_id=prior_ensemble,
-            starting_iteration=storage.get_ensemble(prior_ensemble).iteration + 1
-            if restart_run
-            else 0,
+            starting_iteration=(
+                storage.get_ensemble(prior_ensemble).iteration + 1 if restart_run else 0
+            ),
             minimum_required_realizations=config.analysis_config.minimum_required_realizations,
             ensemble_size=config.model_config.num_realizations,
             experiment_name=args.experiment_name,


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8348

~~blocked by semeio tests~~ should be ok now

**Approach**
Inject validation where needed.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
