### PR TITLE
Have Ert sidebar have correct focus on startup and when simulating

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -118,7 +118,9 @@ class ErtMainWindow(QMainWindow):
         self._experiment_panel: ExperimentPanel | None = None
         self._plot_window: PlotWindow | None = None
         self._manage_experiments_panel: ManageExperimentsPanel | None = None
-        self._add_sidebar_button("Start simulation", QIcon("img:library_add.svg"))
+        self._add_sidebar_button(
+            "Start simulation", QIcon("img:library_add.svg")
+        ).click()
         plot_button = self._add_sidebar_button("Create plot", QIcon("img:timeline.svg"))
         plot_button.setToolTip("Right click to open external window")
         self._add_sidebar_button("Manage experiments", QIcon("img:build_wrench.svg"))

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -237,6 +237,9 @@ class ErtMainWindow(QMainWindow):
             self.config_file,
             self.facade.get_ensemble_size(),
         )
+        experiment_panel.experiment_started.connect(
+            lambda: self.results_button.setChecked(True)
+        )
         self.central_layout.addWidget(experiment_panel)
         self._experiment_panel = experiment_panel
         self.central_panels_map["Start simulation"] = self._experiment_panel


### PR DESCRIPTION
**Issue**
Resolves #9538 

![Screenshot 2024-12-13 at 15 29 45](https://github.com/user-attachments/assets/a6a5fddc-00c4-4238-a282-e6e255af7c69)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
