### PR TITLE
Have cli tests set env variable OMP_NUM_THREADS to 1.

### DIFF
--- a/tests/ert/ui_tests/cli/conftest.py
+++ b/tests/ert/ui_tests/cli/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reduce_omp_num_threads_count():
+    old_omp_num_threads = os.environ.get("OMP_NUM_THREADS")
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    yield
+
+    if old_omp_num_threads is None:
+        del os.environ["OMP_NUM_THREADS"]
+    else:
+        os.environ["OMP_NUM_THREADS"] = old_omp_num_threads


### PR DESCRIPTION
This commit adds an auto-used fixture for all cli tests, that sets the environment variable for numpy multithreading `OMP_NUM_THREADS` to 1.
This might have been the cause of those tests hanging, as numpy uses all resources available if the env variable is not explicitly set

**Issue**
Related to #8787


**Approach**
🎉 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
