### PR TITLE
Mark long running tests as integration_test

### DIFF
--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -151,8 +151,12 @@ def test_group_and_well_have_named_format(keyword, number, name, nx, ny):
     assert make_summary_key(keyword, number, name, nx, ny) == f"{keyword}:{name}"
 
 
-@given(st.text(), st.integers(), st.integers())
-@pytest.mark.parametrize("keyword", inter_region_summary_variables)
+@given(
+    st.sampled_from(inter_region_summary_variables),
+    st.text(),
+    st.integers(),
+    st.integers(),
+)
 def test_inter_region_summary_format_contains_in_and_out_regions(keyword, name, nx, ny):
     number = 3014660
     assert make_summary_key(keyword, number, name, nx, ny) == f"{keyword}:4-82"

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -8,6 +8,7 @@ from _ert.threading import ErtThread
 from .ensemble_evaluator_utils import _mock_ws
 
 
+@pytest.mark.integration_test
 def test_invalid_server():
     port = 7777
     host = "localhost"
@@ -41,6 +42,7 @@ def test_successful_sending(unused_tcp_port):
         assert msg in messages
 
 
+@pytest.mark.integration_test
 def test_retry(unused_tcp_port):
     host = "localhost"
     url = f"ws://{host}:{unused_tcp_port}"

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -84,6 +84,7 @@ async def test_no_config_raises_valueerror_when_running():
         await evaluator.run_and_get_successful_realizations()
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     ("task, task_name"),
     [
@@ -365,6 +366,7 @@ async def test_new_monitor_can_pick_up_where_we_left_off(evaluator_to_use):
                 break
 
 
+@pytest.mark.integration_test
 async def test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_evaluator(
     evaluator_to_use,
 ):

--- a/tests/ert/unit_tests/forward_model_runner/test_job_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_job_dispatch.py
@@ -28,6 +28,7 @@ from tests.ert.utils import _mock_ws_thread, wait_until
 from .test_event_reporter import _wait_until
 
 
+@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_terminate_steps():
     # Executes itself recursively and sleeps for 100 seconds

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -495,6 +495,7 @@ def test_parse_bjobs_invalid_state_is_logged(caplog):
     assert "Unknown state FOO" in caplog.text
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "bjobs_script, expectation",
     [
@@ -1011,6 +1012,7 @@ def not_found_bjobs(monkeypatch, tmp_path):
     bjobs_path.chmod(bjobs_path.stat().st_mode | stat.S_IEXEC)
 
 
+@pytest.mark.integration_test
 async def test_bjobs_exec_host_logs_only_once(tmp_path, job_name, caplog):
     caplog.set_level(logging.INFO)
     os.chdir(tmp_path)
@@ -1258,6 +1260,7 @@ async def test_polling_bhist_fallback(not_found_bjobs, caplog, job_name):
     assert driver._bhist_cache and job_id in driver._bhist_cache
 
 
+@pytest.mark.integration_test
 async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, caplog):
     """This test asserts that it is possible to issue a kill command
     to a realization right after it has been submitted (as in driver.submit()).

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -221,6 +221,7 @@ async def test_cluster_label():
     assert "-l foobar" in Path("captured_qsub_args").read_text(encoding="utf-8")
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "qstat_script, started_expected",
     [
@@ -457,6 +458,7 @@ async def test_that_qsub_will_retry_and_succeed(
     await driver.submit(0, "sleep 10")
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [

--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -289,6 +289,7 @@ async def test_max_running(max_running, mock_driver, storage, tmp_path):
         assert max_running_observed == ensemble_size
 
 
+@pytest.mark.integration_test
 @pytest.mark.timeout(6)
 async def test_max_runtime_while_killing(realization, mock_driver):
     wait_started = asyncio.Event()

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -319,6 +319,7 @@ def test_that_storage_works_with_missing_parameters_and_responses(
             ensembles[0].load_responses("GEN", (0,))
 
 
+@pytest.mark.integration_test
 def test_that_migrate_blockfs_creates_backup_folder(tmp_path, caplog):
     with open(tmp_path / "config.ert", mode="w", encoding="utf-8") as f:
         f.writelines(["NUM_REALIZATIONS 1\n", "ENSPATH", str(tmp_path / "storage")])

--- a/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
+++ b/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
@@ -48,6 +48,7 @@ def test_workflow_thread_cancel_ert_script():
     assert not os.path.exists("wait_finished_2")
 
 
+@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_workflow_thread_cancel_external():
     WorkflowCommon.createWaitJob()


### PR DESCRIPTION
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
