### PR TITLE
Instantiate ert config before starting everest server

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -18,6 +18,7 @@ from everest.detached import (
     start_server,
     wait_for_server,
 )
+from everest.simulator.everest_to_ert import everest_to_ert_config
 from everest.strings import EVEREST
 from everest.util import (
     makedirs_if_needed,
@@ -50,6 +51,12 @@ def everest_entry(args=None):
             signal.SIGINT,
             partial(handle_keyboard_interrupt, options=options),
         )
+
+    # Validate ert config
+    try:
+        _ = everest_to_ert_config(options.config)
+    except ValueError as exc:
+        raise SystemExit(f"Config validation error: {exc}") from exc
 
     if EverestRunModel.create(options.config).check_if_runpath_exists():
         warn_user_that_runpath_is_nonempty()

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -326,7 +326,7 @@ def _is_dir_all_geo(source, ever_config: EverestConfig):
     realizations = ever_config.model.realizations
     if not realizations:
         msg = "Expected realizations when analysing data installation source"
-        raise AssertionError(msg)
+        raise ValueError(msg)
 
     is_dir = []
     for geo_id in realizations:
@@ -336,7 +336,7 @@ def _is_dir_all_geo(source, ever_config: EverestConfig):
                 "Expected source to exist for data installation, "
                 "did not find: {}".format(geo_source)
             )
-            raise AssertionError(msg)
+            raise ValueError(msg)
 
         is_dir.append(os.path.isdir(geo_source))
 


### PR DESCRIPTION
**Issue**
Resolves #9200 


**Approach**
Instantiate ert_confg from everest config before we start everest server and report expectations as config validation error. 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
