### PR TITLE
Add more release-notes categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,10 @@ changelog:
   exclude:
     labels:
         - release-notes:skip
+        - release-notes:flaky-test-fix
+        - release-notes:unreleased-feature-changes
+        - release-notes:unreleased-bug-fix
+        - release-notes:formatting
   categories:
     - title: User impact 🛠
       labels:
@@ -21,6 +25,14 @@ changelog:
     - title: Maintenance
       labels:
         - release-notes:maintenance
+        - release-notes:logging
+        - release-notes:refactor
+    - title: Documentation changes
+      labels:
+        - release-notes:documentation-changes
+    - title: Build System
+      labels:
+        - release-notes:build-system
     - title: Dependencies
       labels:
         - release-notes:dependency


### PR DESCRIPTION
Adds meaningful categories to have better data and avoid overuse of the skip category.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
