### PR TITLE
Clean up analysis config

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -19,10 +19,8 @@ import psutil
 import scipy
 from iterative_ensemble_smoother.experimental import AdaptiveESMDA
 
-from ert.config import GenKwConfig
+from ert.config import ESSettings, GenKwConfig, ObservationGroups, UpdateSettings
 
-from ..config.analysis_config import ObservationGroups, UpdateSettings
-from ..config.analysis_module import ESSettings
 from . import misfit_preprocessor
 from .event import (
     AnalysisCompleteEvent,

--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -1,4 +1,4 @@
-from .analysis_config import AnalysisConfig
+from .analysis_config import AnalysisConfig, ObservationGroups, UpdateSettings
 from .analysis_module import AnalysisModule, ESSettings
 from .capture_validation import capture_validation
 from .design_matrix import DesignMatrix
@@ -69,6 +69,7 @@ __all__ = [
     "HookRuntime",
     "InvalidResponseFile",
     "ModelConfig",
+    "ObservationGroups",
     "ObservationType",
     "ParameterConfig",
     "PriorDict",
@@ -79,6 +80,7 @@ __all__ = [
     "SummaryObservation",
     "SurfaceConfig",
     "TransformFunction",
+    "UpdateSettings",
     "WarningInfo",
     "Workflow",
     "WorkflowJob",

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -197,25 +197,3 @@ class AnalysisConfig:
     @property
     def log_path(self) -> Path:
         return Path(realpath(self.update_log_path))
-
-    def __repr__(self) -> str:
-        return (
-            "AnalysisConfig("
-            f"min_realization={self.minimum_required_realizations}, "
-            f"update_log_path={self.update_log_path}, "
-        )
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, AnalysisConfig):
-            return False
-
-        if self.log_path != other.log_path:
-            return False
-
-        if self.observation_settings != other.observation_settings:
-            return False
-
-        if self.es_module != other.es_module:
-            return False
-
-        return self.minimum_required_realizations == other.minimum_required_realizations

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -29,7 +29,7 @@ from ert.analysis.event import (
     AnalysisErrorEvent,
     AnalysisEvent,
 )
-from ert.config import HookRuntime, QueueSystem
+from ert.config import HookRuntime, QueueSystem, UpdateSettings
 from ert.config.analysis_module import ESSettings
 from ert.config.forward_model_step import ForwardModelStep
 from ert.config.model_config import ModelConfig
@@ -58,7 +58,6 @@ from ert.substitutions import Substitutions
 from ert.trace import tracer
 from ert.workflow_runner import WorkflowRunner
 
-from ..config.analysis_config import UpdateSettings
 from ..run_arg import RunArg
 from .event import (
     AnalysisStatusEvent,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -7,14 +7,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ert.config import ErtConfig, HookRuntime
+from ert.config import ErtConfig, ESSettings, HookRuntime, UpdateSettings
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.storage import Storage
 from ert.trace import tracer
 
-from ..config.analysis_config import UpdateSettings
-from ..config.analysis_module import ESSettings
 from ..run_arg import create_run_arguments
 from .base_run_model import StatusEvents, UpdateRunModel
 

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -6,12 +6,10 @@ from queue import SimpleQueue
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ert.config import ErtConfig
+from ert.config import ErtConfig, ESSettings, UpdateSettings
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.storage import Storage
 
-from ..config.analysis_config import UpdateSettings
-from ..config.analysis_module import ESSettings
 from .base_run_model import ErtRunError, StatusEvents, UpdateRunModel
 
 if TYPE_CHECKING:

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
-from ert.config.analysis_config import UpdateSettings
+from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, UpdateSettings
 from ert.mode_definitions import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -8,14 +8,12 @@ from uuid import UUID
 
 import numpy as np
 
-from ert.config import ErtConfig, HookRuntime
+from ert.config import ErtConfig, ESSettings, HookRuntime, UpdateSettings
 from ert.enkf_main import sample_prior
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.storage import Ensemble, Storage
 from ert.trace import tracer
 
-from ..config.analysis_config import UpdateSettings
-from ..config.analysis_module import ESSettings
 from ..run_arg import create_run_arguments
 from .base_run_model import ErtRunError, StatusEvents, UpdateRunModel
 

--- a/tests/ert/performance_tests/test_analysis.py
+++ b/tests/ert/performance_tests/test_analysis.py
@@ -8,9 +8,7 @@ import xtgeo
 from scipy.ndimage import gaussian_filter
 
 from ert.analysis import smoother_update
-from ert.config import Field, GenDataConfig
-from ert.config.analysis_config import UpdateSettings
-from ert.config.analysis_module import ESSettings
+from ert.config import ESSettings, Field, GenDataConfig, UpdateSettings
 from ert.field_utils import Shape
 
 

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -13,8 +13,7 @@ import pytest
 import xtgeo
 
 from ert.analysis import smoother_update
-from ert.config import ErtConfig, ESSettings
-from ert.config.analysis_config import UpdateSettings
+from ert.config import ErtConfig, ESSettings, UpdateSettings
 from ert.enkf_main import sample_prior
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage

--- a/tests/ert/performance_tests/test_obs_and_responses_performance.py
+++ b/tests/ert/performance_tests/test_obs_and_responses_performance.py
@@ -8,8 +8,13 @@ import polars
 import pytest
 
 from ert.analysis import smoother_update
-from ert.config import ESSettings, GenDataConfig, GenKwConfig, SummaryConfig
-from ert.config.analysis_config import UpdateSettings
+from ert.config import (
+    ESSettings,
+    GenDataConfig,
+    GenKwConfig,
+    SummaryConfig,
+    UpdateSettings,
+)
 from ert.config.gen_kw_config import TransformFunctionDefinition
 from ert.enkf_main import sample_prior
 from ert.storage import open_storage

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -14,9 +14,7 @@ import xtgeo
 from ert.analysis import (
     smoother_update,
 )
-from ert.config import ErtConfig
-from ert.config.analysis_config import UpdateSettings
-from ert.config.analysis_module import ESSettings
+from ert.config import ErtConfig, ESSettings, UpdateSettings
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
 

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -19,9 +19,7 @@ from ert.analysis._es_update import (
     _save_param_ensemble_array_to_disk,
 )
 from ert.analysis.event import AnalysisCompleteEvent, AnalysisErrorEvent
-from ert.config import Field, GenDataConfig, GenKwConfig
-from ert.config.analysis_config import UpdateSettings
-from ert.config.analysis_module import ESSettings
+from ert.config import ESSettings, Field, GenDataConfig, GenKwConfig, UpdateSettings
 from ert.config.gen_kw_config import TransformFunctionDefinition
 from ert.field_utils import Shape
 from ert.storage import open_storage

--- a/tests/ert/unit_tests/config/test_analysis_config.py
+++ b/tests/ert/unit_tests/config/test_analysis_config.py
@@ -1,3 +1,4 @@
+import os.path
 from textwrap import dedent
 
 import hypothesis.strategies as st
@@ -47,7 +48,7 @@ def test_analysis_config_from_file_is_same_as_from_dict(monkeypatch, tmp_path):
             ],
             ConfigKeys.DESIGN_MATRIX: [
                 [
-                    "my_design_matrix.xlsx",
+                    os.path.abspath("my_design_matrix.xlsx"),
                     "DESIGN_SHEET:my_sheet",
                     "DEFAULT_SHEET:my_default_sheet",
                 ]

--- a/tests/ert/unit_tests/run_models/test_model_factory.py
+++ b/tests/ert/unit_tests/run_models/test_model_factory.py
@@ -11,8 +11,8 @@ from ert.config import (
     ConfigWarning,
     ErtConfig,
     ModelConfig,
+    UpdateSettings,
 )
-from ert.config.analysis_config import UpdateSettings
 from ert.mode_definitions import (
     ENSEMBLE_SMOOTHER_MODE,
     ES_MDA_MODE,

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -11,8 +11,7 @@ from resdata.summary import Summary
 
 from ert import LibresFacade
 from ert.analysis import ErtAnalysisError, smoother_update
-from ert.config import ErtConfig, ESSettings
-from ert.config.analysis_config import UpdateSettings
+from ert.config import ErtConfig, ESSettings, UpdateSettings
 from ert.data import MeasuredData
 from ert.enkf_main import sample_prior
 

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -10,8 +10,7 @@ import pytest
 from packaging import version
 
 from ert.analysis import ErtAnalysisError, smoother_update
-from ert.config import ErtConfig, ESSettings
-from ert.config.analysis_config import UpdateSettings
+from ert.config import ErtConfig, ESSettings, UpdateSettings
 from ert.storage import open_storage
 from ert.storage.local_storage import (
     _LOCAL_STORAGE_VERSION,


### PR DESCRIPTION
Clean up some leftover issues with imports and change to dataclass.

Note that `test_analysis_config_from_file_is_same_as_from_dict` before this change never checked anything about the design matrix as the superflous `__eq__` function ignored the design matrix. Therefore the values asserted against was wrong: the xlsx file goes through abspath first.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
