### PR TITLE
Deprecate un-used everest export keywords

### DIFF
--- a/src/everest/api/everest_data_api.py
+++ b/src/everest/api/everest_data_api.py
@@ -426,17 +426,11 @@ class EverestDataAPI:
 
     @property
     def everest_csv(self) -> str:
-        export_filename = (
-            self._config.export.csv_output_filepath
-            if self._config.export is not None
-            else f"{self._config.config_file}.csv"
-        )
-        assert export_filename
-
+        export_filename = f"{self._config.config_file}.csv"
         full_path = os.path.join(self.output_folder, export_filename)
 
         if not os.path.exists(full_path):
             combined_df, _, _ = self.export_dataframes()
             combined_df.write_csv(full_path)
 
-        return os.path.join(self.output_folder, export_filename)
+        return full_path

--- a/src/everest/config/export_config.py
+++ b/src/everest/config/export_config.py
@@ -1,43 +1,69 @@
-from pydantic import BaseModel, Field, field_validator
+from typing import Any
 
-from everest.config.validation_utils import check_writable_filepath
+from pydantic import BaseModel, Field, model_validator
+
+from ert.config.parsing.config_errors import ConfigWarning
 
 
 class ExportConfig(BaseModel, extra="forbid"):
     csv_output_filepath: str | None = Field(
         default=None,
-        description="""Specifies which file to write the export to.
-        Defaults to <config_file_name>.csv in output folder.""",
+        description="'csv_output_filepath' key is deprecated. You can safely remove it from the config file",
     )
     discard_gradient: bool | None = Field(
         default=None,
-        description="If set to True, Everest export will not contain "
-        "gradient simulation data.",
+        description="'discard_gradient' key is deprecated. You can safely remove it from the config file",
     )
     discard_rejected: bool | None = Field(
         default=None,
-        description="""If set to True, Everest export will contain only simulations
-         that have the increase_merit flag set to true.""",
+        description="'discard_rejected' key is deprecated. You can safely remove it from the config file",
     )
     keywords: list[str] | None = Field(
         default=None,
-        description="List of eclipse keywords to be exported into csv.",
+        description="List of eclipse keywords to be exported.",
     )
     batches: list[int] | None = Field(
         default=None,
-        description="list of batches to be exported, default is all batches.",
+        description="'batches' key is deprecated. You can safely remove it from the config file",
     )
     skip_export: bool | None = Field(
         default=None,
-        description="""set to True if export should not
-                     be run after the optimization case.
-                     Default value is False.""",
+        description="'skip_export' key is deprecated. You can safely remove it from the config file",
     )
 
-    @field_validator("csv_output_filepath", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def validate_output_file_writable(cls, csv_output_filepath: str | None) -> str:
-        if csv_output_filepath is None:
-            raise ValueError("csv_output_filepath can not be None")
-        check_writable_filepath(csv_output_filepath)
-        return csv_output_filepath
+    def deprecate_export_keys(cls, values: Any) -> Any:  # pylint: disable=E0213
+        for key in list(values.keys()):
+            match key:
+                case "csv_output_filepath":
+                    values["csv_output_filepath"] = None
+                    ConfigWarning.deprecation_warn(
+                        "'csv_output_filepath' key is deprecated."
+                        " You can safely remove it from the config file"
+                    )
+                case "discard_gradient":
+                    values["discard_gradient"] = None
+                    ConfigWarning.deprecation_warn(
+                        "'discard_gradient' key is deprecated."
+                        " You can safely remove it from the config file"
+                    )
+                case "discard_rejected":
+                    values["discard_rejected"] = None
+                    ConfigWarning.deprecation_warn(
+                        "'discard_rejected' key is deprecated."
+                        " You can safely remove it from the config file"
+                    )
+                case "batches":
+                    values["batches"] = None
+                    ConfigWarning.deprecation_warn(
+                        "'batches' key is deprecated."
+                        " You can safely remove it from the config file"
+                    )
+                case "skip_export":
+                    values["skip_export"] = None
+                    ConfigWarning.deprecation_warn(
+                        "'skip_export' key is deprecated."
+                        " You can safely remove it from the config file"
+                    )
+        return values

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1150,3 +1150,39 @@ def test_load_file_undefined_substitutions(min_config, change_to_tmpdir, capsys)
         "Loading config file <config.yml> failed with: The following key is missing: ['r{{undefined_key }}']"
         in captured.err
     )
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ["csv_output_filepath", "something"],
+        ["csv_output_filepath", ""],
+        ["csv_output_filepath", None],
+        ["discard_gradient", True],
+        ["discard_gradient", None],
+        ["discard_gradient", "None"],
+        ["discard_rejected", True],
+        ["discard_rejected", None],
+        ["discard_rejected", "None"],
+        ["skip_export", True],
+        ["skip_export", None],
+        ["skip_export", "None"],
+        ["batches", [0]],
+        ["batches", []],
+        ["batches", None],
+        ["batches", "None"],
+    ],
+)
+def test_export_deprecated_keys(key, value, min_config, change_to_tmpdir):
+    config = min_config
+    config["export"] = {key: value}
+
+    with open("config.yml", mode="w", encoding="utf-8") as f:
+        yaml.dump(config, f)
+
+    parser = ArgumentParser(prog="test")
+    match_msg = (
+        f"'{key}' key is deprecated. You can safely remove it from the config file"
+    )
+    with pytest.warns(ConfigWarning, match=match_msg):
+        EverestConfig.load_file_with_argparser("config.yml", parser)


### PR DESCRIPTION
**Issue**
No issue

**Approach**
A large part of the everest export config keys are not used anymore. Adding deprecation massages for them. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
