### PR TITLE
Fix fm_dispatch not terminating correctly and gui stuck on fm running when terminating

### DIFF
--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -87,7 +87,9 @@ class Event(Reporter):
             # can be finished but not all the events were sent yet
             self._finished_event_timeout = 600
 
-    def stop(self):
+    def stop(self, exited_event: Exited | None = None):
+        if exited_event:
+            self._statemachine.transition(exited_event)
         self._event_queue.put(Event._sentinel)
         self._done.set()
         if self._event_publisher_thread.is_alive():

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -78,6 +78,7 @@ class ForwardModelRunner:
             yield init_message
 
         for step in step_queue:
+            self._currently_running_step = step
             for status_update in step.run():
                 yield status_update
                 if not status_update.success():

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -357,7 +357,12 @@ class EnsembleEvaluator:
         """
         if self._ensemble.cancellable:
             logger.debug("Cancelling current ensemble")
-            await self._ensemble.cancel()
+            self._ee_tasks.append(
+                asyncio.create_task(
+                    self._ensemble.cancel(), name="ensemble_cancellation_task"
+                )
+            )
+
         else:
             logger.debug("Stopping current ensemble")
             self.stop()
@@ -408,6 +413,7 @@ class EnsembleEvaluator:
                 elif task.get_name() in {
                     "ensemble_task",
                     "listener_task",
+                    "ensemble_cancellation_task",
                 }:
                     timeout = self.CLOSE_SERVER_TIMEOUT
                 else:

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -34,6 +34,7 @@ from _ert.events import (
     RealizationUnknown,
     RealizationWaiting,
 )
+from _ert.forward_model_runner.fm_dispatch import FORWARD_MODEL_TERMINATED_MSG
 from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
 
@@ -411,6 +412,10 @@ class EnsembleSnapshot:
         fm_step_id: str,
         fm_step: FMStepSnapshot,
     ) -> EnsembleSnapshot:
+        if (
+            previous_error := self._fm_step_snapshots[real_id, fm_step_id].get("error")
+        ) and fm_step.get("error") == FORWARD_MODEL_TERMINATED_MSG:
+            fm_step["error"] = previous_error
         self._fm_step_snapshots[real_id, fm_step_id].update(fm_step)
         return self
 

--- a/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/ensemble_evaluator_utils.py
@@ -22,6 +22,7 @@ class TestEnsemble(Ensemble):
             )
             for real_no in range(reals)
         ]
+        self._cancellable = False
         super().__init__(the_reals, {}, QueueConfig(), 0, id_)
 
     async def evaluate(self, config, _, __):
@@ -29,4 +30,4 @@ class TestEnsemble(Ensemble):
 
     @property
     def cancellable(self) -> bool:
-        return False
+        return self._cancellable


### PR DESCRIPTION
**Issue**
Resolves #10055 
Resolves #10059 
Resolves #10060 

**Approach**
This PR issue where cancelling an ensemble in EE would cause messaging (and therefore teardown) from fm_dispatch to hang, due to ensemble.cancel() being blocking. This causes teardown of fm_dispatch to go from 35-40s -> 1s. 

This PR also makes fm_dispatch send ForwardModelStepFailure with the message "fm_dispatch was terminated" when it is being terminated, instead of sending nothing. 

(Screenshot of new behavior in GUI if applicable)
Before:
![image](https://github.com/user-attachments/assets/12a7d974-76c1-4ff0-aba0-5a272008f655)

After:
![image](https://github.com/user-attachments/assets/00ec4830-d0e0-4136-9478-005ef8487b26)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
