### PR TITLE
Ignore non ConfigWarnings when running everest lint command

### DIFF
--- a/src/everest/bin/everlint_script.py
+++ b/src/everest/bin/everlint_script.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
+import warnings
 from functools import partial
 
+from ert.config.parsing.config_errors import ConfigWarning
 from everest.config import EverestConfig
 
 
@@ -17,10 +19,22 @@ def _build_args_parser():
         type=partial(EverestConfig.load_file_with_argparser, parser=arg_parser),
         help="The path to the everest configuration file",
     )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Display verbose errors and warnings",
+    )
     return arg_parser
 
 
 def lint_entry(args=None):
+    match any("-v" in arg or "--verbose" in arg for arg in args):
+        case False:
+            warnings.filterwarnings("ignore")
+            warnings.filterwarnings("default", category=ConfigWarning)
+        case True:
+            pass
     parser = _build_args_parser()
     options = parser.parse_args(args)
     parsed_config = options.config_file


### PR DESCRIPTION
**Issue**
Resolves #9612


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
