### PR TITLE
Speed up tests by reusing plugin manager

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -305,8 +305,9 @@ class ErtConfig:
         forward_model_step_classes: list[type[ForwardModelStepPlugin]] | None = None,
         env_pr_fm_step: dict[str, dict[str, Any]] | None = None,
     ) -> type["ErtConfig"]:
+        pm = ErtPluginManager()
         if forward_model_step_classes is None:
-            forward_model_step_classes = ErtPluginManager().forward_model_steps
+            forward_model_step_classes = pm.forward_model_steps
 
         preinstalled_fm_steps: dict[str, ForwardModelStepPlugin] = {}
         for fm_step_subclass in forward_model_step_classes:
@@ -315,7 +316,7 @@ class ErtConfig:
 
         if env_pr_fm_step is None:
             env_pr_fm_step = _uppercase_subkeys_and_stringify_subvalues(
-                ErtPluginManager().get_forward_model_configuration()
+                pm.get_forward_model_configuration()
             )
 
         class ErtConfigWithPlugins(ErtConfig):
@@ -323,7 +324,7 @@ class ErtConfig:
                 dict[str, ForwardModelStepPlugin]
             ] = preinstalled_fm_steps
             ENV_PR_FM_STEP: ClassVar[dict[str, dict[str, Any]]] = env_pr_fm_step
-            ACTIVATE_SCRIPT = ErtPluginManager().activate_script()
+            ACTIVATE_SCRIPT = pm.activate_script()
 
         assert issubclass(ErtConfigWithPlugins, ErtConfig)
         return ErtConfigWithPlugins

--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -97,8 +97,10 @@ class SimulatorConfig(BaseModel, extra="forbid"):  # type: ignore
     def default_local_queue(cls, v):
         if v is None:
             return LocalQueueOptions(max_running=8)
-        elif "activate_script" not in v and ErtPluginManager().activate_script():
-            v["activate_script"] = ErtPluginManager().activate_script()
+        if "activate_script" not in v and (
+            active_script := ErtPluginManager().activate_script()
+        ):
+            v["activate_script"] = active_script
         return v
 
     @model_validator(mode="before")

--- a/tests/ert/ui_tests/cli/run_cli.py
+++ b/tests/ert/ui_tests/cli/run_cli.py
@@ -5,6 +5,8 @@ from ert.__main__ import ert_parser
 from ert.cli.main import run_cli as cli_runner
 from ert.plugins import ErtPluginManager
 
+PM = ErtPluginManager()
+
 
 def run_cli(*args):
     parser = ArgumentParser(prog="test_main")
@@ -15,7 +17,7 @@ def run_cli(*args):
 
 def run_cli_with_pm(args: list[Any], pm: ErtPluginManager | None = None):
     if pm is None:
-        pm = ErtPluginManager()
+        pm = PM
     parser = ArgumentParser(prog="test_main")
     parsed = ert_parser(parser, args)
     res = cli_runner(parsed, pm)

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -430,7 +430,7 @@ def test_that_deprecated_runpath_substitution_remain_valid(make_run_path):
 def test_write_runpath_file(storage, itr, run_paths):
     runpath_fmt = "simulations/<GEO_ID>/realization-<IENS>/iter-<ITER>"
     runpath_list_path = "a_file_name"
-    ert_config = ErtConfig.with_plugins().from_file_contents(
+    ert_config = ErtConfig.from_file_contents(
         dedent(
             f"""\
             NUM_REALIZATIONS 25


### PR DESCRIPTION
Saves ~35s of collecting plugins on my machine.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
