### PR TITLE
Add right click capability to open external plot windows

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -6,7 +6,7 @@ import webbrowser
 from typing import Dict, List, Optional
 
 from qtpy.QtCore import QSize, Qt, Signal, Slot
-from qtpy.QtGui import QCloseEvent, QCursor, QIcon
+from qtpy.QtGui import QCloseEvent, QCursor, QIcon, QMouseEvent
 from qtpy.QtWidgets import (
     QAction,
     QFrame,
@@ -65,11 +65,12 @@ BUTTON_STYLE_SHEET_DARK: str = (
 class SidebarToolButton(QToolButton):
     right_clicked = Signal()
 
-    def mousePressEvent(self, event) -> None:
-        if event.button() == Qt.MouseButton.RightButton:
-            self.right_clicked.emit()
-        else:
-            super().mousePressEvent(event)
+    def mousePressEvent(self, event: Optional[QMouseEvent]) -> None:
+        if event:
+            if event.button() == Qt.MouseButton.RightButton:
+                self.right_clicked.emit()
+            else:
+                super().mousePressEvent(event)
 
 
 class ErtMainWindow(QMainWindow):

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import functools
 import webbrowser
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from qtpy.QtCore import QSize, Qt, Signal, Slot
 from qtpy.QtGui import QCloseEvent, QCursor, QIcon
@@ -62,6 +62,16 @@ BUTTON_STYLE_SHEET_DARK: str = (
 )
 
 
+class SidebarToolButton(QToolButton):
+    right_clicked = Signal()
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.MouseButton.RightButton:
+            self.right_clicked.emit()
+        else:
+            super().mousePressEvent(event)
+
+
 class ErtMainWindow(QMainWindow):
     close_signal = Signal()
 
@@ -90,6 +100,7 @@ class ErtMainWindow(QMainWindow):
         self.central_widget.setLayout(self.central_layout)
         self.facade = LibresFacade(self.ert_config)
         self.side_frame = QFrame(self)
+        self._external_plot_windows: List[PlotWindow] = []
 
         if self.is_dark_mode():
             self.side_frame.setStyleSheet("background-color: rgb(64, 64, 64);")
@@ -124,6 +135,13 @@ class ErtMainWindow(QMainWindow):
 
     def is_dark_mode(self) -> bool:
         return self.palette().base().color().value() < 70
+
+    def right_clicked(self) -> None:
+        actor = self.sender()
+        if actor and actor.property("index") == "Create plot":
+            pw = PlotWindow(self.config_file, None)
+            pw.show()
+            self._external_plot_windows.append(pw)
 
     def select_central_widget(self) -> None:
         actor = self.sender()
@@ -234,8 +252,8 @@ class ErtMainWindow(QMainWindow):
                     self.help_menu.menuAction(), self.plugins_tool.get_menu()
                 )
 
-    def _add_sidebar_button(self, name: str, icon: QIcon) -> QToolButton:
-        button = QToolButton(self.side_frame)
+    def _add_sidebar_button(self, name: str, icon: QIcon) -> SidebarToolButton:
+        button = SidebarToolButton(self.side_frame)
         button.setFixedSize(85, 95)
         button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
@@ -256,6 +274,7 @@ class ErtMainWindow(QMainWindow):
         self.vbox_layout.addWidget(button)
 
         button.clicked.connect(self.select_central_widget)
+        button.right_clicked.connect(self.right_clicked)
         button.setProperty("index", name)
         return button
 
@@ -308,6 +327,10 @@ class ErtMainWindow(QMainWindow):
         tools_menu.addAction(self.load_results_tool.getAction())
 
     def closeEvent(self, closeEvent: Optional[QCloseEvent]) -> None:
+        for plot_window in self._external_plot_windows:
+            if plot_window:
+                plot_window.close()
+
         if closeEvent is not None:
             if self.notifier.is_simulation_running:
                 closeEvent.ignore()

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -116,7 +116,8 @@ class ErtMainWindow(QMainWindow):
         self._plot_window: Optional[PlotWindow] = None
         self._manage_experiments_panel: Optional[ManageExperimentsPanel] = None
         self._add_sidebar_button("Start simulation", QIcon("img:library_add.svg"))
-        self._add_sidebar_button("Create plot", QIcon("img:timeline.svg"))
+        plot_button = self._add_sidebar_button("Create plot", QIcon("img:timeline.svg"))
+        plot_button.setToolTip("Right click to open external window")
         self._add_sidebar_button("Manage experiments", QIcon("img:build_wrench.svg"))
         self.results_button = self._add_sidebar_button(
             "Simulation status", QIcon("img:in_progress.svg")

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -616,6 +616,8 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, storage, monkeypa
         plot_window = wait_for_child(gui, qtbot, PlotWindow)
         assert plot_window
 
+        prev_open_windows = len(QApplication.topLevelWindows())
+
         def detect_external_plot_widget_open_on_right_click(plot_count: int):
             previous_count = plot_count - 1
             assert len(QApplication.topLevelWindows()) == previous_count
@@ -626,9 +628,9 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, storage, monkeypa
             )
             assert len(QApplication.topLevelWindows()) == plot_count
 
-        detect_external_plot_widget_open_on_right_click(1)
-        detect_external_plot_widget_open_on_right_click(2)
-        detect_external_plot_widget_open_on_right_click(3)
+        detect_external_plot_widget_open_on_right_click(prev_open_windows + 1)
+        detect_external_plot_widget_open_on_right_click(prev_open_windows + 2)
+        detect_external_plot_widget_open_on_right_click(prev_open_windows + 3)
     gui.close()
 
 


### PR DESCRIPTION
**Issue**
Resolves #9130 

Adds PoC right mouse button capability to buttons to allow functionality like opening external plot widgets.
The widgets are closed when the main window is closed.

![Screenshot 2024-11-13 at 08 21 51](https://github.com/user-attachments/assets/1c3fdedc-d522-4392-9947-da4530c68741)

https://github.com/user-attachments/assets/27267594-6668-4a98-9a98-44603080a11b


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
