### PR TITLE
Use uvloop for asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "tabulate",
     "tqdm>=4.62.0",
     "typing_extensions>=4.5",
+    "uvloop",
     "uvicorn >= 0.17.0",
     "websockets < 14",
     "xarray",

--- a/src/_ert/async_utils.py
+++ b/src/_ert/async_utils.py
@@ -4,7 +4,9 @@ import asyncio
 import logging
 import traceback
 from contextlib import suppress
-from typing import Any, Coroutine, Generator, TypeVar, Union
+from typing import Any, Coroutine, Generator, Mapping, TypeVar, Union
+
+import uvloop
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 def new_event_loop() -> asyncio.AbstractEventLoop:
-    loop = asyncio.new_event_loop()
+    loop = uvloop.new_event_loop()
     loop.set_task_factory(_create_task)
     return loop
 
@@ -30,9 +32,10 @@ def get_running_loop() -> asyncio.AbstractEventLoop:
 def _create_task(
     loop: asyncio.AbstractEventLoop,
     coro: Union[Coroutine[Any, Any, _T], Generator[Any, None, _T]],
+    **kwargs: Mapping[str, Any],
 ) -> asyncio.Task[_T]:
     assert asyncio.iscoroutine(coro)
-    task = asyncio.Task(coro, loop=loop)
+    task = asyncio.Task(coro, loop=loop, **kwargs)  # type: ignore
     task.add_done_callback(_done_callback)
     return task
 

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -13,6 +13,7 @@ from argparse import ArgumentParser, ArgumentTypeError
 from typing import Any, Dict, Optional, Sequence, Union
 from uuid import UUID
 
+import uvloop
 import yaml
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.trace import Status, StatusCode
@@ -651,6 +652,7 @@ def log_process_usage() -> None:
 
 @tracer.start_as_current_span("ert.application.start")
 def main() -> None:
+    uvloop.install()
     span = trace.get_current_span()
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     locale.setlocale(locale.LC_NUMERIC, "C")


### PR DESCRIPTION
This replacement loop is significantly faster for sockets and streams

ran this 18 times with and without the changes.
the times reported are from async tasks exceeding 100ms.
`ert ensemble_experiment test-data/ert/heat_equation/config.ert`

![uvloop_vs_main](https://github.com/user-attachments/assets/56d9d3ad-2511-4328-a998-ce9d49c564c2)

> unchanged 18 runs
> max          6.917000s
> mean         0.594342s
> median       0.351000s
> count        6970
> 
> uvloop 18 runs
> max          6.388000s
> mean         0.627854s
> median       0.306000s
> count        3498


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
