### PR TITLE
Add debug info to clipboard capability

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -626,17 +626,7 @@ def ert_parser(parser: Optional[ArgumentParser], args: Sequence[str]) -> Namespa
 def log_process_usage() -> None:
     try:
         usage = resource.getrusage(resource.RUSAGE_SELF)
-
-        if sys.platform == "darwin":
-            # macOS apparently outputs the maxrss value as bytes rather than
-            # kilobytes as on Linux.
-            #
-            # https://stackoverflow.com/questions/59913657/strange-values-of-get-rusage-maxrss-on-macos-and-linux
-            rss_scale = 1000
-        else:
-            rss_scale = 1
-
-        maxrss = usage.ru_maxrss // rss_scale
+        max_rss = ert.shared.status.utils.get_ert_memory_usage()
 
         usage_dict: Dict[str, Union[int, float]] = {
             "User time": usage.ru_utime,
@@ -647,7 +637,7 @@ def log_process_usage() -> None:
             "Socket messages Received": usage.ru_msgrcv,
             "Signals received": usage.ru_nsignals,
             "Swaps": usage.ru_nswap,
-            "Peak memory use (KB)": maxrss,
+            "Peak memory use (KB)": max_rss,
         }
         logger.info(f"Ert process usage: {usage_dict}")
     except Exception as exc:

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -328,26 +328,19 @@ class QueueConfig:
                     "MEMORY_PER_JOB",
                     selected_queue_system == QueueSystem.TORQUE,
                 )
-            if (
-                isinstance(_queue_vals, SlurmQueueOptions)
-                and _queue_vals.memory
-                and realization_memory
-            ):
-                _throw_error_or_warning(
-                    "Do not specify both REALIZATION_MEMORY and SLURM option MEMORY",
-                    "MEMORY",
-                    selected_queue_system == QueueSystem.SLURM,
-                )
-            if (
-                isinstance(_queue_vals, SlurmQueueOptions)
-                and _queue_vals.memory_per_cpu
-                and realization_memory
-            ):
-                _throw_error_or_warning(
-                    "Do not specify both REALIZATION_MEMORY and SLURM option MEMORY_PER_CPU",
-                    "MEMORY_PER_CPU",
-                    selected_queue_system == QueueSystem.SLURM,
-                )
+            if isinstance(_queue_vals, SlurmQueueOptions) and realization_memory:
+                if _queue_vals.memory:
+                    _throw_error_or_warning(
+                        "Do not specify both REALIZATION_MEMORY and SLURM option MEMORY",
+                        "MEMORY",
+                        selected_queue_system == QueueSystem.SLURM,
+                    )
+                if _queue_vals.memory_per_cpu:
+                    _throw_error_or_warning(
+                        "Do not specify both REALIZATION_MEMORY and SLURM option MEMORY_PER_CPU",
+                        "MEMORY_PER_CPU",
+                        selected_queue_system == QueueSystem.SLURM,
+                    )
 
         return QueueConfig(
             job_script,

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import os
+import platform
 from collections import OrderedDict
+from dataclasses import fields
+from datetime import datetime
+from pathlib import Path
 from queue import SimpleQueue
-from typing import TYPE_CHECKING, Any, List, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Type
 
 from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtGui import QIcon, QStandardItemModel
@@ -21,8 +26,14 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+import ert.shared
 from ert.gui.ertnotifier import ErtNotifier
-from ert.run_models import BaseRunModel, StatusEvents, create_model
+from ert.run_models import BaseRunModel, SingleTestRun, StatusEvents, create_model
+from ert.shared.status.utils import (
+    byte_with_unit,
+    format_running_time,
+    get_ert_memory_usage,
+)
 
 from .combobox_with_description import QComboBoxWithDescription
 from .ensemble_experiment_panel import EnsembleExperimentPanel
@@ -40,6 +51,14 @@ if TYPE_CHECKING:
 
 EXPERIMENT_READY_TO_RUN_BUTTON_MESSAGE = "Run Experiment"
 EXPERIMENT_IS_RUNNING_BUTTON_MESSAGE = "Experiment running..."
+
+
+def create_md_table(kv: Dict[str, str], output: str) -> str:
+    for k, v in kv.items():
+        v = v.replace("_", r"\_")
+        output += f"| {k} | {v} |\n"
+    output += "\n"
+    return output
 
 
 class ExperimentPanel(QWidget):
@@ -206,6 +225,8 @@ class ExperimentPanel(QWidget):
             )
             return
 
