### PR TITLE
Set ensemble name of single test run to "ensemble"

### DIFF
--- a/src/ert/gui/simulation/single_test_run_panel.py
+++ b/src/ert/gui/simulation/single_test_run_panel.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 
 from qtpy import QtCore
 from qtpy.QtWidgets import QFormLayout, QLabel
@@ -37,5 +36,4 @@ class SingleTestRunPanel(ExperimentConfigPanel):
         self.setLayout(layout)
 
     def get_experiment_arguments(self) -> Arguments:
-        ensemble_name = f"{datetime.now().strftime('%Y-%m-%dT%H%M')}"
-        return Arguments(TEST_RUN_MODE, ensemble_name, "single_test_run")
+        return Arguments(TEST_RUN_MODE, "ensemble", "single_test_run")

--- a/tests/unit_tests/gui/test_single_test_run.py
+++ b/tests/unit_tests/gui/test_single_test_run.py
@@ -1,6 +1,5 @@
 import contextlib
 import shutil
-from datetime import datetime
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -38,4 +37,7 @@ def test_single_test_run_after_ensemble_experiment(
 
     storage = gui.notifier.storage
     assert "single_test_run" in [exp.name for exp in storage.experiments]
-    assert any(str(datetime.now().year) in ens.name for ens in storage.ensembles)
+    ensemble_names = [ens.name for ens in storage.ensembles]
+    assert "iter-0" in ensemble_names
+    # Default ensemble name when running single test run
+    assert "ensemble" in ensemble_names


### PR DESCRIPTION
No reason to use date as name.
Makes writing tests easier.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
