### PR TITLE
Fix manifest having too many files and not substituting

### DIFF
--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 async def _read_parameters(
     run_path: str,
     realization: int,
+    iteration: int,
     ensemble: Ensemble,
 ) -> LoadResult:
     result = LoadResult(LoadStatus.LOAD_SUCCESSFUL, "")
@@ -28,7 +29,7 @@ async def _read_parameters(
         try:
             start_time = time.perf_counter()
             logger.debug(f"Starting to load parameter: {config.name}")
-            ds = config.read_from_runpath(Path(run_path), realization)
+            ds = config.read_from_runpath(Path(run_path), realization, iteration)
             await asyncio.sleep(0)
             logger.debug(
                 f"Loaded {config.name}",
@@ -60,7 +61,7 @@ async def _write_responses_to_storage(
             start_time = time.perf_counter()
             logger.debug(f"Starting to load response: {config.response_type}")
             try:
-                ds = config.read_from_file(run_path, realization)
+                ds = config.read_from_file(run_path, realization, ensemble.iteration)
             except (FileNotFoundError, InvalidResponseFile) as err:
                 errors.append(str(err))
                 logger.warning(f"Failed to write: {realization}: {err}")
@@ -105,6 +106,7 @@ async def forward_model_ok(
             parameters_result = await _read_parameters(
                 run_path,
                 realization,
+                iter,
                 ensemble,
             )
 

--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Dict, List, Mapping, MutableMapping, Tuple, Un
 import numpy as np
 import xarray as xr
 
+from ert.substitutions import substitute_runpath_name
+
 from .parameter_config import ParameterConfig
 
 if TYPE_CHECKING:
@@ -65,13 +67,17 @@ class ExtParamConfig(ParameterConfig):
                     f"Duplicate keys for key '{self.name}' - keys: {self.input_keys}"
                 )
 
-    def read_from_runpath(self, run_path: Path, real_nr: int) -> xr.Dataset:
+    def read_from_runpath(
+        self, run_path: Path, real_nr: int, iteration: int
+    ) -> xr.Dataset:
         raise NotImplementedError()
 
     def write_to_runpath(
         self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> None:
-        file_path = run_path / self.output_file
+        file_path = run_path / substitute_runpath_name(
+            self.output_file, real_nr, ensemble.iteration
+        )
         Path.mkdir(file_path.parent, exist_ok=True, parents=True)
 
         data: MutableDataType = {}

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -58,7 +58,7 @@ class ParameterConfig(ABC):
         random_seed: int,
         ensemble_size: int,
     ) -> xr.Dataset:
-        return self.read_from_runpath(Path(), real_nr)
+        return self.read_from_runpath(Path(), real_nr, 0)
 
     @abstractmethod
     def __len__(self) -> int:
@@ -69,6 +69,7 @@ class ParameterConfig(ABC):
         self,
         run_path: Path,
         real_nr: int,
+        iteration: int,
     ) -> xr.Dataset:
         """
         This function is responsible for converting the parameter

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -24,7 +24,7 @@ class ResponseConfig(ABC):
     has_finalized_keys: bool = False
 
     @abstractmethod
-    def read_from_file(self, run_path: str, iens: int) -> polars.DataFrame:
+    def read_from_file(self, run_path: str, iens: int, iter: int) -> polars.DataFrame:
         """Reads the data for the response from run_path.
 
         Raises:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Set, Union, no_type_check
 
+from ert.substitutions import substitute_runpath_name
+
 from ._read_summary import read_summary
 from .ensemble_config import Refcase
 from .parsing import ConfigDict, ConfigKeys
@@ -37,8 +39,8 @@ class SummaryConfig(ResponseConfig):
         base = self.input_files[0]
         return [f"{base}.UNSMRY", f"{base}.SMSPEC"]
 
-    def read_from_file(self, run_path: str, iens: int) -> polars.DataFrame:
-        filename = self.input_files[0].replace("<IENS>", str(iens))
+    def read_from_file(self, run_path: str, iens: int, iter: int) -> polars.DataFrame:
+        filename = substitute_runpath_name(self.input_files[0], iens, iter)
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
         if len(data) == 0 or len(keys) == 0:
             # https://github.com/equinor/ert/issues/6974

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -9,6 +9,8 @@ import xarray as xr
 import xtgeo
 from typing_extensions import Self
 
+from ert.substitutions import substitute_runpath_name
+
 from ._option_dict import option_dict
 from ._str_to_bool import str_to_bool
 from .parameter_config import ParameterConfig
@@ -97,10 +99,10 @@ class SurfaceConfig(ParameterConfig):
     def __len__(self) -> int:
         return self.ncol * self.nrow
 
-    def read_from_runpath(self, run_path: Path, real_nr: int) -> xr.Dataset:
-        file_name = self.forward_init_file
-        if "%d" in file_name:
-            file_name = file_name % real_nr  # noqa
+    def read_from_runpath(
+        self, run_path: Path, real_nr: int, iteration: int
+    ) -> xr.Dataset:
+        file_name = substitute_runpath_name(self.forward_init_file, real_nr, iteration)
         file_path = run_path / file_name
         if not file_path.exists():
             raise ValueError(
@@ -137,7 +139,9 @@ class SurfaceConfig(ParameterConfig):
             values=data.values,
         )
 
-        file_path = run_path / self.output_file
+        file_path = run_path / substitute_runpath_name(
+            str(self.output_file), real_nr, ensemble.iteration
+        )
         file_path.parent.mkdir(exist_ok=True, parents=True)
         surf.to_file(file_path, fformat="irap_ascii")
 

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -24,7 +24,7 @@ from numpy.random import SeedSequence
 from ert.config.ert_config import forward_model_data_to_json
 from ert.config.forward_model_step import ForwardModelStep
 from ert.config.model_config import ModelConfig
-from ert.substitutions import Substitutions
+from ert.substitutions import Substitutions, substitute_runpath_name
 
 from .config import (
     ExtParamConfig,
@@ -126,7 +126,7 @@ def _generate_parameter_files(
     _value_export_json(run_path, export_base_name, exports)
 
 
-def _manifest_to_json(ensemble: Ensemble, iens: int = 0) -> Dict[str, Any]:
+def _manifest_to_json(ensemble: Ensemble, iens: int, iter: int) -> Dict[str, Any]:
     manifest = {}
     # Add expected parameter files to manifest
     for param_config in ensemble.experiment.parameter_configuration.values():
@@ -134,15 +134,18 @@ def _manifest_to_json(ensemble: Ensemble, iens: int = 0) -> Dict[str, Any]:
             param_config,
             (ExtParamConfig, GenKwConfig, Field, SurfaceConfig),
         )
-        if param_config.forward_init and param_config.forward_init_file is not None:
-            file_path = param_config.forward_init_file.replace("%d", str(iens))
+        if param_config.forward_init and ensemble.iteration == 0:
+            assert param_config.forward_init_file is not None
+            file_path = substitute_runpath_name(
+                param_config.forward_init_file, iens, iter
+            )
             manifest[param_config.name] = file_path
-        elif param_config.output_file is not None and not param_config.forward_init:
-            manifest[param_config.name] = str(param_config.output_file)
     # Add expected response files to manifest
     for respons_config in ensemble.experiment.response_configuration.values():
         for input_file in respons_config.expected_input_files:
-            manifest[f"{respons_config.response_type}_{input_file}"] = input_file
+            manifest[f"{respons_config.response_type}_{input_file}"] = (
+                substitute_runpath_name(input_file, iens, iter)
+            )
 
     return manifest
 
@@ -271,7 +274,7 @@ def create_run_path(
                     orjson.dumps(forward_model_output, option=orjson.OPT_NON_STR_KEYS)
                 )
             # Write MANIFEST file to runpath use to avoid NFS sync issues
-            data = _manifest_to_json(ensemble, run_arg.iens)
+            data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
             with open(run_path / "manifest.json", mode="wb") as fptr:
                 fptr.write(orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS))
 

--- a/tests/ert/unit_tests/config/egrid_generator.py
+++ b/tests/ert/unit_tests/config/egrid_generator.py
@@ -364,3 +364,40 @@ def global_grids(draw):
 
 
 egrids = st.builds(EGrid, file_heads, global_grids())
+
+
+def simple_grid(dims: Tuple[int, int, int] = (2, 2, 2)):
+    corner_size = (dims[0] + 1) * (dims[1] + 1) * 6
+    coord = np.zeros(
+        shape=corner_size,
+        dtype=np.float32,
+    )
+    zcorn = np.zeros(
+        shape=8 * dims[0] * dims[1] * dims[2],
+        dtype=np.float32,
+    )
+    return EGrid(
+        Filehead(
+            0,
+            2000,
+            0,
+            TypeOfGrid.CORNER_POINT,
+            RockModel.SINGLE_PERMEABILITY_POROSITY,
+            GridFormat.IRREGULAR_CORNER_POINT,
+        ),
+        GlobalGrid(
+            coord=coord,
+            zcorn=zcorn,
+            actnum=None,
+            grid_head=GridHead(
+                TypeOfGrid.CORNER_POINT,
+                *dims,
+                0,
+                1,
+                1,
+                CoordinateType.CARTESIAN,
+                (0, 0, 0),
+                (0, 0, 0),
+            ),
+        ),
+    )

--- a/tests/ert/unit_tests/config/summary_generator.py
+++ b/tests/ert/unit_tests/config/summary_generator.py
@@ -533,3 +533,36 @@ def summaries(
         steps.append(SummaryStep(j, minis))
         j += 1
     return smspec, Unsmry(steps)
+
+
+def simple_unsmry():
+    return Unsmry(
+        steps=[
+            SummaryStep(
+                seqnum=0,
+                ministeps=[
+                    SummaryMiniStep(mini_step=0, params=[0.0, 5.629901e16]),
+                ],
+            )
+        ]
+    )
+
+
+def simple_smspec():
+    return Smspec(
+        nx=2,
+        ny=2,
+        nz=2,
+        restarted_from_step=0,
+        num_keywords=2,
+        restart="        ",
+        keywords=["TIME    ", "FOPR"],
+        well_names=[":+:+:+:+", "        "],
+        region_numbers=[-32676, 0],
+        units=["HOURS   ", "SM3"],
+        start_date=Date(day=1, month=1, year=2014, hour=0, minutes=0, micro_seconds=0),
+        intehead=SmspecIntehead(
+            unit=UnitSystem.METRIC,
+            simulator=Simulator.ECLIPSE_100,
+        ),
+    )

--- a/tests/ert/unit_tests/config/test_gen_data_config.py
+++ b/tests/ert/unit_tests/config/test_gen_data_config.py
@@ -132,7 +132,7 @@ def test_that_invalid_gendata_outfile_error_propagates(tmp_path):
         InvalidResponseFile,
         match="Error reading GEN_DATA.*could not convert string.*4.910405046410615,4.910405046410615.*to float64",
     ):
-        config.read_from_file(tmp_path, 0)
+        config.read_from_file(tmp_path, 0, 0)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -145,7 +145,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(con
             keys=["something"],
             report_steps_list=[None],
             input_files=["output"],
-        ).read_from_file(os.getcwd(), 0)
+        ).read_from_file(os.getcwd(), 0, 0)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):
@@ -155,7 +155,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmp
             keys=["something"],
             report_steps_list=[None],
             input_files=["DOES_NOT_EXIST"],
