### PR TITLE
Use all substitutions for getting file in runpath

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -25,7 +25,7 @@ async def _read_parameters(
         try:
             start_time = time.perf_counter()
             logger.debug(f"Starting to load parameter: {config.name}")
-            ds = config.read_from_runpath(run_arg.file_in_runpath, run_arg.iens)
+            ds = config.read_from_runpath(run_arg.file_in_runpath)
             await asyncio.sleep(0)
             logger.debug(
                 f"Loaded {config.name}",

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from pathlib import Path
 from typing import Iterable
 
 from ert.config import InvalidResponseFile, ParameterConfig, ResponseConfig
@@ -26,7 +25,7 @@ async def _read_parameters(
         try:
             start_time = time.perf_counter()
             logger.debug(f"Starting to load parameter: {config.name}")
-            ds = config.read_from_runpath(Path(run_arg.runpath), run_arg.iens)
+            ds = config.read_from_runpath(run_arg.file_in_runpath, run_arg.iens)
             await asyncio.sleep(0)
             logger.debug(
                 f"Loaded {config.name}",

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -55,7 +55,7 @@ async def _write_responses_to_storage(
             start_time = time.perf_counter()
             logger.debug(f"Starting to load response: {config.response_type}")
             try:
-                ds = config.read_from_file(run_arg.runpath, run_arg.iens)
+                ds = config.read_from_file(run_arg.file_in_runpath)
             except (FileNotFoundError, InvalidResponseFile) as err:
                 errors.append(str(err))
                 logger.warning(f"Failed to write: {run_arg.iens}: {err}")

--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Mapping, MutableMapping, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import xarray as xr
@@ -65,13 +74,15 @@ class ExtParamConfig(ParameterConfig):
                     f"Duplicate keys for key '{self.name}' - keys: {self.input_keys}"
                 )
 
-    def read_from_runpath(self, run_path: Path, real_nr: int) -> xr.Dataset:
+    def read_from_runpath(
+        self, file_in_runpath: Callable[[str], str], real_nr: int
+    ) -> xr.Dataset:
         raise NotImplementedError()
 
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: Ensemble
+        self, file_in_runpath: Callable[[str], str], real_nr: int, ensemble: Ensemble
     ) -> None:
-        file_path = run_path / self.output_file
+        file_path = Path(file_in_runpath(self.output_file))
         Path.mkdir(file_path.parent, exist_ok=True, parents=True)
 
         data: MutableDataType = {}

--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -74,9 +74,7 @@ class ExtParamConfig(ParameterConfig):
                     f"Duplicate keys for key '{self.name}' - keys: {self.input_keys}"
                 )
 
-    def read_from_runpath(
-        self, file_in_runpath: Callable[[str], str], real_nr: int
-    ) -> xr.Dataset:
+    def read_from_runpath(self, file_in_runpath: Callable[[str], str]) -> xr.Dataset:
         raise NotImplementedError()
 
     def write_to_runpath(

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -138,13 +138,9 @@ class Field(ParameterConfig):
 
         return np.size(self.mask) - np.count_nonzero(self.mask)
 
-    def read_from_runpath(
-        self, file_in_runpath: Callable[[str], str], real_nr: int
-    ) -> xr.Dataset:
+    def read_from_runpath(self, file_in_runpath: Callable[[str], str]) -> xr.Dataset:
         t = time.perf_counter()
         file_name = self.forward_init_file
-        if "%d" in file_name:
-            file_name = file_name % real_nr  # noqa
         ds = xr.Dataset(
             {
                 "values": (

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import xarray as xr
@@ -58,7 +58,7 @@ class ParameterConfig(ABC):
         random_seed: int,
         ensemble_size: int,
     ) -> xr.Dataset:
-        return self.read_from_runpath(Path(), real_nr)
+        return self.read_from_runpath(lambda x: x, real_nr)
 
     @abstractmethod
     def __len__(self) -> int:
@@ -66,23 +66,31 @@ class ParameterConfig(ABC):
 
     @abstractmethod
     def read_from_runpath(
-        self,
-        run_path: Path,
-        real_nr: int,
+        self, file_in_runpath: Callable[[str], str], real_nr: int
     ) -> xr.Dataset:
         """
         This function is responsible for converting the parameter
         from the forward model to the internal ert format
+        Args:
+            file_in_runpath: Function for converting a relative path to have
+                cwd in the runpath, e.g. "CASE.UNSMRY" ->
+                "/scratch/realization-0/iter-0/CASE.UNSMRY"
+
         """
 
     @abstractmethod
     def write_to_runpath(
-        self, run_path: Path, real_nr: int, ensemble: Ensemble
+        self, file_in_runpath: Callable[[str], str], real_nr: int, ensemble: Ensemble
     ) -> Optional[Dict[str, Dict[str, float]]]:
         """
         This function is responsible for converting the parameter
         from the internal ert format to the format the forward model
         expects
+        Args:
+            file_in_runpath: Function for converting a relative path to have
+                cwd in the runpath, e.g. "CASE.UNSMRY" ->
+                "/scratch/realization-0/iter-0/CASE.UNSMRY"
+
         """
 
     @abstractmethod

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -54,20 +54,19 @@ class ParameterConfig(ABC):
 
     def sample_or_load(
         self,
+        file_in_config_path: Callable[[str], str],
         real_nr: int,
         random_seed: int,
         ensemble_size: int,
     ) -> xr.Dataset:
-        return self.read_from_runpath(lambda x: x, real_nr)
+        return self.read_from_runpath(file_in_config_path)
 
     @abstractmethod
     def __len__(self) -> int:
         """Number of parameters"""
 
     @abstractmethod
-    def read_from_runpath(
-        self, file_in_runpath: Callable[[str], str], real_nr: int
-    ) -> xr.Dataset:
+    def read_from_runpath(self, file_in_runpath: Callable[[str], str]) -> xr.Dataset:
         """
         This function is responsible for converting the parameter
         from the forward model to the internal ert format

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import polars
 from typing_extensions import Self
@@ -23,8 +23,13 @@ class ResponseConfig(ABC):
     keys: List[str] = dataclasses.field(default_factory=list)
 
     @abstractmethod
-    def read_from_file(self, run_path: str, iens: int) -> polars.DataFrame:
+    def read_from_file(self, file_in_runpath: Callable[[str], str]) -> polars.DataFrame:
         """Reads the data for the response from run_path.
+
+        Args:
+            file_in_runpath: Function for converting a relative path to have
+                cwd in the runpath, e.g. "CASE.UNSMRY" ->
+                "/scratch/realization-0/iter-0/CASE.UNSMRY"
 
         Raises:
             FileNotFoundError: when one of the input_files for the

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional, Set, Union, no_type_check
+from typing import TYPE_CHECKING, Any, Callable, Optional, Set, Union, no_type_check
 
 from ._read_summary import read_summary
 from .ensemble_config import Refcase
@@ -36,9 +36,11 @@ class SummaryConfig(ResponseConfig):
         base = self.input_files[0]
         return [f"{base}.UNSMRY", f"{base}.SMSPEC"]
 
-    def read_from_file(self, run_path: str, iens: int) -> polars.DataFrame:
-        filename = self.input_files[0].replace("<IENS>", str(iens))
-        _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
+    def read_from_file(
+        self, file_in_runpath: Callable[[str], str] = lambda x: x
+    ) -> polars.DataFrame:
+        filename = file_in_runpath(self.input_files[0])
+        _, keys, time_map, data = read_summary(filename, self.keys)
         if len(data) == 0 or len(keys) == 0:
             # https://github.com/equinor/ert/issues/6974
             # There is a bug with storing empty responses so we have

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -97,12 +97,8 @@ class SurfaceConfig(ParameterConfig):
     def __len__(self) -> int:
         return self.ncol * self.nrow
 
-    def read_from_runpath(
-        self, file_in_runpath: Callable[[str], str], real_nr: int
-    ) -> xr.Dataset:
+    def read_from_runpath(self, file_in_runpath: Callable[[str], str]) -> xr.Dataset:
         file_name = self.forward_init_file
-        if "%d" in file_name:
-            file_name = file_name % real_nr  # noqa
         file_path = Path(file_in_runpath(file_name))
         if not file_path.exists():
             raise ValueError(

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -107,7 +107,7 @@ class SurfaceConfig(ParameterConfig):
         if not file_path.exists():
             raise ValueError(
                 "Failed to initialize parameter "
-                f"'{self.name}' in file {file_name}: "
+                f"'{self.name}' in file {file_path}: "
                 "File not found\n"
             )
         surface = xtgeo.surface_from_file(

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -131,11 +131,10 @@ def _manifest_to_json(
             param_config,
             (ExtParamConfig, GenKwConfig, Field, SurfaceConfig),
         )
-        if param_config.forward_init and param_config.forward_init_file is not None:
+        if param_config.forward_init and ensemble.iteration == 0:
+            assert param_config.forward_init_file is not None
             file_path = param_config.forward_init_file.replace("%d", str(iens))
             manifest[param_config.name] = file_in_runpath(file_path)
-        elif param_config.output_file is not None and not param_config.forward_init:
-            manifest[param_config.name] = file_in_runpath(str(param_config.output_file))
     # Add expected response files to manifest
     for respons_config in ensemble.experiment.response_configuration.values():
         for input_file in respons_config.expected_input_files:

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -177,12 +177,22 @@ def sample_prior(
     parameter_configs = ensemble.experiment.parameter_configuration
     if parameters is None:
         parameters = list(parameter_configs.keys())
+
+    def file_in_config_path(real: int) -> Callable[[str], str]:
+        def inner(filename: str) -> str:
+            if "%d" in filename:
+                filename = filename % real  # noqa
+            return filename.replace("<IENS>", str(real)).replace("<ITER>", "0")
+
+        return inner
+
     for parameter in parameters:
         config_node = parameter_configs[parameter]
         if config_node.forward_init:
             continue
         for realization_nr in active_realizations:
             ds = config_node.sample_or_load(
+                file_in_config_path(realization_nr),
                 realization_nr,
                 random_seed=random_seed,
                 ensemble_size=ensemble.ensemble_size,

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -6,7 +6,17 @@ import os
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Union,
+)
 
 import orjson
 from numpy.random import SeedSequence
@@ -112,7 +122,9 @@ def _generate_parameter_files(
     _value_export_json(run_path, export_base_name, exports)
 
 
-def _manifest_to_json(ensemble: Ensemble, iens: int = 0) -> Dict[str, Any]:
+def _manifest_to_json(
+    ensemble: Ensemble, file_in_runpath: Callable[[str], str], iens: int
+) -> Dict[str, Any]:
     manifest = {}
     # Add expected parameter files to manifest
     for param_config in ensemble.experiment.parameter_configuration.values():
@@ -122,13 +134,15 @@ def _manifest_to_json(ensemble: Ensemble, iens: int = 0) -> Dict[str, Any]:
         )
         if param_config.forward_init and param_config.forward_init_file is not None:
             file_path = param_config.forward_init_file.replace("%d", str(iens))
-            manifest[param_config.name] = file_path
+            manifest[param_config.name] = file_in_runpath(file_path)
         elif param_config.output_file is not None and not param_config.forward_init:
-            manifest[param_config.name] = str(param_config.output_file)
+            manifest[param_config.name] = file_in_runpath(str(param_config.output_file))
     # Add expected response files to manifest
     for respons_config in ensemble.experiment.response_configuration.values():
         for input_file in respons_config.expected_input_files:
-            manifest[f"{respons_config.response_type}_{input_file}"] = input_file
+            manifest[f"{respons_config.response_type}_{input_file}"] = file_in_runpath(
+                input_file
+            )
 
     return manifest
 
@@ -240,7 +254,7 @@ def create_run_path(
                     orjson.dumps(forward_model_output, option=orjson.OPT_NON_STR_KEYS)
                 )
             # Write MANIFEST file to runpath use to avoid NFS sync issues
-            data = _manifest_to_json(ensemble, run_arg.iens)
+            data = _manifest_to_json(ensemble, run_arg.file_in_runpath, run_arg.iens)
             with open(run_path / "manifest.json", mode="wb") as fptr:
                 fptr.write(orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS))
 

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -87,8 +87,7 @@ def _value_export_json(
 def _generate_parameter_files(
     parameter_configs: Iterable[ParameterConfig],
     export_base_name: str,
-    run_path: Path,
-    iens: int,
+    runarg: RunArg,
     fs: Ensemble,
     iteration: int,
 ) -> None:
@@ -113,13 +112,13 @@ def _generate_parameter_files(
         # model has completed.
         if node.forward_init and iteration == 0:
             continue
-        export_values = node.write_to_runpath(Path(run_path), iens, fs)
+        export_values = node.write_to_runpath(runarg.file_in_runpath, runarg.iens, fs)
         if export_values:
             exports.update(export_values)
         continue
 
-    _value_export_txt(run_path, export_base_name, exports)
-    _value_export_json(run_path, export_base_name, exports)
+    _value_export_txt(Path(runarg.runpath), export_base_name, exports)
+    _value_export_json(Path(runarg.runpath), export_base_name, exports)
 
 
 def _manifest_to_json(
@@ -238,8 +237,7 @@ def create_run_path(
             _generate_parameter_files(
                 ensemble.experiment.parameter_configuration.values(),
                 model_config.gen_kw_export_name,
-                run_path,
-                run_arg.iens,
+                run_arg,
                 ensemble,
                 ensemble.iteration,
             )

--- a/src/ert/runpaths.py
+++ b/src/ert/runpaths.py
@@ -1,3 +1,4 @@
+import os.path
 from pathlib import Path
 from typing import Iterable, List, Optional, Union
 
@@ -53,6 +54,16 @@ class Runpaths:
             )
             for realization in realizations
         ]
+
+    def runpath_file(self, filename: str, realization: int, iteration: int) -> str:
+        """Given a filename and realization/iter, return the corresponding name
+        of that file in the runpath
+        """
+        if not os.path.isabs(filename):
+            filename = os.path.join(self._runpath_format, filename)
+        return self._substitutions.substitute_real_iter(
+            filename, realization, iteration
+        )
 
     def get_jobnames(self, realizations: Iterable[int], iteration: int) -> List[str]:
         return [

--- a/tests/ert/unit_tests/config/egrid_generator.py
+++ b/tests/ert/unit_tests/config/egrid_generator.py
@@ -364,3 +364,40 @@ def global_grids(draw):
 
 
 egrids = st.builds(EGrid, file_heads, global_grids())
+
+
+def simple_grid(dims: Tuple[int, int, int] = (2, 2, 2)):
+    corner_size = (dims[0] + 1) * (dims[1] + 1) * 6
+    coord = np.zeros(
+        shape=corner_size,
+        dtype=np.float32,
+    )
+    zcorn = np.zeros(
+        shape=8 * dims[0] * dims[1] * dims[2],
+        dtype=np.float32,
+    )
+    return EGrid(
+        Filehead(
+            0,
+            2000,
+            0,
+            TypeOfGrid.CORNER_POINT,
+            RockModel.SINGLE_PERMEABILITY_POROSITY,
+            GridFormat.IRREGULAR_CORNER_POINT,
+        ),
+        GlobalGrid(
+            coord=coord,
+            zcorn=zcorn,
+            actnum=None,
+            grid_head=GridHead(
+                TypeOfGrid.CORNER_POINT,
+                *dims,
+                0,
+                1,
+                1,
+                CoordinateType.CARTESIAN,
+                (0, 0, 0),
+                (0, 0, 0),
+            ),
+        ),
+    )

--- a/tests/ert/unit_tests/config/summary_generator.py
+++ b/tests/ert/unit_tests/config/summary_generator.py
@@ -524,3 +524,36 @@ def summaries(
         steps.append(SummaryStep(j, minis))
         j += 1
     return smspec, Unsmry(steps)
+
+
+def simple_unsmry():
+    return Unsmry(
+        steps=[
+            SummaryStep(
+                seqnum=0,
+                ministeps=[
+                    SummaryMiniStep(mini_step=0, params=[0.0, 5.629901e16]),
+                ],
+            )
+        ]
+    )
+
+
+def simple_smspec():
+    return Smspec(
+        nx=2,
+        ny=2,
+        nz=2,
+        restarted_from_step=0,
+        num_keywords=2,
+        restart="        ",
+        keywords=["TIME    ", "FOPR"],
+        well_names=[":+:+:+:+", "        "],
+        region_numbers=[-32676, 0],
+        units=["HOURS   ", "SM3"],
+        start_date=Date(day=1, month=1, year=2014, hour=0, minutes=0, micro_seconds=0),
+        intehead=SmspecIntehead(
+            unit=UnitSystem.METRIC,
+            simulator=Simulator.ECLIPSE_100,
+        ),
+    )

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -30,10 +30,11 @@ def test_write_to_runpath_produces_the_transformed_field_in_storage(
     assert permx_field.input_transformation is None
     assert permx_field.output_transformation is None
 
+    def file_in_runpath(filename: str):
+        return f"export/with/path/{real}/" + filename
+
     for real in active_realizations:
-        permx_field.write_to_runpath(
-            Path(f"export/with/path/{real}"), real, prior_ensemble
-        )
+        permx_field.write_to_runpath(file_in_runpath, real, prior_ensemble)
         assert read_field(
             f"export/with/path/{real}/permx.grdecl",
             "PERMX",
@@ -50,9 +51,7 @@ def test_write_to_runpath_produces_the_transformed_field_in_storage(
         with pytest.raises(
             KeyError, match=f"No dataset 'PERMX' in storage for realization {real}"
         ):
-            permx_field.write_to_runpath(
-                Path(f"export/with/path/{real}"), real, prior_ensemble
-            )
+            permx_field.write_to_runpath(file_in_runpath, real, prior_ensemble)
         assert not os.path.isfile(f"export/with/path/{real}/permx.grdecl")
 
 

--- a/tests/ert/unit_tests/config/test_gen_data_config.py
+++ b/tests/ert/unit_tests/config/test_gen_data_config.py
@@ -90,7 +90,7 @@ def test_that_invalid_gendata_outfile_error_propagates(tmp_path):
         InvalidResponseFile,
         match="Error reading GEN_DATA.*could not convert string.*4.910405046410615,4.910405046410615.*to float64",
     ):
-        config.read_from_file(tmp_path, 0)
+        config.read_from_file(lambda x: tmp_path / x)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -103,7 +103,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(con
             keys=["something"],
             report_steps_list=[None],
             input_files=["output"],
-        ).read_from_file(os.getcwd(), 0)
+        ).read_from_file(lambda x: os.getcwd() + "/" + x)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):
@@ -113,7 +113,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmp
             keys=["something"],
             report_steps_list=[None],
             input_files=["DOES_NOT_EXIST"],
-        ).read_from_file(tmpdir, 0)
+        ).read_from_file(lambda x: tmpdir + "/" + x)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_directory(
@@ -125,4 +125,4 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
             keys=["something"],
             report_steps_list=[None],
             input_files=["DOES_NOT_EXIST"],
-        ).read_from_file(str(tmp_path / "DOES_NOT_EXIST"), 0)
+        ).read_from_file(lambda x: str(tmp_path / "NOT_A_DIRECTORY" / x))

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -598,8 +598,8 @@ def test_incorrect_values_in_forward_init_file_fails(tmp_path):
             None,
             None,
             [],
-            str(tmp_path / "forward_init_%d"),
-        ).read_from_runpath(lambda f: str(tmp_path / f), 1)
+            str(tmp_path / "forward_init_1"),
+        ).read_from_runpath(lambda f: str(tmp_path / f))
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -599,7 +599,7 @@ def test_incorrect_values_in_forward_init_file_fails(tmp_path):
             None,
             [],
             str(tmp_path / "forward_init_%d"),
-        ).read_from_runpath(tmp_path, 1)
+        ).read_from_runpath(lambda f: str(tmp_path / f), 1)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -33,7 +33,7 @@ def test_reading_empty_summaries_raises(wopr_summary):
     smspec.to_file("CASE.SMSPEC")
     unsmry.to_file("CASE.UNSMRY")
     with pytest.raises(InvalidResponseFile, match="Did not find any summary values"):
-        SummaryConfig("summary", ["CASE"], ["WWCT:OP1"]).read_from_file(".", 0)
+        SummaryConfig("summary", ["CASE"], ["WWCT:OP1"]).read_from_file(lambda x: x)
 
 
 def test_summary_config_normalizes_list_of_keys():
@@ -51,12 +51,16 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(
     Path("CASE.UNSMRY").write_bytes(unsmry)
     Path("CASE.SMSPEC").write_bytes(smspec)
     with suppress(InvalidResponseFile):
-        SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(os.getcwd(), 1)
+        SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(
+            lambda x: os.getcwd() + "/" + x
+        )
 
 
-def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):
+def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmp_path):
     with pytest.raises(FileNotFoundError):
-        SummaryConfig("summary", ["NOT_CASE"], ["FOPR"]).read_from_file(tmpdir, 1)
+        SummaryConfig("summary", ["NOT_CASE"], ["FOPR"]).read_from_file(
+            lambda x: str(tmp_path / x)
+        )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -65,5 +69,5 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
 ):
     with pytest.raises(FileNotFoundError):
         SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(
-            str(tmp_path / "DOES_NOT_EXIST"), 1
+            lambda x: str(tmp_path / "DOES_NOT_EXIST" / x)
         )

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -37,7 +37,7 @@ def test_runpath_roundtrip(tmp_path, storage, surface):
         yinc=surface.yinc,
         rotation=surface.rotation,
         yflip=surface.yflip,
-        forward_init_file="input_%d",
+        forward_init_file="input_0",
         output_file=tmp_path / "output",
         base_surface_path="base_surface",
         update=True,
@@ -48,7 +48,7 @@ def test_runpath_roundtrip(tmp_path, storage, surface):
     surface.to_file(tmp_path / "input_0", fformat="irap_ascii")
 
     # run_path -> storage
-    ds = config.read_from_runpath(lambda f: str(tmp_path / f), 0)
+    ds = config.read_from_runpath(lambda f: str(tmp_path / f))
     ensemble.save_parameters(config.name, 0, ds)
 
     # storage -> run_path

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -48,12 +48,12 @@ def test_runpath_roundtrip(tmp_path, storage, surface):
     surface.to_file(tmp_path / "input_0", fformat="irap_ascii")
 
     # run_path -> storage
-    ds = config.read_from_runpath(tmp_path, 0)
+    ds = config.read_from_runpath(lambda f: str(tmp_path / f), 0)
     ensemble.save_parameters(config.name, 0, ds)
 
     # storage -> run_path
     config.forward_init_file = "output_%d"
-    config.write_to_runpath(tmp_path, 0, ensemble)
+    config.write_to_runpath(lambda f: str(tmp_path / f), 0, ensemble)
 
     # compare contents
     # Data is saved as 'irap_ascii', which means that we only keep 6 significant digits

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -746,7 +746,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         iens = 0
 
         try:
-            ds = summary.read_from_file(self.tmpdir, iens)
+            ds = summary.read_from_file(lambda x: self.tmpdir + "/" + x)
         except Exception as e:  # no match in keys
             assume(False)
             raise AssertionError() from e

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -52,14 +52,14 @@ def storage(tmp_path):
             "BASE_SURFACE:surf0.irap FORWARD_INIT:True",
             True,
             0,
-            "Failed to initialize parameter 'MY_PARAM' in file surf0.irap",
+            "Failed to initialize parameter 'MY_PARAM'",
         ),
         (
             "SURFACE MY_PARAM OUTPUT_FILE:surf.irap INIT_FILES:surf.irap "
             "BASE_SURFACE:surf0.irap FORWARD_INIT:True",
             True,
             0,
-            "Failed to initialize parameter 'MY_PARAM' in file surf.irap",
+            "Failed to initialize parameter 'MY_PARAM'",
         ),
     ],
 )

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -1,16 +1,29 @@
+import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 
+import numpy as np
 import orjson
 import pytest
