### PR TITLE
Avoid UserWarning when vmin==vmax in std_dev plot

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/std_dev.py
+++ b/src/ert/gui/tools/plot/plottery/plots/std_dev.py
@@ -108,8 +108,9 @@ class StdDevPlot:
                 im.set_norm(norm)
 
             padding = 0.05 * (vmax - vmin)
-            for ax_box in boxplot_axes:
-                ax_box.set_ylim(vmin - padding, vmax + padding)
+            if padding > 0.0:
+                for ax_box in boxplot_axes:
+                    ax_box.set_ylim(vmin - padding, vmax + padding)
 
     @staticmethod
     def _colorbar(mappable: Any) -> Any:


### PR DESCRIPTION
**Issue**
Resolves #9657 


**Approach**
`if`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
