### PR TITLE
Fix restart weights

### DIFF
--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -36,7 +36,7 @@ class StringBox(QLineEdit):
         self._validation = ValidationSupport(self)
         self._validator: Optional[ArgumentDefinition] = None
         self._model = model
-        self._disable_validation = False
+        self._enable_validation = True
 
         if placeholder_text:
             self.setPlaceholderText(placeholder_text)
@@ -55,25 +55,26 @@ class StringBox(QLineEdit):
         self.modelChanged()
 
     def validateString(self) -> None:
-        if self._disable_validation:
-            return
-        string_to_validate = str(self.text())
-        if not string_to_validate and self.placeholderText():
-            string_to_validate = self.placeholderText()
-        if self._validator is not None:
-            status = self._validator.validate(string_to_validate)
+        if self._enable_validation:
+            string_to_validate = str(self.text())
+            if not string_to_validate and self.placeholderText():
+                string_to_validate = self.placeholderText()
+            if self._validator is not None:
+                status = self._validator.validate(string_to_validate)
 
-            palette = QPalette()
-            if not status:
-                palette.setColor(self.backgroundRole(), ValidationSupport.ERROR_COLOR)
-                self.setPalette(palette)
-                self._validation.setValidationMessage(
-                    str(status), ValidationSupport.EXCLAMATION
-                )
-            else:
-                palette.setColor(self.backgroundRole(), self._valid_color)
-                self.setPalette(palette)
-                self._validation.setValidationMessage("")
+                palette = QPalette()
+                if not status:
+                    palette.setColor(
+                        self.backgroundRole(), ValidationSupport.ERROR_COLOR
+                    )
+                    self.setPalette(palette)
+                    self._validation.setValidationMessage(
+                        str(status), ValidationSupport.EXCLAMATION
+                    )
+                else:
+                    palette.setColor(self.backgroundRole(), self._valid_color)
+                    self.setPalette(palette)
+                    self._validation.setValidationMessage("")
 
     def emitChange(self, q_string: Any) -> None:
         self.textChanged.emit(str(q_string))
@@ -113,8 +114,5 @@ class StringBox(QLineEdit):
     def get_text(self) -> str:
         return self.text() if self.text() else self.placeholderText()
 
-    def enable_validation(self) -> None:
-        self._disable_validation = False
-
-    def disable_validation(self) -> None:
-        self._disable_validation = True
+    def enable_validation(self, enabled: bool) -> None:
+        self._enable_validation = enabled

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -184,6 +184,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             relative_iteration_weights_model,  # type: ignore
             continuous_update=True,
         )
+        self._relative_iteration_weights_box.setObjectName("weights_input_esmda")
         self._relative_iteration_weights_box.setValidator(NumberListStringArgument())
         layout.addRow("Relative weights:", self._relative_iteration_weights_box)
 

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -149,22 +149,34 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
                 self._ensemble_selector.selected_ensemble.experiment.name
             )
 
+            self._relative_iteration_weights_box.setText(
+                self._ensemble_selector.selected_ensemble.relative_weights
+                or MultipleDataAssimilation.default_weights
+            )
+
     @Slot(bool)
     def update_experiment_edit(self, checked: bool) -> None:
         if checked:
-            self._experiment_name_field.disable_validation()
             self._experiment_name_field.setText(
                 self._ensemble_selector.selected_ensemble.experiment.name
             )
-            self._experiment_name_field.setEnabled(False)
         else:
-            self._experiment_name_field.enable_validation()
             self._experiment_name_field.clear()
-            self._experiment_name_field.setEnabled(True)
+
+        self._experiment_name_field.enable_validation(not checked)
+        self._experiment_name_field.setEnabled(not checked)
+        self._relative_iteration_weights_box.setEnabled(not checked)
 
     def restart_run_toggled(self) -> None:
         self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))
         self._ensemble_selector.setEnabled(self._restart_box.isChecked())
+
+        self._relative_iteration_weights_box.setText(
+            self._ensemble_selector.selected_ensemble.relative_weights
+            or MultipleDataAssimilation.default_weights
+            if self._restart_box.isChecked()
+            else MultipleDataAssimilation.default_weights
+        )
 
     def _createInputForWeights(self, layout: QFormLayout) -> None:
         relative_iteration_weights_model = ValueModel(self.weights)

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -47,6 +47,7 @@ class MultipleDataAssimilation(UpdateRunModel):
         update_settings: UpdateSettings,
         status_queue: SimpleQueue[StatusEvents],
     ):
+        self._relative_weights = weights
         self.weights = self.parse_weights(weights)
 
         self.target_ensemble_format = target_ensemble
@@ -98,10 +99,12 @@ class MultipleDataAssimilation(UpdateRunModel):
                     f"Prior ensemble with ID: {id} does not exists"
                 ) from err
         else:
