### PR TITLE
Give warning when memory usage is set in `LSF_RESOURCE`

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import List, cast
 
 from .deprecation_info import DeprecationInfo
 
@@ -221,5 +222,12 @@ deprecated_keywords_list = [
         message="MEMORY_PER_CPU as QUEUE_OPTION to SLURM is deprecated and will be removed in "
         "the future. Use REALIZATION_MEMORY instead.",
         check=lambda line: "MEMORY_PER_CPU" in line,
+    ),
+    DeprecationInfo(
+        keyword="QUEUE_OPTION",
+        message="Memory requirements in LSF should now be set using REALIZATION_MEMORY and not"
+        " through the LSF_RESOURCE option.",
+        check=lambda line: "LSF_RESOURCE" in line
+        and "mem=" in cast(List[str], line)[-1],
     ),
 ]


### PR DESCRIPTION
This commit gives the user a deprecationwarning when trying to set `mem=...` in the `LSF_RESOURCE` resource string. This is preferred to be set in the new `REALIZATION_MEMORY` option.

Using `REALIZATION_MEMORY` over `LSF_RESOURCE`
* Does not invalidate what we have set as LSF_RESOURCE through the site-config.
* Better handling of memory units (i.e. better UX).
* Makes Ert able to understand the parameter, to be able to compare with actual usage
![image](https://github.com/user-attachments/assets/198969e0-7e05-49b1-a4dc-8acd399b178d)

**Issue**
Resolves #8915

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
