### PR TITLE
Ensure cpu_seconds is always reported increasingly

### DIFF
--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -186,9 +186,11 @@ class ForwardModelStep:
         exit_code = None
 
         max_memory_usage = 0
+        max_cpu_seconds = 0
         fm_step_pids = {int(process.pid)}
         while exit_code is None:
             (memory_rss, cpu_seconds, oom_score, pids) = _get_processtree_data(process)
+            max_cpu_seconds = max(max_cpu_seconds, cpu_seconds or 0)
             fm_step_pids |= pids
             max_memory_usage = max(memory_rss, max_memory_usage)
             yield Running(
@@ -198,7 +200,7 @@ class ForwardModelStep:
                     max_rss=max_memory_usage,
                     fm_step_id=self.index,
                     fm_step_name=self.job_data.get("name"),
-                    cpu_seconds=cpu_seconds,
+                    cpu_seconds=max_cpu_seconds,
                     oom_score=oom_score,
                 ),
             )

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -28,6 +28,10 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
     )
     mock_process.return_value.wait.return_value = 9
 
+    mock_cpu_times = MagicMock()
+    mock_cpu_times.user = 0.0
+    mock_process.return_value.cpu_times.return_value = mock_cpu_times
+
     run = fmstep.run()
 
     assert isinstance(next(run), Start), "run did not yield Start message"


### PR DESCRIPTION
The summation of cpu_seconds for a process and all its descendants can never work properly during teardown of a process tree, as the root process typically outlives its children. Thus, the maximum observed cpu_seconds for a process tree is always the best estimate of the correct sum.

**Issue**
Resolves #9852 

**Approach**
`max`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
