### PR TITLE
Change XML field names in EXIT file from forward model

### DIFF
--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -174,7 +174,7 @@ class File(Reporter):
             file.write(
                 f"  <time>{time.strftime(TIME_FORMAT, time.localtime())}</time>\n"
             )
-            file.write(f"  <job>{fm_step.name()}</job>\n")
+            file.write(f"  <step>{fm_step.name()}</step>\n")
             file.write(f"  <reason>{error_msg}</reason>\n")
             stderr_file = None
             if fm_step.std_err:

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -342,7 +342,7 @@ def log_info_from_exit_file(exit_file_path: Path) -> None:
         )
         return
     filecontents: list[str] = []
-    for element in ["job", "reason", "stderr_file", "stderr"]:
+    for element in ["step", "reason", "stderr_file", "stderr"]:
         filecontents.append(str(exit_file.findtext(element)))
     logger.error(
         "job {} failed with: '{}'\n\tstderr file: '{}',\n\tits contents:{}".format(

--- a/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
@@ -116,7 +116,7 @@ def test_report_with_failed_exit_message_argument(reporter):
         assert "EXIT: 1/massive_failure" in f.readline()
     with open(ERROR_file, encoding="utf-8") as f:
         content = "".join(f.readlines())
-        assert "<job>fmstep1</job>" in content, "ERROR file missing fmstep"
+        assert "<step>fmstep1</step>" in content, "ERROR file missing fmstep"
         assert "<reason>massive_failure</reason>" in content, (
             "ERROR file missing reason"
         )

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -355,7 +355,7 @@ async def test_when_no_checksum_info_is_received_a_warning_is_logged(
 @pytest.mark.usefixtures("use_tmpdir")
 async def test_log_info_from_exit_file(caplog):
     exit_contents = {
-        "job": "foojob",
+        "step": "foojob",
         "reason": "Divizion-by-sero",
         "stderr_file": "somefilename",
         "stderr": "some_error",


### PR DESCRIPTION
job -> step.

**Issue**
Resolves naming inconsistency jobs vs step for the XML EXIT file left in the runpath.

This is potentially a breaking change.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
