### PR TITLE
Logging improvements

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -42,6 +42,8 @@ from ert.validation import (
     ValidationStatus,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def run_ert_storage(args: Namespace, _: Optional[ErtPluginManager] = None) -> None:
     with StorageService.start_server(
@@ -635,9 +637,9 @@ def log_process_usage() -> None:
             "Swaps": usage.ru_nswap,
             "Peak memory use (kB)": maxrss,
         }
-        logging.info(f"Peak memory use: {maxrss} kB", extra=usage_dict)
+        logger.info(f"Peak memory use: {maxrss} kB", extra=usage_dict)
     except Exception as exc:
-        logging.warning(
+        logger.warning(
             f"Exception while trying to log ERT process resource usage: {exc}"
         )
 

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -17,6 +17,8 @@ from .parsing import (
     QueueSystem,
 )
 
+logger = logging.getLogger(__name__)
+
 GENERIC_QUEUE_OPTIONS: List[str] = ["MAX_RUNNING", "SUBMIT_SLEEP"]
 LSF_DRIVER_OPTIONS = [
     "BHIST_CMD",
@@ -194,7 +196,7 @@ class QueueConfig:
                 option_name in queue_options[queue_system]
                 and queue_options[queue_system][option_name] != value
             ):
-                logging.info(
+                logger.info(
                     f"Overwriting QUEUE_OPTION {selected_queue_system} {option_name}:"
                     f" \n Old value: {queue_options[queue_system][option_name]} \n New value: {value}"
                 )

--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -277,9 +277,7 @@ class LegacyEnsemble:
             await cloudevent_unary_send(event_creator(EVTYPE_ENSEMBLE_FAILED, None))
             return
 
-        logger.info(
-            f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}"
-        )
+        logger.info(f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}")
 
         # Dispatch final result from evaluator - FAILED, CANCEL or STOPPED
         await cloudevent_unary_send(event_creator(result, None))

--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -46,7 +46,6 @@ from .state import (
 )
 
 logger = logging.getLogger(__name__)
-scheduler_logger = logging.getLogger("ert.scheduler")
 
 _handle = Callable[..., Any]
 
@@ -251,7 +250,7 @@ class LegacyEnsemble:
                 ee_cert=self._config.cert,
                 ee_token=self._config.token,
             )
-            scheduler_logger.info(
+            logger.info(
                 f"Experiment ran on ORCHESTRATOR: scheduler on {self._queue_config.queue_system} queue"
             )
 
@@ -278,7 +277,7 @@ class LegacyEnsemble:
             await cloudevent_unary_send(event_creator(EVTYPE_ENSEMBLE_FAILED, None))
             return
 
-        scheduler_logger.info(
+        logger.info(
             f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}"
         )
 

--- a/src/ert/gui/tools/export/export_tool.py
+++ b/src/ert/gui/tools/export/export_tool.py
@@ -15,6 +15,8 @@ from ert.gui.tools.export.export_panel import ExportDialog
 
 from .exporter import Exporter
 
+logger = logging.getLogger(__name__)
+
 
 class ExportTool(Tool):
     def __init__(self, config: ErtConfig, notifier: ErtNotifier):
@@ -55,7 +57,7 @@ class ExportTool(Tool):
                 QMessageBox.Ok,
             )
         except UserWarning as usrwarning:
-            logging.error(str(usrwarning))
+            logger.error(str(usrwarning))
             QMessageBox.warning(
                 cast(QWidget, self.parent()),
                 "Failure",

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -2,8 +2,6 @@ version: 1
 formatters:
   terminal:
     (): ert.logging.TerminalFormatter
-  simple:
-    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
   simple_with_threading:
     format: '%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s'
 handlers:
@@ -13,52 +11,6 @@ handlers:
     filename: ert-log.txt
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
-  asyncio_file:
-    level: DEBUG
-    formatter: simple_with_threading
-    filename: asyncio-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  scheduler_file:
-    level: DEBUG
-    formatter: simple_with_threading
-    filename: scheduler-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  event_log_file:
-    level: DEBUG
-    formatter: simple_with_threading
-    filename: event-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  apifile:
-    level: DEBUG
-    formatter: simple
-    filename: api-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  eefile:
-    level: DEBUG
-    formatter: simple_with_threading
-    filename: ee-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  websocketsfile:
-    level: INFO
-    formatter: simple_with_threading
-    filename: websockets-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  migration_handler:
-    level: DEBUG
-    formatter: simple
-    filename: migration-log.txt
-    (): ert.logging.TimestampedFileHandler
-    use_log_dir_from_env: true
-  stream:
-    class: logging.StreamHandler
-    level: DEBUG
-    formatter: simple_with_threading
   terminal:
     level: INFO
     formatter: terminal
@@ -67,32 +19,11 @@ handlers:
 loggers:
   asyncio:
     level: DEBUG
-    handlers: [asyncio_file]
-    propagate: no
   azure.core:
     level: WARNING
-  ert.shared.storage:
-    level: DEBUG
-    handlers: [apifile]
-    propagate: yes
-  ert.event_log:
-    level: DEBUG
-    handlers: [event_log_file]
-    propagate: no
-  ert.shared.status:
-    level: DEBUG
-    handlers: [file]
-    propagate: yes
-  ert.plugins:
-    level: DEBUG
-    propagate: yes
-  ert.ensemble_evaluator:
-    level: DEBUG
-    handlers: [eefile]
-    propagate: no
   ert.storage.migration:
-    level: INFO
-    handlers: [terminal, migration_handler]
+    level: DEBUG
+    handlers: [terminal]
     propagate: yes
   h5py:
     level: INFO
@@ -103,36 +34,11 @@ loggers:
   subscript:
     level: INFO
   websockets:
-    level: DEBUG
-    handlers: [websocketsfile]
-    propagate: no
-  ert.analysis:
-    level: DEBUG
-    propagate: yes
-  ert.config:
-    level: DEBUG
-    propagate: yes
-  ert.enkf_main:
-    level: DEBUG
-    propagate: yes
-  ert.run_arg:
     level: INFO
-    propagate: yes
-  ert.run_context:
-    level: INFO
-    propagate: yes
-  ert.substitution_list:
-    level: INFO
-    propagate: yes
-  ert.callbacks:
-    level: DEBUG
-    propagate: yes
-  ert.scheduler:
-    level: DEBUG
-    handlers: [scheduler_file]
-    propagate: yes
 
 
 root:
   level: DEBUG
   handlers: [file]
+
+disable_existing_loggers: False

--- a/src/ert/plugins/workflow_config.py
+++ b/src/ert/plugins/workflow_config.py
@@ -7,6 +7,8 @@ import tempfile
 from argparse import ArgumentParser
 from typing import Any, Callable, Dict, List, Optional, Type
 
+logger = logging.getLogger(__name__)
+
 
 class WorkflowConfigs:
     """

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -82,7 +82,7 @@ from .event import (
     RunModelUpdateEndEvent,
 )
 
-event_logger = logging.getLogger("ert.event_log")
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ert.config import QueueConfig
@@ -437,9 +437,9 @@ class BaseRunModel:
         self, ee_config: EvaluatorServerConfig, iteration: int
     ) -> bool:
         try:
-            event_logger.debug("connecting to new monitor...")
+            logger.debug("connecting to new monitor...")
             async with Monitor(ee_config.get_connection_info()) as monitor:
-                event_logger.debug("connected")
+                logger.debug("connected")
                 async for event in monitor.track(heartbeat_interval=0.1):
                     if event is not None and event["type"] in (
                         EVTYPE_EE_SNAPSHOT,
@@ -450,29 +450,29 @@ class BaseRunModel:
                             ENSEMBLE_STATE_STOPPED,
                             ENSEMBLE_STATE_FAILED,
                         ]:
-                            event_logger.debug(
+                            logger.debug(
                                 "observed evaluation stopped event, signal done"
                             )
                             await monitor.signal_done()
 
                         if event.data.get(STATUS) == ENSEMBLE_STATE_CANCELLED:
-                            event_logger.debug(
+                            logger.debug(
                                 "observed evaluation cancelled event, exit drainer"
                             )
                             # Allow track() to emit an EndEvent.
                             return False
                     elif event is not None and event["type"] == EVTYPE_EE_TERMINATED:
-                        event_logger.debug("got terminator event")
+                        logger.debug("got terminator event")
 
                     if not self._end_queue.empty():
-                        event_logger.debug("Run model canceled - during evaluation")
+                        logger.debug("Run model canceled - during evaluation")
                         self._end_queue.get()
                         await monitor.signal_cancel()
-                        event_logger.debug(
+                        logger.debug(
                             "Run model canceled - during evaluation - cancel sent"
                         )
         except BaseException:
-            event_logger.exception("unexpected error: ")
+            logger.exception("unexpected error: ")
             # We really don't know what happened...  shut down
             # the thread and get out of here. The monitor has
             # been stopped by the ctx-mgr
@@ -487,7 +487,7 @@ class BaseRunModel:
         ee_config: EvaluatorServerConfig,
     ) -> List[int]:
         if not self._end_queue.empty():
-            event_logger.debug("Run model canceled - pre evaluation")
+            logger.debug("Run model canceled - pre evaluation")
             self._end_queue.get()
             return []
         ee_ensemble = self._build_ensemble(run_args, ensemble.experiment_id)
@@ -501,14 +501,12 @@ class BaseRunModel:
         if not (await self.run_monitor(ee_config, ensemble.iteration)):
             return []
 
-        event_logger.debug(
-            "observed that model was finished, waiting tasks completion..."
-        )
+        logger.debug("observed that model was finished, waiting tasks completion...")
         # The model has finished, we indicate this by sending a DONE
-        event_logger.debug("tasks complete")
+        logger.debug("tasks complete")
 
         if not self._end_queue.empty():
-            event_logger.debug("Run model canceled - post evaluation")
+            logger.debug("Run model canceled - post evaluation")
             self._end_queue.get()
             return []
         await evaluator_task
@@ -630,19 +628,15 @@ class BaseRunModel:
 
         num_successful_realizations = len(successful_realizations)
         self.validate()
-        event_logger.info(
-            f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}"
-        )
-        event_logger.info(
-            f"Experiment ran with number of realizations: {self.ensemble_size}"
-        )
-        event_logger.info(
+        logger.info(f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}")
+        logger.info(f"Experiment ran with number of realizations: {self.ensemble_size}")
+        logger.info(
             f"Experiment run ended with number of realizations succeeding: {num_successful_realizations}"
         )
-        event_logger.info(
+        logger.info(
             f"Experiment run ended with number of realizations failing: {self.ensemble_size - num_successful_realizations}"
         )
-        event_logger.info(f"Experiment run finished in: {self.get_runtime()}s")
+        logger.info(f"Experiment run finished in: {self.get_runtime()}s")
         self.run_workflows(HookRuntime.POST_SIMULATION, self._storage, ensemble)
 
         return num_successful_realizations

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ert.config import QueueConfig
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class EnsembleSmoother(UpdateRunModel):

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ert.config import QueueConfig
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class IteratedEnsembleSmoother(BaseRunModel):

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ert.config import QueueConfig
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class ManualUpdate(UpdateRunModel):

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -20,7 +20,7 @@ from .base_run_model import ErtRunError, StatusEvents, UpdateRunModel
 if TYPE_CHECKING:
     from ert.config import QueueConfig
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class MultipleDataAssimilation(UpdateRunModel):

--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import logging
 from typing import Dict, Mapping, Union
 
 from ert.config.gen_kw_config import GenKwConfig
 from ert.storage import Experiment
-
-logger = logging.getLogger()
 
 _PRIOR_NAME_MAP = {
     "NORMAL": "normal",

--- a/src/ert/simulator/batch_simulator_context.py
+++ b/src/ert/simulator/batch_simulator_context.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from ert.config import ErtConfig
     from ert.storage import Ensemble
 
+logger = logging.getLogger(__name__)
+
 Status = namedtuple("Status", "waiting pending running complete failed")
 
 
@@ -236,7 +238,7 @@ class BatchContext:
         res: List[Optional[Dict[str, "npt.NDArray[np.float64]"]]] = []
         for sim_id in range(len(self)):
             if self.get_job_state(iens=sim_id) != JobState.COMPLETED:
-                logging.error(f"Simulation {sim_id} failed.")
+                logger.error(f"Simulation {sim_id} failed.")
                 res.append(None)
                 continue
             d = {}


### PR DESCRIPTION
**Issue**
We are producing many log files for different modules, and some logs are not propagated correctly 

**Approach**
Have one log file for ERT, all modules propagate logs, handlers filter on log level according to their needs. 
Also, set `disable_existing_loggers: False` as the default behavior is to disable all loggers created using `logging.getLogger`. Otherwise we would need to explicitly enable them again in the logger config, making for a very verbose config. 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [x] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
