### PR TITLE
Allow fm step configuration values to be empty strings

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -127,29 +127,29 @@ def create_forward_model_json(
             )
             return context.substitute_real_iter(string, iens, itr)
 
-        def filter_env_dict(self, d):
-            result = {}
-            for key, value in d.items():
-                new_key = self.substitute(key)
-                new_value = self.substitute(value)
-                if new_value is None:
-                    result[new_key] = None
-                elif not new_value:
-                    result[new_key] = ""
-                elif not (new_value[0] == "<" and new_value[-1] == ">"):
+        def filter_env_dict(self, env_dict: dict[str, str]) -> dict[str, str] | None:
+            substituted_dict = {}
+            for key, value in env_dict.items():
+                substituted_key = self.substitute(key)
+                substituted_value = self.substitute(value)
+                if substituted_value is None:
+                    substituted_dict[substituted_key] = None
+                elif not substituted_value:
+                    substituted_dict[substituted_key] = ""
+                elif not (substituted_value[0] == "<" and substituted_value[-1] == ">"):
                     # Remove values containing "<XXX>". These are expected to be
                     # replaced by substitute, but were not.
-                    result[new_key] = new_value
+                    substituted_dict[substituted_key] = substituted_value
                 else:
                     logger.warning(
-                        f"Environment variable {new_key} skipped due to"
-                        f" unmatched define {new_value}",
+                        f"Environment variable {substituted_key} skipped due to"
+                        f" unmatched define {substituted_value}",
                     )
             # Its expected that empty dicts be replaced with "null"
             # in jobs.json
-            if not result:
+            if not substituted_dict:
                 return None
-            return result
+            return substituted_dict
 
     def handle_default(fm_step: ForwardModelStep, arg: str) -> str:
         return fm_step.default_mapping.get(arg, arg)

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -134,6 +134,8 @@ def create_forward_model_json(
                 new_value = self.substitute(value)
                 if new_value is None:
                     result[new_key] = None
+                elif not new_value:
+                    result[new_key] = ""
                 elif not (new_value[0] == "<" and new_value[-1] == ">"):
                     # Remove values containing "<XXX>". These are expected to be
                     # replaced by substitute, but were not.

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -83,6 +83,17 @@ def test_fm_config_with_empty_config_for_step():
     )
 
 
+def test_fm_config_with_empty_string_for_step():
+    class SomePlugin:
+        @plugin(name="foo")
+        def forward_model_configuration():
+            return {"foo": {"com": ""}}
+
+    assert ErtPluginManager(plugins=[SomePlugin]).get_forward_model_configuration() == {
+        "foo": {"com": ""}
+    }
+
+
 def test_fm_config_merges_data_for_step():
     class SomePlugin:
         @plugin(name="foo")


### PR DESCRIPTION
**Issue**
Resolves bug that can only be triggered through the plugin system

**Approach**
Detect empty string



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
