### PR TITLE
Remove LSF_SERVER from everest and add deprecation warning for simulator server option

### DIFF
--- a/docs/everest/config_generated.rst
+++ b/docs/everest/config_generated.rst
@@ -1001,7 +1001,7 @@ Simulation settings
 **server (optional)**
     Type: *Optional[str]*
 
-    Name of LSF server to use
+    Name of LSF server to use. This option is deprecated and no longer required
 
 
 **slurm_timeout (optional)**

--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -1,6 +1,7 @@
+import warnings
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
+from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt, field_validator
 
 from .has_ert_queue_options import HasErtQueueOptions
 
@@ -96,7 +97,10 @@ class SimulatorConfig(BaseModel, HasErtQueueOptions, extra="forbid"):  # type: i
         default=None,
         description="squeue executable to be used by the slurm queue interface.",
     )
-    server: Optional[str] = Field(default=None, description="Name of LSF server to use")
+    server: Optional[str] = Field(
+        default=None,
+        description="Name of LSF server to use. This option is deprecated and no longer required",
+    )
     slurm_timeout: Optional[int] = Field(
         default=None,
         description="Timeout for cached status used by the slurm queue interface",
@@ -155,3 +159,13 @@ class SimulatorConfig(BaseModel, HasErtQueueOptions, extra="forbid"):  # type: i
         default=None,
         description="String identifier used to map hardware resource usage to a project or account. The project or account does not have to exist.",
     )
+
+    @field_validator("server")
+    @classmethod
+    def validate_server(cls, server):  # pylint: disable=E0213
+        if server is not None and server:
+            warnings.warn(
+                "The simulator server property was deprecated and is no longer needed",
+                DeprecationWarning,
+                stacklevel=1,
+            )

--- a/src/everest/config_keys.py
+++ b/src/everest/config_keys.py
@@ -57,7 +57,6 @@ class ConfigKeys:
     LSF = "lsf"
     LSF_OPTIONS = "options"  # LSF_RESOURCES
     LSF_QUEUE_NAME = "name"
-    LSF_SERVER = "server"
     SLURM = "slurm"
     SLURM_QUEUE = "name"
     SLURM_SBATCH = "sbatch"

--- a/src/everest/queue_driver/queue_driver.py
+++ b/src/everest/queue_driver/queue_driver.py
@@ -8,7 +8,6 @@ from everest.config_keys import ConfigKeys
 _LSF_OPTIONS = [
     (ConfigKeys.CORES, "MAX_RUNNING"),
     (ConfigKeys.LSF_QUEUE_NAME, "LSF_QUEUE"),
-    (ConfigKeys.LSF_SERVER, "LSF_SERVER"),
     (ConfigKeys.LSF_OPTIONS, "LSF_RESOURCE"),
 ]
 

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from typing import List
 
+import pytest
+
 from everest.config import EverestConfig
 from everest.config.control_config import ControlConfig
 from everest.config.control_variable_config import ControlVariableConfig
@@ -284,3 +286,18 @@ def test_that_log_level_property_is_consistent_with_environment_log_level():
         config.logging_level = lvl_str
         assert config.environment.log_level == lvl_str
         assert config.logging_level == lvl_int
+
+
+@pytest.mark.parametrize("server", ["something", "", None])
+def test_deprecation_warning_for_simulator_server(server):
+    config_src = {"simulator": {"server": server}}
+
+    if not server:
+        config = EverestConfig.with_defaults(**config_src)
+    else:
+        with pytest.deprecated_call(
+            match="The simulator server property was deprecated"
+        ):
+            config = EverestConfig.with_defaults(**config_src)
+
+    assert config.simulator.server is None

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -383,7 +383,6 @@ def test_queue_configuration(copy_test_data_to_tmp):
     expected_options = [
         ("LSF", "MAX_RUNNING", 3),
         ("LSF", "LSF_QUEUE", "mr"),
-        ("LSF", "LSF_SERVER", "lx-fastserver01"),
         ("LSF", "LSF_RESOURCE", "span = 1 && select[x86 and GNU/Linux]"),
     ]
 
@@ -400,7 +399,7 @@ def test_queue_config():
     assert config.simulator.resubmit_limit == 17
     assert config.simulator.cores == 3
     assert config.simulator.queue_system == "lsf"
-    assert config.simulator.server == "lx-fastserver01"
+    assert config.simulator.server is None
     opts = "span = 1 && select[x86 and GNU/Linux]"
     assert opts == config.simulator.options
 


### PR DESCRIPTION
**Issue**
Resolves #9037


**Approach**
Remove the LSF_SERVER key and raise DeprecationWarning


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
