### PR TITLE
Add callback system for ert.storage

### DIFF
--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -5,6 +5,8 @@ from ert.storage import Ensemble, Storage
 
 class ErtNotifier(QObject):
     ertChanged = Signal()
+    experimentChanged = Signal()
+    ensembleChanged = Signal()
     storage_changed = Signal(object, name="storageChanged")
     current_ensemble_changed = Signal(object, name="currentEnsembleChanged")
 

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -159,4 +159,4 @@ class StorageWidget(QWidget):
                 iteration=create_experiment_dialog.iteration,
             )
             self._notifier.set_current_ensemble(ensemble)
-            self._notifier.ertChanged.emit()
+            # self._notifier.ertChanged.emit()


### PR DESCRIPTION
**Issue**
Resolves #5867


**Approach**
Add callback system for ert.storage

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
