### PR TITLE
Fix test that could give false positive

### DIFF
--- a/tests/unit_tests/forward_model_runner/test_job.py
+++ b/tests/unit_tests/forward_model_runner/test_job.py
@@ -59,7 +59,7 @@ def test_memory_usage_counts_grandchildren():
                 parent = os.fork()
                 if not parent:
                     os.execv(sys.argv[-2], [sys.argv[-2], str(counter - 1)])
-            time.sleep(0.3)"""  # Too low sleep will make the test faster but flaky
+            time.sleep(1)"""  # Too low sleep will make the test faster but flaky
             )
         )
     executable = os.path.realpath(scriptname)
@@ -80,9 +80,15 @@ def test_memory_usage_counts_grandchildren():
                 max_seen = max(max_seen, status.memory_status.max_rss)
         return max_seen
 
+    # size of the list that gets forked. we will use this when
+    # comparing the memory used with different amounts of forks done.
+    # subtract a little bit (* 0.9) due to natural variance in memory used
+    # when running the program.
+    memory_per_numbers_list = sys.getsizeof(int(0)) * 1e6 * 0.9
+
     max_seens = [max_memory_per_subprocess_layer(layers) for layers in range(3)]
-    assert max_seens[0] < max_seens[1]
-    assert max_seens[1] < max_seens[2]
+    assert max_seens[0] + memory_per_numbers_list < max_seens[1]
+    assert max_seens[1] + memory_per_numbers_list < max_seens[2]
 
 
 @pytest.mark.flaky(reruns=3)


### PR DESCRIPTION
Test could give false positive due to natural variance in memory used per run.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
