### PR TITLE
Ignore erroneous auto-scale configuration, but warn

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -268,11 +268,19 @@ def _load_observations_and_responses(
                 )
             )
 
-        scaling_factors_df = polars.concat(scaling_factors_dfs)
-        ensemble.save_observation_scaling_factors(scaling_factors_df)
+        if len(scaling_factors_dfs):
+            scaling_factors_df = polars.concat(scaling_factors_dfs)
+            ensemble.save_observation_scaling_factors(scaling_factors_df)
 
-        # Recompute with updated scales
-        scaled_errors = errors * scaling
+            # Recompute with updated scales
+            scaled_errors = errors * scaling
+        else:
+            msg = (
+                f"WARNING: Could not auto-scale the observations {auto_scale_observations}. "
+                f"No match with existing active observations {obs_keys}"
+            )
+            logger.warning(msg)
+            print(msg)
 
     update_snapshot = []
     for (


### PR DESCRIPTION
Backport of https://github.com/equinor/ert/pull/9390


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
