### PR TITLE
Remove integration_test mark from ee tests

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -154,7 +154,6 @@ async def test_when_task_prematurely_ends_raises_exception(
         await evaluator.run_and_get_successful_realizations()
 
 
-@pytest.mark.integration_test
 async def test_new_connections_are_no_problem_when_evaluator_is_closing_down(
     evaluator_to_use,
 ):
@@ -269,8 +268,8 @@ async def test_restarted_jobs_do_not_have_error_msgs(evaluator_to_use):
                 break
 
 
-@pytest.mark.integration_test
 @pytest.mark.timeout(20)
+@pytest.mark.integration_test
 async def test_new_monitor_can_pick_up_where_we_left_off(evaluator_to_use):
     evaluator = evaluator_to_use
     token = evaluator._config.token
@@ -407,11 +406,11 @@ async def test_monitor_receive_heartbeats(evaluator_to_use):
         async with Monitor(url, token) as monitor:
             await asyncio.sleep(0.5)
             await monitor.signal_done()
-    # in 0.5 second we should receive at least 2 heartbeats
-    assert received_heartbeats > 1
+    assert received_heartbeats > 1, (
+        "we should have received at least 2 heartbeats in 0.5 secs!"
+    )
 
 
-@pytest.mark.integration_test
 async def test_dispatch_endpoint_clients_can_connect_and_monitor_can_shut_down_evaluator(
     evaluator_to_use,
 ):


### PR DESCRIPTION
The following tests take ca. 0.5 seconds each, so  removing the `integration_test` marker.



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
