### PR TITLE
"disable-monitor" -> "disable-monitoring"

### DIFF
--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -299,7 +299,7 @@ def _run_snake_oil(source_root):
         parser,
         [
             ENSEMBLE_EXPERIMENT_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "--current-ensemble",
             "default_0",
             "snake_oil.ert",
@@ -321,7 +321,7 @@ def _run_heat_equation(source_root):
         parser,
         [
             ES_MDA_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "config.ert",
         ],
     )

--- a/tests/ert/performance_tests/conftest.py
+++ b/tests/ert/performance_tests/conftest.py
@@ -83,7 +83,7 @@ def template_config(request, source_root, tmp_path_factory):
                 parser,
                 [
                     ENSEMBLE_EXPERIMENT_MODE,
-                    "--disable-monitor",
+                    "--disable-monitoring",
                     "poly.ert",
                 ],
             )

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -248,6 +248,6 @@ if __name__ == "__main__":
 def run_poly():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "config.ert",
     )

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -15,7 +15,7 @@ from tests.ert.ui_tests.cli.run_cli import run_cli
 def run_cli_ES_with_case(poly_config):
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "--realizations",
         "1-50",
         poly_config,

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -84,7 +84,7 @@ def test_run_poly_example_with_design_matrix():
 
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "poly.ert",
         "--experiment-name",
         "test-experiment",
@@ -172,7 +172,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, err
         with pytest.raises(ErtCliError, match=error_msg):
             run_cli(
                 ENSEMBLE_EXPERIMENT_MODE,
-                "--disable-monitor",
+                "--disable-monitoring",
                 "poly.ert",
                 "--experiment-name",
                 "test-experiment",
@@ -180,7 +180,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, err
         return
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "poly.ert",
         "--experiment-name",
         "test-experiment",
@@ -267,7 +267,7 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
 
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "poly.ert",
         "--experiment-name",
         "test-experiment",

--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -52,7 +52,7 @@ def obs() -> polars.DataFrame:
 def test_that_posterior_has_lower_variance_than_prior():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "--realizations",
         "1-50",
         "poly.ert",
@@ -126,7 +126,7 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert():
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "snake_oil_surface.ert",
     )
 
@@ -164,7 +164,7 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert():
 def test_update_multiple_param():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "snake_oil.ert",
     )
 
@@ -219,7 +219,7 @@ def test_that_update_works_with_failed_realizations():
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "poly.ert",
     )
 

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -43,14 +43,14 @@ from .run_cli import run_cli
 def test_bad_config_error_message(tmp_path):
     (tmp_path / "test.ert").write_text("NUM_REL 10\n")
     with pytest.raises(ConfigValidationError, match="NUM_REALIZATIONS must be set\\."):
-        run_cli(TEST_RUN_MODE, "--disable-monitor", str(tmp_path / "test.ert"))
+        run_cli(TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert"))
 
 
 def test_test_run_on_lsf_configuration_works_with_no_errors(tmp_path):
     (tmp_path / "test.ert").write_text(
         "NUM_REALIZATIONS 1\nQUEUE_SYSTEM LSF", encoding="utf-8"
     )
-    run_cli(TEST_RUN_MODE, "--disable-monitor", str(tmp_path / "test.ert"))
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert"))
 
 
 @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
     ):
         run_cli(
             mode,
-            "--disable-monitor",
+            "--disable-monitoring",
             "poly-no-gen-kw.ert",
             "--target-ensemble",
             "testensemble-%d",
@@ -92,7 +92,7 @@ def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
     ):
         run_cli(
             ES_MDA_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "poly.ert",
             "--target-ensemble",
             "testensemble-%d",
@@ -108,7 +108,7 @@ def test_field_init_file_not_readable(monkeypatch):
     os.chmod(field_file_rel_path, 0x0)
 
     with pytest.raises(ErtCliError, match="Permission denied:"):
-        run_cli(TEST_RUN_MODE, "--disable-monitor", config_file_name)
+        run_cli(TEST_RUN_MODE, "--disable-monitoring", config_file_name)
 
 
 @pytest.mark.usefixtures("copy_snake_oil_field")
@@ -145,7 +145,7 @@ def test_surface_init_fails_during_forward_model_callback():
     with pytest.raises(
         ErtCliError, match=f"Failed to initialize parameter {parameter_name!r}"
     ):
-        run_cli(TEST_RUN_MODE, "--disable-monitor", config_file_name)
+        run_cli(TEST_RUN_MODE, "--disable-monitoring", config_file_name)
 
 
 @pytest.mark.usefixtures("copy_snake_oil_field")
@@ -212,7 +212,7 @@ def test_that_the_model_raises_exception_if_successful_realizations_less_than_mi
         ErtCliError,
         match="Number of successful realizations",
     ):
