### PR TITLE
Use wait_for_child for getting RunDialog

### DIFF
--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -285,9 +285,7 @@ def run_experiment_fixture(request):
 
         # The Run dialog opens, click show details and wait until done appears
         # then click it
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-
+        run_dialog = wait_for_child(gui, qtbot, RunDialog)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -215,28 +215,26 @@ def esmda_has_run(_esmda_run, tmp_path, monkeypatch):
 def ensemble_experiment_has_run(
     tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory
 ):
-    monkeypatch.chdir(tmp_path)
-    test_files = _ensemble_experiment_run(
-        run_experiment, source_root, tmp_path_factory, True
+    yield from _ensemble_experiment_has_run(
+        tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, True
     )
-    shutil.copytree(test_files, tmp_path, dirs_exist_ok=True)
-    with _open_main_window(tmp_path / "poly.ert") as (
-        gui,
-        _,
-        config,
-    ), StorageService.init_service(
-        project=os.path.abspath(config.ens_path),
-    ):
-        yield gui
 
 
 @pytest.fixture
 def ensemble_experiment_has_run_no_failure(
     tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory
 ):
+    yield from _ensemble_experiment_has_run(
+        tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, False
+    )
+
+
+def _ensemble_experiment_has_run(
+    tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, failing
+):
     monkeypatch.chdir(tmp_path)
     test_files = _ensemble_experiment_run(
-        run_experiment, source_root, tmp_path_factory, False
+        run_experiment, source_root, tmp_path_factory, failing
     )
     shutil.copytree(test_files, tmp_path, dirs_exist_ok=True)
     with _open_main_window(tmp_path / "poly.ert") as (

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -285,7 +285,7 @@ def run_experiment_fixture(request):
 
         # The Run dialog opens, click show details and wait until done appears
         # then click it
-        run_dialog = wait_for_child(gui, qtbot, RunDialog)
+        run_dialog = wait_for_child(gui, qtbot, RunDialog, timeout=10000)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=200000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
@@ -411,9 +411,9 @@ def add_experiment_manually(
 V = TypeVar("V")
 
 
-def wait_for_child(gui, qtbot: QtBot, typ: Type[V], *args, **kwargs) -> V:
-    qtbot.waitUntil(lambda: gui.findChild(typ, *args, **kwargs) is not None)
-    return get_child(gui, typ, *args, **kwargs)
+def wait_for_child(gui, qtbot: QtBot, typ: Type[V], timeout=5000, **kwargs) -> V:
+    qtbot.waitUntil(lambda: gui.findChild(typ) is not None, timeout=timeout)
+    return get_child(gui, typ, **kwargs)
 
 
 def get_child(gui: QWidget, typ: Type[V], *args, **kwargs) -> V:

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -279,8 +279,7 @@ def test_that_run_dialog_can_be_closed_while_file_plot_is_open(
         )
         qtbot.mouseClick(run_experiment, Qt.LeftButton)
 
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=5000)
-        run_dialog = gui.findChild(RunDialog)
+        run_dialog = wait_for_child(gui, qtbot, RunDialog)
         qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
         fm_step_overview = run_dialog._fm_step_overview
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -81,11 +81,9 @@ def test_terminating_experiment_shows_a_confirmation_dialog(
     with qtbot.waitSignal(run_dialog.finished, timeout=30000):
 
         def handle_dialog():
-            qtbot.waitUntil(
-                lambda: run_dialog.findChild(QtWidgets.QMessageBox) is not None
+            confirm_terminate_dialog = wait_for_child(
+                run_dialog, qtbot, QtWidgets.QMessageBox
             )
-            confirm_terminate_dialog = run_dialog.findChild(QtWidgets.QMessageBox)
-            assert isinstance(confirm_terminate_dialog, QtWidgets.QMessageBox)
             dialog_buttons = confirm_terminate_dialog.findChild(
                 QtWidgets.QDialogButtonBox
             ).buttons()


### PR DESCRIPTION
**Issue**
Simplifies for #8838 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
