### PR TITLE
Add runpath validation in gui load_results_manually

### DIFF
--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -25,6 +25,7 @@ from .searchbox import SearchBox
 from .ensembleselector import EnsembleSelector
 from .checklist import CheckList
 from .stringbox import StringBox
+from .multilinestringbox import MultiLineStringBox
 from .listeditbox import ListEditBox
 from .customdialog import CustomDialog
 from .pathchooser import PathChooser
@@ -51,6 +52,7 @@ __all__ = [
     "EnsembleSelector",
     "ErtMessageBox",
     "ListEditBox",
+    "MultiLineStringBox",
     "PathChooser",
     "PathModel",
     "SearchBox",

--- a/src/ert/gui/ertwidgets/multilinestringbox.py
+++ b/src/ert/gui/ertwidgets/multilinestringbox.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from qtpy.QtGui import QPalette
+from qtpy.QtWidgets import QTextEdit
+
+from .validationsupport import ValidationSupport
+
+if TYPE_CHECKING:
+    from ert.validation import ArgumentDefinition
+
+    from .models import TextModel
+
+
+class MultiLineStringBox(QTextEdit):
+    """MultiLineStringBox shows a multiline string. The data structure expected and sent to the
+    getter and setter is a multiline string."""
+
+    def __init__(
+        self,
+        model: TextModel,
+        default_string: str = "",
+        placeholder_text: str = "",
+        minimum_width: int = 250,
+        readonly: bool = False,
+    ):
+        QTextEdit.__init__(self)
+        self.setMinimumWidth(minimum_width)
+        self._validation = ValidationSupport(self)
+        self._validator: Optional[ArgumentDefinition] = None
+        self._model = model
+        self._enable_validation = True
+
+        if placeholder_text:
+            self.setPlaceholderText(placeholder_text)
+        self.textChanged.connect(self.stringBoxChanged)
+
+        self.textChanged.connect(self.validateString)
+
+        self._valid_color = self.palette().color(self.backgroundRole())
+        self.setText(default_string)
+
+        self._model.valueChanged.connect(self.modelChanged)
+        self.modelChanged()
+        self.setReadOnly(readonly)
+
+    def validateString(self) -> None:
+        if not self._enable_validation or self._validator is None:
+            return
+
+        string_to_validate = self.toPlainText()
+        if not string_to_validate and self.placeholderText():
+            string_to_validate = self.placeholderText()
+
+        validation_success = self._validator.validate(string_to_validate)
+
+        palette = self.palette()
+        if not validation_success:
+            palette.setColor(QPalette.ColorRole.Base, ValidationSupport.ERROR_COLOR)
+            self.setPalette(palette)
+            self._validation.setValidationMessage(
+                str(validation_success), ValidationSupport.EXCLAMATION
+            )
+        else:
+            palette.setColor(QPalette.ColorRole.Base, self._valid_color)
+            self.setPalette(palette)
+            self._validation.setValidationMessage("")
+
+    def emitChange(self, q_string: Any) -> None:
+        self.textChanged.emit(str(q_string))
+
+    def stringBoxChanged(self) -> None:
+        """Called whenever the contents of the textedit changes."""
+        text: Optional[str] = self.get_text
+        if not text:
+            text = None
+
+        self._model.setValue(text)
+
+    def modelChanged(self) -> None:
+        """Retrieves data from the model and inserts it into the textedit"""
+        text = self._model.getValue()
+        if text is None:
+            text = ""
+        # If model and view has same text, return
+        if text == self.toPlainText():
+            return
+        self.setText(str(text))
+
+    @property
+    def model(self) -> TextModel:
+        return self._model
+
+    def setValidator(self, validator: ArgumentDefinition) -> None:
+        self._validator = validator
+
+    def getValidationSupport(self) -> ValidationSupport:
+        return self._validation
+
+    def isValid(self) -> bool:
+        return self._validation.isValid()
+
+    @property
+    def get_text(self) -> str:
+        return self.toPlainText() if self.toPlainText() else self.placeholderText()
+
+    def enable_validation(self, enabled: bool) -> None:
+        self._enable_validation = enabled
+
+    def refresh(self) -> None:
+        self.validateString()

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -23,19 +23,24 @@ class LoadResultsTool(Tool):
     def trigger(self) -> None:
         if self._import_widget is None:
             self._import_widget = LoadResultsPanel(self.facade, self._notifier)
-        self._dialog = ClosableDialog(
-            "Load results manually",
-            self._import_widget,
-            self.parent(),  # type: ignore
-        )
-        self._dialog.setObjectName("load_results_manually_tool")
-        loadButton = self._dialog.addButton("Load", self.load)
+            self._import_widget.panelConfigurationChanged.connect(
+                self.validationStatusChanged
+            )
+            self._dialog = ClosableDialog(
+                "Load results manually",
+                self._import_widget,
+                self.parent(),  # type: ignore
+            )
+            self._loadButton = self._dialog.addButton("Load", self.load)
+            self._dialog.setObjectName("load_results_manually_tool")
+
+        else:
+            self._import_widget.refresh()
+
         if not self._import_widget._ensemble_selector.isEnabled():
-            loadButton.setEnabled(False)
-            loadButton.setToolTip("Must load into a ensemble")
-        self._import_widget.panelConfigurationChanged.connect(
-            self.validationStatusChanged
-        )
+            self._loadButton.setEnabled(False)
+            self._loadButton.setToolTip("Must load into a ensemble")
+        assert self._dialog is not None
         self._dialog.exec_()
 
     def load(self, _: Any) -> None:

--- a/src/ert/validation/__init__.py
+++ b/src/ert/validation/__init__.py
@@ -6,6 +6,7 @@ from .proper_name_argument import ProperNameArgument
 from .proper_name_format_argument import ProperNameFormatArgument
 from .range_string_argument import RangeStringArgument
 from .rangestring import mask_to_rangestring, rangestring_to_list, rangestring_to_mask
+from .runpath_argument import RunPathArgument
 from .validation_status import ValidationStatus
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "ProperNameArgument",
     "ProperNameFormatArgument",
     "RangeStringArgument",
+    "RunPathArgument",
     "ValidationStatus",
     "mask_to_rangestring",
     "rangestring_to_list",

--- a/src/ert/validation/runpath_argument.py
+++ b/src/ert/validation/runpath_argument.py
@@ -1,0 +1,27 @@
+import os
+
+from .argument_definition import ArgumentDefinition
+from .validation_status import ValidationStatus
+
+
+class RunPathArgument(ArgumentDefinition):
+    INVALID_PATH = "The specified runpath does not exist."
+    MISSING_PERMISSION = "You are missing permissions for the specified runpath."
+
+    def __init__(self, **kwargs: bool) -> None:
+        super().__init__(**kwargs)
+
+    def validate(self, token: str) -> ValidationStatus:
+        parsed_runpath_without_suffix = "/".join(token.split("/")[:-2])
+        validation_status = super().validate(token)
+
+        if not os.path.isdir(parsed_runpath_without_suffix):
+            validation_status.setFailed()
+            validation_status.addToMessage(RunPathArgument.INVALID_PATH)
+        elif not os.access(parsed_runpath_without_suffix, os.R_OK | os.X_OK):
+            validation_status.setFailed()
+            validation_status.addToMessage(RunPathArgument.MISSING_PERMISSION)
+        else:
+            validation_status.setValue(token)
+
+        return validation_status


### PR DESCRIPTION
The commit adds runpath validation so the load button in `load_results_manually` will be disabled until the runpath exists, and the user has the read/write/execute permissions.
The runpath text box becomes red, and the user can hover it to see the warning message. This is the same way it is done for the other fields. 

**Approach**
😎 

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/2ede24a0-7fa0-4e9b-b45a-66f1904aa156)
![image](https://github.com/user-attachments/assets/4678f934-947a-46b7-bce0-a2a520b5d3c5)
![image](https://github.com/user-attachments/assets/e3c78157-c121-4961-b4c8-0d40e301e9d0)



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
