### PR TITLE
Allow the bhist command to be temporarily unavailable

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -583,12 +583,17 @@ class LsfDriver(Driver):
         if time.time() - self._bhist_cache_timestamp < self._bhist_required_cache_age:
             return {}
 
-        process = await asyncio.create_subprocess_exec(
-            self._bhist_cmd,
-            *[str(job_id) for job_id in missing_job_ids],
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self._bhist_cmd,
+                *[str(job_id) for job_id in missing_job_ids],
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as e:
+            logger.error(str(e))
+            return {}
+
         stdout, stderr = await process.communicate()
         if process.returncode:
             logger.error(

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -435,6 +435,7 @@ class LsfDriver(Driver):
             current_jobids = list(self._jobs.keys())
 
             try:
+                print("POLLLING BJOBS")
                 process = await asyncio.create_subprocess_exec(
                     str(self._bjobs_cmd),
                     "-noheader",

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1270,6 +1270,20 @@ async def test_polling_bhist_fallback(not_found_bjobs, caplog, job_name):
 
 
 @pytest.mark.integration_test
+async def test_no_exception_when_bjobs_does_not_exist(caplog, job_name):
+    caplog.set_level(logging.DEBUG)
+    driver = LsfDriver(
+        bjobs_cmd="/bin_foo/not_existing", bhist_cmd="/bin_bar/not_existing"
+    )
+    driver._poll_period = 0.01
+    await driver.submit(0, "sh", "-c", "sleep 1", name=job_name)
+    await poll(driver, {0})
+    print("waiting..")
+    await asyncio.sleep(1)
+    print(caplog.text)
+
+
+@pytest.mark.integration_test
 async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, caplog):
     """This test asserts that it is possible to issue a kill command
     to a realization right after it has been submitted (as in driver.submit()).


### PR DESCRIPTION
This makes the handling of a FileNotFoundError on bhist similar to the handling of FileNotFoundError from bjobs. It is important not to crash on potentially intermittent failures in code that is rerun every 2 seconds.

**Issue**
Resolves driver crash when filesystem is down temporarily. Observed in span-id 5d8f799c0d5fb127e4c7be3e56239a49


**Approach**
try-catch

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
