### PR TITLE
Ensure SETENV is also substituted when writing json

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -528,7 +528,7 @@ class ErtConfig:
 
         env_vars = {}
         for key, val in config_dict.get("SETENV", []):
-            env_vars[key] = val
+            env_vars[key] = substitutions.substitute(val)
 
         return cls(
             substitutions=substitutions,
@@ -753,7 +753,7 @@ class ErtConfig:
 
         env_vars = {}
         for key, val in config_dict.get("SETENV", []):
-            env_vars[key] = val
+            env_vars[key] = substitutions.substitute(val)
 
         for fm_step_description in config_dict.get(ConfigKeys.FORWARD_MODEL, []):
             if len(fm_step_description) > 1:

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -940,6 +940,29 @@ def test_fm_step_config_via_plugin_is_overridden_by_setenv(monkeypatch):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+def test_setenv_will_be_substituted_in_jobs_json(monkeypatch):
+    Path("config.ert").write_text(
+        dedent(
+            """
+            NUM_REALIZATIONS 1
+            SETENV FOO <NUM_CPU>
+            NUM_CPU 2
+            """
+        ),
+        encoding="utf-8",
+    )
+    ert_config = ErtConfig.with_plugins().from_file("config.ert")
+    step_json = create_forward_model_json(
+        context=ert_config.substitutions,
+        forward_model_steps=ert_config.forward_model_steps,
+        env_vars=ert_config.env_vars,
+        env_pr_fm_step=ert_config.env_pr_fm_step,
+        run_id=None,
+    )
+    assert step_json["global_environment"]["FOO"] == "2"
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_fm_step_config_via_plugin_does_not_override_default_env(monkeypatch):
     monkeypatch.setattr(
         ErtPluginManager,


### PR DESCRIPTION
This is a regression from 1ae12f6efb66e9fa4208faef2a04898043cdcb37

**Issue**
Resolves #9858 


**Approach**
🧠 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
