### PR TITLE
Avoid problem with non-executable name-clash & fix pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ _Short description of the approach_
 - [ ] PR title captures the intent of the changes, and is fitting for release notes.
 - [ ] Added appropriate release note label
 - [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
-- [ ] Make sure unit tests pass locally after every commit (`git rebase -i 10
+- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
       --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)
 
 ## When applicable

--- a/tests/unit_tests/config/parsing/test_lark_parser.py
+++ b/tests/unit_tests/config/parsing/test_lark_parser.py
@@ -300,7 +300,7 @@ def test_that_giving_non_executable_gives_config_validation_error():
     test_config_contents = dedent(
         """
         NUM_REALIZATIONS  1
-        JOB_SCRIPT  hello
+        JOB_SCRIPT  not-an-executable-anyone-would-have-on-their-laptop
         """
     )
     with open(test_config_file_name, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
There is apparently a commonly installed executable named hello from qml_hello

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i 10
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
