### PR TITLE
Improve exit code detection in the slurm driver

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -1828,9 +1828,9 @@ in :ref:`queue-system-chapter`. In brief, the queue systems have the following o
   ``QSTAT_OPTIONS``, ``QUEUE``, ``CLUSTER_LABEL``, ``MAX_RUNNING``, ``NUM_NODES``,
   ``NUM_CPUS_PER_NODE``, ``MEMORY_PER_JOB``, ``KEEP_QSUB_OUTPUT``, ``SUBMIT_SLEEP``,
   ``QUEUE_QUERY_TIMEOUT``
-* :ref:`SLURM <slurm-systems>` — ``SBATCH``, ``SCANCEL``, ``SCONTROL``, ``SQUEUE``,
-  ``PARTITION``, ``SQUEUE_TIMEOUT``, ``MAX_RUNTIME``, ``MEMORY``, ``MEMORY_PER_CPU``,
-  ``INCLUDE_HOST``, ``EXCLUDE_HOST``, ``MAX_RUNNING``
+* :ref:`SLURM <slurm-systems>` — ``SBATCH``, ``SCANCEL``, ``SCONTROL``, ``SACCT``,
+  ``SQUEUE``, ``PARTITION``, ``SQUEUE_TIMEOUT``, ``MAX_RUNTIME``, ``MEMORY``,
+  ``MEMORY_PER_CPU``, ``INCLUDE_HOST``, ``EXCLUDE_HOST``, ``MAX_RUNNING``
 
 In addition, some options apply to all queue systems:
 

--- a/docs/ert/reference/configuration/queue.rst
+++ b/docs/ert/reference/configuration/queue.rst
@@ -416,6 +416,11 @@ only the most necessary options have been added.
 
   Command to modify configuration and state, default ``scontrol``.
 
+.. _slurm_sacct:
+.. topic:: SACCT
+
+  Command used when ``scontrol`` fails, default ``sacct``.
+
 .. _slurm_squeue:
 .. topic:: SQUEUE
 

--- a/docs/everest/config_generated.rst
+++ b/docs/everest/config_generated.rst
@@ -986,6 +986,12 @@ Simulation settings
     scontrol executable to be used by the slurm queue interface.
 
 
+**sacct (optional)**
+    Type: *Optional[str]*
+
+    sacct executable to be used by the slurm queue interface.
+
+
 **squeue (optional)**
     Type: *Optional[str]*
 

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -162,6 +162,7 @@ class SlurmQueueOptions(QueueOptions):
     sbatch: NonEmptyString = "sbatch"
     scancel: NonEmptyString = "scancel"
     scontrol: NonEmptyString = "scontrol"
+    sacct: NonEmptyString = "sacct"
     squeue: NonEmptyString = "squeue"
     exclude_host: str = ""
     include_host: str = ""
@@ -178,6 +179,7 @@ class SlurmQueueOptions(QueueOptions):
         driver_dict["sbatch_cmd"] = driver_dict.pop("sbatch")
         driver_dict["scancel_cmd"] = driver_dict.pop("scancel")
         driver_dict["scontrol_cmd"] = driver_dict.pop("scontrol")
+        driver_dict["sacct_cmd"] = driver_dict.pop("sacct")
         driver_dict["squeue_cmd"] = driver_dict.pop("squeue")
         driver_dict["exclude_hosts"] = driver_dict.pop("exclude_host")
         driver_dict["include_hosts"] = driver_dict.pop("include_host")

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -67,6 +67,7 @@ class SlurmDriver(Driver):
         include_hosts: str = "",
         squeue_cmd: str = "squeue",
         scontrol_cmd: str = "scontrol",
+        sacct_cmd: str = "sacct",
         scancel_cmd: str = "scancel",
         sbatch_cmd: str = "sbatch",
         user: Optional[str] = None,
@@ -119,6 +120,7 @@ class SlurmDriver(Driver):
         self._squeue = squeue_cmd
 
         self._scontrol = scontrol_cmd
