### PR TITLE
Let zmq select port in EnsembleEvaluator

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -104,7 +104,10 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
 
     use_ipc_protocol = model.queue_system == QueueSystem.LOCAL
     evaluator_server_config = EvaluatorServerConfig(
-        custom_port_range=args.port_range, use_ipc_protocol=use_ipc_protocol
+        port_range=None
+        if args.port_range is None
+        else (min(args.port_range), max(args.port_range) + 1),
+        use_ipc_protocol=use_ipc_protocol,
     )
 
     if model.check_if_runpath_exists():

--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -218,7 +218,7 @@ class LegacyEnsemble:
             ce_unary_send_method_name,
             partialmethod(
                 self.__class__.send_event,
-                self._config.get_connection_info().router_uri,
+                self._config.get_uri(),
                 token=self._config.token,
             ),
         )
@@ -267,7 +267,7 @@ class LegacyEnsemble:
                 max_running=self._queue_config.max_running,
                 submit_sleep=self._queue_config.submit_sleep,
                 ens_id=self.id_,
-                ee_uri=self._config.get_connection_info().router_uri,
+                ee_uri=self._config.get_uri(),
                 ee_token=self._config.token,
             )
             logger.info(

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -305,12 +305,17 @@ class EnsembleEvaluator:
                 self._router_socket.curve_publickey = self._config.server_public_key
                 self._router_socket.curve_server = True
 
-            if self._config.router_port:
-                self._router_socket.bind(f"tcp://*:{self._config.router_port}")
+            if self._config.use_ipc_protocol:
+                self._router_socket.bind(self._config.get_uri())
             else:
-                self._router_socket.bind(self._config.url)
+                self._config.router_port = self._router_socket.bind_to_random_port(
+                    "tcp://*",
+                    min_port=self._config.min_port,
+                    max_port=self._config.max_port,
+                )
+
             self._server_started.set_result(None)
-        except zmq.error.ZMQError as e:
+        except zmq.error.ZMQBaseError as e:
             logger.error(f"ZMQ error encountered {e} during evaluator initialization")
             self._server_started.set_exception(e)
             zmq_context.destroy(linger=0)

--- a/src/ert/ensemble_evaluator/evaluator_connection_info.py
+++ b/src/ert/ensemble_evaluator/evaluator_connection_info.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class EvaluatorConnectionInfo:
-    """Read only server-info"""
-
-    router_uri: str
-    token: str | None = None

--- a/src/ert/ensemble_evaluator/monitor.py
+++ b/src/ert/ensemble_evaluator/monitor.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from _ert.events import (
     EETerminated,
@@ -16,10 +16,6 @@ from _ert.events import (
 )
 from _ert.forward_model_runner.client import Client
 
-if TYPE_CHECKING:
-    from ert.ensemble_evaluator.evaluator_connection_info import EvaluatorConnectionInfo
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -30,15 +26,11 @@ class EventSentinel:
 class Monitor(Client):
     _sentinel: Final = EventSentinel()
 
-    def __init__(self, ee_con_info: EvaluatorConnectionInfo) -> None:
+    def __init__(self, uri: str, token: str | None = None) -> None:
         self._id = str(uuid.uuid1()).split("-", maxsplit=1)[0]
         self._event_queue: asyncio.Queue[Event | EventSentinel] = asyncio.Queue()
         self._receiver_timeout: float = 60.0
-        super().__init__(
-            ee_con_info.router_uri,
-            ee_con_info.token,
-            dealer_name=f"client-{self._id}",
-        )
+        super().__init__(uri, token, dealer_name=f"client-{self._id}")
 
     async def process_message(self, msg: str) -> None:
         event = event_from_json(msg)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -348,13 +348,8 @@ class RunDialog(QFrame):
             self._snapshot_model.reset()
             self._tab_widget.clear()
 
-        port_range = None
-        use_ipc_protocol = False
-        if self._run_model.queue_system == QueueSystem.LOCAL:
-            port_range = range(49152, 51819)
-            use_ipc_protocol = True
         evaluator_server_config = EvaluatorServerConfig(
-            custom_port_range=port_range, use_ipc_protocol=use_ipc_protocol
+            use_ipc_protocol=self._run_model.queue_system == QueueSystem.LOCAL
         )
 
         def run() -> None:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -503,7 +503,7 @@ class BaseRunModel(ABC):
     ) -> bool:
         try:
             logger.debug("connecting to new monitor...")
-            async with Monitor(ee_config.get_connection_info()) as monitor:
+            async with Monitor(ee_config.get_uri(), ee_config.token) as monitor:
                 logger.debug("connected")
                 async for event in monitor.track(heartbeat_interval=0.1):
                     if type(event) in {

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -95,9 +95,7 @@ def run_server(
     if args is None:
         args = parse_args()
 
-    if "ERT_STORAGE_TOKEN" in os.environ:
-        authtoken = os.environ["ERT_STORAGE_TOKEN"]
-    else:
+    if (authtoken := os.environ.get("ERT_STORAGE_TOKEN")) is None:
         authtoken = generate_authtoken()
         os.environ["ERT_STORAGE_TOKEN"] = authtoken
 
@@ -106,9 +104,7 @@ def run_server(
         config_args.update(reload=True, reload_dirs=[os.path.dirname(ert_shared_path)])
         os.environ["ERT_STORAGE_DEBUG"] = "1"
 
-    sock = find_available_socket(
-        custom_host=args.host, custom_range=range(51850, 51870)
-    )
+    sock = find_available_socket(host=args.host, port_range=range(51850, 51870 + 1))
     connection_info = _create_connection_info(sock, authtoken)
 
     # Appropriated from uvicorn.main:run

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -85,7 +85,7 @@ class ExperimentRunner(threading.Thread):
             evaluator_server_config = EvaluatorServerConfig()
         else:
             evaluator_server_config = EvaluatorServerConfig(
-                custom_port_range=range(49152, 51819), use_ipc_protocol=False
+                port_range=(49152, 51819), use_ipc_protocol=False
             )
 
         try:

--- a/tests/ert/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/conftest.py
@@ -170,6 +170,6 @@ def _dump_forward_model(forward_model, index):
 @pytest.fixture(name="make_ee_config")
 def make_ee_config_fixture():
     def _ee_config(**kwargs):
-        return EvaluatorServerConfig(custom_port_range=range(1024, 65535), **kwargs)
+        return EvaluatorServerConfig(**kwargs)
 
     return _ee_config

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator_config.py
@@ -4,34 +4,30 @@ from ert.ensemble_evaluator.config import EvaluatorServerConfig
 
 
 def test_ensemble_evaluator_config_tcp_protocol(unused_tcp_port):
-    fixed_port = range(unused_tcp_port, unused_tcp_port)
+    fixed_port = (unused_tcp_port, unused_tcp_port + 1)
     serv_config = EvaluatorServerConfig(
-        custom_port_range=fixed_port,
-        custom_host="127.0.0.1",
+        port_range=fixed_port,
+        host="127.0.0.1",
         use_ipc_protocol=False,
     )
+    serv_config.router_port = unused_tcp_port
     expected_host = "127.0.0.1"
     expected_port = unused_tcp_port
     expected_url = f"tcp://{expected_host}:{expected_port}"
 
-    url = urlparse(serv_config.url)
+    url = urlparse(serv_config.get_uri())
     assert url.hostname == expected_host
     assert url.port == expected_port
-    assert serv_config.url == expected_url
+    assert serv_config.get_uri() == expected_url
     assert serv_config.token is not None
     assert serv_config.server_public_key is not None
     assert serv_config.server_secret_key is not None
-    sock = serv_config.get_socket()
-    assert sock is not None
-    assert not sock._closed
-    sock.close()
 
 
 def test_ensemble_evaluator_config_ipc_protocol():
     serv_config = EvaluatorServerConfig(use_ipc_protocol=True, use_token=False)
 
-    assert serv_config.url.startswith("ipc:///tmp/socket-")
+    assert serv_config.get_uri().startswith("ipc:///tmp/socket-")
     assert serv_config.token is None
     assert serv_config.server_public_key is None
     assert serv_config.server_secret_key is None
-    assert serv_config.get_socket() is None

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -35,17 +35,12 @@ async def test_run_legacy_ensemble(
     tmpdir, make_ensemble, monkeypatch, evaluator_to_use
 ):
     num_reals = 2
-    custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():
         ensemble = make_ensemble(monkeypatch, tmpdir, num_reals, 2)
-        config = EvaluatorServerConfig(
-            custom_port_range=custom_port_range,
-            custom_host="127.0.0.1",
-            use_token=False,
-        )
+        config = EvaluatorServerConfig(use_token=False)
         async with (
             evaluator_to_use(ensemble, config) as evaluator,
-            Monitor(config.get_connection_info()) as monitor,
+            Monitor(config.get_uri(), config.token) as monitor,
         ):
             async for event in monitor.track():
                 if type(event) in {
@@ -70,20 +65,15 @@ async def test_run_and_cancel_legacy_ensemble(
     tmpdir, make_ensemble, monkeypatch, evaluator_to_use
 ):
     num_reals = 2
-    custom_port_range = range(1024, 65535)
     with tmpdir.as_cwd():
         ensemble = make_ensemble(monkeypatch, tmpdir, num_reals, 2, job_sleep=40)
-        config = EvaluatorServerConfig(
-            custom_port_range=custom_port_range,
-            custom_host="127.0.0.1",
-            use_token=False,
-        )
+        config = EvaluatorServerConfig(use_token=False)
 
         terminated_event = False
 
         async with (
             evaluator_to_use(ensemble, config) as evaluator,
-            Monitor(config.get_connection_info()) as monitor,
+            Monitor(config.get_uri(), config.token) as monitor,
         ):
             # on lesser hardware the realizations might be killed by max_runtime
             # and the ensemble is set to STOPPED

--- a/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
@@ -16,7 +16,7 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
     tmpdir, make_ensemble, monkeypatch, caplog
 ):
     num_reals = 1
-    custom_port_range = range(1024, 65535)
+    port_range = (1024, 65535)
 
     async def rename_and_wait():
         Path("real_0/job_test_file").rename("real_0/test")
@@ -25,7 +25,7 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
         Path("real_0/test").rename("real_0/job_test_file")
 
     async def _run_monitor():
-        async with Monitor(config.get_connection_info()) as monitor:
+        async with Monitor(config.get_uri(), config.token) as monitor:
             async for event in monitor.track():
                 if type(event) is ForwardModelStepChecksum:
                     # Monitor got the checksum message renaming the file
@@ -57,8 +57,8 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
         file_path.write_text("test")
         # actual_md5sum = hashlib.md5(file_path.read_bytes()).hexdigest()
         config = EvaluatorServerConfig(
-            custom_port_range=custom_port_range,
-            custom_host="127.0.0.1",
+            port_range=port_range,
+            host="127.0.0.1",
             use_token=False,
         )
         evaluator = EnsembleEvaluator(ensemble, config)

--- a/tests/ert/unit_tests/shared/test_port_handler.py
+++ b/tests/ert/unit_tests/shared/test_port_handler.py
@@ -1,6 +1,5 @@
 import contextlib
 import socket
-import sys
 import threading
 
 import pytest
@@ -50,22 +49,22 @@ def test_that_get_machine_name_is_predictive(mocker):
 
 
 def test_find_available_socket(unused_tcp_port):
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-    sock = find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
+    port_range = range(unused_tcp_port, unused_tcp_port + 1)
+    sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     (
         host,
         port,
     ) = sock.getsockname()
     assert host is not None
     assert port is not None
-    assert port in custom_range
+    assert port in port_range
     assert sock is not None
     assert sock.fileno() != -1
 
 
 def test_find_available_socket_forced(unused_tcp_port):
-    custom_range = range(unused_tcp_port, unused_tcp_port)
-    sock = find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
+    port_range = range(unused_tcp_port, unused_tcp_port)
+    sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     (
         _,
         port,
@@ -79,7 +78,7 @@ def test_invalid_host_name():
     invalid_host = "invalid_host"
 
     with pytest.raises(InvalidHostException) as exc_info:
-        find_available_socket(custom_host=invalid_host)
+        find_available_socket(host=invalid_host)
 
     assert (
         "Trying to bind socket with what looks "
@@ -99,31 +98,20 @@ def test_get_family():
 
 
 def test_gc_closes_socket(unused_tcp_port):
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
+    port_range = range(unused_tcp_port, unused_tcp_port + 1)
 
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
+    orig_sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     _, port = orig_sock.getsockname()
     assert port == unused_tcp_port
     assert orig_sock is not None
     assert orig_sock.fileno() != -1
 
     with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            will_close_then_reopen_socket=True,
-            custom_host="127.0.0.1",
-        )
+        find_available_socket(port_range=port_range, host="127.0.0.1")
 
     orig_sock = None
 
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
+    orig_sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     _, port = orig_sock.getsockname()
     assert port == unused_tcp_port
     assert orig_sock is not None
@@ -161,94 +149,35 @@ def _simulate_server(host, port, sock: socket.socket):
     assert getattr(dummy_server, "data", None) == "Hi there"
 
 
-# Tests below checks results of trying to get a new socket on an
-# already used port over permutations of 3 (boolean) parameters:
-#
-#     - mode when obtaining the first socket (default/reuse)
-#     - activity on original socket or whether it is never used
-#     - original socket live or closed
-#
-# The test-names encodes the permutation, the platform and finally
-# whether subsequent calls to find_available_socket() succeeds with
-# default-mode and/or reuse-mode. For example:
-#
-#     test_def_active_close_macos_nok_ok
-#
-# means obtaining first socket in default-mode, activate it and
-# then close it. On MacOS, trying to obtain it in default mode
-# fails (nok) whereas obtaining it with reuse-flag succeeds (ok)
-#
-#
-# Test identifier                           | mode  | activated | live
-# ------------------------------------------+-------+-----------+------
-# test_def_passive_live_nok_nok_close_ok_ok | def   | false     | both
-#
-# test_def_active_live_nok_nok              | def   | true      | true
-# test_def_active_close_macos_nok_ok        | def   | true      | false
-# test_def_active_close_linux_nok_nok       | def   | true      | false
-#
-# test_reuse_passive_live_macos_nok_nok     | reuse | false     | true
-# test_reuse_passive_live_linux_nok_ok      | reuse | false     | true
-# test_reuse_passive_close_ok_ok            | reuse | false     | false
-# test_reuse_active_live_nok_nok            | reuse | true      | true
-# test_reuse_active_close_nok_ok            | reuse | true      | false
-#
-#
-# Note the behaviour of the first test: The recommended practice
-# is to obtain the port/socket in default mode, keep the socket
-# alive as long as the port is needed and provide dup() of the
-# socket-object to other modules. If the other module cannot use
-# an already bound socket, close the UN-ACTIVATED socket, give
-# the port-number to the module and hope that no-one else grabs
-# the port in the meantime. :)
-#
-# If you (for whatever obscure reason) activated the socket (i.e.
-# some communication happened on the socket) and THEN provides
-# the port-number to another module, you're on the last test and
-# have to use reuse-mode when obtaining the first socket, and pray
-# that the other module set SO_REUSEADDR before attempting to bind
-# its socket.
-
-
-def test_def_passive_live_nok_nok_close_ok_ok(unused_tcp_port):
+def test_socket_can_rebind_if_never_used(unused_tcp_port):
     """
     Executive summary of this test
 
-    1. the original socket is obtained in default, recommended mode
+    1. the original socket is obtained
     2. no activity is triggered on the socket
     3. port is not closed but kept alive
     4. port can not be re-bound in any mode while socket-object is live
     5. port is closed
     6. after socket is closed the port can immediately be re-bound in any mode
     """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
+    port_range = range(unused_tcp_port, unused_tcp_port + 1)
 
     # Opening original socket with will_close_then_reopen_socket=False
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
+    orig_sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     _, port = orig_sock.getsockname()
     assert port == unused_tcp_port
     assert orig_sock is not None
     assert orig_sock.fileno() != -1
 
-    # When the socket is kept open, this port can not be reused
-    # with or without setting will_close_then_reopen_socket
+    # When the socket is kept open
     with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            custom_host="127.0.0.1",
-            will_close_then_reopen_socket=True,
-        )
+        find_available_socket(port_range=port_range, host="127.0.0.1")
 
     orig_sock.close()
 
     # When we close the socket without actually having used it, it is
-    # immediately reusable with or without setting will_close_then_reopen_socket
-    sock = find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
+    # immediately reusable
+    sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     _, port = sock.getsockname()
     assert port == unused_tcp_port
     assert sock is not None
@@ -257,112 +186,25 @@ def test_def_passive_live_nok_nok_close_ok_ok(unused_tcp_port):
     # we want to try again, so close it
     sock.close()
 
-    sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
+    sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     _, port = sock.getsockname()
     assert port == unused_tcp_port
     assert sock is not None
     assert sock.fileno() != -1
 
 
-def test_reuse_active_close_nok_ok(unused_tcp_port):
+def test_socket_can_not_rebind_if_open(unused_tcp_port):
     """
     Executive summary of this test
 
-    1. the original socket is obtained with will_close_then_reopen_socket=True
-    2. activity is triggered on the socket using a dummy-server/client
-    3. socket is closed
-    4. port can not be re-bound in default mode (TIME_WAIT?)...
-    5. ... but can with will_close_then_reopen_socket=True (ignoring TIME_WAIT)
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    # Note: Setting will_close_then_reopen_socket=True on original socket
-    orig_sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    host, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    # Run a dummy-server to actually use the socket a little, then close it
-    _simulate_server(host, port, orig_sock)
-    orig_sock.close()
-
-    # Using will_close_then_reopen_socket=False fails...
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # ... but using will_close_then_reopen_socket=True succeeds
-    sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    host, port = sock.getsockname()
-    assert port == unused_tcp_port
-    assert sock is not None
-    assert sock.fileno() != -1
-
-
-def test_reuse_active_live_nok_nok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained with will_close_then_reopen_socket=True
+    1. the original socket is obtained
     2. activity is triggered on the socket using a dummy-server/client
     3. socket is not closed but kept alive
-    4. port can not be re-bound in default mode (TIME_WAIT?)...
-    5. ... but can with will_close_then_reopen_socket=True (ignoring TIME_WAIT)
+    4. port can not be re-bound while socket-object is live
     """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
+    port_range = range(unused_tcp_port, unused_tcp_port + 1)
 
-    orig_sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    host, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    # Run a dummy-server to actually use the socket a little, then close it
-    _simulate_server(host, port, orig_sock)
-
-    # Even with "will_close_then_reopen_socket"=True when obtaining original
-    # socket, subsequent calls fails
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            custom_host="127.0.0.1",
-            will_close_then_reopen_socket=True,
-        )
-
-
-def test_def_active_live_nok_nok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained in default, recommended mode
-    2. activity is triggered on the socket using a dummy-server/client
-    3. socket is not closed but kept alive
-    4. port can not be re-bound in any mode while socket-object is live
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
+    orig_sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     host, port = orig_sock.getsockname()
     assert port == unused_tcp_port
     assert orig_sock is not None
@@ -373,38 +215,22 @@ def test_def_active_live_nok_nok(unused_tcp_port):
 
     # Immediately trying to bind to the same port fails...
     with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # ... also using will_close_then_reopen_socket=True
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            custom_host="127.0.0.1",
-            will_close_then_reopen_socket=True,
-        )
+        find_available_socket(port_range=port_range, host="127.0.0.1")
 
 
 @pytest.mark.integration_test
-@pytest.mark.skipif(
-    not sys.platform.startswith("darwin"), reason="MacOS-specific socket behaviour"
-)
-def test_def_active_close_macos_nok_ok(unused_tcp_port):
+def test_socket_can_not_rebind_immediately_after_close_if_used(unused_tcp_port):
     """
     Executive summary of this test
 
-    1. the original socket is obtained in default, recommended mode
+    1. the original socket is obtained
     2. activity is triggered on the socket using a dummy-server/client
     3. socket is closed
-    4. after socket is closed the port can not be re-bound in
-       default mode (TIME_WAIT?)...
-    5. ...but it can be re-bound with will_close_then_reopen_socket=True
-       (ignoring TIME_WAIT)
+    4. after socket is closed the port can not be re-bound immediately due to TIME_WAIT
     """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
+    port_range = range(unused_tcp_port, unused_tcp_port + 1)
 
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
+    orig_sock = find_available_socket(port_range=port_range, host="127.0.0.1")
     host, port = orig_sock.getsockname()
     assert port == unused_tcp_port
     assert orig_sock is not None
@@ -416,185 +242,4 @@ def test_def_active_close_macos_nok_ok(unused_tcp_port):
 
     # Immediately trying to bind to the same port fails
     with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # On MacOS, setting will_close_then_reopen_socket=True in subsequent calls allows
-    # to reuse the port
-    sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    host, port = sock.getsockname()
-    assert port == unused_tcp_port
-    assert sock is not None
-    assert sock.fileno() != -1
-
-
-@pytest.mark.integration_test
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"), reason="Linux-specific socket behaviour"
-)
-def test_def_active_close_linux_nok_nok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained in default, recommended mode
-    2. activity is triggered on the socket using a dummy-server/client
-    3. socket is closed
-    4. after socket is closed the port can not be re-bound in
-       default mode (TIME_WAIT?)...
-    5. ...nor with will_close_then_reopen_socket=True (not ignoring TIME_WAIT?)
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    orig_sock = find_available_socket(
-        custom_range=custom_range, custom_host="127.0.0.1"
-    )
-    host, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    # Now, run a dummy-server to actually use the socket a little, then close it
-    _simulate_server(host, port, orig_sock)
-    orig_sock.close()
-
-    # Immediately trying to bind to the same port fails
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # On Linux, setting will_close_then_reopen_socket=True in subsequent calls do
-    # NOT allow reusing the port in this case
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            custom_host="127.0.0.1",
-            will_close_then_reopen_socket=True,
-        )
-
-
-@pytest.mark.integration_test
-@pytest.mark.skipif(
-    not sys.platform.startswith("darwin"), reason="MacOS-specific socket behaviour"
-)
-def test_reuse_passive_live_macos_nok_nok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained with will_close_then_reopen_socket=True
-    2. no activity is triggered on the socket
-    3. the socket is not closed but kept alive
-    4. port can not be re-bound in any mode
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    orig_sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    _, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    # As long as the socket is kept alive this port can not be bound again...
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # ... not even when setting will_close_then_reopen_socket=True
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(
-            custom_range=custom_range,
-            custom_host="127.0.0.1",
-            will_close_then_reopen_socket=True,
-        )
-
-
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"), reason="Linux-specific socket behaviour"
-)
-def test_reuse_passive_live_linux_nok_ok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained with will_close_then_reopen_socket=True
-    2. no activity is triggered on the socket
-    3. the socket is not closed but kept alive
-    4. port can not be re-bound in default mode...
-    5. ... but can with will_close_then_reopen_socket=True
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    # Opening original socket with will_close_then_reopen_socket=True
-    orig_sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    _, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    # As long as the socket is kept alive this port can not be bound again...
-    with pytest.raises(NoPortsInRangeException):
-        find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-
-    # ... but on Linux the port can be re-bound by setting this flag!
-    # This does not seem safe in a multi-user/-process environment!
-    sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    _, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert sock is not None
-    assert sock.fileno() != -1
-
-
-def test_reuse_passive_close_ok_ok(unused_tcp_port):
-    """
-    Executive summary of this test
-
-    1. the original socket is obtained with will_close_then_reopen_socket=True
-    2. no activity is triggered on the socket
-    3. the socket is closed
-    4. port can be re-bound in any mode
-    """
-    custom_range = range(unused_tcp_port, unused_tcp_port + 1)
-
-    orig_sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    _, port = orig_sock.getsockname()
-    assert port == unused_tcp_port
-    assert orig_sock is not None
-    assert orig_sock.fileno() != -1
-
-    orig_sock.close()
-
-    # When we close the socket without actually having used it, it is
-    # immediately reusable with or without setting will_close_then_reopen_socket
-    sock = find_available_socket(custom_range=custom_range, custom_host="127.0.0.1")
-    _, port = sock.getsockname()
-    assert port == unused_tcp_port
-    assert sock is not None
-    assert sock.fileno() != -1
-
-    # we want to try again, so close it
-    sock.close()
-
-    sock = find_available_socket(
-        custom_range=custom_range,
-        custom_host="127.0.0.1",
-        will_close_then_reopen_socket=True,
-    )
-    _, port = sock.getsockname()
-    assert port == unused_tcp_port
-    assert sock is not None
-    assert sock.fileno() != -1
+        find_available_socket(port_range=port_range, host="127.0.0.1")

