### PR TITLE
Resolve typing errors in combobox_with_description

### DIFF
--- a/src/ert/gui/simulation/combobox_with_description.py
+++ b/src/ert/gui/simulation/combobox_with_description.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 from qtpy.QtCore import QModelIndex, QPoint, QSize
 from qtpy.QtGui import QColor, QRegion
@@ -19,11 +19,11 @@ COLOR_HIGHLIGHT_LIGHT = QColor(230, 230, 230, 255)
 COLOR_HIGHLIGHT_DARK = QColor(60, 60, 60, 255)
 
 
-class ComboBoxItemWidget(QWidget):
+class _ComboBoxItemWidget(QWidget):
     def __init__(
         self, label: str, description: str, parent: Optional[QWidget] = None
     ) -> None:
-        super(ComboBoxItemWidget, self).__init__(parent)
+        super().__init__(parent)
         layout = QVBoxLayout()
         layout.setSpacing(2)
         self.setStyleSheet("background: rgba(0,0,0,1);")
@@ -53,7 +53,7 @@ class ComboBoxItemWidget(QWidget):
         self.setLayout(layout)
 
 
-class ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
+class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
     def paint(self, painter: Any, option: Any, index: Any) -> None:
         painter.save()
 
@@ -61,15 +61,15 @@ class ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         description = index.data(DESCRIPTION_ROLE)
 
         if (
-            option.state & QStyle.State_Selected  # type: ignore
-            or option.state & QStyle.State_MouseOver  # type: ignore
+            option.state & QStyle.StateFlag.State_Selected
+            or option.state & QStyle.StateFlag.State_MouseOver
         ):
             color = COLOR_HIGHLIGHT_LIGHT
             if option.palette.text().color().value() > 150:
                 color = COLOR_HIGHLIGHT_DARK
             painter.fillRect(option.rect, color)
 
-        widget = ComboBoxItemWidget(label, description)
+        widget = _ComboBoxItemWidget(label, description)
         widget.setStyle(option.widget.style())
         widget.resize(option.rect.size())
 
@@ -81,23 +81,19 @@ class ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         label = index.data(LABEL_ROLE)
         description = index.data(DESCRIPTION_ROLE)
 
-        widget = ComboBoxItemWidget(label, description)
+        widget = _ComboBoxItemWidget(label, description)
         return widget.sizeHint()
 
 
 class QComboBoxWithDescription(QComboBox):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
-        super(QComboBoxWithDescription, self).__init__(parent)
-        self.setItemDelegate(ComboBoxWithDescriptionDelegate(self))
+        super().__init__(parent)
+        self.setItemDelegate(_ComboBoxWithDescriptionDelegate(self))
 
-    def addItem(self, label: Optional[str], description: Any):  # type: ignore
-        super(QComboBoxWithDescription, self).addItem(label)
+    def addDescriptionItem(self, label: Optional[str], description: Any) -> None:
+        super().addItem(label)
         model = self.model()
         assert model is not None
         index = model.index(self.count() - 1, 0)
         model.setData(index, label, LABEL_ROLE)
         model.setData(index, description, DESCRIPTION_ROLE)
-
-    def addItems(self, items: List[Tuple[str, Any]]):  # type: ignore
-        for label, description in items:
-            self.addItem(label, description)

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -5,7 +5,7 @@ from queue import SimpleQueue
 from typing import TYPE_CHECKING, Any, List, Type
 
 from qtpy.QtCore import QSize, Qt, Signal
-from qtpy.QtGui import QIcon
+from qtpy.QtGui import QIcon, QStandardItemModel
 from qtpy.QtWidgets import (
     QAction,
     QApplication,
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
 from ert.gui.ertnotifier import ErtNotifier
 from ert.run_models import BaseRunModel, StatusEvents, create_model
 
-from ..ertwidgets.combobox_with_description import QComboBoxWithDescription
+from .combobox_with_description import QComboBoxWithDescription
 from .ensemble_experiment_panel import EnsembleExperimentPanel
 from .ensemble_smoother_panel import EnsembleSmootherPanel
 from .evaluate_ensemble_panel import EvaluateEnsemblePanel
@@ -148,16 +148,23 @@ class ExperimentPanel(QWidget):
         self._experiment_stack.addWidget(panel)
         experiment_type = panel.get_experiment_type()
         self._experiment_widgets[experiment_type] = panel
-        self._experiment_type_combo.addItem(
+        self._experiment_type_combo.addDescriptionItem(
             experiment_type.name(), experiment_type.description()
         )
 
         if not mode_enabled:
             item_count = self._experiment_type_combo.count() - 1
-            sim_item = self._experiment_type_combo.model().item(item_count)  # type: ignore
+            model = self._experiment_type_combo.model()
+            assert isinstance(model, QStandardItemModel)
+            sim_item = model.item(item_count)
+            assert sim_item is not None
             sim_item.setEnabled(False)
             sim_item.setToolTip("Both observations and parameters must be defined")
-            sim_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxWarning))  # type: ignore
+            style = self.style()
+            assert style is not None
+            sim_item.setIcon(
+                style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
+            )
 
         panel.simulationConfigurationChanged.connect(self.validationStatusChanged)
         self.experiment_type_changed.connect(panel.experimentTypeChanged)

--- a/tests/unit_tests/gui/test_main_window.py
+++ b/tests/unit_tests/gui/test_main_window.py
@@ -636,6 +636,7 @@ def test_that_es_mda_restart_run_box_is_disabled_when_there_are_no_cases(qtbot):
         assert gui.windowTitle().startswith("ERT - poly.ert")
 
         combo_box = get_child(gui, QComboBox, name="experiment_type")
+        qtbot.mouseClick(combo_box, Qt.MouseButton.LeftButton)
         assert combo_box.count() == 7
         combo_box.setCurrentIndex(5)
 


### PR DESCRIPTION
Just some minor adjustments:

* Move `QComboBoxWithDescription` to where it is used. 
* Add test that renders the box
* Resolve typing errors in overriding of addItem


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