+            sim_args = {"weights": self._relative_weights}
             experiment = self._storage.create_experiment(
                 parameters=self.ert_config.ensemble_config.parameter_configuration,
                 observations=self.ert_config.observations,
                 responses=self.ert_config.ensemble_config.response_configuration,
+                simulation_arguments=sim_args,
                 name=self.experiment_name,
             )
 

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -181,6 +181,10 @@ class LocalEnsemble(BaseMode):
     def experiment(self) -> LocalExperiment:
         return self._storage.get_experiment(self.experiment_id)
 
+    @property
+    def relative_weights(self) -> str:
+        return self._storage.get_experiment(self.experiment_id).relative_weights
+
     def get_realization_mask_without_failure(self) -> npt.NDArray[np.bool_]:
         """
         Mask array indicating realizations without any failure.

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -209,6 +209,10 @@ class LocalExperiment(BaseMode):
             return json.load(f)
 
     @property
+    def relative_weights(self) -> str:
+        return self.metadata.get("weights", "")
+
+    @property
     def name(self) -> str:
         return self._index.name
 

--- a/tests/unit_tests/gui/conftest.py
+++ b/tests/unit_tests/gui/conftest.py
@@ -69,7 +69,7 @@ def opened_main_window(
         yield gui
 
 
-def _new_poly_example(source_root, destination):
+def _new_poly_example(source_root, destination, num_realizations: int = 20):
     shutil.copytree(
         os.path.join(source_root, "test-data", "poly_example"),
         destination,
@@ -81,7 +81,7 @@ def _new_poly_example(source_root, destination):
             if "NUM_REALIZATIONS" in line:
                 # Decrease the number of realizations to speed up the test,
                 # if there is flakyness, this can be increased.
-                print("NUM_REALIZATIONS 20", end="\n")
+                print(f"NUM_REALIZATIONS {num_realizations}", end="\n")
             else:
                 print(line, end="")
 
@@ -106,6 +106,20 @@ def _open_main_window(
 def opened_main_window_clean(source_root, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _new_poly_example(source_root, tmp_path)
+    with _open_main_window(tmp_path / "poly.ert") as (
+        gui,
+        _,
+        config,
+    ), StorageService.init_service(
+        project=os.path.abspath(config.ens_path),
+    ):
+        yield gui
+
+
+@pytest.fixture
+def opened_main_window_minimal_realizations(source_root, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _new_poly_example(source_root, tmp_path, 2)
     with _open_main_window(tmp_path / "poly.ert") as (
         gui,
         _,

--- a/tests/unit_tests/gui/test_restart_esmda.py
+++ b/tests/unit_tests/gui/test_restart_esmda.py
@@ -1,6 +1,7 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox, QComboBox, QWidget
 
+from ert.gui.ertwidgets import StringBox
 from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.run_models import MultipleDataAssimilation
@@ -39,3 +40,50 @@ def test_restart_esmda(ensemble_experiment_has_run_no_failure, qtbot):
     )
 
     qtbot.mouseClick(run_dialog.done_button, Qt.MouseButton.LeftButton)
+
+
+def test_custom_weights_stored_and_retrieved_from_metadata_esmda(
+    opened_main_window_minimal_realizations, qtbot
+):
+    """This tests verifies that weights are stored in the metadata.json file when running esmda
+    and that the content is read back and populated in the GUI when enabling restart functionality.
+    """
+    gui = opened_main_window_minimal_realizations
+
+    experiment_panel = get_child(gui, ExperimentPanel)
+    simulation_mode_combo = get_child(experiment_panel, QComboBox)
+    simulation_mode_combo.setCurrentText(MultipleDataAssimilation.name())
+
+    es_mda_panel = gui.findChild(QWidget, name="ES_MDA_panel")
+    assert es_mda_panel
+
+    custom_weights = "5, 4, 3"
+    default_weights = "4, 2, 1"
+
+    wsb = gui.findChild(StringBox, "weights_input_esmda")
+    assert wsb
+    assert wsb.isEnabled()
+    assert wsb.text() == default_weights
+    wsb.setText(custom_weights)
+
+    # run es_mda
+    run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
+    qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=5000)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=20000)
+    assert (
+        run_dialog._total_progress_label.text()
+        == "Total progress 100% — Experiment completed."
+    )
+    qtbot.mouseClick(run_dialog.done_button, Qt.MouseButton.LeftButton)
+    assert wsb.text() == default_weights
+
+    restart_checkbox = es_mda_panel.findChild(QCheckBox, name="restart_checkbox_esmda")
+    assert restart_checkbox
+    assert not restart_checkbox.isChecked()
+    restart_checkbox.click()
+    # selecting restart will trigger reading of metadata.json containing custom weights
+    assert restart_checkbox.isChecked()
+    assert not wsb.isEnabled()
+    assert wsb.text() == custom_weights


### PR DESCRIPTION
Will add tests when implementation is approved

**Issue**
Resolves #8491 

https://github.com/user-attachments/assets/d448ac8e-b735-43d2-9d69-9470aa61bf12

```
(dev-ert) ➜  33344772-5472-418d-82f2-68eda6eb39af git:(fix_restart_weights) ✗ cat metadata.json
{"weights": "5, 3, 2"}%
```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
