### PR TITLE
Fix flaky debug info button test and change button text

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -225,7 +225,7 @@ class RunDialog(QFrame):
         self.kill_button = QPushButton("Terminate experiment")
         self.restart_button = QPushButton("Rerun failed")
         self.restart_button.setHidden(True)
-        self.copy_debug_info_button = QPushButton("Debug Info")
+        self.copy_debug_info_button = QPushButton("Copy Debug Info")
         self.copy_debug_info_button.setToolTip("Copies useful information to clipboard")
         self.copy_debug_info_button.clicked.connect(self.produce_clipboard_debug_info)
         self.copy_debug_info_button.setObjectName("copy_debug_info_button")

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -614,8 +614,9 @@ def test_that_debug_info_button_provides_data_in_clipboard(qtbot: QtBot, storage
         qtbot.mouseClick(run_experiment, Qt.LeftButton)
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=5000)
         run_dialog = gui.findChild(RunDialog)
-        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True, timeout=10000)
-
+        assert run_dialog is not None
+        run_dialog._run_model.cancel()
+        run_dialog.simulation_done.emit(False, "")
         copy_debug_info_button = gui.findChild(QPushButton, "copy_debug_info_button")
         assert copy_debug_info_button
         assert isinstance(copy_debug_info_button, QPushButton)


### PR DESCRIPTION
**Issue**
Resolves #9115


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
