### PR TITLE
Improve UX for permission errors in storage

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -35,6 +35,7 @@ from ert.plugins import ErtPluginContext, ErtPluginManager
 from ert.run_models.multiple_data_assimilation import MultipleDataAssimilation
 from ert.services import StorageService, WebvizErt
 from ert.shared.storage.command import add_parser_options as ert_api_add_parser_options
+from ert.storage import ErtStorageException
 from ert.trace import trace, tracer, tracer_provider
 from ert.validation import (
     IntegerArgument,
@@ -688,7 +689,7 @@ def main() -> None:
         ) as context:
             logger.info(f"Running ert with {args}")
             args.func(args, context.plugin_manager)
-    except ErtCliError as err:
+    except (ErtCliError, ErtStorageException) as err:
         span.set_status(Status(StatusCode.ERROR))
         span.record_exception(err)
         logger.debug(str(err))


### PR DESCRIPTION
This commit:
* Improves the error message displayed when the dark storage server does not have access to the storage path.
* Makes the dark storage server return a response with status code 401 - unauthorized when the `get_ensemble_record` endpoint fails due to `PermissionError`.
* Makes the failed message in `LegacyEnsemble._evaluate_inner` omit stacktrace when it failed due to PermissionError, making it shorter and more consise.

**Issue**
Resolves #9493

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
