### PR TITLE
Filter out azure.monitor logs from terminal output

### DIFF
--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pathlib
 import sys
+from collections.abc import Callable
 from datetime import datetime
 from types import TracebackType
 from typing import Any
@@ -74,3 +75,15 @@ class TerminalFormatter(logging.Formatter):
         | tuple[None, None, None],
     ) -> str:
         return ""
+
+
+def suppresse_logs(logs_to_suppress: list[str]) -> Callable[[logging.LogRecord], bool]:
+    """Suppresses logs from loggers listed in logs_to_suppress"""
+
+    def filter(record: logging.LogRecord) -> bool:
+        for log_name in logs_to_suppress:
+            if record.name.startswith(log_name):
+                return False
+        return True
+
+    return filter

--- a/src/ert/logging/storage_log.conf
+++ b/src/ert/logging/storage_log.conf
@@ -5,12 +5,17 @@ formatters:
     format: '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
   info:
     format: '%(message)s'
+filters:
+  suppress_not_user_relevant:
+    (): ert.logging.suppresse_logs
+    logs_to_suppress: [azure.monitor]
 handlers:
   default:
     level: WARNING
     formatter: standard
     class: logging.StreamHandler
     stream: ext://sys.stdout
+    filters: [suppress_not_user_relevant]
   infohandler:
     level: INFO
     formatter: info


### PR DESCRIPTION
**Issue**
Resolves #9949 


**Approach**
Added filter to suppress logs to terminal, and verified locally.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
