### PR TITLE
Enforce objectives and controls have at least one element in everest config

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -123,9 +123,10 @@ class EverestConfig(BaseModel):  # type: ignore
          Controls should have unique names each control defines
             a group of control variables
         """,
+        min_length=1,
     )
     objective_functions: list[ObjectiveFunctionConfig] = Field(
-        description="List of objective function specifications",
+        description="List of objective function specifications", min_length=1
     )
     optimization: OptimizationConfig | None = Field(
         default=OptimizationConfig(),
@@ -710,8 +711,17 @@ and environment variables are exposed in the form 'os.NAME', for example:
         without having to provide empty defaults.
         """
         defaults = {
-            "controls": [],
-            "objective_functions": [],
+            "controls": [
+                {
+                    "name": "default_group",
+                    "type": "generic_control",
+                    "initial_guess": 0.5,
+                    "variables": [
+                        {"name": "default_name", "min": 0, "max": 1},
+                    ],
+                }
+            ],
+            "objective_functions": [{"name": "default"}],
             "config_path": ".",
             "model": {"realizations": [0]},
         }

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1025,3 +1025,54 @@ def test_load_file_with_errors(copy_math_func_test_data_to_tmp, capsys):
 
     assert "line: 16, column: 5" in captured.err
     assert "Extra inputs are not permitted (type=extra_forbidden)" in captured.err
+
+
+@pytest.mark.parametrize(
+    ["controls", "objectives", "error_msg"],
+    [
+        (
+            [],
+            [],
+            [
+                "controls\n  List should have at least 1 item after validation, not 0",
+                "objective_functions\n  List should have at least 1 item after validation, not 0",
+            ],
+        ),
+        (
+            [],
+            [{"name": "npv"}],
+            [
+                "controls\n  List should have at least 1 item after validation, not 0",
+            ],
+        ),
+        (
+            [
+                {
+                    "name": "test",
+                    "type": "generic_control",
+                    "initial_guess": 0.5,
+                    "variables": [
+                        {"name": "test", "min": 0, "max": 1},
+                    ],
+                }
+            ],
+            [{"name": "npv"}],
+            [],
+        ),
+    ],
+)
+def test_warning_empty_controls_and_objectives(controls, objectives, error_msg):
+    if error_msg:
+        with pytest.raises(ValueError) as e:
+            EverestConfig.with_defaults(
+                objective_functions=objectives,
+                controls=controls,
+            )
+
+        for msg in error_msg:
+            assert msg in str(e.value)
+    else:
+        EverestConfig.with_defaults(
+            objective_functions=objectives,
+            controls=controls,
+        )


### PR DESCRIPTION
**Issue**
Resolves #9689


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
