### PR TITLE
Make sure run dialog is closed in gui test

### DIFF
--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -712,6 +712,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
 
     QTimer.singleShot(20000, lambda: handle_error_dialog(run_dialog))
     qtbot.waitUntil(run_dialog.done_button.isVisible, timeout=100000)
+    qtbot.mouseClick(run_dialog.done_button, Qt.LeftButton)
 
 
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
@@ -809,14 +810,12 @@ def test_validation_of_experiment_names_in_run_models(
         (IteratedEnsembleSmoother.name(), "iterated_ensemble_smoother_panel"),
     )
     for exp_type, panel_name in experiment_types_to_test:
-        print(f"{exp_type}")
         experiment_types.setCurrentText(exp_type)
 
         experiment_config_panel = get_child(gui, QWidget, name=panel_name)
         experiment_field = get_child(
             experiment_config_panel, StringBox, name="experiment_field"
         )
-        print(f"{experiment_field.get_text=}")
         experiment_field.setText(" @not val id")
         assert not run_experiment.isEnabled()
 


### PR DESCRIPTION
Ensure that the run dialog is closed in `test_that_a_failing_job_shows_error_message_with_context`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
