### PR TITLE
Reimplement objective scaling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.12,<0.13",
+    "ropt[pandas]>=0.13,<0.14",
     "ropt-dakota>=0.11,<0.12",
 ]
 

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -553,8 +553,7 @@ class EverestRunModel(BaseRunModel):
         results: list[dict[str, NDArray[np.float64]]],
         cached_results: dict[int, Any],
     ) -> tuple[NDArray[np.float64], NDArray[np.float64] | None]:
-        # We minimize the negative of the objectives:
-        objectives = -self._get_simulation_results(
+        objectives = self._get_simulation_results(
             results, self._everest_config.objective_names, control_values, batch_data
         )
 

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -195,7 +195,7 @@ class EverestRunModel(BaseRunModel):
             output_dir=Path(self._everest_config.optimization_output_dir),
         )
         self.ever_storage.init(self._everest_config)
-        self.ever_storage.observe_optimizer(optimizer, self._opt_model_transforms)
+        self.ever_storage.observe_optimizer(optimizer)
 
         # Run the optimization:
         optimizer_exit_code = optimizer.run().exit_code

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -387,12 +387,10 @@ class EverestStorage:
         exp = _OptimizerOnlyExperiment(self._output_dir)
         self.data.read_from_experiment(exp)
 
-    def observe_optimizer(
-        self, optimizer: BasicOptimizer, transforms: OptModelTransforms
-    ) -> None:
+    def observe_optimizer(self, optimizer: BasicOptimizer) -> None:
         optimizer.add_observer(
             EventType.FINISHED_EVALUATION,
-            partial(self._on_batch_evaluation_finished, transforms=transforms),
+            partial(self._on_batch_evaluation_finished),
         )
         optimizer.add_observer(
             EventType.FINISHED_OPTIMIZER_STEP, self._on_optimization_finished
@@ -661,14 +659,11 @@ class EverestStorage:
             "perturbation_constraints": perturbation_constraints,
         }
 
-    def _on_batch_evaluation_finished(
-        self, event: Event, transforms: OptModelTransforms
-    ) -> None:
+    def _on_batch_evaluation_finished(self, event: Event) -> None:
         logger.debug("Storing batch results dataframes")
 
         converted_results = tuple(
-            convert_to_maximize(result).transform_back(transforms)
-            for result in event.data.get("results", [])
+            convert_to_maximize(result) for result in event.data.get("results", [])
         )
         results: list[FunctionResults | GradientResults] = []
 

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -14,7 +14,6 @@ import polars as pl
 from ropt.enums import EventType
 from ropt.plan import BasicOptimizer, Event
 from ropt.results import FunctionResults, GradientResults, convert_to_maximize
-from ropt.transforms import OptModelTransforms
 
 from everest.config import EverestConfig
 from everest.strings import EVEREST

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -13,7 +13,7 @@ import numpy as np
 import polars as pl
 from ropt.enums import EventType
 from ropt.plan import BasicOptimizer, Event
-from ropt.results import FunctionResults, GradientResults, convert_to_maximize
+from ropt.results import FunctionResults, GradientResults
 
 from everest.config import EverestConfig
 from everest.strings import EVEREST
@@ -661,14 +661,11 @@ class EverestStorage:
     def _on_batch_evaluation_finished(self, event: Event) -> None:
         logger.debug("Storing batch results dataframes")
 
-        converted_results = tuple(
-            convert_to_maximize(result) for result in event.data.get("results", [])
-        )
         results: list[FunctionResults | GradientResults] = []
 
         best_value = -np.inf
         best_results = None
