### PR TITLE
Combine gen data starting from configs

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -6,10 +6,11 @@ import time
 from pathlib import Path
 from typing import Iterable
 
-from ert.config import ParameterConfig, ResponseConfig
+from ert.config import ParameterConfig
 from ert.run_arg import RunArg
 from ert.storage.realization_storage_state import RealizationStorageState
 
+from .config.standardized_response_config import StandardResponseConfig
 from .load_status import LoadResult, LoadStatus
 
 logger = logging.getLogger(__name__)
@@ -47,24 +48,26 @@ async def _read_parameters(
 
 
 async def _write_responses_to_storage(
-    run_arg: RunArg, response_configs: Iterable[ResponseConfig]
+    run_arg: RunArg, response_configs: Iterable[StandardResponseConfig]
 ) -> LoadResult:
     errors = []
     for config in response_configs:
         try:
             start_time = time.perf_counter()
-            logger.debug(f"Starting to load response: {config.name}")
+            logger.debug(f"Starting to load response: {config.response_type}")
             ds = config.read_from_file(run_arg.runpath, run_arg.iens)
             await asyncio.sleep(0)
             logger.debug(
-                f"Loaded {config.name}",
+                f"Loaded {config.response_type}",
                 extra={"Time": f"{(time.perf_counter() - start_time):.4f}s"},
             )
             start_time = time.perf_counter()
-            run_arg.ensemble_storage.save_response(config.name, ds, run_arg.iens)
+            run_arg.ensemble_storage.save_response(
+                config.response_type, ds, run_arg.iens
+            )
             await asyncio.sleep(0)
             logger.debug(
-                f"Saved {config.name} to storage",
+                f"Saved {config.response_type} to storage",
                 extra={"Time": f"{(time.perf_counter() - start_time):.4f}s"},
             )
         except ValueError as err:

--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -167,12 +167,15 @@ class EnsembleConfig:
                     "In order to use summary responses, ECLBASE has to be set."
                 )
             time_map = set(refcase.dates) if refcase is not None else None
+            smry_kwargs = {}
+            if time_map is not None:
+                smry_kwargs["refcase"] = sorted(time_map)
             response_configs.append(
                 SummaryConfig(
                     name="summary",
                     input_file=eclbase,
                     keys=[i for val in summary_keys for i in val],
-                    kwargs={"refcase": time_map},
+                    kwargs=smry_kwargs,
                 )
             )
 
@@ -203,12 +206,14 @@ class EnsembleConfig:
         assert config_node is not None
         if config_node.name in self:
             raise ConfigValidationError(
-                f"Config node with key {config_node.name!r} already present in ensemble config"
+                f"Config node with key {config_node.name!r} already present in "
+                f"ensemble config"
             )
 
         if isinstance(config_node, ParameterConfig):
             logger.info(
-                f"Adding {type(config_node).__name__} config (of size {len(config_node)}) to parameter_configs"
+                f"Adding {type(config_node).__name__} config (of size "
+                f"{len(config_node)}) to parameter_configs"
             )
             self.parameter_configs[config_node.name] = config_node
         else:

--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -28,6 +28,7 @@ from .gen_kw_config import GenKwConfig
 from .parameter_config import ParameterConfig
 from .parsing import ConfigDict, ConfigKeys, ConfigValidationError
 from .response_config import ResponseConfig
+from .standardized_response_config import StandardResponseConfig
 from .summary_config import SummaryConfig
 from .surface_config import SurfaceConfig
 
@@ -171,7 +172,7 @@ class EnsembleConfig:
                     name="summary",
                     input_file=eclbase,
                     keys=[i for val in summary_keys for i in val],
-                    refcase=time_map,
+                    kwargs={"refcase": time_map},
                 )
             )
 
@@ -242,3 +243,7 @@ class EnsembleConfig:
     @property
     def response_configuration(self) -> List[ResponseConfig]:
         return list(self.response_configs.values())
+
+    @property
+    def standardized_response_configs(self) -> List[StandardResponseConfig]:
+        return StandardResponseConfig.standardize_configs(self.response_configuration)

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List, Literal
 
 import xarray as xr
 
@@ -10,6 +10,14 @@ from ert.config.parameter_config import CustomDict
 @dataclasses.dataclass
 class ResponseConfig(ABC):
     name: str
+    input_file: str = ""
+    keys: List[str] = dataclasses.field(default_factory=list)
+
+    # Note: This is necessary to handle arbitrary
+    # inputs for responses, like report steps for gen data.
+    # This is meant to only be accessed from within the
+    # response config itself when it is reading files from runpath
+    kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     @abstractmethod
     def read_from_file(self, run_path: str, iens: int) -> xr.Dataset: ...
@@ -18,3 +26,16 @@ class ResponseConfig(ABC):
         data = dataclasses.asdict(self, dict_factory=CustomDict)
         data["_ert_kind"] = self.__class__.__name__
         return data
+
+    @property
+    @abstractmethod
+    def cardinality(self) -> Literal["one_per_key", "one_per_realization"]:
+        """Specifies how many files are expected from this config"""
+        ...
+
+    @property
+    @abstractmethod
+    def response_type(self) -> str:
+        """Label to identify what kind of response it is.
+        Must not overlap with that of other response configs."""
+        ...

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -27,6 +27,14 @@ class ResponseConfig(ABC):
         data["_ert_kind"] = self.__class__.__name__
         return data
 
+    @staticmethod
+    def serialize_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return {**kwargs}
+
+    @staticmethod
+    def deserialize_kwargs(kwargs_serialized: Dict[str, Any]) -> Dict[str, Any]:
+        return {**kwargs_serialized}
+
     @property
     @abstractmethod
     def cardinality(self) -> Literal["one_per_key", "one_per_realization"]:

