### PR TITLE
Avoid reserved ports in test_adaptive_localization

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -93,6 +93,8 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
         raise ErtCliError(f"{args.mode} was not valid, failed with: {e}") from e
 
     if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
+        # This is within the range for ephemeral ports as defined by
+        # most unix flavors https://en.wikipedia.org/wiki/Ephemeral_port
         args.port_range = range(49152, 51819)
 
     evaluator_server_config = EvaluatorServerConfig(custom_port_range=args.port_range)

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -19,8 +19,6 @@ def run_cli_ES_with_case(poly_config):
         "--realizations",
         "1-50",
         poly_config,
-        "--port-range",
-        "1024-65535",
         "--experiment-name",
         "test-experiment",
     )


### PR DESCRIPTION
The default for localhost is 49152-51819

**Issue**
Resolves #8867 
Resolves #8787


**Approach**
The default port range on localhost is already maximal within https://en.wikipedia.org/wiki/Ephemeral_port 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
