### PR TITLE
Make tests faster by avoiding StorageService

### DIFF
--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -8,7 +8,6 @@ import sys
 from argparse import ArgumentParser
 from importlib.resources import files
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from hypothesis import HealthCheck, settings
@@ -23,7 +22,6 @@ from ert.cli.main import run_cli
 from ert.config import ErtConfig
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE, ES_MDA_MODE
-from ert.services import StorageService
 from ert.storage import open_storage
 
 from .utils import SOURCE_DIR
@@ -239,20 +237,6 @@ def copy_minimum_case(copy_case):
 @pytest.fixture()
 def use_tmpdir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-
-
-@pytest.fixture()
-def mock_start_server(monkeypatch):
-    start_server = MagicMock()
-    monkeypatch.setattr(StorageService, "start_server", start_server)
-    yield start_server
-
-
-@pytest.fixture()
-def mock_connect(monkeypatch):
-    connect = MagicMock()
-    monkeypatch.setattr(StorageService, "connect", connect)
-    yield connect
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -37,7 +37,6 @@ from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import AddWidget, StorageWidget
 from ert.plugins import ErtPluginContext
 from ert.run_models import EnsembleExperiment, MultipleDataAssimilation
-from ert.services import StorageService
 from ert.storage import Storage, open_storage
 from tests.ert.unit_tests.gui.simulation.test_run_path_dialog import (
     handle_run_path_dialog,
@@ -49,10 +48,7 @@ def open_gui_with_config(config_path) -> Iterator[ErtMainWindow]:
         _open_main_window(config_path) as (
             gui,
             _,
-            config,
-        ),
-        StorageService.init_service(
-            project=os.path.abspath(config.ens_path),
+            __,
         ),
     ):
         yield gui
@@ -190,10 +186,7 @@ def esmda_has_run(_esmda_run, tmp_path, monkeypatch):
         _open_main_window(tmp_path / "poly.ert") as (
             gui,
             _,
-            config,
-        ),
-        StorageService.init_service(
-            project=os.path.abspath(config.ens_path),
+            __,
         ),
     ):
         yield gui

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -289,113 +289,117 @@ def test_that_the_plot_window_contains_the_expected_elements(
     esmda_has_run: ErtMainWindow, qtbot
 ):
     gui = esmda_has_run
-    expected_ensembles = [
-        "es_mda : default_0",
-        "es_mda : default_1",
-        "es_mda : default_2",
-        "es_mda : default_3",
-    ]
+    with StorageService.init_service(
+        project=os.path.abspath(gui.ert_config.ens_path),
+    ):
+        expected_ensembles = [
+            "es_mda : default_0",
+            "es_mda : default_1",
+            "es_mda : default_2",
+            "es_mda : default_3",
+        ]
 
-    # Click on Create plot after esmda has run
-    button_plot_tool = gui.findChild(QToolButton, "button_Create_plot")
-    assert button_plot_tool
-    qtbot.mouseClick(button_plot_tool, Qt.MouseButton.LeftButton)
-    plot_window = wait_for_child(gui, qtbot, PlotWindow)
+        # Click on Create plot after esmda has run
+        button_plot_tool = gui.findChild(QToolButton, "button_Create_plot")
+        assert button_plot_tool
+        qtbot.mouseClick(button_plot_tool, Qt.MouseButton.LeftButton)
+        plot_window = wait_for_child(gui, qtbot, PlotWindow)
 
-    data_types = get_child(plot_window, DataTypeKeysWidget)
-    case_selection = get_child(
-        plot_window, EnsembleSelectListWidget, "ensemble_selector"
-    )
+        data_types = get_child(plot_window, DataTypeKeysWidget)
+        case_selection = get_child(
+            plot_window, EnsembleSelectListWidget, "ensemble_selector"
+        )
 
-    # Assert that the Case selection widget contains the expected ensembles
-    ensemble_names = []
-    for index in range(case_selection.count()):
-        ensemble_names.append(case_selection.item(index).text())
+        # Assert that the Case selection widget contains the expected ensembles
+        ensemble_names = []
+        for index in range(case_selection.count()):
+            ensemble_names.append(case_selection.item(index).text())
 
-    assert sorted(ensemble_names) == expected_ensembles
+        assert sorted(ensemble_names) == expected_ensembles
 
