### PR TITLE
Fix flaky config generator

### DIFF
--- a/tests/unit_tests/config/observations_generator.py
+++ b/tests/unit_tests/config/observations_generator.py
@@ -233,7 +233,7 @@ def observations(draw, ensemble_keys, summary_keys, std_cutoff, start_date):
                         start=st.integers(min_value=1, max_value=10),
                         stop=st.integers(min_value=1, max_value=10),
                         error=st.floats(
-                            min_value=0.0,
+                            min_value=0.01,
                             allow_nan=False,
                             allow_infinity=False,
                             exclude_min=True,


### PR DESCRIPTION
After https://github.com/equinor/ert/commit/2d73055453420815b82f04dec6aca6f693cae005 the tests are flaky due to the generator possibly creating error=0.0


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
