### PR TITLE
Use spawn context for local driver

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -17,6 +17,9 @@ extra_checks = True
 
 exclude = (?x)(src/ert/resources | src/_ert/forward_model_runner)
 
+[mypy-_ert.forward_model_runner.*]
+ignore_errors = True
+
 [mypy-scipy.*]
 ignore_missing_imports = True
 

--- a/src/_ert/forward_model_runner/job_dispatch.py
+++ b/src/_ert/forward_model_runner/job_dispatch.py
@@ -10,11 +10,11 @@ def sigterm_handler(_signo, _stack_frame):
     os.kill(0, signal.SIGTERM)
 
 
-def main():
+def main(argv):
     os.nice(19)
     signal.signal(signal.SIGTERM, sigterm_handler)
     try:
-        job_runner_main(sys.argv)
+        job_runner_main(argv)
     except Exception as e:
         pgid = os.getpgid(os.getpid())
         os.killpg(pgid, signal.SIGTERM)
@@ -22,4 +22,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv)

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -396,7 +396,6 @@ class EnsembleEvaluator:
                 self._server_done.wait(), timeout=self.CLOSE_SERVER_TIMEOUT
             )
         except asyncio.TimeoutError:
-            print("Timeout server done")
             self._server_done.set()
 
     async def _monitor_and_handle_tasks(self) -> None:


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
This makes uncaught exceptions from forward_model_runner propagate, but job_runner_main is already inside a blanket try-catch. When the forward_model_runner exits, it correctly sets the exitcode.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