-    data_names = []
-    data_keys = data_types.data_type_keys_widget
-    for i in range(data_keys.model().rowCount()):
-        index = data_keys.model().index(i, 0)
-        data_names.append(str(index.data(Qt.ItemDataRole.DisplayRole)))
+        data_names = []
+        data_keys = data_types.data_type_keys_widget
+        for i in range(data_keys.model().rowCount()):
+            index = data_keys.model().index(i, 0)
+            data_names.append(str(index.data(Qt.ItemDataRole.DisplayRole)))
 
-    expected_data_names = [
-        "POLY_RES@0",
-        "COEFFS:a",
-        "COEFFS:b",
-        "COEFFS:c",
-    ]
-    expected_data_names.sort()
-    data_names.sort()
-    assert expected_data_names == data_names
+        expected_data_names = [
+            "POLY_RES@0",
+            "COEFFS:a",
+            "COEFFS:b",
+            "COEFFS:c",
+        ]
+        expected_data_names.sort()
+        data_names.sort()
+        assert expected_data_names == data_names
 
-    assert {
-        plot_window._central_tab.tabText(i)
-        for i in range(plot_window._central_tab.count())
-    } == {
-        "Cross ensemble statistics",
-        "Distribution",
-        "Gaussian KDE",
-        "Ensemble",
-        "Histogram",
-        "Statistics",
-        "Std Dev",
-    }
+        assert {
+            plot_window._central_tab.tabText(i)
+            for i in range(plot_window._central_tab.count())
+        } == {
+            "Cross ensemble statistics",
+            "Distribution",
+            "Gaussian KDE",
+            "Ensemble",
+            "Histogram",
+            "Statistics",
+            "Std Dev",
+        }
 
-    model = data_keys.model()
-    assert model is not None
+        model = data_keys.model()
+        assert model is not None
 
-    def click_plotter_item(pos: int) -> None:
-        center = data_keys.visualRect(model.index(pos, 0)).center()
-        viewport = data_keys.viewport()
-        center = viewport.mapToGlobal(center)
-        local_pos = viewport.mapFromGlobal(center)
-        qtbot.mouseClick(data_keys.viewport(), Qt.MouseButton.LeftButton, pos=local_pos)
+        def click_plotter_item(pos: int) -> None:
+            center = data_keys.visualRect(model.index(pos, 0)).center()
+            viewport = data_keys.viewport()
+            center = viewport.mapToGlobal(center)
+            local_pos = viewport.mapFromGlobal(center)
+            qtbot.mouseClick(
+                data_keys.viewport(), Qt.MouseButton.LeftButton, pos=local_pos
+            )
 
-    def click_tab_index(pos: int) -> None:
-        tab_bar = plot_window._central_tab.tabBar()
-        tab_center = tab_bar.tabRect(pos).center()
-        qtbot.mouseClick(tab_bar, Qt.MouseButton.LeftButton, pos=tab_center)
+        def click_tab_index(pos: int) -> None:
+            tab_bar = plot_window._central_tab.tabBar()
+            tab_center = tab_bar.tabRect(pos).center()
+            qtbot.mouseClick(tab_bar, Qt.MouseButton.LeftButton, pos=tab_center)
 
-    # make sure plotter remembers plot types selected previously
-    response_index = 0
-    gen_kw_index = 1
-    response_alternate_index = 1
-    gen_kw_alternate_index = 3
+        # make sure plotter remembers plot types selected previously
+        response_index = 0
+        gen_kw_index = 1
+        response_alternate_index = 1
+        gen_kw_alternate_index = 3
 
-    # check default selections
-    click_plotter_item(response_index)
-    assert plot_window._central_tab.currentIndex() == RESPONSE_DEFAULT
-    click_plotter_item(gen_kw_index)
-    assert plot_window._central_tab.currentIndex() == GEN_KW_DEFAULT
+        # check default selections
+        click_plotter_item(response_index)
+        assert plot_window._central_tab.currentIndex() == RESPONSE_DEFAULT
+        click_plotter_item(gen_kw_index)
+        assert plot_window._central_tab.currentIndex() == GEN_KW_DEFAULT
 
