### PR TITLE
Only use logger.exception for unexpected exceptions

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -17,7 +17,7 @@ import yaml
 
 import ert.shared
 from _ert.threading import set_signal_handler
-from ert.cli.main import ErtCliError, ErtTimeoutError, run_cli
+from ert.cli.main import ErtCliError, run_cli
 from ert.config import ConfigValidationError, ErtConfig, lint_file
 from ert.logging import LOGGING_CONFIG
 from ert.mode_definitions import (
@@ -681,12 +681,12 @@ def main() -> None:
         with ErtPluginContext(logger=logging.getLogger()) as context:
             logger.info(f"Running ert with {args}")
             args.func(args, context.plugin_manager)
-    except (ErtCliError, ErtTimeoutError) as err:
-        logger.exception(str(err))
+    except ErtCliError as err:
+        logger.debug(str(err))
         sys.exit(str(err))
     except ConfigValidationError as err:
         err_msg = err.cli_message()
-        logger.exception(err_msg)
+        logger.debug(err_msg)
         sys.exit(err_msg)
     except BaseException as err:
         logger.exception(f'ERT crashed unexpectedly with "{err}"')

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -34,10 +34,6 @@ class ErtCliError(Exception):
     pass
 
 
-class ErtTimeoutError(Exception):
-    pass
-
-
 def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) -> None:
     ert_dir = os.path.abspath(os.path.dirname(args.config))
     os.chdir(ert_dir)

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -106,7 +106,7 @@ class PlotWindow(QMainWindow):
             self._api = PlotApi()
             self._key_definitions = self._api.all_data_type_keys()
         except (RequestError, TimeoutError) as e:
-            logger.exception(e)
+            logger.exception(f"plot api request failed: {e}")
             open_error_dialog("Request failed", str(e))
             self._key_definitions = []
         QApplication.restoreOverrideCursor()
@@ -191,7 +191,7 @@ class PlotWindow(QMainWindow):
                         ensemble.id, key
                     )
                 except (RequestError, TimeoutError) as e:
-                    logger.exception(e)
+                    logger.exception(f"plot api request failed: {e}")
                     open_error_dialog("Request failed", f"{e}")
 
             observations = None
@@ -201,7 +201,7 @@ class PlotWindow(QMainWindow):
                         [ensembles.id for ensembles in selected_ensembles], key
                     )
                 except (RequestError, TimeoutError) as e:
-                    logger.exception(e)
+                    logger.exception(f"plot api request failed: {e}")
                     open_error_dialog("Request failed", f"{e}")
 
             std_dev_images: Dict[str, npt.NDArray[np.float32]] = {}
@@ -221,7 +221,7 @@ class PlotWindow(QMainWindow):
                             key, ensemble.id, layer
                         )
                     except (RequestError, TimeoutError) as e:
-                        logger.exception(e)
+                        logger.exception(f"plot api request failed: {e}")
                         open_error_dialog("Request failed", f"{e}")
             else:
                 plot_widget.showLayerWidget.emit(False)
@@ -241,7 +241,7 @@ class PlotWindow(QMainWindow):
                     )
 
                 except (RequestError, TimeoutError) as e:
-                    logger.exception(e)
+                    logger.exception(f"plot api request failed: {e}")
                     open_error_dialog("Request failed", f"{e}")
                     plot_context.history_data = None
 


### PR DESCRIPTION
Makes logger.exception only happen for unexpected exceptions.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
