### PR TITLE
Update to ropt 0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,8 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.13,<0.14",
-    "ropt-dakota>=0.11,<0.12",
+    "ropt[pandas]>=0.14,<0.15",
+    "ropt-dakota>=0.14,<0.15",
 ]
 
 [tool.setuptools]

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -657,23 +657,9 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @property
     def constraint_names(self) -> list[str]:
-        names: list[str] = []
-
-        def _add_output_constraint(rhs_value: float | None, suffix=None):
-            if rhs_value is not None:
-                name = constr.name
-                names.append(name if suffix is None else f"{name}:{suffix}")
-
-        for constr in self.output_constraints or []:
-            _add_output_constraint(constr.target)
-            _add_output_constraint(
-                constr.upper_bound, None if constr.lower_bound is None else "upper"
-            )
-            _add_output_constraint(
-                constr.lower_bound, None if constr.upper_bound is None else "lower"
-            )
-
-        return names
+        if self.output_constraints:
+            return [constraint.name for constraint in self.output_constraints]
+        return []
 
     @property
     def result_names(self):
@@ -689,20 +675,11 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @property
     def function_aliases(self) -> dict[str, str]:
-        aliases = {
+        return {
             objective.name: objective.alias
             for objective in self.objective_functions
             if objective.alias is not None
         }
-        constraints = self.output_constraints or []
-        for constraint in constraints:
-            if (
-                constraint.upper_bound is not None
-                and constraint.lower_bound is not None
-            ):
-                aliases[f"{constraint.name}:lower"] = constraint.name
-                aliases[f"{constraint.name}:upper"] = constraint.name
-        return aliases
 
     def to_dict(self) -> dict:
         the_dict = self.model_dump(exclude_none=True)

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -37,40 +37,28 @@
         1.0
       ]
     ],
