### PR TITLE
Propagate SETENV to forward model validation

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -766,10 +766,15 @@ class ErtConfig:
         cls,
         installed_steps: Dict[str, ForwardModelStep],
         substitutions: Substitutions,
-        config_dict,
+        config_dict: dict,
     ) -> List[ForwardModelStep]:
         errors = []
         fm_steps = []
+
+        env_vars = {}
+        for key, val in config_dict.get("SETENV", []):
+            env_vars[key] = val
+
         for fm_step_description in config_dict.get(ConfigKeys.FORWARD_MODEL, []):
             if len(fm_step_description) > 1:
                 unsubstituted_step_name, args = fm_step_description
@@ -836,7 +841,7 @@ class ErtConfig:
                         skip_pre_experiment_validation=True,
                     )
                     job_json = substituted_json["jobList"][0]
-                    fm_step.validate_pre_experiment(job_json)
+                    fm_step.validate_pre_experiment(job_json, env_vars)
                 except ForwardModelStepValidationError as err:
                     errors.append(
                         ConfigValidationError.with_context(

--- a/src/ert/config/forward_model_step.py
+++ b/src/ert/config/forward_model_step.py
@@ -181,7 +181,9 @@ class ForwardModelStep:
             return v
         return Substitutions(v)
 
-    def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
+    def validate_pre_experiment(
+        self, fm_step_json: ForwardModelStepJSON, env_vars: Dict[str, str]
+    ) -> None:
         """
         Raise errors pertaining to the environment not being
         as the forward model step requires it to be. For example

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -1037,7 +1037,7 @@ def test_that_plugin_forward_model_unexpected_errors_show_as_warnings(tmp_path):
             super().__init__(name="FMWithAssertionError", command=["the_executable.sh"])
 
         def validate_pre_experiment(
-            self, fm_step_json: ForwardModelStepJSON, _: dict
+            self, fm_step_json: ForwardModelStepJSON, _: Dict[str, str]
         ) -> None:
             raise AssertionError("I should be a warning")
 
@@ -1049,7 +1049,7 @@ def test_that_plugin_forward_model_unexpected_errors_show_as_warnings(tmp_path):
             )
 
         def validate_pre_experiment(
-            self, fm_step_json: ForwardModelStepJSON, _: dict
+            self, fm_step_json: ForwardModelStepJSON, _: Dict[str, str]
         ) -> None:
             raise ForwardModelStepValidationError("I should not be a warning")
 


### PR DESCRIPTION
The settings implied through SETENV can affect how forward model behave, and may also change how validation should be performed.

This is in particular true for the Eclipse forward model steps which try to validate the requested version. If a different configuration of Eclipse is set through

  SETENV ECL100_SITE_CONFIG somefile.yml

(or for ECL300_SITE_CONFIG) this information must be conveyed to the validation code.

**Issue**
Resolves #9474 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
