### PR TITLE
Stop merging dark storage observations

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -208,16 +208,6 @@ def get_observations_for_obs_keys(
     return observations
 
 
-def get_observation_name(ensemble: Ensemble, observation_keys: List[str]) -> str:
-    observations_dict = ensemble.experiment.observations
-    for key in observation_keys:
-        observation = observations_dict[key]
-        if observation.response == "summary":
-            return observation.name.values.flatten()[0]
-        return key
-    return ""
-
-
 def get_observation_keys_for_response(
     ensemble: Ensemble, response_key: str
 ) -> List[str]:

--- a/src/ert/dark_storage/endpoints/records.py
+++ b/src/ert/dark_storage/endpoints/records.py
@@ -1,5 +1,4 @@
 import io
-from itertools import chain
 from typing import Any, Dict, List, Mapping, Union
 from uuid import UUID, uuid4
 
@@ -14,7 +13,6 @@ from ert.dark_storage.common import (
     ensemble_parameters,
     gen_data_keys,
     get_observation_keys_for_response,
-    get_observation_name,
     get_observations_for_obs_keys,
 )
 from ert.dark_storage.enkf import get_storage
@@ -46,11 +44,12 @@ async def get_record_observations(
         js.ObservationOut(
             id=uuid4(),
             userdata={},
-            errors=list(chain.from_iterable([obs["errors"] for obs in obss])),
-            values=list(chain.from_iterable([obs["values"] for obs in obss])),
-            x_axis=list(chain.from_iterable([obs["x_axis"] for obs in obss])),
-            name=get_observation_name(ensemble, obs_keys),
+            errors=obs["errors"],
+            values=obs["values"],
+            x_axis=obs["x_axis"],
+            name=obs["name"],
         )
+        for obs in obss
     ]
 
 

--- a/tests/performance_tests/test_dark_storage_performance.py
+++ b/tests/performance_tests/test_dark_storage_performance.py
@@ -43,13 +43,13 @@ def get_record_observations(storage, ensemble_id, keyword: str, poly_ran):
         n = int(keyword[4:])
         if n < poly_ran["sum_obs_count"]:
             count = poly_ran["summary_data_entries"] // poly_ran["sum_obs_every"]
-            assert len(obs) == 1
+            assert len(obs) == count
             assert obs[0].errors[0] == 0.1
             assert obs[0].x_axis[0] == "2010-01-02T00:00:00.000000000"
             assert obs[0].values[0] == 2.6357
-            assert len(obs[0].errors) == count
-            assert len(obs[0].x_axis) == count
-            assert len(obs[0].values) == count
+            assert len(obs[0].errors) == 1
+            assert len(obs[0].x_axis) == 1
+            assert len(obs[0].values) == 1
         else:
             assert len(obs) == 0
 
@@ -57,10 +57,10 @@ def get_record_observations(storage, ensemble_id, keyword: str, poly_ran):
         n = int(keyword.split("@")[0][9:])
         if n < poly_ran["gen_obs_count"]:
             count = poly_ran["gen_data_entries"] // poly_ran["gen_obs_every"]
-            assert len(obs) == 1
-            assert len(obs[0].errors) == count
-            assert len(obs[0].x_axis) == count
-            assert len(obs[0].values) == count
+            assert len(obs) == count
+            assert len(obs[0].errors) == 1
+            assert len(obs[0].x_axis) == 1
+            assert len(obs[0].values) == 1
         else:
             assert len(obs) == 0
     else:

--- a/tests/performance_tests/test_dark_storage_performance.py
+++ b/tests/performance_tests/test_dark_storage_performance.py
@@ -42,8 +42,10 @@ def get_record_observations(storage, ensemble_id, keyword: str, poly_ran):
     if "PSUM" in keyword:
         n = int(keyword[4:])
         if n < poly_ran["sum_obs_count"]:
-            count = poly_ran["summary_data_entries"] // poly_ran["sum_obs_every"]
-            assert len(obs) == count
+            num_summary_obs = poly_ran["sum_obs_count"] * (
+                poly_ran["summary_data_entries"] // poly_ran["sum_obs_every"]
+            )
+            assert len(obs) == num_summary_obs
             assert obs[0].errors[0] == 0.1
             assert obs[0].x_axis[0] == "2010-01-02T00:00:00.000000000"
             assert obs[0].values[0] == 2.6357
@@ -56,11 +58,12 @@ def get_record_observations(storage, ensemble_id, keyword: str, poly_ran):
     elif "POLY_RES_" in keyword:
         n = int(keyword.split("@")[0][9:])
         if n < poly_ran["gen_obs_count"]:
-            count = poly_ran["gen_data_entries"] // poly_ran["gen_obs_every"]
-            assert len(obs) == count
-            assert len(obs[0].errors) == 1
-            assert len(obs[0].x_axis) == 1
-            assert len(obs[0].values) == 1
+            num_general_obs = poly_ran["gen_obs_count"]
+            rows_per_obs = poly_ran["gen_data_entries"] // poly_ran["gen_obs_every"]
+            assert len(obs) == num_general_obs
+            assert len(obs[0].errors) == rows_per_obs
+            assert len(obs[0].x_axis) == rows_per_obs
+            assert len(obs[0].values) == rows_per_obs
         else:
             assert len(obs) == 0
     else:


### PR DESCRIPTION
(Tested w/ Webviz ert, looks the same in Observation Analyzer and tests pass)
Current behavior concatenates all observations into one and then gets one "observation name" from the list of all "observation names" which barely makes sense.

This data goes AFAIK only to `src/ert/gui/plottery/plots/observations.py:_plotObservations`, from `PlotWindow.updatePlot -> PlotApi.observations_for_key -> record.py:get_record_observations`, where it does not even directly use the name.

Behavior in plotter seems similar.
<img width="967" alt="Screenshot 2024-09-19 at 10 37 05" src="https://github.com/user-attachments/assets/ef2b444f-85ea-42e5-a2f2-95de8b77161c">
<img width="967" alt="Screenshot 2024-09-19 at 10 39 09" src="https://github.com/user-attachments/assets/57721c87-32c7-413e-97bc-a3b78258a5c8">
