### PR TITLE
Skip reporter if dispatch_url is None

### DIFF
--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -41,7 +41,10 @@ def _setup_reporters(
         reporters.append(reporting.Interactive())
     elif ens_id and experiment_id is None:
         reporters.append(reporting.File())
-        reporters.append(reporting.Event(evaluator_url=dispatch_url, token=ee_token))
+        if dispatch_url is not None:
+            reporters.append(
+                reporting.Event(evaluator_url=dispatch_url, token=ee_token)
+            )
     else:
         reporters.append(reporting.File())
     return reporters


### PR DESCRIPTION
If jobs.json is manually edited and the url is removed (this is relevant when running fm_dispatch manually after the evaluator is shut down), this change avoids a crash (TypeError) when zmq is asked to connect using None as the url.



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
