### PR TITLE
Fix everest caching of test results has race conditions

### DIFF
--- a/tests/everest/entry_points/test_config_branch_entry.py
+++ b/tests/everest/entry_points/test_config_branch_entry.py
@@ -2,11 +2,14 @@ import difflib
 from os.path import exists
 from pathlib import Path
 
+import pytest
+
 from everest.bin.config_branch_script import config_branch_entry
 from everest.config_file_loader import load_yaml
 from everest.everest_storage import EverestStorage
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_config_branch_entry(cached_example):
     path, _, _ = cached_example("math_func/config_minimal.yml")
 
@@ -43,6 +46,7 @@ def test_config_branch_entry(cached_example):
     assert new_controls_initial_guesses == control_values
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_config_branch_preserves_config_section_order(cached_example):
     path, _, _ = cached_example("math_func/config_minimal.yml")
 

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -76,6 +76,7 @@ def test_everest_entry_run(cached_example):
     assert status["status"] == ServerStatus.completed
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_everest_entry_monitor_no_run(cached_example):
     _, config_file, _ = cached_example("math_func/config_minimal.yml")
     with capture_streams():
@@ -89,6 +90,7 @@ def test_everest_entry_monitor_no_run(cached_example):
     assert status["status"] == ServerStatus.never_run
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 @pytest.mark.integration_test
 def test_everest_main_export_entry(cached_example):
     # Setup command line arguments
@@ -99,6 +101,7 @@ def test_everest_main_export_entry(cached_example):
     assert "Everexport is deprecated" in out.getvalue()
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_everest_main_lint_entry(cached_example):
     # Setup command line arguments
     _, config_file, _ = cached_example("math_func/config_minimal.yml")

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -46,7 +46,20 @@ def make_api_snapshot(api) -> dict[str, Any]:
 
 @pytest.mark.parametrize(
     "config_file",
-    ["config_advanced.yml", "config_minimal.yml", "config_multiobj.yml"],
+    [
+        pytest.param(
+            "config_advanced.yml",
+            marks=pytest.mark.xdist_group("math_func/config_advanced.yml"),
+        ),
+        pytest.param(
+            "config_minimal.yml",
+            marks=pytest.mark.xdist_group("math_func/config_minimal.yml"),
+        ),
+        pytest.param(
+            "config_multiobj.yml",
+            marks=pytest.mark.xdist_group("math_func/config_multiobj.yml"),
+        ),
+    ],
 )
 def test_api_snapshots(config_file, snapshot, cached_example):
     config_path, config_file, optimal_result_json = cached_example(
@@ -72,7 +85,20 @@ def test_api_snapshots(config_file, snapshot, cached_example):
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_file",
-    ["config_advanced.yml", "config_minimal.yml", "config_multiobj.yml"],
+    [
+        pytest.param(
+            "config_advanced.yml",
+            marks=pytest.mark.xdist_group("math_func/config_advanced.yml"),
+        ),
+        pytest.param(
+            "config_minimal.yml",
+            marks=pytest.mark.xdist_group("math_func/config_minimal.yml"),
+        ),
+        pytest.param(
+            "config_multiobj.yml",
+            marks=pytest.mark.xdist_group("math_func/config_multiobj.yml"),
+        ),
+    ],
 )
 def test_api_summary_snapshot(config_file, snapshot, cached_example):
     config_path, config_file, _ = cached_example(f"math_func/{config_file}")
@@ -117,7 +143,20 @@ def test_api_summary_snapshot(config_file, snapshot, cached_example):
 
 @pytest.mark.parametrize(
     "config_file",
-    ["config_advanced.yml", "config_minimal.yml", "config_multiobj.yml"],
+    [
+        pytest.param(
+            "config_advanced.yml",
+            marks=pytest.mark.xdist_group("math_func/config_advanced.yml"),
+        ),
+        pytest.param(
+            "config_minimal.yml",
+            marks=pytest.mark.xdist_group("math_func/config_minimal.yml"),
+        ),
+        pytest.param(
+            "config_multiobj.yml",
+            marks=pytest.mark.xdist_group("math_func/config_multiobj.yml"),
+        ),
+    ],
 )
 def test_csv_export(config_file, cached_example, snapshot):
     config_path, config_file, _ = cached_example(f"math_func/{config_file}")

--- a/tests/everest/test_config_branch.py
+++ b/tests/everest/test_config_branch.py
@@ -9,6 +9,7 @@ from everest.bin.config_branch_script import (
 from everest.config_file_loader import load_yaml
 
 
+@pytest.mark.xdist_group("math_func/config_advanced.yml")
 def test_get_controls_for_batch(cached_example):
     path, _, _ = cached_example("math_func/config_advanced.yml")
 
@@ -42,6 +43,7 @@ def test_get_controls_for_batch(cached_example):
     )
 
 
+@pytest.mark.xdist_group("math_func/config_advanced.yml")
 def test_update_controls_initial_guess(cached_example):
     path, _, _ = cached_example("math_func/config_advanced.yml")
 

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -336,6 +336,7 @@ if __name__ == "__main__":
     assert final_state.returncode == 0
 
 
+@pytest.mark.xdist_group(name="math_func/config_multiobj.yml")
 def test_get_opt_status(cached_example):
     _, config_file, _ = cached_example("math_func/config_multiobj.yml")
     config = EverestConfig.load_file(config_file)

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -2,6 +2,8 @@ import os
 import shutil
 from unittest.mock import patch
 
+import pytest
+
 from ert.config import ErtConfig
 from ert.storage import open_storage
 from everest.bin.everest_script import everest_entry
@@ -10,6 +12,7 @@ from everest.detached import ServerStatus
 from everest.simulator.everest_to_ert import _everest_to_ert_config_dict
 
 
+@pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
     _, config, _ = cached_example("math_func/config_minimal.yml")
     config = EverestConfig.load_file(config)

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -15,6 +15,7 @@ CONFIG_FILE_MULTIOBJ = "config_multiobj.yml"
 CONFIG_FILE_ADVANCED = "config_advanced.yml"
 
 
+@pytest.mark.xdist_group("math_func/config_multiobj.yml")
 @pytest.mark.integration_test
 def test_math_func_multiobj(cached_example):
     config_path, config_file, _ = cached_example("math_func/config_multiobj.yml")
@@ -36,6 +37,7 @@ def test_math_func_multiobj(cached_example):
     )
 
 
+@pytest.mark.xdist_group("math_func/config_advanced.yml")
 @pytest.mark.integration_test
 def test_math_func_advanced(cached_example):
     config_path, config_file, _ = cached_example("math_func/config_advanced.yml")


### PR DESCRIPTION
**Issue**
Resolves #9670 


**Approach**
This commit fixes the issue of the tests failing due to a race condition in the cache when multiple workers are using the same test cases. This commit fixes this issue by using pytest-xdist groups, the same way it is done in ert.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
