### PR TITLE
Degrade logged warning to info

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -168,7 +168,7 @@ class LegacyEnsemble:
             walltime = 0
 
         if walltime > 120:
-            logger.warning(
+            logger.info(
                 f"{event.event_type} {step_name} "
                 f"{walltime=} "
                 f"{cpu_seconds=} "


### PR DESCRIPTION
This was a workaround to propagate this particular log through a filter that only propagated warning. Now info logs are also propagated so this workaround is no longer needed.

**Issue**
Resolves visual noise


**Approach**
➖ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
