### PR TITLE
Version 12.1 backport

### DIFF
--- a/src/ert/analysis/misfit_preprocessor.py
+++ b/src/ert/analysis/misfit_preprocessor.py
@@ -17,10 +17,6 @@ def get_scaling_factor(nr_observations: int, nr_components: int) -> float:
         nr_components is the number of primary components from PCA analysis
             below a user threshold
     """
-    logger.info(
-        f"Calculation scaling factor, nr of primary components: "
-        f"{nr_components}, number of observations: {nr_observations}"
-    )
     if nr_components == 0:
         nr_components = 1
         logger.warning(
@@ -160,4 +156,5 @@ def main(
         scale_factor = get_scaling_factor(len(index), components)
         nr_components[index] *= components
         scale_factors[index] *= scale_factor
+    logger.info(f"Calculated scaling factors for {len(scale_factors)} clusters")
     return scale_factors, clusters, nr_components

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -103,8 +103,8 @@ def plotHistogram(
         else:
             current_min = data[ensemble.name].min()
             current_max = data[ensemble.name].max()
-            minimum = current_min if minimum is None else min(minimum, current_min)  # type: ignore
-            maximum = current_max if maximum is None else max(maximum, current_max)  # type: ignore
+            minimum = current_min if minimum is None else min(minimum, current_min)
+            maximum = current_max if maximum is None else max(maximum, current_max)
             max_element_count = max(max_element_count, len(data[ensemble.name].index))
 
     bin_count = ceil(sqrt(max_element_count))

--- a/src/ert/resources/shell_scripts/copy_directory.py
+++ b/src/ert/resources/shell_scripts/copy_directory.py
@@ -18,10 +18,23 @@ def copy_directory(src_path: str, target_path: str) -> None:
         print(f"Copying directory structure {src_path} -> {target_path}")
         if os.path.isdir(target_path):
             target_path = os.path.join(target_path, src_basename)
-        shutil.copytree(src_path, target_path, dirs_exist_ok=True)
+        try:
+            shutil.copytree(src_path, target_path, dirs_exist_ok=True)
+        except shutil.Error as err:
+            # Check for shutil bug in Python <3.14:
+            if len(err.args[0]) > 10 and {
+                len(somestring) for somestring in err.args[0]
+            } == {1}:
+                # https://github.com/python/cpython/issues/102931
+                # This can only occur when the shutil.Error is a single error
+                raise OSError("".join(err.args[0])) from err
+            else:
+                raise OSError(
+                    ", ".join([err_arg[2] for err_arg in err.args[0]])
+                ) from err
     else:
         raise OSError(
-            f"Input argument:'{src_path}' "
+            f"Input argument: '{src_path}' "
             "does not correspond to an existing directory"
         )
 
@@ -31,7 +44,5 @@ if __name__ == "__main__":
     target_path = sys.argv[2]
     try:
         copy_directory(src_path, target_path)
-    except OSError as e:
-        sys.exit(
-            f"COPY_DIRECTORY failed with the following error: {''.join(e.args[0])}"
-        )
+    except OSError as oserror:
+        sys.exit(f"COPY_DIRECTORY failed with the following error(s): {oserror}")

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import ssl
 import threading
 import traceback
 from base64 import b64encode
-from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -439,8 +439,10 @@ def _generate_certificate(cert_folder: str):
         .issuer_name(issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=365))  # 1 year
+        .not_valid_before(datetime.datetime.now(datetime.UTC))
+        .not_valid_after(
+            datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=365)
+        )  # 1 year
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(f"{cert_name}")]),
             critical=False,

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -64,7 +64,9 @@ def warn_user_that_runpath_is_nonempty() -> None:
 
 def _roll_dir(old_name):
     old_name = os.path.realpath(old_name)
-    new_name = old_name + datetime.datetime.utcnow().strftime("__%Y-%m-%d_%H.%M.%S.%f")
+    new_name = old_name + datetime.datetime.now(datetime.UTC).strftime(
+        "__%Y-%m-%d_%H.%M.%S.%f"
+    )
     os.rename(old_name, new_name)
     logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")
 

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
@@ -69,7 +69,7 @@ install_data:
     target: templates
 
 forward_model:
-  - well_swapping run --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
+  - well_swapping --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
 
   ####################################
   # FROM HERE ON, NOTHING NEW...

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
@@ -87,7 +87,7 @@ install_data:
     target: templates
 
 forward_model:
-  - well_swapping run --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
+  - well_swapping --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
 
   ####################################
   # FROM HERE ON, NOTHING NEW...


### PR DESCRIPTION
Backports:
* Compatibility with everest-models 1.3.1 (bugfix compared to 1.3.0)
* Workaround Python bug for shutil.copytree() exceptions 
* Avoid repeated logging for each cluster in misfit analysis
* Avoid deprecated utcnow()



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
