### PR TITLE
Simplify everest visualisation entry test

### DIFF
--- a/tests/everest/entry_points/test_visualization_entry.py
+++ b/tests/everest/entry_points/test_visualization_entry.py
@@ -1,17 +1,33 @@
-from pathlib import Path
 from unittest.mock import patch
 
+import pluggy
+
 from everest.bin.visualization_script import visualization_entry
+from everest.config import EverestConfig
 from everest.detached import ServerStatus
+from everest.plugins import hook_impl, hook_specs
+from everest.strings import EVEREST
 from tests.everest.utils import capture_streams
+
+
+class MockPluginManager(pluggy.PluginManager):
+    def __init__(self):
+        super().__init__(EVEREST)
+        self.add_hookspecs(hook_specs)
+        self.register(hook_impl)
 
 
 @patch(
     "everest.bin.visualization_script.everserver_status",
     return_value={"status": ServerStatus.completed},
 )
-def test_visualization_entry(_, cached_example):
-    config_path, config_file, _ = cached_example("math_func/config_advanced.yml")
+@patch("everest.bin.visualization_script.EverestPluginManager", MockPluginManager)
+def test_expected_message_when_no_visualisation_plugin_is_installed(
+    _, change_to_tmpdir, min_config
+):
+    config_file = "test.yml"
+    config = EverestConfig(**min_config)
+    config.dump(config_file)
     with capture_streams() as (out, _):
-        visualization_entry([str(Path(config_path) / config_file)])
+        visualization_entry([config_file])
     assert "No visualization plugin installed!" in out.getvalue()


### PR DESCRIPTION
**Issue**
Resolves #9729




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
