### PR TITLE
Update ropt 0.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,8 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.14,<0.15",
-    "ropt-dakota>=0.14,<0.15",
+    "ropt[pandas]>=0.15,<0.16",
+    "ropt-dakota>=0.15,<0.16",
 ]
 
 [tool.setuptools]

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -271,7 +271,9 @@ class EverestRunModel(BaseRunModel):
                 case _:
                     self._exit_code = EverestExitCode.COMPLETED
 
-    def _init_transforms(self, variables: NDArray[np.float64]) -> OptModelTransforms:
+    def _init_domain_transforms(
+        self, control_variables: NDArray[np.float64]
+    ) -> OptModelTransforms:
         model_realizations = self._everest_config.model.realizations
         nreal = len(model_realizations)
         realization_weights = self._everest_config.model.realizations_weights
@@ -306,7 +308,7 @@ class EverestRunModel(BaseRunModel):
             )
 
             objectives, constraints, _ = self._run_forward_model(
-                np.repeat(np.expand_dims(variables, axis=0), nreal, axis=0),
+                np.repeat(np.expand_dims(control_variables, axis=0), nreal, axis=0),
                 model_realizations,
             )
 
@@ -332,7 +334,7 @@ class EverestRunModel(BaseRunModel):
     def _create_optimizer(self) -> BasicOptimizer:
         # Initialize the optimization model transforms. This may run one initial
         # ensemble for auto-scaling purposes:
