### PR TITLE
Verify that runpath exists

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -196,6 +196,17 @@ def create_run_path(
         run_path = Path(run_arg.runpath)
         if run_arg.active:
             run_path.mkdir(parents=True, exist_ok=True)
+            mkdir_waittime = 0.0
+            while not run_path.exists() and mkdir_waittime < 5:
+                # This should be a very rare event, but can in theory happen
+                # on network mounted disks.
+                mkdir_waittime += 0.1
+                time.sleep(0.1)
+            if mkdir_waittime > 0:
+                logger.warning(
+                    f"Slow runpath creation, {run_path} took "
+                    f"{mkdir_waittime} seconds to verify for existence."
+                )
             for source_file, target_file in ert_config.ert_templates:
                 target_file = substitution_list.substitute_real_iter(
                     target_file, run_arg.iens, ensemble.iteration


### PR DESCRIPTION
This code should be rarely be triggered, but there are some logged errors that indicates that the runpath is not available right after creation.

**Issue**
Resolves #8866 


**Approach**
🕐 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
