### PR TITLE
Avoid deprecation warning from pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ markers = [
 ]
 log_cli = "false"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 timeout = 360
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This deprecation warning pops up from pytest-asyncio==0.24

**Issue**
Resolves warning from pytest runs:
```
/tmp/f_scout_ci/actions-runner-06/_temp/test-kenv/root/lib64/python3.8/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```

**Approach**
Read https://github.com/pytest-dev/pytest-asyncio/issues/924



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
