### PR TITLE
Resolve polars asof warning

### DIFF
--- a/src/ert/data/_measured_data.py
+++ b/src/ert/data/_measured_data.py
@@ -128,11 +128,12 @@ class MeasuredData:
             )
 
             if "time" in pivoted:
-                joined = observations_for_type.join_asof(
-                    pivoted,
+                joined = observations_for_type.sort(by="time").join_asof(
+                    pivoted.sort(by="time"),
                     by=["response_key", *response_cls.primary_key],
                     on="time",
                     tolerance="1s",
+                    strategy="nearest",
                 )
             else:
                 joined = observations_for_type.join(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -981,11 +981,12 @@ class LocalEnsemble(BaseMode):
                             )
                         )
                     elif "time" in pivoted:
-                        joined = observations_for_type.join_asof(
-                            pivoted,
+                        joined = observations_for_type.sort(by="time").join_asof(
+                            pivoted.sort(by="time"),
                             by=["response_key", *response_cls.primary_key],
                             on="time",
                             tolerance="1s",
+                            strategy="nearest",
                         )
                     else:
                         joined = observations_for_type.join(


### PR DESCRIPTION
Get the following warning now:

```
/data/komodo_dev/ert/src/ert/storage/local_ensemble.py:986: UserWarning: left key of asof join is not sorted.

This can lead to invalid results. Ensure the asof key is sorted
  ).join_asof(
/data/komodo_dev/ert/src/ert/storage/local_ensemble.py:986: UserWarning: right key of asof join is not sorted.

This can lead to invalid results. Ensure the asof key is sorted
  ).join_asof(
```


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
