### PR TITLE
Transpose before calculating covariance in test

### DIFF
--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -33,13 +33,15 @@ def test_field_param_update_using_heat_equation(heat_equation_storage):
         prior_covariance = np.cov(
             prior_result.values.reshape(
                 prior.ensemble_size, param_config.nx * param_config.ny * param_config.nz
-            )
+            ),
+            rowvar=False,
         )
         posterior_covariance = np.cov(
             posterior_result.values.reshape(
                 posterior.ensemble_size,
                 param_config.nx * param_config.ny * param_config.nz,
-            )
+            ),
+            rowvar=False,
         )
         # Check that generalized variance is reduced by update step.
         assert np.trace(prior_covariance) > np.trace(posterior_covariance)


### PR DESCRIPTION
np.cov expects rows to be parameters and columns to be realizations


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
