### PR TITLE
Remove mark applied to a fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,6 @@ def fixture_copy_snake_oil_case_storage(_shared_snake_oil_case, tmp_path, monkey
 @pytest.fixture(
     name="copy_snake_oil_field_storage",
 )
-@pytest.mark.xdist_group(name="snake_oil_case_field_storage")
 def fixture_copy_snake_oil_field_storage(
     _shared_snake_oil_field, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
This never did anything and is now deprecated in pytest.
```

$ pytest -sxv -W error
ImportError while loading conftest '/data/projects/ert/tests/conftest.py'.
tests/conftest.py:213: in <module>
    @pytest.fixture(
/data/venv/311/lib64/python3.11/site-packages/_hypothesis_pytestplugin.py:442: in _ban_given_call
    return _orig_call(self, function)
E   pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
E   See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
```

**Issue**
Resolves pytest warning

**Approach**
✂️ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
