### PR TITLE
Fix progress bar legend getting cut when loading bar shows

### DIFF
--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -28,6 +28,9 @@ class ProgressWidget(QFrame):
         self._waiting_progress_bar = QProgressBar(self)
         self._waiting_progress_bar.setRange(0, 0)
         self._waiting_progress_bar.setFixedHeight(30)
+        waiting_progress_bar_size_policy = self._waiting_progress_bar.sizePolicy()
+        waiting_progress_bar_size_policy.setRetainSizeWhenHidden(True)
+        self._waiting_progress_bar.setSizePolicy(waiting_progress_bar_size_policy)
         self._vertical_layout.addWidget(self._waiting_progress_bar)
 
         self._progress_frame = QFrame(self)
@@ -52,6 +55,9 @@ class ProgressWidget(QFrame):
 
         for state, color in REAL_STATE_TO_COLOR.items():
             label = QLabel(self)
+            label_size_policy = label.sizePolicy()
+            label_size_policy.setRetainSizeWhenHidden(True)
+            label.setSizePolicy(label_size_policy)
             label.setVisible(False)
             label.setObjectName(f"progress_{state}")
             label.setStyleSheet(f"background-color : {QColor(*color).name()}")

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -18,7 +18,7 @@ from ert.ensemble_evaluator.state import REAL_STATE_TO_COLOR
 class ProgressWidget(QFrame):
     def __init__(self) -> None:
         QWidget.__init__(self)
-        self.setFixedHeight(60)
+        self.setFixedHeight(70)
 
         self._vertical_layout = QVBoxLayout(self)
         self._vertical_layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
**Issue**
Resolves #8972 


**Approach**
🏖️         🌊 🏄 

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/26a81d47-ea8f-4891-957f-7a968789e347)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