+import xtgeo
 
-from ert.config import ConfigValidationError, ErtConfig
+from ert.callbacks import forward_model_ok
+from ert.config import (
+    ConfigValidationError,
+    ErtConfig,
+    Field,
+    GenKwConfig,
+    SurfaceConfig,
+)
 from ert.enkf_main import create_run_path, sample_prior
+from ert.load_status import LoadStatus
 from ert.run_arg import create_run_arguments
 from ert.runpaths import Runpaths
 from ert.storage import Storage
+from tests.ert.unit_tests.config.egrid_generator import simple_grid
+from tests.ert.unit_tests.config.summary_generator import simple_smspec, simple_unsmry
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -638,63 +651,147 @@ def test_assert_ertcase_replaced_in_runpath(placeholder, prior_ensemble, storage
     assert jobs_json.exists()
 
 
-@pytest.mark.parametrize("itr", [0, 1, 2, 17])
-def test_create_runpath_adds_manifest_to_runpath(snake_oil_case, storage, itr):
-    ert_config = snake_oil_case
+def save_zeros(prior_ensemble, num_realizations, dim_size):
+    parameter_configs = prior_ensemble.experiment.parameter_configuration
+    for parameter, config_node in parameter_configs.items():
+        for realization_nr in range(num_realizations):
+            if isinstance(config_node, SurfaceConfig):
+                config_node.save_parameters(
+                    prior_ensemble, parameter, realization_nr, np.zeros(dim_size**2)
+                )
+            elif isinstance(config_node, Field):
+                config_node.save_parameters(
+                    prior_ensemble, parameter, realization_nr, np.zeros(dim_size**3)
+                )
+            elif isinstance(config_node, GenKwConfig):
+                config_node.save_parameters(
+                    prior_ensemble, parameter, realization_nr, np.zeros(1)
+                )
+            else:
+                raise ValueError(f"unexpected {config_node}")
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("itr", [0, 1])
+def test_when_manifest_files_are_written_forward_model_ok_succeeds(storage, itr):
+    num_realizations = 2
+    dim_size = 2
+    simple_grid().to_file("GRID.EGRID")
+    Path("base.irap").write_text("", encoding="utf-8")
+    xtgeo.RegularSurface(ncol=dim_size, nrow=dim_size, xinc=1, yinc=1).to_file(
+        "base.irap", fformat="irap_ascii"
+    )
+    for i in range(num_realizations):
+        xtgeo.RegularSurface(ncol=dim_size, nrow=dim_size, xinc=1, yinc=1).to_file(
+            str(i) + "init.irap", fformat="irap_ascii"
+        )
+        xtgeo.GridProperty(
+            ncol=2,
+            nrow=2,
+            nlay=2,
+            name="PORO1",
+            values=np.zeros((dim_size, dim_size, dim_size)),
+        ).to_file(str(i) + "init.roff", fformat="roff")
+        Path(str(i) + "gen_init.txt").write_text("PARMA 1.0\n", encoding="utf-8")
+    Path("gen0.txt").write_text("PARMA NORMAL 0 1\n", encoding="utf-8")
+    Path("gen1.txt").write_text("PARMA NORMAL 0 1\n", encoding="utf-8")
+    Path("template.txt").write_text("<PARMA>", encoding="utf-8")
+
+    config = ErtConfig.from_file_contents(
+        dedent(
+            f"""\
+            NUM_REALIZATIONS {num_realizations}
+            DEFINE <ALL> -<ITER>-<IENS>-<GEO_ID>
+            DEFINE <GEO_ID_0_0> HELLO0
+            DEFINE <GEO_ID_1_0> HELLO1
+            DEFINE <GEO_ID_0_1> HELLO0
+            DEFINE <GEO_ID_1_1> HELLO1
+
+            ECLBASE CASE<ALL>
+            GRID GRID.EGRID
+            SUMMARY FOPR
+            RUNPATH simulations/<GEO_ID>/realization-<IENS>/iter-<ITER>
+
+
+            SURFACE SURF1 OUTPUT_FILE:surf1_output<ALL>.irap BASE_SURFACE:base.irap FORWARD_INIT:True INIT_FILES:surf1_init<ALL>.irap
+            SURFACE SURF2 OUTPUT_FILE:surf2_output<ALL>.irap BASE_SURFACE:base.irap INIT_FILES:%dinit.irap
+            FIELD PORO0 PARAMETER field1<ALL>.roff INIT_FILES:field1_init<ALL>.roff FORWARD_INIT:TRUE
+            FIELD PORO1 PARAMETER field2<ALL>.roff INIT_FILES:%dinit.roff
+            GEN_KW GEN0 gen0.txt INIT_FILES:%dgen_init.txt
+            GEN_KW GEN1 template.txt gen_parameter.txt gen1.txt INIT_FILES:%dgen_init.txt
+            """
+        )
+    )
+
     experiment_id = storage.create_experiment(
-        parameters=ert_config.ensemble_config.parameter_configuration,
-        responses=ert_config.ensemble_config.response_configuration,
+        parameters=config.ensemble_config.parameter_configuration,
+        responses=config.ensemble_config.response_configuration,
     )
     prior_ensemble = storage.create_ensemble(
-        experiment_id, name="prior", ensemble_size=25, iteration=itr
+        experiment_id, name="prior", ensemble_size=num_realizations, iteration=itr
     )
-
-    num_realizations = 25
-    runpath_fmt = (
-        "simulations/<GEO_ID>/realization-<IENS>/iter-<ITER>/"
-        "magic-real-<IENS>/magic-iter-<ITER>"
-    )
-    global_substitutions = ert_config.substitutions
-    for i in range(num_realizations):
-        global_substitutions[f"<GEO_ID_{i}_{itr}>"] = str(10 * i)
 
     run_paths = Runpaths(
-        jobname_format="SNAKE_OIL_%d",
-        runpath_format=runpath_fmt,
-        filename="a_file_name",
-        substitutions=global_substitutions,
+        jobname_format=config.model_config.jobname_format_string,
+        runpath_format=config.model_config.runpath_format_string,
+        filename=str(config.runpath_file),
+        substitutions=config.substitutions,
+        eclbase=config.model_config.eclbase_format_string,
     )
 
-    sample_prior(prior_ensemble, range(num_realizations))
+    if itr == 0:
+        sample_prior(prior_ensemble, range(num_realizations))
+    else:
+        save_zeros(prior_ensemble, num_realizations, dim_size=dim_size)
+
     run_args = create_run_arguments(
         run_paths,
         [True, True],
         prior_ensemble,
     )
 
-    create_run_path(run_args, prior_ensemble, ert_config, run_paths)
+    create_run_path(run_args, prior_ensemble, config, run_paths)
 
-    exp_runpaths = [
-        runpath_fmt.replace("<ITER>", str(itr))
-        .replace("<IENS>", str(run_arg.iens))
-        .replace("<GEO_ID>", str(10 * run_arg.iens))
-        for run_arg in run_args
-        if run_arg.active
-    ]
-    exp_runpaths = list(map(os.path.realpath, exp_runpaths))
-    expected_manifest_values = {
-        "snake_oil_params.txt",
-        "snake_oil_opr_diff_199.txt",
-        "snake_oil_wpr_diff_199.txt",
-        "snake_oil_gpr_diff_199.txt",
-        "SNAKE_OIL_FIELD.UNSMRY",
-        "SNAKE_OIL_FIELD.SMSPEC",
-    }
-    for run_path in exp_runpaths:
+    for i, run_path in enumerate(run_paths.get_paths(range(num_realizations), itr)):
         manifest_path = Path(run_path) / "manifest.json"
         assert manifest_path.exists()
+        expected_files = {
+            run_path + f"/CASE-{itr}-{i}-HELLO{i}.UNSMRY",
+            run_path + f"/CASE-{itr}-{i}-HELLO{i}.SMSPEC",
+        }.union(
+            {
+                run_path + f"/field1_init-{itr}-{i}-HELLO{i}.roff",
+                run_path + f"/surf1_init-{itr}-{i}-HELLO{i}.irap",
+            }
+            if itr == 0
+            else set()
+        )
         with open(manifest_path, encoding="utf-8") as f:
             manifest = orjson.loads(f.read())
-            assert set(manifest.values()) == {
-                run_path + "/" + f for f in expected_manifest_values
-            }
+            assert set(manifest.values()) == expected_files
+
+        # write files in manifest
+        for file in expected_files:
+            if file.endswith("roff"):
+                xtgeo.GridProperty(
+                    ncol=2,
+                    nrow=2,
+                    nlay=2,
+                    name="PORO0",
+                    values=np.zeros((2, 2, 2)),
+                ).to_file(file, fformat="roff")
+            elif file.endswith("irap"):
+                xtgeo.RegularSurface(ncol=2, nrow=3, xinc=1, yinc=1).to_file(
+                    file, fformat="irap_ascii"
+                )
+            elif file.endswith("UNSMRY"):
+                simple_unsmry().to_file(file)
+            elif file.endswith("SMSPEC"):
+                simple_smspec().to_file(file)
+            else:
+                raise AssertionError()
+
+    # When files in manifest are written we expect forward_model_ok to succeed
+    for run_arg in run_args:
+        load_result = asyncio.run(forward_model_ok(run_arg))
+        assert load_result.status == LoadStatus.LOAD_SUCCESSFUL

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -639,7 +639,7 @@ def test_assert_ertcase_replaced_in_runpath(placeholder, prior_ensemble, storage
 
 
 @pytest.mark.parametrize("itr", [0, 1, 2, 17])
-def test_crete_runpath_adds_manifest_to_runpath(snake_oil_case, storage, itr):
+def test_create_runpath_adds_manifest_to_runpath(snake_oil_case, storage, itr):
     ert_config = snake_oil_case
     experiment_id = storage.create_experiment(
         parameters=ert_config.ensemble_config.parameter_configuration,
@@ -695,4 +695,6 @@ def test_crete_runpath_adds_manifest_to_runpath(snake_oil_case, storage, itr):
         assert manifest_path.exists()
         with open(manifest_path, encoding="utf-8") as f:
             manifest = orjson.loads(f.read())
-            assert set(manifest.values()) == expected_manifest_values
+            assert set(manifest.values()) == {
+                run_path + "/" + f for f in expected_manifest_values
+            }


### PR DESCRIPTION
This means that `<IENS>`, `<ITER>` and `<GEO_ID>` works consistently with all file paths.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