-        for item in converted_results:
+        for item in event.data.get("results", []):
             if isinstance(item, GradientResults):
                 results.append(item)
             if (

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -59,8 +59,6 @@ def _parse_controls(controls: FlattenedControls, ropt_config):
 
 
 def _parse_objectives(objective_functions: list[ObjectiveFunctionConfig], ropt_config):
-    scales: list[float] = []
-    auto_scale: list[bool] = []
     weights: list[float] = []
     function_estimator_indices: list[int] = []
     function_estimators: list = []
@@ -68,8 +66,6 @@ def _parse_objectives(objective_functions: list[ObjectiveFunctionConfig], ropt_c
     for objective in objective_functions:
         assert isinstance(objective.name, str)
         weights.append(objective.weight or 1.0)
-        scales.append(objective.scale or 1.0)
-        auto_scale.append(objective.auto_scale or False)
 
         # If any objective specifies an objective type, we have to specify
         # function estimators in ropt to implement these types. This is done by
@@ -95,8 +91,6 @@ def _parse_objectives(objective_functions: list[ObjectiveFunctionConfig], ropt_c
 
     ropt_config["objectives"] = {
         "weights": weights,
-        "scales": scales,
-        "auto_scale": auto_scale,
     }
     if function_estimators:
         # Only needed if we specified at least one objective type:

--- a/src/everest/optimizer/opt_model_transforms.py
+++ b/src/everest/optimizer/opt_model_transforms.py
@@ -56,11 +56,17 @@ class ObjectiveScaler(ObjectiveTransform):
         self._auto_scales = np.asarray(auto_scales, dtype=np.bool_)
         self._weights = np.asarray(weights, dtype=np.float64)
 
+    # The transform methods below all return the negative of the objectives.
+    # This is because Everest maximizes the objectives, while ropt is a minimizer.
+
     def forward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
-        return objectives / self._scales
+        return -objectives / self._scales
 
     def backward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
-        return objectives * self._scales
+        return -objectives * self._scales
+
+    def transform_weighted_objective(self, weighted_objective):
+        return -weighted_objective
 
     def calculate_auto_scales(self, objectives: NDArray[np.float64]) -> None:
         auto_scales = np.abs(

--- a/src/everest/optimizer/opt_model_transforms.py
+++ b/src/everest/optimizer/opt_model_transforms.py
@@ -3,9 +3,9 @@ from collections.abc import Sequence
 import numpy as np
 from numpy.typing import NDArray
 from ropt.transforms import OptModelTransforms
-from ropt.transforms.base import VariableTransform
+from ropt.transforms.base import ObjectiveTransform, VariableTransform
 
-from everest.config import ControlConfig
+from everest.config import ControlConfig, ObjectiveFunctionConfig
 from everest.config.utils import FlattenedControls
 
 
@@ -48,7 +48,36 @@ class ControlScaler(VariableTransform):
         )
 
 
-def get_opt_model_transforms(controls: list[ControlConfig]) -> OptModelTransforms:
+class ObjectiveScaler(ObjectiveTransform):
+    def __init__(
+        self, scales: list[float], auto_scales: list[bool], weights: list[float]
+    ) -> None:
+        self._scales = np.asarray(scales, dtype=np.float64)
+        self._auto_scales = np.asarray(auto_scales, dtype=np.bool_)
+        self._weights = np.asarray(weights, dtype=np.float64)
+
+    def forward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
+        return objectives / self._scales
+
+    def backward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
+        return objectives * self._scales
+
+    def calculate_auto_scales(self, objectives: NDArray[np.float64]) -> None:
+        auto_scales = np.abs(
+            np.nansum(objectives * self._weights[:, np.newaxis], axis=0)
+        )
+        self._scales[self._auto_scales] *= auto_scales[self._auto_scales]
+
+    @property
+    def has_auto_scale(self) -> bool:
+        return bool(np.any(self._auto_scales))
+
+
+def get_optimization_domain_transforms(
+    controls: list[ControlConfig],
+    objectives: list[ObjectiveFunctionConfig],
+    weights: list[float],
+) -> OptModelTransforms:
     flattened_controls = FlattenedControls(controls)
     return OptModelTransforms(
         variables=(
@@ -60,5 +89,16 @@ def get_opt_model_transforms(controls: list[ControlConfig]) -> OptModelTransform
             )
             if any(flattened_controls.auto_scales)
             else None
-        )
+        ),
+        objectives=ObjectiveScaler(
+            [
+                1.0 if objective.scale is None else objective.scale
+                for objective in objectives
+            ],
+            [
+                False if objective.auto_scale is None else objective.auto_scale
+                for objective in objectives
+            ],
+            weights,
+        ),
     )

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -42,7 +42,7 @@
     ],
     "realization_filters": null,
     "scales": [
-      0.6666666667,
+      1.0,
       1.0
     ],
     "weights": [


### PR DESCRIPTION
**Issue**
This PR reimplements objective scaling using the new approach of `ropt `to transform variables and objectives between the  model and optimization domains.

**Approach**
There are three commits:
1. A small commit that uses an improvement in `ropt `to simplify the storage code.
2. A refactoring of the forward model evaluator in the `everest `run model to introduce a clearer boundary between `ropt `and `everest `code.
3. The new implementation of objective scaling.


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
