### PR TITLE
Remove unnecessary wrapper forward_model_data_to_json

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -221,33 +221,6 @@ def create_forward_model_json(
     }
 
 
-def forward_model_data_to_json(
-    substitutions: Substitutions,
-    forward_model_steps: list[ForwardModelStep],
-    env_vars: dict[str, str],
-    env_pr_fm_step: dict[str, dict[str, Any]] | None = None,
-    user_config_file: str | None = "",
-    run_id: str | None = None,
-    iens: int = 0,
-    itr: int = 0,
-    context_env: dict[str, str] | None = None,
-):
-    if context_env is None:
-        context_env = {}
-    if env_pr_fm_step is None:
-        env_pr_fm_step = {}
-    return create_forward_model_json(
-        context=substitutions,
-        forward_model_steps=forward_model_steps,
-        user_config_file=user_config_file,
-        env_vars={**env_vars, **context_env},
-        env_pr_fm_step=env_pr_fm_step,
-        run_id=run_id,
-        iens=iens,
-        itr=itr,
-    )
-
-
 @dataclass
 class ErtConfig:
     DEFAULT_ENSPATH: ClassVar[str] = "storage"

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -14,7 +14,7 @@ import pandas as pd
 import xarray as xr
 from numpy.random import SeedSequence
 
-from ert.config.ert_config import forward_model_data_to_json
+from ert.config.ert_config import create_forward_model_json
 from ert.config.forward_model_step import ForwardModelStep
 from ert.config.model_config import ModelConfig
 from ert.substitutions import Substitutions, substitute_runpath_name
@@ -272,16 +272,15 @@ def create_run_path(
             path = run_path / "jobs.json"
             _backup_if_existing(path)
 
-            forward_model_output = forward_model_data_to_json(
-                substitutions=substitutions,
+            forward_model_output: dict[str, Any] = create_forward_model_json(
+                context=substitutions,
                 forward_model_steps=forward_model_steps,
                 user_config_file=user_config_file,
-                env_vars=env_vars,
+                env_vars={**env_vars, **context_env},
                 env_pr_fm_step=env_pr_fm_step,
                 run_id=run_arg.run_id,
                 iens=run_arg.iens,
                 itr=ensemble.iteration,
-                context_env=context_env,
             )
             with open(run_path / "jobs.json", mode="wb") as fptr:
                 fptr.write(

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -10,7 +10,7 @@ import pytest
 from ert.config import ErtConfig, ForwardModelStep
 from ert.config.ert_config import (
     _forward_model_step_from_config_file,
-    forward_model_data_to_json,
+    create_forward_model_json,
 )
 from ert.substitutions import Substitutions
 
@@ -295,8 +295,8 @@ def test_config_path_and_file(context):
         substitutions=context,
         user_config_file="path_to_config_file/config.ert",
     )
-    steps_json = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    steps_json = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -318,8 +318,8 @@ def test_no_steps(context):
         user_config_file="path_to_config_file/config.ert",
     )
 
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -339,8 +339,8 @@ def test_one_step(fm_step_list, context):
             substitutions=context,
         )
 
-        data = forward_model_data_to_json(
-            substitutions=ert_config.substitutions,
+        data = create_forward_model_json(
+            context=ert_config.substitutions,
             forward_model_steps=ert_config.forward_model_steps,
             env_vars=ert_config.env_vars,
             user_config_file=ert_config.user_config_file,
@@ -357,8 +357,8 @@ def run_all(fm_steplist, context):
         substitutions=context,
     )
 
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -400,8 +400,8 @@ def test_that_values_with_brackets_are_ommitted(caplog, fm_step_list, context):
         forward_model_steps=forward_model_list, substitutions=context
     )
 
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -558,8 +558,8 @@ def test_forward_model_job(job, forward_model, expected_args):
 
     forward_model = ert_config.forward_model_steps
 
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -589,8 +589,8 @@ def test_that_config_path_is_the_directory_of_the_main_ert_config():
         fout.write("FORWARD_MODEL job_name")
 
     ert_config = ErtConfig.from_file("config_file.ert")
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -661,8 +661,8 @@ def test_simulation_job(job, forward_model, expected_args):
         fout.write(forward_model)
 
     ert_config = ErtConfig.from_file("config_file.ert")
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -696,8 +696,8 @@ def test_that_private_over_global_args_gives_logging_message(caplog):
         fout.write("FORWARD_MODEL job_name(<ARG>=B)")
 
     ert_config = ErtConfig.from_file("config_file.ert")
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -735,8 +735,8 @@ def test_that_private_over_global_args_does_not_give_logging_message_for_argpass
         fout.write("FORWARD_MODEL job_name(<ARG>=<ARG>)")
 
     ert_config = ErtConfig.from_file("config_file.ert")
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -786,8 +786,8 @@ def test_that_environment_variables_are_set_in_forward_model(
         fout.write(forward_model)
 
     ert_config = ErtConfig.from_file("config_file.ert")
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -817,8 +817,8 @@ def test_that_executables_in_path_are_not_made_realpath(tmp_path):
     )
 
     ert_config = ErtConfig.from_file(str(config_file))
