### PR TITLE
Improve logging of errors in callback

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -71,6 +71,7 @@ async def _write_responses_to_storage(
             )
         except ValueError as err:
             errors.append(str(err))
+            logger.warning(f"Failed to write: {run_arg.iens}", exc_info=err)
     if errors:
         return LoadResult(LoadStatus.LOAD_FAILURE, "\n".join(errors))
     return LoadResult(LoadStatus.LOAD_SUCCESSFUL, "")
@@ -97,7 +98,7 @@ async def forward_model_ok(
             )
 
     except Exception as err:
-        logging.exception(f"Failed to load results for realization {run_arg.iens}")
+        logger.exception(f"Failed to load results for realization {run_arg.iens}")
         parameters_result = LoadResult(
             LoadStatus.LOAD_FAILURE,
             "Failed to load results for realization "


### PR DESCRIPTION
Adds logging for the _write_response_to_storage as to provide at least the traceback in logs, if something goes wrong.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
