### PR TITLE
Fix ssl error

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -35,8 +35,7 @@ run_ert_with_opm() {
 }
 
 run_everest_tests() {
-    python -m pytest -n auto tests/everest -s \
-    --ignore-glob "*test_visualization_entry*"
+    python -m pytest -n auto tests/everest -s
     return $?
 }
 


### PR DESCRIPTION
**Issue**
Resolves #9623


**Approach**
Remove test_everest_output

The test was checking that starting the Everest server will roll the Everest output folder. Which it should not do and the test was rolling the folder itself.

The test was also starting two Everest servers quickly without waiting for any of them to finish. 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
