### PR TITLE
Fix bug where the iteration (batch) number was not set for Everest

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -437,6 +437,7 @@ class EverestRunModel(BaseRunModel):
         ensemble = self._experiment.create_ensemble(
             name=f"batch_{self._batch_id}",
             ensemble_size=len(evaluated_control_indices),
+            iteration=self._batch_id,
         )
         for sim_id, controls in enumerate(sim_controls.values()):
             self._setup_sim(sim_id, controls, ensemble)
@@ -628,7 +629,9 @@ class EverestRunModel(BaseRunModel):
         substitutions["<BATCH_NAME>"] = ensemble.name
         self.active_realizations = [True] * len(evaluated_control_indices)
         for sim_id, control_idx in enumerate(evaluated_control_indices):
-            substitutions[f"<GEO_ID_{sim_id}_0>"] = str(model_realizations[control_idx])
+            substitutions[f"<GEO_ID_{sim_id}_{ensemble.iteration}>"] = str(
+                model_realizations[control_idx]
+            )
         run_paths = Runpaths(
             jobname_format=self._model_config.jobname_format_string,
             runpath_format=self._model_config.runpath_format_string,

--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -202,7 +202,7 @@ def get_opt_status(output_folder):
 
 def wait_for_server_to_stop(server_context: tuple[str, str, tuple[str, str]], timeout):
     """
-    Checks everest server has stoped _HTTP_REQUEST_RETRY times. Waits
+    Checks everest server has stopped _HTTP_REQUEST_RETRY times. Waits
     progressively longer between each check.
 
     Raise an exception when the timeout is reached.


### PR DESCRIPTION
**Issue**
Minor issues related to: https://github.com/equinor/ert/pull/9691

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
