### PR TITLE
Propogate ens_path to plot_api StorageService.session calls

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import functools
 import webbrowser
+from pathlib import Path
 
 from PyQt6.QtCore import QCoreApplication, QEvent, QSize, Qt
 from PyQt6.QtCore import pyqtSignal as Signal
@@ -148,7 +149,9 @@ class ErtMainWindow(QMainWindow):
     def right_clicked(self) -> None:
         actor = self.sender()
         if actor and actor.property("index") == "Create plot":
-            pw = PlotWindow(self.config_file, None)
+            pw = PlotWindow(
+                self.config_file, Path(self.ert_config.ens_path).absolute(), None
+            )
             pw.show()
             self._external_plot_windows.append(pw)
 
@@ -181,7 +184,9 @@ class ErtMainWindow(QMainWindow):
             if index_name == "Create plot":
                 if self._plot_window:
                     self._plot_window.close()
-                self._plot_window = PlotWindow(self.config_file, self)
+                self._plot_window = PlotWindow(
+                    self.config_file, Path(self.ert_config.ens_path).absolute(), self
+                )
                 self.central_layout.addWidget(self._plot_window)
                 self.central_panels_map["Create plot"] = self._plot_window
 

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from typing import TYPE_CHECKING, cast
@@ -54,6 +56,8 @@ from PyQt6.QtWidgets import (
 from ert.gui.ertwidgets import CopyButton
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import numpy.typing as npt
 
 
@@ -97,7 +101,7 @@ def open_error_dialog(title: str, content: str) -> None:
 
 
 class PlotWindow(QMainWindow):
-    def __init__(self, config_file: str, parent: QWidget | None):
+    def __init__(self, config_file: str, ens_path: Path, parent: QWidget | None):
         super().__init__(parent)
         t = time.perf_counter()
 
@@ -109,7 +113,7 @@ class PlotWindow(QMainWindow):
         self._preferred_ensemble_x_axis_format = PlotContext.INDEX_AXIS
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         try:
-            self._api = PlotApi()
+            self._api = PlotApi(ens_path)
             self._key_definitions = self._api.all_data_type_keys()
         except (RequestError, TimeoutError) as e:
             logger.exception(f"plot api request failed: {e}")

--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -266,7 +266,7 @@ class BaseService:
     def connect(
         cls,
         *,
-        project: os.PathLike[str] | None = None,
+        project: os.PathLike[str],
         timeout: int | None = None,
     ) -> Self:
         if cls._instance is not None:
@@ -274,9 +274,8 @@ class BaseService:
             assert isinstance(cls._instance, cls)
             return cls._instance
 
-        path = Path(project) if project is not None else Path.cwd()
+        path = Path(project)
         name = f"{cls.service_name}_server.json"
-
         # Note: If the caller actually pass None, we override that here...
         if timeout is None:
             timeout = 240

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -14,6 +14,9 @@ from ert.trace import get_traceparent
 HTTPXClientInstrumentor().instrument()
 
 
+import os
+
+
 class StorageService(BaseService):
     service_name = "storage"
 
@@ -56,7 +59,7 @@ class StorageService(BaseService):
     @classmethod
     def init_service(cls, *args: Any, **kwargs: Any) -> _Context[StorageService]:
         try:
-            service = cls.connect(timeout=0, project=kwargs.get("project"))
+            service = cls.connect(timeout=0, project=kwargs.get("project", os.getcwd()))
             # Check the server is up and running
             _ = service.fetch_url()
         except TimeoutError:
@@ -87,11 +90,11 @@ class StorageService(BaseService):
         )
 
     @classmethod
-    def session(cls, timeout: int | None = None) -> Client:
+    def session(cls, project: os.PathLike[str], timeout: int | None = None) -> Client:
         """
         Start a HTTP transaction with the server
         """
