### PR TITLE
Move fixtures to where they are used

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,11 @@ import shutil
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import List, Optional
 from unittest.mock import MagicMock
 
 from qtpy.QtWidgets import QApplication
 
 from _ert.threading import set_signal_handler
-from ert.run_arg import RunArg, create_run_arguments
-from ert.runpaths import Runpaths
 
 if sys.version_info >= (3, 9):
     from importlib.resources import files
@@ -31,7 +28,7 @@ from ert.config import ErtConfig
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE, ES_MDA_MODE
 from ert.services import StorageService
-from ert.storage import Ensemble, open_storage
+from ert.storage import open_storage
 
 from .utils import SOURCE_DIR
 
@@ -474,37 +471,3 @@ def no_cert_in_test(monkeypatch):
             super().__init__(*args, **kwargs)
 
     monkeypatch.setattr("ert.cli.main.EvaluatorServerConfig", MockESConfig)
-
-
-@pytest.fixture
-def run_paths():
-    def func(ert_config: ErtConfig):
-        return Runpaths(
-            jobname_format=ert_config.model_config.jobname_format_string,
-            runpath_format=ert_config.model_config.runpath_format_string,
-            filename=str(ert_config.runpath_file),
-            substitution_list=ert_config.substitution_list,
-        )
-
-    yield func
-
-
-@pytest.fixture
-def run_args(run_paths):
-    def func(
-        ert_config: ErtConfig,
-        ensemble: Ensemble,
-        active_realizations: Optional[int] = None,
-    ) -> List[RunArg]:
-        active_realizations = (
-            ert_config.model_config.num_realizations
-            if active_realizations is None
-            else active_realizations
-        )
-        return create_run_arguments(
-            run_paths(ert_config),
-            [True] * active_realizations,
-            ensemble,
-        )
-
-    yield func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,11 @@
 import fileinput
-import json
 import logging
 import os
 import resource
 import shutil
-import stat
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-from textwrap import dedent
 from typing import List, Optional
 from unittest.mock import MagicMock
 
@@ -477,61 +474,6 @@ def no_cert_in_test(monkeypatch):
             super().__init__(*args, **kwargs)
 
     monkeypatch.setattr("ert.cli.main.EvaluatorServerConfig", MockESConfig)
-
-
-QSTAT_HEADER = (
-    "Job id                         Name            User             Time Use S Queue\n"
-    "-----------------------------  --------------- ---------------  -------- - ---------------\n"
-)
-QSTAT_HEADER_FORMAT = "%-30s %-15s %-15s %-8s %-1s %-5s"
-
-
-@pytest.fixture
-def create_mock_flaky_qstat(monkeypatch, tmp_path):
-    bin_path = tmp_path / "bin"
-    bin_path.mkdir()
-    monkeypatch.chdir(bin_path)
-    monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
-    yield _mock_flaky_qstat
-
-
-def _mock_flaky_qstat(error_message_to_output: str):
-    qsub_path = Path("qsub")
-    qsub_path.write_text("#!/bin/sh\necho '1'")
-    qsub_path.chmod(qsub_path.stat().st_mode | stat.S_IEXEC)
-    qstat_path = Path("qstat")
-    qstat_path.write_text(
-        "#!/bin/sh"
-        + dedent(
-            f"""
-            count=0
-            if [ -f counter_file ]; then
-                count=$(cat counter_file)
-            fi
-            echo "$((count+1))" > counter_file
-            if [ $count -ge 3 ]; then
-                json_flag_set=false;
-                while [ "$#" -gt 0 ]; do
-                    case "$1" in
-                        -Fjson)
-                            json_flag_set=true
-                            ;;
-                    esac
-                    shift
-                done
-                if [ "$json_flag_set" = true ]; then
-                    echo '{json.dumps({"Jobs": {"1": {"Job_Name": "1", "job_state": "E", "Exit_status": "0"}}})}'
-                else
-                    echo "{QSTAT_HEADER}"; printf "{QSTAT_HEADER_FORMAT}" 1 foo someuser 0 E normal
-                fi
-            else
-                echo "{error_message_to_output}" >&2
-                exit 2
-            fi
-        """
-        )
-    )
-    qstat_path.chmod(qstat_path.stat().st_mode | stat.S_IEXEC)
 
 
 @pytest.fixture

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,7 +1,13 @@
 import os
 import sys
