### PR TITLE
Format logged config dict to enhance readability

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -917,7 +917,15 @@ class ErtConfig:
         # In doing do, the message lenght will typically increase a bit. To Avoid hiting the App Insights' hard limit of message length, the limit is set to 80%
         # of MAX_MESSAGE_LENGTH_APP_INSIGHTS = 32768
         SAFE_MESSAGE_LENGTH_LIMIT = 26214  # <= MAX_MESSAGE_LENGTH_APP_INSIGHTS * 0.8
-        config_dict_content = json.dumps(content_dict, indent=2, cls=ContextBoolEncoder)
+        try:
+            config_dict_content = json.dumps(
+                content_dict, indent=2, cls=ContextBoolEncoder
+            )
+        except Exception as err:
+            config_dict_content = str(content_dict)
+            logger.warning(
+                f"Logging of config dict could not be formatted for enhanced readability. {err}"
+            )
         config_dict_content_length = len(config_dict_content)
         if config_dict_content_length > SAFE_MESSAGE_LENGTH_LIMIT:
             config_sections = _split_string_into_sections(

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -913,16 +913,15 @@ class ErtConfig:
 
     @classmethod
     def _log_config_dict(cls, content_dict: dict[str, Any]) -> None:
-        MAX_MESSAGE_LENGTH_APP_INSIGHTS = 32768
-        max_safe_message_length = int(
-            MAX_MESSAGE_LENGTH_APP_INSIGHTS * 0.8
-        )  # The content of the message is sanitized before beeing sendt to App Insigths to make sure GDPR-rules are not violated.
+        # The content of the message is sanitized before beeing sendt to App Insigths to make sure GDPR-rules are not violated.
         # In doing do, the message lenght will typically increase a bit. To Avoid hiting the App Insights' hard limit of message length, the limit is set to 80%
+        # of MAX_MESSAGE_LENGTH_APP_INSIGHTS = 32768
+        SAFE_MESSAGE_LENGTH_LIMIT = 26214  # <= MAX_MESSAGE_LENGTH_APP_INSIGHTS * 0.8
         config_dict_content = json.dumps(content_dict, indent=2, cls=ContextBoolEncoder)
         config_dict_content_length = len(config_dict_content)
-        if config_dict_content_length > max_safe_message_length:
+        if config_dict_content_length > SAFE_MESSAGE_LENGTH_LIMIT:
             config_sections = _split_string_into_sections(
-                config_dict_content, max_safe_message_length
+                config_dict_content, SAFE_MESSAGE_LENGTH_LIMIT
             )
             section_count = len(config_sections)
             for i, section in enumerate(config_sections):
@@ -1104,10 +1103,13 @@ class ErtConfig:
 def _split_string_into_sections(input: str, section_length: int) -> list[str]:
     """
     Splits a string into sections of length section_length
-    and returns it as an list.
+    and returns it as a list.
+
+    If section_length is set to 0 or less, no sectioning is performed and the entire input string
+    is returned as one section in a list
     """
     if section_length < 1:
-        raise ValueError("The section_length argument must be greater or equal to 1")
+        return [input]
     return [input[i : i + section_length] for i in range(0, len(input), section_length)]
 
 

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -2,7 +2,6 @@
 import copy
 import json
 import logging
-import math
 import os
 import re
 from collections import defaultdict
@@ -1107,16 +1106,9 @@ def _split_string_into_sections(input: str, section_length: int) -> list[str]:
     Splits a string into sections of length section_length
     and returns it as an list.
     """
-    string_length = len(input)
     if section_length < 1:
         raise ValueError("The section_length argument must be greater or equal to 1")
-    section_index_range = math.ceil(string_length / section_length)
-    sections = []
-    for i in range(section_index_range):
-        section_start = i * section_length
-        section_end = section_start + section_length
-        sections.append(input[section_start:section_end])
-    return sections
+    return [input[i : i + section_length] for i in range(0, len(input), section_length)]
 
 
 def _get_files_in_directory(job_path, errors):

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -16,9 +16,7 @@ from hypothesis import strategies as st
 from pydantic import RootModel, TypeAdapter
 
 from ert.config import ConfigValidationError, ErtConfig, HookRuntime
-from ert.config.ert_config import (
-    create_forward_model_json,
-)
+from ert.config.ert_config import _split_string_into_sections, create_forward_model_json
 from ert.config.parsing import ConfigKeys, ConfigWarning
 from ert.config.parsing.context_values import (
     ContextBool,
@@ -1851,3 +1849,19 @@ def test_warning_is_emitted_when_malformatted_runpath():
         ("RUNPATH keyword contains no value placeholders" in str(w.message))
         for w in all_warnings
     )
+
+
+@given(input=st.text(), section_length=st.integers(min_value=1))
+def test_split_string_into_sections(input, section_length):
+    split_string = _split_string_into_sections(input, section_length)
+    assert "".join(split_string) == input
+    for section in split_string:
+        assert len(section) <= section_length
+
+
+@given(input=st.text(), section_length=st.integers(max_value=0))
+def test_split_string_into_sections_raise_error_on_invalid_section_length(
+    input, section_length
+):
+    with pytest.raises(ValueError):
+        _split_string_into_sections(input, section_length)

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1851,17 +1851,12 @@ def test_warning_is_emitted_when_malformatted_runpath():
     )
 
 
-@given(input=st.text(), section_length=st.integers(min_value=1))
+@given(input=st.text(), section_length=st.integers())
 def test_split_string_into_sections(input, section_length):
     split_string = _split_string_into_sections(input, section_length)
     assert "".join(split_string) == input
-    for section in split_string:
-        assert len(section) <= section_length
-
-
-@given(input=st.text(), section_length=st.integers(max_value=0))
-def test_split_string_into_sections_raise_error_on_invalid_section_length(
-    input, section_length
-):
-    with pytest.raises(ValueError):
-        _split_string_into_sections(input, section_length)
+    if section_length > 0:
+        for section in split_string:
+            assert len(section) <= section_length
+    else:
+        split_string = [input]


### PR DESCRIPTION
Previously some parts of the config dict has been filtered out from the log message to make it fit within the 32768 message size limit of App Insights (among others forward model steps). These parts should be kept, and instead the config dict logging is split into multiple messages when it exceeds the message size limit of App Insights.  

With this commit the config dict log message(s) will look as follows:
```
2025-02-20 09:50:36.539 | Content of the config_dict (part 1/2): {   
  "DEFINE": [     
    [
      "<CONFIG_PATH>",
      "/var/folders/mg/jwjt9mcj02l1cqy_57szt4hc0000gp/T/tmph0lhx8yc"
    ],...

2025-02-20 09:50:36.540 | Content of the config_dict (part 2/2): 
    <Continues where part 1 stopped>
...
```

**Issue**
Resolves #9315


**Approach**
Log config dict as readable json
Split message if it exceeds the message size limit in App Insights in order to keep all the content

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
