### PR TITLE
Handle empty ensemble in observations view

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -223,9 +223,17 @@ class _EnsembleWidget(QWidget):
         obs = _filter_on_observation_label(obs)
 
         response_key = obs["response_key"].unique().to_list()[0]
-        response_ds = self._ensemble.load_responses(
-            response_key,
-            tuple(self._ensemble.get_realization_list_with_responses()),
+        reals_with_responses = tuple(
+            self._ensemble.get_realization_list_with_responses()
+        )
+
+        response_ds = (
+            self._ensemble.load_responses(
+                response_key,
+                reals_with_responses,
+            )
+            if reals_with_responses
+            else None
         )
 
         scaling_df = self._ensemble.load_observation_scaling_factors()
@@ -260,7 +268,7 @@ class _EnsembleWidget(QWidget):
                 color="black",
             )
 
-        if not response_ds.is_empty():
+        if response_ds is not None and not response_ds.is_empty():
             response_ds_for_label = _filter_on_observation_label(response_ds).rename(
                 {"values": "Responses"}
             )[["response_key", "Responses"]]


### PR DESCRIPTION
**Issue**
Resolves #9549 

![image](https://github.com/user-attachments/assets/68f6d724-5073-47e0-9e8b-8a5e28f343b2)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
