### PR TITLE
Log when evaluator is leaving events

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -106,8 +106,14 @@ class EnsembleEvaluator:
                     function_to_events_map[func] = []
                 function_to_events_map[func].append(event)
 
+            batch_start_time = asyncio.get_running_loop().time()
             for func, events in function_to_events_map.items():
                 await func(events)
+            processing_time = asyncio.get_running_loop().time() - batch_start_time
+            if processing_time > 0.01:
+                logger.info(
+                    f"Processed {len(batch)} events in {processing_time:.3f} seconds."
+                )
 
             self._batch_processing_queue.task_done()
 

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -142,6 +142,8 @@ class EnsembleEvaluator:
                     continue
             self._complete_batch.set()
             await self._batch_processing_queue.put(batch)
+            if self._events.qsize() > 0:
+                logger.info(f"{self._events.qsize()} events left in queue")
 
     async def _fm_handler(self, events: Sequence[FMEvent | RealizationEvent]) -> None:
         await self._append_message(self.ensemble.update_snapshot(events))


### PR DESCRIPTION
The batching interval and size can maybe be tuned slightly, before that it will be quite interesting to know how often message processing is postponed.

This logging feature existed in the sync version of the ensemble evaluator, but was not carried over in 509c224.

**Issue**
Resolves https://github.com/equinor/komodo-releases/issues/6373


**Approach**
Reinstate. 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
