### PR TITLE
Select first realizations by default in gui

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -311,8 +311,7 @@ class RunDialog(QFrame):
 
             widget = RealizationWidget(iter_row)
             widget.setSnapshotModel(self._snapshot_model)
-            widget.itemClicked.connect(self._select_real)
-
+            self._select_real(widget._real_list_model.index(0, 0))
             tab_index = self._tab_widget.addTab(
                 widget, f"Realizations for iteration {index.internalPointer().id_}"
             )
@@ -321,23 +320,22 @@ class RunDialog(QFrame):
 
     @Slot(QModelIndex)
     def _select_real(self, index: QModelIndex) -> None:
-        real = index.row()
-        iter_ = index.model().get_iter()  # type: ignore
-        exec_hosts = None
+        if index.isValid():
+            real = index.row()
+            iter_ = index.model().get_iter()  # type: ignore
+            exec_hosts = None
 
-        iter_node = self._snapshot_model.root.children.get(str(iter_), None)
-        if iter_node:
-            real_node = iter_node.children.get(str(real), None)
-            if real_node:
-                exec_hosts = real_node.data.exec_hosts
+            iter_node = self._snapshot_model.root.children.get(str(iter_), None)
+            if iter_node:
+                real_node = iter_node.children.get(str(real), None)
+                if real_node:
+                    exec_hosts = real_node.data.exec_hosts
 
-        self._fm_step_overview.set_realization(iter_, real)
-        text = (
-            f"Realization id {index.data(RealIens)} in iteration {index.data(IterNum)}"
-        )
-        if exec_hosts and exec_hosts != "-":
-            text += f", assigned to host: {exec_hosts}"
-        self._fm_step_label.setText(text)
+            self._fm_step_overview.set_realization(iter_, real)
+            text = f"Realization id {index.data(RealIens)} in iteration {index.data(IterNum)}"
+            if exec_hosts and exec_hosts != "-":
+                text += f", assigned to host: {exec_hosts}"
+            self._fm_step_label.setText(text)
 
     def run_experiment(self, restart: bool = False) -> None:
         self._restart = restart

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -3,6 +3,7 @@ from typing import Optional
 from qtpy.QtCore import (
     QAbstractItemModel,
     QEvent,
+    QItemSelectionModel,
     QModelIndex,
     QObject,
     QPoint,
@@ -73,6 +74,11 @@ class RealizationWidget(QWidget):
 
         self._real_view.setModel(self._real_list_model)
         self._real_list_model.setIter(self._iter)
+
+        first_real = self._real_list_model.index(0, 0)
+        selection_model = self._real_view.selectionModel()
+        if first_real.isValid() and selection_model:
+            selection_model.select(first_real, QItemSelectionModel.SelectionFlag.Select)
 
     def clearSelection(self) -> None:
         self._real_view.clearSelection()

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -542,6 +542,7 @@ def test_run_dialog_fm_label_show_correct_info(
     assert fm_step_model._real == 0
 
     fm_step_label = run_dialog.findChild(QLabel, name="fm_step_label")
+    assert "Realization id 0 in iteration 0" in fm_step_label.text()
 
     realization_box._item_clicked(run_dialog._fm_step_overview.model().index(0, 0))
     assert (

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -542,7 +542,6 @@ def test_run_dialog_fm_label_show_correct_info(
     assert fm_step_model._real == 0
 
     fm_step_label = run_dialog.findChild(QLabel, name="fm_step_label")
-    assert not fm_step_label.text()
 
     realization_box._item_clicked(run_dialog._fm_step_overview.model().index(0, 0))
     assert (


### PR DESCRIPTION
**Issue**
Resolves #8419


**Approach**
Now when run_dialog is opened, it shows the first realization as default in job_overview and in realization list with proper color highlighting.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