-    # alter selections
-    click_plotter_item(response_index)
-    click_tab_index(response_alternate_index)
-    click_plotter_item(gen_kw_index)
-    click_tab_index(gen_kw_alternate_index)
+        # alter selections
+        click_plotter_item(response_index)
+        click_tab_index(response_alternate_index)
+        click_plotter_item(gen_kw_index)
+        click_tab_index(gen_kw_alternate_index)
 
-    # verify previous selections still valid
-    click_plotter_item(response_index)
-    assert plot_window._central_tab.currentIndex() == response_alternate_index
-    click_plotter_item(gen_kw_index)
-    assert plot_window._central_tab.currentIndex() == gen_kw_alternate_index
+        # verify previous selections still valid
+        click_plotter_item(response_index)
+        assert plot_window._central_tab.currentIndex() == response_alternate_index
+        click_plotter_item(gen_kw_index)
+        assert plot_window._central_tab.currentIndex() == gen_kw_alternate_index
 
-    # finally click all items
-    for i in range(model.rowCount()):
-        click_plotter_item(i)
-        for tab_index in range(plot_window._central_tab.count()):
-            if not plot_window._central_tab.isTabEnabled(tab_index):
-                continue
-            click_tab_index(tab_index)
+        # finally click all items
+        for i in range(model.rowCount()):
+            click_plotter_item(i)
+            for tab_index in range(plot_window._central_tab.count()):
+                if not plot_window._central_tab.isTabEnabled(tab_index):
+                    continue
+                click_tab_index(tab_index)
 
-    plot_window.close()
+        plot_window.close()
 
 
 def test_that_the_manage_experiments_tool_can_be_used(esmda_has_run, qtbot):
     gui = esmda_has_run
-
     button_manage_experiments = gui.findChild(QToolButton, "button_Manage_experiments")
     assert button_manage_experiments
     qtbot.mouseClick(button_manage_experiments, Qt.MouseButton.LeftButton)

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -690,58 +690,48 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, storage, monkeypa
 def test_that_es_mda_restart_run_box_is_disabled_when_there_are_no_cases(qtbot):
     args = Mock()
     args.config = "poly.ert"
-    ert_config = ErtConfig.from_file(args.config)
-    with StorageService.init_service(
-        project=os.path.abspath(ert_config.ens_path),
-    ):
-        gui, *_ = ert.gui.main._start_initial_gui_window(args, GUILogHandler())
-        assert gui.windowTitle().startswith("ERT - poly.ert")
+    gui, *_ = ert.gui.main._start_initial_gui_window(args, GUILogHandler())
+    assert gui.windowTitle().startswith("ERT - poly.ert")
 
-        combo_box = get_child(gui, QComboBox, name="experiment_type")
-        qtbot.mouseClick(combo_box, Qt.MouseButton.LeftButton)
-        assert combo_box.count() == 6
-        combo_box.setCurrentIndex(3)
+    combo_box = get_child(gui, QComboBox, name="experiment_type")
+    qtbot.mouseClick(combo_box, Qt.MouseButton.LeftButton)
+    assert combo_box.count() == 6
+    combo_box.setCurrentIndex(3)
 
-        assert combo_box.currentText() == MultipleDataAssimilation.display_name()
+    assert combo_box.currentText() == MultipleDataAssimilation.display_name()
 
-        es_mda_panel = get_child(gui, QWidget, name="ES_MDA_panel")
-        assert es_mda_panel
+    es_mda_panel = get_child(gui, QWidget, name="ES_MDA_panel")
+    assert es_mda_panel
 
-        restart_button = get_child(
-            es_mda_panel, QCheckBox, name="restart_checkbox_esmda"
-        )
-        ensemble_selector = get_child(es_mda_panel, EnsembleSelector)
+    restart_button = get_child(es_mda_panel, QCheckBox, name="restart_checkbox_esmda")
+    ensemble_selector = get_child(es_mda_panel, EnsembleSelector)
 
-        assert restart_button
+    assert restart_button
 
-        assert len(ensemble_selector._ensemble_list()) == 0
-        assert not restart_button.isEnabled()
+    assert len(ensemble_selector._ensemble_list()) == 0
+    assert not restart_button.isEnabled()
 
-        add_experiment_manually(qtbot, gui, ensemble_name="test_ensemble")
-        assert len(ensemble_selector._ensemble_list()) == 1
+    add_experiment_manually(qtbot, gui, ensemble_name="test_ensemble")
+    assert len(ensemble_selector._ensemble_list()) == 1
 
