### PR TITLE
Enforce correct dtypes in migration

### DIFF
--- a/src/ert/storage/migration/to8.py
+++ b/src/ert/storage/migration/to8.py
@@ -77,8 +77,14 @@ def _migrate_responses_from_netcdf_to_parquet(path: Path) -> None:
                             real_dir / f"{ds_name}.nc", engine="scipy"
                         )
 
-                        pandas_df = gen_data_ds.to_dataframe().dropna()
-                        polars_df = polars.from_pandas(pandas_df.reset_index())
+                        pandas_df = gen_data_ds.to_dataframe().dropna().reset_index()
+                        polars_df = polars.from_pandas(
+                            pandas_df,
+                            schema_overrides={
+                                "values": polars.Float32,
+                                "realization": polars.UInt16,
+                            },
+                        )
                         polars_df = polars_df.rename({"name": "response_key"})
 
                         if "time" in polars_df:


### PR DESCRIPTION
Ensures correctly ported dtypes for port, will otherwise lead to downstream errors. Should be backported to 11.1