### PR TITLE
Have `forward_model_ok` not run if storage in invalid (missing responses.json)

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -254,6 +254,7 @@ class Scheduler:
         # this lock is to assure that no more than 1 task
         # does internalization at a time
         forward_model_ok_lock = asyncio.Lock()
+        forward_model_ok_permanent_error_future: asyncio.Future[str] = asyncio.Future()
         verify_checksum_lock = asyncio.Lock()
         for iens, job in self._jobs.items():
             await asyncio.sleep(0)
@@ -262,6 +263,7 @@ class Scheduler:
                     job.run(
                         sem,
                         forward_model_ok_lock,
+                        forward_model_ok_permanent_error_future,
                         verify_checksum_lock,
                         self._max_submit,
                     ),

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -27,8 +27,7 @@ EnsembleReader = LocalEnsemble
 EnsembleAccessor = LocalEnsemble
 
 
-class ErtStorageException(Exception):
-    pass
+from ert.storage.local_experiment import ErtStorageException
 
 
 def open_storage(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from typing_extensions import deprecated
 
 from ert.config.gen_kw_config import GenKwConfig
+from ert.storage.local_experiment import ErtStorageException
 from ert.storage.mode import BaseMode, Mode, require_write
 
 from .realization_storage_state import RealizationStorageState
@@ -406,8 +407,10 @@ class LocalEnsemble(BaseMode):
         states : list of RealizationStorageState
             list of realization states.
         """
-
-        response_configs = self.experiment.response_configuration
+        try:
+            response_configs = self.experiment.response_configuration
+        except ErtStorageException:
+            response_configs = {}
 
         def _parameters_exist_for_realization(realization: int) -> bool:
             """

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -38,6 +38,10 @@ class _Index(BaseModel):
     name: str
 
 
+class ErtStorageException(Exception):
+    pass
+
+
 class LocalExperiment(BaseMode):
     """
     Represents an experiment within the local storage system of ERT.
@@ -253,6 +257,10 @@ class LocalExperiment(BaseMode):
     @property
     def response_info(self) -> dict[str, Any]:
         info: dict[str, Any]
+        if not (self.mount_point / self._responses_file).exists():
+            raise ErtStorageException(
+                "responses.json does not exist. Please make sure storage is still valid."
+            )
         with open(self.mount_point / self._responses_file, encoding="utf-8") as f:
             info = json.load(f)
         return info

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -135,7 +135,11 @@ async def test_job_run_sends_expected_events(
 
     job_run_task = asyncio.create_task(
         job.run(
-            asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=max_submit
+            asyncio.Semaphore(),
+            asyncio.Lock(),
+            asyncio.Future(),
+            asyncio.Lock(),
+            max_submit=max_submit,
         )
     )
 
@@ -178,7 +182,13 @@ async def test_num_cpu_is_propagated_to_driver(realization: Realization):
     scheduler = create_scheduler()
     job = Job(scheduler, realization)
     job_run_task = asyncio.create_task(
-        job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+        job.run(
+            asyncio.Semaphore(),
+            asyncio.Lock(),
+            asyncio.Future(),
+            asyncio.Lock(),
+            max_submit=1,
+        )
     )
     job.started.set()
     job.returncode.set_result(0)
@@ -201,7 +211,13 @@ async def test_realization_memory_is_propagated_to_driver(realization: Realizati
     scheduler = create_scheduler()
     job = Job(scheduler, realization)
     job_run_task = asyncio.create_task(
-        job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+        job.run(
+            asyncio.Semaphore(),
+            asyncio.Lock(),
+            asyncio.Future(),
+            asyncio.Lock(),
+            max_submit=1,
+        )
     )
     job.started.set()
     job.returncode.set_result(0)
@@ -239,7 +255,13 @@ async def test_when_waiting_for_disk_sync_times_out_an_error_is_logged(
 
     with captured_logs(log_msgs, logging.ERROR):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+            job.run(
+                asyncio.Semaphore(),
+                asyncio.Lock(),
+                asyncio.Future(),
+                asyncio.Lock(),
+                max_submit=1,
+            )
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -270,7 +292,13 @@ async def test_when_files_in_manifest_are_not_created_an_error_is_logged(
 
     with captured_logs(log_msgs, logging.ERROR):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+            job.run(
+                asyncio.Semaphore(),
+                asyncio.Lock(),
+                asyncio.Future(),
+                asyncio.Lock(),
+                max_submit=1,
+            )
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -304,7 +332,13 @@ async def test_when_checksums_do_not_match_a_warning_is_logged(
 
     with captured_logs(log_msgs, logging.WARNING):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+            job.run(
+                asyncio.Semaphore(),
+                asyncio.Lock(),
+                asyncio.Future(),
+                asyncio.Lock(),
+                max_submit=1,
+            )
         )
         job.started.set()
         job.returncode.set_result(0)
@@ -332,7 +366,13 @@ async def test_when_no_checksum_info_is_received_a_warning_is_logged(
 
     with captured_logs(log_msgs, logging.WARNING):
         job_run_task = asyncio.create_task(
-            job.run(asyncio.Semaphore(), asyncio.Lock(), asyncio.Lock(), max_submit=1)
+            job.run(
+                asyncio.Semaphore(),
+                asyncio.Lock(),
+                asyncio.Future(),
+                asyncio.Lock(),
+                max_submit=1,
+            )
         )
         job.started.set()
         job.returncode.set_result(0)


### PR DESCRIPTION
**Issue**
Resolves #9856


**Approach**
This commit makes it so that if a realization fails due to `missing responses.json` (can happen if storage is deleted), we will not run `forward_model_ok` for the next realizations, as it is not something we can recover from. We have this logic to avoid spamming `logger.exception(...)` for something we cannot really handle.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
