### PR TITLE
Use wait_for_child for getting RunDialog in test

### DIFF
--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -72,10 +72,8 @@ def test_restart_failed_realizations(opened_main_window_clean, qtbot):
     run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
     qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
 
-    # The Run dialog opens, wait until done appears, then click done
-    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-    run_dialog = gui.findChild(RunDialog)
-
+    # The Run dialog opens, wait until restart appears and the tab is ready
+    run_dialog = wait_for_child(gui, qtbot, RunDialog)
     qtbot.waitUntil(run_dialog.restart_button.isVisible, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 


### PR DESCRIPTION
Quick cleanup of comment and fetching of RunDialog in test_restart_ensemble

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
