### PR TITLE
Avoid warning from pytest

### DIFF
--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -214,7 +214,7 @@ def test_direct_dark_performance_with_storage(
 def api_and_storage(monkeypatch, tmp_path):
     with open_storage(tmp_path / "storage", mode="w") as storage:
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
-        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", storage.path)
+        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
         api = PlotApi()
         yield api, storage
     if enkf._storage is not None:
@@ -227,7 +227,7 @@ def api_and_storage(monkeypatch, tmp_path):
 def api_and_snake_oil_storage(snake_oil_case_storage, monkeypatch):
     with open_storage(snake_oil_case_storage.ens_path, mode="r") as storage:
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
-        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", storage.path)
+        monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
 
         api = PlotApi()
         yield api, storage


### PR DESCRIPTION
PytestWarning: Value of environment variable ERT_STORAGE_ENS_PATH type should be str, but got PosixPath('/.../storage') (type: PosixPath); converted to str implicitly

**Issue**
⬆️ 

**Approach**
`str()`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
