### PR TITLE
Remove superfluous logging of ensemble id

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -160,8 +160,7 @@ class LegacyEnsemble:
                 f"{cpu_seconds=} "
                 f"{current_memory_usage=} "
                 f"step_index={event.fm_step} "
-                f"real={event.real} "
-                f"ensemble={event.ensemble}"
+                f"real={event.real}"
             )
 
     def update_snapshot(self, events: Sequence[Event]) -> EnsembleSnapshot:


### PR DESCRIPTION
As logging is done with spans active, this is not needed and only adds noise

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