-        assert restart_button.isEnabled()
+    assert restart_button.isEnabled()
 
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_help_menu(qtbot):
     args = Mock()
     args.config = "poly.ert"
-    ert_config = ErtConfig.from_file(args.config)
-    with StorageService.init_service(
-        project=os.path.abspath(ert_config.ens_path),
-    ):
-        gui, *_ = ert.gui.main._start_initial_gui_window(args, GUILogHandler())
-        assert gui.windowTitle().startswith("ERT - poly.ert")
-        menu_bar = gui.menuBar()
-        assert isinstance(menu_bar, QMenuBar)
-        get_child(menu_bar, QAction, name="about_action").trigger()
-        about_dialog = wait_for_child(gui, qtbot, AboutDialog)
-        assert about_dialog.windowTitle() == "About"
-        qtbot.mouseClick(
-            get_child(about_dialog, QPushButton, name="close_button"),
-            Qt.MouseButton.LeftButton,
-        )
+    gui, *_ = ert.gui.main._start_initial_gui_window(args, GUILogHandler())
+    assert gui.windowTitle().startswith("ERT - poly.ert")
+    menu_bar = gui.menuBar()
+    assert isinstance(menu_bar, QMenuBar)
+    get_child(menu_bar, QAction, name="about_action").trigger()
+    about_dialog = wait_for_child(gui, qtbot, AboutDialog)
+    assert about_dialog.windowTitle() == "About"
+    qtbot.mouseClick(
+        get_child(about_dialog, QPushButton, name="close_button"),
+        Qt.MouseButton.LeftButton,
+    )
 
 
 def test_validation_of_experiment_names_in_run_models(

--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -17,7 +17,6 @@ from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.tools.event_viewer import GUILogHandler
 from ert.run_models import EnsembleExperiment
 from ert.run_models.evaluate_ensemble import EvaluateEnsemble
-from ert.services import StorageService
 from ert.storage import Storage, open_storage
 from ert.validation import rangestring_to_mask
 
@@ -83,10 +82,7 @@ def open_gui(tmp_path, monkeypatch, run_experiment, tmp_path_factory):
         _open_main_window(tmp_path) as (
             gui,
             _,
-            config,
-        ),
-        StorageService.init_service(
-            project=os.path.abspath(config.ens_path),
+            __,
         ),
     ):
         yield gui

--- a/tests/ert/ui_tests/gui/test_workflow_tool.py
+++ b/tests/ert/ui_tests/gui/test_workflow_tool.py
@@ -15,7 +15,6 @@ from ert.gui.tools.event_viewer import GUILogHandler
 from ert.gui.tools.workflows import RunWorkflowWidget
 from ert.plugins import ErtPluginContext
 from ert.run_models import EnsembleExperiment
-from ert.services import StorageService
 from ert.storage import Storage, open_storage
 
 from .conftest import get_child, wait_for_child
@@ -57,10 +56,7 @@ def open_gui(tmp_path, monkeypatch):
         _open_main_window(tmp_path) as (
             gui,
             _,
-            config,
-        ),
-        StorageService.init_service(
-            project=os.path.abspath(config.ens_path),
+            __,
         ),
     ):
         yield gui

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -1,4 +1,3 @@
-import os
 from queue import SimpleQueue
 from unittest.mock import MagicMock, Mock, patch
 
@@ -33,7 +32,6 @@ from ert.gui.simulation.view.realization import RealizationWidget
 from ert.gui.tools.file import FileDialog
 from ert.run_models.base_run_model import BaseRunModelAPI
 from ert.run_models.ensemble_experiment import EnsembleExperiment
-from ert.services import StorageService
 from ert.storage import open_storage
 from tests.ert import SnapshotBuilder
 from tests.ert.ui_tests.gui.conftest import wait_for_child
