### PR TITLE
Solve pandas FutureWarning in plotHistogram

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 DESIGN_MATRIX_GROUP = "DESIGN_MATRIX"
 
+from ert.shared.status.utils import convert_to_numeric
+
 
 @dataclass
 class DesignMatrix:
@@ -319,10 +321,3 @@ class DesignMatrix:
             for _, row in default_df.iterrows()
             if row[0] not in existing_parameters
         }
-
-
-def convert_to_numeric(x: str) -> str | float:
-    try:
-        return pd.to_numeric(x)
-    except ValueError:
-        return x

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -9,6 +9,7 @@ import pandas as pd
 from matplotlib.patches import Rectangle
 
 from ert.gui.tools.plot.plot_api import EnsembleObject
+from ert.shared.status.utils import convert_to_numeric
 
 from .plot_tools import PlotTools
 
@@ -87,9 +88,7 @@ def plotHistogram(
 
         if data[ensemble.name].dtype == "object":
             try:
-                data[ensemble.name] = pd.to_numeric(
-                    data[ensemble.name], errors="ignore"
-                )
+                data[ensemble.name] = convert_to_numeric(data[ensemble.name])
             except AttributeError:
                 data[ensemble.name] = data[ensemble.name].convert_objects(
                     convert_numeric=True

--- a/src/ert/shared/status/utils.py
+++ b/src/ert/shared/status/utils.py
@@ -4,6 +4,8 @@ import resource
 import sys
 from pathlib import Path
 
+import pandas as pd
+
 
 def byte_with_unit(byte_count: float) -> str:
     suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]
@@ -92,3 +94,10 @@ def get_mount_directory(runpath: str) -> Path:
         path = path.parent
 
     return path
+
+
+def convert_to_numeric(x: str | pd.Series) -> str | float | pd.Series:
+    try:
+        return pd.to_numeric(x)
+    except ValueError:
+        return x


### PR DESCRIPTION
Solves the following warning:
pandas to_numerics
```
“ignore” is deprecated. Catch exceptions explicitly instead.
```
. https://pandas.pydata.org/docs/reference/api/pandas.to_numeric.html

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
