### PR TITLE
Fix run_dialog second progress bar hanging

### DIFF
--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -74,7 +74,6 @@ class ProgressWidget(QFrame):
     def repaint_components(self) -> None:
         if self._realization_count > 0:
             full_width = self.width()
-            self.stop_waiting_progress_bar()
 
             for state, label in self._progress_label_map.items():
                 label.setVisible(True)
@@ -90,9 +89,16 @@ class ProgressWidget(QFrame):
     def stop_waiting_progress_bar(self) -> None:
         self._waiting_progress_bar.setVisible(False)
 
+    def start_waiting_progress_bar(self) -> None:
+        self._waiting_progress_bar.setVisible(True)
+
     def update_progress(self, status: dict[str, int], realization_count: int) -> None:
         self._status = status
         self._realization_count = realization_count
+        if status.get("Finished", 0) < self._realization_count:
+            self.start_waiting_progress_bar()
+        else:
+            self.stop_waiting_progress_bar()
         self.repaint_components()
 
     def resizeEvent(self, a0: Any, event: Any = None) -> None:


### PR DESCRIPTION
This commit fixes the issue where an experiment failure would leave the second progress bar stuck in indeterminate state. This commit makes it so that second progress bar is invisible as long as there are no realizations or if all realizations are finished.

**Issue**
Resolves #8912


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
