### PR TITLE
Disable experiment types that do parameter updates if there are no params to update

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -65,15 +65,22 @@ def run_cli(args: Namespace, plugin_manager: Optional[ErtPluginManager] = None) 
             f"'OBS_CONFIG observation_file.txt'."
         )
 
-    if not ert_config.ensemble_config.parameter_configs and args.mode in [
+    if args.mode in [
         ENSEMBLE_SMOOTHER_MODE,
         ES_MDA_MODE,
         ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
     ]:
-        raise ErtCliError(
-            f"To run {args.mode}, GEN_KW, FIELD or SURFACE parameters are needed. \n"
-            f"Please add to file {args.config}"
-        )
+        if not ert_config.ensemble_config.parameter_configs:
+            raise ErtCliError(
+                f"To run {args.mode}, GEN_KW, FIELD or SURFACE parameters are needed. \n"
+                f"Please add to file {args.config}"
+            )
+        if not any(
+            p.update for p in ert_config.ensemble_config.parameter_configs.values()
+        ):
+            raise ErtCliError(
+                f"All parameters are set to UPDATE:FALSE in {args.config}"
+            )
 
     storage = open_storage(ert_config.ens_path, "w")
 

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -152,9 +152,9 @@ class ExperimentPanel(QWidget):
             True,
         )
 
-        experiment_type_valid = bool(
-            config.ensemble_config.parameter_configs and config.observations
-        )
+        experiment_type_valid = any(
+            p.update for p in config.ensemble_config.parameter_configs.values()
+        ) and bool(config.observations)
 
         self.addExperimentConfigPanel(
             MultipleDataAssimilationPanel(
@@ -202,7 +202,9 @@ class ExperimentPanel(QWidget):
             sim_item = model.item(item_count)
             assert sim_item is not None
             sim_item.setEnabled(False)
-            sim_item.setToolTip("Both observations and parameters must be defined")
+            sim_item.setToolTip(
+                "Both observations and parameters must be defined.\nThere must be parameters to update."
+            )
             style = self.style()
             assert style is not None
             sim_item.setIcon(

--- a/tests/ert/ui_tests/cli/test_parameter.py
+++ b/tests/ert/ui_tests/cli/test_parameter.py
@@ -1,0 +1,32 @@
+import fileinput
+from argparse import ArgumentParser
+
+import pytest
+
+from ert.__main__ import ert_parser
+from ert.cli.main import ErtCliError, run_cli
+from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_running_smoother_raises_without_updateable_parameters():
+    with fileinput.input("poly.ert", inplace=True) as fin:
+        for line in fin:
+            if "GEN_KW COEFFS coeff_priors" in line:
+                print(f"{line[:-1]} UPDATE:FALSE")
+            else:
+                print(line, end="")
+
+    parser = ArgumentParser(prog="test_main")
+    parsed = ert_parser(
+        parser,
+        [
+            ENSEMBLE_SMOOTHER_MODE,
+            "--disable-monitor",
+            "poly.ert",
+        ],
+    )
+
+    with pytest.raises(ErtCliError) as e:
+        run_cli(parsed)
+    assert "All parameters are set to UPDATE:FALSE in" in str(e)

--- a/tests/ert/ui_tests/gui/test_missing_parameters_to_update.py
+++ b/tests/ert/ui_tests/gui/test_missing_parameters_to_update.py
@@ -1,0 +1,38 @@
+import fileinput
+
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QComboBox
+
+from ert.gui.simulation.experiment_panel import ExperimentPanel
+from tests.ert.ui_tests.gui.conftest import get_child, open_gui_with_config
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_no_updateable_parameters(qtbot):
+    with fileinput.input("poly.ert", inplace=True) as fin:
+        for line in fin:
+            if "GEN_KW COEFFS coeff_priors" in line:
+                print(f"{line[:-1]} UPDATE:FALSE")
+            else:
+                print(line, end="")
+
+    for gui in open_gui_with_config("poly.ert"):
+        experiment_panel = get_child(gui, ExperimentPanel)
+        simulation_mode_combo = get_child(experiment_panel, QComboBox)
+        idx = simulation_mode_combo.findText("Ensemble smoother")
+        assert not (
+            simulation_mode_combo.model().item(idx).flags() & Qt.ItemFlag.ItemIsEnabled
+        )
+        idx = simulation_mode_combo.findText("Multiple data assimilation")
+        assert not (
+            simulation_mode_combo.model().item(idx).flags() & Qt.ItemFlag.ItemIsEnabled
+        )
+        idx = simulation_mode_combo.findText("Iterated ensemble smoother")
+        assert not (
+            simulation_mode_combo.model().item(idx).flags() & Qt.ItemFlag.ItemIsEnabled
+        )
+        idx = simulation_mode_combo.findText("Ensemble experiment")
+        assert (
+            simulation_mode_combo.model().item(idx).flags() & Qt.ItemFlag.ItemIsEnabled
+        )


### PR DESCRIPTION
If all parameters have UPDATE:FALSE set, then we should not let the user select any mode that does parameter updates.

**Issue**
Resolves #8970


**Approach**
Added a check to see if any parameter has update set to true. If it fails we disable experiment types that do parameter updates.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
