### PR TITLE
zmq: speed up tests

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -7,10 +7,6 @@ class TestEnsemble(Ensemble):
     __test__ = False
 
     def __init__(self, iter_, reals, fm_steps, id_):
-        self.iter = iter_
-        self.test_reals = reals
-        self.fm_steps = fm_steps
-
         the_reals = [
             Realization(
                 real_no,

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -382,9 +382,9 @@ async def test_monitor_receive_heartbeats(evaluator_to_use):
 
     with patch.object(Monitor, "_receiver", mock_receiver):
         async with Monitor(conn_info) as monitor:
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(0.5)
             await monitor.signal_done()
-    # in 1 second we should receive at least 2 heartbeats
+    # in 0.5 second we should receive at least 2 heartbeats
     assert received_heartbeats > 1
 
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -393,7 +393,7 @@ async def test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_e
     evaluator_to_use,
 ):
     evaluator = evaluator_to_use
-    evaluator._batching_interval = 10
+    evaluator._batching_interval = 0.2
 
     evaluator._max_batch_size = 4
     conn_info = evaluator._config.get_connection_info()

--- a/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
@@ -108,7 +108,7 @@ async def test_unexpected_close_after_connection_successful(
     ee_con_info = EvaluatorConnectionInfo(f"tcp://127.0.0.1:{unused_tcp_port}")
 
     monkeypatch.setattr(Monitor, "DEFAULT_MAX_RETRIES", 0)
-    monkeypatch.setattr(Monitor, "DEFAULT_ACK_TIMEOUT", 1)
+    monkeypatch.setattr(Monitor, "DEFAULT_ACK_TIMEOUT", 0.5)
 
     async def mock_event_handler(router_socket):
         dealer, _, frame = await router_socket.recv_multipart()


### PR DESCRIPTION
**Issue**
Speed up  tests by:
 -  2 seconds in monitor tests
 - 12 seconds in the evaluator tests

The list of 30 slowest in in ensemble evaluator after this PR
```sh
=================================================================== slowest 30 durations ====================================================================
2.04s call     tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py::test_scheduler_receives_checksum_and_waits_for_disk_sync
1.20s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py::test_retry
1.20s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_unexpected_close_after_connection_successful
1.02s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py::test_run_and_cancel_legacy_ensemble
1.02s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py::test_run_legacy_ensemble
1.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_new_monitor_can_pick_up_where_we_left_off
1.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.51s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_ensure_multi_level_events_in_order
0.51s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_monitor_receive_heartbeats
0.51s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_publisher-publisher_task]
0.51s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_that_monitor_cannot_connect_with_wrong_server_key[False]
0.51s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_new_connections_are_no_problem_when_evaluator_is_closing_down
0.50s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_process_event_buffer-processing_task]
0.50s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.50s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_monitor_receive_heartbeats
0.50s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_batch_events_into_buffer-dispatcher_task]
0.50s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_new_monitor_can_pick_up_where_we_left_off
0.31s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_evaluator
0.25s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_that_monitor_track_can_exit_without_terminated_event_from_evaluator
0.24s call     tests/ert/unit_tests/ensemble_evaluator/test_async_queue_execution.py::test_happy_path
0.23s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py::test_reconnect_when_missing_heartbeat
0.19s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_that_monitor_cannot_connect_with_wrong_server_key[True]
0.15s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_immediate_stop
0.14s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py::test_successful_sending
0.13s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_overspent_cpu_is_logged
0.12s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_that_monitor_can_emit_heartbeats
0.12s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_monitor_connects_and_disconnects_successfully
0.10s call     tests/ert/unit_tests/ensemble_evaluator/test_monitor.py::test_no_connection_established
0.03s setup    tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py::test_queue_config_properties_propagated_to_scheduler
0.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py::test_queue_config_properties_propagated_to_scheduler
==================================================================== 54 passed in 15.99s ====================================================================
```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
