### PR TITLE
Backport Ert 12.1: Ensure cpu_seconds is always reported increasingly

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,18 +69,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
-  test-ert-with-flow:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ '3.11', '3.12' ]
-    uses: ./.github/workflows/test_ert_with_flow.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-    secrets: inherit
-
   test-mac-main-everest:
     if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
+        test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.11', '3.12' ]
         os: [ ubuntu-latest ]
     uses: ./.github/workflows/test_ert.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
+        test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.12' ]
         os: [ 'macos-13', 'macos-14']
         exclude:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,29 +69,27 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
-  test-mac-ert:
-    if: github.ref_type != 'tag' # when not tag
+  test-ert-with-flow:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ 'performance-tests', 'unit-tests', 'gui-tests', 'cli-tests' ]
-        python-version: [ '3.12' ]
-        os: [ 'macos-latest' ]
-    uses: ./.github/workflows/test_ert.yml
+        os: [ ubuntu-latest ]
+        python-version: [ '3.11', '3.12' ]
+    uses: ./.github/workflows/test_ert_with_flow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      test-type: ${{ matrix.test-type }}
     secrets: inherit
 
-  test-mac-everest:
-    if: github.ref_type != 'tag' # when not tag
+  test-mac-main-everest:
+    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:
         test-type: [ 'test', 'integration-test', 'everest-models-test' ]
-        python-version: [ '3.12' ]
         os: [ 'macos-latest' ]
+        python-version: [ '3.12' ]
+
     uses: ./.github/workflows/test_everest.yml
     with:
       os: ${{ matrix.os }}
@@ -99,36 +97,14 @@ jobs:
       test-type: ${{ matrix.test-type }}
     secrets: inherit
 
-
-  test-mac-for-tags-everest:
-    if: github.ref_type == 'tag' # only test all variants for tags
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [ 'test', 'integration-test', 'everest-models-test' ]
-        os: [ 'macos-13', 'macos-14', 'macos-14-large']
-        python-version: [ '3.12' ]
-        exclude:
-          - os: 'macos-13'
-            python-version: '3.12'
-    uses: ./.github/workflows/test_everest.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test-type: ${{ matrix.test-type }}
-    secrets: inherit
-
-  test-mac-for-tags-ert:
-    if: github.ref_type == 'tag' # only test all variants for tags
+  test-mac-main-ert:
+    if: github.ref == 'refs/heads/main' # only perform mac tests on main branch
     strategy:
       fail-fast: false
       matrix:
         test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.12' ]
-        os: [ 'macos-13', 'macos-14']
-        exclude:
-          - os: 'macos-13'
-            python-version: '3.12'
+        os: [ 'macos-latest']
 
     uses: ./.github/workflows/test_ert.yml
     with:
@@ -185,7 +161,7 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build-wheels, test-linux-ert, test-linux-everest, test-mac-for-tags-ert, test-mac-for-tags-everest, docs-ert]
+    needs: [build-wheels, test-linux-ert, test-linux-everest, test-mac-main-ert, test-mac-main-everest, docs-ert]
     permissions:
       id-token: write
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,6 +105,7 @@ jobs:
         test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.12' ]
         os: [ 'macos-latest']
+        select-string: ['"not skip_mac_ci"']
 
     uses: ./.github/workflows/test_ert.yml
     with:

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -7,6 +7,9 @@ on:
         type: string
       test-type:
         type: string
+      select-string:
+        type: string
+        default: "''"
 
 env:
   ERT_SHOW_BACKTRACE: 1
@@ -40,7 +43,7 @@ jobs:
     - name: GUI Test
       if: inputs.test-type == 'gui-tests'
       run: |
-        pytest --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --mpl --benchmark-disable tests/ert/ui_tests/gui --durations=25
+        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --mpl --benchmark-disable tests/ert/ui_tests/gui --durations=25
 
     - name: Upload artifact images
       uses: actions/upload-artifact@v4
@@ -53,7 +56,7 @@ jobs:
     - name: CLI Test
       if: inputs.test-type == 'cli-tests'
       run: |
-        pytest --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --benchmark-disable  --dist loadgroup tests/ert/ui_tests/cli --durations=25
+        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --benchmark-disable  --dist loadgroup tests/ert/ui_tests/cli --durations=25
 
     - name: Unit Test
       if: inputs.test-type == 'performance-and-unit-tests'

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -56,15 +56,10 @@ jobs:
         pytest --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --benchmark-disable  --dist loadgroup tests/ert/ui_tests/cli --durations=25
 
     - name: Unit Test
-      if: inputs.test-type == 'unit-tests'
+      if: inputs.test-type == 'performance-and-unit-tests'
       run: |
-        pytest --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -n logical --show-capture=stderr -v --benchmark-disable --mpl --dist loadgroup tests/ert/unit_tests --durations=25
+        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -n logical --show-capture=stderr -v --benchmark-disable --mpl --dist loadgroup tests/ert/unit_tests tests/ert/performance_tests --durations=25
         pytest --doctest-modules --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml src/ --ignore src/ert/dark_storage
