### PR TITLE
Add everest-models as a package installation when building readthedocs for everest

### DIFF
--- a/docs/everest/.readthedocs.yaml
+++ b/docs/everest/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 python:
   install:
+    - requirements: docs/everest/requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/everest/requirements.txt
+++ b/docs/everest/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/equinor/everest-models.git


### PR DESCRIPTION

**Issue**
Resolves #9930 


**Approach**
Add everest-models as a package installation when building readthedocs for everest

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
