### PR TITLE
Fix rerun button not disabled for ES-MDA

### DIFF
--- a/src/ert/run_models/iterated_ensemble_smoother.py
+++ b/src/ert/run_models/iterated_ensemble_smoother.py
@@ -50,7 +50,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
         update_settings: UpdateSettings,
         status_queue: SimpleQueue[StatusEvents],
     ):
-        self.support_restart = False
         self.analysis_config = analysis_config
         self.update_settings = update_settings
 
@@ -83,6 +82,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
             random_seed=random_seed,
             minimum_required_realizations=minimum_required_realizations,
         )
+        self.support_restart = False
 
         # Initialize sies_smoother to None
         # It is initialized later, but kept track of here

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -51,7 +51,6 @@ class MultipleDataAssimilation(UpdateRunModel):
         update_settings: UpdateSettings,
         status_queue: SimpleQueue[StatusEvents],
     ):
-        self.support_restart = False
         self._relative_weights = weights
         self.weights = self.parse_weights(weights)
 
@@ -89,6 +88,7 @@ class MultipleDataAssimilation(UpdateRunModel):
             random_seed=random_seed,
             minimum_required_realizations=minimum_required_realizations,
         )
+        self.support_restart = False
         self._observations = config.observations
         self._parameter_configuration = config.ensemble_config.parameter_configuration
         self._response_configuration = config.ensemble_config.response_configuration


### PR DESCRIPTION
**Issue**
Resolves #9811


**Approach**
This commit fixes the issue where the rerun button was enabled for ES-MDA and ensemble smoother. The issue was due to us setting support_restart before calling the super class' constructor which overwrote it to False.


(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/a4de9777-f5c5-406b-a590-4cf6688c2551)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
