### PR TITLE
Replace _wait_until with wait_until

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 
@@ -22,13 +21,6 @@ from _ert.forward_model_runner.reporting.message import (
 )
 from _ert.forward_model_runner.reporting.statemachine import TransitionError
 from tests.ert.utils import MockZMQServer
-
-
-def _wait_until(condition, timeout, fail_msg):
-    start = time.time()
-    while not condition():
-        assert start + timeout > time.time(), fail_msg
-        time.sleep(0.1)
 
 
 def test_report_with_successful_start_message_argument(unused_tcp_port):

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -25,15 +25,9 @@ from _ert.forward_model_runner.fm_dispatch import (
 )
 from _ert.forward_model_runner.forward_model_step import killed_by_oom
 from _ert.forward_model_runner.reporting import Event, Interactive, Reporter
-from _ert.forward_model_runner.reporting.message import (
-    Finish,
-    Init,
-    Message,
-)
+from _ert.forward_model_runner.reporting.message import Finish, Init, Message
 from _ert.threading import ErtThread
 from tests.ert.utils import MockZMQServer, wait_until
-
-from .test_event_reporter import _wait_until
 
 
 @pytest.mark.integration_test
@@ -313,11 +307,10 @@ def test_retry_of_jobs_json_file_read(unused_tcp_port, tmp_path, monkeypatch, ca
     )
 
     def create_jobs_file_after_lock():
-        _wait_until(
-            lambda: f"Could not find file {FORWARD_MODEL_DESCRIPTION_FILE}, retrying"
-            in caplog.text,
-            2,
-            f"Did not get expected log message from missing {FORWARD_MODEL_DESCRIPTION_FILE}",
+        wait_until(
+            lambda: f"Could not find file {FORWARD_MODEL_DESCRIPTION_FILE}, retrying",
+            interval=0.1,
+            timeout=2,
         )
         (tmp_path / FORWARD_MODEL_DESCRIPTION_FILE).write_text(jobs_json)
         lock.release()


### PR DESCRIPTION
**Issue**
Utility function _wait_until is used only in a single test function, ~~so moving it there.~~ replacing it with another (similar) one.


**Approach**
:car: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
