### PR TITLE
Small speedup of _fm_step_data

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -45,7 +45,7 @@ IsRealizationRole = UserRole + 9
 IsFMStepRole = UserRole + 10
 StatusRole = UserRole + 11
 
-DURATION = "Duration"
+DURATION: Final = "Duration"
 
 FM_STEP_COLUMNS: Sequence[str] = [
     ids.NAME,
@@ -418,7 +418,7 @@ class SnapshotModel(QAbstractItemModel):
 
         if role == Qt.ItemDataRole.DisplayRole:
             data_name = FM_STEP_COLUMNS[index.column()]
-            if data_name in {ids.MAX_MEMORY_USAGE}:
+            if data_name == ids.MAX_MEMORY_USAGE:
                 data = node.data
                 bytes_: str | None = data.get(data_name)  # type: ignore
                 if bytes_:
@@ -429,7 +429,7 @@ class SnapshotModel(QAbstractItemModel):
                     return "-"
                 return "View" if data_name in node.data else QVariant()
 
-            if data_name in {DURATION}:
+            if data_name == DURATION:
                 start_time = node.data.get(ids.START_TIME)
                 if start_time is None:
                     return QVariant()


### PR DESCRIPTION
By using eq instead of in, you see a small but significant improvement in the snapshot handling benchmark.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
