### PR TITLE
Speed up client-zmq tests

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -55,7 +55,7 @@ async def test_retry(unused_tcp_port):
 async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
     host = "localhost"
     url = f"tcp://{host}:{unused_tcp_port}"
-    monkeypatch.setattr(_ert.forward_model_runner.client, "HEARTBEAT_TIMEOUT", 0.1)
+    monkeypatch.setattr(_ert.forward_model_runner.client, "HEARTBEAT_TIMEOUT", 0.01)
 
     async with (
         MockZMQServer(unused_tcp_port, signal=3) as mock_server,
@@ -64,7 +64,7 @@ async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
         await client.send("start", retries=1)
 
         await mock_server.do_heartbeat()
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
         await mock_server.do_heartbeat()
         await client.send("stop", retries=1)
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -7,14 +7,15 @@ from _ert.forward_model_runner.client import Client, ClientConnectionError
 from tests.ert.utils import MockZMQServer
 
 
-@pytest.mark.integration_test
-async def test_invalid_server():
+async def test_invalid_server(monkeypatch):
     port = 7777
     host = "localhost"
     url = f"tcp://{host}:{port}"
 
+    monkeypatch.setattr(Client, "DEFAULT_MAX_RETRIES", 0)
+
     with pytest.raises(ClientConnectionError):
-        async with Client(url, ack_timeout=1.0):
+        async with Client(url, ack_timeout=0.01):
             pass
 
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -129,6 +129,7 @@ async def test_when_task_prematurely_ends_raises_exception(
         await evaluator.run_and_get_successful_realizations()
 
 
+@pytest.mark.integration_test
 async def test_new_connections_are_no_problem_when_evaluator_is_closing_down(
     evaluator_to_use,
 ):

--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -179,7 +179,6 @@ def test_report_inconsistent_events(unused_tcp_port):
         reporter.report(Finish())
 
 
-@pytest.mark.integration_test
 def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
     # this is to show when the reporter fails ert won't crash nor
     # staying hanging but instead finishes up the job;
@@ -192,7 +191,10 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
     url = f"tcp://{host}:{unused_tcp_port}"
     with MockZMQServer(unused_tcp_port) as mock_server:
         reporter = Event(
-            evaluator_url=url, ack_timeout=2, max_retries=0, finished_event_timeout=2
+            evaluator_url=url,
+            ack_timeout=0.1,
+            max_retries=0,
+            finished_event_timeout=0.1,
         )
         fmstep1 = ForwardModelStep(
             {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -111,6 +111,7 @@ def test_run_dialog_polls_run_model_for_runtime(
     qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True)
 
 
+@pytest.mark.integration_test
 def test_large_snapshot(
     large_snapshot,
     qtbot: QtBot,

--- a/tests/ert/unit_tests/gui/simulation/view/test_realization.py
+++ b/tests/ert/unit_tests/gui/simulation/view/test_realization.py
@@ -80,6 +80,7 @@ def test_delegate_drawing_count(small_snapshot, qtbot):
         )
 
 
+@pytest.mark.integration_test
 def test_selection_success(large_snapshot, qtbot):
     it = 0
     widget = RealizationWidget(it)

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -581,7 +581,7 @@ async def test_that_bsub_will_retry_and_fail(
     bsub_path.chmod(bsub_path.stat().st_mode | stat.S_IEXEC)
     driver = LsfDriver()
     driver._max_bsub_attempts = 2
-    driver._sleep_time_between_cmd_retries = 0.2
+    driver._sleep_time_between_cmd_retries = 0.0
     match_str = (
         f"failed after 2 attempts with exit code {exit_code}.*"
         f'error: "{error_msg if error_msg else "<empty>"}"'
@@ -666,7 +666,7 @@ async def test_that_bsub_will_retry_and_succeed(
     bsub_path.chmod(bsub_path.stat().st_mode | stat.S_IEXEC)
     driver = LsfDriver()
     driver._max_bsub_attempts = 2
-    driver._sleep_time_between_cmd_retries = 0.2
+    driver._sleep_time_between_cmd_retries = 0.0
     await driver.submit(0, "sleep 10")
 
 

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -124,9 +124,8 @@ def test_everest_to_ert_controls():
     )
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
+def test_default_installed_jobs():
+    jobs = [
         "render",
         "recovery_factor",
         "wdreorder",
@@ -140,22 +139,18 @@ def test_everest_to_ert_controls():
         "copy_file",
         "move_file",
         "symlink",
-    ],
-)
-def test_default_installed_jobs(tmp_path, monkeypatch, name):
-    monkeypatch.chdir(tmp_path)
+    ]
     ever_config_dict = EverestConfig.with_defaults(
         **yaml.safe_load(
             dedent(f"""
     model: {{"realizations": [0]}}
-    forward_model:
-      - {name}
+    forward_model: {jobs}
     """)
         )
     )
     config = everest_to_ert_config(ever_config_dict)
     # Index 0 is the copy job for wells.json
-    assert config.forward_model_steps[1].name == name
+    assert [c.name for c in config.forward_model_steps[1:]] == jobs
 
 
 def test_combined_wells_everest_to_ert(tmp_path, monkeypatch):


### PR DESCRIPTION
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
