### PR TITLE
Remove overriding of tempfile.tempdir

### DIFF
--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -161,21 +161,16 @@ class EvaluatorServerConfig:
     ) -> typing.Optional[ssl.SSLContext]:
         if self.cert is None:
             return None
-        backup_default_tmp = tempfile.tempdir
-        try:
-            tempfile.tempdir = os.environ.get("XDG_RUNTIME_DIR", tempfile.gettempdir())
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                tmp_path = pathlib.Path(tmp_dir)
-                cert_path = tmp_path / "ee.crt"
-                with open(cert_path, "w", encoding="utf-8") as filehandle_1:
-                    filehandle_1.write(self.cert)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = pathlib.Path(tmp_dir)
+            cert_path = tmp_path / "ee.crt"
+            with open(cert_path, "w", encoding="utf-8") as filehandle_1:
+                filehandle_1.write(self.cert)
 
-                key_path = tmp_path / "ee.key"
-                if self._key is not None:
-                    with open(key_path, "wb") as filehandle_2:
-                        filehandle_2.write(self._key)
-                context = ssl.SSLContext(protocol=protocol)
-                context.load_cert_chain(cert_path, key_path, self._key_pw)
-                return context
-        finally:
-            tempfile.tempdir = backup_default_tmp
+            key_path = tmp_path / "ee.key"
+            if self._key is not None:
+                with open(key_path, "wb") as filehandle_2:
+                    filehandle_2.write(self._key)
+            context = ssl.SSLContext(protocol=protocol)
+            context.load_cert_chain(cert_path, key_path, self._key_pw)
+            return context


### PR DESCRIPTION
**Issue**
When the jobs are executed on the cluster, /user/run/<userid> is not set up, though XDG_RUNTIME_DIR points to it. This is not a problem for ert as it runs the main application locally, but is a problem for Everest where the main application runs on the cluster. So the way lsf logs in to the node is the reason.

Resolves: #9447 

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
