### PR TITLE
Update ropt to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,8 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.9,<0.10",
-    "ropt-dakota>=0.9,<0.10",
+    "ropt[pandas]>=0.1,<0.11",
+    "ropt-dakota>=0.1,<0.11",
     "seba-sqlite",
 ]
 

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -660,7 +660,7 @@ class EverestRunModel(BaseRunModel):
 
         objectives = self._get_active_results(
             results,
-            metadata.config.objective_functions.names,  # type: ignore
+            metadata.config.objectives.names,  # type: ignore
             control_values,
             active,
         )

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -472,9 +472,7 @@ def _parse_optimization(
             constraint_count = len(
                 ropt_config.get("nonlinear_constraints", {}).get("names", [])
             )
-            ropt_config["objectives"]["realization_filters"] = (
-                objective_count * [0]
-            )
+            ropt_config["objectives"]["realization_filters"] = objective_count * [0]
             if constraint_count > 0:
                 ropt_config["nonlinear_constraints"]["realization_filters"] = (
                     constraint_count * [0]

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -278,7 +278,7 @@ def _parse_objectives(objective_functions: List[ObjectiveFunctionConfig], ropt_c
             transforms.append({"method": objective_type})
         transform_indices.append(transform_idx)
 
-    ropt_config["objective_functions"] = {
+    ropt_config["objectives"] = {
         "names": names,
         "weights": weights,
         "scales": scales,
@@ -286,7 +286,7 @@ def _parse_objectives(objective_functions: List[ObjectiveFunctionConfig], ropt_c
     }
     if transforms:
         # Only needed if we specified at least one objective type:
-        ropt_config["objective_functions"]["function_transforms"] = transform_indices
+        ropt_config["objectives"]["function_transforms"] = transform_indices
         ropt_config["function_transforms"] = transforms
 
 
@@ -468,11 +468,11 @@ def _parse_optimization(
             # indices to any realization filters that should be applied. In this
             # case, we want all objectives and constraints to refer to the same
             # filter implementing cvar:
-            objective_count = len(ropt_config["objective_functions"]["names"])
+            objective_count = len(ropt_config["objectives"]["names"])
             constraint_count = len(
                 ropt_config.get("nonlinear_constraints", {}).get("names", [])
             )
-            ropt_config["objective_functions"]["realization_filters"] = (
+            ropt_config["objectives"]["realization_filters"] = (
                 objective_count * [0]
             )
             if constraint_count > 0:

--- a/tests/everest/test_multiobjective.py
+++ b/tests/everest/test_multiobjective.py
@@ -89,12 +89,12 @@ def test_multi_objectives2ropt(copy_mocked_test_data_to_tmp):
     enopt_config = EnOptConfig.model_validate(
         everest2ropt(EverestConfig.model_validate(config_dict))
     )
-    assert len(enopt_config.objective_functions.names) == 2
-    assert enopt_config.objective_functions.names[1] == ever_objs[1]["name"]
-    assert enopt_config.objective_functions.weights[1] == ever_objs[1]["weight"] / norm
-    assert enopt_config.objective_functions.names[0] == ever_objs[0]["name"]
-    assert enopt_config.objective_functions.weights[0] == ever_objs[0]["weight"] / norm
-    assert enopt_config.objective_functions.scales[0] == ever_objs[0]["normalization"]
+    assert len(enopt_config.objectives.names) == 2
+    assert enopt_config.objectives.names[1] == ever_objs[1]["name"]
+    assert enopt_config.objectives.weights[1] == ever_objs[1]["weight"] / norm
+    assert enopt_config.objectives.names[0] == ever_objs[0]["name"]
+    assert enopt_config.objectives.weights[0] == ever_objs[0]["weight"] / norm
+    assert enopt_config.objectives.scales[0] == ever_objs[0]["normalization"]
 
 
 @pytest.mark.integration_test

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -206,7 +206,7 @@ def test_everest2ropt_cvar():
 
     ropt_config = everest2ropt(EverestConfig.model_validate(config_dict))
 
-    assert ropt_config.objective_functions.realization_filters == [0]
+    assert ropt_config.objectives.realization_filters == [0]
     assert len(ropt_config.realization_filters) == 1
     assert ropt_config.realization_filters[0].method == "sort-objective"
     assert ropt_config.realization_filters[0].options["sort"] == [0]
@@ -218,7 +218,7 @@ def test_everest2ropt_cvar():
     }
 
     ropt_config = everest2ropt(EverestConfig.model_validate(config_dict))
-    assert ropt_config.objective_functions.realization_filters == [0]
+    assert ropt_config.objectives.realization_filters == [0]
     assert len(ropt_config.realization_filters) == 1
     assert ropt_config.realization_filters[0].method == "cvar-objective"
     assert ropt_config.realization_filters[0].options["sort"] == [0]


### PR DESCRIPTION
**Issue**
Update to `ropt==0.10.0`.

There are two breaking changes that my affect existing PRs:
- In the ropt configuration `objective_functions` has been renamed to `objectives`
- The `to_dataframe` method of result objects now take only a single argument, the name of the field to export. The `config` argument has been removed.

After merging, a PR in Komodo will be submitted to update bleeding.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
