### PR TITLE
Use EDS icon and stylesheets for run_dialog splitter

### DIFF
--- a/src/ert/gui/resources/gui/img/drag_handle.svg
+++ b/src/ert/gui/resources/gui/img/drag_handle.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 9h16v2H4zm16 6H4v-2h16z"/></svg>

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -270,6 +270,15 @@ class RunDialog(QDialog):
         adjustable_splitter_layout.setOrientation(Qt.Orientation.Vertical)
         adjustable_splitter_layout.addWidget(self._tab_widget)
 
+        adjustable_splitter_layout.setStyleSheet("""
+            QSplitter::handle {
+                image: url(img:drag_handle.svg);
+                height: 13px;
+                background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+                   stop: 0.1 #10FFFFFF, stop: 0.5 #D3D3D3, stop: 0.9 #10FFFFFF);
+            }
+         """)
+
         self.job_frame = QFrame(self)
         job_frame_layout = QVBoxLayout(self.job_frame)
         job_frame_layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
![Screenshot 2024-08-20 at 08 57 52](https://github.com/user-attachments/assets/64b95267-5336-4bbf-b144-d6e72c710fec)

![Screenshot 2024-08-20 at 08 58 05](https://github.com/user-attachments/assets/66cab885-afba-4a40-ae78-64a6f1ad09f1)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
