### PR TITLE
Fixup logic related to asof join

### DIFF
--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -62,7 +62,11 @@ class EnkfObs:
         for name, dfs in grouped.items():
             non_empty_dfs = [df for df in dfs if not df.is_empty()]
             if len(non_empty_dfs) > 0:
-                datasets[name] = pl.concat(non_empty_dfs).sort("observation_key")
+                ds = pl.concat(non_empty_dfs).sort("observation_key")
+                if "time" in ds:
+                    ds = ds.sort(by="time")
+
+                datasets[name] = ds
 
         self.datasets = datasets
 

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -58,6 +58,7 @@ class SummaryConfig(ResponseConfig):
             }
         )
         df = df.explode("values", "time")
+        df = df.sort(by=["time"])
         return df
 
     @property

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -954,7 +954,10 @@ class LocalEnsemble(BaseMode):
 
                     # Filter out responses without observations
                     for col, observed_values in observed_cols.items():
-                        responses = responses.filter(pl.col(col).is_in(observed_values))
+                        if col != "time":
+                            responses = responses.filter(
+                                pl.col(col).is_in(observed_values)
+                            )
 
                     pivoted = responses.collect().pivot(
                         on="realization",

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -982,7 +982,10 @@ class LocalEnsemble(BaseMode):
                     elif "time" in pivoted:
                         joined = observations_for_type.join_asof(
                             pivoted,
-                            by=["response_key", *response_cls.primary_key],
+                            by=[
+                                "response_key",
+                                *[k for k in response_cls.primary_key if k != "time"],
+                            ],
                             on="time",
                             tolerance="1s",
                         )

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -987,6 +987,7 @@ class LocalEnsemble(BaseMode):
                                 *[k for k in response_cls.primary_key if k != "time"],
                             ],
                             on="time",
+                            strategy="nearest",
                             tolerance="1s",
                         )
                     else:

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -633,6 +633,101 @@ def test_write_transaction_overwrites(tmp_path):
         assert path.read_bytes() == b"deadbeaf"
 
 
+@pytest.mark.parametrize(
+    "perturb_observations, perturb_responses",
+    [
+        pytest.param(
+            False,
+            True,
+            id="Perturbed responses",
+        ),
+        pytest.param(
+            True,
+            False,
+            id="Perturbed observations",
+        ),
+        pytest.param(
+            True,
+            False,
+            id="Perturbed observations & responses",
+        ),
+    ],
+)
+def test_asof_joining_summary(tmp_path, perturb_observations, perturb_responses):
+    with open_storage(tmp_path, mode="w") as storage:
+        response_keys = ["FOPR", "FOPT_OP1", "FOPR:OP3", "FLAP", "F*"]
+        obs_keys = [f"o_{k}" for k in response_keys]
+        times = [datetime(2000, 1, 1, 1, 0)] * len(response_keys)
+        summary_observations = pl.DataFrame(
+            {
+                "observation_key": obs_keys,
+                "response_key": response_keys,
+                "time": pl.Series(
+                    times,
+                    dtype=pl.Datetime("ms"),
+                ),
+                "observations": pl.Series(
+                    [1] * len(response_keys),
+                    dtype=pl.Float32,
+                ),
+                "std": pl.Series(
+                    [0.1] * len(response_keys),
+                    dtype=pl.Float32,
+                ),
+            }
+        )
+
+        experiment = storage.create_experiment(
+            responses=[SummaryConfig(keys=["*"], input_files=["not_relevant"])],
+            observations={"summary": summary_observations},
+        )
+
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=1, iteration=0, name="prior"
+        )
+
+        summary_df = pl.DataFrame(
+            {
+                "response_key": response_keys,
+                "time": pl.Series(times, dtype=pl.Datetime("ms")),
+                "values": pl.Series([0.0, 1.0, 2.0, 3.0, 4.0], dtype=pl.Float32),
+            }
+        )
+
+        ensemble.save_response("summary", summary_df, 0)
+        iens_active_index = np.array([0])
+
+        obs_and_responses_exact = ensemble.get_observations_and_responses(
+            obs_keys, iens_active_index
+        )
+
+        if perturb_responses:
+            perturbed_summary = summary_df.with_columns(
+                pl.when(pl.arange(0, summary_df.height) % 2 != 0)
+                .then(pl.col("time") + pl.duration(milliseconds=500))
+                .otherwise(pl.col("time") - pl.duration(milliseconds=500))
+                .alias("time")
+            )
+            ensemble.save_response("summary", perturbed_summary, 0)
+
+        if perturb_observations:
+            perturbed_observations = summary_observations.with_columns(
+                pl.when(pl.arange(0, summary_observations.height) % 2 != 0)
+                .then(pl.col("time") + pl.duration(milliseconds=500))
+                .otherwise(pl.col("time") - pl.duration(milliseconds=500))
+                .alias("time")
+            )
+            experiment.observations["summary"] = perturbed_observations
+
+        obs_and_responses_perturbed = ensemble.get_observations_and_responses(
+            obs_keys, iens_active_index
+        )
+
+        assert obs_and_responses_exact.drop("index").equals(
+            obs_and_responses_perturbed.drop("index")
+        )
+
+
 @dataclass
 class Ensemble:
     uuid: UUID


