### PR TITLE
Use the configuration file as the everest server job  name

### DIFF
--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -52,7 +52,7 @@ async def start_server(config: EverestConfig, debug: bool = False) -> Driver:
         if debug:
             args.append("--debug")
         poll_task = asyncio.create_task(driver.poll(), name="poll_task")
-        await driver.submit(0, "everserver", *args)
+        await driver.submit(0, "everserver", *args, name=Path(config.config_file).stem)
     except FailedSubmit as err:
         raise ValueError(f"Failed to submit Everserver with error: {err}") from err
     status = await driver.event_queue.get()


### PR DESCRIPTION
**Issue**
Resolves #9737 


**Approach**
Set the job name to the stem of configuration file name.

There is no way to test this automatically. Since it is a generic solution it should work with all drivers that support setting the name of a submitted job. Confirmed to work on SLURM.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
