### PR TITLE
Fix ConfigWarning not calling class method of child classes

### DIFF
--- a/src/ert/config/parsing/config_errors.py
+++ b/src/ert/config/parsing/config_errors.py
@@ -12,20 +12,20 @@ from .types import MaybeWithContext
 class ConfigWarning(UserWarning):
     info: WarningInfo
 
-    @staticmethod
-    def warn(message: str, context: MaybeWithContext = "") -> None:
-        ConfigWarning._formatted_warn(ConfigWarning.with_context(message, context))
+    @classmethod
+    def warn(cls, message: str, context: MaybeWithContext = "") -> None:
+        cls._formatted_warn(cls.with_context(message, context))
 
-    @staticmethod
-    def deprecation_warn(message: str, context: MaybeWithContext = "") -> None:
-        warning = ConfigWarning.with_context(message, context)
+    @classmethod
+    def deprecation_warn(cls, message: str, context: MaybeWithContext = "") -> None:
+        warning = cls.with_context(message, context)
         if not hasattr(context, "token"):
             warning.info.set_context_keyword(context)
         warning.info.is_deprecation = True
-        ConfigWarning._formatted_warn(warning)
+        cls._formatted_warn(warning)
 
-    @staticmethod
-    def _formatted_warn(config_warning: ConfigWarning) -> None:
+    @classmethod
+    def _formatted_warn(cls, config_warning: ConfigWarning) -> None:
         temp = warnings.formatwarning
 
         def ert_formatted_warning(


### PR DESCRIPTION
This commit fixes an issue where the parent class `ConfigWarning` has all methods decorated with `staticmethod`, rather than `classmethod`. The class methods should call the child class's method implementation where they are implemented.


**Approach**
🏎️ 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
