### PR TITLE
Remove get_event_loop, deprecated in py312

### DIFF
--- a/src/_ert/async_utils.py
+++ b/src/_ert/async_utils.py
@@ -18,14 +18,6 @@ def new_event_loop() -> asyncio.AbstractEventLoop:
     return loop
 
 
-def get_running_loop() -> asyncio.AbstractEventLoop:
-    try:
-        return asyncio.get_running_loop()
-    except RuntimeError:
-        asyncio.set_event_loop(new_event_loop())
-        return asyncio.get_event_loop()
-
-
 def _create_task(
     loop: asyncio.AbstractEventLoop,
     coro: Union[Coroutine[Any, Any, _T], Generator[Any, None, _T]],

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -28,7 +28,6 @@ from pydantic.dataclasses import dataclass
 from websockets import ConnectionClosed, Headers
 from websockets.client import connect
 
-from _ert.async_utils import get_running_loop
 from ert.constant_filenames import CERT_FILE
 from ert.event_type_constants import (
     EVTYPE_ENSEMBLE_CANCELLED,
@@ -102,7 +101,7 @@ class Scheduler:
             real.iens: Job(self, real) for real in (realizations or [])
         }
 
-        self._loop = get_running_loop()
+        self._loop = asyncio.get_running_loop()
         self._events: asyncio.Queue[Any] = asyncio.Queue()
 
         self._average_job_runtime: float = 0


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/3228


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
