### PR TITLE
Increase Event reporter timeout after successful Finish event

### DIFF
--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -82,7 +82,10 @@ class Event(Reporter):
         if finished_event_timeout is not None:
             self._finished_event_timeout = finished_event_timeout
         else:
-            self._finished_event_timeout = 60
+            # for the sake of heavy load when using LOCAL_DRIVER
+            # we set the default timeout to 10 minutes since forward model
+            # can be finished but not all the events were sent yet
+            self._finished_event_timeout = 600
 
     def stop(self):
         self._event_queue.put(Event._sentinel)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/9709


**Approach**
For the sake of heavy load when using LOCAL_DRIVER we set the default timeout to 10 minutes since forward model can be finished but not all the events were sent yet.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
