### PR TITLE
Timeout reading information from forward model runner after 60s and proceed with status from queue system

### DIFF
--- a/src/_ert/forward_model_runner/client.py
+++ b/src/_ert/forward_model_runner/client.py
@@ -27,6 +27,10 @@ class ClientConnectionClosedOK(Exception):
 
 
 class Client:
+    DEFAULT_MAX_RETRIES = 10
+    DEFAULT_TIMEOUT_MULTIPLIER = 5
+    CONNECTION_TIMEOUT = 60
+
     def __enter__(self) -> Self:
         return self
 
@@ -49,9 +53,13 @@ class Client:
         url: str,
         token: Optional[str] = None,
         cert: Optional[Union[str, bytes]] = None,
-        max_retries: int = 10,
-        timeout_multiplier: int = 5,
+        max_retries: Optional[int] = None,
+        timeout_multiplier: Optional[int] = None,
     ) -> None:
+        if max_retries is None:
+            max_retries = self.DEFAULT_MAX_RETRIES
+        if timeout_multiplier is None:
+            timeout_multiplier = self.DEFAULT_TIMEOUT_MULTIPLIER
         if url is None:
             raise ValueError("url was None")
         self.url = url
@@ -82,10 +90,10 @@ class Client:
             self.url,
             ssl=self._ssl_context,
             extra_headers=self._extra_headers,
-            open_timeout=60,
-            ping_timeout=60,
-            ping_interval=60,
-            close_timeout=60,
+            open_timeout=self.CONNECTION_TIMEOUT,
+            ping_timeout=self.CONNECTION_TIMEOUT,
+            ping_interval=self.CONNECTION_TIMEOUT,
+            close_timeout=self.CONNECTION_TIMEOUT,
         )
 
     async def _send(self, msg: AnyStr) -> None:

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -58,6 +58,8 @@ class Job:
     (LSF, PBS, SLURM, etc.)
     """
 
+    DEFAULT_CHECKSUM_TIMEOUT = 120
+
     def __init__(self, scheduler: Scheduler, real: Realization) -> None:
         self.real = real
         self.state = JobState.WAITING
@@ -186,8 +188,10 @@ class Job:
         self.returncode.cancel()
 
     async def _verify_checksum(
-        self, checksum_lock: asyncio.Lock, timeout: int = 120
+        self, checksum_lock: asyncio.Lock, timeout: Optional[int] = None
     ) -> None:
+        if timeout is None:
+            timeout = self.DEFAULT_CHECKSUM_TIMEOUT
         # Wait for job runpath to be in the checksum dictionary
         runpath = self.real.run_arg.runpath
         while runpath not in self._scheduler.checksum:


### PR DESCRIPTION
Previously, ert would wait for information from websocket indefinetly. Now, once status is gotten from the queue system for all realizations, getting all information from forward model runner times out after 60 seconds.

This looks ok in gui, but leaves the status of forward model steps unresolved: 

![image_720](https://github.com/user-attachments/assets/7e589a1b-3da1-4aab-8ca8-ea8e609e7d30)

We might want to indicate more clearly that we did not get all the information about the forward model steps.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
