### PR TITLE
Fix storage service not being closed

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,3 +11,13 @@ snake_oil:
 # execute rapid unittests
 rapid-tests:
     nice pytest -n auto tests/ert/unit_tests --hypothesis-profile=fast -m "not integration_test"
+
+check-all:
+    mypy src/ert src/everest
+    pre-commit run --all-files
+    pytest tests/everest -n 4 -m everest_models_test --dist loadgroup
+    pytest tests/everest -n 4 -m integration_test --dist loadgroup
+    pytest tests/ert/ui_tests/ --mpl --dist loadgroup
+    pytest tests/ert/unit_tests/ -n 4 --dist loadgroup
+    pytest --doctest-modules src/ --ignore src/ert/dark_storage
+    pytest tests/ert/performance_tests --benchmark-disable --dist loadgroup

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -53,7 +53,9 @@ logger = logging.getLogger(__name__)
 
 def run_ert_storage(args: Namespace, _: ErtPluginManager | None = None) -> None:
     with StorageService.start_server(
-        verbose=True, project=ErtConfig.from_file(args.config).ens_path
+        verbose=True,
+        project=ErtConfig.from_file(args.config).ens_path,
+        parent_pid=os.getpid(),
     ) as server:
         server.wait()
 

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -139,14 +139,14 @@ def run_server(
 
 
 def terminate_on_parent_death(
-    stopped: threading.Event, poll_interval: float = 1.0
+    stopped: threading.Event, parent: int, poll_interval: float = 1.0
 ) -> None:
     """
     Quit the server when the parent process is no longer running.
     """
 
     def check_parent_alive() -> bool:
-        return os.getppid() != 1
+        return os.getppid() == parent
 
     while check_parent_alive():
         if stopped.is_set():
@@ -182,7 +182,7 @@ def main() -> None:
 
     stopped = threading.Event()
     terminate_on_parent_death_thread = threading.Thread(
-        target=terminate_on_parent_death, args=[stopped, 1.0]
+        target=terminate_on_parent_death, args=[stopped, args.parent_pid, 1.0]
     )
     with ErtPluginContext(logger=logging.getLogger(), trace_provider=tracer_provider):
         terminate_on_parent_death_thread.start()

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -22,6 +22,7 @@ class StorageService(BaseService):
         self,
         exec_args: Sequence[str] = (),
         timeout: int = 120,
+        parent_pid: int | None = None,
         conn_info: Mapping[str, Any] | Exception | None = None,
         project: str | None = None,
         verbose: bool = False,
@@ -39,6 +40,8 @@ class StorageService(BaseService):
                 get_traceparent() if traceparent == "inherit_parent" else traceparent
             )
             exec_args.extend(["--traceparent", str(traceparent)])
+        if parent_pid is not None:
+            exec_args.extend(["--parent_pid", str(parent_pid)])
 
         super().__init__(exec_args, timeout, conn_info, project)
 

--- a/src/ert/shared/storage/command.py
+++ b/src/ert/shared/storage/command.py
@@ -23,6 +23,12 @@ def add_parser_options(ap: ArgumentParser) -> None:
         default=None,
     )
     ap.add_argument(
+        "--parent_pid",
+        type=int,
+        help="The parent process id",
+        default=os.getppid(),
+    )
+    ap.add_argument(
         "--host", type=str, default=os.environ.get("ERT_STORAGE_HOST", "127.0.0.1")
     )
     ap.add_argument(


### PR DESCRIPTION
In ec5397136b5122e8f34c11d9e0df672a3d93affe the implementation of closing on parent process death based on `prctl` was replaced by one using `os.ppid` relying on a process being adopted by process 1 whenever parent dies. However, this is not always the case: https://stackoverflow.com/a/40996664/283240 , e.g. on ubuntu 24.04, the process is adopted by `systemd --user`.

Instead we get the parent pid on start up and check that it is still that pid.


Also adds `check-all` to justfile


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