-        transforms = self._init_transforms(
+        transforms = self._init_domain_transforms(
             np.asarray(
                 FlattenedControls(self._everest_config.controls).initial_guesses,
                 dtype=np.float64,

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -3,7 +3,7 @@ import os
 from typing import Any
 
 import numpy as np
-from ropt.config.enopt import EnOptConfig, EnOptContext
+from ropt.config.enopt import EnOptConfig
 from ropt.enums import PerturbationType, VariableType
 from ropt.transforms import OptModelTransforms
 
@@ -342,7 +342,4 @@ def everest2ropt(
         ropt_config=ropt_config,
     )
 
-    return EnOptConfig.model_validate(
-        ropt_config,
-        context=None if transforms is None else EnOptContext(transforms=transforms),
-    )
+    return EnOptConfig.model_validate(ropt_config, context=transforms)

--- a/src/everest/optimizer/opt_model_transforms.py
+++ b/src/everest/optimizer/opt_model_transforms.py
@@ -18,6 +18,12 @@ from everest.config.utils import FlattenedControls
 
 
 class ControlScaler(VariableTransform):
+    """Transformation object to define a linear scaling of controls.
+
+    This object defines a linear scaling from lower and upper bounds [lb, ub] in
+    the user domain to a target range in the optimizer domain.
+    """
+
     def __init__(
         self,
         lower_bounds: Sequence[float],
@@ -25,7 +31,19 @@ class ControlScaler(VariableTransform):
         scaled_ranges: Sequence[tuple[float, float]],
         auto_scales: Sequence[bool],
     ) -> None:
-        self._scales = [
+        """Transformation object to define a linear scaling.
+
+        This is implemented by internally representing the transformation from
+        the user to the optimizer domain by a subtraction of an offset and a
+        division by a scaling factor.
+
+         Args:
+             lower_bounds:  Lower bounds in the user domain.
+             upper_bounds:  Upper bounds in the user domain.
+             scaled_ranges: target ranges in the optimizer domain.
+             auto_scales:   Flag indicating if scaling is required.
+        """
+        self._scaling_factors = [
             (ub - lb) / (sr[1] - sr[0]) if au else 1.0
             for au, lb, ub, sr in zip(
                 auto_scales, lower_bounds, upper_bounds, scaled_ranges, strict=True
@@ -34,20 +52,47 @@ class ControlScaler(VariableTransform):
         self._offsets = [
             lb - sr[0] * sc if au else 0.0
             for au, lb, sc, sr in zip(
-                auto_scales, lower_bounds, self._scales, scaled_ranges, strict=True
+                auto_scales,
+                lower_bounds,
+                self._scaling_factors,
+                scaled_ranges,
+                strict=True,
             )
         ]
 
-    def forward(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
-        return (values - self._offsets) / self._scales
+    def to_optimizer(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform values to the optimizer domain.
 
-    def backward(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
-        return values * self._scales + self._offsets
+        The transformation is defined by subtracting offsets, followed by
+        division by scaling factors.
 
-    def transform_magnitudes(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
-        return values / self._scales
+        Args:
+            values: The values to transform
 
-    def transform_linear_constraints(  # type: ignore
+        Returns:
+            The transformed values.
+        """
+        return (values - self._offsets) / self._scaling_factors
+
+    def from_optimizer(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+        return values * self._scaling_factors + self._offsets
+
+    def magnitudes_to_optimizer(
+        self, values: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Transform a magnitude value to the optimizer domain.
+
+        Since magnitudes are relative values only a scaling is applied.
+
+        Args:
+            values: The magnitudes to transform.
+
+        Returns:
+            The transformed magnitudes.
+        """
+        return values / self._scaling_factors
+
+    def linear_constraints_to_optimizer(
         self,
         coefficients: NDArray[np.float64],
         lower_bounds: NDArray[np.float64],
@@ -56,81 +101,262 @@ class ControlScaler(VariableTransform):
         r"""Transform a set of linear constraints.
 
         The set of linear constraints can be represented by a matrix equation:
-        $\mathbf{A} \mathbf{x} = \mathbf{b}.
+        $\mathbf{A} \mathbf{x} = \mathbf{b}$. When linearly transforming
+        variables to the optimizer domain, the coefficients ($\mathbf{A}$) and
+        right-hand-side values ($\mathbf{b}$) must be converted to remain valid.
 
-        When rescaling variables, the linear coefficients ($\mathbf{A}$) and
-        right-hand-side values ($\mathbf{b}$) must be converted to remain
-        valid for the scaled variables:
+        Here, the linear transformation of the variables to the optimizer domain
+        is given by the scaling factors $\mathbf{s}_i$ and the offsets $\mathbf{o}_i$:
+
         $$
-        \begin{align}
+        \hat{\mathbf{x}}_i = \frac{\mathbf{x}_i - \mathbf{o}_i}{\mathbf{s}_i}
+        $$
+
+        In the optimizer domeain, the coefficients and right-hand-side values
+        must then be transformed as follows:
+
+        $$ \begin{align}
             \hat{\mathbf{A}} &= \mathbf{A} \mathbf{S} \\
             \hat{\mathbf{b}} &= \mathbf{b} - \mathbf{A}\mathbf{o}
-        \end{align}
-        $$
+        \end{align}$$
 
-        where $\mathbf{S}$ is a diagonal matrix containing the variable
-        scales, and $\mathbf{o}$ is a vector containing the variable offsets.
+        where $\mathbf{S}$ is a diagonal matrix containing the variable scales
+        $\mathbf{s}_i$.
         """
         if self._offsets is not None:
             offsets = np.matmul(coefficients, self._offsets)
             lower_bounds = lower_bounds - offsets  # noqa: PLR6104
             upper_bounds = upper_bounds - offsets  # noqa: PLR6104
-        if self._scales is not None:
-            coefficients = coefficients * self._scales  # noqa: PLR6104
+        if self._scaling_factors is not None:
+            coefficients = coefficients * self._scaling_factors  # noqa: PLR6104
         return coefficients, lower_bounds, upper_bounds
+
+    def bound_constraint_diffs_from_optimizer(
+        self, lower_diffs: NDArray[np.float64], upper_diffs: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Transform constraint differences to the user domain.
+
+        Since these values are differences with respect to a bound, they are not
+        affected by offsets. They are transformed back by multiplying with the
+        scaling factor.
+
+        Args:
+            lower_diffs: Differences with respect to the lower bounds.
+            upper_diffs: Differences with respect to the upper bounds.
+
+        Returns:
+            The re-scaled bounds.
+        """
+        if self._scaling_factors is not None:
+            lower_diffs = lower_diffs * self._scaling_factors  # noqa: PLR6104
+            upper_diffs = upper_diffs * self._scaling_factors  # noqa: PLR6104
+        return lower_diffs, upper_diffs
+
+    def linear_constraints_diffs_from_optimizer(
+        self, lower_diffs: NDArray[np.float64], upper_diffs: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Transform linear constraint differences to the user domain.
+
+        Linear constraints are transformed to remain valid in the optimizer
+        domain, but the equations themselves are not scaled. Hence differences
+        with the right-hand-side are the same in the optimization and user
+        domain.
+
+        Args:
+            lower_diffs: Differences with respect to the lower bounds.
+            upper_diffs: Differences with respect to the upper bounds.
+
+        Note:
+            This method is defined in the base class to raise a not-implemented
+            error, hence it must be overridden even if it just returns its
+            inputs. The transformation logic in `ropt` expects valid results to
+            be returned.
+
+        Returns:
+            The original inputs.
+        """
+        return lower_diffs, upper_diffs
 
 
 class ObjectiveScaler(ObjectiveTransform):
+    """Transformation object for linearly scaling objectives.
+
+    Objectives are transformed to the optimizer domain by division with a
+    scaling factor. Some scaling factors may be calculated after initialization
+    of the object. The `has_auto_scales` property will be true if this
+    calculation is needed, and the `calculate_auto_scales` method can be used to
+    calculate this for each objective from a set of realizations of the objective.
+
+    In addition to scaling, this object also implements the transformation from
+    maximization to minimization by multiplying the objectives with -1.
+    """
+
     def __init__(
         self, scales: list[float], auto_scales: list[bool], weights: list[float]
     ) -> None:
-        self._scales = np.asarray(scales, dtype=np.float64)
+        """Initialize the object.
+
+        Args:
+            scales:      The scales.
+            auto_scales: Flags indicating which objects are auto-scaled.
+            weights:     Weights used to perform auto-scaling.
+        """
+        self._scaling_factors = np.asarray(scales, dtype=np.float64)
         self._auto_scales = np.asarray(auto_scales, dtype=np.bool_)
         self._weights = np.asarray(weights, dtype=np.float64)
 
     # The transform methods below all return the negative of the objectives.
     # This is because Everest maximizes the objectives, while ropt is a minimizer.
 
-    def forward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
-        return -objectives / self._scales
+    def to_optimizer(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform objectives to optimizer space.
 
-    def backward(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
-        return -objectives * self._scales
+        Args:
+            objectives: The objectives to transform.
 
-    def transform_weighted_objective(self, weighted_objective):  # type: ignore
+        Returns:
+            The negative of the scaled objectives.
+        """
+        return -objectives / self._scaling_factors
+
+    def from_optimizer(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform objectives to user space.
+
+        Args:
+            objectives: The objectives to transform.
+
+        Returns:
+            The negative of the re-scaled objectives.
+        """
+        return -objectives * self._scaling_factors
+
+    def weighted_objective_from_optimizer(
+        self, weighted_objective: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Transform the weighted objective to user space.
+
+        The weighted objective is composed of several objectives that may be
+        scaled different. By definition scaling it back somehow is meaningless.
+        However, due to the transformation from maximization to minimization, a
+        factor of -1 is applied.
+
+        Args:
+            weighted_objective: The weighted objective value.
+
+        Returns:
+            The value multiplied with -1.
+        """
         return -weighted_objective
 
     def calculate_auto_scales(self, objectives: NDArray[np.float64]) -> None:
+        """Calculated scales from a set of realizations.
+
+        For selected objectives, this method calculates the scales by a weighted
+        sum of the objectives from an ensemble of objective values.
+
+        The input must be a matrix, where each column represents the different
+        realizations of an objective.
+
+        Args:
+            objectives: The objectives for each realization.
+        """
         auto_scales = np.abs(
             np.nansum(objectives * self._weights[:, np.newaxis], axis=0)
         )
-        self._scales[self._auto_scales] *= auto_scales[self._auto_scales]
+        self._scaling_factors[self._auto_scales] *= auto_scales[self._auto_scales]
 
     @property
     def has_auto_scale(self) -> bool:
+        """Return true if any objective is auto-scaled."""
         return bool(np.any(self._auto_scales))
 
 
 class ConstraintScaler(NonLinearConstraintTransform):
+    """Transformation object for linearly scaling constraints.
+
+    Constraints are transformed to the optimizer domain by division with a
+    scaling factor. Some scaling factors may be calculated after initialization
+    of the object. The `has_auto_scales` property will be true if this
+    calculation is needed, and the `calculate_auto_scales` method can be used to
+    calculate this for each constraint from a set of realizations of the constraint.
+    """
+
     def __init__(
         self, scales: list[float], auto_scales: list[bool], weights: list[float]
     ) -> None:
+        """Initialize the object.
+
+        Args:
+            scales:      The scales.
+            auto_scales: Flags indicating which constraints are auto-scaled.
+            weights:     Weights used to perform auto-scaling.
+        """
         self._scales = np.asarray(scales, dtype=np.float64)
         self._auto_scales = np.asarray(auto_scales, dtype=np.bool_)
         self._weights = np.asarray(weights, dtype=np.float64)
 
-    def transform_bounds(
+    def bounds_to_optimizer(
         self, lower_bounds: NDArray[np.float64], upper_bounds: NDArray[np.float64]
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Transform the bounds of teh constraints to the optimizer domain.
+
+        Args:
+             lower_bounds:  Lower bounds in the user domain.
+             upper_bounds:  Upper bounds in the user domain.
+
+        Returns:
+            The scaled bounds.
+        """
         return lower_bounds / self._scales, upper_bounds / self._scales
 
-    def forward(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
+    def to_optimizer(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform constraints to optimizer space.
+
+        Args:
+            constraints: The constraints to transform.
+
+        Returns:
+            The scaled constraints.
+        """
         return constraints / self._scales
 
-    def backward(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
+    def from_optimizer(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform constraints to user space.
+
+        Args:
+            constraints: The constraints to transform.
+
+        Returns:
+            The negative of the re-scaled constraints.
+        """
         return constraints * self._scales
 
+    def nonlinear_constraint_diffs_from_optimizer(
+        self, lower_diffs: NDArray[np.float64], upper_diffs: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Transform constraint differences to the user domain.
+
+        Args:
+            lower_diffs: Differences with respect to the lower bounds.
+            upper_diffs: Differences with respect to the upper bounds.
+
+        Returns:
+            The re-scaled bounds.
+        """
+        return lower_diffs * self._scales, upper_diffs * self._scales
+
     def calculate_auto_scales(self, constraints: NDArray[np.float64]) -> None:
+        """Calculated scales from a set of realizations.
+
+        For selected constraints, this method calculates the scales by a weighted
+        sum of the constraints from an ensemble of constraint values.
+
+        The input must be a matrix, where each column represents the different
+        realizations of an constraint.
+
+        Args:
+            cnstraints: The constraints for each realization.
+        """
         auto_scales = np.abs(
             np.nansum(constraints * self._weights[:, np.newaxis], axis=0)
         )
@@ -138,6 +364,7 @@ class ConstraintScaler(NonLinearConstraintTransform):
 
     @property
     def has_auto_scale(self) -> bool:
+        """Return true if any constraint is auto-scaled."""
         return bool(np.any(self._auto_scales))
 
 

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -307,7 +307,6 @@ def test_everest2ropt_snapshot(case, snapshot):
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
     ropt_config["optimizer"]["output_dir"] = "not_relevant"
-    del ropt_config["original_inputs"]
 
     ropt_config_str = (
         orjson.dumps(

--- a/uv.lock
+++ b/uv.lock
@@ -834,8 +834,8 @@ requires-dist = [
     { name = "resdata", marker = "extra == 'everest'" },
     { name = "resfo" },
     { name = "resfo", marker = "extra == 'dev'" },
-    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.14,<0.15" },
-    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.14,<0.15" },
+    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.15,<0.16" },
+    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.15,<0.16" },
     { name = "ruamel-yaml", marker = "extra == 'everest'" },
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1,<1.15" },
@@ -3191,35 +3191,34 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.14.0"
+version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/d4/010627ad0d75c372776021469b835dc60b2d1fbca2bc7d3b9db63b8bb81a/ropt-0.14.0.tar.gz", hash = "sha256:1b4ddf7f5c0703151a26c87690a41612cd5ea6815ccaff61c2ba8905b17b3720", size = 138715 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/d8/b17e6c00df878bedceead38e29a1a751f9bd3754a341e0b425fbf709d33d/ropt-0.15.2.tar.gz", hash = "sha256:cb2c7b80f7295ed82324133f60d94b6e4eb83c722908442c61dcf379aa89188a", size = 137367 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/be/a8ecc424d51756c2f2ede3f58acb9e74ee0567112b7e6a115a251b9187a9/ropt-0.14.0-py3-none-any.whl", hash = "sha256:d79b52844b3d5e65d95c59d6862539f99dead61a41570e8b0a6aa6e5cdbe6ac7", size = 147180 },
+    { url = "https://files.pythonhosted.org/packages/8b/4c/aecdda037c73a6b4980e542088891092257ff62410c6b4c8bbf1877dea56/ropt-0.15.2-py3-none-any.whl", hash = "sha256:0a4ec5ceb344b071f7c9bf93ccbdd95e375f452b85f639092fa7b8133ac4a1d5", size = 147174 },
 ]
 
 [package.optional-dependencies]
 pandas = [
     { name = "pandas" },
-    { name = "tabulate" },
 ]
 
 [[package]]
 name = "ropt-dakota"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/49/979eb592941acc4c02cf7a36c3c1d28a0df20d90281ec8f552cdd1df68bf/ropt_dakota-0.14.0.tar.gz", hash = "sha256:7cb16c3361b49a678d89f6ccba977d14fe67ba1aa77427832f068d97960519c8", size = 24015 }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/41/7958ce2cde5c73de7b135d6373928c97c5afabd324d6960f87763ba7ac94/ropt_dakota-0.15.0.tar.gz", hash = "sha256:09aca20b64028e73b74bbd51faf4f3596db4786acd5183456730c55826ebc8c8", size = 23851 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/f1/dec0681fb61132bcfae1ee6cc8c13f54330d621f9bd9a6cb5c3a1a1fbe2b/ropt_dakota-0.14.0-py3-none-any.whl", hash = "sha256:b8bb44417abdc5ae95361084634ddbe4631c10d07bf24932f69925ff0fa5d08d", size = 19685 },
+    { url = "https://files.pythonhosted.org/packages/11/56/c5704d111aa46551350a7cba06aa09ba884cb408cf6e38a7394ae0e8b136/ropt_dakota-0.15.0-py3-none-any.whl", hash = "sha256:fc47ab2dc7734e56704d99c267744de50ee203208bdab90da77c371143544861", size = 19594 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue**
Update to ropt 0.15

**Approach**
Following changes are maded:
- Not related to the 0.15 update:
       - Renamed the `init_transforms` method to `init_domain_transforms`.
- Needed for the 0.15 update:
       1. Ropt now requires evaluations for unscaled controls. Everest must scale again before calling forward models until these are adapted to handle unscaled controls.
       2. Small change in the signature of the context object expected by EnOptConfig.model_validate.
       3. The optimization domain transformation classes have renamed methods that more clear convey their intent.
       4. The transformation classes now support transformation of constraint differences/violations.
       5. A weighting has been introduced for linear constraints after scaling.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