-
-    - name: Performance Test
-      if: inputs.test-type == 'performance-tests'
-      run: |
-        pytest --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -n logical --show-capture=stderr -v --benchmark-disable  --dist loadgroup tests/ert/performance_tests --durations=25
 
     - name: Upload coverage to Codecov
       id: codecov1

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run Tests macOS
       if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
-        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not integration_test and not fails_on_macos_github_workflow" --dist loadgroup -sv
+        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not integration_test and not skip_mac_ci" --dist loadgroup -sv
 
     - name: Run Integration Tests Linux
       if: ${{inputs.test-type == 'integration-test' && runner.os != 'macOS'}}
@@ -55,7 +55,7 @@ jobs:
     - name: Run Integration Tests macOS
       if: ${{inputs.test-type == 'integration-test' && runner.os == 'macOS'}}
       run: |
-        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "integration_test and not fails_on_macos_github_workflow" --dist loadgroup
+        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "integration_test and not skip_mac_ci" --dist loadgroup
 
     - name: Build Documentation
       if: inputs.test-type == 'doc'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ markers = [
     "slow",
     "everest_models_test",
     "integration_test",
-    "fails_on_macos_github_workflow", # Tests marked fail due to gui-related issues
+    "skip_mac_ci",
 ]
 log_cli = "false"
 asyncio_mode = "auto"

--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -188,9 +188,11 @@ class ForwardModelStep:
         exit_code = None
 
         max_memory_usage = 0
+        max_cpu_seconds = 0
         fm_step_pids = {int(process.pid)}
         while exit_code is None:
             (memory_rss, cpu_seconds, oom_score, pids) = _get_processtree_data(process)
+            max_cpu_seconds = max(max_cpu_seconds, cpu_seconds or 0)
             fm_step_pids |= pids
             max_memory_usage = max(memory_rss, max_memory_usage)
             yield Running(
@@ -200,7 +202,7 @@ class ForwardModelStep:
                     max_rss=max_memory_usage,
                     fm_step_id=self.index,
                     fm_step_name=self.job_data.get("name"),
-                    cpu_seconds=cpu_seconds,
+                    cpu_seconds=max_cpu_seconds,
                     oom_score=oom_score,
                 ),
             )

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -1,9 +1,9 @@
+import asyncio
 import contextlib
 import gc
 import io
 import os
 import time
-from asyncio import get_event_loop
 from collections.abc import Awaitable
 from datetime import datetime, timedelta
 from typing import TypeVar
@@ -45,7 +45,13 @@ def use_testclient(monkeypatch):
 
 
 def run_in_loop(coro: Awaitable[T]) -> T:
-    return get_event_loop().run_until_complete(coro)
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
 
 
 def get_single_record_csv(storage, ensemble_id1, keyword, poly_ran):

--- a/tests/ert/ui_tests/cli/test_observation_times.py
+++ b/tests/ert/ui_tests/cli/test_observation_times.py
@@ -57,7 +57,7 @@ observation_times = st.dates(
             }
         )
     ),
-    std_cutoff=st.floats(min_value=0.0, max_value=1.0),
+    std_cutoff=st.floats(min_value=1e-6, max_value=1.0),
     enkf_alpha=st.floats(min_value=3.0, max_value=10.0),
     epsilon=st.sampled_from([0.0, 1.1, 2.0, -2.0]),
 )

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -19,7 +19,7 @@ import numpy as np
 import xtgeo
 from hypothesis import given, note, settings
 from hypothesis.extra.numpy import arrays
-from pytest import MonkeyPatch, TempPathFactory
+from pytest import MonkeyPatch, TempPathFactory, mark
 from resdata import ResDataType
 from resdata.grid import GridGenerator
 from resdata.resfile import ResdataKW
@@ -409,6 +409,7 @@ class SurfaceParameter(Parameter):
         max_size=3,
     ),
 )
+@mark.skip_mac_ci  # test is slow
 def test_that_parameters_are_placed_in_the_runpath_as_expected(
     io_source: IoProvider,
     grid_format: Literal["grid", "egrid"],

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -121,6 +121,7 @@ def plot_figure(qtbot, heat_equation_storage, snake_oil_case_storage, request):
 # The tolerance is chosen by guess, in one bug we observed a
 # mismatch of 58 which would fail the test by being above 10.0
 @pytest.mark.mpl_image_compare(tolerance=10.0)
+@pytest.mark.skip_mac_ci  # test is slow
 def test_that_all_snake_oil_visualisations_matches_snapshot(plot_figure):
     return plot_figure
 

--- a/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
+++ b/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
@@ -111,4 +111,6 @@ class DarkStorageStateTest(StatefulStorageTest):
             del os.environ["ERT_STORAGE_ENS_PATH"]
 
 
-TestDarkStorage = pytest.mark.integration_test(DarkStorageStateTest.TestCase)
+TestDarkStorage = pytest.mark.skip_mac_ci(
+    pytest.mark.integration_test(DarkStorageStateTest.TestCase)
+)

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -28,6 +28,10 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
     )
     mock_process.return_value.wait.return_value = 9
 
