### PR TITLE
Refactor and rename summary_block()

### DIFF
--- a/tests/ert/unit_tests/resources/test_ecl_run_new_config.py
+++ b/tests/ert/unit_tests/resources/test_ecl_run_new_config.py
@@ -6,10 +6,14 @@ import shutil
 import stat
 import subprocess
 import textwrap
+import threading
+import time
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pytest
+import resfo
 import yaml
 
 from tests.ert.utils import SOURCE_DIR
@@ -241,25 +245,59 @@ def test_mpi_run_is_managed_by_system_tool(source_root):
     ).exists(), "There should not be 3 MPI processes"
 
 
-@pytest.mark.integration_test
-@pytest.mark.requires_eclipse
-@pytest.mark.usefixtures("use_tmpdir", "init_eclrun_config")
-def test_summary_block_will_return_something(source_root):
-    shutil.copy(
-        source_root / "test-data/ert/eclipse/SPE1.DATA",
-        "SPE1.DATA",
-    )
-    econfig = ecl_config.Ecl100Config()
-    erun = ecl_run.EclRun("SPE1.DATA", None)
-
-    assert not Path("SPE1.UNSMRY").exists()
+def test_await_completed_summary_file_will_timeout_on_missing_smry():
     assert (
-        erun.summary_block() is None
-    ), "summary_block() should return None where there is no SMRY file"
+        # Expected wait time is 0.3
+        ecl_run.await_completed_unsmry_file(
+            "SPE1.UNSMRY", max_wait=0.3, poll_interval=0.1
+        )
+        > 0.3
+    )
 
-    erun.runEclipse(eclrun_config=ecl_config.EclrunConfig(econfig, "2019.3"))
-    assert Path("SPE1.UNSMRY").exists()
-    assert erun.summary_block() is not None
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_await_completed_summary_file_will_return_asap():
+    resfo.write("FOO.UNSMRY", [("INTEHEAD", np.array([1], dtype=np.int32))])
+    assert (
+        0.01
+        # Expected wait time is the poll_interval
+        < ecl_run.await_completed_unsmry_file(
+            "FOO.UNSMRY", max_wait=0.5, poll_interval=0.1
+        )
+        < 0.4
+    )
+
+
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("use_tmpdir")
+def test_await_completed_summary_file_will_wait_for_slow_smry():
+    # This is a timing test, and has inherent flakiness:
+    #  * Reading and writing to the same smry file at the same time
+    #    can make the reading throw an exception every time, and can
+    #    result in max_wait triggering.
+    #  * If the writer thread is starved, two consecutive polls may
+    #    yield the same summary length, resulting in premature exit.
+    #  * Heavily loaded hardware can make everything go too slow.
+    def slow_smry_writer():
+        for size in range(10):
+            resfo.write(
+                "FOO.UNSMRY", (size + 1) * [("INTEHEAD", np.array([1], dtype=np.int32))]
+            )
+            time.sleep(0.05)
+
+    thread = threading.Thread(target=slow_smry_writer)
+    thread.start()
+    time.sleep(0.1)  # Let the thread start writing
+    assert (
+        0.5
+        # Minimal wait time is around 0.55
+        < ecl_run.await_completed_unsmry_file(
+            "FOO.UNSMRY", max_wait=4, poll_interval=0.21
+        )
+        < 2
+    )
+    thread.join()
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
The logic for determining stable was not correct, if the summary
file was not stable after two reads, it would always timeout. Behaviour
is not defined by tests.

**Issue**
Part of #8925 

**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
