### PR TITLE
Mark a test as flaky

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -248,6 +248,7 @@ async def test_no_resubmit_on_max_runtime_kill(realization, mock_driver):
     assert retries == 1
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("max_running", [0, 1, 2, 10])
 async def test_max_running(max_running, mock_driver, storage, tmp_path):
     runs: List[bool] = []


### PR DESCRIPTION
This is a very rare occurence, reruns should be sufficient

https://github.com/equinor/komodo-releases/actions/runs/12009208597/job/33474244827

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