--- a/tests/ert/unit_tests/test_tracking.py
+++ b/tests/ert/unit_tests/test_tracking.py
@@ -184,11 +184,7 @@ def test_tracking(
         queue,
     )
 
-    evaluator_server_config = EvaluatorServerConfig(
-        custom_port_range=range(1024, 65535),
-        custom_host="127.0.0.1",
-        use_token=False,
-    )
+    evaluator_server_config = EvaluatorServerConfig(use_token=False)
 
     thread = ErtThread(
         name="ert_cli_simulation_thread",
@@ -274,11 +270,7 @@ def test_setting_env_context_during_run(
     ert_config = ErtConfig.from_file(parsed.config)
     os.chdir(ert_config.config_path)
 
-    evaluator_server_config = EvaluatorServerConfig(
-        custom_port_range=range(1024, 65535),
-        custom_host="127.0.0.1",
-        use_token=False,
-    )
+    evaluator_server_config = EvaluatorServerConfig(use_token=False)
     queue = Events()
     model = create_model(
         ert_config,
@@ -350,11 +342,7 @@ def test_run_information_present_as_env_var_in_fm_context(
     ert_config = ErtConfig.from_file(parsed.config)
     os.chdir(ert_config.config_path)
 
-    evaluator_server_config = EvaluatorServerConfig(
-        custom_port_range=range(1024, 65535),
-        custom_host="127.0.0.1",
-        use_token=False,
-    )
+    evaluator_server_config = EvaluatorServerConfig(use_token=False)
     queue = Events()
     model = create_model(ert_config, storage, parsed, queue)
 

--- a/tests/everest/test_simulator_cache.py
+++ b/tests/everest/test_simulator_cache.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from ert.config import QueueSystem
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
@@ -22,12 +21,7 @@ def test_simulator_cache(copy_math_func_test_data_to_tmp):
     config = EverestConfig.model_validate(config_dict)
 
     run_model = EverestRunModel.create(config)
-
-    evaluator_server_config = EvaluatorServerConfig(
-        custom_port_range=range(49152, 51819)
-        if run_model._queue_config.queue_system == QueueSystem.LOCAL
-        else None
-    )
+    evaluator_server_config = EvaluatorServerConfig()
 
     # Modify the forward model function to track number of calls:
     original_call = run_model._forward_model_evaluator


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/9906
Resolves https://github.com/equinor/ert/issues/9987


**Approach**
use zmq's bind_to_random_port instead of finding a port first and then trying to rebind it later.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
