### PR TITLE
Adds teardown to avoid flaky tests with run_dialog

### DIFF
--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -66,7 +66,10 @@ def notifier():
 def run_dialog(qtbot: QtBot, run_model, event_queue, notifier):
     run_dialog = RunDialog("mock.ert", run_model, event_queue, notifier)
     qtbot.addWidget(run_dialog)
-    return run_dialog
+
+    # Teardown
+    yield run_dialog
+    run_dialog.close()
 
 
 def test_terminating_experiment_shows_a_confirmation_dialog(
@@ -102,7 +105,6 @@ def test_run_dialog_polls_run_model_for_runtime(
     )
     event_queue.put(EndEvent(failed=False, msg=""))
     qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True)
-    run_dialog.close()
 
 
 def test_large_snapshot(
@@ -590,7 +592,6 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
 
         QTimer.singleShot(100, lambda: handle_error_dialog(run_dialog))
         qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True, timeout=100000)
-        run_dialog.close()
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
**Issue**
Resolves #9144


**Approach**
Modifies run_dialog fixture to yield instead of return run_dialog and closes it after each test.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
