### PR TITLE
Use more realistic values in example in doc

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -936,7 +936,7 @@ To achieve this:
         -- Permeability must be sampled from the geomodel/simulation grid zone into the ERTBOX grid
         -- and exported to /some/path/filename. Note that the name of the property in the input file
         -- in INIT_FILES must be the same as the ID.
-        FIELD  perm_zone_A  PARAMETER  perm_zone_A.roff  INIT_FILES:/some/path/perm_zone_A.roff  INIT_TRANSFORM:LOG  OUTPUT_TRANSFORM:EXP  MIN:-5.5  MAX:5.5  FORWARD_INIT:True
+        FIELD  perm_zone_A  PARAMETER  perm_zone_A.roff  INIT_FILES:/some/path/perm_zone_A.roff  INIT_TRANSFORM:LOG  OUTPUT_TRANSFORM:EXP  MIN:0  MAX:5000  FORWARD_INIT:True
 
 
 GEN_DATA


### PR DESCRIPTION
Min and max are applied after the output-transformation. For a permeability field this implies that has some implications on what is a realistic value interval.

**Issue**
Resolves doc issue reported on Slack.

**Approach**
🧠 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
