### PR TITLE
Remove MPI capabilities of ecl_run

### DIFF
--- a/tests/ert/unit_tests/resources/test_opm_flow.py
+++ b/tests/ert/unit_tests/resources/test_opm_flow.py
@@ -64,19 +64,6 @@ def fixture_init_flow_config(monkeypatch, tmpdir):
         yield
 
 
-def test_ecl_run_make_LSB_MCPU_machine_list():
-    assert ecl_run.make_LSB_MCPU_machine_list("host1 4 host2 4") == [
-        "host1",
-        "host1",
-        "host1",
-        "host1",
-        "host2",
-        "host2",
-        "host2",
-        "host2",
-    ]
-
-
 @pytest.mark.integration_test
 @flow_installed
 def test_flow(init_flow_config, source_root):
@@ -269,65 +256,3 @@ def test_running_flow_given_env_variables_with_same_name_as_parent_env_variables
         lines = filehandle.readlines()
 
     assert lines == ["OVERWRITTEN1\n", "OVERWRITTEN2\n"]
-
-
-def test_slurm_env_parsing():
-    host_list = ecl_run.make_SLURM_machine_list("ws", "2")
-    assert host_list == ["ws", "ws"]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws1,ws2", "2,3")
-    assert host_list == ["ws1", "ws1", "ws2", "ws2", "ws2"]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws[1-3]", "1,2,3")
-    assert host_list == ["ws1", "ws2", "ws2", "ws3", "ws3", "ws3"]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws[1,3]", "1,3")
-    assert host_list == ["ws1", "ws3", "ws3", "ws3"]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws[1-3,6-8]", "1,2,3,1,2,3")
-    assert host_list == [
-        "ws1",
-        "ws2",
-        "ws2",
-        "ws3",
-        "ws3",
-        "ws3",
-        "ws6",
-        "ws7",
-        "ws7",
-        "ws8",
-        "ws8",
-        "ws8",
-    ]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws[1-3,6-8]", "2(x2),3,1,2(x2)")
-    assert host_list == [
-        "ws1",
-        "ws1",
-        "ws2",
-        "ws2",
-        "ws3",
-        "ws3",
-        "ws3",
-        "ws6",
-        "ws7",
-        "ws7",
-        "ws8",
-        "ws8",
-    ]
-
-    host_list = ecl_run.make_SLURM_machine_list("ws[1-3,6],ws[7-8]", "2(x2),3,1,2(x2)")
-    assert host_list == [
-        "ws1",
-        "ws1",
-        "ws2",
-        "ws2",
-        "ws3",
-        "ws3",
-        "ws3",
-        "ws6",
-        "ws7",
-        "ws7",
-        "ws8",
-        "ws8",
-    ]


### PR DESCRIPTION
This should be handled by the Eclipse wrapper. It is already in place for Eclipse runs, as eclrun is the default, but for Flow usage this is a breaking change

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
