### PR TITLE
Log that NUM_CPU was parsed from DATA

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1127,6 +1127,7 @@ def _substitutions_from_dict(config_dict) -> Substitutions:
     num_cpus = config_dict.get("NUM_CPU")
     if num_cpus is None and "DATA_FILE" in config_dict:
         num_cpus = get_num_cpu_from_data_file(config_dict.get("DATA_FILE"))
+        logger.info(f"Parsed NUM_CPU={num_cpus} from DATA-file")
     if num_cpus is None:
         num_cpus = 1
     subst_list["<NUM_CPU>"] = str(num_cpus)


### PR DESCRIPTION
**Issue**
Part of https://github.com/equinor/fmu-ops/issues/14


**Approach**
➕ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
