### PR TITLE
Return with SIGTERM in mocked kill

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1293,7 +1293,7 @@ async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, 
             {{
                 echo "killed" > {tmp_path}/was_killed
                 do_stop=1
-                exit -1
+                exit 15
             }}
             trap handle SIGTERM
             while [[ $do_stop == 0 ]]


### PR DESCRIPTION
**Issue**
Resolves test failure in https://github.com/equinor/komodo-releases/actions/runs/11153714108/job/31002348945

**Approach**
When the SIGTERM signal is trapped, return SIGTERM as the error code instead of -1 (which is translated to 255 in the log above). The code passed a couple of trials before failing because the test often triggers 143 as an error code.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
