### PR TITLE
Fix bug slurm_driver not using realization_memory

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -97,8 +97,10 @@ async def test_numcpu_sets_ntasks(num_cpu):
 @pytest.mark.usefixtures("capturing_sbatch")
 @given(memory_in_bytes=st.integers(min_value=1))
 async def test_realization_memory(memory_in_bytes):
-    driver = SlurmDriver(realization_memory=memory_in_bytes)
-    await driver.submit(0, "sleep", name="myjobname")
+    driver = SlurmDriver()
+    await driver.submit(
+        0, "sleep", name="myjobname", realization_memory=memory_in_bytes
+    )
     assert f"--mem={memory_in_bytes // 1024**2}M" in Path(
         "captured_sbatch_args"
     ).read_text(encoding="utf-8")


### PR DESCRIPTION
**Issue**
Resolves #10124


**Approach**
This commit removes the realization_memory instance variable on the slurm_driver, and instead gets realization_memory passed as a parameter in the submit method. This is the same way it is done for the other drivers.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
