### PR TITLE
Hide JobOverview when UpdateWidget is visible in run_dialog

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -293,12 +293,8 @@ class RunDialog(QDialog):
         self.on_run_model_event.connect(self._on_event)
 
     def _current_tab_changed(self, index: int) -> None:
-        # Clear the selection in the other tabs
-        for i in range(0, self._tab_widget.count()):
-            if i != index:
-                widget = self._tab_widget.widget(i)
-                if isinstance(widget, RealizationWidget):
-                    widget.clearSelection()
+        widget = self._tab_widget.widget(index)
+        self.job_frame.setHidden(isinstance(widget, UpdateWidget))
 
     @Slot(QModelIndex, int, int)
     def on_snapshot_new_iteration(


### PR DESCRIPTION
**Issue**
Resolves #8495 

Hide JobOverview when UpdateWidget is selected.

Possibly resolved bug where selections are not retained. 🤔 


https://github.com/user-attachments/assets/26e92db0-491b-41c7-9133-10b7d5b206dd


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
