### PR TITLE
Avoid deprecated utcnow()

### DIFF
--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import ssl
 import threading
 import traceback
 from base64 import b64encode
-from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -437,8 +437,10 @@ def _generate_certificate(cert_folder: str):
         .issuer_name(issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))  # 1 year
+        .not_valid_before(datetime.datetime.now(datetime.UTC))
+        .not_valid_after(
+            datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=365)
+        )  # 1 year
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(f"{cert_name}")]),
             critical=False,

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -55,7 +55,9 @@ def warn_user_that_runpath_is_nonempty() -> None:
 
 def _roll_dir(old_name):
     old_name = os.path.realpath(old_name)
-    new_name = old_name + datetime.datetime.utcnow().strftime("__%Y-%m-%d_%H.%M.%S.%f")
+    new_name = old_name + datetime.datetime.now(datetime.UTC).strftime(
+        "__%Y-%m-%d_%H.%M.%S.%f"
+    )
     os.rename(old_name, new_name)
     logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")
 


### PR DESCRIPTION
**Issue**
Resolves warning when running tests.


**Approach**
Do as suggested now that Python 3.8 has been dropped.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
