### PR TITLE
Remove job validation from everest config code

### DIFF
--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -120,10 +120,6 @@ def test_extra_key(min_config):
             "No such file or directory",
         ),
         (
-            {"install_jobs": [{"source": "does_not_exist", "name": "not_relevant"}]},
-            "Is not a file .*/does_not_exist",
-        ),
-        (
             {"install_jobs": [{"source": None, "name": "not_relevant"}]},
             "source\n.* should be a valid string",
         ),
@@ -220,23 +216,6 @@ def test_export_filepath_validation(min_config, tmp_path, monkeypatch, path_val,
         else pytest.raises(ValidationError, match="Invalid type")
     )
     with expectation:
-        EverestConfig(**min_config)
-
-
-@pytest.mark.parametrize(
-    "content, error",
-    [
-        ("ARGUMENT 1\n", "missing EXECUTABLE (.*)"),
-        ("EXECUTABLE /no/such/path\n", "No such executable (.*)"),
-        ("EXECUTABLE my_file\n", "(.*)my_file is not executable"),
-    ],
-)
-def test_ert_job_file(tmp_path, monkeypatch, min_config, content, error):
-    monkeypatch.chdir(tmp_path)
-    Path("my_file").touch()
-    Path("ert_job_file").write_text(content, encoding="utf-8")
-    min_config["install_jobs"] = [{"source": "ert_job_file", "name": "irrelephant"}]
-    with pytest.raises(ValidationError, match=error):
         EverestConfig(**min_config)
 
 


### PR DESCRIPTION
**Issue**
Resolves #9475 


**Approach**
The validation of installed forward/models in the everest config code is duplicating functionality in ERT. Removing it forwards the checking to ERT. The relevant tests are modified to test for ERT errors.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
