### PR TITLE
Validate triangular dist parameters on startup

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -205,6 +205,25 @@ class GenKwConfig(ParameterConfig):
                     ).set_context(self.name)
                 )
 
+        def _check_valid_triangular_parameters(prior: PriorDict) -> None:
+            key = prior["key"]
+            dist = prior["function"]
+            xmin, xmode, xmax = prior["parameters"].values()
+            if not (xmin < xmax):
+                errors.append(
+                    ErrorInfo(
+                        f"Minimum {xmin} must be strictly less than the maxiumum {xmax}"
+                        f" for {dist} distributed parameter {key}",
+                    ).set_context(self.name)
+                )
+            if not (xmin <= xmode <= xmax):
+                errors.append(
+                    ErrorInfo(
+                        f"The mode {xmode} must be between the minimum {xmin} and maximum {xmax}"
+                        f" for {dist} distributed parameter {key}",
+                    ).set_context(self.name)
+                )
+
         unique_keys = set()
         for prior in self.get_priors():
             key = prior["key"]
@@ -219,6 +238,8 @@ class GenKwConfig(ParameterConfig):
             if prior["function"] == "LOGNORMAL":
                 _check_non_negative_parameter("MEAN", prior)
                 _check_non_negative_parameter("STD", prior)
+            elif prior["function"] == "TRIANGULAR":
+                _check_valid_triangular_parameters(prior)
             elif prior["function"] in {"NORMAL", "TRUNCATED_NORMAL"}:
                 _check_non_negative_parameter("STD", prior)
         if errors:


### PR DESCRIPTION
**Issue**
Resolves #9520 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
