### PR TITLE
Add splitter to rundialog to facilitate UI adjustments

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (
     QPlainTextEdit,
     QProgressBar,
     QPushButton,
+    QSplitter,
     QTableView,
     QTabWidget,
     QVBoxLayout,
@@ -190,6 +191,7 @@ class RunDialog(QDialog):
 
         self._isDetailedDialog = True
         self._minimum_width = 1200
+        self._minimum_height = 800
 
         self._ticker = QTimer(self)
         self._ticker.timeout.connect(self._on_ticker)
@@ -209,7 +211,7 @@ class RunDialog(QDialog):
         self._progress_widget = ProgressWidget()
 
         self._tab_widget = QTabWidget(self)
-        self._tab_widget.setMinimumHeight(200)
+        self._tab_widget.setMinimumHeight(250)
         self._tab_widget.currentChanged.connect(self._current_tab_changed)
         self._snapshot_model.rowsInserted.connect(self.on_snapshot_new_iteration)
 
@@ -263,9 +265,14 @@ class RunDialog(QDialog):
         layout.addWidget(self._total_progress_bar)
         layout.addWidget(self._iteration_progress_label)
         layout.addWidget(self._progress_widget)
-        layout.addWidget(self._tab_widget)
         layout.addWidget(self._job_label)
-        layout.addWidget(self._job_overview)
+
+        adjustable_splitter_layout = QSplitter()
+        adjustable_splitter_layout.setOrientation(Qt.Orientation.Vertical)
+        adjustable_splitter_layout.addWidget(self._tab_widget)
+        adjustable_splitter_layout.addWidget(self._job_overview)
+
+        layout.addWidget(adjustable_splitter_layout)
         layout.addWidget(button_widget_container)
 
         self.setLayout(layout)
@@ -276,7 +283,7 @@ class RunDialog(QDialog):
         self.show_details_button.clicked.connect(self.toggle_detailed_progress)
         self.simulation_done.connect(self._on_simulation_done)
 
-        self.setMinimumWidth(self._minimum_width)
+        self.setMinimumSize(self._minimum_width, self._minimum_height)
         self._setDetailedDialog()
         self.finished.connect(self._on_finished)
 


### PR DESCRIPTION
Resolves #8400

Rundialog realization circles and job info table can now be vertically adjusted using the divider between them.
There will be a visual indicator (mouse hand) that hints that the divider is draggable/adjustable.

![Screenshot 2024-08-14 at 16 07 41](https://github.com/user-attachments/assets/01651cba-39a4-4e32-8d46-b0873b625f57)

![Screenshot 2024-08-14 at 16 07 47](https://github.com/user-attachments/assets/9eb7fc18-9518-47e0-90e2-065798672a5b)

![Screenshot 2024-08-14 at 16 07 57](https://github.com/user-attachments/assets/5785f091-b662-4e2a-8cc8-5da2d2b602eb)



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
