### PR TITLE
Fix so `Export tool` does not return duplicate data when storage contains multiple experiments with same ensemble names

### DIFF
--- a/src/ert/gui/tools/export/export_panel.py
+++ b/src/ert/gui/tools/export/export_panel.py
@@ -64,7 +64,7 @@ class ExportDialog(CustomDialog):
         return self.output_path_model.getPath()
 
     @property
-    def ensemble_list(self) -> str:
+    def ensemble_data_as_json(self) -> str:
         ensembles = {
             str(ensemble.id): {
                 "ensemble_name": ensemble.name,

--- a/src/ert/gui/tools/export/export_panel.py
+++ b/src/ert/gui/tools/export/export_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtWidgets import QCheckBox, QWidget
@@ -23,6 +24,7 @@ class ExportDialog(CustomDialog):
         storage: LocalStorage,
         parent: Optional[QWidget] = None,
     ) -> None:
+        self.storage = storage
         description = "The CSV export requires some information before it starts:"
         super().__init__("export", description, parent)
 
@@ -37,9 +39,12 @@ class ExportDialog(CustomDialog):
         )
         design_matrix_path_chooser = PathChooser(self.design_matrix_path_model)
 
-        self.list_edit = ListEditBox(
-            [ensemble.name for ensemble in storage.ensembles if ensemble.has_data()]
-        )
+        ensemble_with_data_dict = {
+            ensemble.id: ensemble.name
+            for ensemble in storage.ensembles
+            if ensemble.has_data()
+        }
+        self.list_edit = ListEditBox(ensemble_with_data_dict)
 
         self.drop_const_columns_check = QCheckBox()
         self.drop_const_columns_check.setChecked(False)
@@ -60,7 +65,16 @@ class ExportDialog(CustomDialog):
 
     @property
     def ensemble_list(self) -> str:
-        return ",".join(self.list_edit.getItems())
+        ensembles = {
+            str(ensemble.id): {
+                "ensemble_name": ensemble.name,
+                "experiment_name": ensemble.experiment.name,
+            }
+            for ensemble in self.storage.ensembles
+            if ensemble.name in self.list_edit.getItems().values()
+        }
+
+        return json.dumps(ensembles)
 
     @property
     def design_matrix_path(self) -> Optional[str]:

