### PR TITLE
Remove logging_level setter from Everest config

### DIFF
--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -240,8 +240,6 @@ def main():
     arg_parser.add_argument("--debug", action="store_true")
     options = arg_parser.parse_args()
     config = EverestConfig.load_file(options.config_file)
-    if options.debug:
-        config.logging_level = "debug"
     status_path = ServerConfig.get_everserver_status_path(config.output_dir)
     host_file = ServerConfig.get_hostfile_path(config.output_dir)
 
@@ -253,7 +251,7 @@ def main():
                 if config.log_dir is None
                 else Path(config.log_dir)
             ),
-            logging_level=config.logging_level,
+            logging_level=config.logging_level if not options.debug else logging.DEBUG,
         )
 
         update_everserver_status(status_path, ServerStatus.starting)

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -281,11 +281,6 @@ def test_that_log_level_property_is_consistent_with_environment_log_level():
         config.environment.log_level = lvl_str
         assert config.logging_level == lvl_int
 
-    for lvl_str, lvl_int in levels.items():
-        config.logging_level = lvl_str
-        assert config.environment.log_level == lvl_str
-        assert config.logging_level == lvl_int
-
 
 @pytest.mark.parametrize("config_class", [SimulatorConfig, ServerConfig])
 @pytest.mark.parametrize("queue_system", ["lsf", "torque", "slurm", "local"])


### PR DESCRIPTION
**Issue**


**Approach**

* Remove the workaround to allow property setters for EverestConfig

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
