### PR TITLE
Fix progress bar showing finished status for unselected reals

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -188,7 +188,6 @@ class BaseRunModel(ABC):
         self.minimum_required_realizations = minimum_required_realizations
         self.active_realizations = copy.copy(active_realizations)
         self.start_iteration = start_iteration
-        self.validate_active_realizations_count()
 
     def log_at_startup(self) -> None:
         keys_to_drop = [
@@ -655,17 +654,6 @@ class BaseRunModel(ABC):
         for run_path in self.paths:
             if Path(run_path).exists():
                 shutil.rmtree(run_path)
-
-    def validate_active_realizations_count(self) -> None:
-        active_realizations_count = self.get_number_of_active_realizations()
-        min_realization_count = self.minimum_required_realizations
-
-        if active_realizations_count < min_realization_count:
-            raise ValueError(
-                f"Number of active realizations ({active_realizations_count}) is less "
-                f"than the specified MIN_REALIZATIONS"
-                f"({min_realization_count})"
-            )
 
     def validate_successful_realizations_count(self) -> None:
         successful_reallizations_count = self.get_number_of_successful_realizations()

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -188,7 +188,7 @@ class BaseRunModel(ABC):
         self.minimum_required_realizations = minimum_required_realizations
         self.active_realizations = copy.copy(active_realizations)
         self.start_iteration = start_iteration
-        self.validate()
+        self.validate_active_realizations_count()
 
     def log_at_startup(self) -> None:
         keys_to_drop = [
@@ -406,8 +406,13 @@ class BaseRunModel(ABC):
                 for real in all_realizations.values():
                     status[str(real["status"])] += 1
 
-        status["Finished"] += self.active_realizations.count(False)
+        status["Finished"] += self._get_number_of_finished_realizations_from_reruns()
         return status
+
+    def _get_number_of_finished_realizations_from_reruns(self) -> int:
+        return self.active_realizations.count(
+            False
+        ) - self._initial_realizations_mask.count(False)
 
     def get_memory_consumption(self) -> int:
         max_memory_consumption: int = 0
@@ -425,7 +430,7 @@ class BaseRunModel(ABC):
         done_realizations = self.active_realizations.count(False)
         all_realizations = self._iter_snapshot[current_iter].reals
         current_progress = 0.0
-        realization_count = len(self.active_realizations)
+        realization_count = self.get_number_of_active_realizations()
 
         if all_realizations:
             for real in all_realizations.values():
@@ -641,6 +646,9 @@ class BaseRunModel(ABC):
         return [real_path.exists() for real_path in realization_set].count(True)
 
     def get_number_of_active_realizations(self) -> int:
+        return self._initial_realizations_mask.count(True)
+
+    def get_number_of_successful_realizations(self) -> int:
         return self.active_realizations.count(True)
 
     def rm_run_path(self) -> None:
@@ -648,13 +656,24 @@ class BaseRunModel(ABC):
             if Path(run_path).exists():
                 shutil.rmtree(run_path)
 
-    def validate(self) -> None:
+    def validate_active_realizations_count(self) -> None:
         active_realizations_count = self.get_number_of_active_realizations()
         min_realization_count = self.minimum_required_realizations
 
         if active_realizations_count < min_realization_count:
             raise ValueError(
                 f"Number of active realizations ({active_realizations_count}) is less "
+                f"than the specified MIN_REALIZATIONS"
+                f"({min_realization_count})"
+            )
+
+    def validate_successful_realizations_count(self) -> None:
+        successful_reallizations_count = self.get_number_of_successful_realizations()
+        min_realization_count = self.minimum_required_realizations
+
+        if successful_reallizations_count < min_realization_count:
+            raise ValueError(
+                f"Number of successful realizations ({successful_reallizations_count}) is less "
                 f"than the specified MIN_REALIZATIONS"
                 f"({min_realization_count})"
             )
@@ -699,7 +718,7 @@ class BaseRunModel(ABC):
             self.active_realizations[iens] = False
 
         num_successful_realizations = len(successful_realizations)
-        self.validate()
+        self.validate_successful_realizations_count()
         logger.info(f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}")
         logger.info(f"Experiment ran with number of realizations: {self.ensemble_size}")
         logger.info(
@@ -748,7 +767,7 @@ class UpdateRunModel(BaseRunModel):
     def update(
         self, prior: Ensemble, posterior_name: str, weight: float = 1.0
     ) -> Ensemble:
-        self.validate()
+        self.validate_successful_realizations_count()
         self.send_event(
             RunModelUpdateBeginEvent(iteration=prior.iteration, run_id=prior.id)
         )

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -94,7 +94,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
         iteration: int,
         initial_mask: npt.NDArray[np.bool_],
     ) -> None:
-        self.validate()
         self.run_workflows(HookRuntime.PRE_UPDATE, self._storage, prior_storage)
         try:
             _, self.sies_smoother = iterative_smoother_update(

--- a/tests/ert/ui_tests/cli/test_missing_runpath.py
+++ b/tests/ert/ui_tests/cli/test_missing_runpath.py
@@ -54,7 +54,7 @@ def test_missing_runpath_has_isolated_failures(tmp_path, monkeypatch):
     try:
         with pytest.raises(
             ErtCliError,
-            match=r"active realizations \(9\) is less than .* MIN_REALIZATIONS\(10\)",
+            match=r"successful realizations \(9\) is less than .* MIN_REALIZATIONS\(10\)",
         ):
             run_cli_with_pm(
                 ["ensemble_experiment", "config.ert", "--disable-monitoring"]
@@ -97,7 +97,7 @@ def test_failing_writes_lead_to_isolated_failures(tmp_path, monkeypatch, pytestc
     with (
         pytest.raises(
             ErtCliError,
-            match=r"(?s)active realizations \(9\) is less than .* MIN_REALIZATIONS\(10\).*"
+            match=r"(?s)successful realizations \(9\) is less than .* MIN_REALIZATIONS\(10\).*"
             r"Driver reported: Could not create submit script: Don't like realization-1",
         ),
         patch_raising_named_temporary_file(queue_system.lower()),

--- a/tests/ert/unit_tests/cli/test_model_hook_order.py
+++ b/tests/ert/unit_tests/cli/test_model_hook_order.py
@@ -28,7 +28,10 @@ EXPECTED_CALL_ORDER = [
 @pytest.fixture
 def patch_base_run_model(monkeypatch):
     monkeypatch.setattr(base_run_model, "create_run_path", MagicMock())
-    monkeypatch.setattr(BaseRunModel, "validate", MagicMock())
+    monkeypatch.setattr(BaseRunModel, "validate_active_realizations_count", MagicMock())
+    monkeypatch.setattr(
+        BaseRunModel, "validate_successful_realizations_count", MagicMock()
+    )
     monkeypatch.setattr(BaseRunModel, "set_env_key", MagicMock())
 
 

--- a/tests/ert/unit_tests/cli/test_model_hook_order.py
+++ b/tests/ert/unit_tests/cli/test_model_hook_order.py
@@ -28,7 +28,6 @@ EXPECTED_CALL_ORDER = [
 @pytest.fixture
 def patch_base_run_model(monkeypatch):
     monkeypatch.setattr(base_run_model, "create_run_path", MagicMock())
-    monkeypatch.setattr(BaseRunModel, "validate_active_realizations_count", MagicMock())
     monkeypatch.setattr(
         BaseRunModel, "validate_successful_realizations_count", MagicMock()
     )

--- a/tests/ert/unit_tests/run_models/test_ensemble_experiment.py
+++ b/tests/ert/unit_tests/run_models/test_ensemble_experiment.py
@@ -25,7 +25,8 @@ def test_check_if_runpath_exists(
             return [f"out/realization-{r}/iter-{iteration}" for r in realizations]
         return [f"out/realization-{r}" for r in realizations]
 
-    EnsembleExperiment.validate = MagicMock()
+    EnsembleExperiment.validate_active_realizations_count = MagicMock()
+    EnsembleExperiment.validate_successful_realizations_count = MagicMock()
     ensemble_experiment = EnsembleExperiment(
         *[MagicMock()] * 2 + [active_mask, MagicMock(), None] + [MagicMock()] * 4
     )

--- a/tests/ert/unit_tests/run_models/test_model_factory.py
+++ b/tests/ert/unit_tests/run_models/test_model_factory.py
@@ -208,12 +208,6 @@ def test_multiple_data_assimilation_restart_paths(
 
     monkeypatch.setattr(
         ert.run_models.base_run_model.BaseRunModel,
-        "validate_active_realizations_count",
-        MagicMock(),
-    )
-
-    monkeypatch.setattr(
-        ert.run_models.base_run_model.BaseRunModel,
         "validate_successful_realizations_count",
         MagicMock(),
     )
@@ -269,11 +263,6 @@ def test_evaluate_ensemble_paths(
     tmp_path, monkeypatch, ensemble_iteration, expected_path
 ):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        ert.run_models.base_run_model.BaseRunModel,
-        "validate_active_realizations_count",
-        MagicMock(),
-    )
 
     monkeypatch.setattr(
         ert.run_models.base_run_model.BaseRunModel,

--- a/tests/ert/unit_tests/run_models/test_model_factory.py
+++ b/tests/ert/unit_tests/run_models/test_model_factory.py
@@ -205,8 +205,17 @@ def test_multiple_data_assimilation_restart_paths(
         prior_ensemble_id=str(uuid1()),
         experiment_name=None,
     )
+
     monkeypatch.setattr(
-        ert.run_models.base_run_model.BaseRunModel, "validate", MagicMock()
+        ert.run_models.base_run_model.BaseRunModel,
+        "validate_active_realizations_count",
+        MagicMock(),
+    )
+
+    monkeypatch.setattr(
+        ert.run_models.base_run_model.BaseRunModel,
+        "validate_successful_realizations_count",
+        MagicMock(),
     )
     storage_mock = MagicMock()
     ensemble_mock = MagicMock()
@@ -261,7 +270,15 @@ def test_evaluate_ensemble_paths(
 ):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        ert.run_models.base_run_model.BaseRunModel, "validate", MagicMock()
+        ert.run_models.base_run_model.BaseRunModel,
+        "validate_active_realizations_count",
+        MagicMock(),
+    )
+
+    monkeypatch.setattr(
+        ert.run_models.base_run_model.BaseRunModel,
+        "validate_successful_realizations_count",
+        MagicMock(),
     )
     storage_mock = MagicMock()
     ensemble_mock = MagicMock()


### PR DESCRIPTION
**Issue**
Resolves #9230

**Approach**
This commit fixes the bug where the gui shows the total count of realizations as the ensemble_size rather than the number of realizations actually selected for the run.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/88acc7c5-938d-4f02-b9da-0c47e81852b8)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