+        self._model = model
+
         QApplication.restoreOverrideCursor()
         if model.check_if_runpath_exists():
             msg_box = QMessageBox(self)
@@ -270,6 +291,8 @@ class ExperimentPanel(QWidget):
             self.parent(),  # type: ignore
             output_path=self.config.analysis_config.log_path,
         )
+        dialog.produce_clipboard_debug_info.connect(self.populate_clipboard_debug_info)
+
         self.run_button.setEnabled(False)
         self.run_button.setText(EXPERIMENT_IS_RUNNING_BUTTON_MESSAGE)
         dialog.run_experiment()
@@ -297,3 +320,59 @@ class ExperimentPanel(QWidget):
             self.run_button.text() == EXPERIMENT_READY_TO_RUN_BUTTON_MESSAGE
             and widget.isConfigurationValid()
         )
+
+    def populate_clipboard_debug_info(self) -> None:
+        kv = {"**Platform**": "", ":-----": ":-----"}
+        kv["Date"] = datetime.now().isoformat(" ", "seconds")
+        kv["OS"] = (
+            platform.system() + " " + platform.release() + " " + platform.machine()
+        )
+        kv["Hostname"] = ert.shared.get_machine_name()
+        kv["Komodo release"] = os.environ.get("KOMODO_RELEASE", "")
+        kv["Python version"] = platform.python_version()
+
+        kv["**Ensemble**"] = ""
+        queue_system = self.config.queue_config.queue_system
+        kv["Queue"] = queue_system.name.capitalize()
+        kv["Simulation mode"] = self.get_current_experiment_type().name()
+        kv["Config file"] = str(Path(self._config_file).absolute())
+        kv["Storage path"] = self.config.ens_path
+        kv["Run path"] = str(self.config.model_config.runpath_format_string)
+        kv["Ensemble size"] = str(self.config.model_config.num_realizations)
+
+        if self.config.queue_config.realization_memory > 0:
+            kv["Realization memory"] = byte_with_unit(
+                self.config.queue_config.realization_memory
+            )
+
+        if self.config.queue_config.max_submit > 1:
+            kv["Max submit"] = str(self.config.queue_config.max_submit)
+        if self.config.queue_config.stop_long_running:
+            kv["Stop long running"] = str(self.config.queue_config.stop_long_running)
+
+        queue_opts = self.config.queue_config.queue_options
+
+        if isinstance(self.get_current_experiment_type(), SingleTestRun):
+            queue_opts = self.config.queue_config.queue_options_test_run
+
+        for field in fields(queue_opts):
+            field_value = getattr(queue_opts, field.name)
+            if field_value is not None:
+                kv[field.name.replace("_", " ").capitalize()] = str(field_value)
+
+        kv["**Status**"] = ""
+        kv["Running time"] = (
+            format_running_time(self._model.get_runtime()).split(":")[1].strip()
+        )
+        kv["Ert max memory"] = byte_with_unit(get_ert_memory_usage())
+        kv["Forward model max memory"] = byte_with_unit(
+            self._model.get_memory_consumption()
+        )
+
+        for status, count in self._model.get_current_status().items():
+            kv[status] = str(count)
+
+        output = create_md_table(kv, "")
+        clipboard = QApplication.clipboard()
+        if clipboard:
+            clipboard.setText(output)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -169,6 +169,7 @@ class JobOverview(QTableView):
 
 class RunDialog(QDialog):
     simulation_done = Signal(bool, str)
+    produce_clipboard_debug_info = Signal()
     on_run_model_event = Signal(object)
     _RUN_TIME_POLL_RATE = 1000
 
