### PR TITLE
Reduce MAX_RUNNING when running tests

### DIFF
--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -184,16 +184,22 @@ def fixture_copy_case(tmp_path_factory, source_root, monkeypatch):
 @pytest.fixture()
 def copy_poly_case(copy_case):
     copy_case("poly_example")
+    with open("poly.ert", "a", encoding="utf-8") as fh:
+        fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 12\n")
 
 
 @pytest.fixture()
 def copy_snake_oil_field(copy_case):
     copy_case("snake_oil_field")
+    with open("snake_oil_field.ert", "a", encoding="utf-8") as fh:
+        fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 12\n")
 
 
 @pytest.fixture()
 def copy_snake_oil_case(copy_case):
     copy_case("snake_oil")
+    with open("snake_oil.ert", "a", encoding="utf-8") as fh:
+        fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 12\n")
 
 
 @pytest.fixture(
@@ -373,7 +379,8 @@ def _run_heat_equation(source_root):
         os.path.join(source_root, "test-data", "ert", "heat_equation"), "test_data"
     )
     os.chdir("test_data")
-
+    with open("config.ert", "a", encoding="utf-8") as fh:
+        fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 12\n")
     parser = ArgumentParser(prog="test_main")
     parsed = ert_parser(
         parser,

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         f.write(
             """
         QUEUE_SYSTEM LOCAL
-QUEUE_OPTION LOCAL MAX_RUNNING 50
+QUEUE_OPTION LOCAL MAX_RUNNING 12
 
 RUNPATH poly_out/realization-<IENS>/iter-<ITER>
 

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -162,7 +162,7 @@ def test_memory_profile_in_running_events():
             for _ in range(10):
                 # 1 Mb allocated pr iteration
                 somelist.append(b' ' * 1024 * 1024)
-                time.sleep(0.1)"""
+                time.sleep(0.15)"""
             )
         )
     executable = os.path.realpath(scriptname)


### PR DESCRIPTION
Should mitigate and hopefully resolve flaky test: "test_that_all_snake_oil_visualizations_matches_snapshot"
Includes quickfix for the recently failing memory profiling unit test, in order for all tests to pass.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
