### PR TITLE
Fix bug manual update step does not stop progress bar indicator

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -450,6 +450,7 @@ class RunDialog(QDialog):
             widget.begin(event)
 
         elif isinstance(event, RunModelUpdateEndEvent):
+            self._progress_widget.stop_waiting_progress_bar()
             if (widget := self._get_update_widget(event.iteration)) is not None:
                 widget.end(event)
 

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -74,7 +74,7 @@ class ProgressWidget(QFrame):
     def repaint_components(self) -> None:
         if self._realization_count > 0:
             full_width = self.width()
-            self._waiting_progress_bar.setVisible(False)
+            self.stop_waiting_progress_bar()
 
             for state, label in self._progress_label_map.items():
                 label.setVisible(True)
@@ -86,6 +86,9 @@ class ProgressWidget(QFrame):
                 label.setText(
                     f" {state} ({self._status.get(state,0)}/{self._realization_count})"
                 )
+
+    def stop_waiting_progress_bar(self) -> None:
+        self._waiting_progress_bar.setVisible(False)
 
     def update_progress(self, status: dict[str, int], realization_count: int) -> None:
         self._status = status


### PR DESCRIPTION
**Issue**
Resolves #8600


**Approach**
🤿 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
