### PR TITLE
Fix capturing of ForwardModelStepWarning

### DIFF
--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -1,5 +1,6 @@
 from .analysis_config import AnalysisConfig
 from .analysis_module import AnalysisModule, ESSettings, IESSettings
+from .capture_validation import capture_validation
 from .enkf_observation_implementation_type import EnkfObservationImplementationType
 from .ensemble_config import EnsembleConfig
 from .ert_config import ErtConfig
@@ -81,6 +82,7 @@ __all__ = [
     "WarningInfo",
     "Workflow",
     "WorkflowJob",
+    "capture_validation",
     "field_transform",
     "lint_file",
 ]

--- a/src/ert/config/capture_validation.py
+++ b/src/ert/config/capture_validation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator, cast
+from warnings import catch_warnings
+
+from .parsing import ConfigValidationError, ConfigWarning, ErrorInfo, WarningInfo
+
+
+@dataclass
+class ValidationMessages:
+    warnings: list[WarningInfo] = field(default_factory=list)
+    deprecations: list[WarningInfo] = field(default_factory=list)
+    errors: list[ErrorInfo] = field(default_factory=list)
+
+
+@contextmanager
+def capture_validation() -> Iterator[ValidationMessages]:
+    logger = logging.getLogger(__name__)
+    validations = ValidationMessages()
+    with catch_warnings(record=True) as all_warnings:
+        try:
+            yield validations
+        except ConfigValidationError as err:
+            validations.errors += err.errors
+
+    for wm in all_warnings:
+        if issubclass(wm.category, ConfigWarning):
+            warning = cast(ConfigWarning, wm.message)
+            if warning.info.is_deprecation:
+                validations.deprecations.append(warning.info)
+            else:
+                validations.warnings.append(warning.info)
+        else:
+            logger.warning(str(wm.message))

--- a/tests/ert/unit_tests/config/test_capture_validation.py
+++ b/tests/ert/unit_tests/config/test_capture_validation.py
@@ -1,0 +1,34 @@
+from ert.config import (
+    ConfigValidationError,
+    ConfigWarning,
+    ForwardModelStepWarning,
+    capture_validation,
+)
+
+
+def test_capture_validation_captures_warnings():
+    with capture_validation() as validation_messages:
+        ConfigWarning.warn("Message")
+
+    assert validation_messages.warnings[0].message == "Message"
+
+
+def test_capture_validation_captures_deprecations():
+    with capture_validation() as validation_messages:
+        ConfigWarning.deprecation_warn("Message")
+
+    assert validation_messages.deprecations[0].message == "Message"
+
+
+def test_capture_validation_captures_validation_errors():
+    with capture_validation() as validation_messages:
+        raise ConfigValidationError("Message")
+
+    assert validation_messages.errors[0].message == "Message"
+
+
+def test_capture_validation_captures_plugin_warnings():
+    with capture_validation() as validation_messages:
+        ForwardModelStepWarning.warn("Message")
+
+    assert validation_messages.warnings[0].message == "Message"


### PR DESCRIPTION
Fixes an issue where ForwardModelStepWarning did not show in Suggestor


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
