### PR TITLE
Backport: Format logged config dict to enhance readability

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -16,9 +16,7 @@ from hypothesis import strategies as st
 from pydantic import RootModel, TypeAdapter
 
 from ert.config import ConfigValidationError, ErtConfig, HookRuntime
-from ert.config.ert_config import (
-    create_forward_model_json,
-)
+from ert.config.ert_config import _split_string_into_sections, create_forward_model_json
 from ert.config.parsing import ConfigKeys, ConfigWarning
 from ert.config.parsing.context_values import (
     ContextBool,
@@ -1851,3 +1849,14 @@ def test_warning_is_emitted_when_malformatted_runpath():
         ("RUNPATH keyword contains no value placeholders" in str(w.message))
         for w in all_warnings
     )
+
+
+@given(input=st.text(), section_length=st.integers())
+def test_split_string_into_sections(input, section_length):
+    split_string = _split_string_into_sections(input, section_length)
+    assert "".join(split_string) == input
+    if section_length > 0:
+        for section in split_string:
+            assert len(section) <= section_length
+    else:
+        split_string = [input]


### PR DESCRIPTION
Previously some parts of the config dict has been filtered out from the log message to make it fit within the 32768 message size limit of App Insights (among others forward model steps). These parts should be kept, and instead the config dict logging is split into multiple messages when it exceeds the message size limit of App Insights.  

With this commit the config dict log message(s) will look as follows:
```
2025-02-20 09:50:36.539 | Content of the config_dict (part 1/2): {   
  "DEFINE": [     
    [
      "<CONFIG_PATH>",
      "/var/folders/mg/jwjt9mcj02l1cqy_57szt4hc0000gp/T/tmph0lhx8yc"
    ],...

2025-02-20 09:50:36.540 | Content of the config_dict (part 2/2): 
    <Continues where part 1 stopped>
...
```

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
