### PR TITLE
Use only get_ensemble_state to check for existing responses/parameters

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -194,6 +194,7 @@ def sample_prior(
             )
             ensemble.save_parameters(parameter, realization_nr, ds)
 
+    ensemble.refresh_ensemble_state()
     logger.debug(f"sample_prior() time_used {(time.perf_counter() - t):.4f}s")
 
 

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -87,7 +87,7 @@ class EnsembleSelector(QComboBox):
                 ensemble
                 for ensemble in self.notifier.storage.ensembles
                 if all(
-                    e == RealizationStorageState.UNDEFINED
+                    RealizationStorageState.UNDEFINED in e
                     for e in ensemble.get_ensemble_state()
                 )
             )

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -298,10 +298,8 @@ class _EnsembleWidget(QWidget):
             self._state_text_edit.clear()
             html = "<table>"
             assert self._ensemble is not None
-            for state_index, value in enumerate(self._ensemble.get_ensemble_state()):
-                html += (
-                    f"<tr><td width=30>{state_index:d}.</td><td>{value.name}</td></tr>"
-                )
+            for state_index, state in enumerate(self._ensemble.get_ensemble_state()):
+                html += f"<tr><td width=30>{state_index:d}.</td><td>{', '.join([s.name for s in state])}</td></tr>"
             html += "</table>"
             self._state_text_edit.setHtml(html)
 
@@ -402,18 +400,20 @@ class _RealizationWidget(QWidget):
 
     @Slot(RealizationStorageState)
     def setRealization(self, ensemble: Ensemble, realization: int) -> None:
-        state = ensemble.get_ensemble_state()[realization]
-        self._state_label.setText(f"Realization state: {state.name}")
+        realization_state = ensemble.get_ensemble_state()[realization]
+        self._state_label.setText(
+            f"Realization state: {', '.join(sorted([s.name for s in realization_state]))}"
+        )
 
         html = "<table>"
-        for name, state in ensemble.get_response_state(realization).items():
-            html += f"<tr><td>{name} - {state.name}</td></tr>"
+        for name, _response_state in ensemble.get_response_state(realization).items():
+            html += f"<tr><td>{name} - {_response_state.name}</td></tr>"
         html += "</table>"
         self._response_text_edit.setHtml(html)
 
         html = "<table>"
-        for name, state in ensemble.get_parameter_state(realization).items():
-            html += f"<tr><td>{name} - {state.name}</td></tr>"
+        for name, _param_state in ensemble.get_parameter_state(realization).items():
+            html += f"<tr><td>{name} - {_param_state.name}</td></tr>"
         html += "</table>"
         self._parameter_text_edit.setHtml(html)
 

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -136,6 +136,7 @@ class LibresFacade:
             ensemble,
             [r for r, active in enumerate(realisations) if active],
         )
+        ensemble.refresh_ensemble_state()
         _logger.debug(
             f"load_from_forward_model() time_used {(time.perf_counter() - t):.4f}s"
         )
@@ -173,6 +174,7 @@ class LibresFacade:
             else:
                 _logger.error(f"Realization: {iens}, load failure: {message}")
 
+        ensemble.refresh_ensemble_state()
         return loaded
 
     def get_observations(self) -> "EnkfObs":

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -574,6 +574,8 @@ class BaseRunModel(ABC):
             self._end_queue.get()
             return []
         await evaluator_task
+        ensemble.refresh_ensemble_state()
+
         return evaluator_task.result()
 
     # This function needs to be there for the sake of testing that expects sync ee run

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -420,6 +420,11 @@ class LocalEnsemble(BaseMode):
             )
         return None
 
