### PR TITLE
Aggregate logging of sampling information

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import math
 import os
 import shutil
@@ -33,8 +32,6 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.storage import Ensemble
-
-_logger = logging.getLogger(__name__)
 
 
 class PriorDict(TypedDict):
@@ -239,7 +236,6 @@ class GenKwConfig(ParameterConfig):
         if self.forward_init_file:
             return self.read_from_runpath(Path(), real_nr)
 
-        _logger.info(f"Sampling parameter {self.name} for realization {real_nr}")
         keys = [e.name for e in self.transform_functions]
         parameter_value = self._sample_value(
             self.name,

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -183,6 +183,9 @@ def sample_prior(
         config_node = parameter_configs[parameter]
         if config_node.forward_init:
             continue
+        logger.info(
+            f"Sampling parameter {config_node.name} for realizations {active_realizations}"
+        )
         for realization_nr in active_realizations:
             ds = config_node.sample_or_load(
                 realization_nr,


### PR DESCRIPTION
A separate log entry for each realization does not provide much extra value

**Issue**
Resolves chatty log

**Approach**
Log once pr ensemble instead.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
