### PR TITLE
Refactor `Storage` to better represent the hierarchy `Storage`->`Experiments`->`Ensembles`

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -415,6 +415,12 @@ def get_ert_parser(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         "updated parameters will be stored.",
     )
     ensemble_smoother_parser.add_argument(
+        "--experiment-name",
+        type=str,
+        default="ensemble-experiment",
+        help="Name of the experiment",
+    )
+    ensemble_smoother_parser.add_argument(
         "--realizations",
         type=valid_realizations,
         help="These are the realizations that will be used to perform experiments."

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -24,26 +24,19 @@ class EnsembleSelector(QComboBox):
     ):
         super().__init__()
         self.notifier = notifier
-
-        # If true current ensemble of ert will be change
         self._update_ert = update_ert
-        # only show initialized ensembles
         self._show_only_undefined = show_only_undefined
         # If True, we filter out any ensembles which have children
         # One use case is if a user wants to rerun because of failures
         # not related to parameterization. We can allow that, but only
         # if the ensemble has not been used in an update, as that would
-        # invalidate the result
+        # invalidate the result.
         self._show_only_no_children = show_only_no_children
         self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
-
         self.setEnabled(False)
 
         if update_ert:
-            # Update ERT when this combo box is changed
             self.currentIndexChanged[int].connect(self._on_current_index_changed)
-
-            # Update this combo box when ERT is changed
             notifier.current_ensemble_changed.connect(
                 self._on_global_current_ensemble_changed
             )
@@ -60,44 +53,41 @@ class EnsembleSelector(QComboBox):
 
     def populate(self) -> None:
         block = self.blockSignals(True)
-
         self.clear()
-
         if self._ensemble_list():
             self.setEnabled(True)
-
         for ensemble in self._ensemble_list():
             self.addItem(ensemble.name, userData=ensemble)
-
         current_index = self.findData(
             self.notifier.current_ensemble, Qt.ItemDataRole.UserRole
         )
-
         self.setCurrentIndex(max(current_index, 0))
-
         self.blockSignals(block)
-
         self.ensemble_populated.emit()
 
     def _ensemble_list(self) -> Iterable[Ensemble]:
+        if not self.notifier.is_storage_available:
+            return []
+
+        all_ensembles = []
+        for experiment in self.notifier.storage.experiments:
+            all_ensembles.extend(experiment.ensembles)
+
         if self._show_only_undefined:
-            ensembles = (
+            all_ensembles = [
                 ensemble
-                for ensemble in self.notifier.storage.ensembles
+                for ensemble in all_ensembles
                 if all(
                     e == RealizationStorageState.UNDEFINED
                     for e in ensemble.get_ensemble_state()
                 )
-            )
-        else:
-            ensembles = self.notifier.storage.ensembles
-        ensemble_list = list(ensembles)
-        if self._show_only_no_children:
-            parents = [
-                ens.parent for ens in self.notifier.storage.ensembles if ens.parent
             ]
-            ensemble_list = [val for val in ensemble_list if val.id not in parents]
-        return sorted(ensemble_list, key=lambda x: x.started_at, reverse=True)
+
+        if self._show_only_no_children:
+            parents = [ens.parent for ens in all_ensembles if ens.parent]
+            all_ensembles = [val for val in all_ensembles if val.id not in parents]
+
+        return sorted(all_ensembles, key=lambda x: x.started_at, reverse=True)
 
     def _on_current_index_changed(self, index: int) -> None:
         self.notifier.set_current_ensemble(self.itemData(index))

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -684,11 +684,10 @@ class UpdateRunModel(BaseRunModel):
                 msg="Creating posterior ensemble..",
             )
         )
