### PR TITLE
Fix source folder for performance_utils.py

### DIFF
--- a/tests/performance_tests/performance_utils.py
+++ b/tests/performance_tests/performance_utils.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 
 import numpy
 import py
@@ -14,6 +15,14 @@ from resdata.summary import Summary
 
 from ert.dark_storage import enkf
 from ert.dark_storage.app import app
+
+
+def source_dir() -> Path:
+    current_path = Path(__file__)
+    source = current_path.parent.parent
+    if not (source / "test-data" / "poly_template").exists():
+        raise RuntimeError("Cannot find the source folder")
+    return source
 
 
 def write_summary_spec(file, keywords):
@@ -150,9 +159,12 @@ if __name__ == "__main__":
             folder.remove()
     else:
         folder = py.path.local(tempfile.mkdtemp())
+
+    source_dir = source_dir()
+
     make_poly_example(
-        folder,
-        "test-data/poly_template",
+        folder=folder,
+        source=source_dir / "test-data/poly_template",
         gen_data_count=3400,
         gen_data_entries=150,
         summary_data_entries=100,


### PR DESCRIPTION
**Issue**

Running  `python performance_utils.py` does not work when running from the folder `tests/performance_tests`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
