### PR TITLE
Export scaled controls when running forward models

### DIFF
--- a/src/everest/config/control_config.py
+++ b/src/everest/config/control_config.py
@@ -179,12 +179,6 @@ sampler to use the same perturbations for each realization.
     def ropt_control_type(self) -> VariableType:
         return VariableType[self.control_type.upper()]
 
-    @property
-    def has_auto_scale(self) -> bool:
-        return self.auto_scale or any(
-            variable.auto_scale for variable in self.variables
-        )
-
     @model_validator(mode="after")
     def validate_variables(self) -> Self:
         if self.variables is None:

--- a/src/everest/config/control_variable_config.py
+++ b/src/everest/config/control_variable_config.py
@@ -11,7 +11,7 @@ from pydantic import (
 from ropt.enums import VariableType
 
 from .sampler_config import SamplerConfig
-from .validation_utils import no_dots_in_string, valid_range
+from .validation_utils import no_dots_in_string
 
 
 class _ControlVariable(BaseModel):
@@ -33,24 +33,6 @@ ignored if the algorithm that is used does not support different control types.
 If `True`, the variable will be optimized, otherwise it will be fixed to the
 initial value.
 """,
-    )
-    auto_scale: bool | None = Field(
-        default=None,
-        description="""
-Can be set to true to re-scale variable from the range
-defined by [min, max] to the range defined by scaled_range (default [0, 1])
-""",
-    )
-    scaled_range: Annotated[tuple[float, float] | None, AfterValidator(valid_range)] = (
-        Field(
-            default=None,
-            description="""
-Can be used to set the range of the variable values
-after scaling (default = [0, 1]).
-
-This option has no effect if auto_scale is not set.
-""",
-        )
     )
     min: float | None = Field(
         default=None,

--- a/src/everest/config/utils.py
+++ b/src/everest/config/utils.py
@@ -66,8 +66,6 @@ class FlattenedControls:
             for key in [
                 "control_type",
                 "enabled",
-                "auto_scale",
-                "scaled_range",
                 "min",
                 "max",
                 "perturbation_magnitude",

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -521,5 +521,11 @@ def everest_to_ert_config(ever_config: EverestConfig) -> ErtConfig:
             input_keys=_get_variables(control.variables),
             output_file=control.name + ".json",
         )
+        if control.auto_scale:
+            ens_config.parameter_configs["rescaled-" + control.name] = ExtParamConfig(
+                name="rescaled-" + control.name,
+                input_keys=_get_variables(control.variables),
+                output_file="rescaled-" + control.name + ".json",
+            )
 
     return ert_config

--- a/test-data/everest/math_func/jobs/distance3.py
+++ b/test-data/everest/math_func/jobs/distance3.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 
 def compute_distance_squared(p, q):
@@ -24,22 +25,24 @@ def main(argv):
     arg_parser.add_argument("--target-file", type=str)
     arg_parser.add_argument("--target", nargs=3, type=float)
     arg_parser.add_argument("--out", type=str)
-    arg_parser.add_argument("--scaling", nargs=4, type=float)
     arg_parser.add_argument("--realization", type=float)
     options, _ = arg_parser.parse_known_args(args=argv)
 
-    point = options.point if options.point else read_point(options.point_file)
+    point = (
+        options.point
+        if options.point
+        else read_point(
+            "rescaled-" + options.point_file
+            if Path("rescaled-" + options.point_file).exists()
+            else options.point_file
+        )
+    )
     if len(point) != 3:
         raise RuntimeError("Failed parsing point")
 
     target = options.target if options.target else read_point(options.target_file)
     if len(target) != 3:
         raise RuntimeError("Failed parsing target")
-
-    if options.scaling is not None:
-        min_range, max_range, target_min, target_max = options.scaling
-        point = [(p - target_min) / (target_max - target_min) for p in point]
-        point = [p * (max_range - min_range) + min_range for p in point]
 
     value = compute_distance_squared(point, target)
     # If any realizations with an index > 0 are passed we make those incorrect

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -139,7 +139,6 @@ def test_math_func_auto_scaled_controls(
             {"weights": {"point.x": 1.0, "point.y": 1.0}, "upper_bound": 0.5}
         ],
     }
-    config_dict["forward_model"][0] += " --scaling -1 1 0.3 0.7"
     config = EverestConfig.model_validate(config_dict)
 
     # Act

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -49,22 +49,6 @@ def test_everest2ropt_controls_auto_scale():
     assert np.allclose(ropt_config.variables.upper_bounds, 0.7)
 
 
-def test_everest2ropt_variables_auto_scale():
-    config = EverestConfig.load_file(os.path.join(_CONFIG_DIR, _CONFIG_FILE))
-    controls = config.controls
-    controls[0].variables[1].auto_scale = True
-    controls[0].variables[1].scaled_range = [0.3, 0.7]
-    ropt_config = everest2ropt(
-        config, transforms=get_opt_model_transforms(config.controls)
-    )
-    assert ropt_config.variables.lower_bounds[0] == 0.0
-    assert ropt_config.variables.upper_bounds[0] == 0.1
-    assert ropt_config.variables.lower_bounds[1] == 0.3
-    assert ropt_config.variables.upper_bounds[1] == 0.7
-    assert np.allclose(ropt_config.variables.lower_bounds[2:], 0.0)
-    assert np.allclose(ropt_config.variables.upper_bounds[2:], 0.1)
-
-
 def test_everest2ropt_controls_input_constraint():
     config = EverestConfig.load_file(
         os.path.join(_CONFIG_DIR, "config_input_constraints.yml")


### PR DESCRIPTION
**Issue**
This would take care of #8814, but putting this on hold now, since this may not be the desired solution.


**Approach**
Export an additional JSON file with rescaled controls, so that forward model can check for its existence and use it.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
