### PR TITLE
Have ModelConfig output better warning when malformatted runpath

### DIFF
--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -8,7 +8,13 @@ from typing import List, Optional, no_type_check
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass
 
-from .parsing import ConfigDict, ConfigKeys, ConfigValidationError, HistorySource
+from .parsing import (
+    ConfigDict,
+    ConfigKeys,
+    ConfigValidationError,
+    ConfigWarning,
+    HistorySource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,11 +76,13 @@ class ModelConfig:
             )
         result = _replace_runpath_format(runpath_format_string)
         if not any(x in result for x in ["<ITER>", "<IENS>"]):
-            logger.warning(
+            msg = (
                 "RUNPATH keyword contains no value placeholders: "
                 f"`{runpath_format_string}`. Valid example: "
                 f"`{DEFAULT_RUNPATH}` "
             )
+            ConfigWarning.warn(msg)
+            logger.warning(msg)
         return result
 
     @field_validator("jobname_format_string", mode="before")

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1852,3 +1852,20 @@ def test_no_warning_when_summary_key_and_simulation_job_present(job_name, key):
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=ConfigWarning)
         ErtConfig.from_file("config_file.ert")
+
+
+def test_warning_is_emitted_when_malformatted_runpath(tmp_path):
+    config_path = tmp_path / "config_file.ert"
+    with open(config_path, "w", encoding="utf-8") as fout:
+        # Write a minimal config file
+        fout.write(
+            "RUNPATH <STORAGE>/runpath/constant-realization-num/constant-iter-num\n"
+        )
+        fout.write("NUM_REALIZATIONS 1\n")
+    with warnings.catch_warnings(record=True) as all_warnings:
+        ErtConfig.from_file(config_path)
+    assert any(
+        ("RUNPATH keyword contains no value placeholders" in str(w.message))
+        for w in all_warnings
+        if isinstance(w.message, ConfigWarning)
+    )


### PR DESCRIPTION
**Issue**
Resolves #9313 


**Approach**
This commit makes ModelConfig emit a ConfigWarning if the input runpath does not contain `<ITER>` or `<IENS>`. This was previously only a warning in the logs, but it should be more noticable.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/b80aa076-49d0-44e4-96c8-7e67955a6620)
```
(py312-arm-venv) arm64 ➜  ert git:(improve-runpath-validation) ✗ ert ensemble_experiment test-data/ert/snake_oil/snake_oil.ert --disable-monitor
RUNPATH keyword contains no value placeholders: `/Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/snake_oil/storage/snake_oil/runpath/realization-IENS/iter-ITER`. Valid example: `simulations/realization-<IENS>/iter-<ITER>` 
Config contains a SUMMARY key but no forward model steps known to generate a summary file
Warning: ERT is running in an existing runpath.
Please be aware of the following:
- Previously generated results might be overwritten.
- Previously generated files might be used if not configured correctly.
- 1 out of 25 realizations are running in existing runpaths.

(py312-arm-venv) arm64 ➜  ert git:(improve-runpath-validation) ✗ 
```

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
