### PR TITLE
Fix bug in careful_copy handling None

### DIFF
--- a/src/ert/resources/shell_scripts/careful_copy_file.py
+++ b/src/ert/resources/shell_scripts/careful_copy_file.py
@@ -5,13 +5,12 @@ import sys
 
 
 def careful_copy_file(src, target=None):
+    if target is None:
+        target = os.path.basename(src)
     if os.path.exists(target):
         print(f"File: {target} already present - not updated")
         return
     if os.path.isfile(src):
-        if target is None:
-            target = os.path.basename(src)
-
         if os.path.isdir(target):
             target_file = os.path.join(target, os.path.basename(src))
             shutil.copyfile(src, target_file)

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import os.path
+import shutil
 import sys
 from contextlib import suppress
 from pathlib import Path
@@ -472,6 +473,22 @@ def test_copy_file3():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+def test_copy_when_target_is_none():
+    Path("somedir").mkdir()
+    Path("somedir/file.txt").write_text("Hei", encoding="utf-8")
+
+    copy_file("somedir/file.txt", None)
+    assert Path("file.txt").read_text(encoding="utf-8") == "Hei"
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_copy_when_target_is_none_in_same_directory():
+    Path("file.txt").write_text("Hei", encoding="utf-8")
+    with pytest.raises(shutil.SameFileError):
+        copy_file("file.txt", None)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_careful_copy_file():
     with open("file1", "w", encoding="utf-8") as f:
         f.write("hei")
@@ -484,6 +501,31 @@ def test_careful_copy_file():
 
     print(careful_copy_file("file1", "file3"))
     assert os.path.isfile("file3")
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_careful_copy_file_when_target_is_none():
+    Path("somedir").mkdir()
+    Path("somedir/file.txt").write_text("Hei", encoding="utf-8")
+
+    careful_copy_file("somedir/file.txt", None)
+    assert Path("file.txt").read_text(encoding="utf-8") == "Hei"
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_careful_copy_when_target_is_none_in_same_directory_is_noop():
+    Path("file.txt").write_text("Hei", encoding="utf-8")
+    careful_copy_file("file.txt", None)  # File will not be touched
+    assert Path("file.txt").read_text(encoding="utf-8") == "Hei"
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_careful_copy_when_target_is_none_does_not_touch_existing():
+    Path("somedir").mkdir()
+    Path("somedir/file.txt").write_text("Hei", encoding="utf-8")
+    Path("file.txt").write_text("I will survive", encoding="utf-8")
+    careful_copy_file("somedir/file.txt", None)
+    assert Path("file.txt").read_text(encoding="utf-8") == "I will survive"
 
 
 @pytest.fixture


### PR DESCRIPTION
The function careful_copy_file was not able to handle None as a target. Added the functionality as probably originally intended and added tests.

**Issue**
Resolves a bug that has never happened in the wild.


**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
