### PR TITLE
Fix azure testing 

### DIFF
--- a/tests/unit_tests/config/test_forward_model.py
+++ b/tests/unit_tests/config/test_forward_model.py
@@ -685,8 +685,13 @@ def test_that_no_error_thrown_when_checking_eclipse_version_and_no_ecl_config_de
     # Write config file
     config_file_name = "test.ert"
     Path(config_file_name).write_text(ert_config_contents, encoding="utf-8")
-
-    _ = ErtConfig.with_plugins().from_file(config_file_name)
+    with patch(
+        "ert.plugins.hook_implementations.forward_model_steps.ErtPluginManager"
+    ) as mock:
+        instance = mock.return_value
+        instance.get_ecl100_config_path.return_value = None
+        instance.get_ecl300_config_path.return_value = None
+        _ = ErtConfig.with_plugins().from_file(config_file_name)
 
 
 def test_that_plugin_forward_models_are_installed(tmp_path):


### PR DESCRIPTION
**Issue**

test_that_no_error_thrown_when_checking_eclipse_version_and_no_ecl_config_defined is failing on azure. 

https://github.com/equinor/komodo-releases/actions/runs/10570071389/job/29284245096


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
