### PR TITLE
Add nicer error message when init fails

### DIFF
--- a/src/everest/__init__.py
+++ b/src/everest/__init__.py
@@ -3,7 +3,15 @@ This is the main Everest module.
 
 """
 
-from .loader import load
+try:
+    from .loader import load
+except Exception as e:
+    print(
+        f"Error during initialization: {e}\nPlease make sure that everest is installed correctly and that all dependencies are updated."
+    )
+    import sys
+
+    sys.exit(1)
 
 try:
     from ert.shared.version import version


### PR DESCRIPTION
**Issue**
Resolves #9466 


**Approach**
To test. 

```
pip install ropt==0.4.3
everest run test-data/everest/math_func/config_advanced.yml

```

Should get a error message not a stacktrace


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
