### PR TITLE
Have ErtStorageExceptions not be unexpected in cli

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -36,6 +36,7 @@ from ert.plugins import ErtPluginContext, ErtPluginManager
 from ert.run_models.multiple_data_assimilation import MultipleDataAssimilation
 from ert.services import StorageService, WebvizErt
 from ert.shared.storage.command import add_parser_options as ert_api_add_parser_options
+from ert.storage import ErtStorageException
 from ert.trace import trace, tracer, tracer_provider
 from ert.validation import (
     IntegerArgument,
@@ -673,7 +674,7 @@ def main() -> None:
         ) as context:
             logger.info(f"Running ert with {args}")
             args.func(args, context.plugin_manager)
-    except ErtCliError as err:
+    except (ErtCliError, ErtStorageException) as err:
         span.set_status(Status(StatusCode.ERROR))
         span.record_exception(err)
         logger.debug(str(err))


### PR DESCRIPTION
This commits makes ErtStorageExceptions not be output as "unexpected error" in cli.

**Issue**
Resolves #9223 


**Approach**
This PR improves the way ErtStorageExceptions are handled and displayed in the cli. Prior to this PR, ErtStorageExceptions were "unexpected" in the cli. 
How it was before this change:
```
(py312-arm-venv) arm64 ➜  ert git:(fix-storag) ✗ ert ensemble_experiment test-data/ert/snake_oil/snake_oil.ert
Config contains a SUMMARY key but no forward model steps known to generate a summary file
ERT crashed unexpectedly with "Failed to open storage: /Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/snake_oil/storage/snake_oil/ensemble with error: Not able to acquire lock for: /Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/snake_oil/storage/snake_oil/ensemble. You may already be running ERT, or another user is using the same ENSPATH.".
See logfile(s) for details:
   /Users/JONAK/Documents/FMU/SCOUT/ert/logs/ert-log-snake_oil-ert-2024-12-02T1300.txt
```
(Screenshot of new behavior in GUI if applicable)
```
(py312-arm-venv) arm64 ➜  ert git:(fix-storag) ✗ ert ensemble_experiment test-data/ert/snake_oil/snake_oil.ert
Config contains a SUMMARY key but no forward model steps known to generate a summary file
Failed to open storage: /Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/snake_oil/storage/snake_oil/ensemble with error: Not able to acquire lock for: /Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/snake_oil/storage/snake_oil/ensemble. You may already be running ERT, or another user is using the same ENSPATH.
```
This is now more similar to how it is output in the gui:
![image](https://github.com/user-attachments/assets/37dc5bb7-c282-4a09-b0cb-c6036429bd09)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