-        ).read_from_file(tmpdir, 0)
+        ).read_from_file(tmpdir, 0, 0)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_directory(
@@ -167,4 +167,4 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
             keys=["something"],
             report_steps_list=[None],
             input_files=["DOES_NOT_EXIST"],
-        ).read_from_file(str(tmp_path / "DOES_NOT_EXIST"), 0)
+        ).read_from_file(str(tmp_path / "DOES_NOT_EXIST"), 0, 0)

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -605,7 +605,7 @@ def test_incorrect_values_in_forward_init_file_fails(tmp_path):
             None,
             [],
             str(tmp_path / "forward_init_%d"),
-        ).read_from_runpath(tmp_path, 1)
+        ).read_from_runpath(tmp_path, 1, 0)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -33,7 +33,7 @@ def test_reading_empty_summaries_raises(wopr_summary):
     smspec.to_file("CASE.SMSPEC")
     unsmry.to_file("CASE.UNSMRY")
     with pytest.raises(InvalidResponseFile, match="Did not find any summary values"):
-        SummaryConfig("summary", ["CASE"], ["WWCT:OP1"]).read_from_file(".", 0)
+        SummaryConfig("summary", ["CASE"], ["WWCT:OP1"]).read_from_file(".", 0, 0)
 
 
 def test_summary_config_normalizes_list_of_keys():
