### PR TITLE
Perform validation earlier by returning EnOptConfig instead of dict 

### DIFF
--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
 )
 
+from ropt.config.enopt import EnOptConfig
 from ropt.enums import ConstraintType, PerturbationType, VariableType
 from typing_extensions import Final, TypeAlias
 
@@ -504,7 +505,7 @@ def _parse_environment(ever_config: EverestConfig, ropt_config):
         ropt_config["gradient"]["seed"] = ever_config.environment.random_seed
 
 
-def everest2ropt(ever_config: EverestConfig) -> Dict[str, Any]:
+def everest2ropt(ever_config: EverestConfig) -> EnOptConfig:
     """Generate a ropt configuration from an Everest one
 
     NOTE: This method is a work in progress. So far only the some of
@@ -531,4 +532,4 @@ def everest2ropt(ever_config: EverestConfig) -> Dict[str, Any]:
     _parse_model(ever_config, ropt_config)
     _parse_environment(ever_config, ropt_config)
 
-    return ropt_config
+    return EnOptConfig.model_validate(ropt_config)


### PR DESCRIPTION
**Issue**
Resolves #9155


**Approach**
When converting EverestConfig into EnOptConfig, return actual EnOptConfig instead of dictionary to perform the validation of the configuration earlier. ~~Still have to do some re-factoring but will discuss with Pieter what he had in mind.~~ After discussing with Pieter: do refactoring in a different PR. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
