### PR TITLE
Fix bug where everest jobs would not pick up the activate script

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -478,6 +478,16 @@ class ErtConfig:
             errors.append(e)
 
         try:
+            if cls.ACTIVATE_SCRIPT:
+                if "QUEUE_OPTION" not in config_dict:
+                    config_dict["QUEUE_OPTION"] = []
+                config_dict["QUEUE_OPTION"].append(
+                    [
+                        QueueSystemWithGeneric.GENERIC,
+                        "ACTIVATE_SCRIPT",
+                        cls.ACTIVATE_SCRIPT,
+                    ]
+                )
             queue_config = QueueConfig.from_dict(config_dict)
         except ConfigValidationError as err:
             errors.append(err)
@@ -678,12 +688,6 @@ class ErtConfig:
                 user_config_dict[keyword] = value + original_entries
             elif keyword not in user_config_dict:
                 user_config_dict[keyword] = value
-        if cls.ACTIVATE_SCRIPT:
-            if "QUEUE_OPTION" not in user_config_dict:
-                user_config_dict["QUEUE_OPTION"] = []
-            user_config_dict["QUEUE_OPTION"].append(
-                [QueueSystemWithGeneric.GENERIC, "ACTIVATE_SCRIPT", cls.ACTIVATE_SCRIPT]
-            )
         return user_config_dict
 
     @classmethod

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -321,3 +321,16 @@ def test_activate_script_plugin_integration():
     with patch("ert.config.ert_config.ErtPluginManager", patched):
         config = ErtConfig.with_plugins().from_file_contents("NUM_REALIZATIONS 1\n")
         assert config.queue_config.queue_options.activate_script == "source something"
+
+
+def test_activate_script_plugin_integration_from_dict():
+    patched = partial(
+        ert.config.ert_config.ErtPluginManager, plugins=[ActivatePlugin()]
+    )
+    with patch("ert.config.ert_config.ErtPluginManager", patched):
+        config = ErtConfig.with_plugins().from_dict(
+            {
+                "NUM_REALIZATIONS": 1,
+            }
+        )
+        assert config.queue_config.queue_options.activate_script == "source something"


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
