### PR TITLE
Fix potentially flaky test for fm_runner

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -308,7 +308,8 @@ def test_retry_of_jobs_json_file_read(unused_tcp_port, tmp_path, monkeypatch, ca
 
     def create_jobs_file_after_lock():
         wait_until(
-            lambda: f"Could not find file {FORWARD_MODEL_DESCRIPTION_FILE}, retrying",
+            lambda: f"Could not find file {FORWARD_MODEL_DESCRIPTION_FILE}, retrying"
+            in caplog.text,
             interval=0.1,
             timeout=2,
         )


### PR DESCRIPTION
**Approach**
This commit fixes a potentially flaky test for fm_runner

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