@@ -564,9 +562,6 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
 
     ert_config = ErtConfig.from_file(config_file)
     with (
-        StorageService.init_service(
-            project=os.path.abspath(ert_config.ens_path),
-        ),
         patch.object(
             ert.run_models.SingleTestRun,
             "run_experiment",
@@ -606,9 +601,6 @@ def test_that_stdout_and_stderr_buttons_react_to_file_content(
     args_mock.config = "snake_oil.ert"
 
     with (
-        StorageService.init_service(
-            project=os.path.abspath(snake_oil_case.ens_path),
-        ),
         open_storage(snake_oil_case.ens_path, mode="w") as storage,
     ):
         gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
@@ -703,25 +695,22 @@ def test_that_design_matrix_show_parameters_button_is_visible(
     args_mock.config = config_file
 
     ert_config = ErtConfig.from_file(config_file)
-    with StorageService.init_service(
-        project=os.path.abspath(ert_config.ens_path),
-    ):
-        gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
-        experiment_panel = gui.findChild(ExperimentPanel)
-        assert experiment_panel
+    gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
+    experiment_panel = gui.findChild(ExperimentPanel)
+    assert experiment_panel
 
-        simulation_mode_combo = experiment_panel.findChild(QComboBox)
-        assert simulation_mode_combo
+    simulation_mode_combo = experiment_panel.findChild(QComboBox)
+    assert simulation_mode_combo
 
-        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
-        simulation_settings = gui.findChild(EnsembleExperimentPanel)
-        show_dm_parameters = simulation_settings.findChild(
-            QPushButton, "show-dm-parameters"
-        )
-        if design_matrix_entry:
-            assert show_dm_parameters
-        else:
-            assert show_dm_parameters is None
+    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+    simulation_settings = gui.findChild(EnsembleExperimentPanel)
+    show_dm_parameters = simulation_settings.findChild(
+        QPushButton, "show-dm-parameters"
+    )
+    if design_matrix_entry:
+        assert show_dm_parameters
+    else:
+        assert show_dm_parameters is None
 
 
 @pytest.mark.parametrize(

--- a/tests/ert/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -15,7 +15,6 @@ from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer.panel import GUILogHandler
 from ert.run_models.ensemble_experiment import EnsembleExperiment
-from ert.services.storage_service import StorageService
 from ert.storage import open_storage
 
 
@@ -59,9 +58,6 @@ def test_run_path_deleted_error(
     args_mock.config = "snake_oil.ert"
 
     with (
-        StorageService.init_service(
-            project=os.path.abspath(snake_oil_case.ens_path),
-        ),
         open_storage(snake_oil_case.ens_path, mode="w") as storage,
     ):
         gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
@@ -108,9 +104,6 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
     args_mock.config = "snake_oil.ert"
 
     with (
-        StorageService.init_service(
-            project=os.path.abspath(snake_oil_case.ens_path),
-        ),
         open_storage(snake_oil_case.ens_path, mode="w") as storage,
     ):
         gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
@@ -155,9 +148,6 @@ def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot
     args_mock.config = "snake_oil.ert"
 
     with (
-        StorageService.init_service(
-            project=os.path.abspath(snake_oil_case.ens_path),
-        ),
         open_storage(snake_oil_case.ens_path, mode="w") as storage,
     ):
         gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)


### PR DESCRIPTION
**Issue**
Resolves #10044

This commit makes some of the tests faster by avoiding using StorageService unless neccessary.

In`ert/unit_tests/gui/simulation/test_run_dialog.py` Tests affected:
* `test_that_design_matrix_show_parameters_button_is_visible`: 10.5s -> 1.01s
* `test_that_exception_in_base_run_model_is_handles`: 4.71s -> 1.04s

In`ert/ui_tests/gui/test_main_window.py`
Tests affected:
* `test_that_es_mda_restart_run_box_is_disabled_when_there_are_no_cases`: 4.17s -> 1.57s
* `test_help_menu`: 4.15s -> 0.53s

In`ert/ui_tests/gui/test_restart_no_responses_and_parameters.py` Tests affected:
* `test_sensitivity_restart`: 4.53s -> 1.83s

In`ert/ui_tests/gui/test_workflow_tool.py`
Tests affected:
* `test_run_export_runpath_workflow`: 6.54s -> 4.57s

In`ert/ui_tests/gui/simulation/test_run_path_dialog.py` Tests affected:
* `test_run_path_deleted_error`: 14.98s -> 7.86s
* `test_run_path_is_deleted`: 8.77s -> 6.39s
* `test_run_path_is_not_deleted`: 8.35s -> 6.33s

Results while testing `pytest tests/ert -n logical`:
this commit: 467.71s
main:  486.76s
(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
