### PR TITLE
Fix unbound event

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -263,7 +263,7 @@ class EnsembleEvaluator:
                             f"closing connection to dispatcher: {ex}"
                         )
                         await websocket.close(
-                            code=1011, reason=f"failed handling {event}"
+                            code=1011, reason=f"failed handling message {raw_msg!r}"
                         )
                         return
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -2,10 +2,12 @@ import asyncio
 import datetime
 from functools import partial
 from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from websockets.server import WebSocketServerProtocol
 
 from _ert.events import (
     EESnapshot,
@@ -61,6 +63,19 @@ async def test_when_task_fails_evaluator_raises_exception(
     )
     with pytest.raises(RuntimeError, match=error_msg):
         await evaluator.run_and_get_successful_realizations()
+
+
+async def test_when_dispatch_is_given_invalid_event_the_socket_is_closed(
+    make_ee_config,
+):
+    evaluator = EnsembleEvaluator(TestEnsemble(0, 2, 2, id_="0"), make_ee_config())
+
+    socket = MagicMock(spec=WebSocketServerProtocol)
+    socket.__aiter__.return_value = ["invalid_json"]
+    await evaluator.handle_dispatch(socket)
+    socket.close.assert_called_once_with(
+        code=1011, reason="failed handling message 'invalid_json'"
+    )
 
 
 async def test_no_config_raises_valueerror_when_running():


### PR DESCRIPTION
Validation is raised from dispatch_event_from_json so event is unbound.



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
