### PR TITLE
Fix unable to have path object in argslist for localdriver

### DIFF
--- a/src/ert/scheduler/local_driver.py
+++ b/src/ert/scheduler/local_driver.py
@@ -63,9 +63,9 @@ class LocalDriver(Driver):
                 raise result
         logger.info("All realization tasks finished")
 
-    async def _run(self, iens: int, executable: str, /, *args: str) -> None:
+    async def _run(self, iens: int, executable: str, /, *args: str | Path) -> None:
         logger.debug(
-            f"Submitting realization {iens} as command '{executable} {' '.join(args)}'"
+            f"Submitting realization {iens} as command '{executable} {' '.join(str(arg) for arg in args)}'"
         )
         try:
             proc = await self._init(
@@ -100,7 +100,7 @@ class LocalDriver(Driver):
             self._sent_finished_events.add(iens)
 
     @staticmethod
-    async def _init(iens: int, executable: str, /, *args: str) -> Process:
+    async def _init(iens: int, executable: str, /, *args: str | Path) -> Process:
         """This method exists to allow for mocking it in tests"""
         return await asyncio.create_subprocess_exec(
             executable,

--- a/tests/ert/unit_tests/scheduler/test_local_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_local_driver.py
@@ -129,3 +129,15 @@ async def test_that_killing_killed_job_does_not_raise():
     await driver.kill(23)
     await driver.kill(23)
     assert driver.event_queue.empty()
+
+
+@pytest.mark.timeout(10)
+async def test_path_as_argument_is_valid(tmp_path):
+    driver = LocalDriver()
+    os.chdir(tmp_path)
+
+    await driver.submit(42, "/usr/bin/env", "touch", Path(tmp_path) / "testfile")
+    assert await driver.event_queue.get() == StartedEvent(iens=42)
+    assert await driver.event_queue.get() == FinishedEvent(iens=42, returncode=0)
+
+    assert Path("testfile").exists()


### PR DESCRIPTION
**Issue**
Resolves #9217 


**Approach**
Call str on the object before joining it.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
