### PR TITLE
Fix bug checksum failures

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -150,9 +150,9 @@ class Job:
                 break
 
             if self.returncode.result() == 0:
-                if self._scheduler._manifest_queue is not None:
-                    await self._verify_checksum()
                 async with forward_model_ok_lock:
+                    if self._scheduler._manifest_queue is not None:
+                        await self._verify_checksum()
                     await self._handle_finished_forward_model()
                 break
 


### PR DESCRIPTION
This commit fixes the bug where multiple realizations try to read checksum at the same time, leading it to grind to a halt.
The issue was fixed by moving the forward_model_ok_lock up a level, so that only one realization can call `verify_checksum` at a time. This also solved the issue where jobs would be shown as stuck in pending even though all forward model steps had completed. This was probably due to checksums all being checked and verified at the same time, which can be IO intensive.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
