### PR TITLE
Log events left in the queue only if it makes sense

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -157,7 +157,7 @@ class EnsembleEvaluator:
                     continue
             self._complete_batch.set()
             await self._batch_processing_queue.put(batch)
-            if self._events.qsize() > 0:
+            if self._events.qsize() > 2 * self._max_batch_size:
                 logger.info(f"{self._events.qsize()} events left in queue")
 
     async def _fm_handler(self, events: Sequence[FMEvent | RealizationEvent]) -> None:

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -120,14 +120,8 @@ class EnsembleEvaluator:
                     function_to_events_map[func] = []
                 function_to_events_map[func].append(event)
 
-            batch_start_time = asyncio.get_running_loop().time()
             for func, events in function_to_events_map.items():
                 await func(events)
-            processing_time = asyncio.get_running_loop().time() - batch_start_time
-            if processing_time > 0.01:
-                logger.info(
-                    f"Processed {len(batch)} events in {processing_time:.3f} seconds."
-                )
 
             self._batch_processing_queue.task_done()
 


### PR DESCRIPTION
**Issue**
The amount of logs has increase 10x fold. This should reduce the amount of logs coming from the evaluator.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
