### PR TITLE
Fix broken ert test_run

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -254,6 +254,7 @@ class QueueConfig:
     max_submit: int = 1
     queue_system: QueueSystem = QueueSystem.LOCAL
     queue_options: QueueOptions = field(default_factory=QueueOptions)
+    queue_options_test_run: QueueOptions = field(default_factory=LocalQueueOptions)
     stop_long_running: bool = False
 
     @no_type_check
@@ -297,6 +298,7 @@ class QueueConfig:
         )
 
         queue_options = _all_validated_queue_options[selected_queue_system]
+        queue_options_test_run = _all_validated_queue_options[QueueSystem.LOCAL]
         queue_options.add_global_queue_options(config_dict)
 
         if queue_options.project_code is None:
@@ -351,6 +353,7 @@ class QueueConfig:
             max_submit,
             selected_queue_system,
             queue_options,
+            queue_options_test_run,
             stop_long_running=stop_long_running,
         )
 
@@ -360,7 +363,8 @@ class QueueConfig:
             self.realization_memory,
             self.max_submit,
             QueueSystem.LOCAL,
-            self.queue_options,
+            self.queue_options_test_run,
+            self.queue_options_test_run,
             stop_long_running=self.stop_long_running,
         )
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -41,6 +41,13 @@ def test_bad_config_error_message(tmp_path):
         run_cli(TEST_RUN_MODE, "--disable-monitor", str(tmp_path / "test.ert"))
 
 
+def test_test_run_on_lsf_configuration_works_with_no_errors(tmp_path):
+    (tmp_path / "test.ert").write_text(
+        "NUM_REALIZATIONS 1\nQUEUE_SYSTEM LSF", encoding="utf-8"
+    )
+    run_cli(TEST_RUN_MODE, "--disable-monitor", str(tmp_path / "test.ert"))
+
+
 @pytest.mark.parametrize(
     "mode",
     [

--- a/tests/unit_tests/config/test_queue_config.py
+++ b/tests/unit_tests/config/test_queue_config.py
@@ -24,7 +24,9 @@ from ert.scheduler import LocalDriver, LsfDriver, OpenPBSDriver, SlurmDriver
 def test_create_local_copy_is_a_copy_with_local_queue_system():
     queue_config = QueueConfig(queue_system=QueueSystem.LSF)
     assert queue_config.queue_system == QueueSystem.LSF
-    assert queue_config.create_local_copy().queue_system == QueueSystem.LOCAL
+    local_queue_config = queue_config.create_local_copy()
+    assert local_queue_config.queue_system == QueueSystem.LOCAL
+    assert isinstance(local_queue_config.queue_options, LocalQueueOptions)
 
 
 @pytest.mark.parametrize("value", [True, False])


### PR DESCRIPTION
The commit 4013764 introduced a regression such that `ert test_run` would fail on any configs that sets a queue system other than "local".

This was due to the function `create_local_copy()` not having been updated to yield the correct QueueOptions object after refactoring.

**Issue**
Resolves #8530

**Approach**
:brain:


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
