### PR TITLE
Fix progress bar not updating realization count for new iterations

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -188,6 +188,7 @@ class BaseRunModel(ABC):
         self.minimum_required_realizations = minimum_required_realizations
         self.active_realizations = copy.copy(active_realizations)
         self.start_iteration = start_iteration
+        self.restart = False
 
     def log_at_startup(self) -> None:
         keys_to_drop = [
@@ -405,7 +406,10 @@ class BaseRunModel(ABC):
                 for real in all_realizations.values():
                     status[str(real["status"])] += 1
 
-        status["Finished"] += self._get_number_of_finished_realizations_from_reruns()
+        if self.restart:
+            status["Finished"] += (
+                self._get_number_of_finished_realizations_from_reruns()
+            )
         return status
 
     def _get_number_of_finished_realizations_from_reruns(self) -> int:
@@ -653,7 +657,11 @@ class BaseRunModel(ABC):
         return [real_path.exists() for real_path in realization_set].count(True)
 
     def get_number_of_active_realizations(self) -> int:
-        return self._initial_realizations_mask.count(True)
+        return (
+            self._initial_realizations_mask.count(True)
+            if self.restart
+            else self.active_realizations.count(True)
+        )
 
     def get_number_of_successful_realizations(self) -> int:
         return self.active_realizations.count(True)

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -63,6 +63,7 @@ class EnsembleExperiment(BaseRunModel):
         restart: bool = False,
     ) -> None:
         self.log_at_startup()
