### PR TITLE
Solve ruff literal-membership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,6 @@ ignore = [
     "PLR0912", # too-many-branches
     "PLR0911", # too-many-return-statements
     "PLC2701", # import-private-name
-    "PLR6201", # literal-membership
     "PLR0914", # too-many-locals
     "PLR6301", # no-self-use
     "PLW1641", # eq-without-hash

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -54,22 +54,22 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
             f"Config contains forward model step {fm_step_name} {count} time(s)",
         )
 
-    if not ert_config.observations and args.mode not in [
+    if not ert_config.observations and args.mode not in {
         ENSEMBLE_EXPERIMENT_MODE,
         TEST_RUN_MODE,
         WORKFLOW_MODE,
-    ]:
+    }:
         raise ErtCliError(
             f"To run {args.mode}, observations are needed. \n"
             f"Please add an observation file to {args.config}. Example: \n"
             f"'OBS_CONFIG observation_file.txt'."
         )
 
-    if args.mode in [
+    if args.mode in {
         ENSEMBLE_SMOOTHER_MODE,
         ES_MDA_MODE,
         ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
-    ]:
+    }:
         if not ert_config.ensemble_config.parameter_configs:
             raise ErtCliError(
                 f"To run {args.mode}, GEN_KW, FIELD or SURFACE parameters are needed. \n"

--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -268,7 +268,7 @@ def _read_spec(
             kw = entry.read_keyword()
             if kw in arrays:
                 arrays[kw] = _check_vals(kw, spec, entry.read_array())
-            if kw in ("WGNAMES ", "NAMES   "):
+            if kw in {"WGNAMES ", "NAMES   "}:
                 wgnames = _check_vals(kw, spec, entry.read_array())
             if kw == "DIMENS  ":
                 vals = _check_vals(kw, spec, entry.read_array())

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -137,7 +137,7 @@ class AnalysisConfig:
                     )
                 )
                 continue
-            if var_name in ["INVERSION", "IES_INVERSION"]:
+            if var_name in {"INVERSION", "IES_INVERSION"}:
                 if value in inversion_str_map[module_name]:
                     new_value = inversion_str_map[module_name][value]
                     if var_name == "IES_INVERSION":

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -219,7 +219,7 @@ class GenKwConfig(ParameterConfig):
             if prior["function"] == "LOGNORMAL":
                 _check_non_negative_parameter("MEAN", prior)
                 _check_non_negative_parameter("STD", prior)
-            elif prior["function"] in ["NORMAL", "TRUNCATED_NORMAL"]:
+            elif prior["function"] in {"NORMAL", "TRUNCATED_NORMAL"}:
                 _check_non_negative_parameter("STD", prior)
         if errors:
             raise ConfigValidationError.from_collected(errors)
@@ -494,7 +494,7 @@ class TransformFunction:
     use_log: bool = False
 
     def __post_init__(self) -> None:
-        if self.transform_function_name in ["LOGNORMAL", "LOGUNIF"]:
+        if self.transform_function_name in {"LOGNORMAL", "LOGUNIF"}:
             self.use_log = True
 
     @staticmethod

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -63,7 +63,7 @@ deprecated_keywords_list = [
             "dimension set using ENKF_NCOMP keyword. "
             "This can be safely removed.",
         ),
