### PR TITLE
Do not cancel ert run in gui test

### DIFF
--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -635,8 +635,7 @@ def test_that_debug_info_button_provides_data_in_clipboard(qtbot: QtBot, storage
         qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=5000)
         run_dialog = gui.findChild(RunDialog)
         assert run_dialog is not None
-        run_dialog._run_model.cancel()
-        run_dialog.simulation_done.emit(False, "")
+        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True, timeout=100000)
         copy_debug_info_button = gui.findChild(QPushButton, "copy_debug_info_button")
         assert copy_debug_info_button
         assert isinstance(copy_debug_info_button, QPushButton)


### PR DESCRIPTION
Resolves: #9420 

This test: `test_that_debug_info_button_provides_data_in_clipboard`, runs in parallel and often fails with ert run not being properly terminated before the test finishes. I believe it is better to just wait longer for the run to finish instead of trying to cancel it.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
