### PR TITLE
Add formatting to simulation mode helptext

### DIFF
--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 class EnsembleExperiment(BaseRunModel):
     """
     This workflow will create a new experiment and a new ensemble from
-    the user configuration. It will never overwrite existing ensembles, and
-    will always sample parameters.
+    the user configuration.<br>It will never overwrite existing ensembles, and
+    will always sample parameters.<br>
     """
 
     def __init__(

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -25,12 +25,10 @@ logger = logging.getLogger(__name__)
 # pylint: disable=too-many-arguments
 class EvaluateEnsemble(BaseRunModel):
     """
-    This workflow will evaluate ensembles which have parameters, but no
-    simulation has been performed, so there are no responses. This can
-    be used in instances where the parameters are sampled manually, or
-    after performing a manual update step. This will always read parameter
-    and response configuration from the stored ensemble, and will not
-    reflect any changes to the user configuration on disk.
+    This workflow will evaluate ensembles which have parameters, but no simulation has been performed, so there are no responses.<br>
+    This can be used in instances where the parameters are sampled manually, or after performing a manual update step.<br>
+    The workflow will always read parameter and response configuration from the stored ensemble,<br>
+    and will not reflect any changes to the user configuration on disk.<br>
     """
 
     def __init__(

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 class SingleTestRun(EnsembleExperiment):
     """
     Single test is equivalent to EnsembleExperiment, in that it
-    samples the prior and evaluates it. There are two key differences:
-    1) Single test run always runs locally using the local queue
-    2) Only a single realization is run
+    samples the prior and evaluates it.<br>There are two key differences:<br>
+    1) Single test run always runs locally using the <b>local queue</b><br>
+    2) Only a <b>single realization</b> is run<br>
     """
 
     def __init__(

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -18,7 +18,7 @@ class SingleTestRun(EnsembleExperiment):
     Single test is equivalent to EnsembleExperiment, in that it
     samples the prior and evaluates it.<br>There are two key differences:<br>
     1) Single test run always runs locally using the <b>local queue</b><br>
-    2) Only a <b>single realization</b> is run<br>
+    2) Only a <b>single realization</b> (realization-0) is run<br>
     """
 
     def __init__(


### PR DESCRIPTION
Make the help text for easy on the eye, and also highlight the limitation imposed on `test-run` simulation mode.

The most prominent changes;

Before;
<img width="861" alt="Screenshot 2024-09-27 at 14 37 41" src="https://github.com/user-attachments/assets/9ba4005c-ce57-48d6-be4d-ad2952e488cb">

After:
<img width="594" alt="Screenshot 2024-09-27 at 13 50 10" src="https://github.com/user-attachments/assets/b719a604-a79a-4c04-b6bf-9c7f37077d16">


**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
