### PR TITLE
Make local_driver use start_new_session when spawning children

### DIFF
--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import os
 import signal
 from asyncio.subprocess import Process
 from contextlib import suppress
@@ -106,7 +105,7 @@ class LocalDriver(Driver):
         return await asyncio.create_subprocess_exec(
             executable,
             *args,
-            preexec_fn=os.setpgrp,
+            start_new_session=True,
         )
 
     @staticmethod


### PR DESCRIPTION
This makes it more in line with lsf driver.
preexec_fn can also deadlock when using fork method for multiprocessing module.

**Approach**
Replaced preexec_fn with start_new_session


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
