### PR TITLE
Replace simulation thread with simulation task in BatchContext

### DIFF
--- a/src/ert/simulator/batch_simulator_context.py
+++ b/src/ert/simulator/batch_simulator_context.py
@@ -156,7 +156,7 @@ class BatchContext:
 
         self._loop.run_until_complete(self.run_forward_model())
 
-    async def run_forward_model(self):
+    async def run_forward_model(self) -> None:
         self._sim_task = self._loop.create_task(
             _submit_and_run_jobqueue(self.ert_config, self._scheduler, self.run_args)
         )

--- a/src/ert/simulator/batch_simulator_context.py
+++ b/src/ert/simulator/batch_simulator_context.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from _ert.threading import ErtThread
+from _ert.async_utils import get_running_loop
 from ert.config import HookRuntime
 from ert.enkf_main import create_run_path
 from ert.ensemble_evaluator import Realization
@@ -70,15 +70,6 @@ def _slug(entity: str) -> str:
     return "".join([x if x.isalnum() else "_" for x in entity.strip()])
 
 
-def _run_forward_model(
-    ert_config: "ErtConfig",
-    scheduler: Scheduler,
-    run_args: List[RunArg],
-) -> None:
-    # run simplestep
-    asyncio.run(_submit_and_run_jobqueue(ert_config, scheduler, run_args))
-
-
 async def _submit_and_run_jobqueue(
     ert_config: "ErtConfig",
     scheduler: Scheduler,
@@ -123,6 +114,7 @@ class BatchContext:
         Handle which can be used to query status and results for batch simulation.
         """
         ert_config = self.ert_config
+        self._loop = get_running_loop()
         driver = create_driver(ert_config.queue_config)
         self._scheduler = Scheduler(
             driver, max_running=self.ert_config.queue_config.max_running
@@ -160,7 +152,10 @@ class BatchContext:
         )
         for workflow in ert_config.hooked_workflows[HookRuntime.PRE_SIMULATION]:
             WorkflowRunner(workflow, None, self.ensemble).run_blocking()
-        self._sim_thread = self._run_simulations_simple_step()
+
+        self._sim_task = self._loop.create_task(
+            _submit_and_run_jobqueue(self.ert_config, self._scheduler, self.run_args)
+        )
 
         # Wait until the queue is active before we finish the creation
         # to ensure sane job status while running
@@ -173,15 +168,6 @@ class BatchContext:
     def get_ensemble(self) -> Ensemble:
         return self.ensemble
 
-    def _run_simulations_simple_step(self) -> Thread:
-        sim_thread = ErtThread(
-            target=lambda: _run_forward_model(
-                self.ert_config, self._scheduler, self.run_args
-            )
-        )
-        sim_thread.start()
-        return sim_thread
-
     def join(self) -> None:
         """
         Will block until the simulation is complete.
@@ -190,7 +176,7 @@ class BatchContext:
             time.sleep(1)
 
     def running(self) -> bool:
-        return self._sim_thread.is_alive() or self._scheduler.is_active()
+        return not self._sim_task.done() or self._scheduler.is_active()
 
     @property
     def status(self) -> Status:
@@ -320,7 +306,7 @@ class BatchContext:
 
     def stop(self) -> None:
         self._scheduler.kill_all_jobs()
-        self._sim_thread.join()
+        self._loop.run_until_complete(self._sim_task)
 
     def run_path(self, iens: int) -> str:
         return self.run_args[iens].runpath


### PR DESCRIPTION
**Issue**
Creating scheduler message queues (via asyncio.Queue) is done in different asyncio loop (and thread too), which might cause an issue when running in python3.8. This replaces the sim thread with sim task in order to make sure that we run on the same loop.


**Approach**
Replace & simplify.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
