### PR TITLE
Use tmp_path for test_everest_to_ert_controls

### DIFF
--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -102,7 +102,8 @@ def test_everest_to_ert_queue_config(config, config_class):
     assert ert_config.queue_config.queue_options == config_class(**config)
 
 
-def test_everest_to_ert_controls():
+def test_everest_to_ert_controls(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     ever_config = EverestConfig.with_defaults(
         **yaml.safe_load(
             dedent("""


### PR DESCRIPTION
Test leaves behind empty folder everest_output when run locally.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
