### PR TITLE
Freeze websockets at < 14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "tqdm>=4.62.0",
     "typing_extensions>=4.5",
     "uvicorn >= 0.17.0",
-    "websockets",
+    "websockets < 14",
     "xarray",
     "xtgeo >= 3.3.0",
 ]


### PR DESCRIPTION
New version of websockets is incompatible with our current code

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
