### PR TITLE
Add test that monitor can't connect to a secured server

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from contextlib import suppress
 
 import pytest
 import zmq
@@ -16,9 +17,13 @@ from ert.ensemble_evaluator import Monitor
 from ert.ensemble_evaluator.config import EvaluatorConnectionInfo
 
 
-async def async_zmq_server(port, handler):
+async def async_zmq_server(port, handler, secret_key: bytes | None = None):
     zmq_context = zmq.asyncio.Context()
     router_socket = zmq_context.socket(zmq.ROUTER)
+    if secret_key is not None:
+        router_socket.curve_secretkey = secret_key
+        router_socket.curve_publickey = zmq.curve_public(secret_key)
+        router_socket.curve_server = True
     router_socket.setsockopt(zmq.LINGER, 0)
     router_socket.bind(f"tcp://*:{port}")
     await handler(router_socket)
@@ -119,6 +124,55 @@ async def test_unexpected_close_after_connection_successful(
             await monitor.signal_done()
 
     await websocket_server_task
+
+
+@pytest.mark.parametrize(
+    "correct_server_key",
+    [
+        pytest.param(True),
+        pytest.param(False),
+    ],
+)
+async def test_that_monitor_cannot_connect_with_wrong_server_key(
+    correct_server_key, monkeypatch, unused_tcp_port
+):
+    public_key, secret_key = zmq.curve_keypair()
+    ee_con_info = EvaluatorConnectionInfo(
+        f"tcp://127.0.0.1:{unused_tcp_port}",
+        public_key.decode("utf-8") if correct_server_key else None,
+    )
+
+    monkeypatch.setattr(Monitor, "DEFAULT_MAX_RETRIES", 0)
+    monkeypatch.setattr(Monitor, "DEFAULT_ACK_TIMEOUT", 1)
+
+    connected = False
+
+    async def mock_event_handler(router_socket):
+        nonlocal connected
+        while True:
+            dealer, _, frame = await router_socket.recv_multipart()
+            await router_socket.send_multipart([dealer, b"", ACK_MSG])
+            if frame == CONNECT_MSG:
+                connected = True
+            elif frame == DISCONNECT_MSG:
+                connected = False
+                return
+
+    websocket_server_task = asyncio.create_task(
+        async_zmq_server(unused_tcp_port, mock_event_handler, secret_key=secret_key)
+    )
+    if correct_server_key:
+        async with Monitor(ee_con_info):
+            assert connected
+        assert connected is False
+    else:
+        with pytest.raises(ClientConnectionError):
+            async with Monitor(ee_con_info):
+                pass
+        assert connected is False
+        websocket_server_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await websocket_server_task
 
 
 async def test_that_monitor_track_can_exit_without_terminated_event_from_evaluator(


### PR DESCRIPTION
**Issue**
Resolves #9624 


**Approach**
Add test that monitor can't connect to a secured server.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
