### PR TITLE
Improve handling of invalid experiments in GUI

### DIFF
--- a/src/ert/dark_storage/endpoints/experiments.py
+++ b/src/ert/dark_storage/endpoints/experiments.py
@@ -27,6 +27,7 @@ def get_experiments(
             userdata={},
         )
         for experiment in storage.experiments
+        if experiment.is_valid()
     ]
 
 

--- a/src/ert/dark_storage/endpoints/records.py
+++ b/src/ert/dark_storage/endpoints/records.py
@@ -124,8 +124,7 @@ def get_ensemble_responses(
 
     response_names_with_observations = set()
     observations = ensemble.experiment.observations
-
-    if len(ensemble.has_data()) == 0:
+    if not ensemble.experiment.is_valid() or len(ensemble.has_data()) == 0:
         return {}
 
     for (

--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -65,3 +65,16 @@ class ErtNotifier(QObject):
     @Slot(bool)
     def set_is_simulation_running(self, is_running: bool) -> None:
         self._is_simulation_running = is_running
+        self.refresh()
+
+    def refresh(self) -> None:
+        if self._storage is None:
+            return
+        self._storage.refresh()
+        self.storage_changed.emit(self._storage)
+
+    def revalidate_storage(self) -> None:
+        if self._storage is None:
+            return
+        if self._storage.check_if_experiment_validity_changed():
+            self.refresh()

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -158,6 +158,7 @@ class ErtMainWindow(QMainWindow):
     def select_central_widget(self) -> None:
         actor = self.sender()
         if actor:
+            self.notifier.revalidate_storage()
             index_name = actor.property("index")
 
             for widget in self.central_panels_map.values():

--- a/src/ert/gui/model/real_list.py
+++ b/src/ert/gui/model/real_list.py
@@ -1,10 +1,15 @@
-from typing import overload
+from typing import cast, overload
 
 from PyQt6.QtCore import QAbstractItemModel, QAbstractProxyModel, QModelIndex, QObject
 from PyQt6.QtCore import pyqtSlot as Slot
 from typing_extensions import override
 
-from ert.gui.model.snapshot import IsEnsembleRole, IsRealizationRole, NodeRole
+from ert.gui.model.snapshot import (
+    IsEnsembleRole,
+    IsRealizationRole,
+    NodeRole,
+    SnapshotModel,
+)
 
 
 class RealListModel(QAbstractProxyModel):
@@ -62,7 +67,7 @@ class RealListModel(QAbstractProxyModel):
     def rowCount(self, parent: QModelIndex | None = None) -> int:
         parent = parent if parent else QModelIndex()
         if not parent.isValid():
-            source_model = self.sourceModel()
+            source_model = cast(SnapshotModel, self.sourceModel())
             assert source_model is not None
             iter_index = source_model.index(self._iter, 0, QModelIndex())
             if iter_index.isValid():

--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -35,7 +35,9 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         lab.setWordWrap(True)
         lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
         layout.addRow(lab)
-        self._ensemble_selector = EnsembleSelector(notifier, show_only_no_children=True)
+        self._ensemble_selector = EnsembleSelector(
+            notifier, show_only_no_children=True, show_only_with_valid_experiment=True
+        )
         layout.addRow("Ensemble:", self._ensemble_selector)
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)

--- a/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
+++ b/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
@@ -75,7 +75,11 @@ class ManageExperimentsPanel(QTabWidget):
 
         ensemble_layout = QHBoxLayout()
         ensemble_label = QLabel("Target ensemble:")
-        ensemble_selector = EnsembleSelector(self.notifier, show_only_undefined=True)
+        ensemble_selector = EnsembleSelector(
+            self.notifier,
+            show_only_undefined=True,
+            show_only_with_valid_experiment=True,
+        )
         ensemble_selector.setMinimumWidth(300)
         ensemble_layout.addWidget(ensemble_label)
         ensemble_layout.addWidget(ensemble_selector)

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -95,6 +95,8 @@ class _ExperimentWidget(QWidget):
 
     @Slot(Experiment)
     def setExperiment(self, experiment: Experiment) -> None:
+        if not experiment.is_valid():
+            return
         self._experiment = experiment
 
         self._name_label.setText(f"Name: {experiment.name!s}")

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -139,7 +139,8 @@ class StorageWidget(QWidget):
             self.onSelectEnsemble.emit(ensemble)
         elif isinstance(cls, ExperimentModel):
             experiment = self._notifier.storage.get_experiment(cls._id)
-            self.onSelectExperiment.emit(experiment)
+            if experiment.is_valid():
+                self.onSelectExperiment.emit(experiment)
         elif isinstance(cls, RealizationModel):
             ensemble = self._notifier.storage.get_ensemble(cls.ensemble_id)
             self.onSelectRealization.emit(ensemble, cls.realization)

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -111,8 +111,8 @@ class PlotApi:
                 response = client.get(
                     f"/experiments/{experiment['id']}/ensembles", timeout=self._timeout
                 )
-                self._check_response(response)
 
+                self._check_response(response)
                 for ensemble in response.json():
                     response = client.get(
                         f"/ensembles/{ensemble['id']}/responses", timeout=self._timeout

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -406,6 +406,11 @@ class LocalEnsemble(BaseMode):
         states : list of RealizationStorageState
             list of realization states.
         """
+        if not self.experiment.is_valid():
+            logger.warning(
+                f"Could not get ensemble state for ensemble ({self.id}) due to invalid experiment ({self.experiment_id}): {self.experiment.error_message}"
+            )
+            return []
 
         response_configs = self.experiment.response_configuration
 

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -75,6 +75,26 @@ class LocalExperiment(BaseMode):
         self._index = _Index.model_validate_json(
             (path / "index.json").read_text(encoding="utf-8")
         )
+        self._validate_files()
+
+    def _validate_files(self) -> None:
+        self.valid_parameters = (self._path / self._parameter_file).exists()
+        self.valid_responses = (self._path / self._responses_file).exists()
+        self.valid_metadata = (self._path / self._metadata_file).exists()
+
+    def is_valid(self) -> bool:
+        return self.valid_parameters and self.valid_responses and self.valid_metadata
+
+    @property
+    def error_message(self) -> str:
+        errors = []
+        if not self.valid_parameters:
+            errors.append("Parameter file is missing")
+        if not self.valid_responses:
+            errors.append("Responses file is missing")
+        if not self.valid_metadata:
+            errors.append("Metadata file is missing")
+        return "\n".join(errors)
 
     @classmethod
     def create(

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -394,6 +394,13 @@ def wait_for_child(gui, qtbot: QtBot, typ: type[V], timeout=5000, **kwargs) -> V
     return get_child(gui, typ, **kwargs)
 
 
+def wait_for_children(
+    gui, qtbot: QtBot, typ: type[V], timeout=5000, **kwargs
+) -> list[V]:
+    qtbot.waitUntil(lambda: gui.findChildren(typ) is not None, timeout=timeout)
+    return get_children(gui, typ, **kwargs)
+
+
 def get_child(gui: QWidget, typ: type[V], *args, **kwargs) -> V:
     child = gui.findChild(typ, *args, **kwargs)
     assert isinstance(child, typ)


### PR DESCRIPTION
**Issue**
Resolves #9493


**Approach**
The commit in this PR:
* Makes storage re-validate when changing between ert modes (manage experiment, run experiment, plot experiment), and emit storage_changed if validity has changed.
* Disables ensembles with invalid experiments from ensemble_selectors (error is shown as tooltip on hover)
* Filters out invalid experiments from dark storage, so plotter won't attempt to plot it. 
* Reloads storage and re-validates on end of experiment, so ert wont crash if responses.json is deleted mid-run.
 
(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/917d1c16-a1a5-42db-842b-41fa68a5aeb0)
(This is when the responses.json file is deleted mid run. Prior to this PR, ert would crash with `ValueError: responses.json does not exist`)


![image](https://github.com/user-attachments/assets/7433c1a3-568b-41e4-9759-35c85adb59b9)
(This is when responses.json is deleted, and we open the plotter. The ensemble exists, but is not given as a option to plot due to it having an invalid experiment)


![image](https://github.com/user-attachments/assets/2d3a4ca3-76e7-4e97-b8de-ceddb9c9ae96)
(This is when responses.json is deleted and we open manage-experiment. The experiment is shown, but cannot be selected. It is greyed out, and gives error as a tooltip when hovered)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
