### PR TITLE
Backport get_num_cpu fixes to Version 12.0

### DIFF
--- a/src/ert/config/_get_num_cpu.py
+++ b/src/ert/config/_get_num_cpu.py
@@ -90,9 +90,9 @@ def _get_num_cpu(
 ) -> Optional[int]:
     """Handles reading the lines in the data file and returns the num_cpu
 
-    TITLE keyword requires skipping two non-empty lines
+    TITLE keyword requires skipping one line
 
-    >>> _get_num_cpu(iter(["TITLE", "", "", "PARALLEL", "3 / -- skipped", "PARALLEL", "4 /"]))
+    >>> _get_num_cpu(iter(["TITLE", "PARALLEL EXAMPLE CASE", "PARALLEL", "4 /"]))
     4
 
     PARALLEL takes presedence even when SLAVES comes first:
@@ -109,15 +109,9 @@ def _get_num_cpu(
                 continue
             keyword = next(words, None)
             keyword = keyword[0 : min(len(keyword), 8)] if keyword is not None else None
-            if keyword == "TITLE":
-                # Skip two non-blank lines following a TITLE
-                for _ in range(2):
-                    line: list[str] = []
-                    while line == []:
-                        nline = parser.next_line(None)
-                        if nline is None:
-                            break
-                        line = list(nline)
+            # Skip one line following a TITLE
+            if keyword == "TITLE" and parser.next_line(None) is None:
+                break
             if keyword == "PARALLEL":
                 while (word := next(words, None)) is None:
                     words = parser.next_line(None)

--- a/src/ert/config/_get_num_cpu.py
+++ b/src/ert/config/_get_num_cpu.py
@@ -78,7 +78,7 @@ def get_num_cpu_from_data_file(data_file: str) -> Optional[int]:
     try:
         with open(data_file, "r", encoding="utf-8") as file:
             return _get_num_cpu(iter(file), data_file)
-    except OSError as err:
+    except (OSError, UnicodeDecodeError) as err:
         ConfigWarning.warn(
             f"Failed to read from DATA_FILE {data_file}: {err}", data_file
         )

--- a/tests/ert/unit_tests/config/test_num_cpu.py
+++ b/tests/ert/unit_tests/config/test_num_cpu.py
@@ -51,11 +51,31 @@ def test_reading_num_cpu_from_data_file_does_not_crash(data_file_contents):
     )
 
 
+@pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
+@given(st.binary())
+@pytest.mark.usefixtures("use_tmpdir")
+def test_reading_num_cpu_from_binary_data_file_does_not_crash(data_file_contents):
+    data_file = "case.data"
+    Path(data_file).write_bytes(data_file_contents)
+    _ = ErtConfig.from_dict(
+        {
+            ConfigKeys.NUM_REALIZATIONS: 1,
+            ConfigKeys.DATA_FILE: data_file,
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "parallelsuffix", [("/"), (" /"), (" DISTRIBUTED/"), (" DISTRIBUTED /")]
 )
 @pytest.mark.parametrize(
-    "casetitle", ["CASE", "-- A CASE --", "PARALLEL Tutorial Case"]
+    "casetitle",
+    [
+        "CASE",
+        "-- A CASE --",
+        "PARALLEL Tutorial Case",
+        "",  # Not valid input in some reservoir simulators
+    ],
 )
 def test_num_cpu_from_data_file_used_if_config_num_cpu_not_set(
     parallelsuffix, casetitle

--- a/tests/ert/unit_tests/config/test_num_cpu.py
+++ b/tests/ert/unit_tests/config/test_num_cpu.py
@@ -33,15 +33,18 @@ def test_num_cpu_from_config_preferred():
     assert ert_config.preferred_num_cpu == config_num_cpu
 
 
+@pytest.mark.parametrize(
+    "parallelsuffix", [("/"), (" /"), (" DISTRIBUTED/"), (" DISTRIBUTED /")]
+)
 @pytest.mark.usefixtures("use_tmpdir")
-def test_num_cpu_from_data_file_used_if_config_num_cpu_not_set():
+def test_num_cpu_from_data_file_used_if_config_num_cpu_not_set(parallelsuffix):
     data_file = "dfile"
     data_file_num_cpu = 4
     with open(file=data_file, mode="w", encoding="utf-8") as data_file_hander:
         data_file_hander.write(
             f"""
 PARALLEL
- {data_file_num_cpu} DISTRIBUTED/
+ {data_file_num_cpu}{parallelsuffix}
 """
         )
     config_dict = {


### PR DESCRIPTION
Backports #9640 and https://github.com/equinor/ert/pull/9395


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
