### PR TITLE
Fix issue where dark_storage did not handle empty responses

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import polars
 import xarray as xr
+from polars.exceptions import ColumnNotFoundError
 
 from ert.config import GenDataConfig, GenKwConfig
 from ert.config.field import Field
@@ -171,7 +172,7 @@ def data_for_key(
                     return data.astype(float)
                 except ValueError:
                     return data
-            except (ValueError, KeyError):
+            except (ValueError, KeyError, ColumnNotFoundError):
                 return pd.DataFrame()
 
     group = key.split(":")[0]


### PR DESCRIPTION
Fixes an issue where empty gen_data responses crashed the plotapi


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
