### PR TITLE
Name job after its executable when not specified

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -49,7 +49,7 @@ class Driver(ABC):
         executable: str,
         /,
         *args: str,
-        name: str = "dummy",
+        name: str | None = None,
         runpath: Path | None = None,
         num_cpu: int | None = 1,
         realization_memory: int | None = 0,

--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -29,7 +29,7 @@ class LocalDriver(Driver):
         executable: str,
         /,
         *args: str,
-        name: str = "dummy",
+        name: str | None = None,
         runpath: Path | None = None,
         num_cpu: int | None = 1,
         realization_memory: int | None = 0,

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -292,13 +292,15 @@ class LsfDriver(Driver):
         executable: str,
         /,
         *args: str,
-        name: str = "dummy",
+        name: str | None = None,
         runpath: Path | None = None,
         num_cpu: int | None = 1,
         realization_memory: int | None = 0,
     ) -> None:
         if runpath is None:
             runpath = Path.cwd()
+        if name is None:
+            name = Path(executable).name
 
         arg_queue_name = ["-q", self._queue_name] if self._queue_name else []
         arg_project_code = ["-P", self._project_code] if self._project_code else []

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -215,13 +215,15 @@ class OpenPBSDriver(Driver):
         executable: str,
         /,
         *args: str,
-        name: str = "dummy",
+        name: str | None = None,
         runpath: Path | None = None,
         num_cpu: int | None = 1,
         realization_memory: int | None = 0,
     ) -> None:
         if runpath is None:
             runpath = Path.cwd()
+        if name is None:
+            name = Path(executable).name
 
         arg_queue_name = ["-q", self._queue_name] if self._queue_name else []
         arg_project_code = ["-A", self._project_code] if self._project_code else []

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -155,13 +155,15 @@ class SlurmDriver(Driver):
         executable: str,
         /,
         *args: str,
-        name: str = "dummy",
+        name: str | None = None,
         runpath: Path | None = None,
         num_cpu: int | None = 1,
         realization_memory: int | None = 0,
     ) -> None:
         if runpath is None:
             runpath = Path.cwd()
+        if name is None:
+            name = Path(executable).name
 
         script = create_submit_script(runpath, executable, args, self.activate_script)
         script_path: Path | None = None

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1167,6 +1167,13 @@ async def test_submit_with_resource_requirement_with_bsub_capture():
     assert "hname" not in Path("captured_bsub_args").read_text(encoding="utf-8")
 
 
+@pytest.mark.usefixtures("capturing_bsub")
+async def test_empty_job_name():
+    driver = LsfDriver()
+    await driver.submit(0, "/bin/sleep")
+    assert " -J sleep " in Path("captured_bsub_args").read_text(encoding="utf-8")
+
+
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 async def test_submit_with_num_cpu(pytestconfig, job_name):

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -166,6 +166,13 @@ async def test_job_name():
 
 
 @pytest.mark.usefixtures("capturing_qsub")
+async def test_empty_job_name():
+    driver = OpenPBSDriver()
+    await driver.submit(0, "/bin/sleep")
+    assert " -Nsleep " in Path("captured_qsub_args").read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("capturing_qsub")
 async def test_job_name_with_prefix():
     driver = OpenPBSDriver(job_prefix="pre_")
     await driver.submit(0, "sleep", name="sleepy")

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -145,6 +145,15 @@ async def test_project_code_is_set(project_code):
 
 
 @pytest.mark.usefixtures("capturing_sbatch")
+async def test_empty_job_name():
+    driver = SlurmDriver()
+    await driver.submit(0, "/bin/sleep")
+    assert "--job-name=sleep" in Path("captured_sbatch_args").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.usefixtures("capturing_sbatch")
 @given(max_runtime=st.floats(min_value=1, max_value=999999999))
 async def test_max_runtime_is_properly_formatted(max_runtime):
     # According to https://slurm.schedmd.com/sbatch.html we accept the formats


### PR DESCRIPTION
**Issue**
Resolves #9437


**Approach**
When the parameter `name` of `driver.submit()` is not set, replace it with the executable name.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
