### PR TITLE
Improve validation for unintialized ensembles in manual update and evaluate ensemble

### DIFF
--- a/src/ert/validation/__init__.py
+++ b/src/ert/validation/__init__.py
@@ -1,5 +1,6 @@
 from .active_range import ActiveRange
 from .argument_definition import ArgumentDefinition
+from .ensemble_realizations_argument import EnsembleRealizationsArgument
 from .integer_argument import IntegerArgument
 from .number_list_string_argument import NumberListStringArgument
 from .proper_name_argument import ProperNameArgument
@@ -12,6 +13,7 @@ from .validation_status import ValidationStatus
 __all__ = [
     "ActiveRange",
     "ArgumentDefinition",
+    "EnsembleRealizationsArgument",
     "IntegerArgument",
     "NumberListStringArgument",
     "ProperNameArgument",

--- a/src/ert/validation/ensemble_realizations_argument.py
+++ b/src/ert/validation/ensemble_realizations_argument.py
@@ -1,0 +1,49 @@
+from typing import TYPE_CHECKING, Optional
+
+from .range_string_argument import RangeStringArgument
+from .rangestring import rangestring_to_list
+from .validation_status import ValidationStatus
+
+if TYPE_CHECKING:
+    from ert.storage import Ensemble
+
+
+class EnsembleRealizationsArgument(RangeStringArgument):
+    UNINITIALIZED_REALIZATIONS_SPECIFIED = (
+        "The specified realization(s) %s are not found in selected ensemble."
+    )
+
+    def __init__(
+        self, ensemble: "Ensemble", max_value: Optional[int], **kwargs: bool
+    ) -> None:
+        super().__init__(max_value, **kwargs)
+        self.__ensemble = ensemble
+
+    def set_ensemble(self, ensemble: "Ensemble") -> None:
+        self.__ensemble = ensemble
+
+    def validate(self, token: str) -> ValidationStatus:
+        if not token:
+            return ValidationStatus()
+
+        validation_status = super().validate(token)
+        if not validation_status:
+            return validation_status
+        attempted_realizations = rangestring_to_list(token)
+
+        invalid_realizations = []
+        initialized_realization_ids = self.__ensemble.is_initalized()
+        for realization in attempted_realizations:
+            if not realization in initialized_realization_ids:
+                invalid_realizations.append(realization)
+
+        if invalid_realizations:
+            validation_status.setFailed()
+            validation_status.addToMessage(
+                EnsembleRealizationsArgument.UNINITIALIZED_REALIZATIONS_SPECIFIED
+                % str(invalid_realizations)
+            )
+            return validation_status
+
+        validation_status.setValue(token)
+        return validation_status


### PR DESCRIPTION
**Issue**
Resolves #8691


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)

![image](https://github.com/user-attachments/assets/c5e93681-ef51-4e64-bc7f-7589789c7f70)



When specifying failed realizations:
![image](https://github.com/user-attachments/assets/e4580ee6-1245-4d18-90fc-78166222d0ec)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
