### PR TITLE
Mute logger.warning from plugin initialization

### DIFF
--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -63,7 +63,15 @@ class ErtPluginManager(pluggy.PluginManager):
                 # displayed. Warnings should be displayed and logged when deprecated
                 # plugins are actually used, not on every startup of Ert.
                 warnings.simplefilter("ignore", category=FutureWarning)
-                self.load_setuptools_entrypoints(_PLUGIN_NAMESPACE)
+
+                # logger.warning() statements also need to be muted:
+                logger = logging.getLogger()
+                orig_level = logger.level
+                try:
+                    logger.setLevel(logging.ERROR)
+                    self.load_setuptools_entrypoints(_PLUGIN_NAMESPACE)
+                finally:
+                    logger.setLevel(orig_level)
         else:
             for plugin in plugins:
                 self.register(plugin)


### PR DESCRIPTION
Users cannot avoid these kinds of log messages if any plugins that issues warnings upon initialization. Plugins must warn when they are actually used.

**Issue**
Resolves #10116 

**Approach**
🔇 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
