### PR TITLE
Remove asyncio.run_in_executor() calls and make scheduler cancel() async

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -6,7 +6,7 @@ import traceback
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from functools import partialmethod
-from typing import Any, Protocol
+from typing import Any
 
 from _ert.events import (
     Event,
@@ -104,7 +104,7 @@ class LegacyEnsemble:
     id_: str
 
     def __post_init__(self) -> None:
-        self._scheduler: _KillAllJobs | None = None
+        self._scheduler: Scheduler | None = None
         self._config: EvaluatorServerConfig | None = None
         self.snapshot: EnsembleSnapshot = self._create_snapshot()
         self.status = self.snapshot.status
@@ -309,14 +309,10 @@ class LegacyEnsemble:
     def cancellable(self) -> bool:
         return True
 
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         if self._scheduler is not None:
-            self._scheduler.kill_all_jobs()
+            await self._scheduler.kill_all_jobs()
         logger.debug("evaluator cancelled")
-
-
-class _KillAllJobs(Protocol):
-    def kill_all_jobs(self) -> None: ...
 
 
 @dataclass

--- a/src/ert/ensemble_evaluator/monitor.py
+++ b/src/ert/ensemble_evaluator/monitor.py
@@ -47,7 +47,6 @@ class Monitor(Client):
     async def signal_cancel(self) -> None:
         await self._event_queue.put(Monitor._sentinel)
         logger.debug(f"monitor-{self._id} asking server to cancel...")
-
         cancel_event = EEUserCancel(monitor=self._id)
         await self.send(event_to_json(cancel_event))
         logger.debug(f"monitor-{self._id} asked server to cancel")

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -503,12 +503,9 @@ class BaseRunModel(ABC):
                         EESnapshotUpdate,
                     }:
                         event = cast(EESnapshot | EESnapshotUpdate, event)
-                        await asyncio.get_running_loop().run_in_executor(
-                            None,
-                            self.send_snapshot_event,
-                            event,
-                            iteration,
-                        )
+
+                        self.send_snapshot_event(event, iteration)
+
                         if event.snapshot.get(STATUS) in {
                             ENSEMBLE_STATE_STOPPED,
                             ENSEMBLE_STATE_FAILED,

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -89,6 +89,7 @@ async def test_run_and_cancel_legacy_ensemble(
             # and the ensemble is set to STOPPED
             monitor._receiver_timeout = 10.0
             cancel = True
+            await evaluator._ensemble._scheduler._running.wait()
             async for event in monitor.track(heartbeat_interval=0.1):
                 # Cancel the ensemble upon the arrival of the first event
                 if cancel:


### PR DESCRIPTION
**Issue**
Resolves #9307 


**Approach**
The commit in this PR removes the asyncio.run_in_executor() calls, and runs the methods directly instead.
It also makes the signal_cancel, and cancel methods async/await instead of asyncio.run_coroutine_threadsafe().

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
