### PR TITLE
Update mac testing workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -81,29 +81,15 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
-  test-mac-ert:
-    if: github.ref_type != 'tag' # when not tag
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
-        python-version: [ '3.12' ]
-        os: [ 'macos-latest' ]
-    uses: ./.github/workflows/test_ert.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test-type: ${{ matrix.test-type }}
-    secrets: inherit
-
-  test-mac-everest:
-    if: github.ref_type != 'tag' # when not tag
+  test-mac-main-everest:
+    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:
         test-type: [ 'test', 'integration-test', 'everest-models-test' ]
-        python-version: [ '3.12' ]
         os: [ 'macos-latest' ]
+        python-version: [ '3.12' ]
+
     uses: ./.github/workflows/test_everest.yml
     with:
       os: ${{ matrix.os }}
@@ -111,36 +97,14 @@ jobs:
       test-type: ${{ matrix.test-type }}
     secrets: inherit
 
-
-  test-mac-for-tags-everest:
-    if: github.ref_type == 'tag' # only test all variants for tags
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [ 'test', 'integration-test', 'everest-models-test' ]
-        os: [ 'macos-13', 'macos-14', 'macos-14-large']
-        python-version: [ '3.12' ]
-        exclude:
-          - os: 'macos-13'
-            python-version: '3.12'
-    uses: ./.github/workflows/test_everest.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test-type: ${{ matrix.test-type }}
-    secrets: inherit
-
-  test-mac-for-tags-ert:
-    if: github.ref_type == 'tag' # only test all variants for tags
+  test-mac-main-ert:
+    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:
         test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.12' ]
-        os: [ 'macos-13', 'macos-14']
-        exclude:
-          - os: 'macos-13'
-            python-version: '3.12'
+        os: [ 'macos-latest']
 
     uses: ./.github/workflows/test_ert.yml
     with:
@@ -197,7 +161,7 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build-wheels, test-linux-ert, test-linux-everest, test-mac-for-tags-ert, test-mac-for-tags-everest, docs-ert]
+    needs: [build-wheels, test-linux-ert, test-linux-everest, test-mac-main-ert, test-mac-main-everest, docs-ert]
     permissions:
       id-token: write
 


### PR DESCRIPTION
Only test on Mac on main-branch
Updated Mac-runners for tests.
Added concurrency groups for cancelling on subsequent pushes to PRs.

⚠️ I need someone with admin-access to change the required tests for this to pass.

Ref:
https://github.com/actions/runner-images/blob/main/README.md#available-images

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
