### PR TITLE
`find_available_port` is available via `__init__` [Issue #8407]

### DIFF
--- a/src/ert/shared/__init__.py
+++ b/src/ert/shared/__init__.py
@@ -16,6 +16,6 @@ def ert_share_path() -> str:
     return str(Path(spec_origin).parent.parent / "resources")
 
 
-from .port_handler import get_machine_name
+from .port_handler import get_machine_name, find_available_port
 
-__all__ = ["ert_share_path", "get_machine_name", "__version__"]
+__all__ = ["ert_share_path", "get_machine_name", "find_available_port", "__version__"]


### PR DESCRIPTION
**Issue**
Resolves #8407


**Approach**
As discussed in the issue, exposing all externally used functions makes renaming the module moot.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)
