### PR TITLE
Mute marginal cpu overspending

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -458,6 +458,7 @@ class EnsembleEvaluator:
 def detect_overspent_cpu(num_cpu: int, real_id: str, fm_step: FMStepSnapshot) -> str:
     """Produces a message warning about misconfiguration of NUM_CPU if
     so is detected. Returns an empty string if everything is ok."""
+    allowed_overspending = 1.05
     now = datetime.datetime.now()
     duration = (
         (fm_step.get(ids.END_TIME) or now) - (fm_step.get(ids.START_TIME) or now)
@@ -466,7 +467,7 @@ def detect_overspent_cpu(num_cpu: int, real_id: str, fm_step: FMStepSnapshot) ->
         return ""
     cpu_seconds = fm_step.get(ids.CPU_SECONDS) or 0.0
     parallelization_obtained = cpu_seconds / duration
-    if parallelization_obtained > num_cpu:
+    if parallelization_obtained > num_cpu * allowed_overspending:
         return (
             f"Misconfigured NUM_CPU, forward model step '{fm_step.get(ids.NAME)}' for "
             f"realization {real_id} spent {cpu_seconds} cpu seconds "

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -538,8 +538,8 @@ async def test_ensure_multi_level_events_in_order(evaluator_to_use):
 @given(
     num_cpu=st.integers(min_value=1, max_value=64),
     start=st.datetimes(),
-    duration=st.integers(min_value=-1, max_value=10000),
-    cpu_seconds=st.floats(min_value=0),
+    duration=st.integers(min_value=-1, max_value=1000),
+    cpu_seconds=st.floats(min_value=0, max_value=2000),
 )
 def test_overspent_cpu_is_logged(
     num_cpu: int,
@@ -556,7 +556,7 @@ def test_overspent_cpu_is_logged(
             cpu_seconds=cpu_seconds,
         ),
     )
-    if duration > 0 and cpu_seconds / duration > num_cpu:
+    if duration > 0 and cpu_seconds / duration > num_cpu * 1.05:
         assert "Misconfigured NUM_CPU" in message
     else:
         assert "NUM_CPU" not in message


### PR DESCRIPTION
There exists logs that a user has overspent with a factor of 1.0. This is not very interesting, so skip logging anything that we don't find significant.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
