### PR TITLE
Fix bug where runpaths were incorrect for restart runs

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -555,7 +555,9 @@ class BaseRunModel(ABC):
     def paths(self) -> List[str]:
         run_paths = []
         active_realizations = np.where(self.active_realizations)[0]
-        for iteration in range(self.start_iteration, self._total_iterations):
+        for iteration in range(
+            self.start_iteration, self._total_iterations + self.start_iteration
+        ):
             run_paths.extend(self.run_paths.get_paths(active_realizations, iteration))
         return run_paths
 

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import numpy as np
 
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.storage import Ensemble, Storage
+from ert.storage import Storage
 
 from ..run_arg import create_run_arguments
 from . import BaseRunModel
@@ -41,27 +41,26 @@ class EvaluateEnsemble(BaseRunModel):
         queue_config: QueueConfig,
         status_queue: SimpleQueue[StatusEvents],
     ):
+        try:
+            self.ensemble = storage.get_ensemble(UUID(ensemble_id))
+        except KeyError as err:
+            raise ValueError(f"No ensemble: {ensemble_id}") from err
         super().__init__(
             config,
             storage,
             queue_config,
             status_queue,
-            start_iteration=0,
+            start_iteration=self.ensemble.iteration,
             total_iterations=1,
             active_realizations=active_realizations,
             minimum_required_realizations=minimum_required_realizations,
             random_seed=random_seed,
         )
-        self.ensemble_id = ensemble_id
 
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
-        ensemble_id = self.ensemble_id
-        ensemble_uuid = UUID(ensemble_id)
-        ensemble = self._storage.get_ensemble(ensemble_uuid)
-        assert isinstance(ensemble, Ensemble)
-
+        ensemble = self.ensemble
         experiment = ensemble.experiment
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
         self.set_env_key("_ERT_ENSEMBLE_ID", str(ensemble.id))

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -37,6 +37,14 @@ class ManualUpdate(UpdateRunModel):
         update_settings: UpdateSettings,
         status_queue: SimpleQueue[StatusEvents],
     ):
+        try:
+            prior_id = UUID(ensemble_id)
+            prior = storage.get_ensemble(prior_id)
+        except (KeyError, ValueError) as err:
+            raise ErtRunError(
+                f"Prior ensemble with ID: {prior_id} does not exists"
+            ) from err
+
         super().__init__(
             es_settings,
             update_settings,
@@ -46,11 +54,11 @@ class ManualUpdate(UpdateRunModel):
             status_queue,
             active_realizations=active_realizations,
             total_iterations=1,
-            start_iteration=0,
+            start_iteration=prior.iteration,
             random_seed=random_seed,
             minimum_required_realizations=minimum_required_realizations,
         )
-        self.prior_ensemble_id = ensemble_id
+        self.prior = prior
         self.target_ensemble_format = target_ensemble
         self.support_restart = False
 
@@ -58,18 +66,11 @@ class ManualUpdate(UpdateRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         logger.info("Running manual update")
+        self.set_env_key("_ERT_EXPERIMENT_ID", str(self.prior.experiment.id))
+        self.set_env_key("_ERT_ENSEMBLE_ID", str(self.prior.id))
+
         ensemble_format = self.target_ensemble_format
-        try:
-            ensemble_id = UUID(self.prior_ensemble_id)
-            prior = self._storage.get_ensemble(ensemble_id)
-            experiment = prior.experiment
-            self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
-            self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
-        except (KeyError, ValueError) as err:
-            raise ErtRunError(
-                f"Prior ensemble with ID: {ensemble_id} does not exists"
-            ) from err
-        self.update(prior, ensemble_format % (prior.iteration + 1))
+        self.update(self.prior, ensemble_format % (self.prior.iteration + 1))
 
     @classmethod
     def name(cls) -> str:

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -79,3 +79,7 @@ class ManualUpdate(UpdateRunModel):
     @classmethod
     def description(cls) -> str:
         return "Load parameters and responses from existing → update"
+
+    def check_if_runpath_exists(self) -> bool:
+        # Will not run a forward model, so does not create files on runpath
+        return False

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -54,10 +54,12 @@ class MultipleDataAssimilation(UpdateRunModel):
         self.restart_run = restart_run
         self.prior_ensemble_id = prior_ensemble_id
         start_iteration = 0
+        total_iterations = len(self.weights) + 1
         if self.restart_run:
             if not self.prior_ensemble_id:
                 raise ValueError("For restart run, prior ensemble must be set")
             start_iteration = storage.get_ensemble(prior_ensemble_id).iteration + 1
+            total_iterations -= start_iteration
         elif not self.experiment_name:
             raise ValueError("For non-restart run, experiment name must be set")
         super().__init__(
@@ -68,7 +70,7 @@ class MultipleDataAssimilation(UpdateRunModel):
             queue_config,
             status_queue,
             active_realizations=active_realizations,
-            total_iterations=len(self.weights) + 1,
+            total_iterations=total_iterations,
             start_iteration=start_iteration,
             random_seed=random_seed,
             minimum_required_realizations=minimum_required_realizations,


### PR DESCRIPTION



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
