### PR TITLE
Add missing params to TorqueQueueOptions when creating Everest server

### DIFF
--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -302,7 +302,11 @@ def get_server_queue_options(
             partition=ever_queue_config.name,
         )
     elif queue_system == QueueSystem.TORQUE:
-        queue = TorqueQueueOptions(activate_script=script)
+        queue = TorqueQueueOptions(
+            activate_script=script,
+            queue=ever_queue_config.name,
+            keep_qsub_output=ever_queue_config.keep_qsub_output,
+        )
     elif queue_system == QueueSystem.LOCAL:
         queue = LocalQueueOptions()
     else:

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -12,6 +12,7 @@ from ert.config.queue_config import (
     LocalQueueOptions,
     LsfQueueOptions,
     SlurmQueueOptions,
+    TorqueQueueOptions,
     activate_script,
 )
 from ert.scheduler.event import FinishedEvent
@@ -197,8 +198,10 @@ def test_detached_mode_config_base(copy_math_func_test_data_to_tmp):
     [
         ("lsf", 2, None),
         ("slurm", 4, None),
+        ("torque", 6, None),
         ("lsf", 3, "test_lsf"),
         ("slurm", 5, "test_slurm"),
+        ("torque", 7, "test_torque"),
     ],
 )
 def test_everserver_queue_config_equal_to_run_config(
@@ -301,6 +304,14 @@ def test_generate_queue_options_no_config():
         (
             {"options": "ever_opt_1", "queue_system": "lsf"},
             LsfQueueOptions(max_running=1, lsf_resource="ever_opt_1"),
+        ),
+        (
+            {
+                "options": "ever_opt_1",
+                "queue_system": "torque",
+                "keep_qsub_output": "1",
+            },
+            TorqueQueueOptions(max_running=1, keep_qsub_output=True),
         ),
     ],
 )


### PR DESCRIPTION
**Issue**
Resolves #9430


**Approach**
Added the parameters `queue` and `keep_qsub_output` to `TorqueQueueOptions` when creating the Everest server.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
