### PR TITLE
Reimplement output constraint scaling

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -34,6 +34,7 @@ from everest.config.utils import FlattenedControls
 from everest.everest_storage import EverestStorage, OptimalResult
 from everest.optimizer.everest2ropt import everest2ropt
 from everest.optimizer.opt_model_transforms import (
+    ConstraintScaler,
     ObjectiveScaler,
     get_optimization_domain_transforms,
 )
@@ -223,20 +224,39 @@ class EverestRunModel(BaseRunModel):
         transforms = get_optimization_domain_transforms(
             self._everest_config.controls,
             self._everest_config.objective_functions,
+            self._everest_config.output_constraints,
             realization_weights,
         )
         # If required, initialize auto-scaling:
         assert isinstance(transforms.objectives, ObjectiveScaler)
-        if transforms.objectives.has_auto_scale:
-            objectives, _, _ = self._run_forward_model(
+        assert transforms.nonlinear_constraints is None or isinstance(
+            transforms.nonlinear_constraints, ConstraintScaler
+        )
+        if transforms.objectives.has_auto_scale or (
+            transforms.nonlinear_constraints
+            and transforms.nonlinear_constraints.has_auto_scale
+        ):
+            # Run the forward model once to find the objective/constraint values
+            # to compute the scales. This will add an ensemble/batch in the
+            # storage that is not part of the optimization run. However, the
+            # results may be used in the optimization via the caching mechanism.
+            objectives, constraints, _ = self._run_forward_model(
                 np.repeat(np.expand_dims(variables, axis=0), nreal, axis=0),
                 realizations,
             )
-            transforms.objectives.calculate_auto_scales(objectives)
+            if transforms.objectives.has_auto_scale:
+                transforms.objectives.calculate_auto_scales(objectives)
+            if (
+                transforms.nonlinear_constraints
+                and transforms.nonlinear_constraints.has_auto_scale
+            ):
+                assert constraints is not None
+                transforms.nonlinear_constraints.calculate_auto_scales(constraints)
         return transforms
 
     def _create_optimizer(self) -> BasicOptimizer:
-        # Initialize the optimization model transforms:
+        # Initialize the optimization model transforms. This may run one initial
+        # ensemble for auto-scaling purposes:
         transforms = self._init_transforms(
             np.asarray(
                 FlattenedControls(self._everest_config.controls).initial_guesses,

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -180,19 +180,12 @@ def _parse_output_constraints(
             raise RuntimeError(
                 "output constraint error: target cannot be combined with bounds"
             )
+        _add_output_constraint(target, ConstraintType.EQ)
         _add_output_constraint(
-            target,
-            ConstraintType.EQ,
+            upper_bound, ConstraintType.LE, None if lower_bound is None else "upper"
         )
         _add_output_constraint(
-            upper_bound,
-            ConstraintType.LE,
-            None if lower_bound is None else "upper",
-        )
-        _add_output_constraint(
-            lower_bound,
-            ConstraintType.GE,
-            None if upper_bound is None else "lower",
+            lower_bound, ConstraintType.GE, None if upper_bound is None else "lower"
         )
 
     ropt_config["nonlinear_constraints"] = {

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -159,8 +159,6 @@ def _parse_output_constraints(
         return
 
     rhs_values: list[float] = []
-    scales: list[float] = []
-    auto_scale: list[bool] = []
     types: list[ConstraintType] = []
 
     def _add_output_constraint(
@@ -168,8 +166,6 @@ def _parse_output_constraints(
     ):
         if rhs_value is not None:
             rhs_values.append(rhs_value)
-            scales.append(constr.scale if constr.scale is not None else 1.0)
-            auto_scale.append(constr.auto_scale or False)
             types.append(constraint_type)
 
     for constr in output_constraints:
@@ -190,8 +186,6 @@ def _parse_output_constraints(
 
     ropt_config["nonlinear_constraints"] = {
         "rhs_values": rhs_values,
-        "scales": scales,
-        "auto_scale": auto_scale,
         "types": types,
     }
 

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -99,7 +99,6 @@ def _parse_objectives(objective_functions: list[ObjectiveFunctionConfig], ropt_c
 
 
 def _parse_input_constraints(
-    controls: FlattenedControls,
     input_constraints: list[InputConstraintConfig] | None,
     formatted_control_names: list[str],
     formatted_control_names_dotdash: list[str],
@@ -350,12 +349,9 @@ def everest2ropt(
     """
     ropt_config: dict[str, Any] = {}
 
-    flattened_controls = FlattenedControls(ever_config.controls)
-
-    _parse_controls(flattened_controls, ropt_config)
+    _parse_controls(FlattenedControls(ever_config.controls), ropt_config)
     _parse_objectives(ever_config.objective_functions, ropt_config)
     _parse_input_constraints(
-        flattened_controls,
         ever_config.input_constraints,
         ever_config.formatted_control_names,
         ever_config.formatted_control_names_dotdash,

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -51,10 +51,10 @@
     "function_estimators": null,
     "realization_filters": null,
     "rhs_values": [
-      0.1
+      1.0
     ],
     "scales": [
-      0.1
+      1.0
     ],
     "types": [
       2

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -48,6 +48,7 @@ def test_everest2ropt_controls_auto_scale():
         transforms=get_optimization_domain_transforms(
             config.controls,
             config.objective_functions,
+            config.output_constraints,
             config.model.realizations_weights,
         ),
     )
@@ -65,6 +66,7 @@ def test_everest2ropt_variables_auto_scale():
         transforms=get_optimization_domain_transforms(
             config.controls,
             config.objective_functions,
+            config.output_constraints,
             config.model.realizations_weights,
         ),
     )
@@ -136,6 +138,7 @@ def test_everest2ropt_controls_input_constraint_auto_scale():
         transforms=get_optimization_domain_transforms(
             config.controls,
             config.objective_functions,
+            config.output_constraints,
             config.model.realizations_weights,
         ),
     )
@@ -280,6 +283,7 @@ def test_everest2ropt_snapshot(case, snapshot):
         transforms=get_optimization_domain_transforms(
             config.controls,
             config.objective_functions,
+            config.output_constraints,
             config.model.realizations_weights,
         ),
     ).model_dump()


### PR DESCRIPTION
**Issue**
This PR reimplements output constraint scaling

**Approach**
See #9985, a similar approach for objective scaling, this PR builds on top of that.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
