### PR TITLE
Clean up ert config tests

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1815,18 +1815,17 @@ def test_no_warning_when_summary_key_and_simulation_job_present(job_name, key):
         ErtConfig.from_file("config_file.ert")
 
 
-def test_warning_is_emitted_when_malformatted_runpath(tmp_path):
-    config_path = tmp_path / "config_file.ert"
-    with open(config_path, "w", encoding="utf-8") as fout:
-        # Write a minimal config file
-        fout.write(
-            "RUNPATH <STORAGE>/runpath/constant-realization-num/constant-iter-num\n"
+def test_warning_is_emitted_when_malformatted_runpath():
+    with warnings.catch_warnings(record=True, category=ConfigWarning) as all_warnings:
+        ErtConfig.from_file_contents(
+            dedent(
+                """\
+                NUM_REALIZATIONS 1
+                RUNPATH <STORAGE>/runpath/constant-realization-num/constant-iter-num
+                """
+            )
         )
-        fout.write("NUM_REALIZATIONS 1\n")
-    with warnings.catch_warnings(record=True) as all_warnings:
-        ErtConfig.from_file(config_path)
     assert any(
         ("RUNPATH keyword contains no value placeholders" in str(w.message))
         for w in all_warnings
-        if isinstance(w.message, ConfigWarning)
     )

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -198,7 +198,6 @@ def test_custom_forward_models_are_logged(caplog):
     ), "check if site-config fm were logged"
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 def test_logging_with_comments(caplog):
     """
     Run logging on an actual config file with line comments

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1317,7 +1317,6 @@ def test_that_substitution_happens_for_include():
         RUNPATH my_silly_runpath<ITER>-<IENS>
         """
     )
-    # The old parser tries to find dir/job2
     os.mkdir("dir")
     with open(test_config_file_name, "w", encoding="utf-8") as fh:
         fh.write(test_config_contents)
@@ -1347,7 +1346,6 @@ def test_that_defines_in_included_files_has_immediate_effect():
         DEFINE <FOO> baz
         """
     )
-    # The old parser tries to find dir/job2
     os.mkdir("dir")
     with open(test_config_file_name, "w", encoding="utf-8") as fh:
         fh.write(test_config_contents)

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -251,15 +251,6 @@ def test_that_parsing_workflows_gives_expected():
         ConfigKeys.NUM_REALIZATIONS: 1,
     }
 
-    with open("minimum_config", "a+", encoding="utf-8") as ert_file:
-        ert_file.write("LOAD_WORKFLOW_JOB workflows/UBER_PRINT print_uber\n")
-        ert_file.write("LOAD_WORKFLOW_JOB workflows/HIDDEN_PRINT\n")
-        ert_file.write("LOAD_WORKFLOW workflows/MAGIC_PRINT magic_print\n")
-        ert_file.write("LOAD_WORKFLOW workflows/NO_PRINT no_print\n")
-        ert_file.write("LOAD_WORKFLOW workflows/SOME_PRINT some_print\n")
-        ert_file.write("HOOK_WORKFLOW magic_print POST_UPDATE\n")
-        ert_file.write("HOOK_WORKFLOW no_print PRE_UPDATE\n")
-
     os.mkdir("workflows")
 
     with open("workflows/MAGIC_PRINT", "w", encoding="utf-8") as f:

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -15,7 +15,7 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from pydantic import RootModel, TypeAdapter
 
-from ert.config import AnalysisConfig, ConfigValidationError, ErtConfig, HookRuntime
+from ert.config import ConfigValidationError, ErtConfig, HookRuntime
 from ert.config.ert_config import (
     create_forward_model_json,
     site_config_location,
@@ -52,17 +52,11 @@ def test_config_can_include_existing_file():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_minimal_ert_configuration():
+def test_that_config_path_substitution_is_the_name_of_the_configs_directory():
     Path("minimal_config.ert").write_text("NUM_REALIZATIONS 1", encoding="utf-8")
     ert_config = ErtConfig.from_file("minimal_config.ert")
 
-    assert ert_config is not None
-
-    assert ert_config.analysis_config is not None
-    assert isinstance(ert_config.analysis_config, AnalysisConfig)
-
     assert ert_config.config_path == os.getcwd()
-
     assert ert_config.substitutions["<CONFIG_PATH>"] == os.getcwd()
 
 

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -425,16 +425,10 @@ def test_ert_config_parses_date():
     assert ert_config.model_config.runpath_format_string == expected_run_path
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 def test_that_subst_list_is_given_default_runpath_file():
-    test_config_file_base = "test"
-    test_config_file_name = f"{test_config_file_base}.ert"
-    test_config_contents = "NUM_REALIZATIONS 1"
-    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
-    ert_config = ErtConfig.from_file(test_config_file_name)
-    assert ert_config.substitutions["<RUNPATH_FILE>"] == os.path.abspath(
-        ErtConfig.DEFAULT_RUNPATH_FILE
-    )
+    assert ErtConfig.from_file_contents("NUM_REALIZATIONS 1").substitutions[
+        "<RUNPATH_FILE>"
+    ] == os.path.abspath(ErtConfig.DEFAULT_RUNPATH_FILE)
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