-    "rhs_values": [
-      0.4
+    "lower_bounds": [
+      null
     ],
-    "types": [
-      1
+    "upper_bounds": [
+      0.4
     ]
   },
   "nonlinear_constraints": {
-    "auto_scale": [
-      false
-    ],
     "function_estimators": null,
+    "lower_bounds": [
+      1.0
+    ],
     "realization_filters": null,
-    "rhs_values": [
-      1.0
-    ],
-    "scales": [
-      1.0
-    ],
-    "types": [
-      2
+    "upper_bounds": [
+      null
     ]
   },
   "objectives": {
-    "auto_scale": [
-      false
-    ],
     "function_estimators": [
       0
     ],
     "realization_filters": null,
-    "scales": [
-      1.0
-    ],
     "weights": [
       1.0
     ]
@@ -102,11 +90,6 @@
     }
   ],
   "variables": {
-    "indices": [
-      0,
-      1,
-      2
-    ],
     "initial_values": [
       0.25,
       0.25,
@@ -117,8 +100,11 @@
       -1.0,
       -1.0
     ],
-    "offsets": null,
-    "scales": null,
+    "mask": [
+      true,
+      true,
+      true
+    ],
     "types": [
       1,
       1,

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -32,16 +32,10 @@
   "linear_constraints": null,
   "nonlinear_constraints": null,
   "objectives": {
-    "auto_scale": [
-      false
-    ],
     "function_estimators": [
       0
     ],
     "realization_filters": null,
-    "scales": [
-      1.0
-    ],
     "weights": [
       1.0
     ]
@@ -72,11 +66,6 @@
     }
   ],
   "variables": {
-    "indices": [
-      0,
-      1,
-      2
-    ],
     "initial_values": [
       0.1,
       0.1,
@@ -87,8 +76,11 @@
       -1.0,
       -1.0
     ],
-    "offsets": null,
-    "scales": null,
+    "mask": [
+      true,
+      true,
+      true
+    ],
     "types": [
       1,
       1,

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -32,19 +32,11 @@
   "linear_constraints": null,
   "nonlinear_constraints": null,
   "objectives": {
-    "auto_scale": [
-      false,
-      false
-    ],
     "function_estimators": [
       0,
       0
     ],
     "realization_filters": null,
-    "scales": [
-      1.0,
-      1.0
-    ],
     "weights": [
       0.6666666666666666,
       0.3333333333333333
@@ -76,11 +68,6 @@
     }
   ],
   "variables": {
-    "indices": [
-      0,
-      1,
-      2
-    ],
     "initial_values": [
       0.0,
       0.0,
@@ -91,8 +78,11 @@
       -1.0,
       -1.0
     ],
-    "offsets": null,
-    "scales": null,
+    "mask": [
+      true,
+      true,
+      true
+    ],
     "types": [
       1,
       1,

--- a/tests/everest/test_multiobjective.py
+++ b/tests/everest/test_multiobjective.py
@@ -81,7 +81,6 @@ def test_multi_objectives2ropt(copy_mocked_test_data_to_tmp):
     config_dict = config.to_dict()
     ever_objs = config_dict["objective_functions"]
     ever_objs[0]["weight"] = 1.33
-    ever_objs[0]["normalization"] = 1
     ever_objs[1]["weight"] = 3.1
     assert len(EverestConfig.lint_config_dict(config_dict)) == 0
 
@@ -93,7 +92,6 @@ def test_multi_objectives2ropt(copy_mocked_test_data_to_tmp):
     assert len(enopt_config.objectives.weights) == 2
     assert enopt_config.objectives.weights[1] == ever_objs[1]["weight"] / norm
     assert enopt_config.objectives.weights[0] == ever_objs[0]["weight"] / norm
-    assert enopt_config.objectives.scales[0] == ever_objs[0]["normalization"]
 
 
 @pytest.mark.integration_test

--- a/tests/everest/test_output_constraints.py
+++ b/tests/everest/test_output_constraints.py
@@ -1,8 +1,8 @@
 import os
 
+import numpy as np
 import pytest
 from ropt.config.enopt import EnOptConfig
-from ropt.enums import ConstraintType
 
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_models.everest_run_model import EverestRunModel
@@ -214,15 +214,13 @@ def test_upper_bound_output_constraint_def(copy_mocked_test_data_to_tmp):
     ropt_conf = EnOptConfig.model_validate(everest2ropt(config))
 
     expected = {
-        "scale": 1.0,
         "name": "some_name",
-        "rhs_value": [5000],
-        "type": ConstraintType.LE,
+        "lower_bounds": -np.inf,
+        "upper_bounds": [5000],
     }
 
-    assert expected["scale"] == 1.0 / ropt_conf.nonlinear_constraints.scales[0]
-    assert expected["rhs_value"] == ropt_conf.nonlinear_constraints.rhs_values[0]
-    assert expected["type"] == ropt_conf.nonlinear_constraints.types[0]
+    assert expected["lower_bounds"] == ropt_conf.nonlinear_constraints.lower_bounds[0]
+    assert expected["upper_bounds"] == ropt_conf.nonlinear_constraints.upper_bounds[0]
 
     EverestRunModel.create(config)
 

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from orjson import orjson
 from pydantic import ValidationError
-from ropt.enums import ConstraintType
 
 from everest.config import EverestConfig
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
@@ -94,14 +93,13 @@ def test_everest2ropt_controls_input_constraint():
     # constraints: LE, GE and EQ.
 
     # Check that the config is defining three input constraints.
-    assert ropt_config.linear_constraints.coefficients.shape[0] == 3
+    assert ropt_config.linear_constraints.coefficients.shape[0] == 2
 
-    # Check the input constraint types
-    exp_type = [ConstraintType.LE, ConstraintType.GE, ConstraintType.EQ]
-    assert exp_type == list(ropt_config.linear_constraints.types)
-    # Check the rhs
-    exp_rhs = [1.0, 0.0, 1.0]
-    assert exp_rhs == ropt_config.linear_constraints.rhs_values.tolist()
+    # Check the bounds:
+    exp_lower_bounds = [0.0, 1.0]
+    exp_upper_bounds = [1.0, 1.0]
+    assert exp_lower_bounds == ropt_config.linear_constraints.lower_bounds.tolist()
+    assert exp_upper_bounds == ropt_config.linear_constraints.upper_bounds.tolist()
 
 
 def test_everest2ropt_controls_input_constraint_auto_scale():
@@ -116,7 +114,8 @@ def test_everest2ropt_controls_input_constraint_auto_scale():
     min_values = ropt_config.variables.lower_bounds.copy()
     max_values = ropt_config.variables.upper_bounds.copy()
     coefficients = ropt_config.linear_constraints.coefficients
-    rhs_values = ropt_config.linear_constraints.rhs_values
+    lower_bounds = ropt_config.linear_constraints.lower_bounds
+    upper_bounds = ropt_config.linear_constraints.upper_bounds
 
     controls = config.controls
     min_values[1] = -1.0
@@ -127,7 +126,10 @@ def test_everest2ropt_controls_input_constraint_auto_scale():
     controls[0].auto_scale = True
     controls[0].scaled_range = [0.3, 0.7]
 
-    scaled_rhs_values = rhs_values - np.matmul(
+    scaled_lower_bounds = lower_bounds - np.matmul(
+        coefficients, min_values - 0.3 * (max_values - min_values) / 0.4
+    )
+    scaled_upper_bounds = upper_bounds - np.matmul(
         coefficients, min_values - 0.3 * (max_values - min_values) / 0.4
     )
     scaled_coefficients = coefficients * (max_values - min_values) / 0.4
@@ -147,8 +149,12 @@ def test_everest2ropt_controls_input_constraint_auto_scale():
         scaled_coefficients,
     )
     assert np.allclose(
-        ropt_config.linear_constraints.rhs_values[0],
-        scaled_rhs_values[0],
+        ropt_config.linear_constraints.lower_bounds[0],
+        scaled_lower_bounds[0],
+    )
+    assert np.allclose(
+        ropt_config.linear_constraints.upper_bounds[0],
+        scaled_upper_bounds[0],
     )
 
 
@@ -165,7 +171,7 @@ def test_everest2ropt_constraints():
     config = os.path.join(_CONFIG_DIR, "config_output_constraints.yml")
     config = EverestConfig.load_file(config)
     ropt_config = everest2ropt(config)
-    assert len(ropt_config.nonlinear_constraints.rhs_values) == 16
+    assert len(ropt_config.nonlinear_constraints.lower_bounds) == 16
 
 
 def test_everest2ropt_backend_options():

--- a/uv.lock
+++ b/uv.lock
@@ -824,8 +824,8 @@ requires-dist = [
     { name = "resdata", marker = "extra == 'everest'" },
     { name = "resfo" },
     { name = "resfo", marker = "extra == 'dev'" },
-    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.13,<0.14" },
-    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.11,<0.12" },
+    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.14,<0.15" },
+    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.14,<0.15" },
     { name = "ruamel-yaml", marker = "extra == 'everest'" },
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1,<1.15" },
@@ -3180,16 +3180,16 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.13.1"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/02/1e67f380d957e661690674caf9d0fb465e04b50a33f176e09df31827a0c0/ropt-0.13.1.tar.gz", hash = "sha256:a73c329acc861221121614813e7316b11f65f3cba3dc24617bd73e4a003dd131", size = 148335 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/d4/010627ad0d75c372776021469b835dc60b2d1fbca2bc7d3b9db63b8bb81a/ropt-0.14.0.tar.gz", hash = "sha256:1b4ddf7f5c0703151a26c87690a41612cd5ea6815ccaff61c2ba8905b17b3720", size = 138715 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/c6/ebde1a91daba824afae0212eb6b12afd1be16656788cc71f3c546f37d7d3/ropt-0.13.1-py3-none-any.whl", hash = "sha256:4fea64617bc0b2057dc93ddcf7117c6bf70a10fdb51e7364d082ad404a1e7b65", size = 159662 },
+    { url = "https://files.pythonhosted.org/packages/4b/be/a8ecc424d51756c2f2ede3f58acb9e74ee0567112b7e6a115a251b9187a9/ropt-0.14.0-py3-none-any.whl", hash = "sha256:d79b52844b3d5e65d95c59d6862539f99dead61a41570e8b0a6aa6e5cdbe6ac7", size = 147180 },
 ]
 
 [package.optional-dependencies]
@@ -3200,15 +3200,15 @@ pandas = [
 
 [[package]]
 name = "ropt-dakota"
-version = "0.11.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/c9/a23a67ed214e8fc12042d839b8bc400d5170629d4db7a4f4ad0d8263a19c/ropt_dakota-0.11.0.tar.gz", hash = "sha256:99e98e01ca12dd66db4deae9139a6d80e283aedeacdf5f6a3b37e6713abf6b91", size = 23856 }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/49/979eb592941acc4c02cf7a36c3c1d28a0df20d90281ec8f552cdd1df68bf/ropt_dakota-0.14.0.tar.gz", hash = "sha256:7cb16c3361b49a678d89f6ccba977d14fe67ba1aa77427832f068d97960519c8", size = 24015 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/49/53d7f068a4899692e300eba6f1bad8360779afa13819e20ec41b7371876a/ropt_dakota-0.11.0-py3-none-any.whl", hash = "sha256:f20683ec0cee2cca4ebdb2ac34d01c70a774e6d8e3cf58c25da4dc6701edb829", size = 19695 },
+    { url = "https://files.pythonhosted.org/packages/19/f1/dec0681fb61132bcfae1ee6cc8c13f54330d621f9bd9a6cb5c3a1a1fbe2b/ropt_dakota-0.14.0-py3-none-any.whl", hash = "sha256:b8bb44417abdc5ae95361084634ddbe4631c10d07bf24932f69925ff0fa5d08d", size = 19685 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue**
This updates Everest to use `ropt` 0.14. That version has significant enhancements on how it handles constraints. In particular, Everest does not need to split two-sided constraints (with both lower and upper bounds) in two separate constraints anymore. This simplifies the corresponding Everest code significantly. Also, reporting and tracking of two-sided constraints in Everest was potentially broken, and now becomes straightforward.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
