### PR TITLE
Remove the UI elements that show current memory usage

### DIFF
--- a/src/ert/gui/model/job_list.py
+++ b/src/ert/gui/model/job_list.py
@@ -88,7 +88,7 @@ class JobListProxyModel(QAbstractProxyModel):
                 header = JOB_COLUMNS[section]
                 if header in [ids.STDOUT, ids.STDERR]:
                     return header.upper()
-                elif header in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
+                elif header in [ids.MAX_MEMORY_USAGE]:
                     header = header.replace("_", " ")
                 return header.capitalize()
             if orientation == Qt.Orientation.Vertical:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -49,7 +49,6 @@ JOB_COLUMNS: Sequence[str] = [
     DURATION,  # Duration is based on two data fields, not coming directly from ert
     ids.STDOUT,
     ids.STDERR,
-    ids.CURRENT_MEMORY_USAGE,
     ids.MAX_MEMORY_USAGE,
 ]
 JOB_COLUMN_SIZE: Final[int] = len(JOB_COLUMNS)
@@ -383,10 +382,7 @@ class SnapshotModel(QAbstractItemModel):
         if role == StatusRole:
             return node.data.status
         if role == MemoryUsageRole:
-            return (
-                node.data.current_memory_usage,
-                node.data.max_memory_usage,
-            )
+            return node.data.max_memory_usage
         return QVariant()
 
     @staticmethod
@@ -422,7 +418,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == Qt.ItemDataRole.DisplayRole:
             data_name = JOB_COLUMNS[index.column()]
-            if data_name in [ids.CURRENT_MEMORY_USAGE, ids.MAX_MEMORY_USAGE]:
+            if data_name in [ids.MAX_MEMORY_USAGE]:
                 data = node.data
                 _bytes: Optional[str] = data.get(data_name)  # type: ignore
                 if _bytes:

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -147,12 +147,9 @@ class RealizationDelegate(QStyledItemDelegate):
             view = parent._real_view
             index = view.indexAt(mouse_pos)
             if index.isValid():
-                (current_memory_usage, maximum_memory_usage) = index.data(
-                    MemoryUsageRole
-                )
-                if current_memory_usage and maximum_memory_usage:
+                maximum_memory_usage = index.data(MemoryUsageRole)
+                if maximum_memory_usage:
                     txt = (
-                        f"Current memory usage:\t{byte_with_unit(current_memory_usage)}\n"
                         f"Maximum memory usage:\t{byte_with_unit(maximum_memory_usage)}"
                     )
                     QToolTip.showText(view.mapToGlobal(mouse_pos), txt)

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -524,16 +524,7 @@ def test_run_dialog_memory_usage_showing(
     assert job_model._real == 0
 
     job_number = 0
-    current_memory_column_index = 6
-    max_memory_column_index = 7
-
-    current_memory_column_proxy_index = job_model.index(
-        job_number, current_memory_column_index
-    )
-    current_memory_value = job_model.data(
-        current_memory_column_proxy_index, Qt.DisplayRole
-    )
-    assert current_memory_value == "50.00 kB"
+    max_memory_column_index = 6
 
     max_memory_column_proxy_index = job_model.index(job_number, max_memory_column_index)
     max_memory_value = job_model.data(max_memory_column_proxy_index, Qt.DisplayRole)


### PR DESCRIPTION
This PR only removes the visuals for `current_memory_usage`.
I am contemplating removing everything related to current memory usage.

![Screenshot 2024-08-15 at 13 19 58](https://github.com/user-attachments/assets/a09e11eb-ecf9-4c1b-93ba-9e492dced9f2)


**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