+    mock_cpu_times = MagicMock()
+    mock_cpu_times.user = 0.0
+    mock_process.return_value.cpu_times.return_value = mock_cpu_times
+
     run = fmstep.run()
 
     assert isinstance(next(run), Start), "run did not yield Start message"

--- a/tests/ert/unit_tests/gui/model/test_snapshot.py
+++ b/tests/ert/unit_tests/gui/model/test_snapshot.py
@@ -10,6 +10,7 @@ from .gui_models_utils import finish_snapshot
 
 
 @pytest.mark.integration_test
+@pytest.mark.skip_mac_ci  # slow
 def test_using_qt_model_tester(qtmodeltester, full_snapshot):
     model = SnapshotModel()
 

--- a/tests/everest/entry_points/test_everexport.py
+++ b/tests/everest/entry_points/test_everexport.py
@@ -102,7 +102,7 @@ def test_everexport_entry_empty(mocked_func, cached_example):
     side_effect=validate_export_mock,
 )
 @patch("everest.bin.utils.export_data")
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_everexport_entry_batches(mocked_func, validate_export_mock, cached_example):
     """Test running everexport with the --batches flag"""
     _, config_file, _ = cached_example("math_func/config_minimal.yml")
@@ -157,7 +157,7 @@ def test_everexport_entry_empty_export(mocked_func, cached_example):
 
 
 @patch("everest.bin.utils.export_data")
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_everexport_entry_no_usr_def_ecl_keys(mocked_func, cached_example):
     """Test running everexport with config file containing only the
     keywords label without any list of keys"""
@@ -191,7 +191,7 @@ def test_everexport_entry_no_usr_def_ecl_keys(mocked_func, cached_example):
 
 
 @patch("everest.bin.utils.export_data")
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_everexport_entry_internalized_usr_def_ecl_keys(mocked_func, cached_example):
     """Test running everexport with config file containing a key in the
     list of user defined ecl keywords, that has been internalized on
@@ -227,7 +227,7 @@ def test_everexport_entry_internalized_usr_def_ecl_keys(mocked_func, cached_exam
 
 
 @patch("everest.bin.utils.export_data")
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_everexport_entry_non_int_usr_def_ecl_keys(mocked_func, caplog, cached_example):
     """Test running everexport  when config file contains non internalized
     ecl keys in the user defined keywords list"""
@@ -270,7 +270,7 @@ def test_everexport_entry_non_int_usr_def_ecl_keys(mocked_func, caplog, cached_e
 
 
 @patch("everest.bin.utils.export_data")
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_everexport_entry_not_available_batches(mocked_func, caplog, cached_example):
     """Test running everexport  when config file contains non existing
     batch numbers in the list of user defined batches"""

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -79,7 +79,7 @@ def test_everest_main_entry_bad_command():
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 def test_everest_entry_run(copy_math_func_test_data_to_tmp):
     # Setup command line arguments

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -166,7 +166,7 @@ controls -> 0 -> initial_guess
     assert validation_msg in err.getvalue()
 
 
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 @pytest.mark.integration_test

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -46,7 +46,7 @@ from everest.util import makedirs_if_needed
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.integration_test
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 @pytest.mark.xdist_group(name="starts_everest")
 async def test_https_requests(copy_math_func_test_data_to_tmp):
     everest_config = EverestConfig.load_file("config_minimal.yml")

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -354,7 +354,7 @@ def test_date_type(date, valid, min_config):
         EverestConfig(**min_config)
 
 
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_lint_everest_models_jobs():
     pytest.importorskip("everest_models")
     config_file = relpath("../../test-data/everest/egg/everest/model/config.yml")

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -241,7 +241,7 @@ def test_summary_default(copy_egg_test_data_to_tmp):
 @hide_opm
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_summary_default_no_opm(copy_egg_test_data_to_tmp):
     config_dir = "everest/model"
     config_file = os.path.join(config_dir, "config.yml")

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -102,7 +102,7 @@ def test_valid_config_file(copy_test_data_to_tmp, monkeypatch):
     assert "could not find expected ':'" in parser.get_error()
 
 
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 def test_valid_forward_model_config_files(copy_test_data_to_tmp, monkeypatch):
@@ -117,7 +117,7 @@ def test_valid_forward_model_config_files(copy_test_data_to_tmp, monkeypatch):
 
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
-@pytest.mark.fails_on_macos_github_workflow
+@pytest.mark.skip_mac_ci
 def test_invalid_forward_model_config_files(copy_test_data_to_tmp, monkeypatch):
     monkeypatch.chdir("valid_config_file/forward_models")
     parser = MockParser()


### PR DESCRIPTION
The summation of cpu_seconds for a process and all its descendants can never work properly during teardown of a process tree, as the root process typically outlives its children. Thus, the maximum observed cpu_seconds for a process tree is always the best estimate of the correct sum.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
