### PR TITLE
Set the default flow simulator version to default

### DIFF
--- a/tests/ert/unit_tests/resources/test_run_flow_simulator.py
+++ b/tests/ert/unit_tests/resources/test_run_flow_simulator.py
@@ -20,7 +20,7 @@ run_reservoirsimulator = import_from_location(
     SOURCE_DIR / "src/ert/resources/forward_models/run_reservoirsimulator.py",
 )
 
-FLOW_VERSION = "daily"
+FLOW_VERSION = "default"
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
daily is too on-premises specific, and will actually not work when the current version of ert-configurations is installed off-premise.

**Issue**
Resolves  test failure off-premise with  ert-configurations installed.

**Approach**
:brain:


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
