### PR TITLE
Have ForwardModelRunner validate executable_file earlier

### DIFF
--- a/src/_ert/forward_model_runner/io/__init__.py
+++ b/src/_ert/forward_model_runner/io/__init__.py
@@ -6,8 +6,8 @@ def cond_unlink(file):
         os.unlink(file)
 
 
-def assert_file_executable(fname):
-    """The function raises an IOError if the given file is either not a file or
+def check_executable(fname) -> str:
+    """The function returns an error message if the given file is either not a file or
     not an executable.
 
     If the given file name is an absolute path, its functionality is straight
@@ -17,7 +17,7 @@ def assert_file_executable(fname):
 
     """
     if not fname:
-        raise IOError("No executable provided!")
+        return "No executable provided!"
     fname = os.path.expanduser(fname)
 
     potential_executables = [os.path.abspath(fname)]
@@ -28,7 +28,8 @@ def assert_file_executable(fname):
         ]
 
     if not any(map(os.path.isfile, potential_executables)):
-        raise IOError(f"{fname} is not a file!")
+        return f"{fname} is not a file!"
 
     if not any(os.access(fn, os.X_OK) for fn in potential_executables):
-        raise IOError(f"{fname} is not an executable!")
+        return f"{fname} is not an executable!"
+    return ""

--- a/src/_ert/forward_model_runner/job.py
+++ b/src/_ert/forward_model_runner/job.py
@@ -14,7 +14,7 @@ from typing import Optional, Tuple
 
 from psutil import AccessDenied, NoSuchProcess, Process, TimeoutExpired, ZombieProcess
 
-from .io import assert_file_executable
+from .io import check_executable
 from .reporting.message import (
     Exited,
     ProcessTreeStatus,
@@ -97,10 +97,7 @@ class Job:
 
         yield start_message
 
-        executable = self.job_data.get("executable")
-        assert_file_executable(executable)
-
-        arg_list = [executable]
+        arg_list = [self.job_data.get("executable")]
         if self.job_data.get("argList"):
             arg_list += self.job_data["argList"]
 
@@ -313,6 +310,9 @@ class Job:
             self.job_data.get("error_file")
         ):
             os.unlink(self.job_data.get("error_file"))
+
+        if executable_error := check_executable(self.job_data.get("executable")):
+            errors.append(str(executable_error))
 
         return errors
 


### PR DESCRIPTION
This commit fixes the issue where the ForwardModelRunner on the job_runner side would crash when validating the existence of a ForwardModelStep executable; causing the drivers to hang while waiting for a never coming return code from JobRunner.

**Issue**
Resolves #8729


**Approach**
⛄ 

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/816d44f2-7fbc-43aa-8a2b-952f973265fb)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
