### PR TITLE
Log more usage statistics, and with f-strings

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -637,7 +637,7 @@ def log_process_usage() -> None:
             "Swaps": usage.ru_nswap,
             "Peak memory use (KB)": maxrss,
         }
-        logger.info(f"Peak memory use: {maxrss} KB", extra=usage_dict)
+        logger.info(f"Ert process usage: {usage_dict}")
     except Exception as exc:
         logger.warning(
             f"Exception while trying to log ERT process resource usage: {exc}"

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -55,9 +55,7 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
     logger = logging.getLogger(__name__)
     for fm_step_name, count in counter_fm_steps.items():
         logger.info(
-            "Config contains forward model step %s %d time(s)",
-            fm_step_name,
-            count,
+            f"Config contains forward model step {fm_step_name} {count} time(s)",
         )
 
     if not ert_config.observations and args.mode not in [

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -349,7 +349,7 @@ class ErtConfig:
         tmp_dict.pop("HOOK_WORKFLOW", None)
         tmp_dict.pop("WORKFLOW_JOB_DIRECTORY", None)
 
-        logger.info("Content of the config_dict: %s", tmp_dict)
+        logger.info(f"Content of the config_dict: {tmp_dict}")
 
     @staticmethod
     def apply_config_content_defaults(content_dict: dict, config_dir: str):
@@ -633,10 +633,8 @@ class ErtConfig:
                         result[new_key] = new_value
                     else:
                         logger.warning(
-                            "Environment variable %s skipped due to"
-                            " unmatched define %s",
-                            new_key,
-                            new_value,
+                            f"Environment variable {new_key} skipped due to"
+                            f" unmatched define {new_value}",
                         )
                 # Its expected that empty dicts be replaced with "null"
                 # in jobs.json

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -116,7 +116,7 @@ def _start_initial_gui_window(
                 and cast(ConfigWarning, w.message).info.is_deprecation
             ]
             error_messages += error.errors
-            logger.info("Error in config file shown in gui: '%s'", str(error))
+            logger.info(f"Error in config file shown in gui: '{error}'")
             return (
                 Suggestor(
                     error_messages,
@@ -147,18 +147,16 @@ def _start_initial_gui_window(
 
     for fm_step_name, count in counter_fm_steps.items():
         logger.info(
-            "Config contains forward model step %s %d time(s)",
-            fm_step_name,
-            count,
+            f"Config contains forward model step {fm_step_name} {count} time(s)",
         )
 
     for wm in all_warnings:
         if wm.category != ConfigWarning:
             logger.warning(str(wm.message))
     for msg in deprecations:
-        logger.info("Suggestion shown in gui '%s'", msg)
+        logger.info(f"Suggestion shown in gui '{msg}'")
     for msg in config_warnings:
-        logger.info("Warning shown in gui '%s'", msg)
+        logger.info(f"Warning shown in gui '{msg}'")
     storage = open_storage(ert_config.ens_path, mode="w")
     _main_window = _setup_main_window(
         ert_config, args, log_handler, storage, plugin_manager


### PR DESCRIPTION
**Issue**
Resolves lack of `extra` propagation, the `extra` dict requires an explicit formatter for it to be logged. 

Also use f-strings for logging all over.

**Approach**
🚋 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
