### PR TITLE
Fix ForwardModels stuck in Running-state when event is lost

### DIFF
--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -67,7 +67,6 @@ class Event(Reporter):
                 self._cert = f.read()
         else:
             self._cert = None
-
         self._statemachine = StateMachine()
         self._statemachine.add_handler((Init,), self._init_handler)
         self._statemachine.add_handler((Start, Running, Exited), self._job_handler)
@@ -163,6 +162,7 @@ class Event(Reporter):
             if msg.success():
                 logger.debug(f"Job {job_name} exited successfully")
                 self._dump_event(ForwardModelStepSuccess(**job_msg))
+
             else:
                 logger.error(
                     _JOB_EXIT_FAILED_STRING.format(

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -298,7 +298,7 @@ async def test_new_monitor_can_pick_up_where_we_left_off(evaluator_to_use):
                 )
                 assert (
                     snapshot.get_fm_step("1", "0")["status"]
-                    == FORWARD_MODEL_STATE_RUNNING
+                    == FORWARD_MODEL_STATE_FINISHED
                 )
                 assert (
                     snapshot.get_fm_step("1", "1")["status"]

--- a/tests/ert/unit_tests/test_tracking.py
+++ b/tests/ert/unit_tests/test_tracking.py
@@ -118,7 +118,7 @@ def check_expression(original, path_expression, expected, msg_start):
         ),
         pytest.param(
             "",
-            '    import os\n    if os.getcwd().split("/")[-2].split("-")[1] == "0": sys.exit(1)',
+            '    import os, sys\n    if os.getcwd().split("/")[-2].split("-")[1] == "0": sys.exit(1)',
             [
                 ENSEMBLE_SMOOTHER_MODE,
                 "--realizations",


### PR DESCRIPTION
**Issue**
Resolves [#9422](https://github.com/equinor/ert/issues/9422)


**Approach**
This commit in this PR makes snapshots overwrite non-finalized states for
forwardmodels if the next forwardmodel has started. This will avoid
forwardmodels being stuck in running/pending if an event is lost. This
is a safe assumption as no forwardmodel will start running before the
previous one has finished successfully.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
