### PR TITLE
Make forward_model_ok an async function

### DIFF
--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import warnings
@@ -52,7 +53,7 @@ def _load_realization(
     realisation: int,
     run_args: List[RunArg],
 ) -> Tuple[LoadResult, int]:
-    result = forward_model_ok(run_args[realisation])
+    result = asyncio.run(forward_model_ok(run_args[realisation]))
     return result, realisation
 
 

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -242,7 +242,7 @@ class Job:
                 logger.error(f"Disk synchronization failed for {file_path}")
 
     async def _handle_finished_forward_model(self) -> None:
-        callback_status, status_msg = forward_model_ok(self.real.run_arg)
+        callback_status, status_msg = await forward_model_ok(self.real.run_arg)
         if self._callback_status_msg:
             self._callback_status_msg = status_msg
         else:

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -62,11 +62,10 @@ def queue_config_fixture():
 @pytest.fixture
 def make_ensemble(queue_config):
     def _make_ensemble_builder(monkeypatch, tmpdir, num_reals, num_jobs, job_sleep=0):
-        monkeypatch.setattr(
-            ert.scheduler.job,
-            "forward_model_ok",
-            lambda _: (LoadStatus.LOAD_SUCCESSFUL, ""),
-        )
+        async def load_successful(_):
+            return (LoadStatus.LOAD_SUCCESSFUL, "")
+
+        monkeypatch.setattr(ert.scheduler.job, "forward_model_ok", load_successful)
         with tmpdir.as_cwd():
             forward_model_list = []
             for job_index in range(0, num_jobs):


### PR DESCRIPTION
forward_model_ok() is in any case called in an async context, but it takes a long time to complete, too long to be sensible in an async context making the async loop non-responsive as long as it runs.

By making it async, and including some asyncio.sleep(0) we will effectively split up its sync part into smaller parts and make the async loop more responsive than before.

This commit only mitigates the problem, it does not solve it. A better solution would to run the IO-bound loading parts into async IO, and the CPU-bound tasks should be offloaded to different processes to avoid Pythons GIL.

**Issue**
Resolves #7275 


**Approach**
Adding asyncio.sleep(0)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