+    def refresh_ensemble_state(self) -> None:
+        self.get_ensemble_state.cache_clear()
+        self.get_ensemble_state()
+
+    @lru_cache  # noqa: B019
     def get_ensemble_state(self) -> List[Set[RealizationStorageState]]:
         """
         Retrieve the state of each realization within ensemble.

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -224,8 +224,12 @@ class LocalEnsemble(BaseMode):
 
         return np.array(
             [
-                self._parameters_exist_for_realization(i)
-                for i in range(self.ensemble_size)
+                state
+                in {
+                    RealizationStorageState.INITIALIZED,
+                    RealizationStorageState.HAS_DATA,
+                }
+                for state in self.get_ensemble_state()
             ]
         )
 
@@ -248,8 +252,8 @@ class LocalEnsemble(BaseMode):
 
         return np.array(
             [
-                self._responses_exist_for_realization(i, key)
-                for i in range(self.ensemble_size)
+                state == RealizationStorageState.HAS_DATA
+                for state in self.get_ensemble_state()
             ]
         )
 

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -225,7 +225,7 @@ class LocalEnsemble(BaseMode):
             [
                 bool(
                     {
-                        RealizationStorageState.INITIALIZED,
+                        RealizationStorageState.PARAMETERS_LOADED,
                         RealizationStorageState.HAS_DATA,
                     }.intersection(state)
                 )
@@ -514,7 +514,7 @@ class LocalEnsemble(BaseMode):
             if _responses_exist_for_realization(realization):
                 _state.add(RealizationStorageState.HAS_DATA)
             if _parameters_exist_for_realization(realization):
-                _state.add(RealizationStorageState.INITIALIZED)
+                _state.add(RealizationStorageState.PARAMETERS_LOADED)
 
             if len(_state) == 0:
                 _state.add(RealizationStorageState.UNDEFINED)
@@ -895,7 +895,7 @@ class LocalEnsemble(BaseMode):
     ) -> Dict[str, RealizationStorageState]:
         path = self._realization_dir(realization)
         return {
-            e: RealizationStorageState.INITIALIZED
+            e: RealizationStorageState.PARAMETERS_LOADED
             if (path / (_escape_filename(e) + ".nc")).exists()
             else RealizationStorageState.UNDEFINED
             for e in self.experiment.parameter_configuration

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -226,7 +226,7 @@ class LocalEnsemble(BaseMode):
                 bool(
                     {
                         RealizationStorageState.PARAMETERS_LOADED,
-                        RealizationStorageState.HAS_DATA,
+                        RealizationStorageState.RESPONSES_LOADED,
                     }.intersection(state)
                 )
                 for state in self.get_ensemble_state()
@@ -252,7 +252,7 @@ class LocalEnsemble(BaseMode):
 
         return np.array(
             [
-                RealizationStorageState.HAS_DATA in state
+                RealizationStorageState.RESPONSES_LOADED in state
                 for state in self.get_ensemble_state()
             ]
         )
@@ -512,7 +512,7 @@ class LocalEnsemble(BaseMode):
                 assert failure
                 _state.add(failure.type)
             if _responses_exist_for_realization(realization):
-                _state.add(RealizationStorageState.HAS_DATA)
+                _state.add(RealizationStorageState.RESPONSES_LOADED)
             if _parameters_exist_for_realization(realization):
                 _state.add(RealizationStorageState.PARAMETERS_LOADED)
 
@@ -906,7 +906,7 @@ class LocalEnsemble(BaseMode):
     ) -> Dict[str, RealizationStorageState]:
         path = self._realization_dir(realization)
         return {
-            e: RealizationStorageState.HAS_DATA
+            e: RealizationStorageState.RESPONSES_LOADED
             if (path / f"{e}.parquet").exists()
             else RealizationStorageState.UNDEFINED
             for e in self.experiment.response_configuration

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -425,11 +425,11 @@ class LocalStorage(BaseMode):
         )
         if prior_ensemble:
             for realization, state in enumerate(prior_ensemble.get_ensemble_state()):
-                if state in [
+                if {
                     RealizationStorageState.LOAD_FAILURE,
                     RealizationStorageState.PARENT_FAILURE,
                     RealizationStorageState.UNDEFINED,
-                ]:
+                }.intersection(state):
                     ens.set_failure(
                         realization,
                         RealizationStorageState.PARENT_FAILURE,

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -148,6 +148,9 @@ class LocalStorage(BaseMode):
         self._ensembles = self._load_ensembles()
         self._experiments = self._load_experiments()
 
+        for ens in self._ensembles.values():
+            ens.refresh_ensemble_state()
+
     def get_experiment(self, uuid: UUID) -> LocalExperiment:
         """
         Retrieves an experiment by UUID.

--- a/src/ert/storage/realization_storage_state.py
+++ b/src/ert/storage/realization_storage_state.py
@@ -4,6 +4,6 @@ from enum import Enum
 class RealizationStorageState(Enum):
     UNDEFINED = 1
     PARAMETERS_LOADED = 2
-    HAS_DATA = 4
+    RESPONSES_LOADED = 4
     LOAD_FAILURE = 8
     PARENT_FAILURE = 16

--- a/src/ert/storage/realization_storage_state.py
+++ b/src/ert/storage/realization_storage_state.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class RealizationStorageState(Enum):
     UNDEFINED = 1
-    INITIALIZED = 2
+    PARAMETERS_LOADED = 2
     HAS_DATA = 4
     LOAD_FAILURE = 8
     PARENT_FAILURE = 16

--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -231,8 +231,8 @@ def test_that_update_works_with_failed_realizations():
         posterior = experiment.get_ensemble_by_name("iter-1")
 
         assert all(
-            posterior.get_ensemble_state()[idx]
-            == RealizationStorageState.PARENT_FAILURE
+            RealizationStorageState.PARENT_FAILURE
+            in posterior.get_ensemble_state()[idx]
             for idx, v in enumerate(prior.get_ensemble_state())
-            if v == RealizationStorageState.LOAD_FAILURE
+            if RealizationStorageState.LOAD_FAILURE in v
         )

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -48,7 +48,8 @@ def test_init_prior(qtbot, storage):
         Qt.MouseButton.LeftButton,
     )
     assert (
-        RealizationStorageState.INITIALIZED in s for s in ensemble.get_ensemble_state()
+        RealizationStorageState.PARAMETERS_LOADED in s
+        for s in ensemble.get_ensemble_state()
     )
     assert ensemble.load_parameters("COEFFS")[
         "transformed_values"

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -36,9 +36,8 @@ def test_init_prior(qtbot, storage):
         name="prior",
     )
     notifier.set_current_ensemble(ensemble)