--- a/src/ert/config/responses_index.py
+++ b/src/ert/config/responses_index.py
@@ -1,0 +1,10 @@
+from typing import Dict, Type
+
+from .gen_data_config import GenDataConfig
+from .response_config import ResponseConfig
+from .summary_config import SummaryConfig
+
+responses_index: Dict[str, Type[ResponseConfig]] = {
+    "SummaryConfig": SummaryConfig,
+    "GenDataConfig": GenDataConfig,
+}

--- a/src/ert/config/standardized_response_config.py
+++ b/src/ert/config/standardized_response_config.py
@@ -1,0 +1,160 @@
+import dataclasses
+from functools import cached_property
+from typing import Any, Dict, List, Literal, Optional
+
+import xarray as xr
+
+from .response_config import ResponseConfig
+from .responses_index import responses_index
+
+
+@dataclasses.dataclass
+class ResponseConfigArgs:
+    name: str
+    input_file: str
+    keys: List[str]
+    kwargs: Dict[str, Any]
+
+    def __post_init__(self):
+        self.keys.sort()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "input_file": self.input_file,
+            "kwargs": self.kwargs,
+            "keys": self.keys,
+        }
+
+
+@dataclasses.dataclass
+class StandardResponseConfig:
+    ert_kind: str
+    args_per_instance: List[ResponseConfigArgs] = dataclasses.field(
+        default_factory=list
+    )
+
+    @staticmethod
+    def create(source_configs: List[ResponseConfig]) -> "StandardResponseConfig":
+        first_config = source_configs[0]
+
+        _ert_kind = first_config.__class__.__name__
+        response_args_list = [
+            ResponseConfigArgs(
+                name=config.name,
+                input_file=config.input_file,
+                kwargs=config.kwargs,
+                keys=list(set(config.keys or {config.name})),
+            )
+            for config in source_configs
+        ]
+
+        return StandardResponseConfig(
+            ert_kind=_ert_kind,
+            args_per_instance=response_args_list,
+        )
+
+    @staticmethod
+    def standardize_configs(
+        response_configs: Optional[List[ResponseConfig]],
+    ) -> List["StandardResponseConfig"]:
+        if response_configs is None:
+            return []
+
+        configs_by_response_type: Dict[str, List[ResponseConfig]] = {}
+        for config in response_configs:
+            response_type = config.response_type
+
+            if response_type not in configs_by_response_type:
+                configs_by_response_type[response_type] = []
+
+            configs_by_response_type[response_type].append(config)
+
+        standard_format_configs: List[StandardResponseConfig] = []
+        for configs in configs_by_response_type.values():
+            standard_config = StandardResponseConfig.create(source_configs=configs)
+            standard_format_configs.append(standard_config)
+
+        standard_format_configs.sort(key=lambda x: x.ert_kind)
+
+        return standard_format_configs
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "_ert_kind": self.ert_kind,
+            "args_per_instance": [x.to_dict() for x in self.args_per_instance],
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "StandardResponseConfig":
+        return cls(
+            ert_kind=d["_ert_kind"],
+            args_per_instance=[
+                ResponseConfigArgs(**args) for args in d["args_per_instance"]
+            ],
+        )
+
+    @property
+    def keys(self) -> List[str]:
+        if self.first_config_instance.cardinality == "one_per_key":
+            return sorted([config.name for config in self.all_config_instances])
+
+        return self.first_config_instance.keys
+
+    @property
+    def cardinality(self) -> Literal["one_per_key", "one_per_realization"]:
+        return self.first_config_instance.cardinality
+
+    @property
+    def response_type(self) -> str:
+        return self.first_config_instance.response_type
+
+    @property
+    def input_files(self) -> List[str]:
+        return [config.input_file for config in self.all_config_instances]
+
+    @property
+    def first_config_instance(self) -> ResponseConfig:
+        return self.all_config_instances[0]
+
+    @cached_property
+    def all_config_instances(self) -> List[ResponseConfig]:
+        configs = []
+        config_cls = responses_index[self.ert_kind]
+
+        for args in self.args_per_instance:
+            instance = config_cls(
+                name=args.name,
+                input_file=args.input_file,
+                keys=args.keys,
+                kwargs=args.kwargs,
+            )
+            configs.append(instance)
+
+        return configs
+
+    @staticmethod
+    def _all_keys(source_configs: List[ResponseConfig]) -> List[str]:
+        if len(source_configs) == 0:
+            return []
+
+        first_config = source_configs[0]
+        if first_config.cardinality == "one_per_key":
+            return [config.name for config in source_configs]
+
+        return first_config.keys
+
+    @cached_property
+    def config_instance(self) -> ResponseConfig:
+        return responses_index[self.ert_kind](**self.to_dict())
+
+    def read_from_file(self, run_path: str, iens: int) -> xr.Dataset:
+        if self.first_config_instance.cardinality == "one_per_key":
+            datasets = []
+            for config in self.all_config_instances:
+                ds = config.read_from_file(run_path, iens)
+                datasets.append(ds.expand_dims(name=[config.name]))
+
+            return xr.concat(datasets, dim="name")
+
+        return self.first_config_instance.read_from_file(run_path, iens)

--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from ert.config import GenDataConfig, GenKwConfig
+from ert.config import GenKwConfig
 from ert.config.field import Field
 from ert.storage import Ensemble, Experiment, Storage
 
