### PR TITLE
Run snapshot_update in executor

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -447,7 +447,13 @@ class BaseRunModel(ABC):
                         EESnapshotUpdate,
                     ):
                         event = cast(Union[EESnapshot, EESnapshotUpdate], event)
-                        self.send_snapshot_event(event, iteration)
+                        await asyncio.get_running_loop().run_in_executor(
+                            None,
+                            self.send_snapshot_event,
+                            event,
+                            iteration,
+                        )
+
                         if event.snapshot.get(STATUS) in [
                             ENSEMBLE_STATE_STOPPED,
                             ENSEMBLE_STATE_FAILED,

--- a/tests/integration_tests/status/test_tracking_integration.py
+++ b/tests/integration_tests/status/test_tracking_integration.py
@@ -206,6 +206,9 @@ def test_tracking(
     snapshots: Dict[str, Snapshot] = {}
 
     thread.join()
+
+    assert isinstance(queue.events[-1], EndEvent)
+
     for event in queue:
         if isinstance(event, FullSnapshotEvent):
             snapshots[event.iteration] = event.snapshot


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8359


**Approach**
`send_snapshot_event` could be more CPU bound that initially though and thus suggestion is to run snapshot_update in executor.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
