### PR TITLE
Avoid asyncio.get_event_loop

### DIFF
--- a/src/_ert/async_utils.py
+++ b/src/_ert/async_utils.py
@@ -22,8 +22,9 @@ def get_running_loop() -> asyncio.AbstractEventLoop:
     try:
         return asyncio.get_running_loop()
     except RuntimeError:
-        asyncio.set_event_loop(new_event_loop())
-        return asyncio.get_event_loop()
+        loop = new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
 
 
 def _create_task(


### PR DESCRIPTION
This function change behaviour in the future (after Python 3.12), and in order to avoid a possible deprecation warning, we just return the loop we just created

**Issue**
Resolves #3228 

**Approach**
rewrite the code

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
