### PR TITLE
Fix the azure logging handler in Everest

### DIFF
--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -50,8 +50,6 @@ from everest.strings import (
 )
 from everest.util import get_azure_logging_handler, makedirs_if_needed, version_info
 
-azure_handler = get_azure_logging_handler()
-
 
 def _get_machine_name() -> str:
     """Returns a name that can be used to identify this machine in a network
@@ -210,6 +208,12 @@ def _configure_loggers(detached_dir: Path, log_dir: Path, logging_level: int) ->
             "filename": path,
         }
 
+    def azure_handler():
+        azure_handler = get_azure_logging_handler()
+        if azure_handler:
+            return azure_handler
+        return logging.NullHandler()
+
     logging_config = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -221,25 +225,19 @@ def _configure_loggers(detached_dir: Path, log_dir: Path, logging_level: int) ->
             "forward_models": make_handler_config(
                 log_dir / "forward_models.log", logging_level
             ),
+            "azure_handler": {"()": azure_handler},
         },
         "loggers": {
             "": {"handlers": ["root"], "level": "NOTSET"},
             "res": {"handlers": ["res"]},
             "everserver": {"handlers": ["everserver"]},
-            "everest": {"handlers": ["everest"]},
+            "everest": {"handlers": ["everest", "azure_handler"]},
             "forward_models": {"handlers": ["forward_models"]},
         },
         "formatters": {
             "default": {"format": DEFAULT_LOGGING_FORMAT},
         },
     }
-
-    if azure_handler:
-        logging_config["handlers"]["azure"] = {
-            "class": "everest.detached.jobs.everserver.azure_handler",
-            "level": logging_level,
-        }
-        logging_config["loggers"]["everest"]["handlers"].append("azure")
 
     logging.config.dictConfig(logging_config)
 

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -50,6 +50,8 @@ from everest.strings import (
 )
 from everest.util import get_azure_logging_handler, makedirs_if_needed, version_info
 
+azure_handler = get_azure_logging_handler()
+
 
 def _get_machine_name() -> str:
     """Returns a name that can be used to identify this machine in a network
@@ -232,10 +234,9 @@ def _configure_loggers(detached_dir: Path, log_dir: Path, logging_level: int) ->
         },
     }
 
-    azure_handler = get_azure_logging_handler()
     if azure_handler:
         logging_config["handlers"]["azure"] = {
-            "class": "azure_handler",
+            "class": "everest.detached.jobs.everserver.azure_handler",
             "level": logging_level,
         }
         logging_config["loggers"]["everest"]["handlers"].append("azure")


### PR DESCRIPTION
**Issue**
The azure logging handler in Everest was broken by a recent change.

**Approach**
The handler string should point to an accessible function, made the handler a global in the everserver module and adjusted the log config accordingly.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
