### PR TITLE
Add design matrix panel for parameters preview

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -142,8 +142,9 @@ class ExperimentPanel(QWidget):
             SingleTestRunPanel(run_path, notifier),
             True,
         )
+        analysis_config = config.analysis_config
         self.addExperimentConfigPanel(
-            EnsembleExperimentPanel(ensemble_size, run_path, notifier),
+            EnsembleExperimentPanel(analysis_config, ensemble_size, run_path, notifier),
             True,
         )
         self.addExperimentConfigPanel(
@@ -154,7 +155,7 @@ class ExperimentPanel(QWidget):
         experiment_type_valid = bool(
             config.ensemble_config.parameter_configs and config.observations
         )
-        analysis_config = config.analysis_config
+
         self.addExperimentConfigPanel(
             MultipleDataAssimilationPanel(
                 analysis_config, run_path, notifier, ensemble_size

--- a/src/ert/gui/tools/design_matrix/design_matrix_panel.py
+++ b/src/ert/gui/tools/design_matrix/design_matrix_panel.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+import pandas as pd
+from qtpy.QtGui import QStandardItem, QStandardItemModel
+from qtpy.QtWidgets import QDialog, QTableView, QVBoxLayout, QWidget
+
+
+class DesignMatrixPanel(QDialog):
+    def __init__(
+        self,
+        design_matrix_df: pd.DataFrame,
+        filename: str,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        self.setWindowTitle(f"Design matrix parameters from {filename}")
+
+        table_view = QTableView(self)
+        table_view.setEditTriggers(QTableView.NoEditTriggers)
+
+        self.model = self.create_model(design_matrix_df)
+        table_view.setModel(self.model)
+
+        table_view.resizeColumnsToContents()
+        table_view.resizeRowsToContents()
+
+        layout = QVBoxLayout()
+        layout.addWidget(table_view)
+        self.setLayout(layout)
+        self.adjustSize()
+
+    @staticmethod
+    def create_model(design_matrix_df: pd.DataFrame) -> QStandardItemModel:
+        model = QStandardItemModel()
+
+        if isinstance(design_matrix_df.columns, pd.MultiIndex):
+            header_labels = [str(col[-1]) for col in design_matrix_df.columns]
+        else:
+            header_labels = design_matrix_df.columns.astype(str).tolist()
+
+        model.setHorizontalHeaderLabels(header_labels)
+
+        for index, _ in design_matrix_df.iterrows():
+            items = [
+                QStandardItem(str(design_matrix_df.at[index, col]))
+                for col in design_matrix_df.columns
+            ]
+            model.appendRow(items)
+        return model

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -708,3 +708,48 @@ def test_that_stdout_and_stderr_buttons_react_to_file_content(
 
         with qtbot.waitSignal(run_dialog.accepted, timeout=30000):
             run_dialog.close()
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "design_matrix_entry",
+    (True, False),
+)
+def test_that_design_matrix_show_parameters_button_is_visible(
+    design_matrix_entry, qtbot: QtBot, storage
+):
+    xls_filename = "design_matrix.xls"
+    with open(f"{xls_filename}", "w", encoding="utf-8"):
+        pass
+    config_file = "minimal_config.ert"
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write("NUM_REALIZATIONS 1")
+        if design_matrix_entry:
+            f.write(
+                f"\nDESIGN_MATRIX {xls_filename} DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultValues"
+            )
+
+    args_mock = Mock()
+    args_mock.config = config_file
+
+    ert_config = ErtConfig.from_file(config_file)
+    with StorageService.init_service(
+        project=os.path.abspath(ert_config.ens_path),
+    ):
+        gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
+        experiment_panel = gui.findChild(ExperimentPanel)
+        assert isinstance(experiment_panel, ExperimentPanel)
+
+        simulation_mode_combo = experiment_panel.findChild(QComboBox)
+        assert isinstance(simulation_mode_combo, QComboBox)
+
+        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+        simulation_settings = gui.findChild(EnsembleExperimentPanel)
+        show_dm_parameters = simulation_settings.findChild(
+            QPushButton, "show-dm-parameters"
+        )
+        if design_matrix_entry:
+            assert isinstance(show_dm_parameters, QPushButton)
+        else:
+            assert show_dm_parameters is None


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/8825


> NB! This PR is based on https://github.com/equinor/ert/pull/8800
> The relevant files are:
> -- src/ert/gui/simulation/ensemble_experiment_panel.py
> -- src/ert/gui/simulation/experiment_panel.py
> -- src/ert/gui/tools/design_matrix/design_matrix_panel.py
> -- tests/ert/unit_tests/gui/simulation/test_run_dialog.py
> 
> Merging is blocked as it requires the PR above to be merged.

Now it's rebased


**Approach**
Add a QDialog that shows pd.DataFrame as QTableView

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