@@ -54,13 +54,15 @@ def get_response_names(ensemble: Ensemble) -> List[str]:
 
 
 def gen_data_keys(ensemble: Ensemble) -> Iterator[str]:
-    for k, v in ensemble.experiment.response_configuration.items():
-        if isinstance(v, GenDataConfig):
-            if v.report_steps is None:
-                yield f"{k}@0"
-            else:
-                for report_step in v.report_steps:
-                    yield f"{k}@{report_step}"
+    for config in ensemble.experiment.response_configuration[
+        "gen_data"
+    ].args_per_instance:
+        report_steps = config.kwargs.get("report_steps")
+        if report_steps is None:
+            yield f"{config.name}@0"
+        else:
+            for report_step in report_steps:
+                yield f"{config.name}@{report_step}"
 
 
 def data_for_key(

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -104,7 +104,9 @@ class BatchSimulator:
 
         for key in results:
             ens_config.addNode(
-                GenDataConfig(name=key, input_file=f"{key}_%d", report_steps=[0])
+                GenDataConfig(
+                    name=key, input_file=f"{key}_%d", kwargs={"report_steps": [0]}
+                )
             )
 
     def _setup_sim(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -845,11 +845,9 @@ class LocalEnsemble(BaseMode):
     ) -> Dict[str, RealizationStorageState]:
         path = self._realization_dir(realization)
         return {
-            e: (
-                RealizationStorageState.INITIALIZED
-                if (path / f"{e}.nc").exists()
-                else RealizationStorageState.UNDEFINED
-            )
+            e: RealizationStorageState.INITIALIZED
+            if (path / f"{e}.nc").exists()
+            else RealizationStorageState.UNDEFINED
             for e in self.experiment.parameter_configuration
         }
 
@@ -858,10 +856,8 @@ class LocalEnsemble(BaseMode):
     ) -> Dict[str, RealizationStorageState]:
         path = self._realization_dir(realization)
         return {
-            e: (
-                RealizationStorageState.HAS_DATA
-                if (path / f"{e}.nc").exists()
-                else RealizationStorageState.UNDEFINED
-            )
+            e: RealizationStorageState.HAS_DATA
+            if (path / f"{e}.nc").exists()
+            else RealizationStorageState.UNDEFINED
             for e in self.experiment.response_configuration
         }

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -26,6 +26,7 @@ from filelock import FileLock, Timeout
 from pydantic import BaseModel, Field
 
 from ert.config import ErtConfig
+from ert.config.standardized_response_config import StandardResponseConfig
 from ert.shared import __version__
 from ert.storage.local_ensemble import LocalEnsemble
 from ert.storage.local_experiment import LocalExperiment
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 6
+_LOCAL_STORAGE_VERSION = 7
 
 
 class _Migrations(BaseModel):
@@ -291,7 +292,9 @@ class LocalStorage(BaseMode):
     def create_experiment(
         self,
         parameters: Optional[List[ParameterConfig]] = None,
-        responses: Optional[List[ResponseConfig]] = None,
+        responses: Optional[
+            Union[List[StandardResponseConfig], List[ResponseConfig]]
+        ] = None,
         observations: Optional[Dict[str, xr.Dataset]] = None,
         simulation_arguments: Optional[Dict[Any, Any]] = None,
         name: Optional[str] = None,
@@ -303,7 +306,7 @@ class LocalStorage(BaseMode):
         ----------
         parameters : list of ParameterConfig, optional
             The parameters for the experiment.
-        responses : list of ResponseConfig, optional
+        responses : list of ResponseConfig or StandardResponseConfig, optional
             The responses for the experiment.
         observations : dict of str to Dataset, optional
             The observations for the experiment.
@@ -443,6 +446,7 @@ class LocalStorage(BaseMode):
             to4,
             to5,
             to6,
+            to7,
         )
 
         try:
@@ -459,7 +463,7 @@ class LocalStorage(BaseMode):
                     f"Cannot migrate storage '{self.path}'. Storage version {version} is newer than the current version {_LOCAL_STORAGE_VERSION}, upgrade ert to continue, or run with a different ENSPATH"
                 )
             elif version < _LOCAL_STORAGE_VERSION:
-                migrations = list(enumerate([to2, to3, to4, to5, to6], start=1))
+                migrations = list(enumerate([to2, to3, to4, to5, to6, to7], start=1))
                 for from_version, migration in migrations[version - 1 :]:
                     print(f"* Updating storage to version: {from_version+1}")
                     migration.migrate(self.path)

--- a/src/ert/storage/migration/block_fs.py
+++ b/src/ert/storage/migration/block_fs.py
@@ -521,23 +521,34 @@ def _migrate_gen_data(
             {"values": data_file.load(block, 0), "report_step": block.report_step}
         )
     for iens, gen_data in realizations.items():
+        datasets = []
         for name, values in gen_data.items():
-            datasets = []
+            dataset_fragments = []
             for value in values:
