### PR TITLE
Fix flaky test check only for ConfigWarnings in test_no_warning_when_summary_key_and_simulation_job_present

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1521,9 +1521,7 @@ def test_general_option_in_local_config_has_priority_over_site_config():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_warning_raised_when_summary_key_and_no_simulation_job_present(caplog, recwarn):
-    caplog.set_level(logging.WARNING)
-
+def test_warning_raised_when_summary_key_and_no_simulation_job_present():
     with open("job_file", "w", encoding="utf-8") as fout:
         fout.write("EXECUTABLE echo\nARGLIST <ECLBASE> <RUNPATH>\n")
 
@@ -1537,18 +1535,11 @@ def test_warning_raised_when_summary_key_and_no_simulation_job_present(caplog, r
         fout.write(
             "FORWARD_MODEL job_name(<ECLBASE>=A/<ECLBASE>, <RUNPATH>=<RUNPATH>/x)\n"
         )
-
-    ErtConfig.from_file("config_file.ert")
-
-    # Check no warning is logged when config contains
-    # forward model step with <ECLBASE> and <RUNPATH> as arguments
-    assert not caplog.text
-    assert len(recwarn) == 1
-    assert issubclass(recwarn[0].category, ConfigWarning)
-    assert (
-        recwarn[0].message.info.message
-        == "Config contains a SUMMARY key but no forward model steps known to generate a summary file"
-    )
+    with pytest.warns(
+        ConfigWarning,
+        match="Config contains a SUMMARY key but no forward model steps known to generate a summary file",
+    ):
+        ErtConfig.from_file("config_file.ert")
 
 
 @pytest.mark.parametrize(
@@ -1576,7 +1567,4 @@ def test_no_warning_when_summary_key_and_simulation_job_present(
 
     ErtConfig.from_file("config_file.ert")
 
-    # Check no warning is logged when config contains
-    # forward model step with <ECLBASE> and <RUNPATH> as arguments
-    assert not caplog.text
-    assert len(recwarn) == 0
+    assert not any(issubclass(w.category, ConfigWarning) for w in recwarn)


### PR DESCRIPTION

**Issue**
Resolves https://github.com/equinor/komodo-releases/issues/6382


**Approach**
check only for ConfigWarnings in test_no_warning_when_summary_key_and_simulation_job_present

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
