### PR TITLE
Adjust histogram boundaries when min(data)==max(data) in plotting

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -133,6 +133,9 @@ def plotHistogram(
                     ),
                 )
             else:
+                if minimum is not None and maximum is not None and minimum == maximum:
+                    minimum -= 0.1
+                    maximum += 0.1
                 config.addLegendItem(
                     ensemble.name,
                     _plotHistogram(

--- a/tests/ert/unit_tests/gui/plottery/test_histogram.py
+++ b/tests/ert/unit_tests/gui/plottery/test_histogram.py
@@ -1,9 +1,10 @@
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pandas as pd
 import pytest
 from matplotlib.figure import Figure
 
+import ert
 from ert.gui.tools.plot.plot_api import EnsembleObject
 from ert.gui.tools.plot.plottery import PlotConfig, PlotContext
 from ert.gui.tools.plot.plottery.plots import HistogramPlot
@@ -70,3 +71,42 @@ def test_histogram(plot_context: PlotContext, ensemble_to_data_map):
         {},
     )
     return figure
+
+
+def test_histogram_plot_for_constant_distribution(monkeypatch):
+    # test that the histogram plot is called with the correct min and max values
+    # when all the parameter values are the same
+    context = Mock(spec=PlotContext)
+    context.log_scale = False
+    context.ensembles.return_value = [
+        EnsembleObject("ensemble_1", "id", False, "experiment_1")
+    ]
+    title = "Histogram with same values"
+    context.plotConfig.return_value = PlotConfig(title=title)
+    value = 0
+    data_map = dict.fromkeys(context.ensembles(), pd.DataFrame([10 * [value]]))
+    min_value = value - 0.1
+    max_value = value + 0.1
+    figure = Figure()
+    mock_plot_histogram = Mock()
+    monkeypatch.setattr(
+        ert.gui.tools.plot.plottery.plots.histogram,
+        "_plotHistogram",
+        mock_plot_histogram,
+    )
+    HistogramPlot().plot(
+        figure,
+        context,
+        data_map,
+        pd.DataFrame(),
+        {},
+    )
+    mock_plot_histogram.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        min_value,
+        max_value,
+    )


### PR DESCRIPTION
**Issue**
If min==max then there is no plot. We expect a single bar of length == ensemble size.
 - [x] Add test when min==max for histogram plot

**Approach**
Adjust boundaries.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
