### PR TITLE
Remove evaluator_server_config_generator fixture

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 import yaml
 
-from ert.config import ConfigWarning, QueueSystem
+from ert.config import ConfigWarning
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
@@ -145,19 +145,7 @@ def change_to_tmpdir(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def evaluator_server_config_generator():
-    def create_evaluator_server_config(run_model):
-        return EvaluatorServerConfig(
-            custom_port_range=range(49152, 51819)
-            if run_model._queue_config.queue_system == QueueSystem.LOCAL
-            else None
-        )
-
-    return create_evaluator_server_config
-
-
-@pytest.fixture
-def cached_example(pytestconfig, evaluator_server_config_generator):
+def cached_example(pytestconfig):
     cache = pytestconfig.cache
 
     def run_config(test_data_case: str):
@@ -171,7 +159,7 @@ def cached_example(pytestconfig, evaluator_server_config_generator):
             shutil.copytree(config_path.parent, my_tmpdir / "everest")
             config = EverestConfig.load_file(my_tmpdir / "everest" / config_file)
             run_model = EverestRunModel.create(config)
-            evaluator_server_config = evaluator_server_config_generator(run_model)
+            evaluator_server_config = EvaluatorServerConfig()
             try:
                 run_model.run_experiment(evaluator_server_config)
             except Exception as e:
@@ -208,7 +196,8 @@ def cached_example(pytestconfig, evaluator_server_config_generator):
 @pytest.fixture
 def min_config():
     yield yaml.safe_load(
-        dedent("""
+        dedent(
+            """
     model: {"realizations": [0]}
     controls:
       -
@@ -221,7 +210,8 @@ def min_config():
     objective_functions:
       - {name: my_objective}
     config_path: .
-    """)
+    """
+        )
     )
 
 

--- a/tests/everest/test_cvar.py
+++ b/tests/everest/test_cvar.py
@@ -1,15 +1,12 @@
 import pytest
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
-from everest.config import (
-    EverestConfig,
-)
+from everest.config import EverestConfig
 
 
 @pytest.mark.integration_test
-def test_mathfunc_cvar(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_mathfunc_cvar(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file("config_minimal.yml")
     config_dict = {
         **config.model_dump(exclude_none=True),
@@ -27,7 +24,7 @@ def test_mathfunc_cvar(
     config = EverestConfig.model_validate(config_dict)
     # Act
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Assert

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -1,15 +1,12 @@
 import pytest
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
-from everest.config import (
-    EverestConfig,
-)
+from everest.config import EverestConfig
 
 
 @pytest.mark.integration_test
-def test_discrete_optimizer(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_discrete_optimizer(copy_math_func_test_data_to_tmp):
     # Arrange
     config = EverestConfig.load_file("config_minimal.yml")
     config_dict = {
@@ -41,7 +38,7 @@ def test_discrete_optimizer(
     config = EverestConfig.model_validate(config_dict)
     # Act
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Assert

--- a/tests/everest/test_fix_control.py
+++ b/tests/everest/test_fix_control.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 
@@ -7,15 +8,13 @@ CONFIG_FILE_ADVANCED = "config_advanced.yml"
 
 
 @pytest.mark.integration_test
-def test_fix_control(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_fix_control(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE_ADVANCED)
     config.controls[0].variables[0].enabled = False
     config.optimization.max_batch_num = 2
 
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Check that the first variable remains fixed:

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 from everest.everest_storage import EverestStorage
@@ -65,9 +66,7 @@ def test_math_func_advanced(cached_example):
 
 
 @pytest.mark.integration_test
-def test_remove_run_path(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_remove_run_path(copy_math_func_test_data_to_tmp):
     with open("config_minimal.yml", encoding="utf-8") as file:
         config_yaml = yaml.safe_load(file)
         config_yaml["simulator"] = {"delete_run_path": True}
@@ -82,7 +81,7 @@ def test_remove_run_path(
     simulation_dir = config.simulation_dir
 
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Check the failed simulation folder still exists
@@ -104,7 +103,7 @@ def test_remove_run_path(
 
     config.simulator.delete_run_path = False
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Check the all simulation folder exist when delete_run_path is set to False
@@ -122,9 +121,7 @@ def test_remove_run_path(
 
 
 @pytest.mark.integration_test
-def test_math_func_auto_scaled_controls(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_math_func_auto_scaled_controls(copy_math_func_test_data_to_tmp):
     # Arrange
     config = EverestConfig.load_file("config_minimal.yml")
     config.controls[0].auto_scale = True
@@ -144,7 +141,7 @@ def test_math_func_auto_scaled_controls(
 
     # Act
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Assert

--- a/tests/everest/test_multiobjective.py
+++ b/tests/everest/test_multiobjective.py
@@ -2,6 +2,7 @@ import pytest
 from ropt.config.enopt import EnOptConfig
 
 from ert.config import ErtConfig
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 from everest.optimizer.everest2ropt import everest2ropt
@@ -96,10 +97,8 @@ def test_multi_objectives2ropt(copy_mocked_test_data_to_tmp):
 
 
 @pytest.mark.integration_test
-def test_multi_objectives_run(
-    copy_mocked_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_multi_objectives_run(copy_mocked_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)

--- a/tests/everest/test_objective_type.py
+++ b/tests/everest/test_objective_type.py
@@ -1,15 +1,12 @@
 import pytest
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
-from everest.config import (
-    EverestConfig,
-)
+from everest.config import EverestConfig
 
 
 @pytest.mark.integration_test
-def test_objective_type(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_objective_type(copy_math_func_test_data_to_tmp):
     # Arrange
     config = EverestConfig.load_file("config_minimal.yml")
     config_dict = {
@@ -26,7 +23,7 @@ def test_objective_type(
     config = EverestConfig.model_validate(config_dict)
     # Act
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # Assert

--- a/tests/everest/test_output_constraints.py
+++ b/tests/everest/test_output_constraints.py
@@ -4,6 +4,7 @@ import pytest
 from ropt.config.enopt import EnOptConfig
 from ropt.enums import ConstraintType
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 from everest.optimizer.everest2ropt import everest2ropt
@@ -227,10 +228,8 @@ def test_upper_bound_output_constraint_def(copy_mocked_test_data_to_tmp):
 
 
 @pytest.mark.integration_test
-def test_sim_output_constraints(
-    copy_mocked_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_sim_output_constraints(copy_mocked_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -6,6 +6,7 @@ import pytest
 from ruamel.yaml import YAML
 
 import everest
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 
@@ -127,12 +128,10 @@ def test_render_executable(copy_template_test_data_to_tmp):
 
 
 @pytest.mark.integration_test
-def test_install_template(
-    copy_template_test_data_to_tmp, evaluator_server_config_generator
-):
+def test_install_template(copy_template_test_data_to_tmp):
     config = EverestConfig.load_file(TMPL_CONFIG_FILE)
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
 
@@ -170,7 +169,7 @@ def test_well_order_template(change_to_tmpdir):
 
 @pytest.mark.integration_test
 def test_user_specified_data_n_template(
-    copy_math_func_test_data_to_tmp, evaluator_server_config_generator
+    copy_math_func_test_data_to_tmp,
 ):
     """
     Ensure that a user specifying a data resource and an installed_template
@@ -220,7 +219,7 @@ def test_user_specified_data_n_template(
     config = EverestConfig.with_defaults(**updated_config_dict)
 
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     # The data should have been loaded and passed through template to file.

--- a/tests/everest/test_workflows.py
+++ b/tests/everest/test_workflows.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
 from everest.config import EverestConfig
 from tests.everest.utils import relpath, skipif_no_everest_models
@@ -12,11 +13,11 @@ CONFIG_FILE = "config_workflow.yml"
 
 
 @pytest.mark.integration_test
-def test_workflow_run(copy_mocked_test_data_to_tmp, evaluator_server_config_generator):
+def test_workflow_run(copy_mocked_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
 
     run_model = EverestRunModel.create(config)
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
     for name in ("pre_simulation", "post_simulation"):
@@ -34,14 +35,13 @@ def test_workflow_run(copy_mocked_test_data_to_tmp, evaluator_server_config_gene
 def test_state_modifier_workflow_run(
     config: str,
     copy_testdata_tmpdir: Callable[[str | None], Path],
-    evaluator_server_config_generator,
 ) -> None:
     cwd = copy_testdata_tmpdir("open_shut_state_modifier")
 
     run_model = EverestRunModel.create(
         EverestConfig.load_file(f"everest/model/{config}.yml")
     )
-    evaluator_server_config = evaluator_server_config_generator(run_model)
+    evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
     paths = list(Path.cwd().glob("**/simulation_0/RESULT.SCH"))
     assert paths


### PR DESCRIPTION
**Issue**
`evaluator_server_config_generator` is no longer required as LOCAL runs exploit ipc protocol (no ports are involved). 


**Approach**
:scissors: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
