### PR TITLE
Warn on full disk

### DIFF
--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os.path
+import shutil
 from datetime import datetime
+from pathlib import Path
 from typing import no_type_check
 
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass
+
+from ert.shared.status.utils import byte_with_unit
 
 from .parsing import (
     ConfigDict,
@@ -42,6 +47,11 @@ DEFAULT_RUNPATH = "simulations/realization-<IENS>/iter-<ITER>"
 DEFAULT_GEN_KW_EXPORT_NAME = "parameters"
 DEFAULT_JOBNAME_FORMAT = "<CONFIG_FILE>-<IENS>"
 DEFAULT_ECLBASE_FORMAT = "ECLBASE<IENS>"
+
+FULL_DISK_PERCENTAGE_THRESHOLD = 0.97
+MINIMUM_BYTES_LEFT_ON_DISK_THRESHOLD = 200 * 1000**3  # 200 GB
+# We give warning if free disk space is less than MINIMUM_BYTES_LEFT_ON_DISK_THRESHOLD
+# and used space in percentage is greater than FULL_DISK_PERCENTAGE_THRESHOLD
 
 
 @dataclass
@@ -83,6 +93,19 @@ class ModelConfig:
             )
             ConfigWarning.warn(msg)
             logger.warning(msg)
+        with contextlib.suppress(Exception):
+            mount_dir = _get_mount_directory(runpath_format_string)
+            total_space, used_space, free_space = shutil.disk_usage(mount_dir)
+            percentage_used = used_space / total_space
+            if (
+                percentage_used > FULL_DISK_PERCENTAGE_THRESHOLD
+                and free_space < MINIMUM_BYTES_LEFT_ON_DISK_THRESHOLD
+            ):
+                msg = (
+                    f"Low disk space: {byte_with_unit(free_space)} free on {mount_dir!s}."
+                    " Consider freeing up some space to ensure successful simulation runs."
+                )
+                ConfigWarning.warn(msg)
         return result
 
     @field_validator("jobname_format_string", mode="before")
@@ -143,3 +166,12 @@ def _replace_runpath_format(format_string: str) -> str:
     format_string = format_string.replace("%d", "<IENS>", 1)
     format_string = format_string.replace("%d", "<ITER>", 1)
     return format_string
+
+
+def _get_mount_directory(runpath: str) -> Path:
+    path = Path(runpath).absolute()
+
+    while not path.is_mount():
+        path = path.parent
+
+    return path

--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -5,13 +5,12 @@ import logging
 import os.path
 import shutil
 from datetime import datetime
-from pathlib import Path
 from typing import no_type_check
 
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass
 
