### PR TITLE
Let flaky adaptive tests be rerun

### DIFF
--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -30,6 +30,7 @@ def run_cli_ES_with_case(poly_config):
     return prior_ensemble, posterior_ensemble
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_adaptive_localization_with_cutoff_1_equals_ensemble_prior():
@@ -60,6 +61,7 @@ def test_that_adaptive_localization_with_cutoff_1_equals_ensemble_prior():
     assert np.allclose(posterior_sample, prior_sample)
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_adaptive_localization_works_with_a_single_observation():
@@ -97,6 +99,7 @@ def test_that_adaptive_localization_works_with_a_single_observation():
     _, _ = run_cli_ES_with_case("poly_localization_0.ert")
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_adaptive_localization_works_with_multiple_observations(snapshot):
@@ -217,6 +220,7 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
     assert set(map(tuple, records_from_pl)) == expected_records
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_adaptive_localization_with_cutoff_0_equals_ESupdate():
@@ -255,6 +259,7 @@ def test_that_adaptive_localization_with_cutoff_0_equals_ESupdate():
     assert np.allclose(posterior_sample_loc0, posterior_sample_noloc, atol=1e-6)
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_posterior_generalized_variance_increases_in_cutoff():


### PR DESCRIPTION
These adaptive localization tests fail very often on weak hardware, and is hampering the deploy process.

Adding reruns on failure will lead to similar hampering when the test actually starts to fail for the correct reasons, but this we have to live with.

**Issue**
Resolves pain by  🩹  (#8787)

**Approach**
♻️ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
