### PR TITLE
Test for re-opening the socket reserved via net_utils

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -48,7 +48,7 @@ from ert.ensemble_evaluator.state import (
     FORWARD_MODEL_STATE_RUNNING,
 )
 from ert.scheduler import JobState
-from ert.shared import find_available_socket
+from ert.shared.net_utils import NoPortsInRangeException, find_available_socket
 
 from .ensemble_evaluator_utils import TestEnsemble
 
@@ -111,16 +111,22 @@ async def test_find_socket_works_with_zmq(unused_tcp_port):
         will_close_then_reopen_socket=True,
     )
     host, port = sock.getsockname()
+
     print(host, port)
 
+    with pytest.raises(NoPortsInRangeException):
+        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
+
     for _ in range(4):
-        try:
-            ctx = zmq.asyncio.Context()
-            socket = ctx.socket(zmq.ROUTER)
-            socket.bind(f"tcp://*:{port}")
-        finally:
-            socket.close()
-            ctx.destroy(linger=0)
+        ctx = zmq.asyncio.Context()
+        socket = ctx.socket(zmq.ROUTER)
+        socket.bind(f"tcp://*:{port}")
+        await asyncio.sleep(0.1)
+        socket.close()
+        ctx.destroy(linger=0)
+        await asyncio.sleep(1.0)
+        with pytest.raises(NoPortsInRangeException):
+            find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
 
 
 async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -105,7 +105,11 @@ async def test_evaluator_handles_dispatchers_connected(
 
 async def test_find_socket_works_with_zmq(unused_tcp_port):
     custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-    sock = find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
+    sock = find_available_socket(
+        custom_range=custom_range,
+        custom_host="127.0.0.1",
+        will_close_then_reopen_socket=True,
+    )
     host, port = sock.getsockname()
     print(host, port)
 


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
