### PR TITLE
Increase timeout of test_that_killed_ert_does_not_leave_storage_server_process

### DIFF
--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -190,6 +190,7 @@ def main() -> None:
             logger = logging.getLogger("ert.shared.storage.info")
             try:
                 logger.info("Starting dark storage")
+                logger.info(f"Started dark storage with parent {args.parent_pid}")
                 run_server(args, debug=False, uvicorn_config=uvicorn_config)
             except SystemExit:
                 logger.info("Stopping dark storage")

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -990,6 +990,9 @@ async def test_that_killed_ert_does_not_leave_storage_server_process():
             if not storage_process.is_running():
                 storage_server_has_shutdown.set()
             await asyncio.sleep(0.1)
+        print(
+            f"Waiting for killed ert:{ert_subprocess.pid} to stop storage:{storage_process.pid}"
+        )
 
-    await asyncio.wait_for(_wait_for_storage_process_to_shut_down(), timeout=45)
+    await asyncio.wait_for(_wait_for_storage_process_to_shut_down(), timeout=90)
     assert not storage_process.is_running()


### PR DESCRIPTION
Also adding more debug info


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
