### PR TITLE
Scheduler now allows other code to run when starting realizations

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -277,6 +277,7 @@ class Scheduler:
         forward_model_ok_lock = asyncio.Lock()
         verify_checksum_lock = asyncio.Lock()
         for iens, job in self._jobs.items():
+            await asyncio.sleep(0)
             if job.state != JobState.ABORTED:
                 self._job_tasks[iens] = asyncio.create_task(
                     job.run(


### PR DESCRIPTION
Make scheduler execute yield during spawning of realizations
This was blocking all other async tasks from running. Nothing could connect to ensemble evaluator during this.

**Issue**
May fix #8787 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
