### PR TITLE
Use a plain dict for queue system options

### DIFF
--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -39,7 +39,7 @@ def test_project_code_is_set_when_forward_model_contains_selected_simulator(
             ConfigKeys.QUEUE_SYSTEM: queue_system,
         }
     )
-    project_code = queue_config.queue_options_as_dict.get("PROJECT_CODE")
+    project_code = queue_config.selected_queue_options.get("PROJECT_CODE")
 
     assert project_code is not None
     assert "flow" in project_code and "rms" in project_code
@@ -56,7 +56,7 @@ def test_project_code_is_not_overwritten_if_set_in_config(queue_system):
             ],
         }
     )
-    project_code = queue_config.queue_options_as_dict.get("PROJECT_CODE")
+    project_code = queue_config.selected_queue_options.get("PROJECT_CODE")
 
     assert project_code == "test_code"
 
@@ -274,8 +274,12 @@ def test_initializing_empty_config_queue_options_resets_to_default_value(
         f.write(f"QUEUE_OPTION {queue_system} {queue_system_option}\n")
         f.write(f"QUEUE_OPTION {queue_system} MAX_RUNNING\n")
     config_object = ErtConfig.from_file(filename)
-    for options in config_object.queue_config.queue_options[queue_system]:
-        assert isinstance(options, tuple)
+
+    if queue_system == "LSF":
+        assert config_object.queue_config.selected_queue_options["LSF_QUEUE"] == ""  # noqa
+    if queue_system == "SLURM":
+        assert config_object.queue_config.selected_queue_options["SQUEUE"] == ""  # noqa
+    assert config_object.queue_config.selected_queue_options["MAX_RUNNING"] == ""  # noqa
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/unit_tests/ensemble_evaluator/conftest.py
@@ -55,7 +55,7 @@ def queue_config_fixture():
         job_script="job_dispatch.py",
         max_submit=1,
         queue_system=QueueSystem.LOCAL,
-        queue_options={QueueSystem.LOCAL: [("MAX_RUNNING", "50")]},
+        queue_options={QueueSystem.LOCAL: {"MAX_RUNNING": "50"}},
     )
 
 

--- a/tests/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/unit_tests/scheduler/test_lsf_driver.py
@@ -188,8 +188,7 @@ async def test_submit_with_project_code():
     queue_config = QueueConfig.from_dict(queue_config_dict)
     driver: LsfDriver = create_driver(queue_config)
     await driver.submit(0, "sleep")
-    queue_option_dict = queue_config.queue_options_as_dict
-    project_code = queue_option_dict["PROJECT_CODE"]
+    project_code = queue_config.selected_queue_options["PROJECT_CODE"]
     assert f"-P {project_code}" in Path("captured_bsub_args").read_text(
         encoding="utf-8"
     )

--- a/tests/unit_tests/scheduler/test_scheduler.py
+++ b/tests/unit_tests/scheduler/test_scheduler.py
@@ -700,7 +700,6 @@ def test_scheduler_create_lsf_driver():
         ],
     }
     queue_config = QueueConfig.from_dict(queue_config_dict)
-    queue_options = queue_config.queue_options_as_dict
     driver: LsfDriver = create_driver(queue_config)
     assert str(driver._bsub_cmd) == bsub_cmd
     assert str(driver._bkill_cmd) == bkill_cmd
@@ -709,7 +708,7 @@ def test_scheduler_create_lsf_driver():
     assert driver._queue_name == queue_name
     assert driver._resource_requirement == lsf_resource
     assert driver._exclude_hosts == ["host1", "host2"]
-    assert driver._project_code == queue_options["PROJECT_CODE"]
+    assert driver._project_code == queue_config.selected_queue_options["PROJECT_CODE"]
 
 
 def test_scheduler_create_openpbs_driver():
@@ -730,8 +729,8 @@ def test_scheduler_create_openpbs_driver():
             ("TORQUE", "QUEUE", queue_name),
             ("TORQUE", "KEEP_QSUB_OUTPUT", keep_qsub_output),
             ("TORQUE", "MEMORY_PER_JOB", memory_per_job),
-            ("TORQUE", "NUM_NODES", num_nodes),
-            ("TORQUE", "NUM_CPUS_PER_NODE", num_cpus_per_node),
+            ("TORQUE", "NUM_NODES", str(num_nodes)),
+            ("TORQUE", "NUM_CPUS_PER_NODE", str(num_cpus_per_node)),
             ("TORQUE", "CLUSTER_LABEL", cluster_label),
             ("TORQUE", "JOB_PREFIX", job_prefix),
             ("TORQUE", "QSUB_CMD", qsub_cmd),
@@ -740,7 +739,6 @@ def test_scheduler_create_openpbs_driver():
         ],
     }
     queue_config = QueueConfig.from_dict(queue_config_dict)
-    queue_option_dict = queue_config.queue_options_as_dict
     driver: OpenPBSDriver = create_driver(queue_config)
     assert driver._queue_name == queue_name
     assert driver._keep_qsub_output == True if keep_qsub_output == "True" else False
@@ -752,4 +750,4 @@ def test_scheduler_create_openpbs_driver():
     assert str(driver._qsub_cmd) == qsub_cmd
     assert str(driver._qstat_cmd) == qstat_cmd
     assert str(driver._qdel_cmd) == qdel_cmd
-    assert driver._project_code == queue_option_dict["PROJECT_CODE"]
+    assert driver._project_code == queue_config.selected_queue_options["PROJECT_CODE"]


### PR DESCRIPTION
This was previously a list of 2-tuples of strings, owing to compatibility with the C drivers which are now purged

**Issue**
Resolves partially #6712 


**Approach**
Switch list of 2-tuples of str with a dict.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
