### PR TITLE
Remove redundant experiment_id from ensemble

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -170,9 +170,7 @@ class LegacyEnsemble:
         async with Client(url, token, cert, max_retries=retries) as client:
             await client._send(to_json(event, data_marshaller=evaluator_marshaller))
 
-    def generate_event_creator(
-        self, experiment_id: Optional[str] = None
-    ) -> Callable[[str, Optional[int]], CloudEvent]:
+    def generate_event_creator(self) -> Callable[[str, Optional[int]], CloudEvent]:
         def event_builder(status: str, real_id: Optional[int] = None) -> CloudEvent:
             source = f"/ert/ensemble/{self.id_}"
             if real_id is not None:
@@ -219,7 +217,6 @@ class LegacyEnsemble:
     async def _evaluate_inner(  # pylint: disable=too-many-branches
         self,
         cloudevent_unary_send: Callable[[CloudEvent], Awaitable[None]],
-        experiment_id: Optional[str] = None,
         scheduler_queue: Optional[asyncio.Queue[CloudEvent]] = None,
         manifest_queue: Optional[asyncio.Queue[CloudEvent]] = None,
     ) -> None:
@@ -235,7 +232,7 @@ class LegacyEnsemble:
         is a function (or bound method) that only takes a CloudEvent as a positional
         argument.
         """
-        event_creator = self.generate_event_creator(experiment_id=experiment_id)
+        event_creator = self.generate_event_creator()
 
         if not self.id_:
             raise ValueError("Ensemble id not set")


### PR DESCRIPTION
**Issue**
`experiment_id` is not used anymore in `ensemble.evaluate` anymore and thus candidate for removal.


**Approach**
:scissors: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
