### PR TITLE
Fix subtypes of ConfigWarning not being caught

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -107,13 +107,13 @@ def _start_initial_gui_window(
             config_warnings = [
                 cast(ConfigWarning, w.message).info
                 for w in all_warnings
-                if w.category == ConfigWarning
+                if issubclass(w.category, ConfigWarning)
                 and not cast(ConfigWarning, w.message).info.is_deprecation
             ]
             deprecations = [
                 cast(ConfigWarning, w.message).info
                 for w in all_warnings
-                if w.category == ConfigWarning
+                if issubclass(w.category, ConfigWarning)
                 and cast(ConfigWarning, w.message).info.is_deprecation
             ]
             error_messages += error.errors
@@ -146,13 +146,13 @@ def _start_initial_gui_window(
     config_warnings = [
         cast(ConfigWarning, w.message).info
         for w in all_warnings
-        if w.category == ConfigWarning
+        if issubclass(w.category, ConfigWarning)
         and not cast(ConfigWarning, w.message).info.is_deprecation
     ]
     deprecations = [
         cast(ConfigWarning, w.message).info
         for w in all_warnings
-        if w.category == ConfigWarning
+        if issubclass(w.category, ConfigWarning)
         and cast(ConfigWarning, w.message).info.is_deprecation
     ]
     counter_fm_steps = Counter(fms.name for fms in ert_config.forward_model_steps)


### PR DESCRIPTION
This commit fixes the issue where subtypes of `ConfigWarning` would not be reported in the `gui/main.py::_start_inititial_gui_window(...)` function.

**Approach**
⛷️ 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
