### PR TITLE
Trigger batching dispatcher on success/failure of ensemble

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -147,6 +147,8 @@ class EnsembleEvaluator:
                     function = event_handler[type(event)]
                     batch.append((function, event))
                     self._events.task_done()
+                    if type(event) in [EnsembleSucceeded, EnsembleFailed]:
+                        break
                 except asyncio.TimeoutError:
                     continue
             self._complete_batch.set()


### PR DESCRIPTION
**Issue**
#9136

**Approach**
Send batch from batching dispatcher immediately when we get EnsembleSucceeded or EnsembleFailed.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
