### PR TITLE
Remove DESIGN_MATRIX_GROUP for parameter_configuration in design matrix

### DIFF
--- a/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
+++ b/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
@@ -77,7 +77,7 @@ def test_merge_multiple_occurrences(
             design_matrix_1.merge_with_other(design_matrix_2)
     else:
         design_matrix_1.merge_with_other(design_matrix_2)
-        design_params = design_matrix_1.parameter_configuration.get("DESIGN_MATRIX", [])
+        design_params = design_matrix_1.parameter_configuration
         assert all(param in design_params for param in ("a", "b", "c", "d"))
         assert design_matrix_1.active_realizations == [True, True, True]
         df = design_matrix_1.design_matrix_df
@@ -181,7 +181,7 @@ def test_reading_design_matrix(tmp_path):
             xl_write, index=False, sheet_name="DefaultValues", header=False
         )
     design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
-    design_params = design_matrix.parameter_configuration.get(DESIGN_MATRIX_GROUP, [])
+    design_params = design_matrix.parameter_configuration
     assert all(param in design_params for param in ("a", "b", "c", "one", "d"))
     assert design_matrix.active_realizations == [True, True, False, False, True]
 

--- a/tests/ert/unit_tests/test_libres_facade.py
+++ b/tests/ert/unit_tests/test_libres_facade.py
@@ -284,7 +284,7 @@ def test_save_parameters_to_storage_from_design_dataframe(
     design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
     with open_storage(tmp_path / "storage", mode="w") as storage:
         experiment_id = storage.create_experiment(
-            parameters=[design_matrix.parameter_configuration[DESIGN_MATRIX_GROUP]]
+            parameters=[design_matrix.parameter_configuration]
         )
         ensemble = storage.create_ensemble(
             experiment_id, name="default", ensemble_size=ensemble_size


### PR DESCRIPTION
**Issue**
Resolves #9718 


**Approach**
The dictionary introduced in parameter configuration in design matrix config seems not to be necessary. :scissors:  

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
