### PR TITLE
Fix recommended pytest command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ _Short description of the approach_
 - [ ] Added appropriate release note label
 - [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
 - [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
-      --exec 'pytest tests/ert/unit_tests -n logical -m "not integration_test"'`)
+      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)
 
 ## When applicable
 - [ ] **When there are user facing changes**: Updated documentation

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are many kinds of tests in the `tests` directory, while iterating on your
 code you can run a fast subset of the tests with
 
 ```sh
-pytest -n logical tests/ert/unit_tests -m "not integration_tests"
+pytest -n auto tests/ert/unit_tests -m "not integration_test"
 ```
 
 [Git LFS](https://git-lfs.com/) must be installed to get all the files. This is

--- a/justfile
+++ b/justfile
@@ -10,4 +10,4 @@ snake_oil:
 
 # execute rapid unittests
 rapid-tests:
-    nice pytest -n logical tests/ert/unit_tests -m "not integration_tests"
+    nice pytest -n auto tests/ert/unit_tests -m "not integration_test"


### PR DESCRIPTION
Since tests run much faster now, `auto` seems to be about twice as fast as `logical`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
