### PR TITLE
zmq: make sure to destroy evaluator zmq context in case server fails on startup

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -313,7 +313,8 @@ class EnsembleEvaluator:
         except zmq.error.ZMQError as e:
             logger.error(f"ZMQ error encountered {e} during evaluator initialization")
             self._server_started.set_exception(e)
-            raise
+            zmq_context.destroy(linger=0)
+            return
         try:
             await self._server_done.wait()
             try:
@@ -338,7 +339,7 @@ class EnsembleEvaluator:
         finally:
             try:
                 self._router_socket.close()
-                zmq_context.destroy()
+                zmq_context.destroy(linger=0)
             except Exception as exc:
                 logger.warning(f"Failed to clean up zmq context {exc}")
             logger.info("ZMQ cleanup done!")

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -98,7 +98,6 @@ async def test_evaluator_handles_dispatchers_connected(
     assert evaluator._dispatchers_empty.is_set()
 
 
-@pytest.mark.integration_test
 async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):
     ee_config = make_ee_config(use_ipc_protocol=False)
     ctx = zmq.asyncio.Context()
@@ -109,7 +108,8 @@ async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):
         with pytest.raises(zmq.error.ZMQError, match="Address already in use"):
             await evaluator.run_and_get_successful_realizations()
     finally:
-        ctx.destroy()
+        socket.close()
+        ctx.destroy(linger=0)
 
 
 async def test_no_config_raises_valueerror_when_running():


### PR DESCRIPTION
**Issue**
Some tests were hanging due to the ee zmq context was not properly destroyed.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
