### PR TITLE
Explicitly sort dicts in test_api_snapshots

### DIFF
--- a/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_advanced.yml/snapshot.json
@@ -1,4 +1,12 @@
 {
+  "accepted_batches": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
   "batches": [
     0,
     1,
@@ -12,17 +20,326 @@
     "point_x-1",
     "point_x-2"
   ],
-  "accepted_batches": [
-    0,
-    1,
-    2,
-    3,
-    4,
-    5
+  "control_values": [
+    {
+      "batch": 0,
+      "control": "point_x-0",
+      "value": 0.25
+    },
+    {
+      "batch": 0,
+      "control": "point_x-1",
+      "value": 0.25
+    },
+    {
+      "batch": 0,
+      "control": "point_x-2",
+      "value": 0.25
+    },
+    {
+      "batch": 0,
+      "control": "point_x-0",
+      "value": 0.25
+    },
+    {
+      "batch": 0,
+      "control": "point_x-1",
+      "value": 0.25
+    },
+    {
+      "batch": 0,
+      "control": "point_x-2",
+      "value": 0.25
+    },
+    {
+      "batch": 1,
+      "control": "point_x-0",
+      "value": 0.25904478
+    },
+    {
+      "batch": 1,
+      "control": "point_x-1",
+      "value": 0.13792475
+    },
+    {
+      "batch": 1,
+      "control": "point_x-2",
+      "value": 0.17336687
+    },
+    {
+      "batch": 1,
+      "control": "point_x-0",
+      "value": 0.25904478
+    },
+    {
+      "batch": 1,
+      "control": "point_x-1",
+      "value": 0.13792475
+    },
+    {
+      "batch": 1,
+      "control": "point_x-2",
+      "value": 0.17336687
+    },
+    {
+      "batch": 2,
+      "control": "point_x-0",
+      "value": 0.31863568
+    },
+    {
+      "batch": 2,
+      "control": "point_x-1",
+      "value": 0.00504358
+    },
+    {
+      "batch": 2,
+      "control": "point_x-2",
+      "value": 0.13385209
+    },
+    {
+      "batch": 2,
+      "control": "point_x-0",
+      "value": 0.31863568
+    },
+    {
+      "batch": 2,
+      "control": "point_x-1",
+      "value": 0.00504358
+    },
+    {
+      "batch": 2,
+      "control": "point_x-2",
+      "value": 0.13385209
+    },
+    {
+      "batch": 3,
+      "control": "point_x-0",
+      "value": 0.24117771
+    },
+    {
+      "batch": 3,
+      "control": "point_x-1",
+      "value": 0.03015417
+    },
+    {
+      "batch": 3,
+      "control": "point_x-2",
+      "value": 0.24583776
+    },
+    {
+      "batch": 3,
+      "control": "point_x-0",
+      "value": 0.24117771
+    },
+    {
+      "batch": 3,
+      "control": "point_x-1",
+      "value": 0.03015417
+    },
+    {
+      "batch": 3,
+      "control": "point_x-2",
+      "value": 0.24583776
+    },
+    {
+      "batch": 4,
+      "control": "point_x-0",
+      "value": 0.15091481
+    },
+    {
+      "batch": 4,
+      "control": "point_x-1",
+      "value": -0.00394611
+    },
+    {
+      "batch": 4,
+      "control": "point_x-2",
+      "value": 0.36960914
+    },
+    {
+      "batch": 4,
+      "control": "point_x-0",
+      "value": 0.15091481
+    },
+    {
+      "batch": 4,
+      "control": "point_x-1",
+      "value": -0.00394611
+    },
+    {
+      "batch": 4,
+      "control": "point_x-2",
+      "value": 0.36960914
+    },
+    {
+      "batch": 5,
+      "control": "point_x-0",
+      "value": 0.1145273
+    },
+    {
+      "batch": 5,
+      "control": "point_x-1",
+      "value": 0.00635029
+    },
+    {
+      "batch": 5,
+      "control": "point_x-2",
+      "value": 0.38836369
+    },
+    {
+      "batch": 5,
+      "control": "point_x-0",
+      "value": 0.1145273
+    },
+    {
+      "batch": 5,
+      "control": "point_x-1",
+      "value": 0.00635029
+    },
+    {
+      "batch": 5,
+      "control": "point_x-2",
+      "value": 0.38836369
+    }
   ],
+  "gradient_values": [
+    {
+      "batch": 0,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.49076627
+    },
+    {
+      "batch": 0,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": -0.50191014
+    },
+    {
+      "batch": 0,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.50424549
+    },
+    {
+      "batch": 1,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.52209326
+    },
+    {
+      "batch": 1,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": -0.28579331
+    },
+    {
+      "batch": 1,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.64869691
+    },
+    {
+      "batch": 2,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.64281291
+    },
+    {
+      "batch": 2,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": -0.00521952
+    },
+    {
+      "batch": 2,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.73152662
+    },
+    {
+      "batch": 3,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.47276201
+    },
+    {
+      "batch": 3,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": -0.0785477
+    },
+    {
+      "batch": 3,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.51539765
+    },
+    {
+      "batch": 4,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.30369426
+    },
+    {
+      "batch": 4,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": 0.02314375
+    },
+    {
+      "batch": 4,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.25834193
+    },
+    {
+      "batch": 5,
+      "control": "point_x-0",
+      "function": "distance",
+      "value": -0.21656122
+    },
+    {
+      "batch": 5,
+      "control": "point_x-1",
+      "function": "distance",
+      "value": -0.00578828
+    },
+    {
+      "batch": 5,
+      "control": "point_x-2",
+      "function": "distance",
+      "value": 0.2172204
+    }
+  ],
+  "input_constraint('point_x-0')": {
+    "max": 1.0,
+    "min": -1.0
+  },
+  "input_constraint('point_x-1')": {
+    "max": 1.0,
+    "min": -1.0
+  },
+  "input_constraint('point_x-2')": {
+    "max": 1.0,
+    "min": -1.0
+  },
   "objective_function_names": [
     "distance"
   ],
+  "optimal_result_json": {
+    "batch": 5,
+    "controls": {
+      "point_x-0": 0.1145273,
+      "point_x-1": 0.00635029,
+      "point_x-2": 0.38836369
+    },
+    "total_objective": -1.52561897
+  },
+  "output_constraint('x-0_coord')": {
+    "right_hand_side": 0.1,
+    "type": "ge"
+  },
   "output_constraint_names": [
     "x-0_coord"
   ],
@@ -34,353 +351,36 @@
     0,
     1
   ],
-  "control_values": [
-    {
-      "control": "point_x-0",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-1",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-2",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-0",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-1",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-2",
-      "batch": 0,
-      "value": 0.25
-    },
-    {
-      "control": "point_x-0",
-      "batch": 1,
-      "value": 0.25904478
-    },
-    {
-      "control": "point_x-1",
-      "batch": 1,
-      "value": 0.13792475
-    },
-    {
-      "control": "point_x-2",
-      "batch": 1,
-      "value": 0.17336687
-    },
-    {
-      "control": "point_x-0",
-      "batch": 1,
-      "value": 0.25904478
-    },
-    {
-      "control": "point_x-1",
-      "batch": 1,
-      "value": 0.13792475
-    },
-    {
-      "control": "point_x-2",
-      "batch": 1,
-      "value": 0.17336687
-    },
-    {
-      "control": "point_x-0",
-      "batch": 2,
-      "value": 0.31863568
-    },
-    {
-      "control": "point_x-1",
-      "batch": 2,
-      "value": 0.00504358
-    },
-    {
-      "control": "point_x-2",
-      "batch": 2,
-      "value": 0.13385209
-    },
-    {
-      "control": "point_x-0",
-      "batch": 2,
-      "value": 0.31863568
-    },
-    {
-      "control": "point_x-1",
-      "batch": 2,
-      "value": 0.00504358
-    },
-    {
-      "control": "point_x-2",
-      "batch": 2,
-      "value": 0.13385209
-    },
-    {
-      "control": "point_x-0",
-      "batch": 3,
-      "value": 0.24117771
-    },
-    {
-      "control": "point_x-1",
-      "batch": 3,
-      "value": 0.03015417
-    },
-    {
-      "control": "point_x-2",
-      "batch": 3,
-      "value": 0.24583776
-    },
-    {
-      "control": "point_x-0",
-      "batch": 3,
-      "value": 0.24117771
-    },
-    {
-      "control": "point_x-1",
-      "batch": 3,
-      "value": 0.03015417
-    },
-    {
-      "control": "point_x-2",
-      "batch": 3,
-      "value": 0.24583776
-    },
-    {
-      "control": "point_x-0",
-      "batch": 4,
-      "value": 0.15091481
-    },
-    {
-      "control": "point_x-1",
-      "batch": 4,
-      "value": -0.00394611
-    },
-    {
-      "control": "point_x-2",
-      "batch": 4,
-      "value": 0.36960914
-    },
-    {
-      "control": "point_x-0",
-      "batch": 4,
-      "value": 0.15091481
-    },
-    {
-      "control": "point_x-1",
-      "batch": 4,
-      "value": -0.00394611
-    },
-    {
-      "control": "point_x-2",
-      "batch": 4,
-      "value": 0.36960914
-    },
-    {
-      "control": "point_x-0",
-      "batch": 5,
-      "value": 0.1145273
-    },
-    {
-      "control": "point_x-1",
-      "batch": 5,
-      "value": 0.00635029
-    },
-    {
-      "control": "point_x-2",
-      "batch": 5,
-      "value": 0.38836369
-    },
-    {
-      "control": "point_x-0",
-      "batch": 5,
-      "value": 0.1145273
-    },
-    {
-      "control": "point_x-1",
-      "batch": 5,
-      "value": 0.00635029
-    },
-    {
-      "control": "point_x-2",
-      "batch": 5,
-      "value": 0.38836369
-    }
-  ],
   "single_objective_values": [
     {
+      "accepted": 1,
       "batch": 0,
-      "objective": -1.6875,
-      "accepted": 1
+      "objective": -1.6875
     },
     {
+      "accepted": 1,
       "batch": 1,
-      "objective": -1.69281773,
-      "accepted": 1
+      "objective": -1.69281773
     },
     {
+      "accepted": 1,
       "batch": 2,
-      "objective": -1.73561919,
-      "accepted": 1
+      "objective": -1.73561919
     },
     {
+      "accepted": 1,
       "batch": 3,
-      "objective": -1.6236748,
-      "accepted": 1
+      "objective": -1.6236748
     },
     {
+      "accepted": 1,
       "batch": 4,
-      "objective": -1.539793,
-      "accepted": 1
+      "objective": -1.539793
     },
     {
+      "accepted": 1,
       "batch": 5,
-      "objective": -1.52561897,
-      "accepted": 1
+      "objective": -1.52561897
     }
-  ],
-  "gradient_values": [
-    {
-      "batch": 0,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.49076627
-    },
-    {
-      "batch": 0,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": -0.50191014
-    },
-    {
-      "batch": 0,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.50424549
-    },
-    {
-      "batch": 1,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.52209326
-    },
-    {
-      "batch": 1,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": -0.28579331
-    },
-    {
-      "batch": 1,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.64869691
-    },
-    {
-      "batch": 2,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.64281291
-    },
-    {
-      "batch": 2,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": -0.00521952
-    },
-    {
-      "batch": 2,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.73152662
-    },
-    {
-      "batch": 3,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.47276201
-    },
-    {
-      "batch": 3,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": -0.0785477
-    },
-    {
-      "batch": 3,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.51539765
-    },
-    {
-      "batch": 4,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.30369426
-    },
-    {
-      "batch": 4,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": 0.02314375
-    },
-    {
-      "batch": 4,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.25834193
-    },
-    {
-      "batch": 5,
-      "function": "distance",
-      "control": "point_x-0",
-      "value": -0.21656122
-    },
-    {
-      "batch": 5,
-      "function": "distance",
-      "control": "point_x-1",
-      "value": -0.00578828
-    },
-    {
-      "batch": 5,
-      "function": "distance",
-      "control": "point_x-2",
-      "value": 0.2172204
-    }
-  ],
-  "input_constraint('point_x-0')": {
-    "min": -1.0,
-    "max": 1.0
-  },
-  "input_constraint('point_x-1')": {
-    "min": -1.0,
-    "max": 1.0
-  },
-  "input_constraint('point_x-2')": {
-    "min": -1.0,
-    "max": 1.0
-  },
-  "output_constraint('x-0_coord')": {
-    "type": "ge",
-    "right_hand_side": 0.1
-  },
-  "optimal_result_json": {
-    "batch": 5,
-    "controls": {
-      "point_x-0": 0.1145273,
-      "point_x-1": 0.00635029,
-      "point_x-2": 0.38836369
-    },
-    "total_objective": -1.52561897
-  }
+  ]
 }

