### PR TITLE
Aggregate duplicate indices by mean in dark storage

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -121,6 +121,9 @@ def data_for_key(
             .to_pandas()
         )
         df = df.set_index(["Date", "Realization"])
+        # This performs the same aggragation by mean of duplicate values
+        # as in ert/analysis/_es_update.py
+        df = df.groupby(["Date", "Realization"]).mean()
         data = df.unstack(level="Date")
         data.columns = data.columns.droplevel(0)
         try:


### PR DESCRIPTION
This should do the same aggregation as https://github.com/equinor/ert/blob/391a25f7c4ed259eb79f69074b2b9df2455ff046/src/ert/analysis/_es_update.py#L168-L175

Resolves https://github.com/equinor/ert/issues/8951

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