-    data = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    data = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -13,7 +13,7 @@ from hypothesis import given, settings
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
 from ert.config.ert_config import (
     _forward_model_step_from_config_file,
-    forward_model_data_to_json,
+    create_forward_model_json,
 )
 from ert.config.forward_model_step import (
     ForwardModelStepJSON,
@@ -503,11 +503,12 @@ def test_that_forward_model_substitution_does_not_warn_about_reaching_max_iterat
 
     ert_config = ErtConfig.with_plugins().from_file(test_config_file_name)
     with caplog.at_level(logging.WARNING):
-        forward_model_data_to_json(
-            substitutions=ert_config.substitutions,
+        create_forward_model_json(
+            context=ert_config.substitutions,
             forward_model_steps=ert_config.forward_model_steps,
             env_vars=ert_config.env_vars,
             user_config_file=ert_config.user_config_file,
+            run_id=None,
             iens=0,
             itr=0,
         )
@@ -721,8 +722,8 @@ def test_that_plugin_forward_models_are_installed(tmp_path):
             getattr(first_fm, a) == v
         ), f"Expected fm[{a}] to be {v} but was {getattr(first_fm,a)}"
 
-    fm_json = forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    fm_json = create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -776,8 +777,8 @@ def test_that_plugin_forward_model_validation_failure_propagates(tmp_path):
     with pytest.raises(
         ConfigValidationError, match="Validation failed for forward model step"
     ):
-        forward_model_data_to_json(
-            substitutions=ert_config.substitutions,
+        create_forward_model_json(
+            context=ert_config.substitutions,
             forward_model_steps=ert_config.forward_model_steps,
             env_vars=ert_config.env_vars,
             user_config_file=ert_config.user_config_file,
@@ -819,8 +820,8 @@ def test_that_plugin_forward_model_validation_accepts_valid_args(tmp_path):
 
     first_fm.validate_pre_realization_run({"argList": ["never"]})
 
-    forward_model_data_to_json(
-        substitutions=ert_config.substitutions,
+    create_forward_model_json(
+        context=ert_config.substitutions,
         forward_model_steps=ert_config.forward_model_steps,
         env_vars=ert_config.env_vars,
         user_config_file=ert_config.user_config_file,
@@ -883,8 +884,8 @@ def test_that_plugin_forward_model_raises_pre_realization_validation_error(tmp_p
         ConfigValidationError,
         match=".*This is a bad forward model step, dont use it.*",
     ):
-        forward_model_data_to_json(
-            substitutions=config.substitutions,
+        create_forward_model_json(
+            context=config.substitutions,
             forward_model_steps=config.forward_model_steps,
             env_vars=config.env_vars,
             user_config_file=config.user_config_file,

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -11,7 +11,7 @@ from _ert.forward_model_runner.runner import ForwardModelRunner
 from ert.config import ErtConfig, ForwardModelStep
 from ert.config.ert_config import (
     _forward_model_step_from_config_file,
-    forward_model_data_to_json,
+    create_forward_model_json,
 )
 from ert.substitutions import Substitutions
 
@@ -235,8 +235,8 @@ assert exec_env["TEST_ENV"] == "123"
     with open("jobs.json", mode="w", encoding="utf-8") as fptr:
         ert_config = ErtConfig(forward_model_steps=[forward_model])
         json.dump(
-            forward_model_data_to_json(
-                substitutions=ert_config.substitutions,
+            create_forward_model_json(
+                context=ert_config.substitutions,
                 forward_model_steps=ert_config.forward_model_steps,
                 env_vars=ert_config.env_vars,
                 user_config_file=ert_config.user_config_file,
@@ -276,8 +276,8 @@ assert os.environ["TEST_ENV"] == "123"
     with open("jobs.json", mode="w", encoding="utf-8") as fptr:
         ert_config = ErtConfig(forward_model_steps=[step])
         json.dump(
-            forward_model_data_to_json(
-                substitutions=ert_config.substitutions,
+            create_forward_model_json(
+                context=ert_config.substitutions,
                 forward_model_steps=ert_config.forward_model_steps,
                 env_vars=ert_config.env_vars,
                 user_config_file=ert_config.user_config_file,
@@ -326,8 +326,8 @@ def test_default_env_variables_available_inside_fm_step_context():
             substitutions=Substitutions({"<RUNPATH>": "./"}),
         )
         json.dump(
-            forward_model_data_to_json(
-                substitutions=ert_config.substitutions,
+            create_forward_model_json(
+                context=ert_config.substitutions,
                 forward_model_steps=ert_config.forward_model_steps,
                 env_vars=ert_config.env_vars,
                 user_config_file=ert_config.user_config_file,


### PR DESCRIPTION
**Issue**
Resolves #9545


**Approach**
Removes extra wrapper layer in ert_config.py (_forward_model_data_to_json_) and updates tests related to it.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
