### PR TITLE
Replace json with orjson for performance reasons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies=[
     "matplotlib",
     "netCDF4",
     "numpy<2",
+    "orjson",
     "packaging",
     "pandas",
     "pluggy>=1.3.0",

--- a/src/_ert_forward_model_runner/reporting/file.py
+++ b/src/_ert_forward_model_runner/reporting/file.py
@@ -1,9 +1,10 @@
 import functools
-import json
 import logging
 import os
 import socket
 import time
+
+import orjson
 
 from _ert_forward_model_runner.io import cond_unlink
 from _ert_forward_model_runner.reporting.base import Reporter
@@ -209,5 +210,5 @@ class File(Reporter):
             )
 
     def _dump_status_json(self):
-        with open(STATUS_json, "w", encoding="utf-8") as fp:
-            json.dump(self.status_dict, fp, indent=4)
+        with open(STATUS_json, "wb") as fp:
+            fp.write(orjson.dumps(self.status_dict, option=orjson.OPT_INDENT_2))

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Union
 
+import orjson
 from numpy.random import SeedSequence
 
 from .config import ParameterConfig
@@ -207,12 +208,14 @@ def create_run_path(
             forward_model_output = ert_config.forward_model_data_to_json(
                 run_arg.run_id, run_arg.iens, ensemble.iteration, context_env
             )
-            with open(run_path / "jobs.json", mode="w", encoding="utf-8") as fptr:
-                json.dump(forward_model_output, fptr)
+            with open(run_path / "jobs.json", mode="wb") as fptr:
+                fptr.write(
+                    orjson.dumps(forward_model_output, option=orjson.OPT_NON_STR_KEYS)
+                )
             # Write MANIFEST file to runpath use to avoid NFS sync issues
-            with open(run_path / "manifest.json", mode="w", encoding="utf-8") as fptr:
+            with open(run_path / "manifest.json", mode="wb") as fptr:
                 data = ert_config.manifest_to_json(run_arg.iens, run_arg.itr)
-                json.dump(data, fptr)
+                fptr.write(orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS))
 
     runpaths.write_runpath_list(
         [ensemble.iteration], [real.iens for real in run_args if real.active]

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import time
@@ -20,6 +19,7 @@ from typing import (
     Sequence,
 )
 
+import orjson
 from pydantic.dataclasses import dataclass
 
 from _ert.async_utils import get_running_loop
@@ -330,8 +330,8 @@ class Scheduler:
             ee_cert_path=cert_path if self._ee_cert is not None else None,
         )
         jobs_path = os.path.join(runpath, "jobs.json")
-        with open(jobs_path, "r", encoding="utf-8") as fp:
-            data = json.load(fp)
-        with open(jobs_path, "w", encoding="utf-8") as fp:
+        with open(jobs_path, "rb") as fp:
+            data = orjson.loads(fp.read())
+        with open(jobs_path, "wb") as fp:
             data.update(asdict(jobs))
-            json.dump(data, fp, indent=4)
+            fp.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))

--- a/tests/unit_tests/test_run_path_creation.py
+++ b/tests/unit_tests/test_run_path_creation.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 
+import orjson
 import pytest
 
 from ert.config import ConfigValidationError, ErtConfig
@@ -547,7 +548,8 @@ def test_num_cpu_subst(
     _create_runpath(config, storage)
 
     with open("simulations/realization-0/iter-0/jobs.json", encoding="utf-8") as f:
-        assert f'"argList": ["{numcpu}"]' in f.read()
+        jobs = orjson.loads(f.read())
+        assert [str(numcpu)] == jobs["jobList"][0]["argList"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
stdlibs json is really slow.
It is especially noticable in _ert_forward_model_runner as the status file is updated quite often.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
