### PR TITLE
Remove unused progress fixture

### DIFF
--- a/tests/integration_tests/status/test_tracking_integration.py
+++ b/tests/integration_tests/status/test_tracking_integration.py
@@ -68,7 +68,7 @@ def check_expression(original, path_expression, expected, msg_start):
 @pytest.mark.parametrize(
     (
         "extra_config, extra_poly_eval, cmd_line_arguments,"
-        "num_successful,num_iters,progress,assert_present_in_snapshot"
+        "num_successful,num_iters,assert_present_in_snapshot"
     ),
     [
         pytest.param(
@@ -82,7 +82,6 @@ def check_expression(original, path_expression, expected, msg_start):
             ],
             0,
             1,
-            1.0,
             [
                 (".*", "reals.*.forward_models.*.status", FORWARD_MODEL_STATE_FAILURE),
                 (
@@ -104,7 +103,6 @@ def check_expression(original, path_expression, expected, msg_start):
             ],
             2,
             1,
-            1.0,
             [(".*", "reals.*.forward_models.*.status", FORWARD_MODEL_STATE_FINISHED)],
             id="ee_poly_experiment",
         ),
@@ -119,7 +117,6 @@ def check_expression(original, path_expression, expected, msg_start):
             ],
             2,
             2,
-            1.0,
             [(".*", "reals.*.forward_models.*.status", FORWARD_MODEL_STATE_FINISHED)],
             id="ee_poly_smoother",
         ),
@@ -135,7 +132,6 @@ def check_expression(original, path_expression, expected, msg_start):
             1,
             1,
             # Fails halfway, due to unable to run update
-            0.5,
             [
                 (
                     "0",
@@ -159,7 +155,6 @@ def test_tracking(
     cmd_line_arguments,
     num_successful,
     num_iters,
-    progress,
     assert_present_in_snapshot,
     storage,
 ):


### PR DESCRIPTION
**Issue**
Progress fixture is not used in test_tracking_integration.


**Approach**
:scissors: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
