### PR TITLE
Fix bug where seed was not set for manual initialization

### DIFF
--- a/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
+++ b/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
@@ -116,6 +116,7 @@ class ManageExperimentsPanel(QTabWidget):
                 ensemble=ensemble_selector.currentData(),
                 active_realizations=[int(i) for i in members_model.getSelectedItems()],
                 parameters=parameters,
+                random_seed=self.ert_config.random_seed,
             )
 
         def update_button_state() -> None:

--- a/tests/unit_tests/gui/tools/test_manage_experiments_tool.py
+++ b/tests/unit_tests/gui/tools/test_manage_experiments_tool.py
@@ -19,6 +19,7 @@ from ert.storage.realization_storage_state import RealizationStorageState
 @pytest.mark.usefixtures("copy_poly_case")
 def test_init_prior(qtbot, storage):
     config = ErtConfig.from_file("poly.ert")
+    config.random_seed = 1234
     notifier = ErtNotifier(config.config_path)
     notifier.set_storage(storage)
     ensemble = storage.create_experiment(
@@ -46,6 +47,9 @@ def test_init_prior(qtbot, storage):
         ensemble.get_ensemble_state()
         == [RealizationStorageState.INITIALIZED] * config.model_config.num_realizations
     )
+    assert ensemble.load_parameters("COEFFS")[
+        "transformed_values"
+    ].mean() == pytest.approx(1.41487404)
 
 
 @pytest.mark.usefixtures("copy_poly_case")


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
