### PR TITLE
Fix test when other plugins could be installed

### DIFF
--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -1,17 +1,19 @@
 import os
 import stat
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
+import everest
 from ert.config import ErtConfig
 from ert.config.queue_config import (
     LocalQueueOptions,
     LsfQueueOptions,
     SlurmQueueOptions,
     TorqueQueueOptions,
+    activate_script,
 )
 from ert.scheduler.event import FinishedEvent
 from everest.config import EverestConfig, InstallJobConfig
@@ -283,6 +285,11 @@ def test_generate_queue_options_no_config():
 def test_generate_queue_options_use_simulator_values(
     queue_options, expected_result, monkeypatch
 ):
+    monkeypatch.setattr(
+        everest.config.server_config.ErtPluginManager,
+        "activate_script",
+        MagicMock(return_value=activate_script()),
+    )
     config = EverestConfig.with_defaults(
         **{"simulator": {"queue_system": queue_options}}
     )


### PR DESCRIPTION



**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
