### PR TITLE
Change obs_and_responses test to benchmark

### DIFF
--- a/tests/ert/performance_tests/test_obs_and_responses_performance.py
+++ b/tests/ert/performance_tests/test_obs_and_responses_performance.py
@@ -424,7 +424,7 @@ def test_time_performance_of_joining_observations_and_responses(
 ):
     alias, ens, observation_keys, mask, _ = setup_benchmark
 
-    if alias not in {"small", "medium"}:
+    if alias != "small":
         pytest.skip()
 
     def run():
@@ -516,7 +516,7 @@ def test_memory_performance_of_doing_es_update(setup_es_benchmark, tmp_path):
 def test_speed_performance_of_doing_es_update(setup_es_benchmark, benchmark):
     alias, prior, posterior, gen_kw_name, _ = setup_es_benchmark
 
-    if alias not in {"small", "medium"}:
+    if alias != "small":
         pytest.skip()
 
     def run():


### PR DESCRIPTION
Fixes unreliable hard limit to benchmark we can control over time

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