@@ -234,6 +235,10 @@ class RunDialog(QDialog):
         self.done_button.setHidden(True)
         self.restart_button = QPushButton("Restart")
         self.restart_button.setHidden(True)
+        self.copy_debug_info_button = QPushButton("Debug Info")
+        self.copy_debug_info_button.setToolTip("Copies useful information to clipboard")
+        self.copy_debug_info_button.clicked.connect(self.produce_clipboard_debug_info)
+        self.copy_debug_info_button.setObjectName("copy_debug_info_button")
 
         size = 20
         spin_movie = QMovie("img:loading.gif")
@@ -252,6 +257,7 @@ class RunDialog(QDialog):
         button_layout.addStretch()
         button_layout.addWidget(self.memory_usage)
         button_layout.addStretch()
+        button_layout.addWidget(self.copy_debug_info_button)
         button_layout.addWidget(self.plot_button)
         button_layout.addWidget(self.kill_button)
         button_layout.addWidget(self.done_button)
@@ -517,6 +523,9 @@ class RunDialog(QDialog):
             self.done_button.setVisible(False)
             self.run_experiment(restart=True)
 
+    def get_runtime(self) -> int:
+        return self._run_model.get_runtime()
+
     def _on_finished(self) -> None:
         for file_dialog in self.findChildren(FileDialog):
             file_dialog.close()
@@ -526,6 +535,8 @@ class RunDialog(QDialog):
         # so call self.close() instead
         if a0 is not None and a0.key() == Qt.Key.Key_Escape:
             self.close()
+        elif a0 is not None and a0.key() == Qt.Key.Key_F1:
+            self.produce_clipboard_debug_info.emit()
         else:
             QDialog.keyPressEvent(self, a0)
 

--- a/src/ert/shared/status/utils.py
+++ b/src/ert/shared/status/utils.py
@@ -1,5 +1,7 @@
 import math
 import os
+import resource
+import sys
 
 
 def byte_with_unit(byte_count: float) -> str:
@@ -69,3 +71,14 @@ def file_has_content(file_path: str) -> bool:
     if file_path_exists:
         return os.path.getsize(file_path) > 0
     return False
+
+
+def get_ert_memory_usage() -> int:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    rss_scale = 1
+    if sys.platform == "darwin":
+        # macOS apparently outputs the maxrss value as bytes rather than kilobytes as on Linux.
+        # https://stackoverflow.com/questions/59913657/strange-values-of-get-rusage-maxrss-on-macos-and-linux
+        rss_scale = 1000
+
+    return usage.ru_maxrss // rss_scale


### PR DESCRIPTION
**Issue**
Resolves #8582 

Pressing `F1` or using the button in run_dialog will yield this markdown in your clipboard

(screenshot and printout are from different runs)

| **Platform** |  |
| :----- | :----- |
| Date | 2024-09-09 09:36:28 |
| OS | Linux 4.18.0-553.8.1.el8\_10.x86\_64 x86\_64 |
| Hostname | st-lintgx0138.st.statoil.no |
| Komodo release | /private/andrli/rhel8-bleed-env |
| Python version | 3.8.17 |
| **Ensemble** |  |
| Queue | Lsf |
| Simulation mode | Ensemble experiment |
| Config file | /private/andrli/project/ert/test-data/poly\_example/poly.ert |
| Storage path | /private/andrli/project/ert/test-data/poly\_example/storage |
| Run path | /private/andrli/project/ert/test-data/poly\_example/poly\_out/realization-<IENS>/iter-<ITER> |
| Ensemble size | 100 |
| Realization memory | 52.43 MB |
| Max running | 50 |
| Submit sleep | 1.0 |
| Lsf queue | mr8 |
| Lsf resource | select[cs && x86\_64Linux] rusage[mem=7000] |
| **Status** |  |
| Running time | 10 seconds |
| Ert max memory | 463.44 KB |
| Forward model max memory | 892.93 KB |
| Running | 1 |
| Pending | 4 |
| Waiting | 95 |

![Screenshot 2024-09-05 at 13 52 36](https://github.com/user-attachments/assets/607b80fb-88a6-4ef8-abf9-60cc55397a09)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
