### PR TITLE
Fix error in job dispatch's memory reporting

### DIFF
--- a/src/_ert_forward_model_runner/job.py
+++ b/src/_ert_forward_model_runner/job.py
@@ -400,6 +400,6 @@ def _get_rss_and_oom_score_for_processtree(
                     else oom_score_child
                 )
             with contextlib.suppress(NoSuchProcess, AccessDenied, ZombieProcess):
-                memory_rss += process.memory_info().rss
+                memory_rss += child.memory_info().rss
 
     return (memory_rss, oom_score)

--- a/tests/unit_tests/forward_model_runner/test_job.py
+++ b/tests/unit_tests/forward_model_runner/test_job.py
@@ -53,12 +53,12 @@ def test_memory_usage_counts_grandchildren():
             import sys
             import time
 
-            counter = int(sys.argv[-1])
-            numbers = list(range(int(1e6)))
+            counter = int(sys.argv[-2])
+            numbers = list(range(int(sys.argv[-1])))
             if counter > 0:
                 parent = os.fork()
                 if not parent:
-                    os.execv(sys.argv[-2], [sys.argv[-2], str(counter - 1)])
+                    os.execv(sys.argv[-3], [sys.argv[-3], str(counter - 1), str(int(1e7))])
             time.sleep(1)"""  # Too low sleep will make the test faster but flaky
             )
         )
@@ -69,7 +69,7 @@ def test_memory_usage_counts_grandchildren():
         job = Job(
             {
                 "executable": executable,
-                "argList": [str(layers)],
+                "argList": [str(layers), str(int(1e6))],
             },
             0,
         )
@@ -84,7 +84,7 @@ def test_memory_usage_counts_grandchildren():
     # comparing the memory used with different amounts of forks done.
     # subtract a little bit (* 0.9) due to natural variance in memory used
     # when running the program.
-    memory_per_numbers_list = sys.getsizeof(int(0)) * 1e6 * 0.9
+    memory_per_numbers_list = sys.getsizeof(int(0)) * 1e7 * 0.90
 
     max_seens = [max_memory_per_subprocess_layer(layers) for layers in range(3)]
     assert max_seens[0] + memory_per_numbers_list < max_seens[1]


### PR DESCRIPTION
**Issue**
Resolves #8642

**Approach**
Child process rss usage was not added. Fixed and updated test so that it will catch this error.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
