### PR TITLE
Only log to terminal when starting dark storage through ert api

### DIFF
--- a/src/ert/logging/storage_log.conf
+++ b/src/ert/logging/storage_log.conf
@@ -31,7 +31,7 @@ loggers:
       level: INFO
     ert.shared.storage.info:
       level: INFO
-      handlers: [infohandler, file]
+      handlers: [file]
       propagate: True
     ert.shared.status:
       level: INFO

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -124,8 +124,14 @@ def run_server(
     server = Server(config, json.dumps(connection_info))
 
     logger = logging.getLogger("ert.shared.storage.info")
-    if args.verbose and logger.level > logging.INFO:
-        logger.setLevel(logging.INFO)
+    if args.verbose:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter("%(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        if logger.level > logging.INFO:
+            logger.setLevel(logging.INFO)
     logger.info("Storage server is ready to accept requests. Listening on:")
     for url in connection_info["urls"]:
         logger.info(f"  {url}")


### PR DESCRIPTION
**Issue**
Resolves #9707 


Utilize the fact that we start dark storage with  verbose=True, when running `ert api`.

```
ert api starts dark storage through:
def run_ert_storage(args: Namespace, _: ErtPluginManager | None = None) -> None:
    with StorageService.start_server(
        verbose=True,
        project=ErtConfig.from_file(args.config).ens_path,
        parent_pid=os.getpid(),
    ) as server:
        server.wait()
```


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
