### PR TITLE
Make sure parameter.txt files with too few values per line is validated

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -156,22 +156,34 @@ class GenKwConfig(ParameterConfig):
                     "Loading GEN_KW from files requires %d in file format", gen_kw
                 )
             )
+
         if errors:
             raise ConfigValidationError.from_collected(errors)
 
         transform_function_definitions: list[TransformFunctionDefinition] = []
         with open(parameter_file, encoding="utf-8") as file:
-            for item in file:
+            for line_number, item in enumerate(file):
                 item = item.split("--")[0]  # remove comments
                 if item.strip():  # only lines with content
                     items = item.split()
-                    transform_function_definitions.append(
-                        TransformFunctionDefinition(
-                            name=items[0],
-                            param_name=items[1],
-                            values=items[2:],
+                    if len(items) < 2:
+                        errors.append(
+                            ConfigValidationError.with_context(
+                                f"Too few values on line {line_number} in parameter file {parameter_file}",
+                                gen_kw,
+                            )
                         )
-                    )
+                    else:
+                        transform_function_definitions.append(
+                            TransformFunctionDefinition(
+                                name=items[0],
+                                param_name=items[1],
+                                values=items[2:],
+                            )
+                        )
+
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
 
         if gen_kw_key == "PRED" and update_parameter:
             ConfigWarning.warn(

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -57,6 +57,20 @@ def test_gen_kw_config_duplicate_keys_raises():
         )
 
 
+def test_short_definition_raises_config_error(tmp_path):
+    parameter_file = tmp_path / "parameter.txt"
+    parameter_file.write_text("incorrect", encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match="Too few values"):
+        GenKwConfig.from_config_list(
+            [
+                "GEN",
+                str(parameter_file),
+                "INIT_FILES:%dgen_init.txt",
+            ]
+        )
+
+
 def test_gen_kw_config_get_priors():
     conf = GenKwConfig(
         name="KW_NAME",

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -57,41 +57,25 @@ def test_gen_kw_config_duplicate_keys_raises():
         )
 
 
-@pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_config_get_priors():
-    parameter_file = "parameters.txt"
-    template_file = "template.txt"
-
-    with open(template_file, "w", encoding="utf-8") as f:
-        f.write("Hello")
-
-    with open(parameter_file, "w", encoding="utf-8") as f:
-        f.write("KEY1  NORMAL 0 1\n")
-        f.write("KEY2  LOGNORMAL 2 3\n")
-        f.write("KEY3  TRUNCATED_NORMAL 4 5 6 7\n")
-        f.write("KEY4  TRIANGULAR 0 1 2\n")
-        f.write("KEY5  UNIFORM 2 3\n")
-        f.write("KEY6  DUNIF 3 0 1\n")
-        f.write("KEY7  ERRF 0 1 2 3\n")
-        f.write("KEY8  DERRF 1 1 2 3 4\n")
-        f.write("KEY9  LOGUNIF 0 1\n")
-        f.write("KEY10  CONST 10\n")
-
-    transform_function_definitions = []
-    with open(parameter_file, encoding="utf-8") as file:
-        for item in file:
-            items = item.split()
-            transform_function_definitions.append(
-                TransformFunctionDefinition(
-                    name=items[0], param_name=items[1], values=items[2:]
-                )
-            )
-
     conf = GenKwConfig(
         name="KW_NAME",
         forward_init=False,
-        template_file=template_file,
-        transform_function_definitions=transform_function_definitions,
+        template_file="template.txt",
+        transform_function_definitions=[
+            TransformFunctionDefinition("KEY1", "NORMAL", ["0", "1"]),
+            TransformFunctionDefinition("KEY2", "LOGNORMAL", ["2", "3"]),
+            TransformFunctionDefinition(
+                "KEY3", "TRUNCATED_NORMAL", ["4", "5", "6", "7"]
+            ),
+            TransformFunctionDefinition("KEY4", "TRIANGULAR", ["0", "1", "2"]),
+            TransformFunctionDefinition("KEY5", "UNIFORM", ["2", "3"]),
+            TransformFunctionDefinition("KEY6", "DUNIF", ["3", "0", "1"]),
+            TransformFunctionDefinition("KEY7", "ERRF", ["0", "1", "2", "3"]),
+            TransformFunctionDefinition("KEY8", "DERRF", ["1", "1", "2", "3", "4"]),
+            TransformFunctionDefinition("KEY9", "LOGUNIF", ["0", "1"]),
+            TransformFunctionDefinition("KEY10", "CONST", ["10"]),
+        ],
         output_file="param.txt",
         update=True,
     )


### PR DESCRIPTION
**Issue**
Resolves #9085 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
