### PR TITLE
Fix everest doc test failing due to missing coverage

### DIFF
--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -76,6 +76,7 @@ jobs:
         python -m everest.docs
 
     - name: Upload coverage to Codecov
+      if: inputs.test-type != 'everest-docs-entry-test'
       id: codecov1
       uses: codecov/codecov-action@v4
       continue-on-error: true
@@ -85,12 +86,12 @@ jobs:
         files: cov1.xml,cov2.xml
         flags: ${{ inputs.test-type }}
     - name: codecov retry sleep
-      if: steps.codecov1.outcome == 'failure'
+      if: steps.codecov1.outcome == 'failure' && inputs.test-type != 'everest-docs-entry-test'
       run: |
         sleep 30
     - name: Codecov retry
       uses: codecov/codecov-action@v4
-      if: steps.codecov1.outcome == 'failure'
+      if: steps.codecov1.outcome == 'failure' && inputs.test-type != 'everest-docs-entry-test'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: cov1.xml,cov2.xml
@@ -98,7 +99,7 @@ jobs:
         fail_ci_if_error: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && inputs.test-type != 'everest-docs-entry-test' }}
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
