### PR TITLE
Fix ambiguous find_unsmry()

### DIFF
--- a/src/ert/resources/forward_models/res/script/ecl_run.py
+++ b/src/ert/resources/forward_models/res/script/ecl_run.py
@@ -167,10 +167,9 @@ def find_unsmry(basepath: Path) -> Optional[Path]:
             "funsmry",
         ]
 
-    dir = basepath.parent
     base = basepath.name
     candidates: List[str] = list(
-        filter(lambda x: _is_unsmry(base, x), os.listdir(dir or "."))
+        filter(lambda x: _is_unsmry(base, x), glob.glob(str(basepath) + "*"))
     )
     if not candidates:
         return None
@@ -178,7 +177,7 @@ def find_unsmry(basepath: Path) -> Optional[Path]:
         raise ValueError(
             f"Ambiguous reference to unsmry in {basepath}, could be any of {candidates}"
         )
-    return Path(dir) / candidates[0]
+    return Path(candidates[0])
 
 
 def await_completed_unsmry_file(


### PR DESCRIPTION
**Issue**
Resolves #9277 


**Approach**
Solve old bug that old code tucked under the carpet.

To reproduce this problem you need to run Eclipse with more than 1 CPU and also leave a similar looking UNSMRY-file to the runpath.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
