### PR TITLE
Remove skipped out-of-memory test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,12 +269,6 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
     parser.addoption(
-        "--runoom",
-        action="store_true",
-        default=False,
-        help="Run Out-of-memory (OOM) test, ensure you are alone on your machine before running",
-    )
-    parser.addoption(
         "--eclipse-simulator",
         action="store_true",
         default=False,
@@ -352,15 +346,6 @@ def pytest_collection_modifyitems(config, items):
                 "--eclipse-simulator"
             ):
                 item.add_marker(pytest.mark.skip("Requires eclipse"))
-
-    if not config.getoption("--runoom"):
-        skip_oom = pytest.mark.skip(
-            "Skipping out-of-memory (oom) test, add --runoom to "
-            "include. Ensure the test will not affect others"
-        )
-        for item in items:
-            if "out_of_memory" in item.keywords:
-                item.add_marker(skip_oom)
 
 
 def _run_snake_oil(source_root):


### PR DESCRIPTION
This test has been moved elsewhere where it is run regularly. Should not keep a test in the repository that is skipped by default, as it is likely to not be able to catch regressions

**Issue**
Resolves https://github.com/equinor/komodo-releases/issues/5858

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
