### PR TITLE
Replace server_started Event with Future to handle exceptions

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -583,7 +583,7 @@ class BaseRunModel(ABC):
         evaluator_task = asyncio.create_task(
             evaluator.run_and_get_successful_realizations()
         )
-        await evaluator._server_started.wait()
+        await evaluator._server_started
         if not (await self.run_monitor(ee_config, ensemble.iteration)):
             return []
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -144,7 +144,7 @@ async def evaluator_to_use_fixture(make_ee_config):
     evaluator = EnsembleEvaluator(ensemble, make_ee_config(use_token=False))
     evaluator._batching_interval = 0.5  # batching can be faster for tests
     run_task = asyncio.create_task(evaluator.run_and_get_successful_realizations())
-    await evaluator._server_started.wait()
+    await evaluator._server_started
     yield evaluator
     evaluator.stop()
     await run_task

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -18,7 +18,7 @@ def evaluator_to_use():
     async def run_evaluator(ensemble, ee_config):
         evaluator = EnsembleEvaluator(ensemble, ee_config)
         run_task = asyncio.create_task(evaluator.run_and_get_successful_realizations())
-        await evaluator._server_started.wait()
+        await evaluator._server_started
         try:
             yield evaluator
         finally:

--- a/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
@@ -66,7 +66,7 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
             run_task = asyncio.create_task(
                 evaluator.run_and_get_successful_realizations()
             )
-            await evaluator._server_started.wait()
+            await evaluator._server_started
             await _run_monitor()
             await run_task
         assert "Waiting for disk synchronization" in caplog.messages


### PR DESCRIPTION
**Issue**
In a very special case zmq server might fail during initialization and all occurrences of `server_started.wait()` will wait indefinitely and therefore replacing it with asyncio.Future which provides additional exception trigger.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
