### PR TITLE
Enforce minimum size on update report widget

### DIFF
--- a/src/ert/gui/simulation/view/update.py
+++ b/src/ert/gui/simulation/view/update.py
@@ -117,6 +117,7 @@ class UpdateWidget(QWidget):
         layout.addWidget(self._progress_bar)
         layout.addWidget(self._tab_widget)
 
+        self.setMinimumHeight(400)
         self.setLayout(layout)
 
     @property


### PR DESCRIPTION
Was:

https://github.com/user-attachments/assets/e99029df-384a-43cc-b873-3403dd03a451



Now:
![Screenshot 2024-08-16 at 10 32 29](https://github.com/user-attachments/assets/769c7b5e-90d8-4cc7-822e-f34ee396bd65)



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
