### PR TITLE
Prevent copying mount point data when setting install_data to a non existing directory

### DIFF
--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -38,3 +39,12 @@ class InstallDataConfig(BaseModel, extra="forbid"):  # type: ignore
         if self.target in (".", "./"):
             self.target = Path(self.source).name
         return self
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def validate_source(cls, source):  # pylint: disable=E0213
+        if source is None or not os.path.isdir(source):
+            raise ValueError(f"'{source}' could not be parsed to a valid path")
+        if os.path.ismount(source):
+            raise ValueError(f"'{source} is a mount point and can't be installed'")
+        return source

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -39,12 +38,3 @@ class InstallDataConfig(BaseModel, extra="forbid"):  # type: ignore
         if self.target in (".", "./"):
             self.target = Path(self.source).name
         return self
-
-    @field_validator("source", mode="before")
-    @classmethod
-    def validate_source(cls, source):  # pylint: disable=E0213
-        if source is None or not os.path.isdir(source):
-            raise ValueError(f"'{source}' could not be parsed to a valid path")
-        if os.path.ismount(source):
-            raise ValueError(f"'{source} is a mount point and can't be installed'")
-        return source

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -221,6 +221,8 @@ def check_path_exists(
 
     expanded_paths = expand_geo_id_paths(str(path_source), realizations)
     for exp_path in [as_abs_path(p, str(config_dir)) for p in expanded_paths]:
+        if os.path.ismount(exp_path):
+            raise ValueError(f"'{exp_path}' is a mount point and can't be handled")
         if not os.path.exists(exp_path):
             raise ValueError(f"No such file or directory {exp_path}")
 


### PR DESCRIPTION
**Issue**
Resolves #9071


**Approach**
Includes additional validation for source path in EverestConfig to avoid copying data from root folder ("/") when install_data template render an invalid string. I'm not sure wether to add this validation actually, I've included in *check_path_exists* function in validation_utils.py but in the first commit there's a glimpse of how it could be if the validation was in *InstallDataConfig* as a pydantic validation of the *source* property itself. Just let me know which one you guys think fits better (or a new one maybe) and I modify it later.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
