### PR TITLE
Mute warnings when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,7 +363,7 @@ def _run_snake_oil(source_root):
         [
             ENSEMBLE_EXPERIMENT_MODE,
             "--disable-monitor",
-            "--current-case",
+            "--current-ensemble",
             "default_0",
             "snake_oil.ert",
         ],

--- a/tests/unit_tests/all/test_main.py
+++ b/tests/unit_tests/all/test_main.py
@@ -53,10 +53,16 @@ def test_argparse_exec_ensemble_experiment_valid_case():
 
 
 def test_argparse_exec_ensemble_experiment_current_case():
-    parsed = ert_parser(
-        None,
-        [ENSEMBLE_EXPERIMENT_MODE, "--current-case", "test_case", "path/to/config.ert"],
-    )
+    with pytest.warns(UserWarning):
+        parsed = ert_parser(
+            None,
+            [
+                ENSEMBLE_EXPERIMENT_MODE,
+                "--current-case",
+                "test_case",
+                "path/to/config.ert",
+            ],
+        )
     assert parsed.mode == ENSEMBLE_EXPERIMENT_MODE
     assert parsed.current_ensemble == "test_case"
     assert parsed.func.__name__ == "run_cli"
@@ -93,18 +99,18 @@ def test_argparse_exec_ensemble_experiment_faulty_realizations():
 @pytest.mark.parametrize(
     "mode", [ITERATIVE_ENSEMBLE_SMOOTHER_MODE, ENSEMBLE_SMOOTHER_MODE]
 )
-def test_argparse_exec_smoother_valid_case(mode):
+def test_argparse_exec_smoother_valid_ensemble(mode):
     parsed = ert_parser(
         None,
         [
             mode,
-            "--target-case",
-            "some_case_%d",
+            "--target-ensemble",
+            "some_ensemble_%d",
             "path/to/config.ert",
         ],
     )
     assert parsed.mode == mode
-    assert parsed.target_ensemble == "some_case_%d"
+    assert parsed.target_ensemble == "some_ensemble_%d"
     assert parsed.func.__name__ == "run_cli"
 
 
@@ -113,8 +119,8 @@ def test_argparse_exec_es_mda_valid_case():
         None,
         [
             ES_MDA_MODE,
-            "--target-case",
-            "some_case%d",
+            "--target-ensemble",
+            "some_ensemble%d",
             "--realizations",
             "1-10",
             "--weights",
@@ -123,7 +129,7 @@ def test_argparse_exec_es_mda_valid_case():
         ],
     )
     assert parsed.mode == ES_MDA_MODE
-    assert parsed.target_ensemble == "some_case%d"
+    assert parsed.target_ensemble == "some_ensemble%d"
     assert parsed.realizations == "1-10"
     assert parsed.weights == "1, 2, 4"
     assert parsed.func.__name__ == "run_cli"
@@ -136,12 +142,12 @@ def test_argparse_exec_es_mda_default_weights():
     assert parsed.func.__name__ == "run_cli"
 
 
-def test_argparse_exec_ensemble_es_mda_restart_case():
+def test_argparse_exec_ensemble_es_mda_restart_ensembler():
     parsed = ert_parser(
-        None, [ES_MDA_MODE, "--restart-case", "test_case", "path/to/config.ert"]
+        None, [ES_MDA_MODE, "--restart-ensemble", "test_ensemble", "path/to/config.ert"]
     )
     assert parsed.mode == ES_MDA_MODE
-    assert parsed.restart_ensemble_id == "test_case"
+    assert parsed.restart_ensemble_id == "test_ensemble"
     assert parsed.func.__name__ == "run_cli"
 
 
@@ -157,15 +163,15 @@ def test_argparse_exec_iterative_ensemble_smoother_current_ensemble():
         None,
         [
             ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
-            "--current-case",
-            "test_case",
-            "--target-case",
-            "test_case_smoother_%d",
+            "--current-ensemble",
+            "test_ensemble",
+            "--target-ensemble",
+            "test_ensemble_smoother_%d",
             "path/to/config.ert",
         ],
     )
     assert parsed.mode == ITERATIVE_ENSEMBLE_SMOOTHER_MODE
