### PR TITLE
Improve error handling in runner.py `job.run(...)`

### DIFF
--- a/src/_ert/forward_model_runner/cli.py
+++ b/src/_ert/forward_model_runner/cli.py
@@ -24,7 +24,7 @@ def _setup_reporters(
     ee_token=None,
     ee_cert_path=None,
     experiment_id=None,
-):
+) -> typing.List[reporting.Reporter]:
     reporters: typing.List[reporting.Reporter] = []
     if is_interactive_run:
         reporters.append(reporting.Interactive())

--- a/src/_ert/forward_model_runner/job.py
+++ b/src/_ert/forward_model_runner/job.py
@@ -83,6 +83,13 @@ class Job:
         self.std_out = job_data.get("stdout")
 
     def run(self):
+        try:
+            for msg in self._run():
+                yield msg
+        except Exception as e:
+            yield Exited(self, exit_code=1).with_error(str(e))
+
+    def _run(self):
         start_message = Start(self)
 
         errors = self._check_job_files()

--- a/src/_ert/forward_model_runner/job_dispatch.py
+++ b/src/_ert/forward_model_runner/job_dispatch.py
@@ -13,7 +13,12 @@ def sigterm_handler(_signo, _stack_frame):
 def main():
     os.nice(19)
     signal.signal(signal.SIGTERM, sigterm_handler)
-    job_runner_main(sys.argv)
+    try:
+        job_runner_main(sys.argv)
+    except Exception as e:
+        pgid = os.getpgid(os.getpid())
+        os.killpg(pgid, signal.SIGTERM)
+        raise e
 
 
 if __name__ == "__main__":

--- a/src/_ert/forward_model_runner/reporting/message.py
+++ b/src/_ert/forward_model_runner/reporting/message.py
@@ -71,17 +71,17 @@ class _MetaMessage(type):
 class Message(metaclass=_MetaMessage):
     def __init__(self, job=None):
         self.timestamp = dt.now()
-        self.job = job
-        self.error_message = None
+        self.job: Optional[Job] = job
+        self.error_message: Optional[str] = None
 
     def __repr__(self):
         return type(self).__name__
 
-    def with_error(self, message):
+    def with_error(self, message: str):
         self.error_message = message
         return self
 
-    def success(self):
+    def success(self) -> bool:
         return self.error_message is None
 
 
@@ -116,7 +116,7 @@ class Finish(Message):
 
 
 class Start(Message):
-    def __init__(self, job):
+    def __init__(self, job: "Job"):
         super().__init__(job)
 
 
@@ -127,7 +127,7 @@ class Running(Message):
 
 
 class Exited(Message):
-    def __init__(self, job, exit_code):
+    def __init__(self, job, exit_code: int):
         super().__init__(job)
         self.exit_code = exit_code
 

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from typing import List
 
 from _ert.forward_model_runner.job import Job
 from _ert.forward_model_runner.reporting.message import Checksum, Finish, Init
@@ -21,7 +22,7 @@ class ForwardModelRunner:
         if self.simulation_id is not None:
             os.environ["ERT_RUN_ID"] = self.simulation_id
 
-        self.jobs = []
+        self.jobs: List[Job] = []
         for index, job_data in enumerate(job_data_list):
             self.jobs.append(Job(job_data, index))
 

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -18,7 +18,6 @@ class ForwardModelRunner:
         self.ert_pid = jobs_data.get("ert_pid")
         self.global_environment = jobs_data.get("global_environment")
         job_data_list = jobs_data["jobList"]
-
         if self.simulation_id is not None:
             os.environ["ERT_RUN_ID"] = self.simulation_id
 
@@ -79,7 +78,6 @@ class ForwardModelRunner:
         for job in job_queue:
             for status_update in job.run():
                 yield status_update
-
                 if not status_update.success():
                     yield Checksum(checksum_dict={}, run_path=os.getcwd())
                     yield Finish().with_error("Not all jobs completed successfully.")


### PR DESCRIPTION
**Issue**
Resolves #8738 


**Approach**
This commit wraps the `job.run(...)` method in a try-except block making sure the `Exited` message is sent if the job_runner crashes. This fixes the bug where ert is hanging when unhandled exceptions are raised in the job runner.

The PR also contains a commit that refactors the mega-method `job.run(...)` into separate methods, making it more readable. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
