### PR TITLE
Add conda support to activation script

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -29,9 +29,12 @@ NonEmptyString = Annotated[str, pydantic.StringConstraints(min_length=1)]
 
 def activate_script() -> str:
     venv = os.environ.get("VIRTUAL_ENV")
-    if not venv:
-        return ""
-    return f"source {venv}/bin/activate"
+    if venv:
+        return f"source {venv}/bin/activate"
+    conda_env = os.environ.get("CONDA_ENV")
+    if conda_env:
+        return f'eval "$(conda shell.bash hook)" && conda activate {conda_env}'
+    return ""
 
 
 @pydantic.dataclasses.dataclass(config={"extra": "forbid", "validate_assignment": True})

--- a/tests/ert/unit_tests/config/test_queue_config.py
+++ b/tests/ert/unit_tests/config/test_queue_config.py
@@ -522,3 +522,26 @@ def test_default_activate_script_generation(expected, monkeypatch, venv):
         monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     options = QueueOptions(name="local")
     assert options.activate_script == expected
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ("my_env", 'eval "$(conda shell.bash hook)" && conda activate my_env'),
+    ],
+)
+def test_conda_activate_script_generation(expected, monkeypatch, env):
+    monkeypatch.setenv("CONDA_ENV", env)
+    options = QueueOptions(name="local")
+    assert options.activate_script == expected
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [("my_env", "source my_env/bin/activate")],
+)
+def test_multiple_activate_script_generation(expected, monkeypatch, env):
+    monkeypatch.setenv("VIRTUAL_ENV", env)
+    monkeypatch.setenv("CONDA_ENV", env)
+    options = QueueOptions(name="local")
+    assert options.activate_script == expected


### PR DESCRIPTION
**Issue**
Resolves #9435


**Approach**
If `VIRTUAL_ENV` environment variable is not set, the `CONDA_ENV` variable is read.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
