### PR TITLE
Warn user about running Everest in existing non-empty RUNPATH

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -428,6 +428,13 @@ class EverestRunModel(BaseRunModel):
             else optimizer_exit_code
         )
 
+    def check_if_runpath_exists(self) -> bool:
+        return (
+            self.everest_config.simulation_dir is not None
+            and os.path.exists(self.everest_config.simulation_dir)
+            and any(os.listdir(self.everest_config.simulation_dir))
+        )
+
     def _handle_errors(
         self,
         batch: int,

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -8,6 +8,7 @@ import signal
 import threading
 from functools import partial
 
+from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
     ServerStatus,
@@ -16,7 +17,11 @@ from everest.detached import (
     start_server,
     wait_for_server,
 )
-from everest.util import makedirs_if_needed, version_info
+from everest.util import (
+    makedirs_if_needed,
+    version_info,
+    warn_user_that_runpath_is_nonempty,
+)
 
 from .utils import (
     handle_keyboard_interrupt,
@@ -43,6 +48,9 @@ def everest_entry(args=None):
             signal.SIGINT,
             partial(handle_keyboard_interrupt, options=options),
         )
+
+    if EverestRunModel.create(options.config).check_if_runpath_exists():
+        warn_user_that_runpath_is_nonempty()
 
     asyncio.run(run_everest(options))
 

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -92,7 +92,7 @@ def _roll_dir(old_name):
     old_name = os.path.realpath(old_name)
     new_name = old_name + datetime.datetime.utcnow().strftime("__%Y-%m-%d_%H.%M.%S.%f")
     os.rename(old_name, new_name)
-    logging.getLogger("everest").info("renamed %s to %s" % (old_name, new_name))
+    logging.getLogger(EVEREST).info("renamed %s to %s" % (old_name, new_name))
 
 
 def load_deck(fname):

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -6,7 +6,7 @@ from ropt.version import version as ropt_version
 
 from ert.shared.version import version as ert_version
 from everest.plugins.everest_plugin_manager import EverestPluginManager
-from everest.strings import DATE_FORMAT, DEFAULT_LOGGING_FORMAT
+from everest.strings import DATE_FORMAT, DEFAULT_LOGGING_FORMAT, EVEREST
 from everest.util.async_run import async_run  # noqa
 
 try:
@@ -74,6 +74,18 @@ def makedirs_if_needed(path, roll_if_exists=False):
             return
         _roll_dir(path)  # exists and should be rolled
     os.makedirs(path)
+
+
+def warn_user_that_runpath_is_nonempty() -> None:
+    print(
+        "Everest is running in an existing runpath.\n\n"
+        "Please be aware of the following:\n"
+        "- Previously generated results "
+        "might be overwritten.\n"
+        "- Previously generated files might "
+        "be used if not configured correctly.\n"
+    )
+    logging.getLogger(EVEREST).warning("Everest is running in an existing runpath")
 
 
 def _roll_dir(old_name):


### PR DESCRIPTION
**Issue**
Resolves #8759


**Approach**
Whenever user specifies an absolute path for the simulation_folder in the Everest config file the RUNPATH can be non-empty. This means unexpected results can occur (previously generated files might be used). With this PR we prompt the user that Everest is run in an existing RUNPATH and ask the user if we should continue this run. ~~In Ert there currently exists functionality for this, but it relies on creating a BaseRunModel, as far as my current knowledge of Everest goes this is done only after we launch the Everserver. Preferably we prompt the user before this happens, I'm still figuring out how to do this. If I don't succeed and we land on this current solution I will need to write some unit-tests for the new functionality.~~ Currently we only check if the directory is non-empty, in the future we might want to check more details such as which realizations are being run and for which already exists data in each existing batch? 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