-        check=lambda line: str(line[1]) in ["ENKF_FORCE_NCOMP"],
+        check=lambda line: str(line[1]) in {"ENKF_FORCE_NCOMP"},
     ),
     DeprecationInfo(
         keyword="RUNPATH",

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -325,9 +325,9 @@ def _validate_summary_values(
     for key, value in inp.items():
         if key == "RESTART":
             date_dict.restart = validate_positive_int(value, key)
-        elif key in ["ERROR", "ERROR_MIN"]:
+        elif key in {"ERROR", "ERROR_MIN"}:
             float_values[str(key)] = validate_positive_float(value, key)
-        elif key in ["DAYS", "HOURS"]:
+        elif key in {"DAYS", "HOURS"}:
             setattr(date_dict, str(key).lower(), validate_positive_float(value, key))
         elif key == "VALUE":
             float_values[str(key)] = validate_float(value, key)
@@ -405,11 +405,11 @@ def _validate_gen_obs_values(
             output.restart = validate_positive_int(value, key)
         elif key == "VALUE":
             output.value = validate_float(value, key)
-        elif key in ["ERROR", "DAYS", "HOURS"]:
+        elif key in {"ERROR", "DAYS", "HOURS"}:
             setattr(output, str(key).lower(), validate_positive_float(value, key))
-        elif key in ["DATE", "INDEX_LIST"]:
+        elif key in {"DATE", "INDEX_LIST"}:
             setattr(output, str(key).lower(), value)
-        elif key in ["OBS_FILE", "INDEX_FILE"]:
+        elif key in {"OBS_FILE", "INDEX_FILE"}:
             filename = value
             if not os.path.isabs(filename):
                 filename = os.path.join(directory, filename)

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -253,7 +253,7 @@ def _group_queue_options_by_queue_system(
         grouped[system] = {
             option_line[1]: option_line[2]
             for option_line in queue_config_list
-            if option_line[0] in (QueueSystemWithGeneric.GENERIC, system)
+            if option_line[0] in {QueueSystemWithGeneric.GENERIC, system}
             # Empty option values are ignored, yields defaults:
             and len(option_line) > 2
         }
@@ -317,7 +317,7 @@ class QueueConfig:
             tags = {
                 fm_name.lower()
                 for fm_name, *_ in config_dict.get(ConfigKeys.FORWARD_MODEL, [])
-                if fm_name in ["RMS", "FLOW", "ECLIPSE100", "ECLIPSE300"]
+                if fm_name in {"RMS", "FLOW", "ECLIPSE100", "ECLIPSE300"}
             }
             if tags:
                 queue_options.project_code = "+".join(tags)

--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -69,10 +69,10 @@ class _EnsembleStateTracker:
         self._state = ENSEMBLE_STATE_STARTED
 
     def _handle_failed(self) -> None:
-        if self._state not in [
+        if self._state not in {
             ENSEMBLE_STATE_UNKNOWN,
             ENSEMBLE_STATE_STARTED,
-        ]:
+        }:
             logger.warning(self._msg, self._state, ENSEMBLE_STATE_FAILED)
         self._state = ENSEMBLE_STATE_FAILED
 

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -186,10 +186,10 @@ class EnsembleEvaluator:
             self.stop()
 
     async def _failed_handler(self, events: Sequence[EnsembleFailed]) -> None:
-        if self.ensemble.status in (
+        if self.ensemble.status in {
             ENSEMBLE_STATE_STOPPED,
             ENSEMBLE_STATE_CANCELLED,
-        ):
+        }:
             return
         # if list is empty this call is not triggered by an
         # event, but as a consequence of some bad state
@@ -263,7 +263,7 @@ class EnsembleEvaluator:
                         )
                         return
 
-                    if type(event) in [EnsembleSucceeded, EnsembleFailed]:
+                    if type(event) in {EnsembleSucceeded, EnsembleFailed}:
                         return
             except ConnectionClosedError as connection_error:
                 # Dispatchers may close the connection abruptly in the case of

--- a/src/ert/gui/model/fm_step_list.py
+++ b/src/ert/gui/model/fm_step_list.py
@@ -86,9 +86,9 @@ class FMStepListProxyModel(QAbstractProxyModel):
         if role == Qt.ItemDataRole.DisplayRole:
             if orientation == Qt.Orientation.Horizontal:
                 header = FM_STEP_COLUMNS[section]
-                if header in [ids.STDOUT, ids.STDERR]:
+                if header in {ids.STDOUT, ids.STDERR}:
                     return header.upper()
-                elif header in [ids.MAX_MEMORY_USAGE]:
+                elif header in {ids.MAX_MEMORY_USAGE}:
                     header = header.replace("_", " ")
                 return header.capitalize()
             if orientation == Qt.Orientation.Vertical:

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -336,11 +336,11 @@ class SnapshotModel(QAbstractItemModel):
             if index.column() == 1:
                 return f"{node.data.status}"
 
-        if role in (
+        if role in {
             Qt.ItemDataRole.StatusTipRole,
             Qt.ItemDataRole.WhatsThisRole,
             Qt.ItemDataRole.ToolTipRole,
-        ):
+        }:
             return ""
 
         if role == Qt.ItemDataRole.SizeHintRole:
@@ -349,11 +349,11 @@ class SnapshotModel(QAbstractItemModel):
         if role == Qt.ItemDataRole.FontRole:
             return QFont()
 
-        if role in (
+        if role in {
             Qt.ItemDataRole.BackgroundRole,
             Qt.ItemDataRole.ForegroundRole,
             Qt.ItemDataRole.DecorationRole,
-        ):
+        }:
             return QColor()
 
         return QVariant()
@@ -395,7 +395,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == Qt.ItemDataRole.FontRole:
             data_name = FM_STEP_COLUMNS[index.column()]
-            if data_name in [ids.STDOUT, ids.STDERR] and file_has_content(
+            if data_name in {ids.STDOUT, ids.STDERR} and file_has_content(
                 index.data(FileRole)
             ):
                 font = QFont()
@@ -404,7 +404,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == Qt.ItemDataRole.ForegroundRole:
             data_name = FM_STEP_COLUMNS[index.column()]
-            if data_name in [ids.STDOUT, ids.STDERR] and file_has_content(
+            if data_name in {ids.STDOUT, ids.STDERR} and file_has_content(
                 index.data(FileRole)
             ):
                 return QColor(Qt.GlobalColor.blue)
@@ -418,18 +418,18 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == Qt.ItemDataRole.DisplayRole:
             data_name = FM_STEP_COLUMNS[index.column()]
-            if data_name in [ids.MAX_MEMORY_USAGE]:
+            if data_name in {ids.MAX_MEMORY_USAGE}:
                 data = node.data
                 bytes_: str | None = data.get(data_name)  # type: ignore
                 if bytes_:
                     return byte_with_unit(float(bytes_))
 
-            if data_name in [ids.STDOUT, ids.STDERR]:
+            if data_name in {ids.STDOUT, ids.STDERR}:
                 if not file_has_content(index.data(FileRole)):
                     return "-"
                 return "View" if data_name in node.data else QVariant()
 
-            if data_name in [DURATION]:
+            if data_name in {DURATION}:
                 start_time = node.data.get(ids.START_TIME)
                 if start_time is None:
                     return QVariant()
@@ -444,7 +444,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == FileRole:
             data_name = FM_STEP_COLUMNS[index.column()]
-            if data_name in [ids.STDOUT, ids.STDERR]:
+            if data_name in {ids.STDOUT, ids.STDERR}:
                 return node.data.get(data_name, QVariant())
 
         if role == RealIens:

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -154,7 +154,7 @@ class FMStepOverview(QTableView):
             index = self.indexAt(event.pos())
             if index.isValid():
                 data_name = FM_STEP_COLUMNS[index.column()]
-                if data_name in [ids.STDOUT, ids.STDERR] and file_has_content(
+                if data_name in {ids.STDOUT, ids.STDERR} and file_has_content(
                     index.data(FileRole)
                 ):
                     self.setCursor(Qt.CursorShape.PointingHandCursor)

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -267,10 +267,10 @@ class PlotWindow(QMainWindow):
         x_axis_type = PlotContext.UNKNOWN_AXIS
         y_axis_type = PlotContext.UNKNOWN_AXIS
 
-        if plot_widget.name in [ENSEMBLE, STATISTICS]:
+        if plot_widget.name in {ENSEMBLE, STATISTICS}:
             x_axis_type = preferred_x_axis_format
             y_axis_type = PlotContext.VALUE_AXIS
-        elif plot_widget.name in [DISTRIBUTION, CROSS_ENSEMBLE_STATISTICS]:
+        elif plot_widget.name in {DISTRIBUTION, CROSS_ENSEMBLE_STATISTICS}:
             y_axis_type = PlotContext.VALUE_AXIS
         elif plot_widget.name == HISTOGRAM:
             x_axis_type = PlotContext.VALUE_AXIS

--- a/src/ert/plugins/__init__.py
+++ b/src/ert/plugins/__init__.py
@@ -20,7 +20,7 @@ def plugin(name: str) -> Callable[[Callable[P, Any]], Callable[P, Any]]:
             res = func(*args, **kwargs)
             if (
                 func.__name__
-                in [
+                in {
                     "installable_jobs",
                     "job_documentation",
                     "installable_workflow_jobs",
@@ -30,10 +30,9 @@ def plugin(name: str) -> Callable[[Callable[P, Any]], Callable[P, Any]]:
                     "ecl100_config_path",
                     "ecl300_config_path",
                     "flow_config_path",
-                    "help_links",
                     "site_config_lines",
                     "activate_script",
-                ]
+                }
                 and res is not None
             ):
                 return PluginResponse(

--- a/src/ert/resources/forward_models/res/script/ecl_config.py
+++ b/src/ert/resources/forward_models/res/script/ecl_config.py
@@ -96,7 +96,7 @@ class EclConfig:
         if version in self._config[Keys.versions]:
             return True
 
-        return self.default_version is not None and version in [None, Keys.default]
+        return self.default_version is not None and version in {None, Keys.default}
 
     def get_eclrun_env(self) -> dict[str, str] | None:
         if "eclrun_env" in self._config:
@@ -108,7 +108,7 @@ class EclConfig:
         return self._config.get(Keys.default_version)
 
     def _get_version(self, version_arg: str | None) -> str:
-        if version_arg in [None, Keys.default]:
+        if version_arg in {None, Keys.default}:
             version = self.default_version
         else:
             version = version_arg

--- a/src/ert/resources/forward_models/res/script/ecl_run.py
+++ b/src/ert/resources/forward_models/res/script/ecl_run.py
@@ -161,10 +161,10 @@ def find_unsmry(basepath: Path) -> Path | None:
         if "." not in path:
             return False
         splitted = path.split(".")
-        return splitted[-2].endswith(base) and splitted[-1].lower() in [
+        return splitted[-2].endswith(base) and splitted[-1].lower() in {
             "unsmry",
             "funsmry",
-        ]
+        }
 
     base = basepath.name
     candidates: list[str] = list(
@@ -268,7 +268,7 @@ class EclRun:
         # Dechipher the ecl_case argument.
         input_arg = ecl_case
         (_, ext) = os.path.splitext(input_arg)
-        if ext and ext in [".data", ".DATA"]:
+        if ext and ext in {".data", ".DATA"}:
             data_file = input_arg
         elif input_arg.islower():
             data_file = input_arg + ".data"

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -436,10 +436,10 @@ class BaseRunModel(ABC):
 
         if all_realizations:
             for real in all_realizations.values():
-                if real["status"] in [
+                if real["status"] in {
                     REALIZATION_STATE_FINISHED,
                     REALIZATION_STATE_FAILED,
-                ]:
+                }:
                     done_realizations += 1
 
             realization_progress = float(done_realizations) / len(
@@ -505,10 +505,10 @@ class BaseRunModel(ABC):
             async with Monitor(ee_config.get_connection_info()) as monitor:
                 logger.debug("connected")
                 async for event in monitor.track(heartbeat_interval=0.1):
-                    if type(event) in (
+                    if type(event) in {
                         EESnapshot,
                         EESnapshotUpdate,
-                    ):
+                    }:
                         event = cast(EESnapshot | EESnapshotUpdate, event)
                         await asyncio.get_running_loop().run_in_executor(
                             None,
@@ -517,10 +517,10 @@ class BaseRunModel(ABC):
                             iteration,
                         )
 
-                        if event.snapshot.get(STATUS) in [
+                        if event.snapshot.get(STATUS) in {
                             ENSEMBLE_STATE_STOPPED,
                             ENSEMBLE_STATE_FAILED,
-                        ]:
+                        }:
                             logger.debug(
                                 "observed evaluation stopped event, signal done"
                             )

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -699,7 +699,7 @@ class EverestRunModel(BaseRunModel):
 
     def send_snapshot_event(self, event: Event, iteration: int) -> None:
         super().send_snapshot_event(event, iteration)
-        if type(event) in (EESnapshot, EESnapshotUpdate):
+        if type(event) in {EESnapshot, EESnapshotUpdate}:
             newstatus = self._simulation_status(self.get_current_snapshot())
             if self.status != newstatus:  # No change in status
                 self._sim_callback(newstatus)

--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -123,7 +123,7 @@ def _bind_socket(
             f"error msg is: {err_info.strerror}"
         ) from err_info
     except OSError as err_info:
-        if err_info.errno in (48, 98):
+        if err_info.errno in {48, 98}:
             raise PortAlreadyInUseException(
                 f"Port {port} already in use."
             ) from err_info

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -260,7 +260,7 @@ class _DetachedMonitor:
                     job_progress[job_idx] = JobProgress(name=job["name"])
                 realization = int(job["realization"])
                 status = job["status"]
-                if status in [JOB_RUNNING, JOB_SUCCESS, JOB_FAILURE]:
+                if status in {JOB_RUNNING, JOB_SUCCESS, JOB_FAILURE}:
                     job_progress[job_idx].status[status].append(realization)
         return job_progress.values()
 

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -34,6 +34,6 @@ class InstallDataConfig(BaseModel, extra="forbid"):  # type: ignore
 
     @model_validator(mode="after")
     def validate_target(self):
-        if self.target in (".", "./"):
+        if self.target in {".", "./"}:
             self.target = Path(self.source).name
         return self

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -158,7 +158,7 @@ def check_path_valid(path: str):
             os.lstat(os.path.join(root, dirname))
 
         except OSError as e:
-            if e.errno in (errno.ENAMETOOLONG, errno.ERANGE):
+            if e.errno in {errno.ENAMETOOLONG, errno.ERANGE}:
                 raise ValueError(e.strerror) from e
         except TypeError as e:
             raise ValueError(str(e)) from e
@@ -279,7 +279,7 @@ def validate_forward_model_configs(
             (
                 i
                 for i, arg in enumerate(args)
-                if arg in ["-c", "--config"] and i + 1 < len(args)
+                if arg in {"-c", "--config"} and i + 1 < len(args)
             ),
             None,
         )
@@ -299,7 +299,7 @@ def validate_forward_model_configs(
         if (index := _job_config_index(*args)) is None:
             raise ValueError(f"No config file specified for job {job}")
 
-        if args[0] in ("run", "lint") and (
+        if args[0] in {"run", "lint"} and (
             errors := lint_forward_model_job(job, args[index : index + 2])
         ):
             raise ValueError("\n\t".join(errors))

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -138,7 +138,7 @@ def _variable_initial_guess_list_injection(
     variables["names"].extend(ropt_names)
     variables["initial_values"].extend(control.initial_values)
     for key, value in asdict(control).items():
-        if key not in (*IGNORE_KEYS, "initial_values"):
+        if key not in {*IGNORE_KEYS, "initial_values"}:
             (gradients if "perturbation" in key else variables)[key].extend(
                 [value] * guesses
             )

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -255,10 +255,10 @@ def run_experiment_fixture(request):
                 lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False),
             )
 
-        if not experiment_mode.name() in (
+        if not experiment_mode.name() in {
             "Ensemble experiment",
             "Evaluate ensemble",
-        ):
+        }:
             QTimer.singleShot(500, handle_dialog)
         qtbot.mouseClick(run_experiment, Qt.LeftButton)
 

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -167,7 +167,7 @@ def valid_queue_values(option_name, queue_system):
     elif option_name in queue_options_by_type["posfloat"][queue_system]:
         return small_floats.map(str)
     elif option_name in queue_options_by_type["posint"][queue_system]:
-        if option_name in ["NUM_NODES", "NUM_CPUS_PER_NODE"]:
+        if option_name in {"NUM_NODES", "NUM_CPUS_PER_NODE"}:
             return st.just("1")
         return positives.map(str)
     elif option_name in queue_options_by_type["bool"][queue_system]:

--- a/tests/ert/unit_tests/config/observations_generator.py
+++ b/tests/ert/unit_tests/config/observations_generator.py
@@ -205,7 +205,7 @@ def summary_observations(
     if time_type == "date":
         date = draw(dates)
         kws["date"] = date.strftime("%Y-%m-%d")
-    if time_type in ["days", "hours"]:
+    if time_type in {"days", "hours"}:
         kws[time_type] = draw(st.floats(min_value=1, max_value=3000))
     if time_type == "restart":
         kws[time_type] = draw(st.integers(min_value=1, max_value=10))

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -263,7 +263,7 @@ def verify_json_dump(fm_steplist, config, selected_steps, run_id):
         step["name"] = default_name_if_none(step["name"])
 
         for key in json_keywords:
-            if key in ["stdout", "stderr"]:
+            if key in {"stdout", "stderr"}:
                 assert (
                     create_std_file(step, std=key, step_index=step_index)
                     == loaded_step[key]

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1659,7 +1659,7 @@ def test_no_timemap_or_refcase_provides_clear_error():
 def test_that_multiple_errors_are_shown_when_validating_observation_config():
     with fileinput.input("observations/observations.txt", inplace=True) as fin:
         for line_number, line in enumerate(fin, 1):
-            if line_number in [13, 32]:
+            if line_number in {13, 32}:
                 continue
             print(line, end="")
 

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -30,7 +30,7 @@ def test_get_ensemble(poly_example_tmp_dir, dark_storage_client):
     ensemble_json = resp.json()
 
     assert ensemble_json["experiment_id"] == experiment_json[0]["id"]
-    assert ensemble_json["userdata"]["name"] in ("iter-0", "iter-1")
+    assert ensemble_json["userdata"]["name"] in {"iter-0", "iter-1"}
     assert ensemble_json["userdata"]["experiment_name"] == experiment_json[0]["name"]
 
 
@@ -48,7 +48,7 @@ def test_get_experiment_ensemble(poly_example_tmp_dir, dark_storage_client):
 
     assert len(ensembles_json) == 2
     assert ensembles_json[0]["experiment_id"] == experiment_json[0]["id"]
-    assert ensembles_json[0]["userdata"]["name"] in ("iter-0", "iter-1")
+    assert ensembles_json[0]["userdata"]["name"] in {"iter-0", "iter-1"}
 
 
 @pytest.mark.integration_test

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -524,7 +524,7 @@ async def test_ensure_multi_level_events_in_order(evaluator_to_use):
                 assert snapshot_event_received == True
                 final_event_was_EETerminated = True
                 assert ensemble_state == ENSEMBLE_STATE_STOPPED
-            if type(event) in [EESnapshot, EESnapshotUpdate]:
+            if type(event) in {EESnapshot, EESnapshotUpdate}:
                 # if we get an snapshot event than this need to be valid
                 assert final_event_was_EETerminated == False
                 snapshot_event_received = True

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -51,13 +51,13 @@ async def test_run_legacy_ensemble(
             Monitor(config) as monitor,
         ):
             async for event in monitor.track():
-                if type(event) in (
+                if type(event) in {
                     EESnapshotUpdate,
                     EESnapshot,
-                ) and event.snapshot.get(identifiers.STATUS) in [
+                } and event.snapshot.get(identifiers.STATUS) in {
                     state.ENSEMBLE_STATE_FAILED,
                     state.ENSEMBLE_STATE_STOPPED,
-                ]:
+                }:
                     await monitor.signal_done()
             assert evaluator._ensemble.status == state.ENSEMBLE_STATE_STOPPED
             assert len(evaluator._ensemble.get_successful_realizations()) == num_reals

--- a/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
@@ -34,13 +34,13 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
                         await asyncio.wait_for(rename_and_wait(), timeout=5)
                     except TimeoutError:
                         await monitor.signal_done()
-                if type(event) in (
+                if type(event) in {
                     EESnapshot,
                     EESnapshotUpdate,
-                ) and event.snapshot.get(identifiers.STATUS) in [
+                } and event.snapshot.get(identifiers.STATUS) in {
                     state.ENSEMBLE_STATE_FAILED,
                     state.ENSEMBLE_STATE_STOPPED,
-                ]:
+                }:
                     await monitor.signal_done()
         return True
 

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -143,7 +143,7 @@ def test_load_history_data_searches_until_history_found(api):
     ensemble_ids = [
         ens.id
         for ens in api.get_all_ensembles()
-        if ens.name in ["no-history", "default_0"]
+        if ens.name in {"no-history", "default_0"}
     ]
     df = api.history_data(ensemble_ids=ensemble_ids, key="FOPR")
     assert_frame_equal(
@@ -155,7 +155,7 @@ def test_load_history_data_returns_empty_frame_if_no_history(api):
     ensemble_ids = [
         ens.id
         for ens in api.get_all_ensembles()
-        if ens.name in ["no-history", "still-no-history"]
+        if ens.name in {"no-history", "still-no-history"}
     ]
     df = api.history_data(ensemble_ids=ensemble_ids, key="FOPR")
     assert_frame_equal(df, pd.DataFrame())

--- a/tests/ert/unit_tests/scheduler/bin/squeue.py
+++ b/tests/ert/unit_tests/scheduler/bin/squeue.py
@@ -56,7 +56,7 @@ def main() -> None:
             if returncode != "0":
                 state = "FAILED"
 
-        if state in ["PENDING", "RUNNING"]:
+        if state in {"PENDING", "RUNNING"}:
             print(f"{job} {state}")
 
 

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1334,7 +1334,7 @@ async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, 
         # get SIGTERM but rather LSF_FAILED_JOB. Whether SIGNAL_OFFSET is
         # added or not depends on various shell configurations and is a
         # detail we do not want to track.
-        assert returncode in (SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB)
+        assert returncode in {SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB}
 
     await poll(driver, {0}, finished=finished)
     assert "ERROR" not in str(caplog.text)

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -72,7 +72,7 @@ async def test_events_produced_from_jobstate_updates(jobstate_sequence: list[str
         jobstate = _parse_jobs_dict({"1": {"job_state": statestr, "Exit_status": 0}})[
             "1"
         ]
-        if statestr in ["E", "F"] and "1" in driver._non_finished_job_ids:
+        if statestr in {"E", "F"} and "1" in driver._non_finished_job_ids:
             driver._non_finished_job_ids.remove("1")
             driver._finished_job_ids.add("1")
         await driver._process_job_update("1", jobstate)

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -186,7 +186,7 @@ def test_individual_control_variable_config(copy_test_data_to_tmp):
         exp_var_def = _perturb_control_zero(config, gmin, gmax, ginit, fill)
 
         # Not complete configuration
-        if None in [gmin, gmax, ginit] and not fill:
+        if None in {gmin, gmax, ginit} and not fill:
             with pytest.raises(expected_exception=ValidationError):
                 EverestConfig.model_validate(config.to_dict())
             continue

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -91,10 +91,7 @@ async def test_https_requests(copy_math_func_test_data_to_tmp):
         server_status = everserver_status(status_path)
 
         # Possible the case completed while waiting for the server to stop
-        assert server_status["status"] in [
-            ServerStatus.stopped,
-            ServerStatus.completed,
-        ]
+        assert server_status["status"] in {ServerStatus.stopped, ServerStatus.completed}
         assert not server_is_running(*server_context)
     else:
         server_status = everserver_status(status_path)


### PR DESCRIPTION
`ruff check --fix --unsafe-fixes
`
# literal-membership (PLR6201)

Derived from the **Pylint** linter.

Fix is always available.

This rule is in preview and is not stable. The `--preview` flag is required for use.

## What it does
Checks for membership tests on `list` and `tuple` literals.

## Why is this bad?
When testing for membership in a static sequence, prefer a `set` literal
over a `list` or `tuple`, as Python optimizes `set` membership tests.

## Example
```python
1 in [1, 2, 3]
```

Use instead:
```python
1 in {1, 2, 3}
```

## Fix safety
This rule's fix is marked as unsafe, as the use of a `set` literal will
error at runtime if the sequence contains unhashable elements (like lists
or dictionaries). While Ruff will attempt to infer the hashability of the
elements, it may not always be able to do so.

## References
- [What’s New In Python 3.2](https://docs.python.org/3/whatsnew/3.2.html#optimizations)

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
