### PR TITLE
Make copy_directories error message readable

### DIFF
--- a/src/ert/resources/shell_scripts/copy_directory.py
+++ b/src/ert/resources/shell_scripts/copy_directory.py
@@ -32,4 +32,6 @@ if __name__ == "__main__":
     try:
         copy_directory(src_path, target_path)
     except IOError as e:
-        sys.exit(f"COPY_DIRECTORY failed with the following error: {e}")
+        sys.exit(
+            f"COPY_DIRECTORY failed with the following error: {''.join(e.args[0])}"
+        )

--- a/tests/unit_tests/shared/share/test_shell.py
+++ b/tests/unit_tests/shared/share/test_shell.py
@@ -400,6 +400,17 @@ def test_copy_directory_error(shell):
 
     assert b"existing directory" in shell.copy_directory("hei", "target").stderr
 
+    empty_dir = "emptytestdir"
+    if not os.path.exists(empty_dir):
+        os.makedirs(empty_dir)
+
+    file_path = os.path.join(empty_dir, "file")
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("some_text")
+
+    assert b"are the same" in shell.copy_directory(empty_dir, ".").stderr
+
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_copy_file(shell):


### PR DESCRIPTION
**Issue**
Resolves #8660 

The error would only occur if copying a folder containing a file.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
