### PR TITLE
Make tests runnable from git worktree

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,6 +28,13 @@ def source_dir() -> Path:
     while current_path != Path("/"):
         if (current_path / ".git").is_dir():
             return current_path
+        # This is to find root dir for git worktrees
+        elif (current_path / ".git").is_file():
+            with open(current_path / ".git", encoding="utf-8") as f:
+                for line in f.readlines():
+                    if "gitdir:" in line:
+                        return current_path
+
         current_path = current_path.parent
     raise RuntimeError("Cannot find the source folder")
 


### PR DESCRIPTION
Current source_dir() implementation will fail if you are trying to run pytest using git worktree 

**Approach**
Modified source_dir() to read .git file that is present in git worktrees

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
