### PR TITLE
Do heartbeat on clients

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 
+import _ert.forward_model_runner.client
 from _ert.forward_model_runner.client import Client, ClientConnectionError
 from tests.ert.utils import MockZMQServer
 
@@ -18,12 +21,12 @@ async def test_invalid_server():
 async def test_successful_sending(unused_tcp_port):
     host = "localhost"
     url = f"tcp://{host}:{unused_tcp_port}"
-    messages_c1 = ["test_1", "test_2", "test_3"]
-    async with MockZMQServer(unused_tcp_port) as mock_server, Client(url) as c1:
-        for message in messages_c1:
-            await c1.send(message)
+    messages = ["test_1", "test_2", "test_3"]
+    async with MockZMQServer(unused_tcp_port) as mock_server, Client(url) as client:
+        for message in messages:
+            await client.send(message)
 
-    for msg in messages_c1:
+    for msg in messages:
         assert msg in mock_server.messages
 
 
@@ -32,14 +35,14 @@ async def test_retry(unused_tcp_port):
     host = "localhost"
     url = f"tcp://{host}:{unused_tcp_port}"
     client_connection_error_set = False
-    messages_c1 = ["test_1", "test_2", "test_3"]
+    messages = ["test_1", "test_2", "test_3"]
     async with (
         MockZMQServer(unused_tcp_port, signal=2) as mock_server,
-        Client(url, ack_timeout=0.5) as c1,
+        Client(url, ack_timeout=0.5) as client,
     ):
-        for message in messages_c1:
+        for message in messages:
             try:
-                await c1.send(message, retries=1)
+                await client.send(message, retries=1)
             except ClientConnectionError:
                 client_connection_error_set = True
                 mock_server.signal(0)
@@ -47,3 +50,26 @@ async def test_retry(unused_tcp_port):
     assert mock_server.messages.count("test_1") == 2
     assert mock_server.messages.count("test_2") == 1
     assert mock_server.messages.count("test_3") == 1
+
+
+async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
+    host = "localhost"
+    url = f"tcp://{host}:{unused_tcp_port}"
+    monkeypatch.setattr(_ert.forward_model_runner.client, "HEARTBEAT_TIMEOUT", 0.1)
+
+    async with (
+        MockZMQServer(unused_tcp_port, signal=3) as mock_server,
+        Client(url) as client,
+    ):
+        await client.send("start", retries=1)
+
+        await mock_server.do_heartbeat()
+        await asyncio.sleep(1)
+        await mock_server.do_heartbeat()
+        await client.send("stop", retries=1)
+
+    # when reconnection happens CONNECT message is sent again
+    assert mock_server.messages.count("CONNECT") == 2
+    assert mock_server.messages.count("DISCONNECT") == 1
+    assert "start" in mock_server.messages
+    assert "stop" in mock_server.messages

--- a/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
@@ -55,8 +55,9 @@ async def test_monitor_connects_and_disconnects_successfully(unused_tcp_port):
     assert msg == DISCONNECT_MSG
 
 
-async def test_no_connection_established(make_ee_config):
+async def test_no_connection_established(monkeypatch, make_ee_config):
     ee_config = make_ee_config()
+    monkeypatch.setattr(Monitor, "DEFAULT_MAX_RETRIES", 0)
     monitor = Monitor(ee_config.get_connection_info())
     monitor._ack_timeout = 0.1
     with pytest.raises(ClientConnectionError):

--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -213,9 +213,7 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
 def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
     # this is to show when the reporter fails but reconnects
     # reporter still manages to send events and completes fine
-    # see assert reporter._timeout_timestamp is not None
-    # meaning Finish event initiated _timeout but timeout wasn't reached since
-    # it finished succesfully
+    # see reporter._event_publisher for more details.
 
     host = "localhost"
     url = f"tcp://{host}:{unused_tcp_port}"


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/9782


**Approach**
Heartbeat task sends HEARTBEAT to all the clients (ie. Monitor) at client.HEARTBEAT_TIMEOUT intervals.
Clients do not reply, just process the message. If client detects a longer delay between two heartbeats, the client will send CONNECT to evaluator in addition; ie. getting the connection re-established after a break. This is to simulate re-connection. Each CONNECT_MSG will then trigger sending FullSnapshot from the ensemble evaluator.

Initially HEARTBEAT_TIMEOUT is set to 5 seconds while Monitor accepts 10 seconds at max as a delay. Additionally, initial connection will now undergo same amount of retries as standard messages.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
