### PR TITLE
Skip executing empty forward model w/ ensemble evaluator

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -453,6 +453,46 @@ class EverestRunModel(BaseRunModel):
             and (active_control_vectors is None or active_control_vectors[idx])
         ]
 
+        if not evaluated_control_indices:
+            cached_results = self._get_cached_results(
+                control_values, model_realizations
+            )
+
+            objectives = np.zeros(
+                (
+                    control_values.shape[0],
+                    len(self._everest_config.objective_names),
+                ),
+                dtype=float64,
+            )
+
+            constraints = (
+                np.zeros(
+                    (
+                        control_values.shape[0],
+                        len(self._everest_config.constraint_names),
+                    ),
+                    dtype=float64,
+                )
+                if self._everest_config.constraint_names
+                else None
+            )
+
+            for control_idx, (
+                cached_objectives,
+                cached_constraints,
+            ) in cached_results.items():
+                objectives[control_idx, ...] = cached_objectives
+                if constraints is not None:
+                    assert cached_constraints is not None
+                    constraints[control_idx, ...] = cached_constraints
+
+                # Increase the batch ID for the next evaluation:
+            self._batch_id += 1
+
+            # Return the results, together with the indices of the evaluated controls:
+            return objectives, constraints, evaluated_control_indices
+
         # Create the batch to run:
         sim_controls = self._create_simulation_controls(
             control_values, evaluated_control_indices

--- a/tests/everest/test_simulator_cache.py
+++ b/tests/everest/test_simulator_cache.py
@@ -8,12 +8,12 @@ from everest.config import EverestConfig
 
 @pytest.mark.integration_test
 def test_simulator_cache(copy_math_func_test_data_to_tmp):
-    n_evals = 0
+    n_invocations = 0
 
     def new_call(*args):
-        nonlocal n_evals
+        nonlocal n_invocations
         result = original_call(*args)
-        n_evals += (result.evaluation_ids >= 0).sum()
+        n_invocations += 1
         return result
 
     config = EverestConfig.load_file("config_minimal.yml")
@@ -24,22 +24,22 @@ def test_simulator_cache(copy_math_func_test_data_to_tmp):
     evaluator_server_config = EvaluatorServerConfig()
 
     # Modify the forward model function to track number of calls:
-    original_call = run_model._forward_model_evaluator
-    run_model._forward_model_evaluator = new_call
+    original_call = run_model._evaluate_and_postprocess
+    run_model._evaluate_and_postprocess = new_call
 
     # First run populates the cache:
     run_model.run_experiment(evaluator_server_config)
-    assert n_evals > 0
+    assert n_invocations > 0
     variables1 = list(run_model.result.controls.values())
     assert np.allclose(variables1, [0.5, 0.5, 0.5], atol=0.02)
 
     # Now do another run, where the functions should come from the cache:
-    n_evals = 0
+    n_invocations = 0
 
     # The batch_id was used as a stopping criterion, so it must be reset:
     run_model._batch_id = 0
 
     run_model.run_experiment(evaluator_server_config)
-    assert n_evals == 0
+    assert n_invocations == 0
     variables2 = list(run_model.result.controls.values())
     assert np.array_equal(variables1, variables2)


### PR DESCRIPTION
Resolves #10075 
Correct everest behavior. If it found the simulation results in cache, it should not have to create a runpath, evaluate the forward model etc. This will make it also skip creating the ensemble in storage, this behavior will/should be revisited in the future as we use ERT storage for the simulation results.