### PR TITLE
Fix mismatch between selected iteration and visually indicated realization selected

### DIFF
--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -136,7 +136,7 @@ class Monitor:
             )
 
     def _print_progress(self, event: SnapshotUpdateEvent) -> None:
-        current_iteration = min(event.total_iterations, event.current_iteration + 1)
+        current_iteration = min(event.total_iterations, event.iteration + 1)
         if self._start_time is not None:
             elapsed = datetime.now() - self._start_time
         else:

--- a/src/ert/ensemble_evaluator/event.py
+++ b/src/ert/ensemble_evaluator/event.py
@@ -6,7 +6,6 @@ from .snapshot import EnsembleSnapshot
 @dataclass
 class _UpdateEvent:
     iteration_label: str
-    current_iteration: int
     total_iterations: int
     progress: float
     realization_count: int

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -296,6 +296,9 @@ class RunDialog(QFrame):
 
     def _current_tab_changed(self, index: int) -> None:
         widget = self._tab_widget.widget(index)
+        if isinstance(widget, RealizationWidget):
+            widget.refresh_current_selection()
+
         self.fm_step_frame.setHidden(isinstance(widget, UpdateWidget))
 
     @Slot(QModelIndex, int, int)

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -81,6 +81,10 @@ class RealizationWidget(QWidget):
     def clearSelection(self) -> None:
         self._real_view.clearSelection()
 
+    def refresh_current_selection(self) -> None:
+        selected_reals = self._real_view.selectedIndexes()
+        self._item_clicked(selected_reals[0])
+
 
 class RealizationDelegate(QStyledItemDelegate):
     def __init__(self, size: QSize, parent: QObject) -> None:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -462,7 +462,6 @@ class BaseRunModel(ABC):
             self.send_event(
                 FullSnapshotEvent(
                     iteration_label=f"Running forecast for iteration: {iteration}",
-                    current_iteration=iteration,
                     total_iterations=self._total_iterations,
                     progress=current_progress,
                     realization_count=realization_count,
@@ -487,7 +486,6 @@ class BaseRunModel(ABC):
             self.send_event(
                 SnapshotUpdateEvent(
                     iteration_label=f"Running forecast for iteration: {iteration}",
-                    current_iteration=iteration,
                     total_iterations=self._total_iterations,
                     progress=current_progress,
                     realization_count=realization_count,

--- a/tests/ert/unit_tests/cli/test_cli_monitor.py
+++ b/tests/ert/unit_tests/cli/test_cli_monitor.py
@@ -77,7 +77,6 @@ def test_print_progress():
     monitor._start_time = datetime.now()
     general_event = SnapshotUpdateEvent(
         iteration_label="Test Phase",
-        current_iteration=0,
         total_iterations=2,
         progress=0.5,
         realization_count=100,

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -119,7 +119,6 @@ def test_large_snapshot(
         FullSnapshotEvent(
             snapshot=large_snapshot,
             iteration_label="Foo",
-            current_iteration=0,
             total_iterations=1,
             progress=0.5,
             realization_count=4,
@@ -129,7 +128,6 @@ def test_large_snapshot(
         FullSnapshotEvent(
             snapshot=large_snapshot,
             iteration_label="Foo",
-            current_iteration=0,
             total_iterations=1,
             progress=0.5,
             realization_count=4,
@@ -172,7 +170,6 @@ def test_large_snapshot(
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -184,7 +181,6 @@ def test_large_snapshot(
                         [], status=state.REALIZATION_STATE_FINISHED
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -212,7 +208,6 @@ def test_large_snapshot(
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -224,7 +219,6 @@ def test_large_snapshot(
                         ["0"], status=state.REALIZATION_STATE_FINISHED
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -256,7 +250,6 @@ def test_large_snapshot(
                         .build(["0", "1"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -273,7 +266,6 @@ def test_large_snapshot(
                     )
                     .build(["1"], status=state.REALIZATION_STATE_RUNNING),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -290,7 +282,6 @@ def test_large_snapshot(
                     )
                     .build(["0"], status=state.REALIZATION_STATE_FAILED),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -316,7 +307,6 @@ def test_large_snapshot(
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -335,7 +325,6 @@ def test_large_snapshot(
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -377,7 +366,6 @@ def test_run_dialog(events, tab_widget_count, qtbot: QtBot, run_dialog, event_qu
                         .build(["0"], state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -396,7 +384,6 @@ def test_run_dialog(events, tab_widget_count, qtbot: QtBot, run_dialog, event_qu
                     )
                     .build(["0"], status=state.REALIZATION_STATE_RUNNING),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.5,
                     realization_count=4,
@@ -415,7 +402,6 @@ def test_run_dialog(events, tab_widget_count, qtbot: QtBot, run_dialog, event_qu
                     )
                     .build(["0"], status=state.REALIZATION_STATE_FINISHED),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=1,
                     realization_count=4,
@@ -486,7 +472,6 @@ def test_run_dialog_memory_usage_showing(
                         )
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,
@@ -519,7 +504,6 @@ def test_run_dialog_memory_usage_showing(
                         .build(["0", "1"], status=state.REALIZATION_STATE_UNKNOWN)
                     ),
                     iteration_label="Foo",
-                    current_iteration=0,
                     total_iterations=1,
                     progress=0.25,
                     realization_count=4,


### PR DESCRIPTION
**Issue**
Resolves #9498 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
