### PR TITLE
Change port range of dark storage

### DIFF
--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -96,7 +96,9 @@ def run_server(args: argparse.Namespace | None = None, debug: bool = False) -> N
         config_args.update(reload=True, reload_dirs=[os.path.dirname(ert_shared_path)])
         os.environ["ERT_STORAGE_DEBUG"] = "1"
 
-    sock = find_available_socket(custom_host=args.host)
+    sock = find_available_socket(
+        custom_host=args.host, custom_range=range(51850, 51870)
+    )
     connection_info = _create_connection_info(sock, authtoken)
 
     # Appropriated from uvicorn.main:run


### PR DESCRIPTION
backport from main

There is an issue where dark storage would try to use the same port as ensemble evaluator.
Switching the port range for dark storage should fix this problem until we can fix the bug.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'pytest tests/ert/unit_tests tests/everest -n auto --hypothesis-profile=fast -m "not integration_test"'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
