### PR TITLE
Send resubmit event to evaluator to reset snapshot

### DIFF
--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -23,6 +23,7 @@ class Id:
     REALIZATION_UNKNOWN_TYPE = Literal["realization.unknown"]
     REALIZATION_WAITING_TYPE = Literal["realization.waiting"]
     REALIZATION_TIMEOUT_TYPE = Literal["realization.timeout"]
+    REALIZATION_RESUBMIT_TYPE = Literal["realization.resubmit"]
     REALIZATION_FAILURE: Final = "realization.failure"
     REALIZATION_PENDING: Final = "realization.pending"
     REALIZATION_RUNNING: Final = "realization.running"
@@ -30,6 +31,7 @@ class Id:
     REALIZATION_UNKNOWN: Final = "realization.unknown"
     REALIZATION_WAITING: Final = "realization.waiting"
     REALIZATION_TIMEOUT: Final = "realization.timeout"
+    REALIZATION_RESUBMIT: Final = "realization.resubmit"
 
     ENSEMBLE_STARTED_TYPE = Literal["ensemble.started"]
     ENSEMBLE_SUCCEEDED_TYPE = Literal["ensemble.succeeded"]
@@ -109,6 +111,10 @@ class RealizationBaseEvent(BaseEvent):
 
 class RealizationPending(RealizationBaseEvent):
     event_type: Id.REALIZATION_PENDING_TYPE = Id.REALIZATION_PENDING
+
+
+class RealizationResubmit(RealizationBaseEvent):
+    event_type: Id.REALIZATION_RESUBMIT_TYPE = Id.REALIZATION_RESUBMIT
 
 
 class RealizationRunning(RealizationBaseEvent):
@@ -196,6 +202,7 @@ RealizationEvent = (
     | RealizationTimeout
     | RealizationUnknown
     | RealizationWaiting
+    | RealizationResubmit
 )
 
 EnsembleEvent = EnsembleStarted | EnsembleSucceeded | EnsembleFailed | EnsembleCancelled

--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -13,7 +13,6 @@ from ert.ensemble_evaluator import EnsembleSnapshot, state
 from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator.snapshot import (
     EnsembleSnapshotMetadata,
-    RealId,
     convert_iso8601_to_datetime,
 )
 from ert.gui.model.node import (
@@ -109,27 +108,14 @@ class SnapshotModel(QAbstractItemModel):
                     state.REAL_STATE_TO_COLOR[status]
                 ]
 
-        metadata["sorted_real_ids"] = sorted(ensemble.reals.keys(), key=int)
+        metadata["sorted_real_ids"] = sorted(reals.keys(), key=int)
         metadata["sorted_fm_step_ids"] = defaultdict(list)
 
-        running_fm_step_id: dict[RealId, int] = {}
-        for (real_id, fm_step_id), fm_step_snapshot in fm_step_snapshots.items():
-            if fm_step_snapshot == state.FORWARD_MODEL_STATE_RUNNING:
-                running_fm_step_id[real_id] = int(fm_step_id)
-
-        for (real_id, fm_step_id), fm_step_snapshot in fm_step_snapshots.items():
+        for (real_id, fm_step_id), fm_step_status in fm_step_snapshots.items():
             metadata["sorted_fm_step_ids"][real_id].append(fm_step_id)
-            if (
-                real_id in running_fm_step_id
-                and int(fm_step_id) > running_fm_step_id[real_id]
-            ):
-                # Triggered on resubmitted realizations
-                color = _QCOLORS[
-                    state.FORWARD_MODEL_STATE_TO_COLOR[state.FORWARD_MODEL_STATE_START]
-                ]
-            else:
-                color = _QCOLORS[state.FORWARD_MODEL_STATE_TO_COLOR[fm_step_snapshot]]
-            metadata["aggr_fm_step_status_colors"][real_id][fm_step_id] = color
+            metadata["aggr_fm_step_status_colors"][real_id][fm_step_id] = _QCOLORS[
+                state.FORWARD_MODEL_STATE_TO_COLOR[fm_step_status]
+            ]
 
         ensemble.merge_metadata(metadata)
         return ensemble

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 class JobState(StrEnum):
     WAITING = "WAITING"
+    RESUBMITTING = "RESUBMITTING"
     SUBMITTING = "SUBMITTING"
     PENDING = "PENDING"
     RUNNING = "RUNNING"
@@ -44,6 +45,7 @@ class JobState(StrEnum):
 _queue_jobstate_event_type = {
     JobState.WAITING: Id.REALIZATION_WAITING,
     JobState.SUBMITTING: Id.REALIZATION_WAITING,
+    JobState.RESUBMITTING: Id.REALIZATION_RESUBMIT,
     JobState.PENDING: Id.REALIZATION_PENDING,
     JobState.RUNNING: Id.REALIZATION_RUNNING,
     JobState.ABORTING: Id.REALIZATION_FAILURE,
@@ -176,6 +178,7 @@ class Job:
                 logger.warning(message)
                 self.returncode = asyncio.Future()
                 self.started.clear()
+                await self._send(JobState.RESUBMITTING)
             else:
                 current_span.set_status(Status(StatusCode.ERROR))
                 await self._send(JobState.FAILED)

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -155,8 +155,16 @@ async def test_job_run_sends_expected_events(
 
     await assert_scheduler_events(
         scheduler,
-        [JobState.WAITING, JobState.SUBMITTING, JobState.PENDING, JobState.RUNNING]
-        * max_submit
+        (
+            [
+                JobState.WAITING,
+                JobState.SUBMITTING,
+                JobState.PENDING,
+                JobState.RUNNING,
+                JobState.RESUBMITTING,
+            ]
+            * max_submit
+        )[:-1]
         + [expected_final_event],
     )
     scheduler.driver.submit.assert_called_with(


### PR DESCRIPTION
Instead of trying to loop over and check for consistency of the snapshots on the gui side we instead send a event when we resubmit a job indicating to the evaluator that the snapshot should be cleared.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
