### PR TITLE
Make sure check-all runs the same as github actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ _Short description of the approach_
 - [ ] Added appropriate release note label
 - [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
 - [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
-      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)
+      --exec 'just rapid-tests'`)
 
 ## When applicable
 - [ ] **When there are user facing changes**: Updated documentation

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -155,7 +155,7 @@ jobs:
 
     - name: Test docs
       run: |
-        sphinx-build -n -v -E -W ./docs/ert ./ert_docs
+        just build-ert-docs
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -15,6 +15,7 @@ env:
   ERT_SHOW_BACKTRACE: 1
   ECL_SKIP_SIGNAL: 1
   UV_SYSTEM_PYTHON: 1
+  ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
 
 jobs:
   tests-ert:
@@ -47,7 +48,7 @@ jobs:
     - name: GUI Test
       if: inputs.test-type == 'gui-tests'
       run: |
-        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --mpl --benchmark-disable tests/ert/ui_tests/gui --durations=25
+        just ert-gui-tests
 
     - name: Upload artifact images
       uses: actions/upload-artifact@v4
@@ -60,13 +61,13 @@ jobs:
     - name: CLI Test
       if: inputs.test-type == 'cli-tests'
       run: |
-        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --benchmark-disable  --dist loadgroup tests/ert/ui_tests/cli --durations=25
+        just ert-cli-tests
 
     - name: Unit Test
       if: inputs.test-type == 'performance-and-unit-tests'
       run: |
-        pytest -m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -n logical --show-capture=stderr -v --benchmark-disable --mpl --dist loadgroup tests/ert/unit_tests tests/ert/performance_tests --durations=25
-        pytest --doctest-modules --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml src/ --ignore src/ert/dark_storage
+        just ert-unit-tests
+        ERT_PYTEST_ARGS="-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable" just ert-doc-tests
 
     - name: Upload coverage to Codecov
       id: codecov1

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -45,12 +45,12 @@ jobs:
     - name: Run Tests Linux
       if: ${{ inputs.test-type == 'test' && runner.os != 'macOS'}}
       run: |
-        pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy --dist loadgroup -sv
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy --dist loadgroup -sv' just everest-tests
 
     - name: Run Tests macOS
       if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
-        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" --dist loadgroup -sv
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" --dist loadgroup -sv' just everest-tests
 
     - name: Build Documentation
       if: inputs.test-type == 'doc'
@@ -62,7 +62,7 @@ jobs:
       if: inputs.test-type == 'everest-models-test'
       run: |
         uv pip install git+https://github.com/equinor/everest-models.git
-        python -m pytest tests/everest -n 4 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m everest_models_test --dist loadgroup
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m everest_models_test --dist loadgroup' just everest-tests
 
     - name: Upload coverage to Codecov
       if: inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc'

--- a/README.md
+++ b/README.md
@@ -74,10 +74,17 @@ pytest tests/
 ```
 
 There are many kinds of tests in the `tests` directory, while iterating on your
-code you can run a fast subset of the tests with
+code you can run a fast subset of the tests with by using the rapid checks from the
+justfile:
 
 ```sh
-pytest -n auto --hypothesis-profile=fast tests/ert/unit_tests tests/everest -m "not integration_test"
+just rapid-tests
+```
+
+You can also run all of the checks in parallel with
+
+```sh
+just check-all
 ```
 
 [Git LFS](https://git-lfs.com/) must be installed to get all the files. This is
@@ -104,9 +111,10 @@ git submodule foreach "git lfs pull"
 You can build the documentation after installation by running
 ```sh
 pip install ".[dev]"
-sphinx-build -n -v -E -W ./docs/ert ./ert_docs
+just build-docs
 ```
-and then open the generated `./ert_docs/index.html` in a browser.
+and then open the generated `./ert_docs/index.html` or
+`./everest_docs/index.html` in a browser.
 
 To automatically reload on changes you may use
 

--- a/justfile
+++ b/justfile
@@ -8,16 +8,37 @@ poly:
 snake_oil:
     ert gui test-data/ert/snake_oil/snake_oil.ert
 
+pytest_args := env("ERT_PYTEST_ARGS", "--quiet")
+
 # execute rapid unittests
 rapid-tests:
     nice pytest -n auto tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not integration_test"
 
-check-all:
+ert-gui-tests:
+    pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui
+
+ert-cli-tests:
+    pytest {{pytest_args}} tests/ert/ui_tests/cli
+
+ert-unit-tests:
+    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests
+
+ert-doc-tests:
+    pytest {{pytest_args}} --doctest-modules src/ --ignore src/ert/dark_storage
+
+everest-tests:
+    pytest {{pytest_args}} tests/everest -n 4 --dist loadgroup
+
+build-everest-docs:
+    sphinx-build -n -v -E -W ./docs/everest ./everest_docs
+
+build-ert-docs:
+    sphinx-build -n -v -E -W ./docs/ert ./ert_docs
+
+build-docs: build-ert-docs build-everest-docs
+
+check-types:
     mypy src/ert src/everest
-    pre-commit run --all-files
-    pytest tests/everest -n 4 -m everest_models_test --dist loadgroup
-    pytest tests/everest -n 4 -m integration_test --dist loadgroup
-    pytest tests/ert/ui_tests/ --mpl --dist loadgroup
-    pytest tests/ert/unit_tests/ -n 4 --dist loadgroup
-    pytest --doctest-modules src/ --ignore src/ert/dark_storage
-    pytest tests/ert/performance_tests --benchmark-disable --dist loadgroup
+
+check-all:
+    parallel -j8 ::: 'just ert-gui-tests' 'just ert-cli-tests' 'just ert-unit-tests' 'just ert-doc-tests' 'just everest-tests' 'just check-types' 'just build-everest-docs' 'just build-ert-docs'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ dev = [
     "pytest>6",
     "resdata",
     "resfo",
+    "rust-just",
     "scikit-learn",
     "sphinx",
     "sphinx-argparse",


### PR DESCRIPTION
Also uses gnu-parallel in the check-all command which makes it take ~11m which is about 2-3 minutes faster than running the actions.

A few notes on differences:

* cli tests no longer run with `--benchmark-disable --dist loadgroup` as those do nothing unless you use the benchmark fixture or xdist
* `-n 4` is used for unit tests instead of `-n logical` as that means better usage of cores in `just check-all`, note that this increases the number of process used on mac runners for unit tests from 3 to 4.
* `--show-capture=stderr` is no longer used for unit tests, which was the only place where this was used. This only means that stderr is placed together with the captured output instead of inline.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release