### PR TITLE
Log wall- and cputime for each finished forward model step

### DIFF
--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -11,16 +11,16 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 
 class Id:
-    FORWARD_MODEL_STEP_START_TYPE = Literal["forward_model_job.start"]
-    FORWARD_MODEL_STEP_RUNNING_TYPE = Literal["forward_model_job.running"]
-    FORWARD_MODEL_STEP_SUCCESS_TYPE = Literal["forward_model_job.success"]
-    FORWARD_MODEL_STEP_FAILURE_TYPE = Literal["forward_model_job.failure"]
-    FORWARD_MODEL_STEP_CHECKSUM_TYPE = Literal["forward_model_job.checksum"]
-    FORWARD_MODEL_STEP_START: Final = "forward_model_job.start"
-    FORWARD_MODEL_STEP_RUNNING: Final = "forward_model_job.running"
-    FORWARD_MODEL_STEP_SUCCESS: Final = "forward_model_job.success"
-    FORWARD_MODEL_STEP_FAILURE: Final = "forward_model_job.failure"
-    FORWARD_MODEL_STEP_CHECKSUM: Final = "forward_model_job.checksum"
+    FORWARD_MODEL_STEP_START_TYPE = Literal["forward_model_step.start"]
+    FORWARD_MODEL_STEP_RUNNING_TYPE = Literal["forward_model_step.running"]
+    FORWARD_MODEL_STEP_SUCCESS_TYPE = Literal["forward_model_step.success"]
+    FORWARD_MODEL_STEP_FAILURE_TYPE = Literal["forward_model_step.failure"]
+    FORWARD_MODEL_STEP_CHECKSUM_TYPE = Literal["forward_model_step.checksum"]
+    FORWARD_MODEL_STEP_START: Final = "forward_model_step.start"
+    FORWARD_MODEL_STEP_RUNNING: Final = "forward_model_step.running"
+    FORWARD_MODEL_STEP_SUCCESS: Final = "forward_model_step.success"
+    FORWARD_MODEL_STEP_FAILURE: Final = "forward_model_step.failure"
+    FORWARD_MODEL_STEP_CHECKSUM: Final = "forward_model_step.checksum"
 
     REALIZATION_FAILURE_TYPE = Literal["realization.failure"]
     REALIZATION_PENDING_TYPE = Literal["realization.pending"]

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import typing
 from collections import defaultdict
@@ -45,6 +46,8 @@ from _ert.events import (
 )
 from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
+
+logger = logging.getLogger(__name__)
 
 if sys.version_info < (3, 11):
     from backports.datetime_fromisoformat import MonkeyPatch  # type: ignore
@@ -331,6 +334,39 @@ class EnsembleSnapshot:
                 start_time = convert_iso8601_to_datetime(timestamp)
             elif e_type in {ForwardModelStepSuccess, ForwardModelStepFailure}:
                 end_time = convert_iso8601_to_datetime(timestamp)
+
+                try:
+                    start_time = self._fm_step_snapshots[event.real, event.fm_step].get(
+                        "start_time"
+                    )
+                    cpu_seconds = self._fm_step_snapshots[
+                        event.real, event.fm_step
+                    ].get("cpu_seconds")
+                    fm_step_name = source_snapshot.reals[event.real]["fm_steps"][
+                        event.fm_step
+                    ]["name"]
+                    if start_time is not None:
+                        logger.warning(
+                            f"{event.event_type} {fm_step_name} "
+                            f"walltime={(end_time - start_time).total_seconds()} "
+                            f"cputime={cpu_seconds} "
+                            f"ensemble={event.ensemble} "
+                            f"step_index={event.fm_step} "
+                            f"real={event.real}"
+                        )
+                    else:
+                        logger.warning(
+                            f"Should log fm_step runtime, but start_time was None, "
+                            f"{event.event_type} {fm_step_name=} "
+                            f"endtime={end_time.isoformat()} "
+                            f"cputime={cpu_seconds} "
+                            f"ensemble={event.ensemble} "
+                            f"step_index={event.fm_step} "
+                            f"real={event.real}"
+                        )
+                except BaseException as e:
+                    logger.warning(f"Should log fm_step runtime, but got exception {e}")
+
                 if type(event) is ForwardModelStepFailure:
                     error = event.error_msg if event.error_msg else ""
                 else:


### PR DESCRIPTION
**Issue**
Resolves lack of runtime logging pr. step


**Approach**
:tap fast on keyboard:


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
