### PR TITLE
Use forkserver instead of fork for multiprocessing

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import locale
 import logging
 import logging.config
+import multiprocessing
 import os
 import re
 import resource
@@ -706,4 +707,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    if (
+        sys.platform == "linux"
+        and multiprocessing.get_start_method(allow_none=True) != "forkserver"
+    ):
+        multiprocessing.set_start_method("forkserver")
     main()

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -1,5 +1,6 @@
 import fileinput
 import logging
+import multiprocessing
 import os
 import resource
 import shutil
@@ -485,3 +486,12 @@ def no_cert_in_test(monkeypatch):
             super().__init__(*args, **kwargs)
 
     monkeypatch.setattr("ert.cli.main.EvaluatorServerConfig", MockESConfig)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_multiprocessing_method():
+    if (
+        sys.platform == "linux"
+        and multiprocessing.get_start_method(allow_none=True) != "forkserver"
+    ):
+        multiprocessing.set_start_method("forkserver")


### PR DESCRIPTION
Polars gives warnings if using fork.
preexec_fn in create_subprocess_exec is unsafe using fork.
python 3.14 will set forkserver as default on linux/bsd.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
