### PR TITLE
Add pyright settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,3 +201,16 @@ allowed-confusables = ["–"]
 
 [tool.ruff.lint.pylint]
 max-args = 20
+
+[tool.pyright]
+include = ["src"]
+exclude = ["tests"]
+reportMissingImports = "error"
+typeCheckingMode = "standard"
+pythonVersion = "3.8"
+
+[tool.pyright.defineConstant]
+PYSIDE6 = false
+PYQT5 = true
+PYSIDE2 = false
+PYQT6 = false


### PR DESCRIPTION
Adds pyright settings to pyproject.toml.
This will also turn on pyright/pylance for vscode users by default. It can be turned off in the IDE if not wanted.

pyright will not be added to the required type tests with this PR

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
