### PR TITLE
Remove python 3.12 x86-64 MacOS 14 build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,11 +62,9 @@ jobs:
       matrix:
         test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.8', '3.12' ]
-        os: [ 'macos-13', 'macos-14', 'macos-14-large']
+        os: [ 'macos-13', 'macos-14']
         exclude:
           - os: 'macos-14'
-            python-version: '3.8'
-          - os: 'macos-14-large'
             python-version: '3.8'
           - os: 'macos-13'
             python-version: '3.12'
@@ -79,7 +77,7 @@ jobs:
     secrets: inherit
 
   test-mac:
-    if: github.ref_type != 'tag' # one combination when not tag
+    if: github.ref_type != 'tag' # when not tag
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Issue**
Resolves #8764 

Removes failing `macOS-14-large` runn erthat uses `x86-64` from build-matrix.
The build already skips python `3.8`, and when removing `3.12` also, the runner is left unused.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
