### PR TITLE
Fixups for terminate experiment correctness

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -281,7 +281,6 @@ class EnsembleEvaluator:
                 else:
                     logger.error(f"Unexpected error when listening to messages: {e}")
             except asyncio.CancelledError:
-                self._router_socket.close()
                 return
 
     async def forward_checksum(self, event: Event) -> None:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import numpy as np
 
 from _ert.events import EESnapshot, EESnapshotUpdate, EETerminated, Event
-from ert.analysis import (
-    ErtAnalysisError,
-    smoother_update,
-)
+from ert.analysis import ErtAnalysisError, smoother_update
 from ert.analysis.event import (
     AnalysisCompleteEvent,
     AnalysisDataEvent,
@@ -600,6 +597,7 @@ class BaseRunModel(ABC):
         )
         await evaluator._server_started
         if not (await self.run_monitor(ee_config, ensemble.iteration)):
+            await evaluator_task
             return []
 
         logger.debug("observed that model was finished, waiting tasks completion...")
@@ -609,6 +607,7 @@ class BaseRunModel(ABC):
         if not self._end_queue.empty():
             logger.debug("Run model canceled - post evaluation")
             self._end_queue.get()
+            await evaluator_task
             return []
         await evaluator_task
         ensemble.refresh_ensemble_state()


### PR DESCRIPTION
**Issue**
 - In case that termination  of experiment happens monitor returns immediately and thus killing the entire ensemble task and thus evaluator does not finish. 
 - router_socket.close() should be called only by the server task



**Approach**
Await evaluator task

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
