### PR TITLE
Avoid possible UnboundLocalError for end_event

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -13,7 +13,7 @@ from _ert.threading import ErtThread
 from ert.cli.monitor import Monitor
 from ert.cli.workflow import execute_workflow
 from ert.config import ErtConfig, QueueSystem
-from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig
 from ert.mode_definitions import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -128,6 +128,7 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
             out = sys.stderr
         monitor = Monitor(out=out, color_always=args.color_always)
         thread.start()
+        end_event: Optional[EndEvent] = None
         try:
             end_event = monitor.monitor(
                 status_queue, ert_config.analysis_config.log_path
@@ -139,7 +140,7 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
     thread.join()
     storage.close()
 
-    if end_event.failed:
+    if end_event is not None and end_event.failed:
         # If monitor has not reported, give some info if the job failed
         msg = end_event.msg if args.disable_monitoring else ""
         raise ErtCliError(msg)


### PR DESCRIPTION
The error has been observed to occur in the log. Not trying to display further error messages to why it is None.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
