### PR TITLE
Fix wrong workflow reference in build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -92,7 +92,7 @@ jobs:
         test-type: [ 'test', 'integration-test', 'everest-models-test' ]
         python-version: [ '3.12' ]
         os: [ 'macos-latest' ]
-    uses: ./.github/workflows/test_ert.yml
+    uses: ./.github/workflows/test_everest.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -34,7 +34,7 @@ jobs:
       uses: astral-sh/setup-uv@v3
 
     - name: Install HDF5 source files on mac
-      if: ${{ inputs.os == 'macOS' && (inputs.python-version == '3.8' || inputs.python-version == '3.9' )}}
+      if: ${{ runner.os == 'macOS' && (inputs.python-version == '3.8' || inputs.python-version == '3.9' )}}
       run: brew install hdf5
 
     - name: Install Everest and dependencies
@@ -42,22 +42,22 @@ jobs:
         uv pip install ".[dev,everest]"
 
     - name: Run Tests Linux
-      if: ${{ inputs.test-type == 'test' && inputs.os != 'macOS'}}
+      if: ${{ inputs.test-type == 'test' && runner.os != 'macOS'}}
       run: |
         pytest tests/everest -n 4 -m "not ui_test and not integration_test" --dist loadgroup -sv
 
     - name: Run Tests macOS
-      if: ${{ inputs.test-type == 'test' && inputs.os == 'macOS'}}
+      if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
         python -m pytest tests/everest -n 4 -m "not ui_test and not integration_test and not fails_on_macos_github_workflow" --dist loadgroup -sv
 
     - name: Run Integration Tests Linux
-      if: ${{inputs.test-type == 'integration-test' && inputs.os != 'macOS'}}
+      if: ${{inputs.test-type == 'integration-test' && runner.os != 'macOS'}}
       run: |
         pytest tests/everest -n 4 -m "integration_test" --dist loadgroup
 
     - name: Run Integration Tests macOS
-      if: ${{inputs.test-type == 'integration-test' && inputs.os == 'macOS'}}
+      if: ${{inputs.test-type == 'integration-test' && runner.os == 'macOS'}}
       run: |
         python -m pytest tests/everest -n 4 -m "integration_test and not fails_on_macos_github_workflow" --dist loadgroup
 


### PR DESCRIPTION
Should reference `test_everest.yml` and not `test_ert.yml`
Also fixed if statements, `inputs.os` is `macos-latest` whereas `runner.os` is `macOS`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
