### PR TITLE
Add _verify_checksum lock in job.py

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -275,10 +275,16 @@ class Scheduler:
         # this lock is to assure that no more than 1 task
         # does internalization at a time
         forward_model_ok_lock = asyncio.Lock()
+        verify_checksum_lock = asyncio.Lock()
         for iens, job in self._jobs.items():
             if job.state != JobState.ABORTED:
                 self._job_tasks[iens] = asyncio.create_task(
-                    job.run(sem, forward_model_ok_lock, self._max_submit),
+                    job.run(
+                        sem,
+                        forward_model_ok_lock,
+                        verify_checksum_lock,
+                        self._max_submit,
+                    ),
                     name=f"job-{iens}_task",
                 )
             else:

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -135,7 +135,9 @@ async def test_job_run_sends_expected_events(
     job.started.set()
 
     job_run_task = asyncio.create_task(
-        job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=max_submit)
+        job.run(
+            asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=max_submit
+        )
     )
 
     for attempt in range(max_submit):
@@ -177,7 +179,7 @@ async def test_num_cpu_is_propagated_to_driver(realization: Realization):
     scheduler = create_scheduler()
     job = Job(scheduler, realization)
     job_run_task = asyncio.create_task(
-        job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+        job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
     )
     job.started.set()
     job.returncode.set_result(0)
@@ -200,7 +202,7 @@ async def test_realization_memory_is_propagated_to_driver(realization: Realizati
     scheduler = create_scheduler()
     job = Job(scheduler, realization)
     job_run_task = asyncio.create_task(
-        job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+        job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
     )
     job.started.set()
     job.returncode.set_result(0)
@@ -238,7 +240,7 @@ async def test_when_waiting_for_disk_sync_times_out_an_error_is_logged(
 
     with captured_logs(log_msgs, logging.ERROR):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -269,7 +271,7 @@ async def test_when_files_in_manifest_are_not_created_an_error_is_logged(
 
     with captured_logs(log_msgs, logging.ERROR):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -303,7 +305,7 @@ async def test_when_checksums_do_not_match_a_warning_is_logged(
 
     with captured_logs(log_msgs, logging.WARNING):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -331,7 +333,7 @@ async def test_when_no_checksum_info_is_received_a_warning_is_logged(
 
     with captured_logs(log_msgs, logging.WARNING):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), max_submit=1)
+            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
         )
         job.started.set()
         job.returncode.set_result(0)


### PR DESCRIPTION
**Issue**
This should help speed things up when a lot of jobs finish about the same time, and a lot of i/o is going on. 

**Approach**
This removes the usage of the `forward_model_ok_lock` when sleeping until checksum_path exist. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
