### PR TITLE
Fix up more unit tests

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -535,16 +535,17 @@ class CopyDebugInfoButton(QPushButton):
     _initial_text = "Copy Debug Info"
     _clicked_text = "Copied..."
 
-    def __init__(self, on_click: Callable[[], None]):
+    def __init__(self, on_click: Callable[[], None], time_to_alternate: int = 1000):
         QPushButton.__init__(self, CopyDebugInfoButton._initial_text)
         self.setToolTip("Copies useful information to clipboard")
         self.setObjectName("copy_debug_info_button")
         self.setFixedWidth(140)
+        self.time_to_alternate = time_to_alternate
 
         def alternate_button_text_on_click_and_call_callback() -> None:
             self._alternate_button_text()
             on_click()
-            QTimer.singleShot(1000, self._alternate_button_text)
+            QTimer.singleShot(self.time_to_alternate, self._alternate_button_text)
 
         self.clicked.connect(alternate_button_text_on_click_and_call_callback)
 

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from unittest.mock import MagicMock
 
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import assume, example, given, settings
 from hypothesis import strategies as st
 from pydantic import RootModel, TypeAdapter
 
@@ -552,46 +552,43 @@ def test_queue_config_max_running_invalid_values(max_running_value, expected_err
 
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
+@settings(max_examples=10)
 @given(st.integers(min_value=0), st.integers(min_value=0), st.integers(min_value=0))
+@example(1, 1, 2)  # error
+@example(2, 1, 2)  # no error
+@example(2, 1, 0)  # no error
+@example(2, 0, 1)  # no error
 def test_num_cpu_vs_torque_queue_cpu_configuration(
     num_cpu_int, num_nodes_int, num_cpus_per_node_int
 ):
     # Only strictly positive ints are valid configuration values,
     # zero values are used to represent the "not configured" scenario:
-    num_cpu = str(num_cpu_int) if num_cpu_int > 0 else ""
-    num_nodes = str(num_nodes_int) if num_nodes_int > 0 else ""
-    num_cpus_per_node = str(num_cpus_per_node_int) if num_cpus_per_node_int > 0 else ""
-
-    if num_nodes or num_cpus_per_node:
-        expected_error = (
-            "product .* must be equal"
-            if (num_cpu_int or 1) != (num_nodes_int or 1) * (num_cpus_per_node_int or 1)
-            else None
-        )
-    else:
-        expected_error = None
+    num_cpu = f"NUM_CPU {num_cpu_int}" if num_cpu_int else ""
+    num_nodes = (
+        f"QUEUE_OPTION TORQUE NUM_NODES {num_nodes_int}" if num_nodes_int else ""
+    )
+    num_cpus_per_node = (
+        f"QUEUE_OPTION TORQUE NUM_CPUS_PER_NODE {num_cpus_per_node_int}"
+        if num_cpus_per_node_int
+        else ""
+    )
 
     test_config_contents = dedent(
-        """
+        f"""\
         NUM_REALIZATIONS 1
-        DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>-<DATE>
-        RUNPATH <STORAGE>/runpath/realization-<IENS>/iter-<ITER>
-        ENSPATH <STORAGE>/ensemble
         QUEUE_SYSTEM TORQUE
+        {num_cpu}
+        {num_nodes}
+        {num_cpus_per_node}
         """
     )
-    if num_cpu:
-        test_config_contents += f"NUM_CPU {num_cpu}\n"
-    if num_nodes:
-        test_config_contents += f"QUEUE_OPTION TORQUE NUM_NODES {num_nodes}\n"
-    if num_cpus_per_node:
-        test_config_contents += (
-            f"QUEUE_OPTION TORQUE NUM_CPUS_PER_NODE {num_cpus_per_node}\n"
-        )
-    if expected_error:
+
+    if (num_nodes or num_cpus_per_node) and (
+        (num_cpu_int or 1) != (num_nodes_int or 1) * (num_cpus_per_node_int or 1)
+    ):
         with pytest.raises(
             expected_exception=ConfigValidationError,
-            match=expected_error,
+            match="product .* must be equal",
         ):
             ErtConfig.from_file_contents(test_config_contents)
     else:
@@ -607,9 +604,6 @@ def test_that_non_existent_job_directory_gives_config_validation_error():
             dedent(
                 """
                 NUM_REALIZATIONS  1
-                DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>-<DATE>
-                RUNPATH <STORAGE>/runpath/realization-<IENS>/iter-<ITER>
-                ENSPATH <STORAGE>/ensemble
                 INSTALL_JOB_DIRECTORY does_not_exist
                 """
             )
@@ -623,9 +617,6 @@ def test_that_empty_job_directory_gives_warning(tmp_path):
             dedent(
                 f"""
                 NUM_REALIZATIONS  1
-                DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>-<DATE>
-                RUNPATH <STORAGE>/runpath/realization-<IENS>/iter-<ITER>
-                ENSPATH <STORAGE>/ensemble
                 INSTALL_JOB_DIRECTORY {tmp_path / 'empty'}
                 """
             )

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -480,6 +480,7 @@ def test_that_ert_config_has_valid_schema():
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.usefixtures("set_site_config")
+@pytest.mark.integration_test
 @settings(max_examples=10)
 @given(config_generators())
 def test_that_parsing_ert_config_result_in_expected_values(

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -330,6 +330,7 @@ ARG_TYPE 0 STRING
     ]
 
 
+@pytest.mark.integration_test
 @settings(max_examples=10)
 @given(config_generators())
 def test_ert_config_throws_on_missing_forward_model_step(

--- a/tests/ert/unit_tests/gui/ertwidgets/test_copy_debug_info_button.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_copy_debug_info_button.py
@@ -11,7 +11,7 @@ def test_copy_debug_info_button_alterates_text_when_pressed(qtbot: QtBot):
         nonlocal button_clicked
         button_clicked = True
 
-    button = CopyDebugInfoButton(on_click=on_click)
+    button = CopyDebugInfoButton(on_click=on_click, time_to_alternate=10)
     qtbot.addWidget(button)
 
     assert button.text() == CopyDebugInfoButton._initial_text

--- a/tests/ert/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/ert/unit_tests/gui/simulation/view/test_realization.py
@@ -51,6 +51,7 @@ class MockDelegate(QStyledItemDelegate):
         return self._size
 
 
+@pytest.mark.integration_test
 def test_delegate_drawing_count(small_snapshot, qtbot):
     it = 0
     widget = RealizationWidget(it)

--- a/tests/ert/unit_tests/scheduler/test_local_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_local_driver.py
@@ -69,6 +69,7 @@ async def test_kill_before_running(sleep_before_killing):
 
 
 @pytest.mark.timeout(10)
+@pytest.mark.integration_test
 async def test_kill_unresponsive_process(monkeypatch, tmp_path):
     # Reduce timeout to something more appropriate for a test
     monkeypatch.setattr(local_driver, "_TERMINATE_TIMEOUT", 0.1)


### PR DESCRIPTION
Speeds up some unit tests to take less than a second. Mark remaining tests taking more than a second as integration_test


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
