### PR TITLE
Allow user to inhibit tab changes during simulation

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -332,7 +332,8 @@ class RunDialog(QDialog):
             tab_index = self._tab_widget.addTab(
                 widget, f"Realizations for iteration {index.internalPointer().id_}"
             )
-            self._tab_widget.setCurrentIndex(tab_index)
+            if self._tab_widget.currentIndex() == self._tab_widget.count() - 2:
+                self._tab_widget.setCurrentIndex(tab_index)
 
     @Slot(QModelIndex)
     def _select_real(self, index: QModelIndex) -> None:
@@ -449,7 +450,10 @@ class RunDialog(QDialog):
             iteration = event.iteration
             widget = UpdateWidget(iteration)
             tab_index = self._tab_widget.addTab(widget, f"Update {iteration}")
-            self._tab_widget.setCurrentIndex(tab_index)
+
+            if self._tab_widget.currentIndex() == self._tab_widget.count() - 2:
+                self._tab_widget.setCurrentIndex(tab_index)
+
             widget.begin(event)
 
         elif isinstance(event, RunModelUpdateEndEvent):


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8493

Ert will only change tab index if the last index is the current active one.

https://github.com/user-attachments/assets/b900c307-6b8b-4efa-9c06-95b628bf32cb



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