-from ert.shared.status.utils import byte_with_unit
+from ert.shared.status.utils import byte_with_unit, get_mount_directory
 
 from .parsing import (
     ConfigDict,
@@ -94,7 +93,7 @@ class ModelConfig:
             ConfigWarning.warn(msg)
             logger.warning(msg)
         with contextlib.suppress(Exception):
-            mount_dir = _get_mount_directory(runpath_format_string)
+            mount_dir = get_mount_directory(runpath_format_string)
             total_space, used_space, free_space = shutil.disk_usage(mount_dir)
             percentage_used = used_space / total_space
             if (
@@ -166,12 +165,3 @@ def _replace_runpath_format(format_string: str) -> str:
     format_string = format_string.replace("%d", "<IENS>", 1)
     format_string = format_string.replace("%d", "<ITER>", 1)
     return format_string
-
-
-def _get_mount_directory(runpath: str) -> Path:
-    path = Path(runpath).absolute()
-
-    while not path.is_mount():
-        path = path.parent
-
-    return path

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -64,11 +64,12 @@ from ert.shared.status.utils import (
     byte_with_unit,
     file_has_content,
     format_running_time,
+    get_mount_directory,
 )
 
 from ..find_ert_info import find_ert_info
 from .queue_emitter import QueueEmitter
-from .view import ProgressWidget, RealizationWidget, UpdateWidget
+from .view import DiskSpaceWidget, ProgressWidget, RealizationWidget, UpdateWidget
 
 _TOTAL_PROGRESS_TEMPLATE = "Total progress {total_progress}% — {iteration_label}"
 
@@ -220,6 +221,9 @@ class RunDialog(QFrame):
 
         self.running_time = QLabel("")
         self.memory_usage = QLabel("")
+        self.disk_space = DiskSpaceWidget(
+            get_mount_directory(run_model.run_paths._runpath_format)
+        )
 
         self.kill_button = QPushButton("Terminate experiment")
         self.restart_button = QPushButton("Rerun failed")
@@ -244,6 +248,8 @@ class RunDialog(QFrame):
         button_layout.addWidget(self.running_time)
         button_layout.addStretch()
         button_layout.addWidget(self.memory_usage)
+        button_layout.addStretch()
+        button_layout.addWidget(self.disk_space)
         button_layout.addStretch()
         button_layout.addWidget(self.copy_debug_info_button)
         button_layout.addWidget(self.kill_button)
@@ -424,6 +430,8 @@ class RunDialog(QFrame):
         self.running_time.setText(format_running_time(runtime))
 
         maximum_memory_usage = self._snapshot_model.root.max_memory_usage
+
+        self.disk_space.update_status()
 
         if maximum_memory_usage:
             self.memory_usage.setText(

--- a/src/ert/gui/simulation/view/__init__.py
+++ b/src/ert/gui/simulation/view/__init__.py
@@ -1,5 +1,6 @@
+from .disk_space_widget import DiskSpaceWidget
 from .progress_widget import ProgressWidget
 from .realization import RealizationWidget
 from .update import UpdateWidget
 
-__all__ = ["ProgressWidget", "RealizationWidget", "UpdateWidget"]
+__all__ = ["DiskSpaceWidget", "ProgressWidget", "RealizationWidget", "UpdateWidget"]

--- a/src/ert/gui/simulation/view/disk_space_widget.py
+++ b/src/ert/gui/simulation/view/disk_space_widget.py
@@ -1,0 +1,79 @@
+import contextlib
+import shutil
+from pathlib import Path
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QProgressBar, QWidget
+
+from ert.shared.status.utils import byte_with_unit
+
+CRITICAL_RED = "#e74c3c"
+WARNING_YELLOW = "#f1c40f"
+NORMAL_GREEN = "#2ecc71"
+
+
+class DiskSpaceWidget(QWidget):
+    def __init__(self, mount_path: Path, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self.mount_path = mount_path
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        # Text label
+        self.usage_label = QLabel(self)
+        self.space_left_label = QLabel(self)
+
+        # Progress bar
+        self.progress_bar = QProgressBar(self)
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setTextVisible(True)
+        self.progress_bar.setFixedWidth(100)
+        self.progress_bar.setAlignment(Qt.AlignCenter)  # type: ignore
+
+        layout.addWidget(self.usage_label)
+        layout.addWidget(self.progress_bar)
+        layout.addWidget(self.space_left_label)
+
+    def _get_status(self) -> tuple[float, str] | None:
+        with contextlib.suppress(Exception):
+            disk_info = shutil.disk_usage(self.mount_path)
+            percentage_used = (disk_info.used / disk_info.total) * 100
+            return percentage_used, byte_with_unit(disk_info.free)
+        return None
+
+    def update_status(self) -> None:
+        """Update both the label and progress bar with current disk usage"""
+        if (disk_info := self._get_status()) is not None:
+            usage, space_left = disk_info
+            self.usage_label.setText("Disk space runpath:")
+            self.progress_bar.setValue(int(usage))
+            self.progress_bar.setFormat(f"{usage:.1f}%")
+
+            # Set color based on usage threshold
+            if usage >= 90:
+                color = CRITICAL_RED
+            elif usage >= 70:
+                color = WARNING_YELLOW
+            else:
+                color = NORMAL_GREEN
+
+            self.progress_bar.setStyleSheet(f"""
+                QProgressBar {{
+                    border: 1px solid #ccc;
+                    border-radius: 2px;
+                    text-align: center;
+                }}
+
+                QProgressBar::chunk {{
+                    background-color: {color};
+                }}
+            """)
+
+            self.space_left_label.setText(f"{space_left} free")
+
+            self.setVisible(True)
+        else:
+            self.setVisible(False)

--- a/src/ert/shared/status/utils.py
+++ b/src/ert/shared/status/utils.py
@@ -2,6 +2,7 @@ import math
 import os
 import resource
 import sys
+from pathlib import Path
 
 
 def byte_with_unit(byte_count: float) -> str:
@@ -82,3 +83,12 @@ def get_ert_memory_usage() -> int:
         rss_scale = 1000
 
     return usage.ru_maxrss // rss_scale
+
+
+def get_mount_directory(runpath: str) -> Path:
+    path = Path(runpath).absolute()
+
+    while not path.is_mount():
+        path = path.parent
+
+    return path

--- a/tests/ert/unit_tests/config/test_model_config.py
+++ b/tests/ert/unit_tests/config/test_model_config.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from ert.config import ModelConfig
-from ert.config.parsing import ConfigKeys, ConfigValidationError
+from ert.config.parsing import ConfigKeys, ConfigValidationError, ConfigWarning
 
 
 def test_default_model_config_run_path(tmpdir):
@@ -61,3 +64,54 @@ def test_that_invalid_time_map_file_raises_config_validation_error(tmpdir):
 
         with pytest.raises(ConfigValidationError, match="Could not read timemap file"):
             _ = ModelConfig.from_dict({ConfigKeys.TIME_MAP: "time_map.txt"})
+
+
+@pytest.mark.parametrize(
+    "total_space, used_space, to_warn, expected_warning",
+    [
+        pytest.param(
+            10 * 1000**4,  # 10 TB
+            9.75 * 1000**4,  # 9.75 TB
+            False,
+            None,
+            id="Low disk space percentage on large disk",
+        ),
+        pytest.param(
+            100 * 1000**3,  # 100 GB
+            99 * 1000**3,  # 99 GB
+            True,
+            "Low disk space: 1.00 GB free on",
+            id="Low disk space small disk",
+        ),
+        pytest.param(
+            10 * 1000**5,  # 10 PB
+            9.99994 * 1000**5,  # 9.99994 PB
+            True,
+            "Low disk space: 60.00 GB free on",
+            id="Low disk space small disk",
+        ),
+        pytest.param(
+            100 * 1000**3,  # 100 GB
+            75 * 1000**3,  # 75 GB
+            False,
+            None,
+            id="Sufficient disk space",
+        ),
+    ],
+)
+def test_warning_when_full_disk(
+    tmp_path, recwarn, total_space, used_space, to_warn, expected_warning
+):
+    Path(tmp_path / "simulations").mkdir()
+    runpath = f"{tmp_path!s}/simulations/realization-%d/iter-%d"
+    with patch(
+        "ert.config.model_config.shutil.disk_usage",
+        return_value=(total_space, used_space, total_space - used_space),
+    ):
+        if to_warn:
+            with pytest.warns(ConfigWarning, match=expected_warning):
+                _ = ModelConfig(num_realizations=1, runpath_format_string=runpath)
+        else:
+            _ = ModelConfig(num_realizations=1, runpath_format_string=runpath)
+            for w in recwarn:
+                assert not issubclass(w.category, ConfigWarning)

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -48,6 +48,9 @@ def run_model():
     run_model.format_error.return_value = ""
     run_model.get_runtime.return_value = 1
     run_model.support_restart = True
+    run_paths_mock = MagicMock()
+    run_paths_mock._runpath_format = "/"
+    run_model.run_paths = run_paths_mock
     return run_model
 
 

--- a/tests/ert/unit_tests/gui/simulation/view/test_disk_space_widget.py
+++ b/tests/ert/unit_tests/gui/simulation/view/test_disk_space_widget.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+from ert.gui.simulation.view import DiskSpaceWidget
+from ert.gui.simulation.view.disk_space_widget import (
+    CRITICAL_RED,
+    NORMAL_GREEN,
+    WARNING_YELLOW,
+)
+
+
+def test_disk_space_widget(qtbot):
+    disk_space_widget = DiskSpaceWidget("/tmp")
+    qtbot.addWidget(disk_space_widget)
+    disk_space_widget._get_status = MagicMock()
+
+    disk_space_widget._get_status.return_value = (20.0, "2 jiggabytes")
+    disk_space_widget.update_status()
+    assert disk_space_widget.space_left_label.text() == "2 jiggabytes free"
+    assert disk_space_widget.progress_bar.value() == 20
+    assert NORMAL_GREEN in disk_space_widget.progress_bar.styleSheet()
+
+    disk_space_widget._get_status.return_value = (88.0, "2mb")
+    disk_space_widget.update_status()
+    assert disk_space_widget.space_left_label.text() == "2mb free"
+    assert disk_space_widget.progress_bar.value() == 88
+    assert WARNING_YELLOW in disk_space_widget.progress_bar.styleSheet()
+
+    disk_space_widget._get_status.return_value = (99.9, "2 bytes")
+    disk_space_widget.update_status()
+    assert disk_space_widget.space_left_label.text() == "2 bytes free"
+    assert disk_space_widget.progress_bar.value() == 99
+    assert CRITICAL_RED in disk_space_widget.progress_bar.styleSheet()
+
+    disk_space_widget._get_status.return_value = None
+    disk_space_widget.update_status()
+    assert not disk_space_widget.isVisible()


### PR DESCRIPTION
**Issue**
Resolves #8921 


The following is presented if disk is "close" to full:
![image](https://github.com/user-attachments/assets/2dd1d82e-bbf1-4790-a4af-3c4fbc68f155)

![image](https://github.com/user-attachments/assets/43e3ca66-2ce8-42c2-ac21-628cb74eb583)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