--- a/src/ert/gui/tools/export/export_tool.py
+++ b/src/ert/gui/tools/export/export_tool.py
@@ -40,7 +40,7 @@ class ExportTool(Tool):
             self._run_export(
                 [
                     dialog.output_path,
-                    dialog.ensemble_list,
+                    dialog.ensemble_data_as_json,
                     dialog.design_matrix_path,
                     True,
                     dialog.drop_const_columns,

--- a/src/ert/resources/workflows/jobs/internal-gui/scripts/csv_export.py
+++ b/src/ert/resources/workflows/jobs/internal-gui/scripts/csv_export.py
@@ -54,17 +54,19 @@ class CSVExportJob(ErtScript):
         workflow_args,
     ):
         output_file = workflow_args[0]
-        ensemble_list = None if len(workflow_args) < 2 else workflow_args[1]
+        ensemble_data_as_json = None if len(workflow_args) < 2 else workflow_args[1]
         design_matrix_path = None if len(workflow_args) < 3 else workflow_args[2]
         _ = True if len(workflow_args) < 4 else workflow_args[3]
         drop_const_cols = False if len(workflow_args) < 5 else workflow_args[4]
         facade = LibresFacade(ert_config)
 
-        ensemble_dict = json.loads(ensemble_list) if ensemble_list else {}
+        ensemble_data_as_dict = (
+            json.loads(ensemble_data_as_json) if ensemble_data_as_json else {}
+        )
 
         # Use the keys (UUIDs as strings) to get ensembles
         ensembles = []
-        for ensemble_id in ensemble_dict:
+        for ensemble_id in ensemble_data_as_dict:
             ensemble = self.storage.get_ensemble(ensemble_id)
             ensembles.append(ensemble)
 

--- a/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -60,7 +60,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
 
     Optional arguments:
 
-     ensemble_list: a comma separated list of ensembles to export (no spaces allowed)
+     ensemble_data_as_json: a comma separated list of ensembles to export (no spaces allowed)
                 if no list is provided the current ensemble is exported
 
     """
@@ -82,19 +82,20 @@ class GenDataRFTCSVExportJob(ErtPlugin):
 
         output_file = workflow_args[0]
         trajectory_path = workflow_args[1]
-        ensemble_list = None if len(workflow_args) < 3 else workflow_args[2]
+        ensemble_data_as_json = None if len(workflow_args) < 3 else workflow_args[2]
         drop_const_cols = False if len(workflow_args) < 4 else bool(workflow_args[3])
 
         wells = set()
 
-        # Parse the ensemble_list from JSON string to dictionary
-        ensemble_dict = json.loads(ensemble_list) if ensemble_list else {}
+        ensemble_data_as_dict = (
+            json.loads(ensemble_data_as_json) if ensemble_data_as_json else {}
+        )
 
-        if not ensemble_dict:
+        if not ensemble_data_as_dict:
             raise UserWarning("No ensembles given to load from")
 
         data = []
-        for ensemble_id, ensemble_info in ensemble_dict.items():
+        for ensemble_id, ensemble_info in ensemble_data_as_dict.items():
             ensemble_name = ensemble_info["ensemble_name"]
 
             try:
@@ -238,7 +239,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         success = dialog.showAndTell()
 
         if success:
-            ensemble_list = {
+            ensemble_data_as_dict = {
                 str(ensemble.id): {
                     "ensemble_name": ensemble.name,
                     "experiment_name": ensemble.experiment.name,
@@ -251,7 +252,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                     output_path_model.getPath(),
                     trajectory_model.getPath(),
                     json.dumps(
-                        ensemble_list
+                        ensemble_data_as_dict
                     ),  # Return the ensemble list as a JSON string
                     drop_const_columns_check.isChecked(),
                 ]

--- a/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
+++ b/src/ert/resources/workflows/jobs/internal-gui/scripts/gen_data_rft_export.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import os
 
 import numpy
@@ -77,16 +78,8 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         storage,
         workflow_args,
     ):
-        """The run method will export the RFT's for all wells and all ensembles.
+        """The run method will export the RFT's for all wells and all ensembles."""
 
-        The successful operation of this method hinges on two naming
-        conventions:
-
-          1. All the GEN_DATA RFT observations have key RFT_$WELL
-          2. The trajectory files are in $trajectory_path/$WELL.txt
-             or $trajectory_path/$WELL_R.txt
-
-        """
         output_file = workflow_args[0]
         trajectory_path = workflow_args[1]
         ensemble_list = None if len(workflow_args) < 3 else workflow_args[2]
@@ -94,20 +87,18 @@ class GenDataRFTCSVExportJob(ErtPlugin):
 
         wells = set()
 
-        ensemble_names = []
-        if ensemble_list is not None:
-            ensemble_names = ensemble_list.split(",")
+        # Parse the ensemble_list from JSON string to dictionary
+        ensemble_dict = json.loads(ensemble_list) if ensemble_list else {}
 
-        if len(ensemble_names) == 0:
+        if not ensemble_dict:
             raise UserWarning("No ensembles given to load from")
 
         data = []
-        for ensemble_name in ensemble_names:
-            ensemble_name = ensemble_name.strip()
-            ensemble_data = []
+        for ensemble_id, ensemble_info in ensemble_dict.items():
+            ensemble_name = ensemble_info["ensemble_name"]
 
             try:
-                ensemble = storage.get_ensemble_by_name(ensemble_name)
+                ensemble = storage.get_ensemble(ensemble_id)
             except KeyError as exc:
                 raise UserWarning(
                     f"The ensemble '{ensemble_name}' does not exist!"
@@ -130,6 +121,7 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                     " GENERAL_OBSERVATIONS starting with RFT_*"
                 )
 
+            ensemble_data = []
             for obs_key in obs_keys:
                 well = obs_key.replace("RFT_", "")
                 wells.add(well)
@@ -154,8 +146,6 @@ class GenDataRFTCSVExportJob(ErtPlugin):
                     index=index,
                     columns=realizations,
                 )
-
-                realizations = ensemble.get_realization_list_with_responses()
 
                 # Trajectory
                 trajectory_file = os.path.join(trajectory_path, f"{well}.txt")
@@ -223,8 +213,12 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         trajectory_chooser = PathChooser(trajectory_model)
         trajectory_chooser.setObjectName("trajectory_chooser")
 
-        all_ensemble_list = [ensemble.name for ensemble in storage.ensembles]
-        list_edit = ListEditBox(all_ensemble_list)
+        ensemble_with_data_dict = {
+            ensemble.id: ensemble.name
+            for ensemble in storage.ensembles
+            if ensemble.has_data()
+        }
+        list_edit = ListEditBox(ensemble_with_data_dict)
         list_edit.setObjectName("list_of_ensembles")
 
         drop_const_columns_check = QCheckBox()
@@ -244,12 +238,21 @@ class GenDataRFTCSVExportJob(ErtPlugin):
         success = dialog.showAndTell()
 
         if success:
-            ensemble_list = ",".join(list_edit.getItems())
+            ensemble_list = {
+                str(ensemble.id): {
+                    "ensemble_name": ensemble.name,
+                    "experiment_name": ensemble.experiment.name,
+                }
+                for ensemble in storage.ensembles
+                if ensemble.name in list_edit.getItems().values()
+            }
             with contextlib.suppress(ValueError):
                 return [
                     output_path_model.getPath(),
                     trajectory_model.getPath(),
-                    ensemble_list,
+                    json.dumps(
+                        ensemble_list
+                    ),  # Return the ensemble list as a JSON string
                     drop_const_columns_check.isChecked(),
                 ]
 

--- a/tests/unit_tests/gui/test_csv_export.py
+++ b/tests/unit_tests/gui/test_csv_export.py
@@ -19,8 +19,9 @@ from ert.run_models import EnsembleExperiment
 from .conftest import get_child, wait_for_child
 
 
-def export_data(gui, qtbot, ensemble_select, export_path="output.csv"):
+def export_data(gui, qtbot, ensemble_select):
     file_name = None
+    export_path = "output.csv"
 
     def handle_export_dialog():
         nonlocal file_name

--- a/tests/unit_tests/gui/test_csv_export.py
+++ b/tests/unit_tests/gui/test_csv_export.py
@@ -85,7 +85,7 @@ def test_csv_export(esmda_has_run, qtbot, ensemble_select):
     verify_exported_content(file_name, gui, ensemble_select)
 
 
-def run_experiment_and_export(gui, qtbot):
+def run_experiment_via_gui(gui, qtbot):
     experiment_panel = get_child(gui, ExperimentPanel)
     simulation_mode_combo = get_child(experiment_panel, QComboBox)
     simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
@@ -110,7 +110,7 @@ def test_that_export_tool_does_not_produce_duplicate_data(
 ):
     gui = ensemble_experiment_has_run_no_failure
 
-    run_experiment_and_export(gui, qtbot)
+    run_experiment_via_gui(gui, qtbot)
 
     file_name = export_data(gui, qtbot, "*")
 

--- a/tests/unit_tests/gui/test_csv_export.py
+++ b/tests/unit_tests/gui/test_csv_export.py
@@ -133,7 +133,9 @@ def test_that_export_tool_does_not_produce_duplicate_data(
     with open_storage("storage") as storage:
         experiments = [exp.name for exp in storage.experiments]
         ensembles = [ens.name for ens in storage.ensembles]
-        assert experiments == ["ensemble_experiment_0", "ensemble_experiment"]
+        assert sorted(experiments) == sorted(
+            ["ensemble_experiment_0", "ensemble_experiment"]
+        )
         assert ensembles == ["iter-0", "iter-0"]
 
     # Split the dataframe into two halves

--- a/tests/unit_tests/gui/test_csv_export.py
+++ b/tests/unit_tests/gui/test_csv_export.py
@@ -105,6 +105,9 @@ def run_experiment_via_gui(gui, qtbot):
     qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
 
+from ert.storage import open_storage
+
+
 def test_that_export_tool_does_not_produce_duplicate_data(
     ensemble_experiment_has_run_no_failure, qtbot
 ):
@@ -124,6 +127,14 @@ def test_that_export_tool_does_not_produce_duplicate_data(
     file_name = export_data(gui, qtbot, "*")
 
     df = pd.read_csv(file_name)
+
+    # Make sure there are two identically named ensembles in two
+    # different experiments.
+    with open_storage("storage") as storage:
+        experiments = [exp.name for exp in storage.experiments]
+        ensembles = [ens.name for ens in storage.ensembles]
+        assert experiments == ["ensemble_experiment_0", "ensemble_experiment"]
+        assert ensembles == ["iter-0", "iter-0"]
 
     # Split the dataframe into two halves
     half_point = len(df) // 2

--- a/tests/unit_tests/gui/test_csv_export.py
+++ b/tests/unit_tests/gui/test_csv_export.py
@@ -108,6 +108,15 @@ def run_experiment_via_gui(gui, qtbot):
 def test_that_export_tool_does_not_produce_duplicate_data(
     ensemble_experiment_has_run_no_failure, qtbot
 ):
+    """
+    Ensures the export tool does not produce duplicate data by comparing
+    the first and second halves of the exported CSV.
+
+    This test addresses a previous issue where running two experiments with
+    ensembles of the same name caused duplicated data in the export. The code
+    has been fixed to prevent this, ensuring unique data even with identical
+    ensemble names across different experiments.
+    """
     gui = ensemble_experiment_has_run_no_failure
 
     run_experiment_via_gui(gui, qtbot)
@@ -115,5 +124,13 @@ def test_that_export_tool_does_not_produce_duplicate_data(
     file_name = export_data(gui, qtbot, "*")
 
     df = pd.read_csv(file_name)
-    # Make sure data is not duplicated.
-    assert df.iloc[0]["COEFFS:a"] != df.iloc[20]["COEFFS:a"]
+
+    # Split the dataframe into two halves
+    half_point = len(df) // 2
+    first_half = df.iloc[:half_point]
+    second_half = df.iloc[half_point:]
+
+    # Ensure the two halves are not identical
+    assert not first_half.equals(
+        second_half
+    ), "The first half of the data is identical to the second half."


### PR DESCRIPTION
**Issue**
Resolves #8555 

Have to stop using `storage.get_ensemble_by_name` as ensemble names are not unique across experiments.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
