### PR TITLE
Have all drivers' poll method ignore out of memory errors

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -448,6 +448,11 @@ class LsfDriver(Driver):
             except FileNotFoundError as e:
                 logger.error(str(e))
                 return
+            except OSError as e:
+                if "Cannot allocate memory" in str(e):
+                    logger.debug(str(e))
+                    continue
+                raise e
 
             stdout, stderr = await process.communicate()
             if process.returncode:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -324,6 +324,11 @@ class OpenPBSDriver(Driver):
                 except FileNotFoundError as e:
                     logger.error(str(e))
                     return
+                except OSError as e:
+                    if "Cannot allocate memory" in str(e):
+                        logger.debug(str(e))
+                        continue
+                    raise e
                 stdout, stderr = await process.communicate()
                 if process.returncode not in {0, QSTAT_UNKNOWN_JOB_ID}:
                     # Any unknown job ids will yield QSTAT_UNKNOWN_JOB_ID, but

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -274,6 +274,11 @@ class SlurmDriver(Driver):
             except FileNotFoundError as e:
                 logger.error(str(e))
                 return
+            except OSError as e:
+                if "Cannot allocate memory" in str(e):
+                    logger.debug(str(e))
+                    continue
+                raise e
             stdout, stderr = await process.communicate()
             if process.returncode:
                 logger.warning(


### PR DESCRIPTION
**Issue**


**Approach**
This commit makes it so that an OSError with the message `Cannot
allocate memory` in all drivers' poll subprocess in the
`driver.poll`-method are ignored. This is applicable for all drivers
except for local, which does not poll.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
