### PR TITLE
Fix everest output folder rolling

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -52,15 +52,6 @@ def everest_entry(args=None):
             partial(handle_keyboard_interrupt, options=options),
         )
 
-    # Validate ert config
-    try:
-        _ = everest_to_ert_config(options.config)
-    except ValueError as exc:
-        raise SystemExit(f"Config validation error: {exc}") from exc
-
-    if EverestRunModel.create(options.config).check_if_runpath_exists():
-        warn_user_that_runpath_is_nonempty()
-
     asyncio.run(run_everest(options))
 
 
@@ -116,6 +107,16 @@ async def run_everest(options):
             logger.info("Everest forward model contains job {}".format(job_name))
 
         makedirs_if_needed(options.config.output_dir, roll_if_exists=True)
+
+        # Validate ert config
+        try:
+            _ = everest_to_ert_config(options.config)
+        except ValueError as exc:
+            raise SystemExit(f"Config validation error: {exc}") from exc
+
+        if EverestRunModel.create(options.config).check_if_runpath_exists():
+            warn_user_that_runpath_is_nonempty()
+
         try:
             output_dir = options.config.output_dir
             config_file = options.config.config_file


### PR DESCRIPTION
**Issue**
If ert config is initialized before executing rolling logic we end up with two Everest output folders the current one and an empty rolled one.


**Approach**
Move instances of ert config initialization after rolling logic


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
