### PR TITLE
Change look&feel of simulation mode combobox

### DIFF
--- a/src/ert/gui/ertwidgets/combobox_with_description.py
+++ b/src/ert/gui/ertwidgets/combobox_with_description.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional, Tuple
 
 from qtpy.QtCore import QModelIndex, QPoint, QSize
-from qtpy.QtGui import QRegion
+from qtpy.QtGui import QColor, QRegion
 from qtpy.QtWidgets import (
     QComboBox,
     QLabel,
@@ -14,6 +14,9 @@ from qtpy.QtWidgets import (
 
 LABEL_ROLE = -3994
 DESCRIPTION_ROLE = -4893
+
+COLOR_HIGHLIGHT_LIGHT = QColor(230, 230, 230, 255)
+COLOR_HIGHLIGHT_DARK = QColor(60, 60, 60, 255)
 
 
 class ComboBoxItemWidget(QWidget):
@@ -29,7 +32,7 @@ class ComboBoxItemWidget(QWidget):
             """
             padding-top:5px;
             padding-left: 5px;
-            background: rgba(0,0,0,0.03);
+            background: rgba(0,0,0,0);
             font-weight: bold;
             font-size: 13px;
         """
@@ -38,9 +41,8 @@ class ComboBoxItemWidget(QWidget):
         self.description.setStyleSheet(
             """
             padding-bottom: 10px;
-            border-bottom: 1px dashed rgba(255,255,255,0.5);
             padding-left: 10px;
-            background: rgba(0,0,0,0.03);
+            background: rgba(0,0,0,0);
             font-style: italic;
             font-size: 12px;
         """
@@ -62,7 +64,10 @@ class ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
             option.state & QStyle.State_Selected  # type: ignore
             or option.state & QStyle.State_MouseOver  # type: ignore
         ):
-            painter.fillRect(option.rect, option.palette.highlight())
+            color = COLOR_HIGHLIGHT_LIGHT
+            if option.palette.text().color().value() > 150:
+                color = COLOR_HIGHLIGHT_DARK
+            painter.fillRect(option.rect, color)
 
         widget = ComboBoxItemWidget(label, description)
         widget.setStyle(option.widget.style())


### PR DESCRIPTION
Checked on RGS, looks as intended there too. ✅ 

Was:
<img width="424" alt="Screenshot 2024-08-14 at 14 01 37" src="https://github.com/user-attachments/assets/fe67537a-307c-43e9-bad4-618d06651fd2">

Change:



<img width="424" alt="Screenshot 2024-08-14 at 13 55 19" src="https://github.com/user-attachments/assets/19d57d2f-b2f4-4e48-af92-b4e1d023b5af">
<img width="424" alt="Screenshot 2024-08-14 at 13 55 09" src="https://github.com/user-attachments/assets/6b1367bc-7f59-48e4-8a3b-1394fa5216c5">



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
