### PR TITLE
Split design matrix into two genkw groups

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -179,6 +179,12 @@ class DesignMatrix:
             skiprows=1,
         )
         design_matrix_df.columns = param_names.to_list()
+        # categorical_columns = design_matrix_df.select_dtypes(
+        #     include=["object"]
+        # ).columns.tolist()
+        # numerical_columns = design_matrix_df.select_dtypes(
+        #     include=["number"]
+        # ).columns.tolist()
 
         if "REAL" in design_matrix_df.columns:
             if not is_integer_dtype(design_matrix_df.dtypes["REAL"]) or any(


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/9981

**Approach**
To make it possible to store the correct data types for both categorical and numerical data into xarray, we need to use two distinct genkw groups.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
