### PR TITLE
Fix typing in test

### DIFF
--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -280,7 +280,7 @@ def test_num_cpu_is_propagated_from_config_to_ensemble(run_args):
 def test_get_current_status(
     initial_active_realizations,
     new_active_realizations,
-    real_status_dict: dict[str, str],
+    real_status_dict,
     expected_result,
 ):
     """Active realizations gets changed when we choose to rerun, and the result from the previous run should be included in the current_status."""


### PR DESCRIPTION

**Approach**
This commit fixes the issue where some typing in a test is non py3.8 compatible
(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
