### PR TITLE
Move max_runtime to QueueConfig

### DIFF
--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -34,7 +34,6 @@ class UpdateSettings:
 
 @dataclass
 class AnalysisConfig:
-    max_runtime: int | None = None
     minimum_required_realizations: int = 0
     update_log_path: str | Path = "update_log"
     es_module: ESSettings = field(default_factory=ESSettings)
@@ -188,7 +187,6 @@ class AnalysisConfig:
             raise ConfigValidationError.from_collected(all_errors)
 
         config = cls(
-            max_runtime=config_dict.get(ConfigKeys.MAX_RUNTIME),
             minimum_required_realizations=min_realization,
             update_log_path=config_dict.get(ConfigKeys.UPDATE_LOG_PATH, "update_log"),
             observation_settings=obs_settings,
@@ -207,7 +205,6 @@ class AnalysisConfig:
     def __repr__(self) -> str:
         return (
             "AnalysisConfig("
-            f"max_runtime={self.max_runtime}, "
             f"min_realization={self.minimum_required_realizations}, "
             f"update_log_path={self.update_log_path}, "
         )
@@ -217,9 +214,6 @@ class AnalysisConfig:
             return False
 
         if self.log_path != other.log_path:
-            return False
-
-        if self.max_runtime != other.max_runtime:
             return False
 
         if self.observation_settings != other.observation_settings:

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -271,6 +271,7 @@ class QueueConfig:
     ) = pydantic.Field(default_factory=LocalQueueOptions, discriminator="name")
     queue_options_test_run: LocalQueueOptions = field(default_factory=LocalQueueOptions)
     stop_long_running: bool = False
+    max_runtime: int | None = None
 
     @no_type_check
     @classmethod
@@ -347,6 +348,7 @@ class QueueConfig:
             queue_options,
             queue_options_test_run,
             stop_long_running=bool(stop_long_running),
+            max_runtime=config_dict.get(ConfigKeys.MAX_RUNTIME),
         )
 
     def create_local_copy(self) -> QueueConfig:
@@ -358,6 +360,7 @@ class QueueConfig:
             self.queue_options_test_run,
             self.queue_options_test_run,
             stop_long_running=bool(self.stop_long_running),
+            max_runtime=self.max_runtime,
         )
 
     @property

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -610,7 +610,7 @@ class BaseRunModel(ABC):
                     active=run_arg.active,
                     iens=run_arg.iens,
                     fm_steps=self.ert_config.forward_model_steps,
-                    max_runtime=self.ert_config.analysis_config.max_runtime,
+                    max_runtime=self._queue_config.max_runtime,
                     run_arg=run_arg,
                     num_cpu=self.ert_config.preferred_num_cpu,
                     job_script=self.ert_config.queue_config.job_script,

--- a/tests/ert/unit_tests/config/test_analysis_config.py
+++ b/tests/ert/unit_tests/config/test_analysis_config.py
@@ -240,19 +240,6 @@ def test_std_cutoff_is_set_from_corresponding_key(value):
     )
 
 
-def test_default_max_runtime_is_unlimited():
-    assert AnalysisConfig.from_dict({}).max_runtime is None
-    assert AnalysisConfig().max_runtime is None
-
-
-@given(st.integers(min_value=1))
-def test_max_runtime_is_set_from_corresponding_keyword(value):
-    assert (
-        AnalysisConfig.from_dict({ConfigKeys.MAX_RUNTIME: value}).max_runtime == value
-    )
-    assert AnalysisConfig(max_runtime=value).max_runtime == value
-
-
 @given(st.integers(min_value=1))
 def test_default_min_realization_is_all_realizations(value):
     assert (

--- a/tests/ert/unit_tests/config/test_queue_config.py
+++ b/tests/ert/unit_tests/config/test_queue_config.py
@@ -483,3 +483,14 @@ def test_default_activate_script_generation(expected, monkeypatch, venv):
         monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     options = QueueOptions(name="local")
     assert options.activate_script == expected
+
+
+def test_default_max_runtime_is_unlimited():
+    assert QueueConfig.from_dict({}).max_runtime is None
+    assert QueueConfig().max_runtime is None
+
+
+@given(st.integers(min_value=1))
+def test_max_runtime_is_set_from_corresponding_keyword(value):
+    assert QueueConfig.from_dict({ConfigKeys.MAX_RUNTIME: value}).max_runtime == value
+    assert QueueConfig(max_runtime=value).max_runtime == value


### PR DESCRIPTION
Some drive by cleaning, does not really seem to belong with the analysis config, but with the queue_config.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
