### PR TITLE
Fix everest tests failing when using editable installs

### DIFF
--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -3,7 +3,10 @@ import argparse
 import logging
 import sys
 
-from ert.shared.version import __version__ as everest_version
+try:
+    from ert.shared.version import __version__ as everest_version
+except ImportError:
+    everest_version = "0.0.0"
 from everest.bin.config_branch_script import config_branch_entry
 from everest.bin.everconfigdump_script import config_dump_entry
 from everest.bin.everest_script import everest_entry

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -4,7 +4,10 @@ import os
 
 from ropt.version import version as ropt_version
 
-from ert.shared.version import version as ert_version
+try:
+    from ert.shared.version import version as ert_version
+except ImportError:
+    ert_version = "0.0.0"
 from everest.strings import DATE_FORMAT, EVEREST
 
 try:


### PR DESCRIPTION
When running with editable installs you might often end up removing the version file and consequently everest will fail due to ImportError.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
