### PR TITLE
Speed up batching of events in evaluator

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -131,11 +131,12 @@ class EnsembleEvaluator:
             ):
                 self._complete_batch.clear()
                 try:
-                    event = await asyncio.wait_for(self._events.get(), timeout=0.1)
+                    event = self._events.get_nowait()
                     function = event_handler[type(event)]
                     batch.append((function, event))
                     self._events.task_done()
-                except TimeoutError:
+                except asyncio.QueueEmpty:
+                    await asyncio.sleep(0.1)
                     continue
             self._complete_batch.set()
             await self._batch_processing_queue.put(batch)
@@ -381,7 +382,7 @@ class EnsembleEvaluator:
                     raise task_exception
                 elif task.get_name() == "server_task":
                     return
-                elif task.get_name() == "ensemble_task" or task.get_name() in {
+                elif task.get_name() in {
                     "ensemble_task",
                     "listener_task",
                 }:


### PR DESCRIPTION
**Issue**
It seems that `asyncio wait_for` used in evaluator is "slow" in performance when dealing with `O(100K)` events in the event queue. Therefore the suggestion is to replace it with direct fetching (via `get_nowait()`) and instead just sleep whenever the event queue is empty.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
