### PR TITLE
Use queue to exchange events between scheduler and evaluator

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -10,7 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from cloudevents.conversion import to_json
 from cloudevents.http import CloudEvent
 from lxml import etree
 
@@ -146,7 +145,7 @@ class Job:
                 break
 
             if self.returncode.result() == 0:
-                if self._scheduler.wait_for_checksum():
+                if self._scheduler._manifest_queue is not None:
                     await self._verify_checksum()
                 await self._handle_finished_forward_model()
                 break
@@ -173,7 +172,7 @@ class Job:
             }
         )
         assert self._scheduler._events is not None
-        await self._scheduler._events.put(to_json(timeout_event))
+        await self._scheduler._events.put(timeout_event)
         logger.error(
             f"Realization {self.iens} stopped due to MAX_RUNTIME={self.real.max_runtime} seconds"
         )
@@ -290,7 +289,7 @@ class Job:
             },
             event_data,
         )
-        await self._scheduler._events.put(to_json(event))
+        await self._scheduler._events.put(event)
 
 
 def log_info_from_exit_file(exit_file_path: Path) -> None:

--- a/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -70,7 +70,7 @@ class TestEnsemble(Ensemble):
         ]
         super().__init__(the_reals, {}, QueueConfig(), 0, id_)
 
-    async def evaluate(self, config):
+    async def evaluate(self, config, _, __):
         event_id = 0
         await wait_for_evaluator(
             base_url=config.url,

--- a/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -1,78 +1,35 @@
-from http import HTTPStatus
-
 import pytest
-from cloudevents.http import from_json
-from websockets.server import serve
 
-from _ert.async_utils import get_running_loop
-from ert.ensemble_evaluator._wait_for_evaluator import wait_for_evaluator
 from ert.scheduler import Scheduler, create_driver
-
-
-async def mock_ws(host, port, done):
-    events = []
-
-    async def process_request(path, request_headers):
-        if path == "/healthcheck":
-            return HTTPStatus.OK, {}, b""
-
-    async def _handler(websocket, path):
-        while True:
-            event = await websocket.recv()
-            events.append(event)
-            cloud_event = from_json(event)
-            if cloud_event["type"] == "com.equinor.ert.realization.success":
-                break
-
-    async with serve(_handler, host, port, process_request=process_request):
-        await done
-    return events
 
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
 async def test_happy_path(
     tmpdir,
-    unused_tcp_port,
     make_ensemble,
     queue_config,
     monkeypatch,
 ):
-    host = "localhost"
-    url = f"ws://{host}:{unused_tcp_port}"
-
-    done = get_running_loop().create_future()
-    mock_ws_task = get_running_loop().create_task(mock_ws(host, unused_tcp_port, done))
-    await wait_for_evaluator(base_url=url, timeout=5)
-
     ensemble = make_ensemble(monkeypatch, tmpdir, 1, 1)
 
     queue = Scheduler(
-        create_driver(queue_config), ensemble.reals, ee_uri=url, ens_id="ee_0"
+        driver=create_driver(queue_config),
+        realizations=ensemble.reals,
+        ens_id="ee_0",
     )
 
     await queue.execute()
 
-    done.set_result(None)
-
-    await mock_ws_task
-
-    mock_ws_task.result()
-
-    assert mock_ws_task.done()
-
-    first_expected_queue_event_type = "WAITING"
-
-    for received_event, expected_type, expected_queue_event_type in zip(
-        [mock_ws_task.result()[0], mock_ws_task.result()[-1]],
-        ["waiting", "success"],
-        [first_expected_queue_event_type, "COMPLETED"],
-    ):
-        assert from_json(received_event)["source"] == "/ert/ensemble/ee_0/real/0"
+    type_states = ["waiting", "waiting", "pending", "running", "success"]
+    event_states = ["WAITING", "SUBMITTING", "PENDING", "RUNNING", "COMPLETED"]
+    id_state = 0
+    while not queue._events.empty():
+        received_event = await queue._events.get()
+        assert received_event["source"] == "/ert/ensemble/ee_0/real/0"
         assert (
-            from_json(received_event)["type"]
-            == f"com.equinor.ert.realization.{expected_type}"
+            received_event["type"]
+            == f"com.equinor.ert.realization.{type_states[id_state]}"
         )
-        assert from_json(received_event).data == {
-            "queue_event_type": expected_queue_event_type
-        }
+        assert received_event.data == {"queue_event_type": event_states[id_state]}
+        id_state += 1

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from typing import List
 
 import pytest
-import websockets
-from cloudevents.http import from_json
 
 from ert.config import QueueConfig
 from ert.constant_filenames import CERT_FILE
@@ -21,7 +19,7 @@ from ert.event_type_constants import (
 from ert.load_status import LoadResult, LoadStatus
 from ert.run_arg import RunArg
 from ert.scheduler import LsfDriver, OpenPBSDriver, create_driver, job, scheduler
-from ert.scheduler.job import JobState
+from ert.scheduler.job import EVTYPE_REALIZATION_TIMEOUT, JobState
 
 
 def create_jobs_json(realization: Realization) -> None:
@@ -224,7 +222,7 @@ async def test_max_runtime(realization, mock_driver, caplog):
     timeouteventfound = False
     while not timeouteventfound and not sch._events.empty():
         event = await sch._events.get()
-        if from_json(event)["type"] == "com.equinor.ert.realization.timeout":
+        if event["type"] == EVTYPE_REALIZATION_TIMEOUT:
             timeouteventfound = True
     assert timeouteventfound
 
@@ -324,7 +322,7 @@ async def test_max_runtime_while_killing(realization, mock_driver):
     timeouteventfound = False
     while not timeouteventfound and not sch._events.empty():
         event = await sch._events.get()
-        if from_json(event)["type"] == "com.equinor.ert.realization.timeout":
+        if event["type"] == EVTYPE_REALIZATION_TIMEOUT:
             timeouteventfound = True
 
     # Assert that a timeout_event is actually emitted, because killing took a
@@ -374,7 +372,7 @@ async def test_that_job_does_not_retry_when_killed_by_scheduler(
     while not sch._events.empty():
         event = await sch._events.get()
     assert event is not None
-    assert from_json(event)["type"] == "com.equinor.ert.realization.failure"
+    assert event["type"] == "com.equinor.ert.realization.failure"
 
 
 async def test_is_active(mock_driver, realization):
@@ -475,7 +473,9 @@ async def test_that_long_running_jobs_were_stopped(storage, tmp_path, mock_drive
     ]
 
     sch = scheduler.Scheduler(
-        mock_driver(wait=wait, kill=kill), realizations, max_running=ensemble_size
+        mock_driver(wait=wait, kill=kill),
+        realizations,
+        max_running=ensemble_size,
     )
 
     assert await sch.execute(min_required_realizations=5) == EVTYPE_ENSEMBLE_SUCCEEDED
@@ -513,7 +513,10 @@ async def test_submit_sleep(
     ]
 
     sch = scheduler.Scheduler(
-        mock_driver(wait=wait), realizations, submit_sleep=submit_sleep, max_running=0
+        mock_driver(wait=wait),
+        realizations,
+        submit_sleep=submit_sleep,
+        max_running=0,
     )
     await sch.execute()
 
@@ -574,71 +577,6 @@ async def test_submit_sleep_with_max_running(
 
 async def mock_failure(message, *args, **kwargs):
     raise RuntimeError(message)
-
-
-async def _mock_ws(set_when_done: asyncio.Event, handler, port: int):
-    async with websockets.server.serve(handler, "127.0.0.1", port):
-        await set_when_done.wait()
-
-
-async def test_scheduler_publishes_to_websocket(
-    mock_driver, realization, unused_tcp_port
-):
-    set_when_done = asyncio.Event()
-
-    events_received: List[str] = []
-
-    async def mock_ws_event_handler(websocket):
-        nonlocal events_received
-        async for message in websocket:
-            events_received.append(message)
-        await websocket.close()
-
-    websocket_server_task = asyncio.create_task(
-        _mock_ws(set_when_done, mock_ws_event_handler, unused_tcp_port)
-    )
-
-    driver = mock_driver()
-    sch = scheduler.Scheduler(
-        driver, [realization], ee_uri=f"ws://127.0.0.1:{unused_tcp_port}"
-    )
-    await sch.execute()
-
-    # publisher_done is set only if CLOSE_PUBLISHER_SENTINEL was received
-    assert sch._publisher_done.is_set()
-
-    set_when_done.set()
-    await websocket_server_task
-    assert [
-        json.loads(event)["data"]["queue_event_type"] for event in events_received
-    ] == ["WAITING", "SUBMITTING", "PENDING", "RUNNING", "COMPLETED"]
-
-    assert (
-        sch._events.empty()
-    ), "Schedulers internal event queue must be empty before finish"
-
-
-async def test_scheduler_finish_when_evaluator_quits_prematurely(
-    mock_driver, realization, unused_tcp_port, caplog
-):
-    set_when_done = asyncio.Event()
-
-    websocket_server_task = asyncio.create_task(
-        _mock_ws(set_when_done, None, unused_tcp_port)
-    )
-
-    driver = mock_driver()
-    sch = scheduler.Scheduler(
-        driver, [realization], ee_uri=f"ws://127.0.0.1:{unused_tcp_port}"
-    )
-    scheduler._queue_timeout = 0.1
-    set_when_done.set()
-    await sch.execute()
-
-    await websocket_server_task
-
-    assert sch._events.qsize() == 6  # we expect 5 events + the sentinel object
-    assert "6 items left unprocessed in the queue!" in caplog.text
 
 
 @pytest.mark.timeout(5)
@@ -777,4 +715,4 @@ async def test_callback_status_message_present_in_event_on_load_failure(
     while not sch._events.empty():
         event = await sch._events.get()
 
-    assert expected_error in from_json(event).data["callback_status_message"]
+    assert expected_error in event.data["callback_status_message"]


### PR DESCRIPTION
**Issue**
~~Resolves https://github.com/equinor/ert/issues/7721~~
Resolves https://github.com/equinor/ert/issues/8485


**Approach**
This PR removes websockets based communication between scheduler and ensemble evaluator. It is replaced by two message queues, which are provided in `LegacyEnsemble.evaluate` function by the ensemble evaluator and passed over to scheduler:

 - `scheduler_queue`: responsible for providing `CloudEvent` (representing realization and driver events) for evaluator
 - `manifest_queue`: responsible for providing `CloudEvent` (representing notification manifest checksum Event) for scheduler


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
