### PR TITLE
Mute asserted warnings in schema deprecations

### DIFF
--- a/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -19,105 +19,87 @@ def test_is_angle_bracketed():
     assert not DeprecationInfo.is_angle_bracketed("")
 
 
-def make_suggestion_list(path):
-    with warnings.catch_warnings(record=True) as all_warnings:
-        _ = ErtConfig.from_file(path)
-    return [
-        str(w.message)
-        for w in all_warnings
-        if w.category == ConfigWarning and w.message.info.is_deprecation
-    ]
-
-
 @pytest.mark.parametrize("kw", JUST_REMOVE_KEYWORDS)
 def test_that_suggester_gives_simple_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(f"The keyword {kw} no longer" in s for s in suggestions)
+    with pytest.warns(ConfigWarning, match=f"The keyword {kw} no longer"):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_havana_fault_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nHAVANA_FAULT\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The behavior of HAVANA_FAULT can be reproduced using" in s for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning, match="The behavior of HAVANA_FAULT can be reproduced using"
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 @pytest.mark.parametrize("kw", REPLACE_WITH_GEN_KW)
 def test_that_suggester_gives_gen_kw_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "ert.readthedocs.io/en/latest/reference/configuration/keywords.html#gen-kw" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="ert.readthedocs.io/en/latest/reference/configuration/keywords.html#gen-kw",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 @pytest.mark.parametrize("kw", RSH_KEYWORDS)
 def test_that_suggester_gives_rsh_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "deprecated and removed support for RSH queues." in s for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning, match="deprecated and removed support for RSH queues"
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 @pytest.mark.parametrize("kw", USE_QUEUE_OPTION)
 def test_that_suggester_gives_queue_option_migrations(tmp_path, kw):
     (tmp_path / "config.ert").write_text(f"NUM_REALIZATIONS 1\n{kw}\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        f"The {kw} keyword has been removed. For most cases " in s for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning, match=f"The {kw} keyword has been removed. For most cases "
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_refcase_list_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nREFCASE_LIST case.DATA\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The corresponding plotting functionality was removed in 2015" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="The corresponding plotting functionality was removed in 2015",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_rftpath_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRFTPATH rfts/\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The corresponding plotting functionality was removed in 2015" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="The corresponding plotting functionality was removed in 2015",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_end_date_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nEND_DATE 2023.01.01\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any("only display a warning in case of problems" in s for s in suggestions)
+    with pytest.warns(
+        ConfigWarning, match="only display a warning in case of problems"
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_rerun_start_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nRERUN_START 2023.01.01\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "used for the deprecated run mode ENKF_ASSIMILATION" in s for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning, match="used for the deprecated run mode ENKF_ASSIMILATION"
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_delete_runpath_migration(tmp_path):
     (tmp_path / "config.ert").write_text("NUM_REALIZATIONS 1\nDELETE_RUNPATH TRUE\n")
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any("It was removed in 2017" in s for s in suggestions)
+    with pytest.warns(ConfigWarning, match="It was removed in 2017"):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_suggester_gives_runpath_deprecated_specifier_migration(tmp_path):
@@ -129,77 +111,83 @@ def test_suggester_gives_runpath_deprecated_specifier_migration(tmp_path):
         match="RUNPATH keyword contains deprecated value"
         r" placeholders: %d, instead use: .*real-<IENS>\/iter-<ITER>",
     ):
-        _ = ErtConfig.from_file(tmp_path / "config.ert")
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_suggester_gives_no_runpath_deprecated_specifier_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nRUNPATH real-<IENS>/iter-<ITER>\n"
     )
-    no_suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
+    # Assert no warnings from this line:  FIXMEEEE
+    ErtConfig.from_file(tmp_path / "config.ert")
 
-    (tmp_path / "config.wrong.ert").write_text(
+    (tmp_path / "config_wrong.ert").write_text(
         "NUM_REALIZATIONS 1\nRUNPATH real-%d/iter-%d\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.wrong.ert"))
