### PR TITLE
Merge marker used for simulation fw models in Everest and Ert

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -37,7 +37,7 @@ run_ert_with_opm () {
 run_everest_tests () {
     python -m pytest tests/everest -s \
     --ignore-glob "*test_visualization_entry*" \
-     -m "not simulation_test and not ui_test"
+     -m "not requires_eclipse and not ui_test"
     xvfb-run -s "-screen 0 640x480x24" --auto-servernum python -m pytest tests/everest -s -m "ui_test"
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ markers = [
     "slow",
     "everest_models_test",
     "integration_test",
-    "simulation_test",
     "ui_test",
     "fails_on_macos_github_workflow", # Tests marked fail due to gui-related issues
 ]

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -678,7 +678,7 @@ def test_init_egg_model(copy_egg_test_data_to_tmp):
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 @skipif_no_simulator
-@pytest.mark.simulation_test
+@pytest.mark.requires_eclipse
 def test_run_egg_model(copy_egg_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
 
@@ -802,7 +802,7 @@ def test_egg_model_wells_json_output_no_none(copy_egg_test_data_to_tmp):
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 @skipif_no_simulator
-@pytest.mark.simulation_test
+@pytest.mark.requires_eclipse
 @pytest.mark.timeout(0)
 def test_egg_snapshot(snapshot, copy_egg_test_data_to_tmp):
     # shutil.copytree(relpath(ROOT), tmp_path, dirs_exist_ok=True)

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -462,7 +462,7 @@ def test_summary_default_no_opm(copy_egg_test_data_to_tmp):
     assert set(sum_keys[0]) == set(res_conf["SUMMARY"][0])
 
 
-@pytest.mark.simulation_test
+@pytest.mark.requires_eclipse
 def test_install_data(copy_test_data_to_tmp):
     """
     TODO: When default jobs are handled in Everest this test should not


### PR DESCRIPTION
**Issue**
Resolves #[8859](https://github.com/equinor/ert/issues/8859)


**Approach**
Merge the markers in Everest to the ones we use in Ert for when the eclipse simulator is not available.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
