### PR TITLE
Mark rarely flaky test as flaky with reruns

### DIFF
--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -218,6 +218,7 @@ def test_that_duplicate_summary_time_steps_does_not_fail(
     )
 
 
+@pytest.mark.flaky(reruns=5)
 def test_that_mismatched_responses_gives_nan_measured_data(ert_config, prior_ensemble):
     sample_prior(prior_ensemble, range(prior_ensemble.ensemble_size))
 


### PR DESCRIPTION
This test has been observed to have a flaky ratio around 1:10000.

**Issue**
Resolves #9637 


**Approach**
♻️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
