### PR TITLE
Simplify ensemble evaluator shutdown timeout

### DIFF
--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -958,7 +958,7 @@ def test_that_connection_errors_do_not_effect_final_result(
     monkeypatch.setattr(Client, "DEFAULT_MAX_RETRIES", 0)
     monkeypatch.setattr(Client, "DEFAULT_TIMEOUT_MULTIPLIER", 0)
     monkeypatch.setattr(Client, "CONNECTION_TIMEOUT", 1)
-    monkeypatch.setattr(EnsembleEvaluator, "CLOSE_SERVER_TIMEOUT", 0)
+    monkeypatch.setattr(EnsembleEvaluator, "CLOSE_SERVER_TIMEOUT", 0.01)
     monkeypatch.setattr(Job, "DEFAULT_CHECKSUM_TIMEOUT", 0)
 
     def raise_connection_error(*args, **kwargs):


### PR DESCRIPTION
The timeout task was not always awaited. F.ex. if an exception was raised. This could cause issues with tests.

**Approach**
Replaced the task with the built-in timeout function of asyncio.wait

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
