### PR TITLE
Use only tcp protocol for everest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,6 @@ jobs:
     secrets: inherit
 
   test-mac-main-everest:
-    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:
@@ -98,7 +97,6 @@ jobs:
     secrets: inherit
 
   test-mac-main-ert:
-    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -21,17 +21,9 @@ from cryptography.x509.oid import NameOID
 from dns import resolver, reversename
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import (
-    JSONResponse,
-    PlainTextResponse,
-    Response,
-)
-from fastapi.security import (
-    HTTPBasic,
-    HTTPBasicCredentials,
-)
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from ert.config.parsing.queue_system import QueueSystem
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestExitCode, EverestRunModel
 from everest import export_to_csv, export_with_progress
@@ -305,12 +297,10 @@ def main():
             simulation_callback=partial(_sim_monitor, shared_data=shared_data),
             optimization_callback=partial(_opt_monitor, shared_data=shared_data),
         )
-        if run_model._queue_config.queue_system == QueueSystem.LOCAL:
-            evaluator_server_config = EvaluatorServerConfig()
-        else:
-            evaluator_server_config = EvaluatorServerConfig(
-                custom_port_range=range(49152, 51819), use_ipc_protocol=False
-            )
+
+        evaluator_server_config = EvaluatorServerConfig(
+            custom_port_range=range(49152, 51819), use_ipc_protocol=False
+        )
 
         run_model.run_experiment(evaluator_server_config)
 


### PR DESCRIPTION
**Issue**
When running everest on MacOS, ipc protocol seems to have issues. This will enforce to use only tcp protocol when running everest.


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
