### PR TITLE
Revert "Increase sleep in memory profile test from 0.1 -> 0.15"

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -162,7 +162,7 @@ def test_memory_profile_in_running_events():
             for _ in range(10):
                 # 1 Mb allocated pr iteration
                 somelist.append(b' ' * 1024 * 1024)
-                time.sleep(0.15)"""
+                time.sleep(0.1)"""
             )
         )
     executable = os.path.realpath(scriptname)


### PR DESCRIPTION
This reverts commit 98576cc8ad12e751a19340e8fa350ef08ed3ee59.

Changing the sleep time affects the rate of memory allocation, which the assert further down depends on.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
