### PR TITLE
Try to mitigate flakyness in cpu_seconds_can_detect_multiprocess

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -45,8 +45,8 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
 @pytest.mark.usefixtures("use_tmpdir")
 def test_cpu_seconds_can_detect_multiprocess():
     """Run a fm step that sets of two simultaneous processes that
-    each run for 1 and 2 seconds respectively. We should be able to detect
-    the total cpu seconds consumed to be roughly 3 seconds.
+    each run for 2 and 3 seconds respectively. We should be able to detect
+    the total cpu seconds consumed to be roughly the sum.
 
     The test is flaky in that it tries to gather cpu_seconds data while
     the subprocesses are running. On a loaded CPU this is not very robust,
@@ -72,8 +72,8 @@ def test_cpu_seconds_can_detect_multiprocess():
             textwrap.dedent(
                 """\
             #!/bin/sh
-            python busy.py 1 &
-            python busy.py 2"""
+            python busy.py 2 &
+            python busy.py 3"""
             )
         )
     executable = os.path.realpath(scriptname)
@@ -89,7 +89,7 @@ def test_cpu_seconds_can_detect_multiprocess():
     for status in fmstep.run():
         if isinstance(status, Running):
             cpu_seconds = max(cpu_seconds, status.memory_status.cpu_seconds)
-    assert 2.5 < cpu_seconds < 4.5
+    assert 3.2 < cpu_seconds < 5.5
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
**Issue**
Tries to solve #10009 


**Approach**
Spend more time, and allow more slack.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
