### PR TITLE
Fix everest batch numbering

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -682,17 +682,20 @@ class EverestRunModel(BaseRunModel):
                     self._simulator_cache.add_simulation_results(
                         sim_idx, real_id, control_values, objectives, constraints
                     )
-        self.batch_id += 1
 
         # Note the negative sign for the objective results. Everest aims to do a
         # maximization, while the standard practice of minimizing is followed by
         # ropt. Therefore we will minimize the negative of the objectives:
-        return EvaluatorResult(
+        evaluator_result = EvaluatorResult(
             objectives=-objectives,
             constraints=constraints,
             batch_id=self.batch_id,
             evaluation_ids=sim_ids,
         )
+
+        self.batch_id += 1
+
+        return evaluator_result
 
     def send_snapshot_event(self, event: Event, iteration: int) -> None:
         super().send_snapshot_event(event, iteration)


### PR DESCRIPTION
**Issue**
A small  bug exists in the new everest base number which makes the batch  number incorrect in `ropt`.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
