### PR TITLE
Mitigate flakyness for LSF kill test on busy test nodes

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_generic_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_generic_driver.py
@@ -162,13 +162,9 @@ async def test_kill_actually_kills(driver: Driver, tmp_path, pytestconfig):
         # Allow more time when tested on a real compute cluster to avoid false positives.
         job_kill_window = 60
         test_grace_time = 120
-    elif sys.platform.startswith("darwin"):
-        # Mitigate flakiness on low-power test nodes
-        job_kill_window = 5
-        test_grace_time = 8
     else:
-        job_kill_window = 1
-        test_grace_time = 2
+        job_kill_window = 5  # Busy test nodes require a long kill window
+        test_grace_time = 8
 
     async def kill_job_once_started(iens):
         nonlocal driver


### PR DESCRIPTION
A kill window of 1 second is not enough on real-life test nodes.

**Issue**
```
Mon, 11 Nov 2024 10:23:49 GMT         # Give the script a chance to finish if it is running
Mon, 11 Nov 2024 10:23:49 GMT         await asyncio.sleep(test_grace_time)
Mon, 11 Nov 2024 10:23:49 GMT >       assert not Path("survived").exists(), "Job should have been killed"
Mon, 11 Nov 2024 10:23:49 GMT E       AssertionError: Job should have been killed
Mon, 11 Nov 2024 10:23:49 GMT E       assert not True
Mon, 11 Nov 2024 10:23:49 GMT E        +  where True = exists()
Mon, 11 Nov 2024 10:23:49 GMT E        +    where exists = PosixPath('survived').exists
Mon, 11 Nov 2024 10:23:49 GMT E        +      where PosixPath('survived') = Path('survived')
```

**Approach**
🕙 
(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
