### PR TITLE
Remove unused help_text fm_step property

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1124,7 +1124,6 @@ def _forward_model_step_from_config_file(
             required_keywords=content_dict.get("REQUIRED", []),
             exec_env=exec_env,
             default_mapping=default_mapping,
-            help_text=content_dict.get("HELP_TEXT", ""),
         )
     except IOError as err:
         raise ConfigValidationError.with_context(str(err), config_file) from err

--- a/src/ert/config/forward_model_step.py
+++ b/src/ert/config/forward_model_step.py
@@ -145,7 +145,6 @@ class ForwardModelStep:
         private_args: A dictionary of user-provided keyword arguments.
             For example, if the user provides <A>=2, the dictionary will contain
             { "A": "2" }
-        help_text: Some meaningless old code we don't really need, not used anywhere
     """
 
     name: str
@@ -166,7 +165,6 @@ class ForwardModelStep:
     exec_env: dict[str, Union[int, str]] = field(default_factory=dict)
     default_mapping: dict[str, Union[int, str]] = field(default_factory=dict)
     private_args: SubstitutionList = field(default_factory=SubstitutionList)
-    help_text: str = ""
 
     default_env: ClassVar[dict[str, str]] = {
         "_ERT_ITERATION_NUMBER": "<ITER>",
@@ -254,7 +252,6 @@ class ForwardModelStepPlugin(ForwardModelStep):
             exec_env=exec_env,
             default_mapping=default_mapping,
             private_args=SubstitutionList(),
-            help_text="",
         )
 
     @staticmethod

--- a/src/ert/config/parsing/forward_model_keywords.py
+++ b/src/ert/config/parsing/forward_model_keywords.py
@@ -27,4 +27,3 @@ class ForwardModelStepKeys(StrEnum):
     EXEC_ENV = "EXEC_ENV"
     DEFAULT = "DEFAULT"
     PRIVATE_ARGS = "PRIVATE_ARGS"
-    HELP_TEXT = "HELP_TEXT"

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -694,7 +694,6 @@ def test_that_plugin_forward_models_are_installed(tmp_path):
         },
         "exec_env": {},
         "default_mapping": {},
-        "help_text": "",
         "private_args": SubstitutionList(
             {
                 "<arg1>": "hello",


### PR DESCRIPTION
It says it is unused, and it seems correct that it is unused. No traces to be found in related repositories using this property

**Issue**
Resolves LOC


**Approach**
✂️ 

 `grep -r help_text` on Komodo 2024.09.03 as deployed on disk does not yield any related hits. 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
