### PR TITLE
wip: Proof of concept for checking whether submission to a queue will…

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -117,6 +117,7 @@ class TorqueQueueOptions(QueueOptions):
     cluster_label: Optional[NonEmptyString] = None
     job_prefix: Optional[NonEmptyString] = None
     keep_qsub_output: bool = False
+    skip_submission_check: bool = False
 
     qstat_options: Optional[str] = pydantic.Field(default=None, deprecated=True)
     queue_query_timeout: Optional[str] = pydantic.Field(default=None, deprecated=True)

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -90,14 +90,16 @@ class Driver(ABC):
         error_message: Optional[str] = None
 
         for _ in range(retries):
-            process = await asyncio.create_subprocess_exec(
-                *cmd_with_args,
-                stdin=asyncio.subprocess.PIPE if stdin else None,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *cmd_with_args,
+                    stdin=asyncio.subprocess.PIPE if stdin else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except FileNotFoundError as error:
+                return (False, str(error))
             stdout, stderr = await process.communicate(stdin)
-
             assert process.returncode is not None
             outputs = (
                 f"exit code {process.returncode}, "


### PR DESCRIPTION

**Issue**
Resolves #7112


**Approach**
Start a background task when initializing the driver that will try to submit. If it reaches a conclusion, it will affect how `submit()` behaves - it will fail the realization immediately if it knows submission is impossible.

Still, the user will get three lines of output for every realization as the situation is not recognized by the scheduler in this PR.

At least, this PR serves to demonstrate how ridiculouslysimple it is to add new QUEUE_OPTIONs to a driver after moving to Pydantic dataclasses.

![image](https://github.com/user-attachments/assets/9f3af6c0-e4c0-48b3-9c28-c0d0b521028b)



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
