### PR TITLE
Have parameter config keep parameters types when using design matrix with categorical data

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -65,9 +65,24 @@ def _value_export_json(
     if len(values) == 0:
         return
 
+    def parse_value(value: float | int | str) -> float | int | str:
+        if isinstance(value, float | int):
+            return value
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return value
+
     # Hierarchical
-    json_out: dict[str, float | dict[str, float]] = {
-        key: dict(param_map.items()) for key, param_map in values.items()
+    json_out: dict[str, float | dict[str, float | int | str]] = {
+        key: {
+            inner_key: parse_value(inner_value)
+            for inner_key, inner_value in param_map.items()
+        }
+        for key, param_map in values.items()
     }
 
     # Disallow NaN from being written: ERT produces the parameters and the only


### PR DESCRIPTION
**Issue**
Resolves #9810


**Approach**
This commit makes enkf_main's _value_export_json keep types when dumping the json. Before this commit, all values (also numerical) were turned to strings if used alongside categorical values.

parameters.json in runpath for poly_example with design_matrix after this commit:
```
{
"DESIGN_MATRIX" : {
"a" : 0, 
"category" : "cat1", 
"b" : 1, 
"c" : 2
}
}
```

parameters.json in runpath for poly_example with design_matrix prior to this commit:
```
{
"DESIGN_MATRIX" : {
"a" : "0", 
"category" : "cat1", 
"b" : "1", 
"c" : "2"
}
}
```
(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
