### PR TITLE
Change style for disabled simulation modes

### DIFF
--- a/src/ert/gui/simulation/combobox_with_description.py
+++ b/src/ert/gui/simulation/combobox_with_description.py
@@ -68,12 +68,12 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         label = index.data(LABEL_ROLE)
         description = index.data(DESCRIPTION_ROLE)
 
-        is_enabled = option.state & QStyle.State_Enabled
+        is_enabled = option.state & QStyle.State_Enabled  # type: ignore
 
         if is_enabled and (
             option.state & QStyle.State_Selected  # type: ignore
-            or option.state & QStyle.State_MouseOver
-        ):  # type: ignore
+            or option.state & QStyle.State_MouseOver  # type: ignore
+        ):
             color = COLOR_HIGHLIGHT_LIGHT
             if option.palette.text().color().value() > 150:
                 color = COLOR_HIGHLIGHT_DARK

--- a/src/ert/gui/simulation/combobox_with_description.py
+++ b/src/ert/gui/simulation/combobox_with_description.py
@@ -21,15 +21,22 @@ COLOR_HIGHLIGHT_DARK = QColor(60, 60, 60, 255)
 
 class _ComboBoxItemWidget(QWidget):
     def __init__(
-        self, label: str, description: str, parent: Optional[QWidget] = None
+        self,
+        label: str,
+        description: str,
+        enabled: bool = True,
+        parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         layout = QVBoxLayout()
         layout.setSpacing(2)
         self.setStyleSheet("background: rgba(0,0,0,1);")
         self.label = QLabel(label)
+        color = "color: rgba(192,192,192,80);" if not enabled else ";"
+
         self.label.setStyleSheet(
-            """
+            f"""
+            {color}
             padding-top:5px;
             padding-left: 5px;
             background: rgba(0,0,0,0);
@@ -39,7 +46,8 @@ class _ComboBoxItemWidget(QWidget):
         )
         self.description = QLabel(description)
         self.description.setStyleSheet(
-            """
+            f"""
+            {color}
             padding-bottom: 10px;
             padding-left: 10px;
             background: rgba(0,0,0,0);
@@ -60,16 +68,18 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         label = index.data(LABEL_ROLE)
         description = index.data(DESCRIPTION_ROLE)
 
-        if (
-            option.state & QStyle.StateFlag.State_Selected
-            or option.state & QStyle.StateFlag.State_MouseOver
-        ):
+        is_enabled = option.state & QStyle.State_Enabled
+
+        if is_enabled and (
+            option.state & QStyle.State_Selected  # type: ignore
+            or option.state & QStyle.State_MouseOver
+        ):  # type: ignore
             color = COLOR_HIGHLIGHT_LIGHT
             if option.palette.text().color().value() > 150:
                 color = COLOR_HIGHLIGHT_DARK
             painter.fillRect(option.rect, color)
 
-        widget = _ComboBoxItemWidget(label, description)
+        widget = _ComboBoxItemWidget(label, description, is_enabled)
         widget.setStyle(option.widget.style())
         widget.resize(option.rect.size())
 


### PR DESCRIPTION
**Issue**
Resolves #8531 

⚠️ I set simulation modes containing the word "experiment" as disabled for this test;

Video shows both light and dark mode effects.

https://github.com/user-attachments/assets/682a0c6b-c134-4dcf-b7f3-7db03102822b



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