-                datasets.append(
+                dataset_fragments.append(
                     xr.Dataset(
-                        {"values": (["report_step", "index"], [value["values"]])},
+                        {
+                            "values": (
+                                ["report_step", "index"],
+                                [value["values"]],
+                            )
+                        },
                         coords={
                             "index": range(len(value["values"])),
                             "report_step": [value["report_step"]],
                         },
                     )
                 )
-            ensemble.save_response(
-                name,
-                xr.combine_by_coords(datasets),  # type: ignore
-                iens,
+
+            datasets.append(
+                xr.combine_by_coords(dataset_fragments).expand_dims(name=[name])
             )
+
+        ensemble.save_response(
+            "gen_data",
+            xr.concat(datasets, dim="name"),  # type: ignore
+            iens,
+        )
 
 
 def _migrate_gen_kw_info(

--- a/src/ert/storage/migration/to7.py
+++ b/src/ert/storage/migration/to7.py
@@ -1,0 +1,146 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import xarray as xr
+
+info = "Standardize response configs"
+
+
+def _migrate_response_configs(path: Path) -> None:
+    for experiment in path.glob("experiments/*"):
+        with open(experiment / "responses.json", encoding="utf-8") as fin:
+            responses = json.load(fin)
+
+        standardized = {}
+
+        if "summary" in responses:
+            original = responses["summary"]
+
+            smry_kwargs = {}
+            if "refcase" in original:
+                smry_kwargs["refcase"] = original["refcase"]
+
+            standardized["summary"] = {
+                "_ert_kind": "SummaryConfig",
+                "args_per_instance": [
+                    {
+                        "name": "summary",
+                        "input_file": original["input_file"],
+                        "keys": sorted(
+                            set(original["keys"])
+                        ),  # Note: Maybe a bit more of a "cleanup" than migrate,
+                        # but sometimes there are duplicate keys in configs
+                        # ref the storage migration tests
+                        "kwargs": smry_kwargs,
+                    }
+                ],
+            }
+
+        gendata_responses = {
+            k: v for k, v in responses.items() if v["_ert_kind"] == "GenDataConfig"
+        }
+
+        if gendata_responses:
+            args_per_instance: List[Dict[str, Any]] = []
+            standardized["gen_data"] = {
+                "_ert_kind": "GenDataConfig",
+                "args_per_instance": args_per_instance,
+            }
+            for name, info in gendata_responses.items():
+                instance_kwargs: Dict[str, Any] = {}
+                instance_args = {
+                    "name": name,
+                    "input_file": info["input_file"],
+                    "kwargs": instance_kwargs,
+                }
+
+                if "report_steps" in info:
+                    instance_kwargs["report_steps"] = info["report_steps"]
+
+                if "index" in info:
+                    instance_kwargs["index"] = info["index"]
+
+                if instance_kwargs:
+                    instance_args["kwargs"] = instance_kwargs
+
+                instance_args["keys"] = [name]
+
+                args_per_instance.append(instance_args)
+
+        with open(experiment / "responses.json", "w", encoding="utf-8") as fout:
+            json.dump(standardized, fout)
+
+
+def _ensure_coord_order(
+    ds: xr.Dataset, dim_order_explicit: Optional[List[str]] = None
+) -> xr.Dataset:
+    # Copypaste'd from LocalEnsemble
+    data_vars = list(ds.data_vars.keys())
+
+    # We assume only data vars with the same dimensions,
+    # i.e., (realization, *index) for all of them.
+    dim_order_of_first_var = (
+        ds[data_vars[0]].dims if dim_order_explicit is None else dim_order_explicit
+    )
+    return ds[[*dim_order_of_first_var, *data_vars]].sortby(
+        dim_order_of_first_var[0]  # "realization" / "realizations"
+    )
+
+
+def _migrate_response_datasets(path: Path) -> None:
+    for experiment in path.glob("experiments/*"):
+        ensembles = path.glob("ensembles/*")
+
+        experiment_id = None
+        with open(experiment / "index.json", encoding="utf-8") as f:
+            exp_index = json.load(f)
+            experiment_id = exp_index["id"]
+
+        responses_file = experiment / "responses.json"
+        with open(responses_file, encoding="utf-8", mode="r") as f:
+            responses_obj = json.load(f)
+
+        assert (
+            responses_obj is not None
+        ), f"Failed to load responses.json @ {responses_file}"
+
+        gendata_keys = {
+            k for k, v in responses_obj.items() if v["_ert_kind"] == "GenDataConfig"
+        }
+
+        for ens in ensembles:
+            with open(ens / "index.json", encoding="utf-8") as f:
+                ens_file = json.load(f)
+                if ens_file["experiment_id"] != experiment_id:
+                    continue
+
+            real_dirs = [*ens.glob("realization-*")]
+
+            for real_dir in real_dirs:
+                # Combine responses, for every response name
+                gen_data_datasets = [
+                    (
+                        real_dir / f"{gendata_name}.nc",
+                        xr.open_dataset(real_dir / f"{gendata_name}.nc").expand_dims(
+                            name=[gendata_name], axis=1
+                        ),
+                    )
+                    for gendata_name in gendata_keys
+                    if os.path.exists(real_dir / f"{gendata_name}.nc")
+                ]
+
+                if gen_data_datasets:
+                    gen_data_combined = _ensure_coord_order(
+                        xr.concat([ds for _, ds in gen_data_datasets], dim="name")
+                    )
+                    gen_data_combined.to_netcdf(real_dir / "gen_data.nc")
+
+                    for p in [ds_path for ds_path, _ in gen_data_datasets]:
+                        os.remove(p)
+
+
+def migrate(path: Path) -> None:
+    _migrate_response_datasets(path)
+    _migrate_response_configs(path)

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -220,10 +220,14 @@ def test_gen_data_obs_data_mismatch(storage, uniform_parameter):
         )
         data = rng.uniform(0.8, 1, 3)
         prior.save_response(
-            "RESPONSE",
+            "gen_data",
             xr.Dataset(
-                {"values": (["report_step", "index"], [data])},
-                coords={"index": range(len(data)), "report_step": [0]},
+                {"values": (["name", "report_step", "index"], [[data]])},
+                coords={
+                    "name": ["RESPONSE"],
+                    "index": range(len(data)),
+                    "report_step": [0],
+                },
             ),
             iens,
         )
@@ -279,10 +283,14 @@ def test_gen_data_missing(storage, uniform_parameter, obs):
         )
         data = rng.uniform(0.8, 1, 2)  # Importantly, shorter than obs
         prior.save_response(
-            "RESPONSE",
+            "gen_data",
             xr.Dataset(
-                {"values": (["report_step", "index"], [data])},
-                coords={"index": range(len(data)), "report_step": [0]},
+                {"values": (["name", "report_step", "index"], [[data]])},
+                coords={
+                    "name": ["RESPONSE"],
+                    "index": range(len(data)),
+                    "report_step": [0],
+                },
             ),
             iens,
         )
@@ -369,10 +377,14 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
 
         data = rng.uniform(0.8, 1, 10)
         prior.save_response(
-            "RESPONSE",
+            "gen_data",
             xr.Dataset(
-                {"values": (["report_step", "index"], [data])},
-                coords={"index": range(len(data)), "report_step": [0]},
+                {"values": (["name", "report_step", "index"], [[data]])},
+                coords={
+                    "name": ["RESPONSE"],
+                    "index": range(len(data)),
+                    "report_step": [0],
+                },
             ),
             iens,
         )

--- a/tests/integration_tests/snapshots/test_storage_migration/test_that_storage_matches/responses
+++ b/tests/integration_tests/snapshots/test_storage_migration/test_that_storage_matches/responses
@@ -1,1 +1,1 @@
-{'GEN': GenDataConfig(name='GEN', input_file='gen%d.txt', report_steps=[1]), 'summary': SummaryConfig(name='summary', input_file='CASE', keys=['FOPR', 'RWPR'], refcase={})}
+{'summary': StandardResponseConfig(ert_kind='SummaryConfig', args_per_instance=[ResponseConfigArgs(name='summary', input_file='CASE', keys=['FOPR', 'RWPR'], kwargs={})]), 'gen_data': StandardResponseConfig(ert_kind='GenDataConfig', args_per_instance=[ResponseConfigArgs(name='GEN', input_file='gen%d.txt', keys=['GEN'], kwargs={'report_steps': [1]})])}

--- a/tests/integration_tests/test_storage_migration.py
+++ b/tests/integration_tests/test_storage_migration.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -112,8 +113,16 @@ def test_that_storage_matches(
         assert len(ensembles) == 1
         ensemble = ensembles[0]
 
+        # Remove refcase from summary config
+        responses_path = experiment._path / experiment._responses_file
+        with open(responses_path, "r", encoding="utf-8") as f:
+            responses_json = json.load(f)
+            responses_json["summary"]["args_per_instance"][0]["kwargs"] = {}
+
+        with open(responses_path, "w", encoding="utf-8") as f:
+            json.dump(responses_json, f)
+
         # We need to normalize some irrelevant details:
-        experiment.response_configuration["summary"].refcase = {}
         experiment.parameter_configuration["PORO"].mask_file = ""
         if version.parse(ert_version).major == 5:
             # In this version we were not saving the full parameter

--- a/tests/performance_tests/test_memory_usage.py
+++ b/tests/performance_tests/test_memory_usage.py
@@ -73,15 +73,16 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
         source = storage.create_ensemble(experiment_id, name="prior", ensemble_size=100)
 
         realizations = list(range(ert_config.model_config.num_realizations))
-        for _, obs in ert_config.observations.items():
-            data_key = obs.attrs["response"]
-            for real in realizations:
+        for real in realizations:
+            gendatas = []
+            for _, obs in ert_config.observations.items():
+                data_key = obs.attrs["response"]
                 if data_key != "summary":
                     obs_highest_index_used = max(obs.index.values)
-                    source.save_response(
-                        data_key,
-                        make_gen_data(int(obs_highest_index_used) + 1),
-                        real,
+                    gendatas.append(
+                        make_gen_data(int(obs_highest_index_used) + 1).expand_dims(
+                            name=[data_key]
+                        )
                     )
                 else:
                     obs_time_list = ens_config.refcase.all_dates
@@ -90,6 +91,12 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
                         make_summary_data(["summary"], obs_time_list),
                         real,
                     )
+
+            source.save_response(
+                "gen_data",
+                xr.concat(gendatas, dim="name"),
+                real,
+            )
 
         sample_prior(source, realizations, ens_config.parameters)
 

--- a/tests/unit_tests/analysis/test_es_update.py
+++ b/tests/unit_tests/analysis/test_es_update.py
@@ -398,10 +398,14 @@ def test_smoother_snapshot_alpha(
         )
         data = rng.uniform(0.8, 1, 3)
         prior_storage.save_response(
-            "RESPONSE",
+            "gen_data",
             xr.Dataset(
-                {"values": (["report_step", "index"], [data])},
-                coords={"index": range(len(data)), "report_step": [0]},
+                {"values": (["name", "report_step", "index"], [[data]])},
+                coords={
+                    "name": ["RESPONSE"],
+                    "index": range(len(data)),
+                    "report_step": [0],
+                },
             ),
             iens,
         )
@@ -559,10 +563,14 @@ def test_and_benchmark_adaptive_localization_with_fields(
         )
 
         prior_ensemble.save_response(
-            "RESPONSE",
+            "gen_data",
             xr.Dataset(
-                {"values": (["report_step", "index"], [Y[:, iens]])},
-                coords={"index": range(len(Y[:, iens])), "report_step": [0]},
+                {"values": (["name", "report_step", "index"], [[Y[:, iens]]])},
+                coords={
+                    "name": ["RESPONSE"],
+                    "index": range(len(Y[:, iens])),
+                    "report_step": [0],
+                },
             ),
             iens,
         )

--- a/tests/unit_tests/config/test_gen_data_config.py
+++ b/tests/unit_tests/config/test_gen_data_config.py
@@ -14,7 +14,7 @@ from ert.config import ConfigValidationError, GenDataConfig
 )
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_data_config(name: str, report_steps: List[int]):
-    gdc = GenDataConfig(name=name, report_steps=report_steps)
+    gdc = GenDataConfig(name=name, kwargs={"report_steps": report_steps})
     assert gdc.name == name
     assert gdc.report_steps == sorted(report_steps)
 
@@ -26,11 +26,11 @@ def test_gen_data_default_report_step():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_data_eq_config():
-    alt1 = GenDataConfig(name="ALT1", report_steps=[2, 1, 3])
-    alt2 = GenDataConfig(name="ALT1", report_steps=[2, 3, 1])
-    alt3 = GenDataConfig(name="ALT1", report_steps=[3])
-    alt4 = GenDataConfig(name="ALT4", report_steps=[3])
-    alt5 = GenDataConfig(name="ALT4", report_steps=[4])
+    alt1 = GenDataConfig(name="ALT1", kwargs={"report_steps": [2, 1, 3]})
+    alt2 = GenDataConfig(name="ALT1", kwargs={"report_steps": [2, 3, 1]})
+    alt3 = GenDataConfig(name="ALT1", kwargs={"report_steps": [3]})
+    alt4 = GenDataConfig(name="ALT4", kwargs={"report_steps": [3]})
+    alt5 = GenDataConfig(name="ALT4", kwargs={"report_steps": [4]})
 
     assert alt1 == alt2  # name and ordered steps ok
     assert alt1 != alt3  # amount steps differ

--- a/tests/unit_tests/config/test_standard_response_config.py
+++ b/tests/unit_tests/config/test_standard_response_config.py
@@ -215,7 +215,7 @@ def test_reading_summary_through_standardized_spec(tmp_path):
     assert ds["name"].data.tolist() == summary_keys
 
     for _, _ds in ds.groupby("name"):
-        assert len(_ds["values"]) == num_timesteps
+        assert _ds["values"].size == num_timesteps
 
 
 def test_standard_response_json_writing(tmp_path):

--- a/tests/unit_tests/config/test_standard_response_config.py
+++ b/tests/unit_tests/config/test_standard_response_config.py
@@ -1,0 +1,249 @@
+import os
+
+import numpy as np
+
+from ert.config import GenDataConfig, SummaryConfig
+from ert.config.standardized_response_config import (
+    StandardResponseConfig,
+)
+from ert.storage import open_storage
+from tests.performance_tests.performance_utils import (
+    write_summary_data,
+    write_summary_spec,
+)
+
+
+def test_that_summary_to_standard_response_config_works():
+    summary_config = SummaryConfig(
+        name="summary", input_file="summaryOUT", keys=["A", "B", "C", "D", "E"]
+    )
+    standardized_configs_list = StandardResponseConfig.standardize_configs(
+        [summary_config]
+    )
+    assert len(standardized_configs_list) == 1
+    standardized = standardized_configs_list[0]
+
+    assert standardized.keys == ["A", "B", "C", "D", "E"]
+    assert standardized.input_files == ["summaryOUT"]
+    assert standardized.cardinality == "one_per_realization"
+    assert standardized.response_type == "summary"
+
+
+def test_that_multiple_gendatas_to_standard_response_config_works():
+    alt1 = GenDataConfig(
+        name="ALT1", input_file="f1", kwargs={"report_steps": [2, 1, 3]}
+    )
+    alt2 = GenDataConfig(
+        name="ALT2", input_file="f2", kwargs={"report_steps": [2, 3, 1]}
+    )
+    alt3 = GenDataConfig(name="ALT3", input_file="f3", kwargs={"report_steps": [3]})
+    alt4 = GenDataConfig(name="ALT4", input_file="f4", kwargs={"report_steps": [3]})
+    alt5 = GenDataConfig(name="ALT5", input_file="f5", kwargs={"report_steps": [4]})
+
+    standardized_configs_list = StandardResponseConfig.standardize_configs(
+        [alt1, alt2, alt3, alt4, alt5]
+    )
+
+    assert len(standardized_configs_list) == 1
+    standardized_config = standardized_configs_list[0]
+    assert standardized_config.keys == ["ALT1", "ALT2", "ALT3", "ALT4", "ALT5"]
+    assert standardized_config.input_files == ["f1", "f2", "f3", "f4", "f5"]
+    assert standardized_config.cardinality == "one_per_key"
+    assert standardized_config.response_type == "gen_data"
+
+
+def test_that_single_gendata_to_standard_response_config_works():
+    standardized_configs_list = StandardResponseConfig.standardize_configs(
+        [
+            GenDataConfig(
+                name="ALT1", input_file="f1", kwargs={"report_steps": [2, 1, 3]}
+            )
+        ]
+    )
+
+    assert len(standardized_configs_list) == 1
+    standardized_config = standardized_configs_list[0]
+    assert standardized_config.keys == ["ALT1"]
+    assert standardized_config.input_files == ["f1"]
+    assert standardized_config.cardinality == "one_per_key"
+    assert standardized_config.response_type == "gen_data"
+
+
+def test_read_and_combine_gendata_from_runpath(tmp_path):
+    alt1 = GenDataConfig(
+        name="ALT1", input_file="f1@%d", kwargs={"report_steps": [2, 1, 3]}
+    )
+    alt2 = GenDataConfig(
+        name="ALT2", input_file="f2@%d", kwargs={"report_steps": [2, 3, 1]}
+    )
+    alt3 = GenDataConfig(name="ALT3", input_file="f3@%d", kwargs={"report_steps": [3]})
+    alt4 = GenDataConfig(name="ALT4", input_file="f4@%d", kwargs={"report_steps": [3]})
+    gendata_list = [alt1, alt2, alt3, alt4]
+
+    standardized_configs_list = StandardResponseConfig.standardize_configs(gendata_list)
+
+    assert len(standardized_configs_list) == 1
+    standardized_config = standardized_configs_list[0]
+    assert standardized_config.keys == ["ALT1", "ALT2", "ALT3", "ALT4"]
+    assert standardized_config.input_files == [
+        "f1@%d",
+        "f2@%d",
+        "f3@%d",
+        "f4@%d",
+    ]
+    assert standardized_config.cardinality == "one_per_key"
+    assert standardized_config.response_type == "gen_data"
+
+    run_path = tmp_path / "iter-0" / "realization-0"
+    os.mkdir(tmp_path / "iter-0")
+    os.mkdir(run_path)
+
+    lines_per_config = {
+        alt1.name: 1,
+        alt2.name: 20,
+        alt3.name: 30,
+        alt4.name: 40,
+    }
+
+    # Create some gen data files in the runpath
+    for config in [alt1, alt2, alt3, alt4]:
+        num_lines = lines_per_config[config.name]
+        for report_step in config.report_steps or [""]:
+            file_path = run_path / (f"{config.input_file}" % report_step)
+
+            some_data = np.linspace(
+                100 * report_step,
+                99 + 100 * report_step,
+                num_lines,
+            )
+
+            with open(file_path, "w+", encoding="utf-8") as f:
+                np.savetxt(f, some_data, fmt="%f")
+
+    combined_ds = standardized_config.read_from_file(run_path=run_path, iens=0)
+
+    # Approximation for correctness:
+    # Assert that the non-nan line count for each report step
+    # matches up with the expected lines per report step
+    all_report_steps = set.union(*[set(config.report_steps) for config in gendata_list])
+    for report_step in all_report_steps:
+        expected_n_lines = sum(
+            lines_per_config[config.name]
+            for config in gendata_list
+            if report_step in config.report_steps
+        )
+
+        assert (
+            len(combined_ds.sel(report_step=report_step).to_dataframe().dropna())
+            == expected_n_lines
+        )
+
+
+def test_read_and_combine_gendata_from_runpath_without_report_step(tmp_path):
+    alt5 = GenDataConfig(name="ALT5", input_file="f5@%d")
+    alt6 = GenDataConfig(name="ALT6", input_file="f6@")
+    gendata_list = [alt5, alt6]
+
+    standardized_configs_list = StandardResponseConfig.standardize_configs(gendata_list)
+
+    assert len(standardized_configs_list) == 1
+    standardized_config = standardized_configs_list[0]
+    assert standardized_config.keys == ["ALT5", "ALT6"]
+    assert standardized_config.input_files == [
+        "f5@%d",
+        "f6@",
+    ]
+    assert standardized_config.cardinality == "one_per_key"
+    assert standardized_config.response_type == "gen_data"
+
+    run_path = tmp_path / "iter-0" / "realization-0"
+    os.mkdir(tmp_path / "iter-0")
+    os.mkdir(run_path)
+
+    lines_per_config = {
+        "ALT5": 101,
+        "ALT6": 101,
+    }
+
+    # Create some gen data files in the runpath
+    for config in [alt5, alt6]:
+        num_lines = lines_per_config[config.name]
+        file_path = run_path / config.input_file
+
+        some_data = np.linspace(
+            100,
+            199,
+            num_lines,
+        )
+
+        with open(file_path, "w+", encoding="utf-8") as f:
+            np.savetxt(f, some_data, fmt="%f")
+
+    combined_ds = standardized_config.read_from_file(run_path=run_path, iens=0)
+
+    expected_n_lines = sum(lines_per_config[config.name] for config in gendata_list)
+
+    assert len(combined_ds.to_dataframe().dropna()) == expected_n_lines
+
+
+def test_reading_summary_through_standardized_spec(tmp_path):
+    summary_keys = ["PSUMA", "PSUMB", "PSUMC", "PSUMD", "PSUME"]
+    num_timesteps = 100
+    summary_config = SummaryConfig(
+        name="summary", input_file="summaryOUT", keys=summary_keys
+    )
+
+    standardized_configs_list = StandardResponseConfig.standardize_configs(
+        [summary_config]
+    )
+    assert len(standardized_configs_list) == 1
+    standardized = standardized_configs_list[0]
+
+    run_path = tmp_path / "iter-0" / "realization-0"
+    os.mkdir(tmp_path / "iter-0")
+    os.mkdir(run_path)
+
+    write_summary_spec(run_path / "summaryOUT.SMSPEC", summary_keys)
+    write_summary_data(
+        run_path / "summaryOUT.UNSMRY",
+        num_timesteps,
+        summary_keys,
+        3,
+    )
+
+    ds = standardized.read_from_file(run_path, 0)
+    assert ds["name"].data.tolist() == summary_keys
+
+    for _, _ds in ds.groupby("name"):
+        assert len(_ds["values"]) == num_timesteps
+
+
+def test_standard_response_json_writing(tmp_path):
+    summary_keys = ["PSUMA", "PSUMB", "PSUMC", "PSUMD", "PSUME"]
+    summary_config = SummaryConfig(
+        name="summary", input_file="summaryOUT", keys=summary_keys
+    )
+
+    alt1 = GenDataConfig(
+        name="ALT1", input_file="f1@%d", kwargs={"report_steps": [2, 1, 3]}
+    )
+    alt2 = GenDataConfig(
+        name="ALT2", input_file="f2@%d", kwargs={"report_steps": [2, 3, 1]}
+    )
+    alt3 = GenDataConfig(name="ALT3", input_file="f3@%d", kwargs={"report_steps": [3]})
+    alt4 = GenDataConfig(name="ALT4", input_file="f4@%d", kwargs={"report_steps": [3]})
+    alt5 = GenDataConfig(name="ALT5", input_file="f5@%d")
+    gendata_list = [alt1, alt2, alt3, alt4, alt5]
+
+    with open_storage(tmp_path / "storage", mode="w") as storage:
+        exp = storage.create_experiment(responses=[*gendata_list, summary_config])
+        response_config = exp.response_configuration
+        assert (
+            response_config["summary"]
+            == StandardResponseConfig.standardize_configs([summary_config])[0]
+        )
+
+        assert (
+            response_config["gen_data"]
+            == StandardResponseConfig.standardize_configs(gendata_list)[0]
+        )

--- a/tests/unit_tests/config/test_summary_config.py
+++ b/tests/unit_tests/config/test_summary_config.py
@@ -24,7 +24,7 @@ def test_rading_empty_summaries_raises(wopr_summary):
     smspec.to_file("CASE.SMSPEC")
     unsmry.to_file("CASE.UNSMRY")
     with pytest.raises(ValueError, match="Did not find any summary values"):
-        SummaryConfig("summary", "CASE", ["WWCT:OP1"], None).read_from_file(".", 0)
+        SummaryConfig("summary", "CASE", ["WWCT:OP1"]).read_from_file(".", 0)
 
 
 def test_summary_config_normalizes_list_of_keys():

--- a/tests/unit_tests/simulator/test_batch_sim.py
+++ b/tests/unit_tests/simulator/test_batch_sim.py
@@ -340,7 +340,10 @@ def test_batch_simulation_suffixes(batch_sim_example, storage):
     keys = ("W1", "W2", "W3")
     for result, (_, controls) in zip(results, case_data):
         expected = [controls["WELL_ON_OFF"][key] ** 2 for key in keys]
-        assert list(result["ON_OFF"]) == expected
+
+        # [:3] slicing can be removed when responses are not stored in netcdf leading
+        # to redundant nans from combining->selecting
+        assert list(result["ON_OFF"][:3]) == expected
 
         expected = [
             v**2 for key in keys for _, v in controls["WELL_ORDER"][key].items()

--- a/tests/unit_tests/storage/migration/test_version_2.py
+++ b/tests/unit_tests/storage/migration/test_version_2.py
@@ -24,16 +24,14 @@ def test_migrate_responses(setup_case, set_ert_config):
         response_info = json.loads(
             (experiment._path / "responses.json").read_text(encoding="utf-8")
         )
-        assert (
-            list(experiment.response_configuration.values())
-            == ert_config.ensemble_config.response_configuration
-        )
-    assert list(response_info) == [
-        "SNAKE_OIL_OPR_DIFF",
-        "SNAKE_OIL_WPR_DIFF",
-        "SNAKE_OIL_GPR_DIFF",
+        assert experiment.response_configuration == {
+            config.response_type: config
+            for config in ert_config.ensemble_config.standardized_response_configs
+        }
+    assert set(response_info) == {
+        "gen_data",
         "summary",
-    ]
+    }
 
 
 def test_migrate_gen_kw_config(setup_case, set_ert_config):

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -32,6 +32,7 @@ from ert.config.enkf_observation_implementation_type import (
 from ert.config.gen_kw_config import TransformFunctionDefinition
 from ert.config.general_observation import GenObservation
 from ert.config.observation_vector import ObsVector
+from ert.config.standardized_response_config import StandardResponseConfig
 from ert.storage import open_storage
 from ert.storage.local_storage import _LOCAL_STORAGE_VERSION
 from ert.storage.mode import ModeError
@@ -367,7 +368,6 @@ response_configs = st.lists(
                 alphabet=st.characters(min_codepoint=65, max_codepoint=90)
             ),
             keys=summary_keys,
-            refcase=st.just(None),
         ),
     ),
     unique_by=lambda x: x.name,
@@ -655,10 +655,10 @@ class StatefulStorageTest(RuleBasedStateMachine):
         assert sorted(model_experiment.ensembles) == sorted(
             e.id for e in storage_experiment.ensembles
         )
-        assert (
-            list(storage_experiment.response_configuration.values())
-            == model_experiment.responses
-        )
+        assert list(
+            storage_experiment.response_configuration.values()
+        ) == StandardResponseConfig.standardize_configs(model_experiment.responses)
+
         for obskey, obs in model_experiment.observations.items():
             assert obskey in storage_experiment.observations
             assert_allclose(obs, storage_experiment.observations[obskey])


### PR DESCRIPTION
Starting from configs, aim to remove logic/format discrepancies between summary/gendata.
TLDR;
* Standardize response configs into one common, serializable format after parsing from config (this format can be used and treated the same throughout the rest of the ert execution)
* It is still possible to implement response configs in the "old" format without worrying about the standard config they are later parsed into.
* Individual response configs are responsible for serializing/deserializing their kwargs, needed for datetimes/other custom formats.
* Override of [gendata/summary]config`.to_dict()` to return "old style" dict of config due to it being used in old storage migrations.