### PR TITLE
Pretty print manifest.json

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -284,12 +284,19 @@ def create_run_path(
             )
             with open(run_path / "jobs.json", mode="wb") as fptr:
                 fptr.write(
-                    orjson.dumps(forward_model_output, option=orjson.OPT_NON_STR_KEYS)
+                    orjson.dumps(
+                        forward_model_output,
+                        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
+                    )
                 )
             # Write MANIFEST file to runpath use to avoid NFS sync issues
             data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
             with open(run_path / "manifest.json", mode="wb") as fptr:
-                fptr.write(orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS))
+                fptr.write(
+                    orjson.dumps(
+                        data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2
+                    )
+                )
 
     runpaths.write_runpath_list(
         [ensemble.iteration], [real.iens for real in run_args if real.active]


### PR DESCRIPTION
jobs.json was already effectively pretty-printed as it is overwritten at a later stage, but now both writes of jobs.json are consistent in printing pretty.

**Issue**
Resolves #9555 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