-        run_cli(mode, "--disable-monitor", "failing_realizations.ert")
+        run_cli(mode, "--disable-monitoring", "failing_realizations.ert")
 
 
 @pytest.fixture
@@ -276,7 +276,7 @@ def test_that_setenv_sets_environment_variables_in_jobs(setenv_config):
     # When running the jobs
     run_cli(
         TEST_RUN_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         str(setenv_config),
     )
 
@@ -515,9 +515,9 @@ def test_that_stop_on_fail_workflow_jobs_stop_ert(
 
     if expect_stopped:
         with pytest.raises(Exception, match=r"Workflow job .* failed with error"):
-            run_cli(TEST_RUN_MODE, "--disable-monitor", "poly.ert")
+            run_cli(TEST_RUN_MODE, "--disable-monitoring", "poly.ert")
     else:
-        run_cli(TEST_RUN_MODE, "--disable-monitor", "poly.ert")
+        run_cli(TEST_RUN_MODE, "--disable-monitoring", "poly.ert")
 
 
 @pytest.mark.usefixtures("copy_poly_case")
@@ -582,7 +582,7 @@ def test_that_pre_post_experiment_hook_works(monkeypatch, capsys):
         )
 
     for mode in [ITERATIVE_ENSEMBLE_SMOOTHER_MODE, ES_MDA_MODE, ENSEMBLE_SMOOTHER_MODE]:
-        run_cli(mode, "--disable-monitor", "poly.ert")
+        run_cli(mode, "--disable-monitoring", "poly.ert")
 
         captured = capsys.readouterr()
         assert "first" in captured.out
@@ -612,7 +612,7 @@ def test_es_mda(snapshot):
 
     run_cli(
         ES_MDA_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "--target-ensemble",
         "iter-%d",
         "--realizations",
@@ -661,7 +661,7 @@ def test_cli_does_not_run_without_observations(mode, target):
     remove_linestartswith("poly.ert", "OBS_CONFIG")
 
     with pytest.raises(ErtCliError, match=f"To run {mode}, observations are needed."):
-        run_cli(mode, "--disable-monitor", "--target-ensemble", target, "poly.ert")
+        run_cli(mode, "--disable-monitoring", "--target-ensemble", target, "poly.ert")
 
 
 @pytest.mark.usefixtures("copy_poly_case")
@@ -677,7 +677,7 @@ def test_ensemble_smoother():
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_cli_test_run(mock_cli_run):
-    run_cli(TEST_RUN_MODE, "--disable-monitor", "poly.ert")
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "poly.ert")
 
     monitor_mock, thread_join_mock, thread_start_mock = mock_cli_run
     monitor_mock.assert_called_once()