--- a/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_minimal.yml/snapshot.json
@@ -1,4 +1,8 @@
 {
+  "accepted_batches": [
+    0,
+    2
+  ],
   "batches": [
     0,
     1,
@@ -9,116 +13,88 @@
     "point_y",
     "point_z"
   ],
-  "accepted_batches": [
-    0,
-    2
-  ],
-  "objective_function_names": [
-    "distance"
-  ],
-  "output_constraint_names": [],
-  "realizations": [
-    0
-  ],
-  "simulations": [
-    0
-  ],
   "control_values": [
     {
-      "control": "point_x",
       "batch": 0,
+      "control": "point_x",
       "value": 0.1
     },
     {
+      "batch": 0,
       "control": "point_y",
-      "batch": 0,
       "value": 0.1
     },
     {
+      "batch": 0,
       "control": "point_z",
-      "batch": 0,
       "value": 0.1
     },
     {
-      "control": "point_x",
       "batch": 1,
+      "control": "point_x",
       "value": 0.90038639
     },
     {
-      "control": "point_y",
       "batch": 1,
+      "control": "point_y",
       "value": 0.90054756
     },
     {
-      "control": "point_z",
       "batch": 1,
+      "control": "point_z",
       "value": 0.89933796
     },
     {
-      "control": "point_x",
       "batch": 2,
+      "control": "point_x",
       "value": 0.50014777
     },
     {
-      "control": "point_y",
       "batch": 2,
+      "control": "point_y",
       "value": 0.50022835
     },
     {
+      "batch": 2,
       "control": "point_z",
-      "batch": 2,
       "value": 0.49962361
-    }
-  ],
-  "single_objective_values": [
-    {
-      "batch": 0,
-      "objective": -0.47999999,
-      "accepted": 1
-    },
-    {
-      "batch": 1,
-      "objective": -0.48021799,
-      "accepted": 0
-    },
-    {
-      "batch": 2,
-      "objective": -2.2e-7,
-      "accepted": 1
     }
   ],
   "gradient_values": [
     {
       "batch": 0,
-      "function": "distance",
       "control": "point_x",
+      "function": "distance",
       "value": 0.80038641
     },
     {
       "batch": 0,
-      "function": "distance",
       "control": "point_y",
+      "function": "distance",
       "value": 0.80054758
     },
     {
       "batch": 0,
-      "function": "distance",
       "control": "point_z",
+      "function": "distance",
       "value": 0.79933798
     }
   ],
   "input_constraint('point_x')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
   "input_constraint('point_y')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
   "input_constraint('point_z')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
+  "objective_function_names": [
+    "distance"
+  ],
   "optimal_result_json": {
     "batch": 2,
     "controls": {
@@ -127,5 +103,29 @@
       "point_z": 0.49962361
     },
     "total_objective": -2.2e-7
-  }
+  },
+  "output_constraint_names": [],
+  "realizations": [
+    0
+  ],
+  "simulations": [
+    0
+  ],
+  "single_objective_values": [
+    {
+      "accepted": 1,
+      "batch": 0,
+      "objective": -0.47999999
+    },
+    {
+      "accepted": 0,
+      "batch": 1,
+      "objective": -0.48021799
+    },
+    {
+      "accepted": 1,
+      "batch": 2,
+      "objective": -2.2e-7
+    }
+  ]
 }

