### PR TITLE
Move type parsing for genkw from `enkf_main` to `gen_kw_config`

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -332,8 +332,23 @@ class GenKwConfig(ParameterConfig):
                 f" is of size {len(self.transform_functions)}, expected {array.size}"
             )
 
+        def parse_value(value: float | int | str) -> float | int | str:
+            if isinstance(value, float | int):
+                return value
+            try:
+                return int(value)
+            except ValueError:
+                try:
+                    return float(value)
+                except ValueError:
+                    return value
+
         data = dict(
-            zip(array["names"].values.tolist(), array.values.tolist(), strict=False)
+            zip(
+                array["names"].values.tolist(),
+                [parse_value(i) for i in array.values],
+                strict=False,
+            )
         )
 
         log10_data = {
@@ -358,7 +373,6 @@ class GenKwConfig(ParameterConfig):
                 template = template.replace(f"<{key}>", f"{value:.6g}")
             with open(run_path / target_file, "w", encoding="utf-8") as f:
                 f.write(template)
-
         if log10_data:
             return {self.name: data, f"LOG10_{self.name}": log10_data}
         else:

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -65,24 +65,9 @@ def _value_export_json(
     if len(values) == 0:
         return
 
-    def parse_value(value: float | int | str) -> float | int | str:
-        if isinstance(value, float | int):
-            return value
-        try:
-            return int(value)
-        except ValueError:
-            try:
-                return float(value)
-            except ValueError:
-                return value
-
     # Hierarchical
-    json_out: dict[str, float | dict[str, float | int | str]] = {
-        key: {
-            inner_key: parse_value(inner_value)
-            for inner_key, inner_value in param_map.items()
-        }
-        for key, param_map in values.items()
+    json_out: dict[str, float | dict[str, float]] = {
+        key: dict(param_map.items()) for key, param_map in values.items()
     }
 
     # Disallow NaN from being written: ERT produces the parameters and the only


### PR DESCRIPTION

**Approach**
Move the logic to a better place.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
