### PR TITLE
Relax requirement for flaky cpu multiprocess test

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -43,12 +43,12 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
         next(run)
 
 
-@pytest.mark.flaky(reruns=5)
+@pytest.mark.flaky(reruns=10)
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_cpu_seconds_can_detect_multiprocess():
     """Run a fm step that sets of two simultaneous processes that
-    each run for 1 second. We should be able to detect the total
+    each run for 2 second. We should be able to detect the total
     cpu seconds consumed to be roughly 2 seconds.
 
     The test is flaky in that it tries to gather cpu_seconds data while
@@ -64,7 +64,7 @@ def test_cpu_seconds_can_detect_multiprocess():
                 """\
             import time
             now = time.time()
-            while time.time() < now + 1:
+            while time.time() < now + 2:
                 pass"""
             )
         )
@@ -91,7 +91,7 @@ def test_cpu_seconds_can_detect_multiprocess():
     for status in fmstep.run():
         if isinstance(status, Running):
             cpu_seconds = max(cpu_seconds, status.memory_status.cpu_seconds)
-    assert 1.4 < cpu_seconds < 2.2
+    assert 2.5 < cpu_seconds < 4.5
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
**Issue**
Resolves 🩸 with 🩹  (#8798 )

**Approach**
🕐 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