-    assert parsed.current_ensemble == "test_case"
+    assert parsed.current_ensemble == "test_ensemble"
     assert parsed.func.__name__ == "run_cli"
 
 

--- a/tests/unit_tests/config/test_analysis_config.py
+++ b/tests/unit_tests/config/test_analysis_config.py
@@ -1,4 +1,3 @@
-import warnings
 from textwrap import dedent
 
 import hypothesis.strategies as st
@@ -265,13 +264,12 @@ ANALYSIS_SET_VAR STD_ENKF INVERSION SUBSPACE"""
     ],
 )
 def test_incorrect_variable_deprecation_warning(config, expected):
-    with warnings.catch_warnings(record=True) as all_warnings:
-        _ = AnalysisConfig.from_dict(
+    with pytest.warns(match=expected):
+        AnalysisConfig.from_dict(
             {
                 ConfigKeys.ANALYSIS_SET_VAR: [config],
             }
         )
-    assert expected in [str(warning.message) for warning in all_warnings]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/config/test_ensemble_config.py
+++ b/tests/unit_tests/config/test_ensemble_config.py
@@ -136,7 +136,7 @@ def test_ensemble_config_duplicate_node_names():
     with pytest.raises(
         ConfigValidationError,
         match="GEN_KW and GEN_DATA contained duplicate name: Test_name",
-    ):
+    ), pytest.warns(match="The template file .* is empty"):
         EnsembleConfig.from_dict(config_dict=config_dict)
 
 

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -505,6 +505,7 @@ def test_that_subst_list_is_given_default_runpath_file():
     )
 
 
+@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.usefixtures("set_site_config")
 @settings(max_examples=10)
 @given(config_generators())
@@ -518,6 +519,7 @@ def test_that_creating_ert_config_from_dict_is_same_as_from_file(
         ) == ErtConfig.from_file(filename)
 
 
+@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.usefixtures("set_site_config")
 @settings(max_examples=10)
 @given(config_generators())
@@ -611,6 +613,7 @@ def test_queue_config_max_running_invalid_values(max_running_value, expected_err
         ErtConfig.from_file(test_config_file_name)
 
 
+@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.usefixtures("use_tmpdir")
 @given(st.integers(min_value=0), st.integers(min_value=0), st.integers(min_value=0))
 def test_num_cpu_vs_torque_queue_cpu_configuration(
@@ -1617,6 +1620,7 @@ def test_using_relative_path_to_eclbase_sets_jobname_to_basename(tmp_path):
     )
 
 
+@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize(
     "param_config", ["coeffs_priors", "template.txt output.txt coeffs_priors"]
 )

--- a/tests/unit_tests/config/test_ert_config.py
+++ b/tests/unit_tests/config/test_ert_config.py
@@ -444,7 +444,7 @@ def test_data_file_with_non_utf_8_character_gives_error_message(tmpdir):
             ConfigValidationError,
             match="Unsupported non UTF-8 character "
             f"'ÿ' found in file: {data_file_path!r}",
-        ):
+        ), pytest.warns(match="Failed to read NUM_CPU"):
             ErtConfig.from_file("config.ert")
 
 

--- a/tests/unit_tests/shared/share/test_subprocess.py
+++ b/tests/unit_tests/shared/share/test_subprocess.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from subprocess import PIPE, Popen, TimeoutExpired
 
 import pytest
@@ -26,7 +27,7 @@ ecl_run = import_from_location(
 )
 
 
-def _find_system_pipe_max_size():
+def _find_system_pipe_max_size() -> int:
     """This method finds the limit of the system pipe-buffer which
     might be taken into account when using subprocesses with pipes."""
     p = Popen(["dd", "if=/dev/zero", "bs=1"], stdin=PIPE, stdout=PIPE)
@@ -34,12 +35,15 @@ def _find_system_pipe_max_size():
         p.wait(timeout=1)
     except TimeoutExpired:
         p.kill()
+        assert p.stdout is not None
         return len(p.stdout.read())
 
-    return None
+    return 2**16
 
 
+warnings.simplefilter("ignore", ResourceWarning)
 _maxBytes = _find_system_pipe_max_size() - 1
+warnings.resetwarnings()
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
**Issue**
Resolves warnings emitted from pytest.


**Approach**
Solve warnings individually

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
