### PR TITLE
Refactor BatchSimulator

### DIFF
--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -29,9 +29,7 @@ class ExtParamConfig(ParameterConfig):
     If a list of strings is given, the order is preserved.
     """
 
-    input_keys: Union[List[str], Dict[str, List[Tuple[str, str]]]] = field(
-        default_factory=list
-    )
+    input_keys: Union[List[str], Dict[str, List[str]]] = field(default_factory=list)
     forward_init: bool = False
     output_file: str = ""
     forward_init_file: str = ""
@@ -136,16 +134,14 @@ class ExtParamConfig(ParameterConfig):
         """
         if isinstance(self.input_keys, dict) and isinstance(key, tuple):
             key, suffix = key
-            return (
-                key in self.input_keys and suffix in self.input_keys[key]  # type: ignore[comparison-overlap]
-            )
+            return key in self.input_keys and suffix in self.input_keys[key]
         else:
             return key in self.input_keys
 
     def __repr__(self) -> str:
         return f"ExtParamConfig(keys={self.input_keys})"
 
-    def __getitem__(self, index: str) -> List[Tuple[str, str]]:
+    def __getitem__(self, index: str) -> List[str]:
         """Retrieve an item from the configuration
 
         If @index is a string, assumes its a key and retrieves the suffixes

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -557,6 +557,23 @@ def _generate_exp_ert_config(config_path, output_dir):
         "ECLBASE": "eclipse/model/EGG",
         "RANDOM_SEED": 123456,
         "SUMMARY": SUM_KEYS,
+        "GEN_DATA": [("rf", "RESULT_FILE:rf")],
+        "EXT_PARAM": {
+            "well_rate": {
+                "PROD1": ["1"],
+                "PROD2": ["1"],
+                "PROD3": ["1"],
+                "PROD4": ["1"],
+                "INJECT1": ["1"],
+                "INJECT2": ["1"],
+                "INJECT3": ["1"],
+                "INJECT4": ["1"],
+                "INJECT5": ["1"],
+                "INJECT6": ["1"],
+                "INJECT7": ["1"],
+                "INJECT8": ["1"],
+            },
+        },
     }
 
 

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -134,6 +134,24 @@ def build_snake_dict(output_dir, queue_system, report_steps=False):
         elif queue_system == ConfigKeys.SLURM:
             return slurm_queue_system()
 
+    def make_ext_param():
+        return {
+            "group": [
+                "W1",
+                "W2",
+                "W3",
+                "W4",
+            ],
+        }
+
+    def make_gen_data():
+        return [
+            (
+                "snake_oil_nvp",
+                "RESULT_FILE:snake_oil_nvp",
+            ),
+        ]
+
     ert_config = {
         "DEFINE": [("<CONFIG_PATH>", os.path.abspath(SNAKE_CONFIG_DIR))],
         "RUNPATH": os.path.join(
@@ -153,6 +171,8 @@ def build_snake_dict(output_dir, queue_system, report_steps=False):
             os.path.realpath("snake_oil/everest/model"),
             "everest_output/simulation_results",
         ),
+        "EXT_PARAM": make_ext_param(),
+        "GEN_DATA": make_gen_data(),
     }
     ert_config.update(make_queue_system(queue_system))
     return ert_config
@@ -207,6 +227,32 @@ def build_tutorial_dict(config_dir, output_dir):
             os.path.realpath("mocked_test_case"),
             "everest_output/simulation_results",
         ),
+        "EXT_PARAM": {
+            "group": [
+                "w00",
+                "w01",
+                "w02",
+                "w03",
+                "w04",
+                "w05",
+                "w06",
+                "w07",
+                "w08",
+                "w09",
+                "w10",
+                "w11",
+                "w12",
+                "w13",
+                "w14",
+                "w15",
+            ],
+        },
+        "GEN_DATA": [
+            (
+                "npv_function",
+                "RESULT_FILE:npv_function",
+            ),
+        ],
     }
 
 


### PR DESCRIPTION
**Issue**
Resolves #8753

We probably will replace the `BatchSimulator `in the future with other ERT functionality, so this PR might not be entirely necessary. Nevertheless, I think the refactored code is clearer which may be useful when we do the work to replace `BatchSimulator`.

**Approach**
- Add some `GEN_DATA` keys to the generated ert config
-  Add some code to handle `ExtParamConfig` parameter configs

**Note**
I handle `ExtParamConfig` by parsing them in `ensemble_config.py`. Currently it seems that `ExtParamConfig` does not have a corresponding keyword, which would make sense if we assume this is only used in the ert configs generated by everest. For this reason I just drop the data to be added in the generated ert config and generate the corresponding `ExtParamConfig` objects in `ExtParamConfig.from_dict`. We should discuss if that is an acceptable solution.

One consequence of this PR is that a lot of tests break that assume that the `BatchSimulator` can be initialized from an ERT config file. That is not possible anymore, presumably the `GEN_DATA` could be added to ERT config files, but the `ExtParamConfig` data cannot. Rather than changing the tests, I chose to patch the BatchSimulator class in the file to recover the old behavior, so that the batch simulator itself can still be tested.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
