### PR TITLE
Remove current iteration and current label from run models

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -340,7 +340,6 @@ class RunDialog(QDialog):
             a0.ignore()
 
     def run_experiment(self, restart: bool = False) -> None:
-        self._run_model.reset()
         self._snapshot_model.reset()
         self._tab_widget.clear()
 

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -156,7 +156,6 @@ class BaseRunModel:
         and contains logic for interacting with the Ensemble Evaluator by running
         the forward model and passing events back through the supplied queue.
         """
-        self.current_iteration: int = 0
         self._total_iterations = total_iterations
         self._current_iteration_label: str = "Starting..."
 
@@ -248,9 +247,6 @@ class BaseRunModel:
 
     def cancel(self) -> None:
         self._end_queue.put("END")
-
-    def reset(self) -> None:
-        self.current_iteration = 0
 
     def has_failed_realizations(self) -> bool:
         return any(self._create_mask_from_failed_realizations())
@@ -403,7 +399,7 @@ class BaseRunModel:
             self.send_event(
                 FullSnapshotEvent(
                     iteration_label=self._current_iteration_label,
-                    current_iteration=self.current_iteration,
+                    current_iteration=iteration,
                     total_iterations=self._total_iterations,
                     progress=current_progress,
                     realization_count=realization_count,
@@ -427,7 +423,7 @@ class BaseRunModel:
             self.send_event(
                 SnapshotUpdateEvent(
                     iteration_label=self._current_iteration_label,
-                    current_iteration=self.current_iteration,
+                    current_iteration=iteration,
                     total_iterations=self._total_iterations,
                     progress=current_progress,
                     realization_count=realization_count,
@@ -613,7 +609,6 @@ class BaseRunModel:
         evaluator_server_config: EvaluatorServerConfig,
     ) -> int:
         iteration = ensemble.iteration
-        self.current_iteration = iteration
         self._current_iteration_label = f"Running simulation for iteration: {iteration}"
         create_run_path(
             run_args,

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -95,8 +95,6 @@ class EnsembleExperiment(BaseRunModel):
             evaluator_server_config,
         )
 
-        self.current_iteration = 1
-
     @classmethod
     def run_message(cls) -> str:
         return "Running ensemble experiment..."

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -56,7 +56,6 @@ class EnsembleExperiment(BaseRunModel):
         evaluator_server_config: EvaluatorServerConfig,
         restart: bool = False,
     ) -> None:
-        self._current_iteration_label = self.run_message()
         if not restart:
             self.experiment = self._storage.create_experiment(
                 name=self.experiment_name,
@@ -94,10 +93,6 @@ class EnsembleExperiment(BaseRunModel):
             self.ensemble,
             evaluator_server_config,
         )
-
-    @classmethod
-    def run_message(cls) -> str:
-        return "Running ensemble experiment..."
 
     @classmethod
     def name(cls) -> str:

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -108,8 +108,6 @@ class EnsembleSmoother(UpdateRunModel):
             evaluator_server_config,
         )
 
-        self.current_iteration = 2
-
     @classmethod
     def name(cls) -> str:
         return "Ensemble smoother"

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -59,9 +59,7 @@ class EnsembleSmoother(UpdateRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
-        log_msg = "Running ES"
-        logger.info(log_msg)
-        self._current_iteration_label = log_msg
+        logger.info("Running ES")
         ensemble_format = self.target_ensemble_format
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -57,8 +57,6 @@ class EvaluateEnsemble(BaseRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
-        self._current_iteration_label = "Running evaluate experiment..."
-
         ensemble_id = self.ensemble_id
         ensemble_uuid = UUID(ensemble_id)
         ensemble = self._storage.get_ensemble(ensemble_uuid)

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -81,8 +81,6 @@ class EvaluateEnsemble(BaseRunModel):
             evaluator_server_config,
         )
 
-        self.current_iteration = ensemble.iteration + 1
-
     @classmethod
     def name(cls) -> str:
         return "Evaluate ensemble"

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -93,7 +93,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
         iteration: int,
         initial_mask: npt.NDArray[np.bool_],
     ) -> None:
-        self._current_iteration_label = "Pre processing update..."
         self.run_workflows(HookRuntime.PRE_UPDATE, self._storage, prior_storage)
         try:
             _, self.sies_smoother = iterative_smoother_update(
@@ -115,8 +114,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
             raise ErtRunError(
                 f"Update algorithm failed with the following error: {e}"
             ) from e
-
-        self._current_iteration_label = "Post processing update..."
         self.run_workflows(HookRuntime.POST_UPDATE, self._storage, posterior_storage)
 
     def run_experiment(
@@ -127,7 +124,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
             f'iteration{"s" if (self._total_iterations != 1) else ""}.'
         )
         logger.info(log_msg)
-        self._current_iteration_label = log_msg
 
         target_ensemble_format = self.target_ensemble_format
         experiment = self._storage.create_experiment(

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -57,9 +57,7 @@ class ManualUpdate(UpdateRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
-        log_msg = "Running manual update"
-        logger.info(log_msg)
-        self._current_iteration_label = log_msg
+        logger.info("Running manual update")
         ensemble_format = self.target_ensemble_format
         try:
             ensemble_id = UUID(self.prior_ensemble_id)

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -77,9 +77,7 @@ class MultipleDataAssimilation(UpdateRunModel):
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
-        log_msg = f"Running ES-MDA with normalized weights {self.weights}"
-        logger.info(log_msg)
-        self._current_iteration_label = log_msg
+        logger.info(f"Running ES-MDA with normalized weights {self.weights}")
 
         if self.restart_run:
             id = self.prior_ensemble_id

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from typing_extensions import override
-
 from ert.config import ErtConfig
 from ert.run_models import EnsembleExperiment
 
@@ -44,11 +42,6 @@ class SingleTestRun(EnsembleExperiment):
             status_queue=status_queue,
             random_seed=random_seed,
         )
-
-    @override
-    @classmethod
-    def run_message(cls) -> str:
-        return "Running single realisation test ..."
 
     @classmethod
     def name(cls) -> str:


### PR DESCRIPTION
This sentralizes the iteration number, meaning that we dont have to keep the (correct) state individually in all the run models.

Run label was not being used, it was only pased on when events were being sent, so set it explicitly there instead.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
