### PR TITLE
Add integration tests for parallel flow simulator

### DIFF
--- a/tests/ert/ui_tests/cli/test_run_flow_simulator.py
+++ b/tests/ert/ui_tests/cli/test_run_flow_simulator.py
@@ -1,0 +1,160 @@
+import re
+import shutil
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from ert.mode_definitions import TEST_RUN_MODE
+
+from .run_cli import run_cli
+
+
+@pytest.fixture()
+def eightcells(use_tmpdir, source_root):
+    shutil.copy(
+        source_root / "test-data/ert/eclipse/EIGHTCELLS.DATA", "EIGHTCELLS.DATA"
+    )
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.parametrize("num_cpu", [1, 2])
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_numcpu_maps_to_mpi_processes_with_flow(num_cpu):
+    Path("flow.ert").write_text(
+        dedent(f"""
+    NUM_REALIZATIONS 1
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    NUM_CPU {num_cpu}
+    FORWARD_MODEL FLOW
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(rf"Number of MPI processes:\s+{num_cpu}", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+1", flow_stdout)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_user_can_specify_threads_and_oversubscribe_compute_node():
+    Path("flow.ert").write_text(
+        dedent("""
+    NUM_REALIZATIONS 1
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    NUM_CPU 1
+    FORWARD_MODEL FLOW(<OPTS>="--threads 2")  -- OPTS is parsed by flowrun
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(r"Number of MPI processes:\s+1", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+2", flow_stdout)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_user_can_specify_threads_and_mpi_processes_and_oversubscribe_compute_node():
+    Path("flow.ert").write_text(
+        dedent("""
+    NUM_REALIZATIONS 1
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    NUM_CPU 1
+    FORWARD_MODEL FLOW(<OPTS>="--np 2 --threads 2")  -- OPTS is parsed by flowrun
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(r"Number of MPI processes:\s+2", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+2", flow_stdout)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_setenv_can_be_used_to_set_threads():
+    Path("flow.ert").write_text(
+        dedent("""
+    NUM_REALIZATIONS 1
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    SETENV OMP_NUM_THREADS 2
+    NUM_CPU 1
+    FORWARD_MODEL FLOW()
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(r"Number of MPI processes:\s+1", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+2", flow_stdout)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_ert_will_fetch_parallel_keyword_and_set_mpi_processes():
+    deck = Path("EIGHTCELLS.DATA").read_text(encoding="utf-8")
+    assert "PARALLEL" not in deck
+    Path("EIGHTCELLS.DATA").write_text(
+        deck.replace("DIMENS", "PARALLEL\n 2 /\n\nDIMENS"), encoding="utf-8"
+    )
+    Path("flow.ert").write_text(
+        dedent("""
+    NUM_REALIZATIONS 1
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    FORWARD_MODEL FLOW()
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(r"Number of MPI processes:\s+2", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+1", flow_stdout)
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("eightcells")
+@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
+def test_num_cpu_wins_over_parallel_in_deck():
+    deck = Path("EIGHTCELLS.DATA").read_text(encoding="utf-8")
+    assert "PARALLEL" not in deck
+    Path("EIGHTCELLS.DATA").write_text(
+        deck.replace("DIMENS", "PARALLEL\n 4 /\n\nDIMENS"), encoding="utf-8"
+    )
+    Path("flow.ert").write_text(
+        dedent("""
+    NUM_REALIZATIONS 1
+    NUM_CPU 2
+    ECLBASE EIGHTCELLS
+    DATA_FILE EIGHTCELLS.DATA
+    RUNPATH realization-<IENS>
+    FORWARD_MODEL FLOW()
+    """).strip(),
+        encoding="utf-8",
+    )
+
+    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
+    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
+    assert re.search(r"Number of MPI processes:\s+2", flow_stdout)
+    assert re.search(r"Threads per MPI process:\s+1", flow_stdout)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/scout/issues/1098 

**Approach**
Run full CLI integration tests to state how flow should behave. These tests will not run in Github Actions, only during komodo environment tests or in local enviroments where `ert-configurations` is installed.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
