### PR TITLE
Mark config sections as optional if all members are also optional.

### DIFF
--- a/docs/everest/config_generated.rst
+++ b/docs/everest/config_generated.rst
@@ -1,6 +1,6 @@
-model (required)
+model (optional)
 ----------------
-Type: *ModelConfig*
+Type: *Optional[ModelConfig]*
 
 Configuration of the Everest model
 
@@ -341,9 +341,9 @@ a group of control variables
 
 
 
-optimization (required)
+optimization (optional)
 -----------------------
-Type: *OptimizationConfig*
+Type: *Optional[OptimizationConfig]*
 
 Optimizer options
 
@@ -694,14 +694,14 @@ List of objective function specifications
 
 
 
-environment (required)
+environment (optional)
 ----------------------
-Type: *EnvironmentConfig*
+Type: *Optional[EnvironmentConfig]*
 
 The environment of Everest, specifies which folders are used for simulation and output, as well as the level of detail in Everest-logs
 
 **simulation_folder (optional)**
-    Type: *str*
+    Type: *Optional[str]*
 
     Folder used for simulation by Everest
 

--- a/src/everest/config/environment_config.py
+++ b/src/everest/config/environment_config.py
@@ -6,7 +6,7 @@ from everest.config.validation_utils import check_path_valid
 
 
 class EnvironmentConfig(BaseModel, extra="forbid"):  # type: ignore
-    simulation_folder: str = Field(
+    simulation_folder: Optional[str] = Field(
         default="simulation_folder", description="Folder used for simulation by Everest"
     )
     output_folder: Optional[str] = Field(

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -107,15 +107,20 @@ class EverestConfig(BaseModelWithPropertySupport):  # type: ignore
     objective_functions: List[ObjectiveFunctionConfig] = Field(
         description="List of objective function specifications",
     )
-    optimization: OptimizationConfig = Field(description="Optimizer options")
-    model: ModelConfig = Field(
+    optimization: Optional[OptimizationConfig] = Field(
+        default=OptimizationConfig(),
+        description="Optimizer options",
+    )
+    model: Optional[ModelConfig] = Field(
+        default=ModelConfig(),
         description="Configuration of the Everest model",
     )
 
     # It IS required but is currently used in a non-required manner by tests
     # Thus, it is to be made explicitly required as the other logic
     # is being rewritten
-    environment: EnvironmentConfig = Field(
+    environment: Optional[EnvironmentConfig] = Field(
+        default=EnvironmentConfig(),
         description="The environment of Everest, specifies which folders are used "
         "for simulation and output, as well as the level of detail in Everest-logs",
     )
@@ -747,9 +752,6 @@ and environment variables are exposed in the form 'os.NAME', for example:
         defaults = {
             "controls": [],
             "objective_functions": [],
-            "optimization": OptimizationConfig(),
-            "model": ModelConfig(),
-            "environment": EnvironmentConfig(),
             "config_path": ".",
         }
 

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -917,18 +917,14 @@ def test_that_missing_required_fields_cause_error():
     error_dicts = e.value.errors()
 
     # Expect missing error for:
-    # controls, objective_functions, optimization,
-    # model, environment, config_path,
-    assert len(error_dicts) == 6
+    # controls, objective_functions, config_path
+    assert len(error_dicts) == 3
 
     config_with_defaults = EverestConfig.with_defaults()
     config_args = {}
     required_argnames = [
         "controls",
         "objective_functions",
-        "optimization",
-        "model",
-        "environment",
         "config_path",
     ]
 

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -13,10 +13,7 @@ from tests.everest.test_config_validation import has_error
 from tests.everest.utils import relpath
 
 REQUIRED_TOP_KEYS = (
-    ConfigKeys.OPTIMIZATION,
     ConfigKeys.OBJECTIVE_FUNCTIONS,
-    ConfigKeys.ENVIRONMENT,
-    ConfigKeys.MODEL,
     ConfigKeys.CONTROLS,
 )
 OPTIONAL_TOP_KEYS = (

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -72,14 +72,14 @@ def test_valid_config_file():
 
     assert EverestConfig.load_file_with_argparser("test", parser=parser) is not None
 
-    config.environment = None
+    config.objective_functions = None
     yaml = YAML(typ="safe", pure=True)
     with open("test", "w", encoding="utf-8") as f:
         yaml.dump(config.to_dict(), f)
 
     # Check a valid config file is also linted
     assert EverestConfig.load_file_with_argparser("test", parser=parser) is None
-    assert "environment" in parser.get_error()
+    assert "objective_functions" in parser.get_error()
     assert "Field required" in parser.get_error()
 
     # Check a invalid yaml errors are reported to the parser


### PR DESCRIPTION
**Issue**
Resolves #8748


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
