### PR TITLE
Fix timeout issue with macos-14-large

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         test-type: [ 'test', 'integration-test', 'everest-models-test' ]
         python-version: [ '3.8', '3.12' ]
-        os: [ 'macos-13', 'macos-14']
+        os: [ 'macos-13', 'macos-14', 'macos-14-large']
         exclude:
           - os: 'macos-14'
             python-version: '3.8'

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -326,7 +326,6 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
         assert lines[3].strip() == "fourth:foo"
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.usefixtures("copy_poly_case")
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
This fixes building on macos-14-large . Successful run can be seen here: https://github.com/equinor/ert/actions/runs/11209258553/job/31154191458?pr=8892

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