+from typing import List, Optional
 
 import pytest
+
+from ert.config import ErtConfig
+from ert.run_arg import RunArg, create_run_arguments
+from ert.runpaths import Runpaths
+from ert.storage import Ensemble
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -26,3 +32,37 @@ def snake_oil_field_example(setup_case):
 def prior_ensemble(storage):
     experiment_id = storage.create_experiment()
     return storage.create_ensemble(experiment_id, name="prior", ensemble_size=100)
+
+
+@pytest.fixture
+def run_paths():
+    def func(ert_config: ErtConfig):
+        return Runpaths(
+            jobname_format=ert_config.model_config.jobname_format_string,
+            runpath_format=ert_config.model_config.runpath_format_string,
+            filename=str(ert_config.runpath_file),
+            substitution_list=ert_config.substitution_list,
+        )
+
+    yield func
+
+
+@pytest.fixture
+def run_args(run_paths):
+    def func(
+        ert_config: ErtConfig,
+        ensemble: Ensemble,
+        active_realizations: Optional[int] = None,
+    ) -> List[RunArg]:
+        active_realizations = (
+            ert_config.model_config.num_realizations
+            if active_realizations is None
+            else active_realizations
+        )
+        return create_run_arguments(
+            run_paths(ert_config),
+            [True] * active_realizations,
+            ensemble,
+        )
+
+    yield func

--- a/tests/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/unit_tests/scheduler/test_openpbs_driver.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import shlex
@@ -31,13 +32,19 @@ from ert.scheduler.openpbs_driver import (
     _create_job_class,
     _parse_jobs_dict,
 )
-from tests.conftest import QSTAT_HEADER, QSTAT_HEADER_FORMAT
 from tests.ui_tests.cli.run_cli import run_cli
 from tests.utils import poll
 
 from .conftest import mock_bin
 
 pytestmark = pytest.mark.xdist_group("openpbs")
+
+
+QSTAT_HEADER = (
+    "Job id                         Name            User             Time Use S Queue\n"
+    "-----------------------------  --------------- ---------------  -------- - ---------------\n"
+)
+QSTAT_HEADER_FORMAT = "%-30s %-15s %-15s %-8s %-1s %-5s"
 
 
 @given(st.lists(st.sampled_from(JOB_STATES)))
@@ -505,6 +512,54 @@ async def test_keep_qsub_output(value: bool):
         assert " -o /dev/null -e /dev/null" in Path("captured_qsub_args").read_text(
             encoding="utf-8"
         )
+
+
+@pytest.fixture
+def create_mock_flaky_qstat(monkeypatch, tmp_path):
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    monkeypatch.chdir(bin_path)
+    monkeypatch.setenv("PATH", f"{bin_path}:{os.environ['PATH']}")
+    yield _mock_flaky_qstat
+
+
+def _mock_flaky_qstat(error_message_to_output: str):
+    qsub_path = Path("qsub")
+    qsub_path.write_text("#!/bin/sh\necho '1'")
+    qsub_path.chmod(qsub_path.stat().st_mode | stat.S_IEXEC)
+    qstat_path = Path("qstat")
+    qstat_path.write_text(
+        "#!/bin/sh"
+        + dedent(
+            f"""
+            count=0
+            if [ -f counter_file ]; then
+                count=$(cat counter_file)
+            fi
+            echo "$((count+1))" > counter_file
+            if [ $count -ge 3 ]; then
+                json_flag_set=false;
+                while [ "$#" -gt 0 ]; do
+                    case "$1" in
+                        -Fjson)
+                            json_flag_set=true
+                            ;;
+                    esac
+                    shift
+                done
+                if [ "$json_flag_set" = true ]; then
+                    echo '{json.dumps({"Jobs": {"1": {"Job_Name": "1", "job_state": "E", "Exit_status": "0"}}})}'
+                else
+                    echo "{QSTAT_HEADER}"; printf "{QSTAT_HEADER_FORMAT}" 1 foo someuser 0 E normal
+                fi
+            else
+                echo "{error_message_to_output}" >&2
+                exit 2
+            fi
+        """
+        )
+    )
+    qstat_path.chmod(qstat_path.stat().st_mode | stat.S_IEXEC)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Moved some fixtures to where they are used.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