-
-    assert not any(
-        "RUNPATH keyword contains deprecated value placeholders" in s
-        for s in no_suggestions
-    ) and any(
-        "RUNPATH keyword contains deprecated value placeholders" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning, match="RUNPATH keyword contains deprecated value placeholders"
+    ):
+        ErtConfig.from_file(tmp_path / "config_wrong.ert")
 
 
 def test_suggester_gives_plot_settings_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nPLOT_SETTINGS some args\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The keyword PLOT_SETTINGS was removed in 2019 and has no effect" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="The keyword PLOT_SETTINGS was removed in 2019 and has no effect",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_suggester_gives_update_settings_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nUPDATE_SETTINGS some args\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The UPDATE_SETTINGS keyword has been removed and no longer" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="The UPDATE_SETTINGS keyword has been removed and no longer",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 @pytest.mark.parametrize("definer", ["DEFINE", "DATA_KW"])
-def test_suggester_gives_deprecated_define_migration_hint(tmp_path, definer):
+@pytest.mark.parametrize(
+    "definition, expected",
+    [
+        ("<KEY1> x1", None),
+        (
+            "A B",
+            "Using .* with substitution strings that are not of the form '<KEY>' is deprecated. "
+            "Please change A to <A>",
+        ),
+        (
+            "<A<B>> C",
+            "Using .* with substitution strings that are not of the form '<KEY>' is deprecated. "
+            "Please change <A<B>> to <AB>",
+        ),
+        (
+            "<A><B> C",
+            "Using .* with substitution strings that are not of the form '<KEY>' is deprecated. "
+            "Please change <A><B> to <AB>",
+        ),
+    ],
+)
+def test_suggester_gives_deprecated_define_migration_hint(
+    tmp_path, definer, definition, expected
+):
     (tmp_path / "config.ert").write_text(
-        "NUM_REALIZATIONS 1\n"
-        f"{definer} <KEY1> x1\n"
-        f"{definer} A B\n"
-        f"{definer} <A<B>> C\n"
-        f"{definer} <A><B> C\n"
+        "NUM_REALIZATIONS 1\n" f"{definer} {definition}\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-    assert len(suggestions) == 3
-    for suggestion, expected in zip(
-        suggestions,
-        [
-            " Please change A to <A>",
-            " Please change <A<B>> to <AB>",
-            " Please change <A><B> to <AB>",
-        ],
-    ):
-        assert (
-            f"Using {definer} with substitution strings"
-            " that are not of the form '<KEY>' is deprecated." in suggestion
-        )
-        assert suggestion.endswith(expected)
+    print(f"{definer} {definition}")
+    if expected:
+        with pytest.warns(ConfigWarning, match=expected):
+            ErtConfig.from_file(tmp_path / "config.ert")
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_suggester_does_not_report_non_existent_path_due_to_missing_pre_defines(
@@ -209,32 +197,28 @@ def test_suggester_does_not_report_non_existent_path_due_to_missing_pre_defines(
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nLOAD_WORKFLOW <CONFIG_PATH>/workflow\n"
     )
-    assert [
-        x
-        for x in make_suggestion_list(str(tmp_path / "config.ert"))
-        if "DATA_KW" not in x and "DEFINE" not in x
-    ] == []
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_schedule_prediciton_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nSCHEDULE_PREDICTION_FILE no no no\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "The 'SCHEDULE_PREDICTION_FILE' config keyword has been removed" in s
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="The 'SCHEDULE_PREDICTION_FILE' config keyword has been removed",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")
 
 
 def test_that_suggester_gives_job_prefix_migration(tmp_path):
     (tmp_path / "config.ert").write_text(
         "NUM_REALIZATIONS 1\nQUEUE_OPTION TORQUE JOB_PREFIX foo\n"
     )
-    suggestions = make_suggestion_list(str(tmp_path / "config.ert"))
-
-    assert any(
-        "JOB_PREFIX as QUEUE_OPTION to the TORQUE system is deprecated" in str(s)
-        for s in suggestions
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="JOB_PREFIX as QUEUE_OPTION to the TORQUE system is deprecated",
+    ):
+        ErtConfig.from_file(tmp_path / "config.ert")


### PR DESCRIPTION
Seemingly pytest also catches the warnings that warnings.catch_warnings() catch, so let us use pytest.warns instead. Otherwise these expected warnings are hard to mute.

**Issue**
Resolves pytest warnings.

**Approach**
see commit message


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
