### PR TITLE
Fix flaky storage test

### DIFF
--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -739,9 +739,11 @@ class StatefulStorageTest(RuleBasedStateMachine):
         model_experiment.ensembles[ensemble.id] = model_ensemble
         state = [RealizationStorageState.PARENT_FAILURE] * size
         iens = 1
-        if list(prior.response_values.keys()) == [
-            r.name for r in model_experiment.responses
-        ]:
+        if (
+            list(prior.response_values.keys())
+            == [r.name for r in model_experiment.responses]
+            and not iens in prior.failure_messages
+        ):
             state[iens] = RealizationStorageState.UNDEFINED
         assert ensemble.get_ensemble_state() == state
 


### PR DESCRIPTION
Fixes stateful storage test not accounting for setting a failure.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

