### PR TITLE
Avoid repeated logging for each cluster in misfit analysis

### DIFF
--- a/src/ert/analysis/misfit_preprocessor.py
+++ b/src/ert/analysis/misfit_preprocessor.py
@@ -17,10 +17,6 @@ def get_scaling_factor(nr_observations: int, nr_components: int) -> float:
         nr_components is the number of primary components from PCA analysis
             below a user threshold
     """
-    logger.info(
-        f"Calculation scaling factor, nr of primary components: "
-        f"{nr_components}, number of observations: {nr_observations}"
-    )
     if nr_components == 0:
         nr_components = 1
         logger.warning(
@@ -160,4 +156,5 @@ def main(
         scale_factor = get_scaling_factor(len(index), components)
         nr_components[index] *= components
         scale_factors[index] *= scale_factor
+    logger.info(f"Calculated scaling factors for {len(scale_factors)} clusters")
     return scale_factors, clusters, nr_components


### PR DESCRIPTION
**Issue**
Resolves #9347 


**Approach**

Condense what is logged.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
