### PR TITLE
Only disable weights when weights have been found in storage

### DIFF
--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -153,6 +153,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
                 self._ensemble_selector.selected_ensemble.relative_weights
                 or MultipleDataAssimilation.default_weights
             )
+            self._evaluate_weights_box_enabled()
 
     @Slot(bool)
     def update_experiment_edit(self, checked: bool) -> None:
@@ -165,7 +166,13 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
 
         self._experiment_name_field.enable_validation(not checked)
         self._experiment_name_field.setEnabled(not checked)
-        self._relative_iteration_weights_box.setEnabled(not checked)
+        self._evaluate_weights_box_enabled()
+
+    def _evaluate_weights_box_enabled(self) -> None:
+        self._relative_iteration_weights_box.setEnabled(
+            not self._restart_box.isChecked()
+            or not self._ensemble_selector.selected_ensemble.relative_weights
+        )
 
     def restart_run_toggled(self) -> None:
         self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))


### PR DESCRIPTION
**Issue**
Resolves #8611 

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
