### PR TITLE
Fix analysispanel test failing on mac

### DIFF
--- a/tests/ert/unit_tests/gui/run_analysis/test_analysispanel.py
+++ b/tests/ert/unit_tests/gui/run_analysis/test_analysispanel.py
@@ -13,6 +13,7 @@ from ert.gui.ertwidgets.analysismodulevariablespanel import AnalysisModuleVariab
 def panel_with_localization_on(qtbot: QtBot):
     def func(settings, ensemble_size):
         widget = AnalysisModuleVariablesPanel(settings, ensemble_size)
+        widget.show()
         qtbot.addWidget(widget)
         check_box = widget.findChild(QCheckBox, name="localization")
         qtbot.mouseClick(check_box, Qt.MouseButton.LeftButton)


### PR DESCRIPTION
**Approach**
Fix analysispanel test failing on mac

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
