### PR TITLE
Use Lock mechanism for forward_model_ok

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -147,7 +147,8 @@ class Job:
             if self.returncode.result() == 0:
                 if self._scheduler._manifest_queue is not None:
                     await self._verify_checksum()
-                await self._handle_finished_forward_model()
+                async with self._scheduler._forward_model_ok_lock:
+                    await self._handle_finished_forward_model()
                 break
 
             if attempt < max_submit - 1:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -106,6 +106,10 @@ class Scheduler:
         self._completed_jobs_num: int = 0
         self.completed_jobs: asyncio.Queue[int] = asyncio.Queue()
 
+        # this lock is to assure that no more than 1 task
+        # does internalization at a time
+        self._forward_model_ok_lock: asyncio.Lock = asyncio.Lock()
+
         self._cancelled = False
         if max_submit < 0:
             raise ValueError(


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8070


**Approach**
Make sure that we will not run more than 1 internalization job at a time. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
