### PR TITLE
fixup get_ensemble_responses logic in dark storage

### DIFF
--- a/src/ert/dark_storage/endpoints/records.py
+++ b/src/ert/dark_storage/endpoints/records.py
@@ -116,6 +116,10 @@ def get_ensemble_responses(
 
     response_names_with_observations = set()
     observations = ensemble.experiment.observations
+
+    if len(ensemble.has_data()) == 0:
+        return {}
+
     for (
         response_type,
         response_config,


### PR DESCRIPTION
**Issue**
An ensemble may have no responses, but belong to an experiment where response keys are already registered. If this ensemble does not have data, it should still not return responses in dark storage