+        self._sacct = sacct_cmd
         self._scontrol_cache_timestamp = 0.0
         self._scontrol_required_cache_age = 30
         self._scontrol_cache: dict[str, ScontrolInfo] = {}
@@ -367,6 +369,18 @@ class SlurmDriver(Driver):
         ) and missing_job_id in self._scontrol_cache:
             return self._scontrol_cache[missing_job_id]
 
+        info = await self._run_scontrol(missing_job_id)
+        if info is None:
+            logger.error("scontrol failed, trying sacct")
+            info = await self._run_sacct(missing_job_id)
+        if info is None:
+            return None
+
+        self._scontrol_cache[missing_job_id] = info
+        self._scontrol_cache_timestamp = time.time()
+        return info
+
+    async def _run_scontrol(self, missing_job_id: str) -> Optional[ScontrolInfo]:
         process = await asyncio.create_subprocess_exec(
             self._scontrol,
             "show",
@@ -384,17 +398,47 @@ class SlurmDriver(Driver):
             )
             return None
 
-        info = None
         try:
-            info = _parse_scontrol_output(stdout.decode(errors="ignore"))
+            return _parse_scontrol_output(stdout.decode(errors="ignore"))
         except Exception as err:
             logger.error(
-                f"Could no parse scontrol stdout {stdout.decode(errors='ignore')}: {err}"
+                f"Could not parse scontrol stdout {stdout.decode(errors='ignore')}: {err}"
             )
-            return info
-        self._scontrol_cache[missing_job_id] = info
-        self._scontrol_cache_timestamp = time.time()
-        return info
+        return None
+
+    async def _run_sacct(self, missing_job_id: str) -> Optional[ScontrolInfo]:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self._sacct,
+                "-X",
+                "-n",
+                "-o",
+                "State,ExitCode",
+                "-P",
+                "-j",
+                str(missing_job_id),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            logger.error("sacct binary not found")
+            return None
+        stdout, stderr = await process.communicate()
+        if process.returncode:
+            logger.error(
+                f"sacct gave returncode {process.returncode} with "
+                f"output{stdout.decode(errors='ignore').strip()} "
+                f"and error {stderr.decode(errors='ignore').strip()}"
+            )
+            return None
+
+        try:
+            return _parse_sacct_output(stdout.decode(errors="ignore"))
+        except Exception as err:
+            logger.error(
+                f"Could not parse sacct stdout {stdout.decode(errors='ignore')}: {err}"
+            )
+        return None
 
     async def finish(self) -> None:
         pass
@@ -447,3 +491,11 @@ def _parse_scontrol_output(output: str) -> ScontrolInfo:
     if exit_code_str:
         exit_code = int(exit_code_str.split(":")[0])
     return ScontrolInfo(JobStatus[values["JobState"]], exit_code)
+
+
+def _parse_sacct_output(output: str) -> ScontrolInfo:
+    items = output.split("|")
+    exit_code = None
+    if len(items) > 0 and items[1]:
+        exit_code = int(items[1].split(":")[0])
+    return ScontrolInfo(JobStatus[items[0]], exit_code)

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -371,7 +371,7 @@ class SlurmDriver(Driver):
 
         info = await self._run_scontrol(missing_job_id)
         if info is None:
-            logger.error("scontrol failed, trying sacct")
+            logger.warning("scontrol failed, trying sacct")
             info = await self._run_sacct(missing_job_id)
         if info is None:
             return None
@@ -391,7 +391,7 @@ class SlurmDriver(Driver):
         )
         stdout, stderr = await process.communicate()
         if process.returncode:
