### PR TITLE
Avoid non-informative ValueError in parameter/response configuration

### DIFF
--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -244,20 +244,14 @@ class LocalExperiment(BaseMode):
     @property
     def parameter_info(self) -> dict[str, Any]:
         info: dict[str, Any]
-        path = self.mount_point / self._parameter_file
-        if not path.exists():
-            raise ValueError(f"{self._parameter_file!s} does not exist")
-        with open(path, encoding="utf-8") as f:
+        with open(self.mount_point / self._parameter_file, encoding="utf-8") as f:
             info = json.load(f)
         return info
 
     @property
     def response_info(self) -> dict[str, Any]:
         info: dict[str, Any]
-        path = self.mount_point / self._responses_file
-        if not path.exists():
-            raise ValueError(f"{self._responses_file!s} does not exist")
-        with open(path, encoding="utf-8") as f:
+        with open(self.mount_point / self._responses_file, encoding="utf-8") as f:
             info = json.load(f)
         return info
 


### PR DESCRIPTION
This avoids the error message "ValueError: responses.json does not exist" and instead you get "FileNotFoundError: [Errno 2] No such file or directory: 'path/to/storage/.../responses.json'".

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
