### PR TITLE
Backport: Log how long `rm_run_path()` takes

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -13,6 +12,7 @@ from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import QDockWidget, QMainWindow, QTabWidget, QWidget
 
 from ert.gui.ertwidgets import showWaitCursorWhileWaiting
+from ert.utils import log_duration
 
 from .customize import PlotCustomizer
 from .data_type_keys_widget import DataTypeKeysWidget
@@ -101,9 +101,9 @@ def open_error_dialog(title: str, content: str) -> None:
 
 
 class PlotWindow(QMainWindow):
+    @log_duration(logger, logging.INFO, "PlotWindow.__init__")
     def __init__(self, config_file: str, ens_path: Path, parent: QWidget | None):
         super().__init__(parent)
-        t = time.perf_counter()
 
         logger.info("PlotWindow __init__")
         self.setMinimumWidth(850)
@@ -178,8 +178,6 @@ class PlotWindow(QMainWindow):
         self.addDock("Plot ensemble", self._ensemble_selection_widget)
 
         self._data_type_keys_widget.selectDefault()
-
-        logger.info(f"PlotWindow __init__ done. time={time.perf_counter() - t}")
 
     @Slot(int)
     def currentTabChanged(self, index: int) -> None:

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -54,6 +54,7 @@ from ert.runpaths import Runpaths
 from ert.storage import Ensemble, Storage
 from ert.substitutions import Substitutions
 from ert.trace import tracer
+from ert.utils import log_duration
 from ert.workflow_runner import WorkflowRunner
 
 from ..config.workflow_fixtures import WorkflowFixtures
@@ -693,6 +694,7 @@ class BaseRunModel(ABC):
     def get_number_of_successful_realizations(self) -> int:
         return self.active_realizations.count(True)
 
+    @log_duration(logger, logging.INFO)
     def rm_run_path(self) -> None:
         for run_path in self.paths:
             if Path(run_path).exists():

--- a/src/ert/utils/__init__.py
+++ b/src/ert/utils/__init__.py
@@ -1,0 +1,32 @@
+import logging
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def log_duration(
+    logger: logging.Logger,
+    logging_level: int = logging.DEBUG,
+    custom_name: str | None = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    This is a decorator that logs the time it takes for a function to execute
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            t = time.perf_counter()
+            result = func(*args, **kwargs)
+            elapsed_time = time.perf_counter() - t
+            name = custom_name if custom_name else f"{func.__name__}()"
+            logger.log(logging_level, f"{name} time_used={elapsed_time:.4f}s")
+            return result
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
**Approach**
This PR backports the commit that adds some duration logging to `rm_run_path()` and refactors the duration logging functions into a reusable decorator.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
