### PR TITLE
Remove checks for storage_server.json in storage

### DIFF
--- a/src/ert/dark_storage/client/_session.py
+++ b/src/ert/dark_storage/client/_session.py
@@ -1,63 +1,8 @@
-import json
-import os
-from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 
 class ConnInfo(BaseModel):
     base_url: str
     auth_token: Optional[str] = None
-
-
-ENV_VAR = "ERT_STORAGE_CONNECTION_STRING"
-
-# Avoid searching for the connection information on every request. We assume
-# that a single client process will only ever want to connect to a single ERT
-# Storage server during its lifetime, so we don't provide an API for managing
-# this cache.
-_CACHED_CONN_INFO: Optional[ConnInfo] = None
-
-
-def find_conn_info() -> ConnInfo:
-    """
-    The base url and auth token are read from either:
-    The file `storage_server.json`, starting from the current working directory
-    or the environment variable `ERT_STORAGE_CONNECTION_STRING`
-
-    In both cases the configuration is represented by JSON representation of the
-    `ConnInfo` pydantic model.
-
-    In the event that nothing is found, a RuntimeError is raised.
-    """
-    global _CACHED_CONN_INFO  # noqa: PLW0603
-    if _CACHED_CONN_INFO is not None:
-        return _CACHED_CONN_INFO
-
-    conn_str = os.environ.get(ENV_VAR)
-
-    # This could be an empty string rather than None, as by the shell
-    # invocation: env ERT_STORAGE_CONNECTION_STRING= python
-    if not conn_str:
-        # Look for `storage_server.json` from cwd up to root.
-        root = Path("/")
-        path = Path.cwd()
-        while path != root:
-            try:
-                conn_str = (path / "storage_server.json").read_text()
-                break
-            except FileNotFoundError:
-                path = path.parent
-
-    if not conn_str:
-        raise RuntimeError("No Storage connection configuration found")
-
-    try:
-        conn_info = ConnInfo.parse_obj(json.loads(conn_str))
-        _CACHED_CONN_INFO = conn_info
-        return conn_info
-    except json.JSONDecodeError as e:
-        raise RuntimeError("Invalid storage conneciton configuration") from e
-    except ValidationError as e:
-        raise RuntimeError("Invalid storage conneciton configuration") from e

--- a/src/ert/dark_storage/client/async_client.py
+++ b/src/ert/dark_storage/client/async_client.py
@@ -1,8 +1,6 @@
-from typing import Optional
-
 import httpx
 
-from ._session import ConnInfo, find_conn_info
+from ._session import ConnInfo
 
 
 class AsyncClient(httpx.AsyncClient):
@@ -11,10 +9,7 @@ class AsyncClient(httpx.AsyncClient):
     interact with ERT Storage's API
     """
 
-    def __init__(self, conn_info: Optional[ConnInfo] = None) -> None:
-        if conn_info is None:
-            conn_info = find_conn_info()
-
+    def __init__(self, conn_info: ConnInfo) -> None:
         headers = {}
         if conn_info.auth_token is not None:
             headers = {"Token": conn_info.auth_token}

--- a/src/ert/dark_storage/client/client.py
+++ b/src/ert/dark_storage/client/client.py
@@ -1,8 +1,6 @@
-from typing import Optional
-
 import httpx
 
-from ._session import ConnInfo, find_conn_info
+from ._session import ConnInfo
 
 
 class Client(httpx.Client):
@@ -11,10 +9,7 @@ class Client(httpx.Client):
     interact with ERT Storage's API
     """
 
-    def __init__(self, conn_info: Optional[ConnInfo] = None) -> None:
-        if conn_info is None:
-            conn_info = find_conn_info()
-
+    def __init__(self, conn_info: ConnInfo) -> None:
         headers = {}
         if conn_info.auth_token is not None:
             headers = {"Token": conn_info.auth_token}


### PR DESCRIPTION
We no longer use this file for connection info.
Seems to be leftovers from earlier code.

**Issue**
Resolves #8452 


**Approach**
remove all use of storage_server.json


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
