### PR TITLE
Pin opentelemetry exactly to avoid pip issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dependencies = [
     "openpyxl",                                # extra dependency for pandas (excel)
     "opentelemetry-api<1.30.0",
     "opentelemetry-sdk<1.30.0",
-    "opentelemetry-instrumentation-fastapi<0.51b0",
-    "opentelemetry-instrumentation-httpx<0.51b0",
-    "opentelemetry-instrumentation-threading<0.51b0",
+    "opentelemetry-instrumentation-fastapi==0.50b0",
+    "opentelemetry-instrumentation-httpx==0.50b0",
+    "opentelemetry-instrumentation-threading==0.50b0",
     "orjson",
     "packaging",
     "pandas",


### PR DESCRIPTION
Pip will not find any opentelemetry packages less than 0.51b0 as opentelemetry only provides beta releases (unless --pre is supplied to pip). Workaround by pinning to an exact version until opentelemetry comes with a release newer than 0.51b0

**Issue**
Resolves #10110 


**Approach**
🪡 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
