### PR TITLE
Remove hide details button in rundialog

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -192,7 +192,6 @@ class RunDialog(QDialog):
         self._event_queue = event_queue
         self._notifier = notifier
 
-        self._isDetailedDialog = True
         self._minimum_width = 1200
         self._minimum_height = 800
 
@@ -234,8 +233,6 @@ class RunDialog(QDialog):
         self.done_button.setHidden(True)
         self.restart_button = QPushButton("Restart")
         self.restart_button.setHidden(True)
-        self.show_details_button = QPushButton("Show details")
-        self.show_details_button.setCheckable(True)
 
         size = 20
         spin_movie = QMovie("img:loading.gif")
@@ -254,7 +251,6 @@ class RunDialog(QDialog):
         button_layout.addStretch()
         button_layout.addWidget(self.memory_usage)
         button_layout.addStretch()
-        button_layout.addWidget(self.show_details_button)
         button_layout.addWidget(self.plot_button)
         button_layout.addWidget(self.kill_button)
         button_layout.addWidget(self.done_button)
@@ -283,11 +279,9 @@ class RunDialog(QDialog):
         self.kill_button.clicked.connect(self.killJobs)  # type: ignore
         self.done_button.clicked.connect(self.accept)
         self.restart_button.clicked.connect(self.restart_failed_realizations)
-        self.show_details_button.clicked.connect(self.toggle_detailed_progress)
         self.simulation_done.connect(self._on_simulation_done)
 
         self.setMinimumSize(self._minimum_width, self._minimum_height)
-        self._setDetailedDialog()
         self.finished.connect(self._on_finished)
 
         self.on_run_model_event.connect(self._on_event)
@@ -299,20 +293,6 @@ class RunDialog(QDialog):
                 widget = self._tab_widget.widget(i)
                 if isinstance(widget, RealizationWidget):
                     widget.clearSelection()
