### PR TITLE
Try to mitigate flakiness in driver test

### DIFF
--- a/tests/integration_tests/scheduler/test_generic_driver.py
+++ b/tests/integration_tests/scheduler/test_generic_driver.py
@@ -123,27 +123,26 @@ async def test_kill_gives_correct_state(driver: Driver, tmp_path, request):
 @pytest.mark.flaky(reruns=5)
 async def test_repeated_submit_same_iens(driver: Driver, tmp_path):
     """Submits are allowed to be repeated for the same iens, and are to be
-    handled according to FIFO, but this cannot be guaranteed as it depends
+    handled according to FIFO, but this order cannot be guaranteed as it depends
     on the host operating system."""
     os.chdir(tmp_path)
     await driver.submit(
         0,
         "sh",
         "-c",
-        f"echo started > {tmp_path}/submit1; echo submit1 > {tmp_path}/submissionrace",
+        f"echo submit1 > {tmp_path}/submissionrace; touch {tmp_path}/submit1",
         name="submit1",
     )
     await driver.submit(
         0,
         "sh",
         "-c",
-        f"echo started > {tmp_path}/submit2; echo submit2 > {tmp_path}/submissionrace",
+        f"echo submit2 > {tmp_path}/submissionrace; touch {tmp_path}/submit2",
         name="submit2",
     )
     # Wait until both submissions have done their thing:
     while not Path("submit1").exists() or not Path("submit2").exists():
         await asyncio.sleep(0.1)
-    await asyncio.sleep(0.1)
     assert Path("submissionrace").read_text(encoding="utf-8") == "submit2\n"
 
 


### PR DESCRIPTION
If the echo command takes more than 0.1 sec, this could yield flakiness, so change the logic to avoid that pitfall.

**Issue**
Could theoretically solve the flakiness in https://github.com/equinor/ert/actions/runs/10284734597/job/28461458673

**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
