### PR TITLE
Fix job label not updating when selecting same index

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import (
     QAbstractItemView,
     QDialog,
     QDialogButtonBox,
+    QFrame,
     QHBoxLayout,
     QHeaderView,
     QLabel,
@@ -264,13 +265,18 @@ class RunDialog(QDialog):
         layout.addWidget(self._total_progress_bar)
         layout.addWidget(self._iteration_progress_label)
         layout.addWidget(self._progress_widget)
-        layout.addWidget(self._job_label)
 
         adjustable_splitter_layout = QSplitter()
         adjustable_splitter_layout.setOrientation(Qt.Orientation.Vertical)
         adjustable_splitter_layout.addWidget(self._tab_widget)
-        adjustable_splitter_layout.addWidget(self._job_overview)
 
+        self.job_frame = QFrame(self)
+        job_frame_layout = QVBoxLayout(self.job_frame)
+        job_frame_layout.setContentsMargins(0, 0, 0, 0)
+        job_frame_layout.addWidget(self._job_label)
+        job_frame_layout.addWidget(self._job_overview)
+
+        adjustable_splitter_layout.addWidget(self.job_frame)
         layout.addWidget(adjustable_splitter_layout)
         layout.addWidget(button_widget_container)
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -307,7 +307,7 @@ class RunDialog(QDialog):
 
             widget = RealizationWidget(iter_row)
             widget.setSnapshotModel(self._snapshot_model)
-            widget.currentChanged.connect(self._select_real)
+            widget.itemClicked.connect(self._select_real)
 
             tab_index = self._tab_widget.addTab(
                 widget, f"Realizations for iteration {index.internalPointer().id_}"

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 from qtpy.QtCore import (
     QAbstractItemModel,
@@ -54,10 +54,7 @@ class RealizationWidget(QWidget):
             f"QListView {{ background-color: {self.palette().color(QPalette.Window).name()}; }}"
         )
 
-        def _emit_change(current: QModelIndex, previous: Any) -> None:
-            self.currentChanged.emit(current)
-
-        self._real_view.currentChanged = _emit_change  # type: ignore
+        self._real_view.clicked.connect(self._item_clicked)
 
         layout = QVBoxLayout()
         layout.addWidget(self._real_view)
@@ -65,7 +62,10 @@ class RealizationWidget(QWidget):
         self.setLayout(layout)
 
     # Signal when the user selects another real
-    currentChanged = Signal(QModelIndex)
+    itemClicked = Signal(QModelIndex)
+
+    def _item_clicked(self, item: QModelIndex) -> None:
+        self.itemClicked.emit(item)
 
     def setSnapshotModel(self, model: QAbstractItemModel) -> None:
         self._real_list_model = RealListModel(self, self._iter)

--- a/tests/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/unit_tests/gui/simulation/test_run_dialog.py
@@ -401,7 +401,7 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
             realization_widget._real_list_model.index(0, 0)
         ).center()
 
-        with qtbot.waitSignal(realization_widget.currentChanged, timeout=30000):
+        with qtbot.waitSignal(realization_widget.itemClicked, timeout=30000):
             qtbot.mouseClick(
                 realization_widget._real_view.viewport(),
                 Qt.LeftButton,
@@ -594,7 +594,7 @@ def test_that_stdout_and_stderr_buttons_react_to_file_content(
             realization_widget._real_list_model.index(0, 0)
         ).center()
 
-        with qtbot.waitSignal(realization_widget.currentChanged, timeout=30000):
+        with qtbot.waitSignal(realization_widget.itemClicked, timeout=30000):
             qtbot.mouseClick(
                 realization_widget._real_view.viewport(),
                 Qt.LeftButton,

--- a/tests/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/unit_tests/gui/simulation/view/test_realization.py
@@ -75,7 +75,7 @@ def test_selection_success(large_snapshot, qtbot):
         return isinstance(node, _Node) and str(node.id_) == str(selection_id)
 
     with qtbot.waitSignal(
-        widget.currentChanged, timeout=30000, check_params_cb=check_selection_cb
+        widget.itemClicked, timeout=30000, check_params_cb=check_selection_cb
     ):
         qtbot.mouseClick(
             widget._real_view.viewport(),


### PR DESCRIPTION
Fixes bug where selecting the same indices from different tab would not update the label.
Moved label back just above the job_overview.

![Screenshot 2024-08-19 at 14 48 12](https://github.com/user-attachments/assets/c1c4a637-3b21-48b0-85f6-970e14136671)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
