### PR TITLE
Fix select-string

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -9,7 +9,7 @@ on:
         type: string
       select-string:
         type: string
-        default: "''"
+        default: '""'
 
 env:
   ERT_SHOW_BACKTRACE: 1
@@ -67,7 +67,7 @@ jobs:
       if: inputs.test-type == 'performance-and-unit-tests'
       run: |
         just ert-unit-tests
-        ERT_PYTEST_ARGS="-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable" just ert-doc-tests
+        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' just ert-doc-tests
 
     - name: Upload coverage to Codecov
       id: codecov1

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -98,6 +98,7 @@ async def test_evaluator_handles_dispatchers_connected(
     assert evaluator._dispatchers_empty.is_set()
 
 
+@pytest.mark.integration_test
 async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):
     ee_config = make_ee_config(use_ipc_protocol=False)
     ctx = zmq.asyncio.Context()


### PR DESCRIPTION
Run where this worked correctly on mac: https://github.com/equinor/ert/actions/runs/13025635665/job/36334142343?pr=9895

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
