### PR TITLE
Use get_ensemble in csv-export

### DIFF
--- a/src/ert/gui/tools/export/export_panel.py
+++ b/src/ert/gui/tools/export/export_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtWidgets import QCheckBox, QWidget
@@ -25,33 +26,38 @@ class ExportDialog(CustomDialog):
     ) -> None:
         description = "The CSV export requires some information before it starts:"
         super().__init__("export", description, parent)
-
+        self.storage = storage  # Store the storage reference
         subs_list = ert_config.substitution_list
         default_csv_output_path = subs_list.get("<CSV_OUTPUT_PATH>", "output.csv")
         self.output_path_model = PathModel(default_csv_output_path)
         output_path_chooser = PathChooser(self.output_path_model)
-
         design_matrix_default = subs_list.get("<DESIGN_MATRIX_PATH>", "")
         self.design_matrix_path_model = PathModel(
             design_matrix_default, is_required=False, must_exist=True
         )
         design_matrix_path_chooser = PathChooser(self.design_matrix_path_model)
 
-        self.list_edit = ListEditBox(
-            [ensemble.name for ensemble in storage.ensembles if ensemble.has_data()]
-        )
+        # Create a dictionary of ensemble names to their IDs and experiment names
+        self.ensemble_dict = {
+            ensemble.name: {
+                "ensemble_id": str(ensemble.id),
+                "experiment_name": ensemble.experiment.name,
+            }
+            for ensemble in storage.ensembles
+            if ensemble.has_data()
+        }
+
+        self.list_edit = ListEditBox(list(self.ensemble_dict.keys()))
 
         self.drop_const_columns_check = QCheckBox()
         self.drop_const_columns_check.setChecked(False)
         self.drop_const_columns_check.setToolTip(
             "If checked, exclude columns whose value is the same for every entry"
         )
-
         self.addLabeledOption("Output file path", output_path_chooser)
         self.addLabeledOption("Design matrix path", design_matrix_path_chooser)
         self.addLabeledOption("List of ensembles to export", self.list_edit)
         self.addLabeledOption("Drop constant columns", self.drop_const_columns_check)
-
         self.addButtons()
 
     @property
@@ -60,7 +66,16 @@ class ExportDialog(CustomDialog):
 
     @property
     def ensemble_list(self) -> str:
-        return ",".join(self.list_edit.getItems())
+        selected_ensembles = self.list_edit.getItems()
+        selected_dict = {
+            self.ensemble_dict[name]["ensemble_id"]: {
+                "name": name,
+                "experiment_name": self.ensemble_dict[name]["experiment_name"],
+            }
+            for name in selected_ensembles
+            if name in self.ensemble_dict
+        }
+        return json.dumps(selected_dict)
 
     @property
     def design_matrix_path(self) -> Optional[str]:


### PR DESCRIPTION
- Run two experiments named `exp1` and `exp2`, both with one ensemble named `ensemble` and export csv:

`self.storage.get_ensemble_by_name(ensemble)` returns the "top" ensemble which means that `output.csv` contains duplicate data. For example, these are two different rows:

```console
0,0,,ensemble,0.7354534183678605,0.07936331957553952,4.152897506818011,16.270732534942358,16.270732534942358
0,0,,ensemble,0.7354534183678605,0.07936331957553952,4.152897506818011,16.270732534942358,16.270732534942358
```

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
