### PR TITLE
Improve UX for permission errors in storage

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -303,7 +303,10 @@ class LegacyEnsemble:
 
             self._scheduler.add_dispatch_information_to_jobs_file()
             result = await self._scheduler.execute(min_required_realizations)
-
+        except PermissionError as error:
+            logger.exception((f"Unexpected exception in ensemble: \n {error!s}"))
+            await event_unary_send(event_creator(Id.ENSEMBLE_FAILED))
+            return
         except Exception as exc:
             logger.exception(
                 (

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -89,6 +89,8 @@ class PlotApi:
 
     @staticmethod
     def _check_response(response: httpx._models.Response) -> None:
+        if response.status_code == httpx.codes.UNAUTHORIZED:
+            raise httpx.RequestError(message=f"{response.text}")
         if response.status_code != httpx.codes.OK:
             raise httpx.RequestError(
                 f" Please report this error and try restarting the application."

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -121,7 +121,7 @@ def plotHistogram(
         if use_log_scale:
             axes[ensemble.name].set_xscale("log")
 
-        if not data[ensemble.name].empty:
+        if ensemble.name in data and not data[ensemble.name].empty:
             if categorical:
                 config.addLegendItem(
                     ensemble.name,


### PR DESCRIPTION
**Issue**
Resolves #9169 


**Approach**
The commit in this PR:
* Improves the error message displayed when the dark storage server does not have access to the storage path.
* Makes the dark storage server return a response with status code 401 - unauthorized when the `get_ensemble_record` endpoint fails due to `PermissionError`.
* Makes the failed message in `LegacyEnsemble._evaluate_inner` omit stacktrace when it failed due to PermissionError, making it shorter and more consise.

(Screenshot of new behavior in GUI if applicable)
The new error message in the gui is more useful to the user:
![image](https://github.com/user-attachments/assets/1ab0acf2-6050-4de9-8fce-abf12a169e80)

The new error message in the logs:
```
2024-12-03 12:30:20,275 - ert.gui.tools.plot.plot_window - MainThread - ERROR - plot api request failed: {"detail":"[Errno 13] Permission denied: '/Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/poly_example/storage/ensembles/9fe766dc-d2c7-4b4c-8109-de03ad179a08/realization-0/COEFFS.nc'"}
Traceback (most recent call last):
  File "/Users/JONAK/Documents/FMU/SCOUT/ert/src/ert/gui/tools/plot/plot_window.py", line 191, in updatePlot
    ensemble_to_data_map[ensemble] = self._api.data_for_key(
                                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/JONAK/Documents/FMU/SCOUT/ert/src/ert/gui/tools/plot/plot_api.py", line 177, in data_for_key
    self._check_response(response)
  File "/Users/JONAK/Documents/FMU/SCOUT/ert/src/ert/gui/tools/plot/plot_api.py", line 93, in _check_response
    raise httpx.RequestError(message=f"{response.text}")
httpx.RequestError: {"detail":"[Errno 13] Permission denied: '/Users/JONAK/Documents/FMU/SCOUT/ert/test-data/ert/poly_example/storage/ensembles/9fe766dc-d2c7-4b4c-8109-de03ad179a08/realization-0/COEFFS.nc'"}
```


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
