### PR TITLE
Only read process tree once per job_dispatch report

### DIFF
--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -12,7 +12,17 @@ import time
 from datetime import datetime as dt
 from pathlib import Path
 from subprocess import Popen, run
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Sequence, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+)
 
 from psutil import AccessDenied, NoSuchProcess, Process, TimeoutExpired, ZombieProcess
 
@@ -30,7 +40,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def killed_by_oom(pids: Sequence[int]) -> bool:
+def killed_by_oom(pids: Set[int]) -> bool:
     """Will try to detect if a process (or any of its descendants) was killed
     by the Linux OOM-killer.
 
@@ -188,7 +198,8 @@ class ForwardModelStep:
         max_memory_usage = 0
         fm_step_pids = {int(process.pid)}
         while exit_code is None:
-            (memory_rss, cpu_seconds, oom_score) = _get_processtree_data(process)
+            (memory_rss, cpu_seconds, oom_score, pids) = _get_processtree_data(process)
+            fm_step_pids |= pids
             max_memory_usage = max(memory_rss, max_memory_usage)
             yield Running(
                 self,
@@ -210,11 +221,7 @@ class ForwardModelStep:
                 )
                 if isinstance(potential_exited_msg, Exited):
                     yield potential_exited_msg
-
                     return
-                fm_step_pids |= {
-                    int(child.pid) for child in process.children(recursive=True)
-                }
 
         ensure_file_handles_closed([stdin, stdout, stderr])
         exited_message = self._create_exited_message_based_on_exit_code(
@@ -227,7 +234,7 @@ class ForwardModelStep:
         max_memory_usage: int,
         target_file_mtime: Optional[int],
         exit_code: int,
-        fm_step_pids: Sequence[int],
+        fm_step_pids: Set[int],
     ) -> Exited:
         if exit_code != 0:
             exited_message = self._create_exited_msg_for_non_zero_exit_code(
@@ -254,7 +261,7 @@ class ForwardModelStep:
         self,
         max_memory_usage: int,
         exit_code: int,
-        fm_step_pids: Sequence[int],
+        fm_step_pids: Set[int],
     ) -> Exited:
         # All child pids for the forward model step. Need to track these in order to be able
         # to detect OOM kills in case of failure.
@@ -429,7 +436,7 @@ def ensure_file_handles_closed(file_handles: Sequence[io.TextIOWrapper | None]) 
 
 def _get_processtree_data(
     process: Process,
-) -> Tuple[int, float, Optional[int]]:
+) -> Tuple[int, float, Optional[int], Set[int]]:
     """Obtain the oom_score (the Linux kernel uses this number to
     decide which process to kill first in out-of-memory siturations).
 
@@ -449,6 +456,7 @@ def _get_processtree_data(
     # A value of None means that we have no information.
     memory_rss = 0
     cpu_seconds = 0.0
+    pids = set()
     with contextlib.suppress(ValueError, FileNotFoundError):
         oom_score = int(
             Path(f"/proc/{process.pid}/oom_score").read_text(encoding="utf-8")
@@ -482,10 +490,11 @@ def _get_processtree_data(
                     if oom_score is not None
                     else oom_score_child
                 )
+                pids.add(int(child.pid))
             with (
                 contextlib.suppress(NoSuchProcess, AccessDenied, ZombieProcess),
                 child.oneshot(),
             ):
                 memory_rss += child.memory_info().rss
                 cpu_seconds += child.cpu_times().user
-    return (memory_rss, cpu_seconds, oom_score)
+    return (memory_rss, cpu_seconds, oom_score, pids)

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -175,7 +175,7 @@ class MockedProcess:
 
 
 def test_cpu_seconds_for_process_with_children():
-    (_, cpu_seconds, _) = _get_processtree_data(MockedProcess(123))
+    (_, cpu_seconds, _, _) = _get_processtree_data(MockedProcess(123))
     assert cpu_seconds == 123 / 10.0 + 124 / 10.0
 
 
@@ -189,7 +189,7 @@ def test_oom_score_is_max_over_processtree():
 
     with patch("pathlib.Path.read_text", autospec=True) as mocked_read_text:
         mocked_read_text.side_effect = read_text_side_effect
-        (_, _, oom_score) = _get_processtree_data(MockedProcess(123))
+        (_, _, oom_score, _) = _get_processtree_data(MockedProcess(123))
 
     assert oom_score == 456
 


### PR DESCRIPTION
Related to #9212

**Approach**
Only call process.children(recursive=True) once per report.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
