### PR TITLE
Use placeholder text when creating experiments in manage experiment tool

### DIFF
--- a/src/ert/gui/ertwidgets/create_experiment_dialog.py
+++ b/src/ert/gui/ertwidgets/create_experiment_dialog.py
@@ -40,7 +40,7 @@ class CreateExperimentDialog(QDialog):
         self._experiment_edit = StringBox(
             TextModel(""),
             placeholder_text=notifier.storage.get_unique_experiment_name(
-                "My_experiment"
+                "new_experiment"
             ),
             minimum_width=200,
         )
@@ -49,7 +49,7 @@ class CreateExperimentDialog(QDialog):
         ensemble_label = QLabel("Ensemble name:")
         self._ensemble_edit = StringBox(
             TextModel(""),
-            placeholder_text=notifier.storage.get_unique_experiment_name("My_ensemble"),
+            placeholder_text=notifier.storage.get_unique_experiment_name("ensemble"),
             minimum_width=200,
         )
         self._ensemble_edit.setValidator(ProperNameArgument())


### PR DESCRIPTION
Actually uses the placeholder text, so you can create an experiment without input. And attempts to create a unique experiment name for you.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
