### PR TITLE
Add get_experiment_by_name to storage

### DIFF
--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -200,6 +200,26 @@ class LocalExperiment(BaseMode):
             ens for ens in self._storage.ensembles if ens.experiment_id == self.id
         )
 
+    def get_ensemble_by_name(self, name: str) -> LocalEnsemble:
+        """
+        Retrieves an ensemble by name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the ensemble to retrieve.
+
+        Returns
+        -------
+        local_ensemble : LocalEnsemble
+            The ensemble associated with the given name.
+        """
+
+        for ens in self.ensembles:
+            if ens.name == name:
+                return ens
+        raise KeyError(f"Ensemble with name '{name}' not found")
+
     @property
     def metadata(self) -> Dict[str, Any]:
         path = self.mount_point / self._metadata_file

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -147,6 +147,27 @@ class LocalStorage(BaseMode):
 
         return self._experiments[uuid]
 
+    def get_experiment_by_name(self, name: str) -> LocalExperiment:
+        """
+        Retrieves an experiment by name.
+        Parameters
+        ----------
+        name : str
+            The name of the experiment to retrieve.
+        Returns
+        -------
+        local_experiment : LocalExperiment
+            The experiment associated with the given name.
+        Raises
+        ------
+        KeyError
+            If no experiment with the given name is found.
+        """
+        for exp in self._experiments.values():
+            if exp.name == name:
+                return exp
+        raise KeyError(f"Experiment with name '{name}' not found")
+
     def get_ensemble(self, uuid: Union[UUID, str]) -> LocalEnsemble:
         """
         Retrieves an ensemble by UUID.

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -753,15 +753,16 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
     num_realizations = ert_config.model_config.num_realizations
     with open_storage(ert_config.ens_path, mode="w") as storage:
         experiment_id = storage.create_experiment(
-            ert_config.ensemble_config.parameter_configuration
+            ert_config.ensemble_config.parameter_configuration, name="test-experiment"
         )
         ensemble = storage.create_ensemble(
             experiment_id, name="iter-0", ensemble_size=num_realizations
         )
         sample_prior(ensemble, prior_mask)
-        prior_values = storage.get_ensemble(ensemble.id).load_parameters("COEFFS")[
-            "values"
-        ]
+        experiment = storage.get_experiment_by_name("test-experiment")
+        prior_values = experiment.get_ensemble_by_name(ensemble.name).load_parameters(
+            "COEFFS"
+        )["values"]
     with caplog.at_level(logging.INFO):
         run_cli(
             ENSEMBLE_EXPERIMENT_MODE,

--- a/tests/unit_tests/storage/test_local_storage.py
+++ b/tests/unit_tests/storage/test_local_storage.py
@@ -60,6 +60,21 @@ def test_create_experiment(tmp_path):
             assert index["name"] == "test-experiment"
 
 
+def test_that_loading_non_existing_experiment_throws(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage, pytest.raises(
+        KeyError, match="Experiment with name 'non-existing-experiment' not found"
+    ):
+        storage.get_experiment_by_name("non-existing-experiment")
+
+
+def test_that_loading_non_existing_ensemble_throws(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage, pytest.raises(
+        KeyError, match="Ensemble with name 'non-existing-ensemble' not found"
+    ):
+        experiment = storage.create_experiment(name="test-experiment")
+        experiment.get_ensemble_by_name("non-existing-ensemble")
+
+
 def test_that_saving_empty_responses_fails_nicely(tmp_path):
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment()


### PR DESCRIPTION
Experiment names are unique and its easier to get by name than by uuid. Also adding get_ensemble_by_name to experiment class because ensembles names are unique within an experiment.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
