### PR TITLE
Add --ert-integration mark to semeio tests

### DIFF
--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -56,4 +56,4 @@ jobs:
       run: |
         pushd semeio
         VIRTUAL_ENV=../.venv uv pip install ".[test]"
-        UV_PROJECT_ENVIRONMENT=../.venv uv run --no-sync pytest
+        UV_PROJECT_ENVIRONMENT=../.venv uv run --no-sync pytest --ert-integration


### PR DESCRIPTION
Runs 11 additional "ert-integration" tests that I would assume it makes sense to run?

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
