### PR TITLE
Avoid forward model crash after MPI NOSIM E100 run

### DIFF
--- a/src/ert/resources/forward_models/res/script/ecl_run.py
+++ b/src/ert/resources/forward_models/res/script/ecl_run.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from pathlib import Path
 from random import random
-from typing import List
+from typing import List, Optional
 
 import resfo
 from ecl_config import EclConfig, EclrunConfig, Simulator
@@ -157,7 +157,7 @@ def pushd(run_path):
     os.chdir(starting_directory)
 
 
-def find_unsmry(basepath: Path) -> Path:
+def find_unsmry(basepath: Path) -> Optional[Path]:
     def _is_unsmry(base: str, path: str) -> bool:
         if "." not in path:
             return False
@@ -173,7 +173,7 @@ def find_unsmry(basepath: Path) -> Path:
         filter(lambda x: _is_unsmry(base, x), os.listdir(dir or "."))
     )
     if not candidates:
-        raise ValueError(f"Could not find any unsmry matching case path {basepath}")
+        return None
     if len(candidates) > 1:
         raise ValueError(
             f"Ambiguous reference to unsmry in {basepath}, could be any of {candidates}"


### PR DESCRIPTION
This fixes a regression from 2453a2c.

**Issue**
Resolves one of two bugs in #9277 


**Approach**
Prior to 2453a2c, the exception from not finding any unsrmy file was swallowed. With this PR, it is again swallowed.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
