### PR TITLE
Use lalr parser for main ert config

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -402,6 +402,16 @@ def test_that_double_comments_are_handled():
     assert ert_config.model_config.jobname_format_string == "&SUM$VAR@12@#£¤<"
 
 
+def test_that_strings_escape_comments():
+    ert_config = ErtConfig.from_file_contents(
+        """
+        NUM_REALIZATIONS 1
+        JOBNAME " -- "
+        """
+    )
+    assert ert_config.model_config.jobname_format_string == " -- "
+
+
 @pytest.mark.filterwarnings("ignore:.*Unknown keyword.*:ert.config.ConfigWarning")
 def test_bad_user_config_file_error_message():
     with pytest.raises(ConfigValidationError, match="NUM_REALIZATIONS must be set"):

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -414,7 +414,7 @@ def test_that_quotations_in_forward_model_arglist_are_handled_correctly():
 
 
 def test_that_positional_forward_model_args_gives_config_validation_error():
-    with pytest.raises(ConfigValidationError, match="Did not expect character: <"):
+    with pytest.raises(ConfigValidationError, match="Did not expect token: <IENS>"):
         _ = ErtConfig.from_file_contents(
             """
             NUM_REALIZATIONS  1


### PR DESCRIPTION
This is for performance reasons. May cause ambiguous config files to no longer be parsed, but it should not have any effect.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
