### PR TITLE
Have run simulation button disabled when running

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -168,7 +168,6 @@ class RunDialog(QFrame):
     simulation_done = Signal(bool, str)
     produce_clipboard_debug_info = Signal()
     progress_update_event = Signal(dict, int)
-    finished = Signal()
     _RUN_TIME_POLL_RATE = 1000
 
     def __init__(
@@ -289,8 +288,6 @@ class RunDialog(QFrame):
         self.simulation_done.connect(self._on_simulation_done)
 
         self.setMinimumSize(1200, 600)
-        self.finished.connect(self._on_finished)
-
         self._restart = False
         self.flag_simulation_done = False
 
@@ -392,7 +389,7 @@ class RunDialog(QFrame):
             # Normally this slot would be invoked by the signal/slot system,
             # but the worker is busy tracking the evaluation.
             self._run_model.cancel()
-            self.finished.emit()
+            self.simulation_done.emit(True, "")
         return kill_job
 
     @Slot(bool, str)
@@ -402,6 +399,7 @@ class RunDialog(QFrame):
         self.restart_button.setVisible(self._run_model.has_failed_realizations())
         self.restart_button.setEnabled(self._run_model.support_restart)
         self._notifier.set_is_simulation_running(False)
+        self.flag_simulation_done = True
         if failed:
             self.update_total_progress(1.0, "Failed")
             self._progress_widget.set_ensemble_failed()
@@ -410,6 +408,8 @@ class RunDialog(QFrame):
             self.fail_msg_box.show()
         else:
             self.update_total_progress(1.0, "Experiment completed.")
+        for file_dialog in self.findChildren(FileDialog):
+            file_dialog.close()
 
     @Slot()
     def _on_ticker(self) -> None:
@@ -427,7 +427,6 @@ class RunDialog(QFrame):
     def _on_event(self, event: object) -> None:
         if isinstance(event, EndEvent):
             self.simulation_done.emit(event.failed, event.msg)
-            self.finished.emit()
             self._ticker.stop()
         elif isinstance(event, FullSnapshotEvent):
             if event.snapshot is not None:
@@ -530,11 +529,6 @@ class RunDialog(QFrame):
             self.restart_button.setVisible(False)
             self.kill_button.setVisible(True)
             self.run_experiment(restart=True)
-
-    def _on_finished(self) -> None:
-        self.flag_simulation_done = True
-        for file_dialog in self.findChildren(FileDialog):
-            file_dialog.close()
 
 
 # Cannot use a non-static method here as

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -75,7 +75,7 @@ def test_terminating_experiment_shows_a_confirmation_dialog(
     run_dialog.run_experiment()
     event_queue.put(EndEvent(failed=False, msg=""))
 
-    with qtbot.waitSignal(run_dialog.finished, timeout=10000):
+    with qtbot.waitSignal(run_dialog.simulation_done, timeout=10000):
 
         def handle_dialog():
             confirm_terminate_dialog = wait_for_child(


### PR DESCRIPTION
Fixes issue where run button was not disabled during simulations.
Removed duplicate signal `finished`, and moved functionality together with `simulation_done` signal.

**Issue**
Resolves #9078 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
