### PR TITLE
Use plot() instead of deprecated plot_date()

### DIFF
--- a/src/ert/gui/plottery/plots/ensemble.py
+++ b/src/ert/gui/plottery/plots/ensemble.py
@@ -50,7 +50,6 @@ class EnsemblePlot:
                     config,
                     data,
                     f"{ensemble.experiment_name} : {ensemble.name}",
-                    plot_context.isDateSupportActive(),
                 )
                 config.nextColor()
 
@@ -72,34 +71,22 @@ class EnsemblePlot:
         plot_config: PlotConfig,
         data: pd.DataFrame,
         ensemble_label: str,
-        is_date_supported: bool,
     ) -> None:
         style = plot_config.defaultStyle()
 
         if len(data) == 1 and not style.marker:
             style.marker = "."
 
-        if is_date_supported:
-            lines = axes.plot_date(
-                x=data.index.to_numpy(),
-                y=data.to_numpy(),
-                color=style.color,
-                alpha=style.alpha,
-                linewidth=style.width,
-                markersize=style.size,
-                fmt=f"{style.marker}{style.line_style}",
-            )
-        else:
-            lines = axes.plot(
-                data.index.to_numpy(),
-                data.to_numpy(),
-                color=style.color,
-                alpha=style.alpha,
-                marker=style.marker,
-                linestyle=style.line_style,
-                linewidth=style.width,
-                markersize=style.size,
-            )
+        lines = axes.plot(
+            data.index.to_numpy(),
+            data.to_numpy(),
+            color=style.color,
+            alpha=style.alpha,
+            marker=style.marker,
+            linewidth=style.width,
+            linestyle=style.line_style,
+            markersize=style.size,
+        )
 
         if len(lines) > 0:
             plot_config.addLegendItem(ensemble_label, lines[0])

--- a/src/ert/gui/plottery/plots/history.py
+++ b/src/ert/gui/plottery/plots/history.py
@@ -16,18 +16,17 @@ def plotHistory(plot_context: "PlotContext", axes: "Axes") -> None:
     ):
         return
 
-    data = plot_context.history_data
-
     style = plot_config.historyStyle()
 
-    lines = axes.plot_date(
-        x=data.index.values,
-        y=data,
+    lines = axes.plot(
+        plot_context.history_data.index.values,
+        plot_context.history_data,
         color=style.color,
         alpha=style.alpha,
         linewidth=style.width,
         markersize=style.size,
-        fmt=f"{style.marker}{style.line_style}",
+        marker=style.marker,
+        linestyle=style.line_style,
     )
 
     if len(lines) > 0 and style.isVisible():


### PR DESCRIPTION
plot_date() has been discouraged since matplotlib 3.5, and deprecated from 3.9. Instead we use plot() directly, and the datatype of the first argument (the x-data) will determine the kind of plot.

**Issue**
Resolves 
```
tests/unit_tests/gui/plottery/test_plotting_of_snake_oil.py::test_that_all_plotter_filter_boxes_yield_expected_filter_results[0]
  /data/projects/ert/src/ert/gui/plottery/plots/ensemble.py:83: MatplotlibDeprecationWarning: The plot_date function was deprecated in Matplotlib 3.9 and will be removed in 3.11. Use plot instead.
    lines = axes.plot_date(

```
(on python 3.11)

**Approach**
Change.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
