### PR TITLE
Set status explicitly in progress_bar_label

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -397,11 +397,13 @@ class RunDialog(QDialog):
         self.kill_button.setHidden(True)
         self.restart_button.setVisible(self._run_model.has_failed_realizations())
         self.restart_button.setEnabled(self._run_model.support_restart)
-        self.update_total_progress(1.0, msg)
         self._notifier.set_is_simulation_running(False)
         if failed:
+            self.update_total_progress(1.0, "Failed")
             self.fail_msg_box = ErtMessageBox("ERT experiment failed!", msg, self)
             self.fail_msg_box.exec_()
+        else:
+            self.update_total_progress(1.0, "Experiment completed.")
 
     @Slot()
     def _on_ticker(self) -> None:


### PR DESCRIPTION
**Issue**
Resolves #8505 

Just show "Failed" as before.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
