### PR TITLE
Use ERT storage as simulator cache

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -276,7 +276,8 @@ class EverestRunModel(BaseRunModel):
     ) -> None:
         self.log_at_startup()
         self._eval_server_cfg = evaluator_server_config
-        self._experiment = self._storage.create_experiment(
+
+        self._experiment = self._experiment or self._storage.create_experiment(
             name=f"EnOpt@{datetime.datetime.now().strftime('%Y-%m-%d@%H:%M:%S')}",
             parameters=self._parameter_configuration,
             responses=self._response_configuration,

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -1085,3 +1085,90 @@ class LocalEnsemble(BaseMode):
         self._storage._write_transaction(
             self._path / "index.json", self._index.model_dump_json().encode("utf-8")
         )
+
+    @property
+    def all_parameters_and_gen_data(self) -> pl.DataFrame | None:
+        """
+        Only for Everest wrt objectives/constraints,
+        disregards summary data and primary key values
+        """
+        param_dfs = []
+        for param_group in self.experiment.parameter_configuration:
+            params_pd = self.load_parameters(param_group)["values"].to_pandas()
+
+            assert isinstance(params_pd, pd.DataFrame)
+            params_pd = params_pd.reset_index()
+            param_df = pl.from_pandas(params_pd)
+
+            param_columns = [c for c in param_df.columns if c != "realizations"]
+            param_df = param_df.rename(
+                {
+                    **{
+                        c: param_group + "." + c.replace("\0", ".")
+                        for c in param_columns
+                    },
+                    "realizations": "realization",
+                }
+            )
+            param_df = param_df.cast(
+                {
+                    "realization": pl.UInt16,
+                    **{c: pl.Float64 for c in param_df.columns if c != "realization"},
+                }
+            )
+            param_dfs.append(param_df)
+
+        responses = self.load_responses(
+            "gen_data", tuple(self.get_realization_list_with_responses())
+        )
+
+        if responses is None:
+            return pl.concat(param_dfs)
+
+        params_wide = pl.concat(
+            [
+                pdf.sort("realization").drop("realization")
+                if i > 0
+                else pdf.sort("realization")
+                for i, pdf in enumerate(param_dfs)
+            ],
+            how="horizontal",
+        )
+
+        responses_wide = responses["realization", "response_key", "values"].pivot(
+            on="response_key", values="values"
+        )
+
+        params_and_responses = responses_wide.join(
+            params_wide, on="realization"
+        ).with_columns(pl.lit(self.iteration).alias("batch"))
+
+        assert self.everest_realization_info is not None
+
+        model_realization_mapping = {
+            k: v["model_realization"] for k, v in self.everest_realization_info.items()
+        }
+        perturbation_mapping = {
+            k: v["perturbation"] for k, v in self.everest_realization_info.items()
+        }
+
+        params_and_responses = params_and_responses.with_columns(
+            pl.col("realization")
+            .replace(model_realization_mapping)
+            .alias("model_realization"),
+            pl.col("realization")
+            .cast(pl.Int32)
+            .replace(perturbation_mapping)
+            .alias("perturbation"),
+        )
+
+        column_order = [
+            "batch",
+            "model_realization",
+            "perturbation",
+            "realization",
+            *[c for c in responses_wide.columns if c != "realization"],
+            *[c for c in params_wide.columns if c != "realization"],
+        ]
+
+        return params_and_responses[column_order]

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -390,3 +390,19 @@ class LocalExperiment(BaseMode):
 
         if self.response_type_to_response_keys is not None:
             del self.response_type_to_response_keys
+
+    @property
+    def all_parameters_and_gen_data(self) -> pl.DataFrame | None:
+        if not self.ensembles:
+            return None
+
+        ensemble_dfs = [
+            e.all_parameters_and_gen_data
+            for e in self.ensembles
+            if e.all_parameters_and_gen_data is not None
+        ]
+
+        if not ensemble_dfs:
+            return None
+
+        return pl.concat(ensemble_dfs)

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -289,7 +289,7 @@ class EverestStorage:
     def _enforce_dtypes(df: pl.DataFrame) -> pl.DataFrame:
         dtypes = {
             "batch_id": pl.UInt32,
-            "perturbation": pl.UInt32,
+            "perturbation": pl.Int32,
             "realization": pl.UInt32,
             # -1 is used as a value in simulator cache.
             # thus we need signed, otherwise we could do unsigned

--- a/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/all_batches.json
+++ b/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/all_batches.json
@@ -1,0 +1,162 @@
+[
+  {
+    "R1": 0.0,
+    "R2": 0.0,
+    "batch": 0,
+    "model_realization": 0,
+    "perturbation": -1,
+    "point.P1": 0.0,
+    "point.P2": 0.0,
+    "realization": 0
+  },
+  {
+    "R1": 10.0,
+    "R2": 10.0,
+    "batch": 0,
+    "model_realization": 5,
+    "perturbation": -1,
+    "point.P1": 1.0,
+    "point.P2": 1.0,
+    "realization": 1
+  },
+  {
+    "R1": 0.1,
+    "R2": 0.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 0,
+    "point.P1": 0.1,
+    "point.P2": 0.1,
+    "realization": 0
+  },
+  {
+    "R1": 10.1,
+    "R2": 10.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 1,
+    "point.P1": 1.1,
+    "point.P2": 1.1,
+    "realization": 1
+  },
+  {
+    "R1": 20.1,
+    "R2": 20.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 2,
+    "point.P1": 2.1,
+    "point.P2": 2.1,
+    "realization": 2
+  },
+  {
+    "R1": 30.1,
+    "R2": 30.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 0,
+    "point.P1": 3.1,
+    "point.P2": 3.1,
+    "realization": 3
+  },
+  {
+    "R1": 40.1,
+    "R2": 40.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 1,
+    "point.P1": 4.1,
+    "point.P2": 4.1,
+    "realization": 4
+  },
+  {
+    "R1": 50.1,
+    "R2": 50.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 2,
+    "point.P1": 5.1,
+    "point.P2": 5.1,
+    "realization": 5
+  },
+  {
+    "R1": 0.2,
+    "R2": 0.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": -1,
+    "point.P1": 0.2,
+    "point.P2": 0.2,
+    "realization": 0
+  },
+  {
+    "R1": 10.2,
+    "R2": 10.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": -1,
+    "point.P1": 1.2,
+    "point.P2": 1.2,
+    "realization": 1
+  },
+  {
+    "R1": 20.2,
+    "R2": 20.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 0,
+    "point.P1": 2.2,
+    "point.P2": 2.2,
+    "realization": 2
+  },
+  {
+    "R1": 30.2,
+    "R2": 30.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 1,
+    "point.P1": 3.2,
+    "point.P2": 3.2,
+    "realization": 3
+  },
+  {
+    "R1": 40.2,
+    "R2": 40.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 2,
+    "point.P1": 4.2,
+    "point.P2": 4.2,
+    "realization": 4
+  },
+  {
+    "R1": 50.2,
+    "R2": 50.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 0,
+    "point.P1": 5.2,
+    "point.P2": 5.2,
+    "realization": 5
+  },
+  {
+    "R1": 60.2,
+    "R2": 60.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 1,
+    "point.P1": 6.2,
+    "point.P2": 6.2,
+    "realization": 6
+  },
+  {
+    "R1": 70.2,
+    "R2": 70.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 2,
+    "point.P1": 7.2,
+    "point.P2": 7.2,
+    "realization": 7
+  }
+]

--- a/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_0.json
+++ b/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_0.json
@@ -1,0 +1,22 @@
+[
+  {
+    "R1": 0.0,
+    "R2": 0.0,
+    "batch": 0,
+    "model_realization": 0,
+    "perturbation": -1,
+    "point.P1": 0.0,
+    "point.P2": 0.0,
+    "realization": 0
+  },
+  {
+    "R1": 10.0,
+    "R2": 10.0,
+    "batch": 0,
+    "model_realization": 5,
+    "perturbation": -1,
+    "point.P1": 1.0,
+    "point.P2": 1.0,
+    "realization": 1
+  }
+]

--- a/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_1.json
+++ b/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_1.json
@@ -1,0 +1,62 @@
+[
+  {
+    "R1": 0.1,
+    "R2": 0.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 0,
+    "point.P1": 0.1,
+    "point.P2": 0.1,
+    "realization": 0
+  },
+  {
+    "R1": 10.1,
+    "R2": 10.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 1,
+    "point.P1": 1.1,
+    "point.P2": 1.1,
+    "realization": 1
+  },
+  {
+    "R1": 20.1,
+    "R2": 20.1,
+    "batch": 1,
+    "model_realization": 0,
+    "perturbation": 2,
+    "point.P1": 2.1,
+    "point.P2": 2.1,
+    "realization": 2
+  },
+  {
+    "R1": 30.1,
+    "R2": 30.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 0,
+    "point.P1": 3.1,
+    "point.P2": 3.1,
+    "realization": 3
+  },
+  {
+    "R1": 40.1,
+    "R2": 40.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 1,
+    "point.P1": 4.1,
+    "point.P2": 4.1,
+    "realization": 4
+  },
+  {
+    "R1": 50.1,
+    "R2": 50.1,
+    "batch": 1,
+    "model_realization": 5,
+    "perturbation": 2,
+    "point.P1": 5.1,
+    "point.P2": 5.1,
+    "realization": 5
+  }
+]

--- a/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_2.json
+++ b/tests/ert/unit_tests/storage/snapshots/test_local_storage/test_that_all_parameters_and_gen_data_consolidation_works/batch_2.json
@@ -1,0 +1,82 @@
+[
+  {
+    "R1": 0.2,
+    "R2": 0.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": -1,
+    "point.P1": 0.2,
+    "point.P2": 0.2,
+    "realization": 0
+  },
+  {
+    "R1": 10.2,
+    "R2": 10.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": -1,
+    "point.P1": 1.2,
+    "point.P2": 1.2,
+    "realization": 1
+  },
+  {
+    "R1": 20.2,
+    "R2": 20.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 0,
+    "point.P1": 2.2,
+    "point.P2": 2.2,
+    "realization": 2
+  },
+  {
+    "R1": 30.2,
+    "R2": 30.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 1,
+    "point.P1": 3.2,
+    "point.P2": 3.2,
+    "realization": 3
+  },
+  {
+    "R1": 40.2,
+    "R2": 40.2,
+    "batch": 2,
+    "model_realization": 0,
+    "perturbation": 2,
+    "point.P1": 4.2,
+    "point.P2": 4.2,
+    "realization": 4
+  },
+  {
+    "R1": 50.2,
+    "R2": 50.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 0,
+    "point.P1": 5.2,
+    "point.P2": 5.2,
+    "realization": 5
+  },
+  {
+    "R1": 60.2,
+    "R2": 60.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 1,
+    "point.P1": 6.2,
+    "point.P2": 6.2,
+    "realization": 6
+  },
+  {
+    "R1": 70.2,
+    "R2": 70.2,
+    "batch": 2,
+    "model_realization": 5,
+    "perturbation": 2,
+    "point.P1": 7.2,
+    "point.P2": 7.2,
+    "realization": 7
+  }
+]


### PR DESCRIPTION
Replaces simulator cache with that of ERT storage by introducing a dataframe of simulation controls & results per experiment, which we can search for results.

**Issue**
Resolves https://github.com/equinor/ert/issues/9751
Resolves https://github.com/equinor/ert/issues/9674


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
