### PR TITLE
Remove std cutoff filtering in HISTORY_OBSERVATION

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -906,7 +906,6 @@ class ErtConfig:
                 )
             obs_config_content = parse(obs_config_file)
             history = self.model_config.history_source
-            std_cutoff = self.analysis_config.observation_settings.std_cutoff
             time_len = len(obs_time_list)
             ensemble_config = self.ensemble_config
             config_errors: List[ErrorInfo] = []
@@ -919,7 +918,6 @@ class ErtConfig:
                                 ensemble_config,
                                 values,
                                 obs_name,
-                                std_cutoff,
                                 history,
                                 time_len,
                             )

--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -95,7 +95,6 @@ class EnkfObs:
         ensemble_config: "EnsembleConfig",
         history_observation: HistoryValues,
         summary_key: str,
-        std_cutoff: float,
         history_type: HistorySource,
         time_len: int,
     ) -> Dict[str, ObsVector]:
@@ -151,14 +150,7 @@ class EnkfObs:
                 segment_instance,
             )
         data: Dict[Union[int, datetime], Union[GenObservation, SummaryObservation]] = {}
-        for i, (date, error, value) in enumerate(zip(refcase.dates, std_dev, values)):
-            if error <= std_cutoff:
-                ConfigWarning.ert_context_warn(
-                    "Too small observation error in observation"
-                    f" {summary_key}:{i} - ignored",
-                    summary_key,
-                )
-                continue
+        for date, error, value in zip(refcase.dates, std_dev, values):
             data[date] = SummaryObservation(summary_key, summary_key, value, error)
 
         return {

--- a/tests/unit_tests/config/test_observations.py
+++ b/tests/unit_tests/config/test_observations.py
@@ -900,57 +900,6 @@ def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
         assert observations["FWPR"].observations[datetime(2014, 9, 11)].std == 10000
 
 
-@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
-def test_that_std_cutoff_is_applied(tmpdir):
-    with tmpdir.as_cwd():
-        config = dedent(
-            """
-        NUM_REALIZATIONS 2
-
-        ECLBASE ECLIPSE_CASE
-        REFCASE ECLIPSE_CASE
-        STD_CUTOFF 0.1
-        OBS_CONFIG observations
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
-        with open("observations", "w", encoding="utf-8") as fo:
-            fo.writelines(
-                dedent(
-                    """
-                    HISTORY_OBSERVATION  FOPR
-                    {
-                       ERROR       = 0.05;
-                       ERROR_MODE  = ABS;
-                    };
-                    HISTORY_OBSERVATION  FGPR
-                    {
-                       ERROR       = 0.1;
-                       ERROR_MODE  = REL;
-                    };
-                    """
-                )
-            )
-        with open("time_map.txt", "w", encoding="utf-8") as fo:
-            fo.writelines("2023-02-01")
-        run_sim(
-            datetime(2014, 9, 10),
-            [(k, "SM3/DAY", None) for k in ["FOPR", "FOPRH", "FGPR", "FGPRH"]],
-            {"FOPRH": 20, "FGPRH": 15},
-        )
-
-        ert_config = ErtConfig.from_file("config.ert")
-
-        observations = ert_config.enkf_obs
-        assert observations["FGPR"].observation_key == "FGPR"
-        assert observations["FGPR"].observations[datetime(2014, 9, 11)].value == 15.0
-        assert observations["FGPR"].observations[datetime(2014, 9, 11)].std == 1.5
-
-        assert observations["FOPR"].observation_key == "FOPR"
-        assert len(observations["FOPR"]) == 0
-
-
 @pytest.mark.parametrize("obs_type", ["HISTORY_OBSERVATION", "SUMMARY_OBSERVATION"])
 @pytest.mark.parametrize(
     "obs_content, match",


### PR DESCRIPTION
**Issue**
Resolves #8353


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
