### PR TITLE
Fix some warnings

### DIFF
--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -8,7 +8,7 @@ import tempfile
 import typing
 import warnings
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 from cryptography import x509
@@ -71,8 +71,8 @@ def _generate_certificate(
         .issuer_name(issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))  # 1 year
+        .not_valid_before(datetime.now(UTC))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=365))  # 1 year
         .add_extension(
             x509.SubjectAlternativeName(
                 [

--- a/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -23,7 +23,7 @@ def _mock_ws(host, port, messages, delay_startup=0):
     loop = new_event_loop()
     done = loop.create_future()
 
-    async def _handler(websocket, path):
+    async def _handler(websocket):
         while True:
             msg = await websocket.recv()
             messages.append(msg)

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -186,7 +186,7 @@ def test_plot_api_request_errors(api):
 def api_and_storage(monkeypatch, tmp_path):
     with open_storage(tmp_path / "storage", mode="w") as storage:
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
-        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", storage.path)
+        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
         api = PlotApi()
         yield api, storage
     if enkf._storage is not None:


### PR DESCRIPTION
This fixes a few warnings from our unit tests

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
