### PR TITLE
Backport bugfixes gui to 12

### DIFF
--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -103,9 +103,9 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             self._active_realizations_model,  # type: ignore
             "config/simulation/active_realizations",
         )
+        self._active_realizations_field.setObjectName("active_realizations_box")
         self._active_realizations_field.setValidator(RangeStringArgument(ensemble_size))
         self._ensemble_selector = EnsembleSelector(notifier)
-        self._realizations_from_fs()
         layout.addRow("Active realizations:", self._active_realizations_field)
 
         self._restart_box = QCheckBox("")
@@ -114,6 +114,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._restart_box.toggled.connect(self.update_experiment_edit)
 
         self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))
+        self._ensemble_selector.setEnabled(False)
         layout.addRow("Restart run:", self._restart_box)
 
         self._ensemble_selector.ensemble_populated.connect(self.restart_run_toggled)
@@ -189,6 +190,11 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             if self._restart_box.isChecked()
             else MultipleDataAssimilation.default_weights
         )
+        if self._restart_box.isChecked():
+            self._realizations_from_fs()
+        else:
+            # If box is unchecked we reset to the default mask
+            self._active_realizations_field.model.setValue(value="")
 
     def _createInputForWeights(self, layout: QFormLayout) -> None:
         relative_iteration_weights_model = ValueModel(self.weights)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -311,6 +311,7 @@ class RunDialog(QFrame):
 
             widget = RealizationWidget(iter_row)
             widget.setSnapshotModel(self._snapshot_model)
+            widget.itemClicked.connect(self._select_real)
             self._select_real(widget._real_list_model.index(0, 0))
             tab_index = self._tab_widget.addTab(
                 widget, f"Realizations for iteration {index.internalPointer().id_}"

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -472,8 +472,14 @@ def test_run_dialog_memory_usage_showing(
                             name="fm_step_0",
                             status=state.FORWARD_MODEL_STATE_START,
                         )
+                        .add_fm_step(
+                            fm_step_id="1",
+                            index="1",
+                            name="fm_step_1",
+                            status=state.FORWARD_MODEL_STATE_START,
+                        )
                         .build(
-                            ["0"],
+                            ["0", "1"],
                             status=state.REALIZATION_STATE_UNKNOWN,
                             exec_hosts="COMP_01",
                         )
@@ -503,7 +509,13 @@ def test_run_dialog_memory_usage_showing(
                             name="fm_step_0",
                             status=state.FORWARD_MODEL_STATE_START,
                         )
-                        .build(["0"], status=state.REALIZATION_STATE_UNKNOWN)
+                        .add_fm_step(
+                            fm_step_id="1",
+                            index="1",
+                            name="fm_step_1",
+                            status=state.FORWARD_MODEL_STATE_START,
+                        )
+                        .build(["0", "1"], status=state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
                     current_iteration=0,
@@ -541,12 +553,15 @@ def test_run_dialog_fm_label_show_correct_info(
     fm_step_model = run_dialog._fm_step_overview.model()
     assert fm_step_model._real == 0
 
+    # default selection should yield realization 0, iteration 0
     fm_step_label = run_dialog.findChild(QLabel, name="fm_step_label")
     assert "Realization id 0 in iteration 0" in fm_step_label.text()
 
-    realization_box._item_clicked(run_dialog._fm_step_overview.model().index(0, 0))
+    # clicking realization 1 should update fm_label with realization 1, iteration 0
+    realization_box._item_clicked(run_dialog._fm_step_overview.model().index(1, 0))
+
     assert (
-        fm_step_label.text() == f"Realization id 0 in iteration 0{expected_host_info}"
+        fm_step_label.text() == f"Realization id 1 in iteration 0{expected_host_info}"
     )
 
 


### PR DESCRIPTION
Backports of https://github.com/equinor/ert/pull/9398 and https://github.com/equinor/ert/pull/9391 to version 12 branch.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
