### PR TITLE
Fix handling '/' in _get_num_cpu

### DIFF
--- a/src/ert/config/_get_num_cpu.py
+++ b/src/ert/config/_get_num_cpu.py
@@ -102,8 +102,8 @@ def _get_num_cpu(
 
     """
     parser = _Parser(lines_iter)
+    slaves_num_cpu = None
     try:
-        slaves_num_cpu = None
         while (words := parser.next_line(None)) is not None:
             if not words:
                 continue
@@ -177,6 +177,18 @@ def _split_line(line: str) -> Iterator[str]:
 
     >>> list(_split_line("3 1.0 3*4 PORO 3*INC 'HELLO WORLD ' 3*'NAME'"))
     ['3', '1.0', '3*4', 'PORO', '3*INC', 'HELLO WORLD ', '3*', 'NAME']
+    >>> list(_split_line("KEYWORD 3.14/"))
+    ['KEYWORD', '3.14', '/']
+    >>> list(_split_line("KEYWORD '3.14/'"))
+    ['KEYWORD', '3.14/']
+    >>> list(_split_line("KEYWORD '3.14'/"))
+    ['KEYWORD', '3.14', '/']
+    >>> list(_split_line("ALLPROPS/"))
+    ['ALLPROPS', '/']
+    >>> list(_split_line("ALLPROPS -- A comment"))
+    ['ALLPROPS']
+    >>> list(_split_line("ALLPROPS / Also a comment"))
+    ['ALLPROPS', '/']
     """
     value = ""
     inside_str = None
@@ -198,6 +210,13 @@ def _split_line(line: str) -> Iterator[str]:
         elif value and value[-1] == "-" and char == "-":
             # a comment
             value = value[0:-1]
+            break
+        elif char == "/":
+            # End of statement
+            if value:
+                yield value
+                value = ""
+            yield "/"
             break
         elif char.isspace():
             # delimiting space


### PR DESCRIPTION
**Issue**
Resolves #9369 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
