### PR TITLE
Add logging of duplicate gen_kw parameter names

### DIFF
--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -56,6 +56,9 @@ class EnsembleConfig:
             [p.name for p in self.parameter_configs.values()],
             [key for config in self.response_configs.values() for key in config.keys],
         )
+        self._check_for_duplicate_gen_kw_param_names(
+            [p for p in self.parameter_configs.values() if isinstance(p, GenKwConfig)]
+        )
 
         self.grid_file = _get_abs_path(self.grid_file)
 
@@ -71,6 +74,23 @@ class EnsembleConfig:
                 f" duplicate name{'s' if len(duplicate_names) > 1 else ''}:"
                 f" {','.join(duplicate_names)}",
                 duplicate_names[0],
+            )
+
+    @staticmethod
+    def _check_for_duplicate_gen_kw_param_names(gen_kw_list: list[GenKwConfig]) -> None:
+        gen_kw_param_count = Counter(
+            keyword.name for p in gen_kw_list for keyword in p.transform_functions
+        )
+        duplicate_gen_kw_names = [
+            (n, c) for n, c in gen_kw_param_count.items() if c > 1
+        ]
+
+        if duplicate_gen_kw_names:
+            duplicates_formatted = ", ".join(
+                f"{name}({count})" for name, count in duplicate_gen_kw_names
+            )
+            logger.info(
+                f"Found duplicate GEN_KW parameter names: {duplicates_formatted}"
             )
 
     @no_type_check


### PR DESCRIPTION


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