### PR DESCRIPTION
Fixes 3 bugs with asof join relating to time-based observations/responses:

1. Non-exact time matches were filtered out before the asof join ever happened, making it behave like an exact join
2. `time` was in both the `on` and `by` argument, see closer description at the bottom of this comment***
3. The default strategy is apparently `backward`, what we want it `nearest`, as the observations/responses may deviate both forwards and backwards in time

We also want to sort the summary/observations before doing the asof join, meaning we can discard the sorting of observations by obs_name, as that sorting is applied explicitly just before the join anyway. Meaning, we can store time-based responses and observations sorted by time.

***For the polars asof join, it seems that including the `on` argument in the `by` argument will make it behave like an exact join, thus we exclude `time` from the `on argument.
```
pivoted
Out[1]: 
shape: (5, 3)
┌──────────────┬─────────────────────────┬─────┐
│ response_key ┆ time                    ┆ 0   │
│ ---          ┆ ---                     ┆ --- │
│ cat          ┆ datetime[ms]            ┆ f32 │
╞══════════════╪═════════════════════════╪═════╡
│ FOPR         ┆ 2000-01-01 00:59:59.500 ┆ 0.0 │
│ FOPT_OP1     ┆ 2000-01-01 01:00:00.500 ┆ 1.0 │
│ FOPR:OP3     ┆ 2000-01-01 00:59:59.500 ┆ 2.0 │
│ FLAP         ┆ 2000-01-01 01:00:00.500 ┆ 3.0 │
│ F*           ┆ 2000-01-01 00:59:59.500 ┆ 4.0 │
└──────────────┴─────────────────────────┴─────┘
observations_by_type
Out[2]: 
{'summary': shape: (5, 5)
 ┌─────────────────┬──────────────┬─────────────────────┬──────────────┬─────┐
 │ observation_key ┆ response_key ┆ time                ┆ observations ┆ std │
 │ ---             ┆ ---          ┆ ---                 ┆ ---          ┆ --- │
 │ str             ┆ str          ┆ datetime[ms]        ┆ f32          ┆ f32 │
 ╞═════════════════╪══════════════╪═════════════════════╪══════════════╪═════╡
 │ o_FOPR          ┆ FOPR         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 │
 │ o_FOPT_OP1      ┆ FOPT_OP1     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 │
 │ o_FOPR:OP3      ┆ FOPR:OP3     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 │
 │ o_FLAP          ┆ FLAP         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 │
 │ o_F*            ┆ F*           ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 │
 └─────────────────┴──────────────┴─────────────────────┴──────────────┴─────┘}
observations_for_type.join_asof(
                            pivoted,
                            by=[
                                "response_key",
                                "time",
                            ],
                            on="time",
                            strategy="nearest",
                            tolerance="1s",
                        )
Out[3]: 
shape: (5, 6)
┌─────────────────┬──────────────┬─────────────────────┬──────────────┬─────┬──────┐
│ observation_key ┆ response_key ┆ time                ┆ observations ┆ std ┆ 0    │
│ ---             ┆ ---          ┆ ---                 ┆ ---          ┆ --- ┆ ---  │
│ str             ┆ cat          ┆ datetime[ms]        ┆ f32          ┆ f32 ┆ f32  │
╞═════════════════╪══════════════╪═════════════════════╪══════════════╪═════╪══════╡
│ o_FOPR          ┆ FOPR         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ null │
│ o_FOPT_OP1      ┆ FOPT_OP1     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ null │
│ o_FOPR:OP3      ┆ FOPR:OP3     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ null │
│ o_FLAP          ┆ FLAP         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ null │
│ o_F*            ┆ F*           ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ null │
└─────────────────┴──────────────┴─────────────────────┴──────────────┴─────┴──────┘
observations_for_type.join_asof(
                            pivoted,
                            by=[
                                "response_key",
                            ],
                            on="time",
                            strategy="nearest",
                            tolerance="1s",
                        )
Out[4]: 
shape: (5, 6)
┌─────────────────┬──────────────┬─────────────────────┬──────────────┬─────┬─────┐
│ observation_key ┆ response_key ┆ time                ┆ observations ┆ std ┆ 0   │
│ ---             ┆ ---          ┆ ---                 ┆ ---          ┆ --- ┆ --- │
│ str             ┆ cat          ┆ datetime[ms]        ┆ f32          ┆ f32 ┆ f32 │
╞═════════════════╪══════════════╪═════════════════════╪══════════════╪═════╪═════╡
│ o_FOPR          ┆ FOPR         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ 0.0 │
│ o_FOPT_OP1      ┆ FOPT_OP1     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ 1.0 │
│ o_FOPR:OP3      ┆ FOPR:OP3     ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ 2.0 │
│ o_FLAP          ┆ FLAP         ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ 3.0 │
│ o_F*            ┆ F*           ┆ 2000-01-01 01:00:00 ┆ 1.0          ┆ 0.1 ┆ 4.0 │
└─────────────────┴──────────────┴─────────────────────┴──────────────┴─────┴─────┘
```