--- a/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_api_snapshots/test_api_snapshots/config_multiobj.yml/snapshot.json
@@ -1,4 +1,8 @@
 {
+  "accepted_batches": [
+    0,
+    2
+  ],
   "batches": [
     0,
     1,
@@ -9,141 +13,107 @@
     "point_y",
     "point_z"
   ],
-  "accepted_batches": [
-    0,
-    2
-  ],
-  "objective_function_names": [
-    "distance_p",
-    "distance_q"
-  ],
-  "output_constraint_names": [],
-  "realizations": [
-    0
-  ],
-  "simulations": [
-    0
-  ],
   "control_values": [
     {
-      "control": "point_x",
       "batch": 0,
+      "control": "point_x",
       "value": 0.0
     },
     {
+      "batch": 0,
       "control": "point_y",
-      "batch": 0,
       "value": 0.0
     },
     {
+      "batch": 0,
       "control": "point_z",
-      "batch": 0,
       "value": 0.0
     },
     {
-      "control": "point_x",
       "batch": 1,
+      "control": "point_x",
       "value": -0.00420218
     },
     {
-      "control": "point_y",
       "batch": 1,
+      "control": "point_y",
       "value": -0.0112982
     },
     {
-      "control": "point_z",
       "batch": 1,
+      "control": "point_z",
       "value": 1.0
     },
     {
-      "control": "point_x",
       "batch": 2,
+      "control": "point_x",
       "value": -0.00210079
     },
     {
-      "control": "point_y",
       "batch": 2,
+      "control": "point_y",
       "value": -0.00564829
     },
     {
+      "batch": 2,
       "control": "point_z",
-      "batch": 2,
       "value": 0.49992811
-    }
-  ],
-  "single_objective_values": [
-    {
-      "batch": 0,
-      "objective": -2.33333333,
-      "accepted": 1,
-      "distance_p": -0.75,
-      "distance_q": -1.58333333
-    },
-    {
-      "batch": 1,
-      "objective": -2.33352598,
-      "accepted": 0,
-      "distance_p": -0.76564598,
-      "distance_q": -1.56787999
-    },
-    {
-      "batch": 2,
-      "objective": -2.00004834,
-      "accepted": 1,
-      "distance_p": -0.50778502,
-      "distance_q": -1.49226332
     }
   ],
   "gradient_values": [
     {
       "batch": 0,
-      "function": "distance_p",
       "control": "point_x",
+      "function": "distance_p",
       "value": 0.99589284
     },
     {
       "batch": 0,
-      "function": "distance_p",
       "control": "point_y",
+      "function": "distance_p",
       "value": 0.98866227
     },
     {
       "batch": 0,
-      "function": "distance_p",
       "control": "point_z",
+      "function": "distance_p",
       "value": 1.00465235
     },
     {
       "batch": 0,
-      "function": "distance_q",
       "control": "point_x",
+      "function": "distance_q",
       "value": -3.00456477
     },
     {
       "batch": 0,
-      "function": "distance_q",
       "control": "point_y",
+      "function": "distance_q",
       "value": -3.011388
     },
     {
       "batch": 0,
-      "function": "distance_q",
       "control": "point_z",
+      "function": "distance_q",
       "value": 1.0044895
     }
   ],
   "input_constraint('point_x')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
   "input_constraint('point_y')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
   "input_constraint('point_z')": {
-    "min": -1.0,
-    "max": 1.0
+    "max": 1.0,
+    "min": -1.0
   },
+  "objective_function_names": [
+    "distance_p",
+    "distance_q"
+  ],
   "optimal_result_json": {
     "batch": 2,
     "controls": {
@@ -152,5 +122,35 @@
       "point_z": 0.49992811
     },
     "total_objective": -2.00004834
-  }
+  },
+  "output_constraint_names": [],
+  "realizations": [
+    0
+  ],
+  "simulations": [
+    0
+  ],
+  "single_objective_values": [
+    {
+      "accepted": 1,
+      "batch": 0,
+      "distance_p": -0.75,
+      "distance_q": -1.58333333,
+      "objective": -2.33333333
+    },
+    {
+      "accepted": 0,
+      "batch": 1,
+      "distance_p": -0.76564598,
+      "distance_q": -1.56787999,
+      "objective": -2.33352598
+    },
+    {
+      "accepted": 1,
+      "batch": 2,
+      "distance_p": -0.50778502,
+      "distance_q": -1.49226332,
+      "objective": -2.00004834
+    }
+  ]
 }

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -66,7 +66,9 @@ def test_api_snapshots(config_file, snapshot, cached_example):
     rounded_json_snapshot = _round_floats(json_snapshot, 8)
 
     snapshot_str = (
-        orjson.dumps(rounded_json_snapshot, option=orjson.OPT_INDENT_2)
+        orjson.dumps(
+            rounded_json_snapshot, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS
+        )
         .decode("utf-8")
         .strip()
         + "\n"


### PR DESCRIPTION
Ensures they are sorted, avoid flakiness as seen in https://github.com/equinor/ert/actions/runs/12666231370/job/35297228355?pr=9161 where it fails due to different sorting on linux w/ python 3.11