-
-    def _setSimpleDialog(self) -> None:
-        self._isDetailedDialog = False
-        self._tab_widget.setVisible(False)
-        self._job_label.setVisible(False)
-        self._job_overview.setVisible(False)
-        self.show_details_button.setText("Show details")
-
-    def _setDetailedDialog(self) -> None:
-        self._isDetailedDialog = True
-        self._tab_widget.setVisible(True)
-        self._job_label.setVisible(True)
-        self._job_overview.setVisible(True)
-        self.show_details_button.setText("Hide details")
 
     @Slot(QModelIndex, int, int)
     def on_snapshot_new_iteration(
@@ -522,15 +502,6 @@ class RunDialog(QDialog):
             self.kill_button.setVisible(True)
             self.done_button.setVisible(False)
             self.run_experiment(restart=True)
-
-    @Slot()
-    def toggle_detailed_progress(self) -> None:
-        if self._isDetailedDialog:
-            self._setSimpleDialog()
-        else:
-            self._setDetailedDialog()
-
-        self.adjustSize()
 
     def _on_finished(self) -> None:
         for file_dialog in self.findChildren(FileDialog):

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -304,8 +304,6 @@ def run_experiment_fixture(request):
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
         run_dialog = gui.findChild(RunDialog)
 
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -518,29 +518,6 @@ def test_run_dialog_memory_usage_showing(
     assert max_memory_value == "60.00 kB"
 
 
-@pytest.mark.usefixtures("use_tmpdir", "set_site_config")
-def test_that_gui_runs_a_minimal_example(qtbot: QtBot, storage):
-    config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1")
-    args_mock = Mock()
-    args_mock.config = config_file
-
-    ert_config = ErtConfig.from_file(config_file)
-    with StorageService.init_service(
-        project=os.path.abspath(ert_config.ens_path),
-    ):
-        gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
-        qtbot.addWidget(gui)
-        run_experiment = gui.findChild(QToolButton, name="run_experiment")
-
-        qtbot.mouseClick(run_experiment, Qt.LeftButton)
-
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-        qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
-
-
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
     config_file = "minimal_config.ert"

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -95,13 +95,6 @@ def test_terminating_experiment_shows_a_confirmation_dialog(
         qtbot.mouseClick(run_dialog.kill_button, Qt.LeftButton)
 
 
-def test_detail_view_toggle(qtbot: QtBot, run_dialog: RunDialog):
-    details_toggled = "Hide" in run_dialog.show_details_button.text()
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-    keyword = "Show" if details_toggled else "Hide"
-    qtbot.waitUntil(lambda: keyword in run_dialog.show_details_button.text())
-
-
 def test_run_dialog_polls_run_model_for_runtime(
     qtbot: QtBot, run_dialog: RunDialog, run_model, notifier, event_queue
 ):
@@ -154,7 +147,6 @@ def test_large_snapshot(
         lambda: run_dialog._total_progress_bar.value() == 100,
         timeout=timeout_per_iter * 3,
     )
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(
         lambda: run_dialog._tab_widget.count() == 2, timeout=timeout_per_iter
     )
@@ -362,7 +354,6 @@ def test_run_dialog(events, tab_widget_count, qtbot: QtBot, run_dialog, event_qu
     for event in events:
         event_queue.put(event)
 
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(
         lambda: run_dialog._tab_widget.count() == tab_widget_count, timeout=5000
     )
@@ -403,9 +394,6 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
 
         qtbot.waitUntil(job_overview.isVisible, timeout=20000)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-        qtbot.waitUntil(job_overview.isHidden, timeout=20000)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
         realization_widget = run_dialog.findChild(RealizationWidget)
 
@@ -509,7 +497,6 @@ def test_run_dialog_memory_usage_showing(
     for event in events:
         event_queue.put(event)
 
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(
         lambda: run_dialog._tab_widget.count() == tab_widget_count, timeout=5000
     )
@@ -533,10 +520,6 @@ def test_run_dialog_memory_usage_showing(
 
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 def test_that_gui_runs_a_minimal_example(qtbot: QtBot, storage):
-    """
-    This is a regression test for a crash happening when clicking show details
-    when running a minimal example.
-    """
     config_file = "minimal_config.ert"
     with open(config_file, "w", encoding="utf-8") as f:
         f.write("NUM_REALIZATIONS 1")
@@ -555,7 +538,6 @@ def test_that_gui_runs_a_minimal_example(qtbot: QtBot, storage):
 
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
         run_dialog = gui.findChild(RunDialog)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
 
 
@@ -589,7 +571,6 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
         qtbot.mouseClick(run_experiment, Qt.LeftButton)
 
         run_dialog = wait_for_child(gui, qtbot, RunDialog)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
         QTimer.singleShot(100, lambda: handle_error_dialog(run_dialog))
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
@@ -629,9 +610,6 @@ def test_that_stdout_and_stderr_buttons_react_to_file_content(
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
         job_overview = run_dialog._job_overview
         qtbot.waitUntil(job_overview.isVisible, timeout=20000)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
-        qtbot.waitUntil(job_overview.isHidden, timeout=20000)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
         realization_widget = run_dialog.findChild(RealizationWidget)
 

--- a/tests/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -90,7 +90,6 @@ def test_run_path_deleted_error(
 
             qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
         run_dialog = gui.findChild(RunDialog)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
         qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
@@ -136,7 +135,6 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
 
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
         run_dialog = gui.findChild(RunDialog)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
         qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
@@ -180,7 +178,6 @@ def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot
 
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=10000)
         run_dialog = gui.findChild(RunDialog)
-        qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
         qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)

--- a/tests/unit_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/unit_tests/gui/test_full_manual_update_workflow.py
@@ -42,10 +42,8 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot):
     # Click start simulation and agree to the message
     run_experiment = get_child(experiment_panel, QWidget, name="run_experiment")
     qtbot.mouseClick(run_experiment, Qt.LeftButton)
-    # The Run dialog opens, click show details and wait until done appears
-    # then click it
+    # The Run dialog opens, wait until done appears, then click done
     run_dialog = wait_for_child(gui, qtbot, RunDialog)
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
     qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -646,7 +646,6 @@ def test_that_a_failing_job_shows_error_message_with_context(
     qtbot.mouseClick(run_experiment, Qt.LeftButton)
 
     run_dialog = wait_for_child(gui, qtbot, RunDialog)
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
 
     QTimer.singleShot(20000, lambda: handle_error_dialog(run_dialog))
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)

--- a/tests/unit_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/unit_tests/gui/test_restart_ensemble_experiment.py
@@ -72,12 +72,9 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
     qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
 
-    # The Run dialog opens, click show details and wait until done appears
-    # then click it
+    # The Run dialog opens, wait until done appears, then click done
     qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
     run_dialog = gui.findChild(RunDialog)
-
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.MouseButton.LeftButton)
 
     qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)

--- a/tests/unit_tests/gui/test_single_test_run.py
+++ b/tests/unit_tests/gui/test_single_test_run.py
@@ -30,10 +30,8 @@ def test_single_test_run_after_ensemble_experiment(
 
     run_experiment = get_child(experiment_panel, QWidget, name="run_experiment")
     qtbot.mouseClick(run_experiment, Qt.LeftButton)
-    # The Run dialog opens, click show details and wait until done appears
-    # then click it
+    # The Run dialog opens, wait until done appears, then click done
     run_dialog = wait_for_child(gui, qtbot, RunDialog)
-    qtbot.mouseClick(run_dialog.show_details_button, Qt.LeftButton)
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
     qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)


### PR DESCRIPTION
We already show all details by default, and there is no obvious reason why users would want to hide the details whenever ert is running


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
