### PR TITLE
Fix the everest doc generator

### DIFF
--- a/src/everest/docs/__main__.py
+++ b/src/everest/docs/__main__.py
@@ -1,15 +1,25 @@
+import sys
 from pathlib import Path
 
 from everest.docs.generate_docs_from_config_spec import generate_docs_pydantic_to_rst
 
-committed_file = (
-    Path(__file__).parents[3] / "docs" / "everest" / "config_generated.rst"
-).resolve()
+GENERATED_FILE = Path("docs") / "everest" / "config_generated.rst"
 
+parts = GENERATED_FILE.parts
+while parts and not Path(*parts).exists():
+    parts = parts[1:]
+if not parts:
+    print(
+        f"""The file to update ('{GENERATED_FILE}') was not found.
+The generator must be run from one of the parent directories of
+'{GENERATED_FILE.parts[-1]}' within the ERT source directory.
+Please change the current directory accordingly and re-run."""
+    )
+    sys.exit()
 
-print(f"Writing new docs contents to {committed_file}")
 docs_content = generate_docs_pydantic_to_rst()
-with open(committed_file, "w", encoding="utf-8") as fp:
+with Path(*parts).open("w", encoding="utf-8") as fp:
     fp.write(docs_content)
 
-print(f"Writing updated docs to {committed_file} complete, you may now commit it.")
+print(f"Generated docs written to {GENERATED_FILE}")
+print("Please commit the generated file.")


### PR DESCRIPTION
The generator would only function within a
editable install. The behavior is changed such
that it has to be run from within the ERT
repository, in one of the parent directories of
the file that is generated.

**Issue**
Resolves #8821


**Approach**
Change the generator to function only when started within the ERT source tree.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
