### PR TITLE
Drop fm_dispatch reporters on error

### DIFF
--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -91,7 +91,7 @@ class ForwardModelStep:
         self.std_err = job_data.get("stderr")
         self.std_out = job_data.get("stdout")
 
-    def run(self) -> Generator[Start | Exited | Running | None]:
+    def run(self) -> Generator[Start | Exited | Running]:
         try:
             yield from self._run()
         except Exception as e:
@@ -151,7 +151,7 @@ class ForwardModelStep:
             combined_environment = {**os.environ, **environment}
         return combined_environment
 
-    def _run(self) -> Generator[Start | Exited | Running | None]:
+    def _run(self) -> Generator[Start | Exited | Running]:
         start_message = self.create_start_message_and_check_job_files()
 
         yield start_message

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -1,11 +1,12 @@
 import hashlib
 import json
 import os
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
 from _ert.forward_model_runner.forward_model_step import ForwardModelStep
-from _ert.forward_model_runner.reporting.message import Checksum, Finish, Init
+from _ert.forward_model_runner.reporting.message import Checksum, Finish, Init, Message
 
 
 class ForwardModelRunner:
@@ -49,7 +50,7 @@ class ForwardModelRunner:
                 info["error"] = f"Expected file {path} not created by forward model!"
         return manifest
 
-    def run(self, names_of_steps_to_run: list[str]):
+    def run(self, names_of_steps_to_run: list[str]) -> Generator[Message]:
         if not names_of_steps_to_run:
             step_queue = self.steps
         else:


### PR DESCRIPTION
**Issue**
Resolves #9706

Fixes a very rare scenario where reporting has thrown an unrecoverable error. We then stop using the reporter and carry on.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