-    assert (
-        ensemble.get_ensemble_state()
-        == [RealizationStorageState.UNDEFINED] * config.model_config.num_realizations
+    assert all(
+        RealizationStorageState.UNDEFINED in s for s in ensemble.get_ensemble_state()
     )
 
     tool = ManageExperimentsPanel(
@@ -49,8 +48,7 @@ def test_init_prior(qtbot, storage):
         Qt.MouseButton.LeftButton,
     )
     assert (
-        ensemble.get_ensemble_state()
-        == [RealizationStorageState.INITIALIZED] * config.model_config.num_realizations
+        RealizationStorageState.INITIALIZED in s for s in ensemble.get_ensemble_state()
     )
     assert ensemble.load_parameters("COEFFS")[
         "transformed_values"
@@ -105,8 +103,8 @@ def test_that_init_updates_the_info_tab(qtbot, storage):
     # Change back to first tab
     tool.setCurrentIndex(0)
     ensemble_widget._currentTabChanged(1)
-    assert "INITIALIZED" in html_edit.toPlainText()
-    assert not "RealizationStorageState.INITIALIZED" in html_edit.toPlainText()
+    assert "PARAMETERS_LOADED" in html_edit.toPlainText()
+    assert not "RealizationStorageState.PARAMETERS_LOADED" in html_edit.toPlainText()
 
     # select the observation
     storage_info_widget = tool._storage_info_widget
@@ -375,11 +373,14 @@ def test_realization_view(
 
     realization_widget = tool._storage_info_widget._content_layout.currentWidget()
 
-    assert realization_widget._state_label.text() == "Realization state: HAS_DATA"
-    assert {"gen_data - HAS_DATA", "summary - HAS_DATA"}.issubset(
+    assert (
+        realization_widget._state_label.text()
+        == "Realization state: PARAMETERS_LOADED, RESPONSES_LOADED"
+    )
+    assert {"gen_data - RESPONSES_LOADED", "summary - RESPONSES_LOADED"}.issubset(
         set(realization_widget._response_text_edit.toPlainText().splitlines())
     )
     assert (
         realization_widget._parameter_text_edit.toPlainText()
-        == "\nSNAKE_OIL_PARAM - INITIALIZED\n"
+        == "\nSNAKE_OIL_PARAM - PARAMETERS_LOADED\n"
     )

--- a/tests/ert/unit_tests/dark_storage/test_common.py
+++ b/tests/ert/unit_tests/dark_storage/test_common.py
@@ -98,5 +98,6 @@ def test_data_for_key_returns_empty_gen_data_config(tmp_path):
             ),
             0,
         )
+        ensemble.refresh_ensemble_state()
         data = data_for_key(ensemble, "response@0")
         assert not data.empty

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -413,7 +413,8 @@ def test_ensemble_no_parameters(storage):
         name="prior",
     )
     assert all(
-        RealizationStorageState.HAS_DATA in s for s in ensemble.get_ensemble_state()
+        RealizationStorageState.RESPONSES_LOADED in s
+        for s in ensemble.get_ensemble_state()
     )
 
 
@@ -1005,7 +1006,9 @@ class StatefulStorageTest(RuleBasedStateMachine):
             # If expecting no responses, i.e., it has empty .keys in all response
             # configs, it will be a HAS_DATA even if no responses were ever saved
             if not is_expecting_responses:
-                assert RealizationStorageState.HAS_DATA in edited_posterior_state
+                assert (
+                    RealizationStorageState.RESPONSES_LOADED in edited_posterior_state
+                )
             else:
                 assert self.iens_to_edit not in prior.failure_messages
                 assert RealizationStorageState.UNDEFINED in edited_posterior_state


### PR DESCRIPTION
(also one step closer to statemap)

Removes duplication of looped calls to `_responses_exist_for_realization`, `_parameters_exist_for_realization`, which are now only called from within one place. Makes it easier to add a global state to them when they are invoked for all reals.

Return set of `RealizationStorageState` from `get_ensemble_state()` and show accordingly in GUI:
<img width="929" alt="Screenshot 2024-10-28 at 09 42 19" src="https://github.com/user-attachments/assets/61d66248-eca7-4db1-a83f-77534a23713e">

<img width="955" alt="Screenshot 2024-10-28 at 09 42 57" src="https://github.com/user-attachments/assets/a9af76b4-9ea2-48fc-9701-e2b350f9249e">