@@ -51,12 +51,12 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(
     Path("CASE.UNSMRY").write_bytes(unsmry)
     Path("CASE.SMSPEC").write_bytes(smspec)
     with suppress(InvalidResponseFile):
-        SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(os.getcwd(), 1)
+        SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(os.getcwd(), 1, 0)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):
     with pytest.raises(FileNotFoundError):
-        SummaryConfig("summary", ["NOT_CASE"], ["FOPR"]).read_from_file(tmpdir, 1)
+        SummaryConfig("summary", ["NOT_CASE"], ["FOPR"]).read_from_file(tmpdir, 1, 0)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -65,5 +65,5 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
 ):
     with pytest.raises(FileNotFoundError):
         SummaryConfig("summary", ["CASE"], ["FOPR"]).read_from_file(
-            str(tmp_path / "DOES_NOT_EXIST"), 1
+            str(tmp_path / "DOES_NOT_EXIST"), 1, 0
         )

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -48,7 +48,7 @@ def test_runpath_roundtrip(tmp_path, storage, surface):
     surface.to_file(tmp_path / "input_0", fformat="irap_ascii")
 
     # run_path -> storage
-    ds = config.read_from_runpath(tmp_path, 0)
+    ds = config.read_from_runpath(tmp_path, 0, 0)
     ensemble.save_parameters(config.name, 0, ds)
 
     # storage -> run_path

