### PR TITLE
Run snake oil field storage in same xdist group

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,7 @@ def fixture_copy_snake_oil_case_storage(_shared_snake_oil_case, tmp_path, monkey
 @pytest.fixture(
     name="copy_snake_oil_field_storage",
 )
+@pytest.mark.xdist_group(name="snake_oil_case_field_storage")
 def fixture_copy_snake_oil_field_storage(
     _shared_snake_oil_field, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
**Issue**
Resolves #8427


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
