### PR TITLE
Replace deprecated polars count with len

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "packaging",
     "pandas",
     "pluggy>=1.3.0",
-    "polars",
+    "polars>=1",
     "psutil",
     "pyarrow",  # extra dependency for pandas (parquet)
     "pydantic > 2, < 2.10",

--- a/src/ert/gui/ertwidgets/models/ertsummary.py
+++ b/src/ert/gui/ertwidgets/models/ertsummary.py
@@ -37,6 +37,6 @@ class ErtSummary:
     def getObservations(self) -> list[ObservationCount]:
         counts: list[ObservationCount] = []
         for df in self.ert_config.observations.values():
-            counts.extend(df.group_by("observation_key").count().to_dicts())  #  type: ignore
+            counts.extend(df.group_by("observation_key").len(name="count").to_dicts())  #  type: ignore
 
         return sorted(counts, key=lambda k: k["observation_key"].lower())


### PR DESCRIPTION
Get following warning when running tests:

```
tests/ert/unit_tests/gui/simulation/test_run_path_dialog.py: 6 warnings
  /data/komodo_dev/ert/src/ert/gui/ertwidgets/models/ertsummary.py:40: DeprecationWarning: `GroupBy.count` is deprecated. It has been renamed to `len`.
    counts.extend(df.group_by("observation_key").count().to_dicts())  #  type: ignore
```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
