### PR TITLE
Skip using importlib in test_fm_dispatch

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import glob
-import importlib
 import json
 import os
 import signal
@@ -99,15 +98,11 @@ else:
         )
     os.chmod("setsid", 0o755)
 
-    fm_dispatch_script = importlib.util.find_spec(
-        "_ert.forward_model_runner.fm_dispatch"
-    ).origin
     # (we wait for the process below)
     fm_dispatch_process = Popen(
         [
             os.getcwd() + "/setsid",
-            sys.executable,
-            fm_dispatch_script,
+            "fm_dispatch.py",
             os.getcwd(),
         ]
     )
@@ -259,15 +254,11 @@ def test_fm_dispatch_run_subset_specified_as_parameter():
         )
     os.chmod("setsid", 0o755)
 
-    fm_dispatch_script = importlib.util.find_spec(
-        "_ert.forward_model_runner.fm_dispatch"
-    ).origin
     # (we wait for the process below)
     fm_dispatch_process = Popen(
         [
             os.getcwd() + "/setsid",
-            sys.executable,
-            fm_dispatch_script,
+            "fm_dispatch.py",
             os.getcwd(),
             "step_B",
             "step_C",


### PR DESCRIPTION
Simplifies the tests by just calling fm_dispatch.py. The importlib way was a leftover from how this test was orginially implemented in https://github.com/equinor/ert/commit/7fedcfb6ecf998a9089e187e7cbeb533e3b26abd  when fm_dispatch.py (then job_dispatch.py) was not available in the command line.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
