### PR TITLE
Validate inputs in load results manually

### DIFF
--- a/src/ert/gui/tools/load_results/__init__.py
+++ b/src/ert/gui/tools/load_results/__init__.py
@@ -1,2 +1,4 @@
-from .load_results_panel import LoadResultsPanel  # noqa: F401
-from .load_results_tool import LoadResultsTool  # noqa: F401
+from .load_results_panel import LoadResultsPanel
+from .load_results_tool import LoadResultsTool
+
+__all__ = ["LoadResultsPanel", "LoadResultsTool"]

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -33,6 +33,9 @@ class LoadResultsTool(Tool):
         if not self._import_widget._ensemble_selector.isEnabled():
             loadButton.setEnabled(False)
             loadButton.setToolTip("Must load into a ensemble")
+        self._import_widget.panelConfigurationChanged.connect(
+            self.validationStatusChanged
+        )
         self._dialog.exec_()
 
     def load(self, _: Any) -> None:
@@ -42,3 +45,10 @@ class LoadResultsTool(Tool):
         self._dialog.toggleButton(caption="Load", enabled=False)
         self._import_widget.load()
         self._dialog.accept()
+
+    def validationStatusChanged(self) -> None:
+        assert self._dialog is not None
+        assert self._import_widget is not None
+        self._dialog.toggleButton(
+            caption="Load", enabled=self._import_widget.isConfigurationValid()
+        )

--- a/tests/unit_tests/gui/tools/test_load_results_manually.py
+++ b/tests/unit_tests/gui/tools/test_load_results_manually.py
@@ -1,0 +1,52 @@
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QPushButton
+
+from ert.gui.ertwidgets import ClosableDialog, StringBox
+from ert.gui.ertwidgets.ensembleselector import EnsembleSelector
+from ert.gui.tools.load_results import LoadResultsPanel
+
+from ..conftest import (
+    get_child,
+    wait_for_child,
+)
+
+
+def test_validation(ensemble_experiment_has_run_no_failure, qtbot):
+    gui = ensemble_experiment_has_run_no_failure
+    ensemble_name = "iter-0"
+
+    def handle_load_results_dialog():
+        dialog = wait_for_child(gui, qtbot, ClosableDialog)
+        panel = get_child(dialog, LoadResultsPanel)
+
+        ensemble_selector = get_child(panel, EnsembleSelector)
+        index = ensemble_selector.findText(ensemble_name, Qt.MatchFlag.MatchContains)
+        ensemble_selector.setCurrentIndex(index)
+
+        load_button = get_child(panel.parent(), QPushButton, name="Load")
+
+        active_realizations = get_child(
+            panel, StringBox, name="active_realizations_lrm"
+        )
+        default_value_active_reals = active_realizations.get_text
+        active_realizations.setText(
+            f"0-{ensemble_selector.selected_ensemble.ensemble_size + 1}"
+        )
+
+        assert not load_button.isEnabled()
+        active_realizations.setText(default_value_active_reals)
+        assert load_button.isEnabled()
+
+        iterations_field = get_child(panel, StringBox, name="iterations_field_lrm")
+        default_value_iteration = iterations_field.get_text
+        iterations_field.setText("-10")
+
+        assert not load_button.isEnabled()
+        iterations_field.setText(default_value_iteration)
+        assert load_button.isEnabled()
+
+        dialog.close()
+
+    QTimer.singleShot(1000, handle_load_results_dialog)
+    load_results_tool = gui.tools["Load results manually"]
+    load_results_tool.trigger()


### PR DESCRIPTION
**Issue**
Resolves #8618 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
