### PR TITLE
Fix right_click external plotter flaky test

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -151,6 +151,9 @@ class ErtMainWindow(QMainWindow):
             pw.show()
             self._external_plot_windows.append(pw)
 
+    def get_external_plot_windows(self) -> list[PlotWindow]:
+        return self._external_plot_windows
+
     def select_central_widget(self) -> None:
         actor = self.sender()
         if actor:

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -9,10 +9,8 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import pytest
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtGui import QWindow
 from qtpy.QtWidgets import (
     QAction,
-    QApplication,
     QCheckBox,
     QComboBox,
     QDoubleSpinBox,
@@ -650,11 +648,12 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, storage, monkeypa
         button_plot_tool = gui.findChild(SidebarToolButton, "button_Create_plot")
         assert button_plot_tool
 
-        def top_level_plotter_windows() -> list[QWindow]:
+        def top_level_plotter_windows() -> list[PlotWindow]:
+            plot_windows = gui.get_external_plot_windows()
             top_level_plot_windows = []
-            top_level_windows = QApplication.topLevelWindows()
-            for win in top_level_windows:
-                if "Plotting" in win.title() and win.isVisible():
+
+            for win in plot_windows:
+                if "Plotting" in win.windowTitle() and win.isVisible():
                     top_level_plot_windows.append(win)
             return top_level_plot_windows
 


### PR DESCRIPTION
**Issue**
Resolves [#9643](https://github.com/equinor/ert/issues/9643)


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