-        inst = cls.connect(timeout=timeout)
+        inst = cls.connect(timeout=timeout, project=project)
         return Client(
             conn_info=ConnInfo(
                 base_url=inst.fetch_url(), auth_token=inst.fetch_auth()[1]

--- a/src/ert/shared/storage/connection.py
+++ b/src/ert/shared/storage/connection.py
@@ -7,7 +7,7 @@ from ert.services import StorageService
 
 
 def get_info(
-    project_id: os.PathLike[str] | None = None,
+    project_id: os.PathLike[str],
 ) -> dict[str, str | tuple[str, Any]]:
     client = StorageService.connect(project=project_id)
     return {

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 @pytest.fixture(autouse=True)
 def use_testclient(monkeypatch):
     client = TestClient(app)
-    monkeypatch.setattr(StorageService, "session", lambda: client)
+    monkeypatch.setattr(StorageService, "session", lambda project: client)
 
     def test_escape(s: str) -> str:
         """
@@ -215,10 +215,11 @@ def test_direct_dark_performance_with_storage(
 
 @pytest.fixture
 def api_and_storage(monkeypatch, tmp_path):
-    with open_storage(tmp_path / "storage", mode="w") as storage:
+    ens_path = tmp_path / "storage"
+    with open_storage(ens_path, mode="w") as storage:
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
         monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
-        api = PlotApi()
+        api = PlotApi(ens_path)
         yield api, storage
     if enkf._storage is not None:
         enkf._storage.close()
@@ -232,7 +233,7 @@ def api_and_snake_oil_storage(snake_oil_case_storage, monkeypatch):
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
         monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
 
-        api = PlotApi()
+        api = PlotApi(snake_oil_case_storage.ens_path)
         yield api, storage
 
     if enkf._storage is not None:

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -32,7 +32,7 @@ class MockResponse:
 @pytest.fixture
 def api(tmpdir, source_root, monkeypatch):
     @contextmanager
-    def session():
+    def session(project: str):
         yield MagicMock(get=mocked_requests_get)
 
     monkeypatch.setattr(StorageService, "session", session)
@@ -42,7 +42,7 @@ def api(tmpdir, source_root, monkeypatch):
         test_data_dir = os.path.join(test_data_root, "snake_oil")
         shutil.copytree(test_data_dir, "test_data")
         os.chdir("test_data")
-        api = PlotApi()
+        api = PlotApi(test_data_dir)
         yield api
 
 

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -23,7 +23,7 @@ from tests.ert.unit_tests.gui.tools.plot.conftest import MockResponse
 @pytest.fixture(autouse=True)
 def use_testclient(monkeypatch):
     client = TestClient(app)
-    monkeypatch.setattr(StorageService, "session", lambda: client)
+    monkeypatch.setattr(StorageService, "session", lambda project: client)
 
     def test_escape(s: str) -> str:
         """
@@ -184,10 +184,11 @@ def test_plot_api_request_errors(api):
 
 @pytest.fixture
 def api_and_storage(monkeypatch, tmp_path):
-    with open_storage(tmp_path / "storage", mode="w") as storage:
+    ens_path = tmp_path / "storage"
+    with open_storage(ens_path, mode="w") as storage:
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
         monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
-        api = PlotApi()
+        api = PlotApi(ens_path)
         yield api, storage
     if enkf._storage is not None:
         enkf._storage.close()

--- a/tests/ert/unit_tests/services/test_base_service.py
+++ b/tests/ert/unit_tests/services/test_base_service.py
@@ -203,9 +203,9 @@ os.write(fd, b'{"authtoken": "test123", "urls": ["url"]}')
 os.close(fd)
 """
 )
-def test_singleton_connect(server_script):
+def test_singleton_connect(tmp_path, server_script):
     with _DummyService.start_server(exec_args=[str(server_script)]) as server:
-        client = _DummyService.connect(timeout=30)
+        client = _DummyService.connect(project=tmp_path, timeout=30)
         assert server is client
 
 
@@ -231,7 +231,7 @@ def test_singleton_connect_early(server_script, tmp_path):
         def run(self):
             start_event.set()
             try:
-                self.client = _DummyService.connect(timeout=30)
+                self.client = _DummyService.connect(project=tmp_path, timeout=30)
             except Exception as ex:
                 self.exception = ex
             ready_event.set()


### PR DESCRIPTION
**Issue**
Might resolve https://github.com/equinor/ert/issues/9999

In the current code, if `cls._instance` is none in `_base_service.py`, then one guesses that the storage path is `cwd`, which will almost never work in proper cases.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
