### PR TITLE
Allow  dark mode color scheme in side panel

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -41,13 +41,24 @@ BUTTON_STYLE_SHEET: str = """
         padding-top: 5px;
         padding-bottom: 10px;
     }
-    QToolButton:hover {
-        background-color: rgba(50, 50, 50, 90);
-    }
     QToolButton::menu-indicator {
         right: 10px; bottom: 5px;
     }
 """
+
+BUTTON_STYLE_SHEET_LIGHT: str = (
+    BUTTON_STYLE_SHEET
+    + """
+    QToolButton:hover {background-color: rgba(50, 50, 50, 90);}
+    """
+)
+
+BUTTON_STYLE_SHEET_DARK: str = (
+    BUTTON_STYLE_SHEET
+    + """
+    QToolButton:hover {background-color: rgba(30, 30, 30, 150);}
+    """
+)
 
 
 class ErtMainWindow(QMainWindow):
@@ -76,7 +87,12 @@ class ErtMainWindow(QMainWindow):
         self.central_widget.setLayout(self.central_layout)
         self.facade = LibresFacade(self.ert_config)
         self.side_frame = QFrame(self)
-        self.side_frame.setStyleSheet("background-color: lightgray;")
+
+        if self.is_dark_mode():
+            self.side_frame.setStyleSheet("background-color: rgb(64, 64, 64);")
+        else:
+            self.side_frame.setStyleSheet("background-color: lightgray;")
+
         self.vbox_layout = QVBoxLayout(self.side_frame)
         self.side_frame.setLayout(self.vbox_layout)
 
@@ -102,6 +118,9 @@ class ErtMainWindow(QMainWindow):
 
         self.__add_tools_menu()
         self.__add_help_menu()
+
+    def is_dark_mode(self) -> bool:
+        return self.palette().base().color().value() < 70
 
     def select_central_widget(self) -> None:
         actor = self.sender()
@@ -216,7 +235,11 @@ class ErtMainWindow(QMainWindow):
         button = QToolButton(self.side_frame)
         button.setFixedSize(85, 95)
         button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-        button.setStyleSheet(BUTTON_STYLE_SHEET)
+
+        button.setStyleSheet(
+            BUTTON_STYLE_SHEET_DARK
+        ) if self.is_dark_mode() else button.setStyleSheet(BUTTON_STYLE_SHEET_LIGHT)
+
         pad = 45
         icon_size = QSize(button.size().width() - pad, button.size().height() - pad)
         button.setIconSize(icon_size)


### PR DESCRIPTION
Differentiate between dark and light modes.

If someone knows how to toggle this on TGX, let me know. 💡 
![Screenshot 2024-10-29 at 14 17 40](https://github.com/user-attachments/assets/d64f73cf-a5cd-4609-8489-7a11c718be84)

macOS:

![Screenshot 2024-10-29 at 14 11 39](https://github.com/user-attachments/assets/076de311-2a35-4c09-9316-411e0eaab521)

![Screenshot 2024-10-29 at 14 11 08](https://github.com/user-attachments/assets/6820ca92-ff88-4b69-8816-0b2de566e839)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