@@ -694,7 +694,7 @@ def test_that_running_ies_with_different_steplength_produces_different_result():
     def _run(target, experiment_name):
         run_cli(
             ITERATIVE_ENSEMBLE_SMOOTHER_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "--target-ensemble",
             f"{target}-%d",
             "--realizations",
@@ -789,7 +789,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
     with caplog.at_level(logging.INFO):
         run_cli(
             ENSEMBLE_EXPERIMENT_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "poly.ert",
             "--current-case=iter-0",
             "--realizations",
@@ -819,7 +819,7 @@ def test_failing_job_cli_error_message():
         "RuntimeError: Argh",
     ]
     try:
-        run_cli(TEST_RUN_MODE, "--disable-monitor", "poly.ert")
+        run_cli(TEST_RUN_MODE, "--disable-monitoring", "poly.ert")
     except ErtCliError as error:
         for substring in expected_substrings:
             assert substring in f"{error}"
@@ -839,7 +839,7 @@ def test_exclude_parameter_from_update():
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "--target-ensemble",
         "iter-%d",
         "--realizations",
@@ -899,7 +899,7 @@ def test_that_log_is_cleaned_up_from_repeated_forward_model_steps(caplog):
     with caplog.at_level(logging.INFO):
         run_cli(
             "ensemble_experiment",
-            "--disable-monitor",
+            "--disable-monitoring",
             "poly_repeated_forward_model_steps.ert",
             "--realizations",
             "0-4",
@@ -948,7 +948,7 @@ def test_that_a_custom_eclrun_can_be_activated_through_setenv():
     run_cli(
         TEST_RUN_MODE,
         str(config_file),
-        "--disable-monitor",
+        "--disable-monitoring",
     )
 
 

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "config.ert",
         )
         config = ErtConfig.from_file("config.ert")
@@ -339,7 +339,7 @@ def test_foward_init_false():
     config = ErtConfig.from_file("config_forward_init_false.ert")
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
-        "--disable-monitor",
+        "--disable-monitoring",
         "config_forward_init_false.ert",
         "--experiment-name",
         "es-test",

--- a/tests/ert/ui_tests/cli/test_observation_times.py
+++ b/tests/ert/ui_tests/cli/test_observation_times.py
@@ -122,7 +122,7 @@ def test_small_time_mismatches_are_ignored(
         with pytest.raises(ErtCliError, match="No active observations"):
             run_cli(
                 ES_MDA_MODE,
-                "--disable-monitor",
+                "--disable-monitoring",
                 str(tmp_path / "config.ert"),
                 "--weights=0,1",
             )

--- a/tests/ert/ui_tests/cli/test_parameter.py
+++ b/tests/ert/ui_tests/cli/test_parameter.py
@@ -22,7 +22,7 @@ def test_running_smoother_raises_without_updateable_parameters():
         parser,
         [
             ENSEMBLE_SMOOTHER_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "poly.ert",
         ],
     )

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -440,7 +440,9 @@ def test_that_parameters_are_placed_in_the_runpath_as_expected(
         smspec.to_file("ECLBASE.SMSPEC")
         unsmry.to_file("ECLBASE.UNSMRY")
 
-        run_cli_with_pm([ENSEMBLE_EXPERIMENT_MODE, "--disable-monitor", "config.ert"])
+        run_cli_with_pm(
+            [ENSEMBLE_EXPERIMENT_MODE, "--disable-monitoring", "config.ert"]
+        )
 
         mask = np.logical_not(
             np.array(io_source.actnum).reshape(io_source.dims, order="F")

--- a/tests/ert/ui_tests/cli/test_parameter_sample_types.py
+++ b/tests/ert/ui_tests/cli/test_parameter_sample_types.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,
-            "--disable-monitor",
+            "--disable-monitoring",
             "config.ert",
         )
         with open_storage(tmpdir / "storage") as storage:

--- a/tests/ert/ui_tests/cli/test_shell.py
+++ b/tests/ert/ui_tests/cli/test_shell.py
@@ -35,7 +35,7 @@ FORWARD_MODEL MOVE_DIRECTORY(<FROM>=mydir3, <TO>=mydir4/mydir3)
         with open("file.txt", "w", encoding="utf-8") as file_h:
             file_h.write("something")
 
-        run_cli_with_pm(["test_run", "--disable-monitor", ert_config_fname])
+        run_cli_with_pm(["test_run", "--disable-monitoring", ert_config_fname])
 
         with open("realization-0/iter-0/moved.txt", encoding="utf-8") as output_file:
             assert output_file.read() == "something"

--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -195,7 +195,7 @@ def test_update_lowers_generalized_variance_or_deactivates_observations(
             try:
                 run_cli(
                     ENSEMBLE_SMOOTHER_MODE,
-                    "--disable-monitor",
+                    "--disable-monitoring",
                     "--experiment-name",
                     "experiment",
                     "config.ert",

--- a/tests/ert/unit_tests/dark_storage/conftest.py
+++ b/tests/ert/unit_tests/dark_storage/conftest.py
@@ -32,7 +32,7 @@ def poly_example_tmp_dir_shared(
             parser,
             [
                 ENSEMBLE_SMOOTHER_MODE,
-                "--disable-monitor",
+                "--disable-monitoring",
                 "--realizations",
                 "1,2,4",
                 "poly.ert",


### PR DESCRIPTION
`"disable-monitor"` does not exist?
ref ert main:
```
cli_parser.add_argument(
            "--disable-monitoring",
            action="store_true",
            help="Monitoring will continuously print the status of the realisations"
            + " classified into Waiting, Pending, Running, Failed, Finished"
            + " and Unknown.",
            default=False,
        )
```
