### PR TITLE
Revert "Use uvloop for asyncio"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ dependencies = [
     "tabulate",
     "tqdm>=4.62.0",
     "typing_extensions>=4.5",
-    "uvloop",
     "uvicorn >= 0.17.0",
     "websockets",
     "xarray",

--- a/src/_ert/async_utils.py
+++ b/src/_ert/async_utils.py
@@ -4,9 +4,7 @@ import asyncio
 import logging
 import traceback
 from contextlib import suppress
-from typing import Any, Coroutine, Generator, Mapping, TypeVar, Union
-
-import uvloop
+from typing import Any, Coroutine, Generator, TypeVar, Union
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +13,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 def new_event_loop() -> asyncio.AbstractEventLoop:
-    loop = uvloop.new_event_loop()
+    loop = asyncio.new_event_loop()
     loop.set_task_factory(_create_task)
     return loop
 
@@ -32,10 +30,9 @@ def get_running_loop() -> asyncio.AbstractEventLoop:
 def _create_task(
     loop: asyncio.AbstractEventLoop,
     coro: Union[Coroutine[Any, Any, _T], Generator[Any, None, _T]],
-    **kwargs: Mapping[str, Any],
 ) -> asyncio.Task[_T]:
     assert asyncio.iscoroutine(coro)
-    task = asyncio.Task(coro, loop=loop, **kwargs)  # type: ignore
+    task = asyncio.Task(coro, loop=loop)
     task.add_done_callback(_done_callback)
     return task
 

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -13,7 +13,6 @@ from argparse import ArgumentParser, ArgumentTypeError
 from typing import Any, Dict, Optional, Sequence, Union
 from uuid import UUID
 
-import uvloop
 import yaml
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.trace import Status, StatusCode
@@ -636,7 +635,6 @@ def log_process_usage() -> None:
 
 @tracer.start_as_current_span("ert.application.start")
 def main() -> None:
-    uvloop.install()
     span = trace.get_current_span()
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     locale.setlocale(locale.LC_NUMERIC, "C")


### PR DESCRIPTION
This reverts commit d11ba38bd8f93808ae60d320e03ab10725294dec.
This was done due to issues with uvloop when attempting to use uvloop for our tests.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
