### PR TITLE
Non optional everest model and nonzero realizations

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -148,8 +148,7 @@ class EverestConfig(BaseModelWithPropertySupport):  # type: ignore
         default=OptimizationConfig(),
         description="Optimizer options",
     )
-    model: ModelConfig | None = Field(
-        default=ModelConfig(),
+    model: ModelConfig = Field(
         description="Configuration of the Everest model",
     )
 
@@ -463,13 +462,11 @@ and environment variables are exposed in the form 'os.NAME', for example:
     @model_validator(mode="after")
     def validate_maintained_forward_models(self) -> Self:
         install_data = self.install_data
-        model = self.model
-        realizations = model.realizations if model else [0]
 
         with InstallDataContext(install_data, self.config_path) as context:
-            for realization in realizations:
+            for realization in self.model.realizations:
                 context.add_links_for_realization(realization)
-                validate_forward_model_configs(self.forward_model, self.install_jobs)
+            validate_forward_model_configs(self.forward_model, self.install_jobs)
         return self
 
     @model_validator(mode="after")
@@ -769,6 +766,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
             "controls": [],
             "objective_functions": [],
             "config_path": ".",
+            "model": {"realizations": [0]},
         }
 
         return EverestConfig.model_validate({**defaults, **kwargs})

--- a/src/everest/config/model_config.py
+++ b/src/everest/config/model_config.py
@@ -5,10 +5,10 @@ from ert.config import ConfigWarning
 
 class ModelConfig(BaseModel, extra="forbid"):  # type: ignore
     realizations: list[NonNegativeInt] = Field(
-        default_factory=lambda: [],
         description="""List of realizations to use in optimization ensemble.
 
 Typically, this is a list [0, 1, ..., n-1] of all realizations in the ensemble.""",
+        min_length=1,
     )
     data_file: str | None = Field(
         default=None,
@@ -27,6 +27,9 @@ If specified, it must be a list of numeric values, one per realization.""",
     @model_validator(mode="before")
     @classmethod
     def remove_deprecated(cls, values):
+        if values is None:
+            return values
+
         if values.get("report_steps") is not None:
             ConfigWarning.warn(
                 "report_steps no longer has any effect and can be removed."
@@ -34,19 +37,15 @@ If specified, it must be a list of numeric values, one per realization.""",
             values.pop("report_steps")
         return values
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_realizations_weights_same_cardinaltiy(cls, values):  # pylint: disable=E0213
-        weights = values.get("realizations_weights")
-        reals = values.get("realizations")
-
+    @model_validator(mode="after")
+    def validate_realizations_weights_same_cardinaltiy(self):  # pylint: disable=E0213
+        weights = self.realizations_weights
         if not weights:
-            return values
+            return self
 
-        if len(weights) != len(reals):
+        if len(weights) != len(self.realizations):
             raise ValueError(
                 "Specified realizations_weights must have one"
                 " weight per specified realization in realizations"
             )
-
-        return values
+        return self

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -504,15 +504,13 @@ def test_complete_status_for_normal_run_monitor(
     return_value={"status": ServerStatus.never_run, "message": None},
 )
 def test_validate_ert_config_before_starting_everest_server(
-    server_is_running_mock, server_status_mock, tmpdir, monkeypatch
+    server_is_running_mock, server_status_mock, copy_math_func_test_data_to_tmp
 ):
-    path = tmpdir / "new_folder"
-    os.makedirs(path)
-    monkeypatch.chdir(path)
-    config_file = path / "minimal_config.yml"
+    config_file = "config_minimal.yml"
     everest_config = EverestConfig.with_defaults()
+    everest_config.model.realizations = []
     everest_config.dump(config_file)
-    everest_config.config_path = Path(config_file).absolute()
-    error = "Expected realizations when analysing data installation source"
-    with pytest.raises(SystemExit, match=f"Config validation error: {error}"):
+    everest_config.config_path = Path(config_file)
+
+    with pytest.raises(SystemExit):
         everest_entry([str(everest_config.config_path)])

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -5,6 +5,7 @@ import warnings
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -891,8 +892,8 @@ def test_that_missing_required_fields_cause_error():
     error_dicts = e.value.errors()
 
     # Expect missing error for:
-    # controls, objective_functions, config_path
-    assert len(error_dicts) == 3
+    # controls, objective_functions, config_path, model
+    assert len(error_dicts) == 4
 
     config_with_defaults = EverestConfig.with_defaults()
     config_args = {}
@@ -900,6 +901,7 @@ def test_that_missing_required_fields_cause_error():
         "controls",
         "objective_functions",
         "config_path",
+        "model",
     ]
 
     for key in required_argnames:
@@ -958,24 +960,26 @@ def test_that_non_existing_workflow_jobs_cause_error():
     ],
 )
 def test_warning_forward_model_write_objectives(objective, forward_model, warning_msg):
-    if warning_msg is not None:
-        with pytest.warns(ConfigWarning, match=warning_msg):
-            EverestConfig.with_defaults(
-                objective_functions=[{"name": o} for o in objective],
-                forward_model=forward_model,
-            )
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", category=ConfigWarning)
-            EverestConfig.with_defaults(
-                objective_functions=[{"name": o} for o in objective],
-                forward_model=forward_model,
-            )
+    # model.realizations is non-empty and therefore this test will run full validation on forward model schema, we don't want that for this test
+    with patch("everest.config.everest_config.validate_forward_model_configs"):
+        if warning_msg is not None:
+            with pytest.warns(ConfigWarning, match=warning_msg):
+                EverestConfig.with_defaults(
+                    objective_functions=[{"name": o} for o in objective],
+                    forward_model=forward_model,
+                )
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=ConfigWarning)
+                EverestConfig.with_defaults(
+                    objective_functions=[{"name": o} for o in objective],
+                    forward_model=forward_model,
+                )
 
 
-def test_deprecated_keyword():
+def test_deprecated_keyword_report_steps():
     with pytest.warns(ConfigWarning, match="report_steps .* can be removed"):
-        ModelConfig(**{"report_steps": []})
+        ModelConfig(**{"realizations": [0], "report_steps": []})
 
 
 def test_load_file_non_existing():


### PR DESCRIPTION
**Issue**
Resolves #9368 


**Approach**
Make `ModelConfig` required and enforce `realizations` length > 0. Add some more meaningful error messages too. I am still using `list[NonNegativeInt]` (with `min_length=1` in `Field`) instead of `conlist` since this was ill-advised (see discussion here https://github.com/microsoft/pylance-release/issues/5457).

**NOTE**: If I don't add `if values is None:` we get this error when `model` is specified but left empty: `'NoneType' object has no attribute 'get'` which doesn't tell the user anything :)

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
