### PR TITLE
Make rapid tests rapid again

### DIFF
--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -122,7 +122,7 @@ def extract_errors_from_file(path: str):
     return re.findall(r"(Error \w+.*)", content)
 
 
-def wait_for_server(output_dir: str, timeout: int) -> None:
+def wait_for_server(output_dir: str, timeout: int | float) -> None:
     """
     Checks everest server has started _HTTP_REQUEST_RETRY times. Waits
     progressively longer between each check.

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -73,6 +73,7 @@ def run_dialog(qtbot: QtBot, run_model, event_queue, notifier):
     yield run_dialog
 
 
+@pytest.mark.integration_test
 def test_terminating_experiment_shows_a_confirmation_dialog(qtbot: QtBot, run_dialog):
     run_dialog.run_experiment()
 

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -149,7 +149,7 @@ def test_wait_for_server(server_is_running_mock, caplog):
     with pytest.raises(
         RuntimeError, match=r"Failed to get reply from server .* timeout"
     ):
-        wait_for_server(config.output_dir, timeout=1)
+        wait_for_server(config.output_dir, timeout=0.01)
 
     assert not caplog.messages
 


### PR DESCRIPTION


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
