### PR TITLE
Add detached rundialog for everest

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from pathlib import Path
 from queue import SimpleQueue
@@ -58,7 +59,11 @@ from ert.run_models import (
     RunModelUpdateEndEvent,
     StatusEvents,
 )
-from ert.run_models.event import RunModelDataEvent, RunModelErrorEvent
+from ert.run_models.event import (
+    EverestBatchResultEvent,
+    RunModelDataEvent,
+    RunModelErrorEvent,
+)
 from ert.shared.status.utils import (
     byte_with_unit,
     file_has_content,
@@ -165,6 +170,12 @@ class FMStepOverview(QTableView):
         return super().mouseMoveEvent(e)
 
 
+@dataclasses.dataclass
+class _BatchResultInfo:
+    is_gradient: bool = False
+    is_function: bool = False
+
+
 class RunDialog(QFrame):
     simulation_done = Signal(bool, str)
     progress_update_event = Signal(dict, int)
@@ -198,6 +209,9 @@ class RunDialog(QFrame):
         self._ticker.timeout.connect(self._on_ticker)
 
         self._is_everest = is_everest
+
+        if is_everest:
+            self._batch_result_infos: list[_BatchResultInfo] = []
 
         self._total_progress_label = QLabel(
             _TOTAL_PROGRESS_TEMPLATE.format(
@@ -325,15 +339,19 @@ class RunDialog(QFrame):
             widget = RealizationWidget(iter_row)
             widget.setSnapshotModel(self._snapshot_model)
             widget.itemClicked.connect(self._select_real)
+            widget.setProperty("identifier", f"tab-iter-{iteration}")
             self._select_real(widget._real_list_model.index(0, 0))
             tab_index = self._tab_widget.addTab(
                 widget,
                 f"Realizations for iteration {iteration}"
                 if not self._is_everest
-                else f"Simulations for batch {iteration}",
+                else f"Batch {iteration}...",
             )
             if self._tab_widget.currentIndex() == self._tab_widget.count() - 2:
                 self._tab_widget.setCurrentIndex(tab_index)
+
+            if self._is_everest:
+                self._batch_result_infos.append(_BatchResultInfo())
 
     @Slot(QModelIndex)
     def _select_real(self, index: QModelIndex) -> None:
@@ -500,6 +518,23 @@ class RunDialog(QFrame):
             case RunModelErrorEvent():
                 self._get_update_widget(event.iteration).error(event)
                 event.write_as_csv(self.output_path)
+            case EverestBatchResultEvent():
+                result_info = self._batch_result_infos[event.batch]
+
+                if event.result_type == "FunctionResult":
+                    result_info.is_gradient = True
+
+                if event.result_type == "GradientResult":
+                    result_info.is_function = True
+
+                tab_text = f" Batch {event.batch}: " + (
+                    "fn+∇"
+                    if (result_info.is_function and result_info.is_gradient)
+                    else "∇"
+                    if result_info.is_gradient
+                    else "fn"
+                )
+                self._tab_widget.setTabText(event.batch, tab_text)
 
     def _get_update_widget(self, iteration: int) -> UpdateWidget:
         for i in range(self._tab_widget.count()):

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -71,6 +71,7 @@ from .queue_emitter import QueueEmitter
 from .view import DiskSpaceWidget, ProgressWidget, RealizationWidget, UpdateWidget
 
 _TOTAL_PROGRESS_TEMPLATE = "Total progress {total_progress}% — {iteration_label}"
+_EVEREST_TOTAL_PROGRESS_TEMPLATE = "Batch {iteration} progress: {total_progress}%"
 
 
 class FMStepOverview(QTableView):
@@ -177,6 +178,7 @@ class RunDialog(QFrame):
         notifier: ErtNotifier,
         parent: QWidget | None = None,
         output_path: Path | None = None,
+        is_everest: bool | None = False,
     ):
         super().__init__(parent)
         self.output_path = output_path
@@ -194,6 +196,8 @@ class RunDialog(QFrame):
 
         self._ticker = QTimer(self)
         self._ticker.timeout.connect(self._on_ticker)
+
+        self._is_everest = is_everest
 
         self._total_progress_label = QLabel(
             _TOTAL_PROGRESS_TEMPLATE.format(
@@ -311,6 +315,8 @@ class RunDialog(QFrame):
             iter_row = start
             self._iteration_progress_label.setText(
                 f"Progress for iteration {iteration}"
+                if not self._is_everest
+                else f"Progress for batch {iteration}"
             )
 
             widget = RealizationWidget(iter_row)
@@ -318,7 +324,10 @@ class RunDialog(QFrame):
             widget.itemClicked.connect(self._select_real)
             self._select_real(widget._real_list_model.index(0, 0))
             tab_index = self._tab_widget.addTab(
-                widget, f"Realizations for iteration {iteration}"
+                widget,
+                f"Realizations for iteration {iteration}"
+                if not self._is_everest
+                else f"Simulations for batch {iteration}",
             )
             if self._tab_widget.currentIndex() == self._tab_widget.count() - 2:
                 self._tab_widget.setCurrentIndex(tab_index)
@@ -337,7 +346,14 @@ class RunDialog(QFrame):
                     exec_hosts = real_node.data.exec_hosts
 
             self._fm_step_overview.set_realization(iter_, real)
-            text = f"Realization id {index.data(RealIens)} in iteration {index.data(IterNum)}"
+
+            if not self._is_everest:
+                text = f"Realization id {index.data(RealIens)} in iteration {index.data(IterNum)}"
+            else:
+                text = (
+                    f"Simulation {index.data(RealIens)} in batch {index.data(IterNum)}"
+                )
+
             if exec_hosts and exec_hosts != "-":
                 text += f", assigned to host: {exec_hosts}"
             self._fm_step_label.setText(text)
@@ -448,7 +464,9 @@ class RunDialog(QFrame):
                         model._update_snapshot(event.snapshot, str(event.iteration))
                     else:
                         model._add_snapshot(event.snapshot, str(event.iteration))
-                self.update_total_progress(event.progress, event.iteration_label)
+                self.update_total_progress(
+                    event.progress, event.iteration_label, event.iteration
+                )
                 self._progress_widget.update_progress(status_count, realization_count)
                 self.progress_update_event.emit(status_count, realization_count)
             case SnapshotUpdateEvent(
@@ -457,7 +475,9 @@ class RunDialog(QFrame):
                 if event.snapshot is not None:
                     model._update_snapshot(event.snapshot, str(event.iteration))
                 self._progress_widget.update_progress(status_count, realization_count)
-                self.update_total_progress(event.progress, event.iteration_label)
+                self.update_total_progress(
+                    event.progress, event.iteration_label, event.iteration
+                )
                 self.progress_update_event.emit(status_count, realization_count)
             case RunModelUpdateBeginEvent(iteration=iteration):
                 widget = UpdateWidget(iteration)
@@ -486,18 +506,26 @@ class RunDialog(QFrame):
         raise ValueError("Could not find UpdateWidget")
 
     def update_total_progress(
-        self, progress_value: float, iteration_label: str
+        self, progress_value: float, iteration_label: str, iteration: int | None = None
     ) -> None:
         progress = int(progress_value * 100)
         if not (0 <= progress <= 100):
             logger = logging.getLogger(__name__)
             logger.warning(f"Total progress bar exceeds [0-100] range: {progress}")
         self._total_progress_bar.setValue(progress)
-        self._total_progress_label.setText(
-            _TOTAL_PROGRESS_TEMPLATE.format(
-                total_progress=progress, iteration_label=iteration_label
+
+        if self._is_everest:
+            self._total_progress_label.setText(
+                _EVEREST_TOTAL_PROGRESS_TEMPLATE.format(
+                    total_progress=progress, iteration=iteration
+                )
             )
-        )
+        else:
+            self._total_progress_label.setText(
+                _TOTAL_PROGRESS_TEMPLATE.format(
+                    total_progress=progress, iteration_label=iteration_label
+                )
+            )
 
     def restart_failed_realizations(self) -> None:
         msg = QMessageBox(self)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -295,6 +295,8 @@ class RunDialog(QFrame):
         self._restart = False
         self.flag_simulation_done = False
 
+        self._latest_iteration = 0
+
     def is_simulation_done(self) -> bool:
         return self.flag_simulation_done
 
@@ -311,7 +313,8 @@ class RunDialog(QFrame):
     ) -> None:
         if not parent.isValid():
             index = self._snapshot_model.index(start, 0, parent)
-            iteration = cast(IterNode, index.internalPointer()).id_
+            iteration = int(cast(IterNode, index.internalPointer()).id_)
+            self._latest_iteration = iteration
             iter_row = start
             self._iteration_progress_label.setText(
                 f"Progress for iteration {iteration}"
@@ -508,6 +511,9 @@ class RunDialog(QFrame):
     def update_total_progress(
         self, progress_value: float, iteration_label: str, iteration: int | None = None
     ) -> None:
+        if iteration is None:
+            iteration = self._latest_iteration
+
         progress = int(progress_value * 100)
         if not (0 <= progress <= 100):
             logger = logging.getLogger(__name__)

--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -83,7 +83,10 @@ class EverestMain:
 
     def gui(self, _: list[str]) -> None:
         """Start the graphical user interface (Removed)"""
-        print("The gui command has been removed. Please use the run command instead.")
+        print(
+            "The gui command has been removed. "
+            "Please use the run command with the --gui option instead."
+        )
 
     def export(self, args: list[str]) -> None:
         """Export data from a completed optimization case"""

--- a/src/everest/gui/everest_client.py
+++ b/src/everest/gui/everest_client.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import logging
+import queue
+import ssl
+import time
+import traceback
+from base64 import b64encode
+from http import HTTPStatus
+
+import requests
+from pydantic import ValidationError
+from requests import HTTPError
+from websockets.sync.client import connect
+
+from _ert.threading import ErtThread
+from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.run_models import BaseRunModelAPI
+from ert.run_models.event import StatusEvents, status_event_from_json
+from everest.strings import (
+    OPT_PROGRESS_ENDPOINT,
+    START_EXPERIMENT_ENDPOINT,
+    STOP_ENDPOINT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EverestClient:
+    def __init__(
+        self,
+        url: str,
+        cert_file: str,
+        username: str,
+        password: str,
+        ssl_context: ssl.SSLContext,
+    ):
+        self._url = url
+        self._cert = cert_file
+        self._username = username
+        self._password = password
+        self._ssl_context = ssl_context
+
+        self._progress_endpoint = "/".join([url, OPT_PROGRESS_ENDPOINT])
+        self._stop_endpoint = "/".join([url, STOP_ENDPOINT])
+        self._start_endpoint = "/".join([url, START_EXPERIMENT_ENDPOINT])
+
+        self._is_alive = False
+
+    @property
+    def credentials(self) -> str:
+        return b64encode(f"{self._username}:{self._password}".encode()).decode()
+
+    def setup_event_queue_from_ws_endpoint(
+        self,
+        refresh_interval: float = 0.01,
+        open_timeout: float = 30,
+        websocket_recv_timeout: float = 1.0,
+    ) -> tuple[queue.SimpleQueue[StatusEvents], ErtThread]:
+        event_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
+
+        def passthrough_ws_events() -> None:
+            try:
+                with connect(
+                    self._url.replace("https://", "wss://") + "/events",
+                    ssl=self._ssl_context,
+                    open_timeout=open_timeout,
+                    additional_headers={"Authorization": f"Basic {self.credentials}"},
+                ) as websocket:
+                    while not self._is_alive:
+                        try:
+                            message = websocket.recv(timeout=websocket_recv_timeout)
+                        except TimeoutError:
+                            message = None
+                        if message:
+                            try:
+                                event = status_event_from_json(message)
+                                event_queue.put(event)
+                            except ValidationError as e:
+                                logger.error(
+                                    "Error when processing event %s", exc_info=e
+                                )
+
+                        time.sleep(refresh_interval)
+            except:
+                logging.debug(traceback.format_exc())
+
+        monitor_thread = ErtThread(
+            name="everest_gui_event_monitor",
+            target=passthrough_ws_events,
+            daemon=True,
+        )
+
+        return event_queue, monitor_thread
+
+    def create_run_model_api(
+        self, queue_system: str, runpath_format_string: str
+    ) -> BaseRunModelAPI:
+        def start_fn(
+            evaluator_server_config: EvaluatorServerConfig, restart: bool = False
+        ) -> None:
+            pass
+
+        return BaseRunModelAPI(
+            experiment_name="Everest Experiment",
+            queue_system=queue_system,
+            runpath_format_string=runpath_format_string,
+            support_restart=False,
+            start_simulations_thread=start_fn,
+            cancel=self.stop,
+            get_runtime=lambda: -1,  # Not currently shown in Everest gui
+            has_failed_realizations=lambda: False,
+        )
+
+    def stop(self) -> None:
+        try:
+            response = requests.post(
+                self._stop_endpoint,
+                verify=self._cert,
+                auth=(self._username, self._password),
+                proxies={"http": None, "https": None},  # type: ignore
+            )
+
+            if response.status_code == 200:
+                logger.info("Cancelled experiment from Everest")
+                print("Successfully cancelled experiment")
+            else:
+                logger.error(
+                    f"Failed to cancel Everest experiment: POST @ {self._stop_endpoint}, "
+                    f"server responded with status {response.status_code}: "
+                    f"{HTTPStatus(response.status_code).phrase}"
+                )
+                print("Failed to cancel experiment")
+
+        except requests.exceptions.ConnectionError as e:
+            logger.error(
+                f"Connection error when cancelling Everest experiment: {''.join(traceback.format_exception(e))}"
+            )
+            print("Failed to cancel experiment")
+
+        except HTTPError as e:
+            logger.error(
+                f"HTTP error when cancelling Everest experiment: {''.join(traceback.format_exception(e))}"
+            )
+            print("Failed to cancel experiment")

--- a/src/everest/gui/main.py
+++ b/src/everest/gui/main.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from importlib.resources import files
+from signal import SIG_DFL, SIGINT, signal
+
+from PyQt6.QtCore import QDir
+from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import QApplication
+
+from everest.gui.main_window import EverestMainWindow
+
+
+def run_gui(config_file: str) -> None:
+    # Replace Python's exception handler for SIGINT with the system default.
+    #
+    # Python's SIGINT handler is the one that raises KeyboardInterrupt. This is
+    # okay normally (if a bit ugly), but when control is given to Qt this
+    # exception handler will either get deadlocked because Python never gets
+    # control back, or gets eaten by Qt because it ignores exceptions that
+    # happen in Qt slots.
+    signal(SIGINT, SIG_DFL)
+
+    QDir.addSearchPath(
+        "img", str(files("ert.gui").joinpath("../../ert/gui/resources/gui/img"))
+    )
+
+    app = QApplication(
+        ["everest"]
+    )  # Early so that QT is initialized before other imports
+    app.setWindowIcon(QIcon("img:ert_icon.svg"))
+
+    # Add arg parser if we are to pass more opts
+
+    window = EverestMainWindow(config_file)
+    window.run()
+    window.adjustSize()
+    window.show()
+    window.activateWindow()
+    window.raise_()
+    app.exec()

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import ssl
+
+from PyQt6.QtCore import pyqtSignal as Signal
+from PyQt6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QMainWindow,
+)
+
+from ert.gui.ertnotifier import ErtNotifier
+from ert.gui.simulation.run_dialog import RunDialog
+from ert.plugins import ErtPluginManager
+from everest.config import EverestConfig, ServerConfig
+from everest.detached import wait_for_server
+from everest.gui.everest_client import EverestClient
+
+
+class EverestMainWindow(QMainWindow):
+    close_signal = Signal()
+
+    def __init__(
+        self,
+        config_file: str,
+    ):
+        QMainWindow.__init__(self)
+        self.config_file = config_file
+
+        self.setWindowTitle(f"Everest - {config_file}")
+        self.plugin_manager = ErtPluginManager()
+        self.central_widget = QFrame(self)
+        self.central_layout = QHBoxLayout(self.central_widget)
+        self.central_layout.setContentsMargins(0, 0, 0, 0)
+        self.central_layout.setSpacing(0)
+        self.central_widget.setLayout(self.central_layout)
+
+        self._run_dialog: RunDialog | None = None
+
+        self.central_widget.setMinimumWidth(1500)
+        self.central_widget.setMinimumHeight(800)
+        self.setCentralWidget(self.central_widget)
+
+    def run(self) -> None:
+        ever_config = EverestConfig.load_file(self.config_file)
+
+        wait_for_server(ever_config.output_dir, 60)
+
+        server_context = ServerConfig.get_server_context(ever_config.output_dir)
+        url, cert, auth = server_context
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(cafile=cert)
+        username, password = auth
+
+        client = EverestClient(
+            url=url,
+            cert_file=cert,
+            username=username,
+            password=password,
+            ssl_context=ssl_context,
+        )
+
+        assert ever_config.simulator is not None
+        assert ever_config.simulator.queue_system is not None
+        sim_dir = ever_config.simulation_dir
+
+        assert sim_dir is not None
+        run_model_api = client.create_run_model_api(
+            ever_config.simulator.queue_system.name, runpath_format_string=sim_dir
+        )
+        event_queue, event_monitor_thread = client.setup_event_queue_from_ws_endpoint(
+            refresh_interval=0.02, open_timeout=40, websocket_recv_timeout=1.0
+        )
+
+        run_dialog = RunDialog(
+            config_file=self.config_file,
+            run_model_api=run_model_api,
+            event_queue=event_queue,
+            is_everest=True,
+            notifier=ErtNotifier(),
+        )
+
+        self.central_layout.addWidget(run_dialog)
+        self._run_dialog = run_dialog
+        event_monitor_thread.start()
+        self._run_dialog.setup_event_monitoring()

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -1,0 +1,183 @@
+import logging
+import ssl
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import uvicorn
+from fastapi import FastAPI
+from starlette.responses import Response
+
+from everest.bin.everest_script import everest_entry
+from everest.config import EverestConfig, ServerConfig
+from everest.detached import wait_for_server
+from everest.detached.jobs.everserver import _find_open_port
+from everest.gui.everest_client import EverestClient
+from everest.strings import STOP_ENDPOINT
+
+
+@pytest.fixture
+def client_server_mock() -> tuple[FastAPI, threading.Thread, EverestClient]:
+    server_app = FastAPI()
+    host = "127.0.0.1"
+    port = _find_open_port(host, lower=5000, upper=5800)
+    server_url = f"http://{host}:{port}"
+
+    server = uvicorn.Server(
+        uvicorn.Config(server_app, host=host, port=port, log_level="info")
+    )
+
+    server_thread = threading.Thread(
+        target=server.run,
+        daemon=True,
+    )
+
+    everest_client = EverestClient(
+        url=server_url,
+        cert_file="N/A",
+        username="",
+        password="",
+        ssl_context=ssl.create_default_context(),
+    )
+
+    yield server_app, server_thread, everest_client
+
+    if server_thread.is_alive():
+        server.should_exit = True
+        server_thread.join()
+
+
+def test_that_stop_invokes_correct_endpoint(
+    caplog, client_server_mock: tuple[FastAPI, threading.Thread, EverestClient]
+):
+    server_app, server_thread, client = client_server_mock
+
+    @server_app.post(f"/{STOP_ENDPOINT}")
+    def stop():
+        return Response("STOP..", 200)
+
+    server_thread.start()
+    time.sleep(0.1)
+
+    with caplog.at_level(logging.INFO):
+        client.stop()
+
+    assert "Cancelled experiment from Everest" in caplog.messages
+    server_thread.should_exit = True
+
+
+def test_that_stop_errors_on_non_ok_httpcode(
+    caplog, client_server_mock: tuple[FastAPI, threading.Thread, EverestClient]
+):
+    server_app, server_thread, client = client_server_mock
+
+    @server_app.post(f"/{STOP_ENDPOINT}")
+    def stop():
+        return Response("STOP..", 505)
+
+    server_thread.start()
+    time.sleep(0.1)
+
+    with caplog.at_level(logging.ERROR):
+        client.stop()
+
+    assert any(
+        "Failed to cancel Everest experiment" in m
+        and "server responded with status 505" in m
+        for m in caplog.messages
+    )
+
+
+def test_that_stop_errors_on_server_down(
+    caplog, client_server_mock: tuple[FastAPI, threading.Thread, EverestClient]
+):
+    _, _, client = client_server_mock
+
+    with caplog.at_level(logging.ERROR):
+        client.stop()
+
+    assert any(
+        "Connection error when cancelling Everest experiment" in m
+        for m in caplog.messages
+    )
+
+
+def test_that_stop_errors_on_server_up_but_endpoint_down(
+    caplog, client_server_mock: tuple[FastAPI, threading.Thread, EverestClient]
+):
+    _, server_thread, client = client_server_mock
+
+    server_thread.start()
+    time.sleep(0.1)
+
+    with caplog.at_level(logging.ERROR):
+        client.stop()
+
+    assert any(
+        "server responded with status 404: Not Found" in m for m in caplog.messages
+    )
+
+
+def test_that_multiple_everest_clients_can_connect_to_server(cached_example):
+    # We use a cached run for the reference list of received events
+    path, config_file, _, server_events_list = cached_example(
+        "math_func/config_minimal.yml"
+    )
+
+    config_path = Path(path) / config_file
+    ever_config = EverestConfig.load_file(config_path)
+
+    # Run the case through everserver
+    everest_main_thread = threading.Thread(
+        target=everest_entry, args=[[str(config_path)]]
+    )
+
+    everest_main_thread.start()
+    wait_for_server(ever_config.output_dir, 60)
+
+    server_context = ServerConfig.get_server_context(ever_config.output_dir)
+    url, cert, auth = server_context
+
+    ssl_context = ssl.create_default_context()
+    ssl_context.load_verify_locations(cafile=cert)
+    username, password = auth
+
+    client_event_queues = []
+    for _ in range(5):
+        client = EverestClient(
+            url=url,
+            cert_file=cert,
+            username=username,
+            password=password,
+            ssl_context=ssl_context,
+        )
+
+        # Connect to the websockets endpoint
+        client_event_queue, monitor_thread = client.setup_event_queue_from_ws_endpoint()
+        client_event_queues.append(client_event_queue)
+        monitor_thread.start()
+
+    # Wait until the server has finished running the simulation
+    everest_main_thread.join()
+
+    # Expect all the clients to hold the same events
+    client_event_lists = []
+    for event_queue in client_event_queues:
+        event_list = []
+        while not event_queue.empty():
+            event_list.append(event_queue.get())
+
+        client_event_lists.append(event_list)
+
+    first = client_event_lists[0]
+    assert all(first == other for other in client_event_lists[1:])
+
+    first_everevents = [e.event_type for e in first if "Everest" in e.event_type]
+    server_everevents = [
+        e.event_type for e in server_events_list if "Everest" in e.event_type
+    ]
+
+    # Compare only everest events, as the events from the forward model
+    # are (at time of writing) not deterministic enough to expect equality
+    assert first_everevents == server_everevents


### PR DESCRIPTION
**Issue**
Resolves #9983 


**Approach**
Connects to websocket endpoint and maps it to a queue and runs the RunDialog as normal.

How to run:

terminal 1:
```
everest run test-data/everest/math_func/config_advanced.yml
```
gui/monitor terminals:
```
everest gui test-data/everest/math_func/config_advanced.yml
```

(Screenshot of new behavior in GUI if applicable)
![Feb-24-2025 08-35-49](https://github.com/user-attachments/assets/3ba1ffaa-cdc2-4cda-98d6-3cd90413933d)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
