### PR TITLE
Fix second progressbar

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -344,7 +344,6 @@ class RunDialog(QFrame):
 
     def run_experiment(self, restart: bool = False) -> None:
         self._restart = restart
-        self._progress_widget.set_ensemble_running()
         self.flag_simulation_done = False
         if restart is False:
             self._snapshot_model.reset()
@@ -404,7 +403,6 @@ class RunDialog(QFrame):
         self._notifier.set_is_simulation_running(False)
         if failed:
             self.update_total_progress(1.0, "Failed")
-            self._progress_widget.set_ensemble_failed()
             self.fail_msg_box = ErtMessageBox("ERT experiment failed!", msg, self)
             self.fail_msg_box.setModal(True)
             self.fail_msg_box.show()

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -403,6 +403,9 @@ class RunDialog(QFrame):
         self._notifier.set_is_simulation_running(False)
         if failed:
             self.update_total_progress(1.0, "Failed")
+
+            self._progress_widget.set_all_failed()
+
             self.fail_msg_box = ErtMessageBox("ERT experiment failed!", msg, self)
             self.fail_msg_box.setModal(True)
             self.fail_msg_box.show()

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -81,6 +81,7 @@ class ProgressWidget(QFrame):
         self._update_waiting_progress_bar()
         if self._realization_count > 0:
             full_width = self.width()
+            self.stop_waiting_progress_bar()
 
             for state, label in self._progress_label_map.items():
                 label.setVisible(True)

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.ensemble_evaluator.state import REAL_STATE_TO_COLOR, REALIZATION_STATE_FAILED
+from ert.ensemble_evaluator.state import REAL_STATE_TO_COLOR
 
 
 class ProgressWidget(QFrame):
@@ -72,7 +72,6 @@ class ProgressWidget(QFrame):
             self._horizontal_legend_layout.addWidget(label)
 
     def repaint_components(self) -> None:
-        self._update_waiting_progress_bar()
         if self._realization_count > 0:
             full_width = self.width()
             self.stop_waiting_progress_bar()
@@ -91,31 +90,17 @@ class ProgressWidget(QFrame):
     def stop_waiting_progress_bar(self) -> None:
         self._waiting_progress_bar.setVisible(False)
 
+    def start_waiting_progress_bar(self) -> None:
+        self._waiting_progress_bar.setVisible(True)
+
     def update_progress(self, status: dict[str, int], realization_count: int) -> None:
         self._status = status
         self._realization_count = realization_count
+        if status.get("Finished", 0) < self._realization_count:
+            self.start_waiting_progress_bar()
+        else:
+            self.stop_waiting_progress_bar()
         self.repaint_components()
-
-    def _update_waiting_progress_bar(self) -> None:
-        self._waiting_progress_bar.setVisible(
-            self._status.get("Finished", 0) + self._status.get("Failed", 0)
-            < self._realization_count
-        )
-
-    def set_ensemble_failed(self) -> None:
-        self._reset_progress_labels()
-
-        failed_label = self._progress_label_map[REALIZATION_STATE_FAILED]
-        failed_label.setFixedWidth(self.width())
-        failed_label.setVisible(True)
-        self.stop_waiting_progress_bar()
-
-    def set_ensemble_running(self) -> None:
-        self._reset_progress_labels()
-
-    def _reset_progress_labels(self) -> None:
-        for label in self._progress_label_map.values():
-            label.setVisible(False)
 
     def resizeEvent(self, a0: Any, event: Any = None) -> None:
         self.repaint_components()

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -28,9 +28,6 @@ class ProgressWidget(QFrame):
         self._waiting_progress_bar = QProgressBar(self)
         self._waiting_progress_bar.setRange(0, 0)
         self._waiting_progress_bar.setFixedHeight(30)
-        waiting_progress_bar_size_policy = self._waiting_progress_bar.sizePolicy()
-        waiting_progress_bar_size_policy.setRetainSizeWhenHidden(True)
-        self._waiting_progress_bar.setSizePolicy(waiting_progress_bar_size_policy)
         self._vertical_layout.addWidget(self._waiting_progress_bar)
 
         self._progress_frame = QFrame(self)
@@ -55,9 +52,6 @@ class ProgressWidget(QFrame):
 
         for state, color in REAL_STATE_TO_COLOR.items():
             label = QLabel(self)
-            label_size_policy = label.sizePolicy()
-            label_size_policy.setRetainSizeWhenHidden(True)
-            label.setSizePolicy(label_size_policy)
             label.setVisible(False)
             label.setObjectName(f"progress_{state}")
             label.setStyleSheet(f"background-color : {QColor(*color).name()}")

--- a/src/ert/gui/simulation/view/progress_widget.py
+++ b/src/ert/gui/simulation/view/progress_widget.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ert.ensemble_evaluator.state import REAL_STATE_TO_COLOR
+from ert.ensemble_evaluator.state import ENSEMBLE_STATE_FAILED, REAL_STATE_TO_COLOR
 
 
 class ProgressWidget(QFrame):
@@ -92,6 +92,14 @@ class ProgressWidget(QFrame):
 
     def start_waiting_progress_bar(self) -> None:
         self._waiting_progress_bar.setVisible(True)
+
+    def set_all_failed(self) -> None:
+        self.stop_waiting_progress_bar()
+        full_width = self.width()
+        for state, label in self._progress_label_map.items():
+            label.setVisible(True)
+            width = full_width if state == ENSEMBLE_STATE_FAILED else 0
+            label.setFixedWidth(width)
 
     def update_progress(self, status: dict[str, int], realization_count: int) -> None:
         self._status = status

--- a/tests/ert/ui_tests/gui/test_missing_runpath.py
+++ b/tests/ert/ui_tests/gui/test_missing_runpath.py
@@ -86,7 +86,6 @@ def test_missing_runpath_has_isolated_failures(
                     QLabel, name="progress_label_text_Finished"
                 ).text()
             )
-            assert not run_dialog._progress_widget._waiting_progress_bar.isVisible()
             assert (
                 "1/10"
                 in run_dialog._progress_widget.findChild(


### PR DESCRIPTION
Currently the progress widget will sometimes show both the waiting progress bar and the labels and the waiting progress bar will occupy the space regardless of whether it is hidden. This fixes the issue so that the failed label is all that will be shown when there is an ensemble failure.

[Screencast from 2024-10-28 14-43-31.webm](https://github.com/user-attachments/assets/1520cdef-212e-49de-84f0-5459492fef15)


[Screencast from 2024-10-28 14-57-49.webm](https://github.com/user-attachments/assets/a0cbd323-0cd7-4c26-9edd-389fcc41ca21)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
