### PR TITLE
zmq: make sure no clients are connected when closing mockzmqsever

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -67,6 +67,9 @@ async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
             await mock_server.do_heartbeat()
             await client.send("stop", retries=1)
 
+    # the client should be disconnected
+    assert len(mock_server.dealers) == 0
+
     # when reconnection happens CONNECT message is sent again
     assert mock_server.messages.count("CONNECT") == 2
     assert mock_server.messages.count("DISCONNECT") == 1

--- a/tests/ert/utils.py
+++ b/tests/ert/utils.py
@@ -111,6 +111,7 @@ class MockZMQServer:
     async def mock_zmq_server(self):
         zmq_context = zmq.asyncio.Context()
         self.router_socket = zmq_context.socket(zmq.ROUTER)
+        self.router_socket.setsockopt(zmq.LINGER, 0)
         self.router_socket.bind(f"tcp://*:{self.port}")
 
         self.handler_task = asyncio.create_task(self._handler())


### PR DESCRIPTION
**Issue**
In the tests which use MockZMQServer, the server might close down sooner; ie. before the actual client disconnects and thus this should prevent the server to close before the last client disconnected.

The flaky error:
```
test_reconnect_when_missing_heartbeat: tests.ert.unit_tests.ensemble_evaluator.test_ensemble_client
AssertionError: assert 0 == 1
 +  where 0 = <built-in method count of list object at 0x7f19166bbac0>('DISCONNECT')
 +    where <built-in method count of list object at 0x7f19166bbac0> = ['CONNECT', 'start', 'stop', 'CONNECT'].count
 +      where ['CONNECT', 'start', 'stop', 'CONNECT'] = <tests.ert.utils.MockZMQServer object at 0x7f190ce4ced0>.messages
unused_tcp_port = 37287
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f190ce4e450>
```

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