+        self.restart = restart
         if not restart:
             self.experiment = self._storage.create_experiment(
                 name=self.experiment_name,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -62,6 +62,7 @@ class EnsembleSmoother(UpdateRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
+        self.restart = restart
         ensemble_format = self.target_ensemble_format
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -64,6 +64,7 @@ class EvaluateEnsemble(BaseRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
+        self.restart = restart
         ensemble = self.ensemble
         experiment = ensemble.experiment
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -267,6 +267,7 @@ class EverestRunModel(BaseRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
+        self.restart = restart
         self.eval_server_cfg = evaluator_server_config
         self._experiment = self._storage.create_experiment(
             name=f"EnOpt@{datetime.datetime.now().strftime('%Y-%m-%d@%H:%M:%S')}",

--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -122,7 +122,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
-
+        self.restart = restart
         target_ensemble_format = self.target_ensemble_format
         experiment = self._storage.create_experiment(
             parameters=self.ert_config.ensemble_config.parameter_configuration,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -85,6 +85,7 @@ class MultipleDataAssimilation(UpdateRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
+        self.restart = restart
         if self.restart_run:
             id = self.prior_ensemble_id
             try:

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -203,6 +203,49 @@ def test_num_cpu_is_propagated_from_config_to_ensemble(run_args):
 
 
 @pytest.mark.parametrize(
+    "real_status_dict, expected_result",
+    [
+        pytest.param(
+            {"0": "Finished", "1": "Finished", "2": "Finished"},
+            {"Finished": 3},
+            id="ran_all_realizations_and_all_succeeded",
+        ),
+        pytest.param(
+            {"0": "Finished", "1": "Finished", "2": "Failed"},
+            {"Finished": 2, "Failed": 1},
+            id="ran_all_realizations_and_some_failed",
+        ),
+        pytest.param(
+            {"0": "Finished", "1": "Running", "2": "Failed"},
+            {"Finished": 1, "Failed": 1, "Running": 1},
+            id="ran_all_realizations_and_result_was_mixed",
+        ),
+    ],
+)
+def test_get_current_status(
+    real_status_dict,
+    expected_result,
+):
+    config = ErtConfig.from_file_contents("NUM_REALIZATIONS 3")
+    initial_active_realizations = [True] * 3
+    new_active_realizations = [True] * 3
+    brm = BaseRunModel(
+        config=config,
+        storage=MagicMock(spec=Storage),
+        queue_config=config.queue_config,
+        status_queue=MagicMock(spec=SimpleQueue),
+        active_realizations=initial_active_realizations,
+    )
+    snapshot_dict_reals = {}
+    for index, realization_status in real_status_dict.items():
+        snapshot_dict_reals[index] = {"status": realization_status}
+    iter_snapshot = EnsembleSnapshot.from_nested_dict({"reals": snapshot_dict_reals})
+    brm._iter_snapshot[0] = iter_snapshot
+    brm.active_realizations = new_active_realizations
+    assert dict(brm.get_current_status()) == expected_result
+
+
+@pytest.mark.parametrize(
     "initial_active_realizations, new_active_realizations, real_status_dict, expected_result",
     [
         pytest.param(
@@ -242,27 +285,6 @@ def test_num_cpu_is_propagated_from_config_to_ensemble(run_args):
         ),
         pytest.param(
             [True, True, True],
-            [True, True, True],
-            {"0": "Finished", "1": "Finished", "2": "Finished"},
-            {"Finished": 3},
-            id="ran_all_realizations_and_all_succeeded",
-        ),
-        pytest.param(
-            [True, True, True],
-            [True, True, True],
-            {"0": "Finished", "1": "Finished", "2": "Failed"},
-            {"Finished": 2, "Failed": 1},
-            id="ran_all_realizations_and_some_failed",
-        ),
-        pytest.param(
-            [True, True, True],
-            [True, True, True],
-            {"0": "Finished", "1": "Running", "2": "Failed"},
-            {"Finished": 1, "Failed": 1, "Running": 1},
-            id="ran_all_realizations_and_result_was_mixed",
-        ),
-        pytest.param(
-            [True, True, True],
             [True, True, False],
             {"0": "Finished", "1": "Finished"},
             {"Finished": 3},
@@ -277,7 +299,7 @@ def test_num_cpu_is_propagated_from_config_to_ensemble(run_args):
         ),
     ],
 )
-def test_get_current_status(
+def test_get_current_status_when_rerun(
     initial_active_realizations,
     new_active_realizations,
     real_status_dict: dict[str, str],
@@ -292,6 +314,7 @@ def test_get_current_status(
         status_queue=MagicMock(spec=SimpleQueue),
         active_realizations=initial_active_realizations,
     )
+    brm.restart = True
     snapshot_dict_reals = {}
     for index, realization_status in real_status_dict.items():
         snapshot_dict_reals[index] = {"status": realization_status}
@@ -299,3 +322,65 @@ def test_get_current_status(
     brm._iter_snapshot[0] = iter_snapshot
     brm.active_realizations = new_active_realizations
     assert dict(brm.get_current_status()) == expected_result
+
+
+def test_get_current_status_for_new_iteration_when_realization_failed_in_previous_run():
+    """Active realizations gets changed when we run next iteration, and the failed realizations from
+    the previous run should not be present in the current_status."""
+    initial_active_realizations = [True] * 5
+    # Realization 0,1, and 3 failed in the previous iteration
+    new_active_realizations = [False, False, True, False, True]
+    config = ErtConfig.from_file_contents("NUM_REALIZATIONS 5")
+    brm = BaseRunModel(
+        config=config,
+        storage=MagicMock(spec=Storage),
+        queue_config=config.queue_config,
+        status_queue=MagicMock(spec=SimpleQueue),
+        active_realizations=initial_active_realizations,
+    )
+    snapshot_dict_reals = {
+        "2": {"status": "Running"},
+        "4": {"status": "Finished"},
+    }
+    iter_snapshot = EnsembleSnapshot.from_nested_dict({"reals": snapshot_dict_reals})
+    brm._iter_snapshot[0] = iter_snapshot
+    brm.active_realizations = new_active_realizations
+
+    assert brm.restart is False
+    assert dict(brm.get_current_status()) == {"Running": 1, "Finished": 1}
+
+
+@pytest.mark.parametrize(
+    "new_active_realizations, was_rerun, expected_result",
+    [
+        pytest.param(
+            [False, False, False, True, False],
+            True,
+            5,
+            id="rerun_so_total_realization_count_is_not_affected_by_previous_failed_realizations",
+        ),
+        pytest.param(
+            [True, True, False, False, False],
+            False,
+            2,
+            id="new_iteration_so_total_realization_count_is_only_previously_successful_realizations",
+        ),
+    ],
+)
+def test_get_number_of_active_realizations_varies_when_rerun_or_new_iteration(
+    new_active_realizations, was_rerun, expected_result
+):
+    """When rerunning, we include all realizations in the total amount of active realization.
+    When running a new iteration based on the result of the previous iteration, we only include the successful realizations."""
+    initial_active_realizations = [True] * 5
+    config = ErtConfig.from_file_contents("NUM_REALIZATIONS 5")
+    brm = BaseRunModel(
+        config=config,
+        storage=MagicMock(spec=Storage),
+        queue_config=config.queue_config,
+        status_queue=MagicMock(spec=SimpleQueue),
+        active_realizations=initial_active_realizations,
+    )
+    brm.active_realizations = new_active_realizations
+    brm.restart = was_rerun
+    assert brm.get_number_of_active_realizations() == expected_result


### PR DESCRIPTION
**Issue**
Resolves #9455



**Approach**
This PR fixes the bug introduced in 31e607b066ab79415671f83f2d57c7400c4d4e98, where the status reporting in GUI was done the same way when rerunning failed realizations, and running new iterations. This is an issue because when rerunning failed realizations, we want to show all realizations and add the finished/failed count from the previous run, while new iterations should drop the failed realizations altogether.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
