### PR TITLE
Fix small typo in Everest docs

### DIFF
--- a/docs/everest/minimal_example.rst
+++ b/docs/everest/minimal_example.rst
@@ -201,7 +201,7 @@ everest_config.yml::
 
 **Details**
 
-``simulation_f0older``: folder path where the simulation information will be written to.
+``simulation_folder``: folder path where the simulation information will be written to.
 
 ``output_folder``: folder path where the optimization information will be written.
 

--- a/docs/everest/theory.rst
+++ b/docs/everest/theory.rst
@@ -77,7 +77,7 @@ To approximate the gradient the following steps are taken:
 #. A user must choose an initial assignment of the controls. For instance in :numref:`fig_enopt_objfunc` the point ``(u1 = -1, u2 = 0)`` has been chosen.
 #. Around this initial choice of ``u1`` and ``u2``, Everest will generate a set of normally (Gaussian) distributed perturbed controls which can be seen as blue dots in :numref:`fig_enopt_objfunc`.
 #. Then, the objective function value for each of these blue dots will be evaluated. These are represented as the red dots.
-#. Now we have all the information required to approximate the gradient of the objective function. An estrimate of the gradient at the initial point is determined by computing the linear regression through the red dots (green line).
+#. Now we have all the information required to approximate the gradient of the objective function. An estimate of the gradient at the initial point is determined by computing the linear regression through the red dots (green line).
 #. We use a simple line-search algorithm to take a step along the gradient direction and to find an "updated" set of controls.
 #. The entire process is repeated till convergence is observed (i.e. little/no change in the objective function).
 


### PR DESCRIPTION
**Issue**
No issue attached to this PR


**Approach**
Fixes two small typo's I spotted while going through the documentation. In several places we are still referring to the "old" Everest repo, we need to make sure when we remove this repo we point to the Ert repo. For example, the "pip install git+https://github.com/equinor/everest.git" should be changed to "pip install . "[everest]"" and we should link to the Ert repo or this specific folder: https://github.com/equinor/ert/tree/main/src/everest .

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
