### PR TITLE
Fix GUI showing `ERT experiment failed!` twice on terminate experiment

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -394,7 +394,6 @@ class RunDialog(QFrame):
             # Normally this slot would be invoked by the signal/slot system,
             # but the worker is busy tracking the evaluation.
             self._run_model_api.cancel()
-            self.simulation_done.emit(True, "")
         return kill_job
 
     @Slot(bool, str)

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -82,6 +82,9 @@ def run_dialog(qtbot: QtBot, run_model_api, event_queue, notifier):
 def test_terminating_experiment_shows_a_confirmation_dialog(qtbot: QtBot, run_dialog):
     run_dialog.run_experiment()
 
+    run_dialog._run_model_api.cancel = lambda: run_dialog.simulation_done.emit(
+        True, "foo bar error"
+    )
     with qtbot.waitSignal(run_dialog.simulation_done, timeout=10000):
 
         def handle_dialog():


### PR DESCRIPTION
**Issue**
Resolves #10063 


**Approach**
The issue was caused by us emitting the simulation_done signal twice on termination. This was most likely originally due to https://github.com/equinor/ert/issues/10055, so it would take a while before the actual signal we wanted was emitted. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
