### PR TITLE
Fix restart experiment by updating shapshot only

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -233,7 +233,7 @@ class RunDialog(QDialog):
         self.kill_button = QPushButton("Terminate experiment")
         self.done_button = QPushButton("Done")
         self.done_button.setHidden(True)
-        self.restart_button = QPushButton("Restart")
+        self.restart_button = QPushButton("Rerun failed")
         self.restart_button.setHidden(True)
         self.copy_debug_info_button = QPushButton("Debug Info")
         self.copy_debug_info_button.setToolTip("Copies useful information to clipboard")

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -170,7 +170,6 @@ class FMStepOverview(QTableView):
 class RunDialog(QDialog):
     simulation_done = Signal(bool, str)
     produce_clipboard_debug_info = Signal()
-    on_run_model_event = Signal(object)
     _RUN_TIME_POLL_RATE = 1000
 
     def __init__(
@@ -304,8 +303,6 @@ class RunDialog(QDialog):
 
         self.setMinimumSize(self._minimum_width, self._minimum_height)
         self.finished.connect(self._on_finished)
-
-        self.on_run_model_event.connect(self._on_event)
 
         self._restart = False
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -307,6 +307,8 @@ class RunDialog(QDialog):
 
         self.on_run_model_event.connect(self._on_event)
 
+        self._restart = False
+
     def _current_tab_changed(self, index: int) -> None:
         widget = self._tab_widget.widget(index)
         self.fm_step_frame.setHidden(isinstance(widget, UpdateWidget))
@@ -348,8 +350,10 @@ class RunDialog(QDialog):
             a0.ignore()
 
     def run_experiment(self, restart: bool = False) -> None:
-        self._snapshot_model.reset()
-        self._tab_widget.clear()
+        self._restart = restart
+        if restart is False:
+            self._snapshot_model.reset()
+            self._tab_widget.clear()
 
         port_range = None
         if self._run_model.queue_system == QueueSystem.LOCAL:
@@ -431,7 +435,14 @@ class RunDialog(QDialog):
             self.done_button.setHidden(False)
         elif isinstance(event, FullSnapshotEvent):
             if event.snapshot is not None:
-                self._snapshot_model._add_snapshot(event.snapshot, str(event.iteration))
+                if self._restart:
+                    self._snapshot_model._update_snapshot(
+                        event.snapshot, str(event.iteration)
+                    )
+                else:
+                    self._snapshot_model._add_snapshot(
+                        event.snapshot, str(event.iteration)
+                    )
             self.update_total_progress(event.progress, event.iteration_label)
             self._progress_widget.update_progress(
                 event.status_count, event.realization_count

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -394,6 +394,7 @@ class BaseRunModel(ABC):
                 for real in all_realizations.values():
                     status[str(real["status"])] += 1
 
+        status["Finished"] += self.active_realizations.count(False)
         return status
 
     def get_memory_consumption(self) -> int:
@@ -409,10 +410,10 @@ class BaseRunModel(ABC):
 
     def _current_progress(self) -> tuple[float, int]:
         current_iter = max(list(self._iter_snapshot.keys()))
-        done_realizations = 0
+        done_realizations = self.active_realizations.count(False)
         all_realizations = self._iter_snapshot[current_iter].reals
         current_progress = 0.0
-        realization_count = len(all_realizations)
+        realization_count = len(self.active_realizations)
 
         if all_realizations:
             for real in all_realizations.values():
@@ -422,7 +423,9 @@ class BaseRunModel(ABC):
                 ]:
                     done_realizations += 1
 
-            realization_progress = float(done_realizations) / len(all_realizations)
+            realization_progress = float(done_realizations) / len(
+                self.active_realizations
+            )
             current_progress = (
                 (current_iter + realization_progress) / self._total_iterations
                 if self._total_iterations != 1

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -113,13 +113,15 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
-    # Assert that the number of boxes in the detailed view is
-    # equal to the number of previously failed realizations
+    # We expect to have the same amount of realizations in list_model
+    # since we reuse the snapshot_model
     realization_widget = run_dialog._tab_widget.currentWidget()
     assert isinstance(realization_widget, RealizationWidget)
     list_model = realization_widget._real_view.model()
     assert list_model
-    assert list_model.rowCount() == len(failed_realizations)
+    assert (
+        list_model.rowCount() == experiment_panel.config.model_config.num_realizations
+    )
 
     # Second restart
     assert any(run_dialog._run_model._create_mask_from_failed_realizations())
@@ -142,12 +144,14 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
-    # Assert that the number of boxes in the detailed view is
-    # equal to the number of previously failed realizations
+    # We expect to have the same amount of realizations in list_model
+    # since we reuse the snapshot_model
     realization_widget = run_dialog._tab_widget.currentWidget()
     assert isinstance(realization_widget, RealizationWidget)
     list_model = realization_widget._real_view.model()
     assert list_model
-    assert list_model.rowCount() == len(failed_realizations)
+    assert (
+        list_model.rowCount() == experiment_panel.config.model_config.num_realizations
+    )
 
     qtbot.mouseClick(run_dialog.done_button, Qt.MouseButton.LeftButton)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8032


**Approach**
When restart happens just re-use the old snapshot model.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/c00f5cc6-bffc-49c3-9219-c270860cc584)

The only issue is that the number of realizations (in the status bar) is different than what GUI shows.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure tests pass locally (after every commit!)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