--- a/tests/ert/unit_tests/dark_storage/test_common.py
+++ b/tests/ert/unit_tests/dark_storage/test_common.py
@@ -64,7 +64,7 @@ def test_data_for_key_gives_mean_for_duplicate_values(tmp_path):
         )
         smspec.to_file(tmp_path / "CASE.SMSPEC")
         unsmry.to_file(tmp_path / "CASE.UNSMRY")
-        ds = summary_config.read_from_file(tmp_path, 0)
+        ds = summary_config.read_from_file(tmp_path, 0, 0)
         ensemble.save_response(summary_config.response_type, ds, 0)
         df = data_for_key(ensemble, "NRPPR:WELLNAME")
         assert list(df.columns) == [pd.Timestamp("2014-01-16 05:00:00")]

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -893,7 +893,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         unsmry.to_file(self.tmpdir + f"/{summary.input_files[0]}.UNSMRY")
 
         try:
-            ds = summary.read_from_file(self.tmpdir, self.iens_to_edit)
+            ds = summary.read_from_file(self.tmpdir, self.iens_to_edit, 0)
         except Exception as e:  # no match in keys
             assume(False)
             raise AssertionError() from e


### PR DESCRIPTION
Also makes substitution of <IENS> and <ITER> for all parameters and responses


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