-        posterior = self._storage.create_ensemble(
-            prior.experiment,
+        posterior = prior.experiment.create_ensemble(
+            name=posterior_name,
             ensemble_size=prior.ensemble_size,
             iteration=prior.iteration + 1,
-            name=posterior_name,
             prior_ensemble=prior,
         )
         if prior.iteration == 0:

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -39,7 +39,6 @@ class EnsembleExperiment(BaseRunModel):
         self.experiment_name = experiment_name
         self.experiment: Experiment | None = None
         self.ensemble: Ensemble | None = None
-
         super().__init__(
             config,
             storage,
@@ -63,8 +62,8 @@ class EnsembleExperiment(BaseRunModel):
                 observations=self.ert_config.observations,
                 responses=self.ert_config.ensemble_config.response_configuration,
             )
-            self.ensemble = self._storage.create_ensemble(
-                self.experiment,
+            assert self.experiment
+            self.ensemble = self.experiment.create_ensemble(
                 name=self.ensemble_name,
                 ensemble_size=self.ensemble_size,
             )
@@ -82,6 +81,7 @@ class EnsembleExperiment(BaseRunModel):
             np.array(self.active_realizations, dtype=bool),
             ensemble=self.ensemble,
         )
+
         sample_prior(
             self.ensemble,
             np.where(self.active_realizations)[0],

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -19,7 +19,6 @@ from .base_run_model import StatusEvents, UpdateRunModel
 if TYPE_CHECKING:
     from ert.config import QueueConfig
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -53,7 +52,6 @@ class EnsembleSmoother(UpdateRunModel):
         )
         self.target_ensemble_format = target_ensemble
         self.experiment_name = experiment_name
-
         self.support_restart = False
 
     def run_experiment(
@@ -67,39 +65,36 @@ class EnsembleSmoother(UpdateRunModel):
             responses=self.ert_config.ensemble_config.response_configuration,
             name=self.experiment_name,
         )
-
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
-        prior = self._storage.create_ensemble(
-            experiment,
-            ensemble_size=self.ensemble_size,
+
+        prior = experiment.create_ensemble(
             name=ensemble_format % 0,
+            ensemble_size=self.ensemble_size,
         )
         self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
+
         prior_args = create_run_arguments(
             self.run_paths,
             np.array(self.active_realizations, dtype=bool),
             ensemble=prior,
         )
-
         sample_prior(
             prior,
             np.where(self.active_realizations)[0],
             random_seed=self.random_seed,
         )
-
         self._evaluate_and_postprocess(
             prior_args,
             prior,
             evaluator_server_config,
         )
-        posterior = self.update(prior, ensemble_format % 1)
 
+        posterior = self.update(prior, ensemble_format % 1)
         posterior_args = create_run_arguments(
             self.run_paths,
             np.array(self.active_realizations, dtype=bool),
             ensemble=posterior,
         )
-
         self._evaluate_and_postprocess(
             posterior_args,
             posterior,

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -133,10 +133,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
             responses=self.ert_config.ensemble_config.response_configuration,
             name=self.experiment_name,
         )
-        prior = self._storage.create_ensemble(
-            experiment=experiment,
-            ensemble_size=self.ensemble_size,
+        prior = experiment.create_ensemble(
             name=target_ensemble_format % 0,
+            ensemble_size=self.ensemble_size,
         )
         self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
@@ -172,9 +171,8 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 )
             )
 
-            posterior = self._storage.create_ensemble(
-                experiment,
-                name=target_ensemble_format % (prior_iter + 1),  # noqa
+            posterior = experiment.create_ensemble(
+                name=target_ensemble_format % (prior_iter + 1),
                 ensemble_size=prior.ensemble_size,
                 iteration=prior_iter + 1,
                 prior_ensemble=prior,
@@ -194,8 +192,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
                     initial_mask=initial_mask,
                 )
 
-                # sies iteration starts at 1, we keep iters at 0,
-                # so we subtract sies to be 0-indexed
                 analysis_success = prior_iter < (self.sies_iteration - 1)
                 if analysis_success:
                     update_success = True

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -105,11 +105,10 @@ class MultipleDataAssimilation(UpdateRunModel):
                 name=self.experiment_name,
             )
 
-            prior = self._storage.create_ensemble(
-                experiment,
+            prior = experiment.create_ensemble(
+                name=self.target_ensemble_format % 0,
                 ensemble_size=self.ensemble_size,
                 iteration=0,
-                name=self.target_ensemble_format % 0,
             )
             self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
             self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))

--- a/src/ert/simulator/batch_simulator.py
+++ b/src/ert/simulator/batch_simulator.py
@@ -9,7 +9,10 @@ from ert.config import ErtConfig, ExtParamConfig, GenDataConfig
 from .batch_simulator_context import BatchContext
 
 if TYPE_CHECKING:
-    from ert.storage import Ensemble, Storage
+    from ert.storage import (
+        Ensemble,
+        Storage,
+    )
 
 
 class BatchSimulator:
@@ -230,8 +233,7 @@ class BatchSimulator:
             parameters=self.ert_config.ensemble_config.parameter_configuration,
             responses=self.ert_config.ensemble_config.response_configuration,
         )
-        ensemble = storage.create_ensemble(
-            experiment.id,
+        ensemble = experiment.create_ensemble(
             name=case_name,
             ensemble_size=self.ert_config.model_config.num_realizations,
         )

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -1,3 +1,8 @@
+"""
+Hierarchical Structure:
+The code follows a clear hierarchical structure: Storage -> Experiment -> Ensemble.
+"""
+
 from __future__ import annotations
 
 import os

--- a/tests/integration_tests/analysis/test_es_update.py
+++ b/tests/integration_tests/analysis/test_es_update.py
@@ -57,13 +57,16 @@ def test_that_posterior_has_lower_variance_than_prior():
         "--disable-monitor",
         "--realizations",
         "1-50",
+        "--experiment-name",
+        "testing",
         "poly.ert",
     )
     facade = LibresFacade.from_config_file("poly.ert")
     with open_storage(facade.enspath) as storage:
-        prior_ensemble = storage.get_ensemble_by_name("iter-0")
+        experiment = storage.get_experiment_by_name("testing")
+        prior_ensemble = experiment.get_ensemble_by_name("iter-0")
         df_default = prior_ensemble.load_all_gen_kw_data()
-        posterior_ensemble = storage.get_ensemble_by_name("iter-1")
+        posterior_ensemble = experiment.get_ensemble_by_name("iter-1")
         df_target = posterior_ensemble.load_all_gen_kw_data()
 
         # The std for the ensemble should decrease
@@ -170,8 +173,9 @@ def test_update_multiple_param():
     ert_config = ErtConfig.from_file("snake_oil.ert")
 
     storage = open_storage(ert_config.ens_path)
-    prior_ensemble = storage.get_ensemble_by_name("iter-0")
-    posterior_ensemble = storage.get_ensemble_by_name("iter-1")
+    experiment = storage.get_experiment_by_name("ensemble-experiment")
+    prior_ensemble = experiment.get_ensemble_by_name("iter-0")
+    posterior_ensemble = experiment.get_ensemble_by_name("iter-1")
 
     prior_array = _all_parameters(prior_ensemble, list(range(10)))
     posterior_array = _all_parameters(posterior_ensemble, list(range(10)))


### PR DESCRIPTION
We have talked about making the concept of `Experiment` more central in ert.
For example, e want to be able to select and delete experiments from the GUI and have a nice API to use via Jupyter Notebooks.

As a step towards this, I propose a refactor of the storage that better reflects the hierarchy of `Storage`->`Experiments`->`Ensembles`.

Main ideas:
- `Storage` is responsible for creating and deleting `Experiments`
- `Experiment` is responsible for creating and (eventually perhaps) deleting `Ensembles`
- `Ensemble` has methods for reading parameters, responses etc.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
