### PR TITLE
Fix ert crashes if invalid range string in REPORT_STEPS config

### DIFF
--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -55,16 +55,24 @@ class GenDataConfig(ResponseConfig):
             options = option_dict(gen_data, 1)
             name = gen_data[0]
             res_file = options.get("RESULT_FILE")
+            report_steps_value = options.get("REPORT_STEPS", "")
 
             if res_file is None:
                 raise ConfigValidationError.with_context(
                     f"Missing or unsupported RESULT_FILE for GEN_DATA key {name!r}",
                     name,
                 )
+            try:
+                _report_steps: Optional[List[int]] = rangestring_to_list(
+                    report_steps_value
+                )
+            except ValueError as e:
+                raise ConfigValidationError.with_context(
+                    f"The REPORT_STEPS setting: {report_steps_value} is invalid"
+                    ' - must be a valid range string: e.g.: "0-1, 4-6, 8"',
+                    gen_data,
+                ) from e
 
-            _report_steps: Optional[List[int]] = rangestring_to_list(
-                options.get("REPORT_STEPS", "")
-            )
             _report_steps = sorted(_report_steps) if _report_steps else None
             if os.path.isabs(res_file):
                 result_file_context = next(

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -68,7 +68,7 @@ class GenDataConfig(ResponseConfig):
                 )
             except ValueError as e:
                 raise ConfigValidationError.with_context(
-                    f"The REPORT_STEPS setting: {report_steps_value} is invalid"
+                    f"The REPORT_STEPS setting: {report_steps_value} for {name} is invalid"
                     ' - must be a valid range string: e.g.: "0-1, 4-6, 8"',
                     gen_data,
                 ) from e

--- a/tests/ert/unit_tests/config/test_gen_data_config.py
+++ b/tests/ert/unit_tests/config/test_gen_data_config.py
@@ -66,6 +66,48 @@ def test_malformed_or_missing_gen_data_result_file(result_file, error_message):
         GenDataConfig.from_config_dict({"GEN_DATA": [config_line.split()]})
 
 
+@pytest.mark.parametrize(
+    "report_step_arg, error_message",
+    [
+        pytest.param(
+            "H",
+            "must be a valid range string",
+            id="Invalid REPORT_STEPS argument",
+        ),
+        pytest.param(
+            "H,1-3",
+            "must be a valid range string",
+            id="Invalid REPORT_STEPS argument",
+        ),
+        pytest.param(
+            "invalid-range-argument",
+            "must be a valid range string",
+            id="Invalid REPORT_STEPS argument",
+        ),
+        pytest.param(
+            "1-2,5-8",
+            None,
+            id="This should not fail",
+        ),
+        pytest.param(
+            "1",
+            None,
+            id="This should not fail",
+        ),
+    ],
+)
+def test_malformed_report_step_argument(report_step_arg, error_message):
+    config_line = f"POLY_RES RESULT_FILE:poly_%d.out REPORT_STEPS:{report_step_arg}"
+    if error_message:
+        with pytest.raises(
+            ConfigValidationError,
+            match=error_message,
+        ):
+            GenDataConfig.from_config_dict({"GEN_DATA": [config_line.split()]})
+    else:
+        GenDataConfig.from_config_dict({"GEN_DATA": [config_line.split()]})
+
+
 def test_that_invalid_gendata_outfile_error_propagates(tmp_path):
     (tmp_path / "poly.out").write_text("""
         4.910405046410615,4.910405046410615


### PR DESCRIPTION
**Issue**
Resolves #9057


**Approach**
Added new test catching the bug and implemented a fix

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
