### PR TITLE
Add snapshot event for STOP_LONG_RUNNING

### DIFF
--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -23,6 +23,7 @@ class Id:
     REALIZATION_UNKNOWN_TYPE = Literal["realization.unknown"]
     REALIZATION_WAITING_TYPE = Literal["realization.waiting"]
     REALIZATION_TIMEOUT_TYPE = Literal["realization.timeout"]
+    REALIZATION_STOPPED_LONG_RUNNING_TYPE = Literal["realization.stoppedlongrunning"]
     REALIZATION_RESUBMIT_TYPE = Literal["realization.resubmit"]
     REALIZATION_FAILURE: Final = "realization.failure"
     REALIZATION_PENDING: Final = "realization.pending"
@@ -31,6 +32,7 @@ class Id:
     REALIZATION_UNKNOWN: Final = "realization.unknown"
     REALIZATION_WAITING: Final = "realization.waiting"
     REALIZATION_TIMEOUT: Final = "realization.timeout"
+    REALIZATION_STOPPED_LONG_RUNNING: Final = "realization.stoppedlongrunning"
     REALIZATION_RESUBMIT: Final = "realization.resubmit"
 
     ENSEMBLE_STARTED_TYPE = Literal["ensemble.started"]
@@ -142,6 +144,12 @@ class RealizationTimeout(RealizationBaseEvent):
     event_type: Id.REALIZATION_TIMEOUT_TYPE = Id.REALIZATION_TIMEOUT
 
 
+class RealizationStoppedLongRunning(RealizationBaseEvent):
+    event_type: Id.REALIZATION_STOPPED_LONG_RUNNING_TYPE = (
+        Id.REALIZATION_STOPPED_LONG_RUNNING
+    )
+
+
 class EnsembleBaseEvent(BaseEvent):
     ensemble: str | None = None
 
@@ -200,6 +208,7 @@ RealizationEvent = (
     | RealizationSuccess
     | RealizationFailed
     | RealizationTimeout
+    | RealizationStoppedLongRunning
     | RealizationUnknown
     | RealizationWaiting
     | RealizationResubmit

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -198,7 +198,7 @@ class Job:
         )
         assert self._scheduler._events is not None
         await self._scheduler._events.put(timeout_event)
-        logger.error(
+        logger.warning(
             f"Realization {self.iens} stopped due to MAX_RUNTIME={self.real.max_runtime} seconds"
         )
         self.returncode.cancel()


### PR DESCRIPTION
This makes the effect of STOP_LONG_RUNNING visible in the GUI.

**Issue**
Resolves #10016

**Approach**
Replicate the behaviour and code for MAX_RUNTIME.

![stop_long_running](https://github.com/user-attachments/assets/3d5e97a8-150c-456c-bcc7-b3bb85ef2fce)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
