### PR TITLE
Include site config when running missing runpath test

### DIFF
--- a/tests/ert/ui_tests/cli/test_missing_runpath.py
+++ b/tests/ert/ui_tests/cli/test_missing_runpath.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from ert.cli.main import ErtCliError
+from ert.plugins import ErtPluginContext
 
 from .run_cli import run_cli_with_pm
 
@@ -96,5 +97,10 @@ def test_failing_writes_lead_to_isolated_failures(tmp_path, monkeypatch, pytestc
         ErtCliError,
         match=r"(?s)active realizations \(9\) is less than .* MIN_REALIZATIONS\(10\).*"
         r"Driver reported: Could not create submit script: Don't like realization-1",
-    ), patch_raising_named_temporary_file(queue_system.lower()):
-        run_cli_with_pm(["ensemble_experiment", "config.ert", "--disable-monitoring"])
+    ), patch_raising_named_temporary_file(
+        queue_system.lower()
+    ), ErtPluginContext() as context:
+        run_cli_with_pm(
+            ["ensemble_experiment", "config.ert", "--disable-monitoring"],
+            pm=context.plugin_manager,
+        )


### PR DESCRIPTION
Needs to include site config when running on lsf


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
