### PR TITLE
Assume non-LSF host error is flaky

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -94,7 +94,14 @@ _STATE_ORDER: dict[Type[AnyJob], int] = {
 LSF_INFO_JSON_FILENAME = "lsf_info.json"
 FLAKY_SSH_RETURNCODE = 255
 JOB_ALREADY_FINISHED_BKILL_MSG = "Job has already finished"
-BSUB_FAILURE_MESSAGES = ("Job not submitted",)
+BSUB_FAILURE_MESSAGES = (
+    "Error in rusage section",
+    "Expeced number, string",
+    "No such queue",
+    "Too many processors requested",
+    "cannot be used in the resource requirement section",
+    "duplicate section",
+)
 
 
 def _parse_jobs_dict(jobs: Mapping[str, JobState]) -> dict[str, AnyJob]:

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -607,7 +607,6 @@ async def test_that_bsub_will_retry_and_fail(
             " '&' cannot be used in the resource requirement section. Job not submitted.",
         ),
         (255, "Error in rusage section. Job not submitted."),
-        (255, "Job not submitted."),
     ],
 )
 async def test_that_bsub_will_fail_without_retries(
@@ -633,6 +632,8 @@ async def test_that_bsub_will_fail_without_retries(
     [
         (0, "void"),
         (FLAKY_SSH_RETURNCODE, ""),
+        (0, "Request from non-LSF host rejected"),
+        (FLAKY_SSH_RETURNCODE, "Request from non-LSF host rejected"),
     ],
 )
 async def test_that_bsub_will_retry_and_succeed(


### PR DESCRIPTION
The LSF driver experiences crashes stemming from bsub returning with the error message 'Request from non-LSF host rejected'. There are reasons to believe this is not a permanent error, but some flakyness in the IP infrastructure, and thus should should be categorized as a retriable failure.

The reason for believing this is flakyness is mostly from the fact that the same error is also seen on 'bjobs'-calls. If it was a permanent failure scenario, there would be an enourmous amount of error from these bjobs calls, but there is not.

**Issue**
Resolves #9185 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
