### PR TITLE
Combine dicts instead of mutating user environment variables

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -651,13 +651,13 @@ class ErtConfig:
         itr: int = 0,
         context_env: Optional[Dict[str, str]] = None,
     ):
-        if context_env is not None:
-            self.env_vars.update(context_env)
+        if context_env is None:
+            context_env = {}
         return self._create_forward_model_json(
             context=self.substitution_list,
             forward_model_steps=self.forward_model_steps,
             user_config_file=self.user_config_file,
-            env_vars=self.env_vars,
+            env_vars={**self.env_vars, **context_env},
             run_id=run_id,
             iens=iens,
             itr=itr,


### PR DESCRIPTION
This mutates the user configuration while running, which seems like a bad thing to do.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
