### PR TITLE
Resolve flakyness in test_kill_before_submit

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1326,7 +1326,10 @@ async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, 
         # detail we do not want to track.
         assert returncode in (SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
 
+        if returncode != LSF_FAILED_JOB:
+            # We will only see the was_killed file if a compute node
+            # got a chance to start to job script:
+            wait_until((tmp_path / "was_killed").exists, timeout=4)
+
     await poll(driver, {0}, finished=finished)
     assert "ERROR" not in str(caplog.text)
-
-    wait_until((tmp_path / "was_killed").exists, timeout=10)


### PR DESCRIPTION
Sometimes the job actually starts on a compute node and sometimes it does not before it is removed/killed. In the the latter case, code previous to this commit will fail as it asserts that the job script has actually started to run.

**Issue**
Resolves flakyness.

**Approach**
Don't wait for file when it should not be there.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