-            logger.error(
+            logger.warning(
                 f"scontrol gave returncode {process.returncode} with "
                 f"output{stdout.decode(errors='ignore').strip()} "
                 f"and error {stderr.decode(errors='ignore').strip()}"
@@ -401,7 +401,7 @@ class SlurmDriver(Driver):
         try:
             return _parse_scontrol_output(stdout.decode(errors="ignore"))
         except Exception as err:
-            logger.error(
+            logger.warning(
                 f"Could not parse scontrol stdout {stdout.decode(errors='ignore')}: {err}"
             )
         return None
@@ -421,11 +421,11 @@ class SlurmDriver(Driver):
                 stderr=asyncio.subprocess.PIPE,
             )
         except FileNotFoundError:
-            logger.error("sacct binary not found")
+            logger.warning("sacct binary not found")
             return None
         stdout, stderr = await process.communicate()
         if process.returncode:
-            logger.error(
+            logger.warning(
                 f"sacct gave returncode {process.returncode} with "
                 f"output{stdout.decode(errors='ignore').strip()} "
                 f"and error {stderr.decode(errors='ignore').strip()}"
@@ -435,7 +435,7 @@ class SlurmDriver(Driver):
         try:
             return _parse_sacct_output(stdout.decode(errors="ignore"))
         except Exception as err:
-            logger.error(
+            logger.warning(
                 f"Could not parse sacct stdout {stdout.decode(errors='ignore')}: {err}"
             )
         return None

--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -93,6 +93,10 @@ class SimulatorConfig(BaseModel, HasErtQueueOptions, extra="forbid"):  # type: i
         default=None,
         description="scontrol executable to be used by the slurm queue interface.",
     )
+    sacct: Optional[str] = Field(
+        default=None,
+        description="sacct executable to be used by the slurm queue interface.",
+    )
     squeue: Optional[str] = Field(
         default=None,
         description="squeue executable to be used by the slurm queue interface.",

--- a/src/everest/config_keys.py
+++ b/src/everest/config_keys.py
@@ -62,6 +62,7 @@ class ConfigKeys:
     SLURM_SBATCH = "sbatch"
     SLURM_SCANCEL = "scancel"
     SLURM_SCONTROL = "scontrol"
+    SLURM_SACCT = "sacct"
     SLURM_SQUEUE = "squeue"
     SLURM_SQUEUE_TIMEOUT = "squeue_timeout"
     SLURM_MAX_RUNTIME = "slurm_timeout"

--- a/src/everest/queue_driver/queue_driver.py
+++ b/src/everest/queue_driver/queue_driver.py
@@ -17,6 +17,7 @@ _SLURM_OPTIONS = [
     (ConfigKeys.SLURM_SBATCH, "SBATCH"),
     (ConfigKeys.SLURM_SCANCEL, "SCANCEL"),
     (ConfigKeys.SLURM_SCONTROL, "SCONTROL"),
+    (ConfigKeys.SLURM_SACCT, "SACCT"),
     (ConfigKeys.SLURM_SQUEUE, "SQUEUE"),
     (ConfigKeys.SLURM_MAX_RUNTIME, "MAX_RUNTIME"),
     (ConfigKeys.SLURM_MEMORY, "MEMORY"),

--- a/tests/ert/unit_tests/scheduler/bin/sacct
+++ b/tests/ert/unit_tests/scheduler/bin/sacct
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Mocks the Slurm provided sacct utility
+exec "${PYTHON:-$(which python3)}" "$(dirname $0)/sacct.py" "$@"

--- a/tests/ert/unit_tests/scheduler/bin/sacct.py
+++ b/tests/ert/unit_tests/scheduler/bin/sacct.py
@@ -1,0 +1,62 @@
+"""
+This script partially mocks the Slurm provided utility sacct:
+
+"view or modify Slurm configuration and state"
+
+"""
+
+import argparse
+import glob
+import os
+from pathlib import Path
+from typing import Literal, Optional
+
+JobState = Literal["PENDING", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"]
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-X", action="store_true")
+    parser.add_argument("-n", action="store_true")
+    parser.add_argument("-o", type=str)
+    parser.add_argument("-P", action="store_true")
+    parser.add_argument("-j", type=str)
+    return parser
+
+
+def read(path: Path, default: Optional[str] = None) -> Optional[str]:
+    return path.read_text().strip() if path.exists() else default
+
+
+def main() -> None:
+    args = get_parser().parse_args()
+
+    assert args.o.strip() == "State,ExitCode"
+
+    jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
+
+    for pidfile in glob.glob(f"{jobs_path}/*.pid"):
+        job = pidfile.split("/")[-1].split(".")[0]
+        if args.j and job != args.j:
+            continue
+        pid = read(Path(pidfile))
+        returncode = read(jobs_path / f"{job}.returncode")
+        cancelled = read(jobs_path / f"{job}.cancelled", default="no")
+        state: JobState = "PENDING"
+
+        if pid is not None and returncode is None:
+            state = "RUNNING"
+        elif pid is not None and cancelled == "yes":
+            state = "CANCELLED"
+            returncode = 0
+        elif pid is not None and returncode is not None:
+            if returncode == "0":
+                state = "COMPLETED"
+            if returncode != "0":
+                state = "FAILED"
+
+        print(f"{state}|{returncode}:0")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -462,7 +462,13 @@ async def test_kill_before_submit_is_finished(
 
 
 @pytest.mark.parametrize("cmd, exit_code", [("true", 0), ("false", 1)])
-async def test_slurm_uses_sacct(monkeypatch, tmp_path, caplog, cmd, exit_code):
+async def test_slurm_uses_sacct(
+    monkeypatch, tmp_path, caplog, cmd, exit_code, pytestconfig
+):
+    # On a real SLURM system, sacct may not be configured, so we skip:
+    if pytestconfig.getoption("slurm"):
+        pytest.skip()
+
     os.chdir(tmp_path)
 
     bin_path = tmp_path / "bin"

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -461,7 +461,8 @@ async def test_kill_before_submit_is_finished(
     ).exists(), "The process children of the job should also have been killed"
 
 
-async def test_slurm_uses_sacct(monkeypatch, tmp_path, caplog):
+@pytest.mark.parametrize("cmd, exit_code", [("true", 0), ("false", 1)])
+async def test_slurm_uses_sacct(monkeypatch, tmp_path, caplog, cmd, exit_code):
     os.chdir(tmp_path)
 
     bin_path = tmp_path / "bin"
@@ -477,8 +478,8 @@ async def test_slurm_uses_sacct(monkeypatch, tmp_path, caplog):
     scontrol_path.chmod(scontrol_path.stat().st_mode | stat.S_IEXEC)
 
     driver = SlurmDriver()
-    await driver.submit(0, "false")
-    assert await driver._get_exit_code(driver._iens2jobid[0]) == 1
+    await driver.submit(0, cmd)
+    assert await driver._get_exit_code(driver._iens2jobid[0]) == exit_code
 
     # Make sure sacct was tried:
     assert "scontrol failed, trying sacct" in caplog.text

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -62,6 +62,7 @@ from tests.everest.utils import (
                 "include_hosts": "host5,host6,host7,host8",
                 "memory": "1000M",
                 "queue_name": "default-queue",
+                "sacct_cmd": "sacct",
                 "sbatch_cmd": "sbatch",
                 "scancel_cmd": "scancel",
                 "scontrol_cmd": "scontrol",


### PR DESCRIPTION
**Issue**
The slurm driver is performing very badly in some cases, when many small jobs were submitted. As it turns out, the use of `scontrol` to extract the exit code of finished jobs may fail, since SLURM does not maintain the information of finished jobs indefinitely in memory for use with `scontrol`. If this happens this leads to many retries of `scontrol`, and the exit code is finally not retrieved. In such a case it is possible to fall back on the `sattr` command which is able to retrieve the information for jobs.

This PR adds `sattr` as a fallback in cases where `scontrol` fails. The `scontrol` command is still preferred and tried first, because depending on the configuration of the SLURM cluster it many not be guaranteed that `sattr` can be used. If that is the case, the code falls back to its old behavior of retrying.

**Approach**
- Add `sattr` command to the slurm options.
- If `scontrol` failure is detected, try `sattr`.
- If `sattr` is not available or fails, fall back on the old retry behavior.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
