### PR TITLE
Move migration obs writing logic to ert_config

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -122,6 +122,10 @@ class ErtConfig:
 
         self.observations: Dict[str, xr.Dataset] = self.enkf_obs.datasets
 
+    def write_observations_to_folder(self, dest: Path) -> None:
+        for name, dataset in self.observations.items():
+            dataset.to_netcdf(dest / f"{name}", engine="scipy")
+
     @staticmethod
     def with_plugins(
         forward_model_step_classes: Optional[List[Type[ForwardModelStepPlugin]]] = None,

--- a/src/ert/storage/migration/to4.py
+++ b/src/ert/storage/migration/to4.py
@@ -20,8 +20,7 @@ def migrate(path: Path) -> None:
         if observations:
             output_path = experiment / "observations"
             output_path.mkdir(parents=True, exist_ok=True)
-            for name, dataset in observations.items():
-                dataset.to_netcdf(output_path / f"{name}", engine="scipy")
+            ert_config.write_observations_to_folder(dest=output_path)
         with open(experiment / "parameter.json", encoding="utf-8") as fin:
             parameters_json = json.load(fin)
         with open(experiment / "parameter.json", "w", encoding="utf-8") as fout:


### PR DESCRIPTION
Makes the migration agnostic of ertconfig specifics. 

pros:
* Removes requirement for `.to4.py` to always output **one netcdf file per  observation key**
* Lets us change ert structure/format of observations in ERT config without changing migration

cons: 
* Will have to keep manually in sync with observation-writing in `local_experiment.py` (for now just a single if statement, likely not that many in the future)
* Further migration increments to observations will have to check if they are already migrated to the latest (which they will be if a `.to4()` migration is done
