### PR TITLE
Have CopyDebugInfoButton change text to `Copied...` on click

### DIFF
--- a/tests/ert/unit_tests/gui/ertwidgets/test_copy_debug_info_button.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_copy_debug_info_button.py
@@ -1,0 +1,23 @@
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import Qt
+
+from ert.gui.simulation.run_dialog import CopyDebugInfoButton
+
+
+def test_copy_debug_info_button_alterates_text_when_pressed(qtbot: QtBot):
+    button_clicked = False
+
+    def on_click():
+        nonlocal button_clicked
+        button_clicked = True
+
+    button = CopyDebugInfoButton(on_click=on_click)
+    qtbot.addWidget(button)
+
+    assert button.text() == CopyDebugInfoButton._initial_text
+    qtbot.mouseClick(button, Qt.MouseButton.LeftButton)
+    assert button.text() == CopyDebugInfoButton._clicked_text
+    qtbot.wait_until(
+        lambda: button.text() == CopyDebugInfoButton._initial_text, timeout=2000
+    )
+    assert button_clicked


### PR DESCRIPTION
This commit refactors the copydebuginfobutton in run_dialog.py into its own class, and makes it change text `Copy Debug Info` -> `Copied...` when clicked while running the callback passed to it. After one second, it changes it text back to `Copy Debug Info`.


**Approach**
🚠 

(Screenshot of new behavior in GUI if applicable)

https://github.com/user-attachments/assets/7bfbd699-3bcf-4fd3-a144-6ef2aad1ee58



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
