### PR TITLE
Fix faulty validation for maintained forward model objectives.

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -438,7 +438,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @model_validator(mode="after")
     def validate_maintained_forward_model_write_objectives(self) -> Self:
-        if not self.objective_functions:
+        if not self.objective_functions or not self.forward_model:
             return self
         objectives = {objective.name for objective in self.objective_functions}
         check_forward_model_objective(self.forward_model, objectives)

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -952,37 +952,41 @@ def test_that_non_existing_workflow_jobs_cause_error():
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 @pytest.mark.parametrize(
-    ["objective", "warning_msg"],
+    ["objective", "forward_model", "warning_msg"],
     [
         (
             ["npv", "rf"],
+            ["rf -s TEST -o rf"],
             "Warning: Forward model might not write the required output file for \\['npv'\\]",
         ),
         (
             ["npv", "npv2"],
+            ["rf -s TEST -o rf"],
             "Warning: Forward model might not write the required output files for \\['npv', 'npv2'\\]",
         ),
-        (["rf"], None),
+        (
+            ["rf"],
+            ["rf -s TEST -o rf"],
+            None,
+        ),
+        (
+            ["rf"],
+            None,
+            None,
+        ),
     ],
 )
-def test_warning_forward_model_write_objectives(objective, warning_msg):
-    fm_steps = [
-        "well_constraints  -i files/well_readydate.json -c files/wc_config.yml -rc well_rate.json -o wc_wells.json",
-        "add_templates     -i wc_wells.json -c files/at_config.yml -o at_wells.json",
-        "schmerge          -s eclipse/include/schedule/schedule.tmpl -i at_wells.json -o eclipse/include/schedule/schedule.sch",
-        "eclipse100 TEST.DATA --version 2020.2",
-        "rf -s TEST -o rf",
-    ]
+def test_warning_forward_model_write_objectives(objective, forward_model, warning_msg):
     if warning_msg is not None:
         with pytest.warns(ConfigWarning, match=warning_msg):
             EverestConfig.with_defaults(
                 objective_functions=[{"name": o} for o in objective],
-                forward_model=fm_steps,
+                forward_model=forward_model,
             )
     else:
         with warnings.catch_warnings():
             warnings.simplefilter("error", category=ConfigWarning)
             EverestConfig.with_defaults(
                 objective_functions=[{"name": o} for o in objective],
-                forward_model=fm_steps,
+                forward_model=forward_model,
             )


### PR DESCRIPTION
**Issue**
Validation fails when `everest` config contains objectives but no `forward_model` section 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
