### PR TITLE
Remove tests for OMP_NUM_THREADS

### DIFF
--- a/tests/ert/ui_tests/cli/test_run_flow_simulator.py
+++ b/tests/ert/ui_tests/cli/test_run_flow_simulator.py
@@ -83,28 +83,6 @@ def test_user_can_specify_threads_and_mpi_processes_and_oversubscribe_compute_no
 
 @pytest.mark.usefixtures("eightcells")
 @pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
-def test_setenv_can_be_used_to_set_threads():
-    Path("flow.ert").write_text(
-        dedent("""
-    NUM_REALIZATIONS 1
-    ECLBASE EIGHTCELLS
-    DATA_FILE EIGHTCELLS.DATA
-    RUNPATH realization-<IENS>
-    SETENV OMP_NUM_THREADS 2
-    NUM_CPU 1
-    FORWARD_MODEL FLOW()
-    """).strip(),
-        encoding="utf-8",
-    )
-
-    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
-    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
-    assert re.search(r"Number of MPI processes:\s+1", flow_stdout)
-    assert re.search(r"Threads per MPI process:\s+2", flow_stdout)
-
-
-@pytest.mark.usefixtures("eightcells")
-@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
 def test_ert_will_fetch_parallel_keyword_and_set_mpi_processes():
     deck = Path("EIGHTCELLS.DATA").read_text(encoding="utf-8")
     assert "PARALLEL" not in deck
@@ -126,39 +104,6 @@ def test_ert_will_fetch_parallel_keyword_and_set_mpi_processes():
     flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
     assert re.search(r"Number of MPI processes:\s+2", flow_stdout)
     assert re.search(r"Threads per MPI process:\s+1", flow_stdout)
-
-
-@pytest.mark.usefixtures("eightcells")
-@pytest.mark.skipif(not shutil.which("flowrun"), reason="flowrun not available")
-@pytest.mark.parametrize("num_cpu", [1, 2])
-def test_flow_will_always_obey_omp_num_threads_also_when_mpi_is_active(num_cpu):
-    """This part of flow Ert cannot control, and this scenario should thus be
-    avoided. However, if the users use SETENV manually it will happen.
-    SETENV takes precedence over plugin env configuration so configuriation of
-    the FLOW forward model through plugins will not help either."""
-    deck = Path("EIGHTCELLS.DATA").read_text(encoding="utf-8")
-    assert "PARALLEL" not in deck
-    Path("flow.ert").write_text(
-        dedent(f"""
-    NUM_REALIZATIONS 1
-    ECLBASE EIGHTCELLS
-    NUM_CPU {num_cpu}
-    DATA_FILE EIGHTCELLS.DATA
-    SETENV OMP_NUM_THREADS 2
-    RUNPATH realization-<IENS>
-    FORWARD_MODEL FLOW()
-    """).strip(),
-        encoding="utf-8",
-    )
-
-    run_cli(TEST_RUN_MODE, "--disable-monitoring", "flow.ert")
-    flow_stdout = Path("realization-0/FLOW.stdout.0").read_text(encoding="utf-8")
-    assert (
-        "Warning: Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process"
-        in flow_stdout
-    )
-    assert re.search(rf"Number of MPI processes:\s+{num_cpu}", flow_stdout)
-    assert re.search(r"Threads per MPI process:\s+2", flow_stdout)
 
 
 @pytest.mark.usefixtures("eightcells")


### PR DESCRIPTION
This test depends on a separate implementation of a flowrun executable, and an example of this executabe just changed implementation to always overwrite the environment variable OMP_NUM_THREADS in order to successfully control the behaviour of flow.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
