### PR TITLE
Add test for the propagation of queue_options from ertconfig to cluster

### DIFF
--- a/tests/ert/unit_tests/scheduler/bin/bhist.py
+++ b/tests/ert/unit_tests/scheduler/bin/bhist.py
@@ -83,18 +83,16 @@ def main() -> None:
 
     jobs_output: list[Job] = []
     for job in args.jobs:
-        job_name: str = read(jobs_path / f"{job}.name") or "_"
+        job_name: str = read(jobs_path / job / "name") or "_"
         assert job_name is not None
 
-        submit_time_millis: int = int(
-            os.path.getctime(jobs_path / f"{job}.name") * 1000
-        )
+        submit_time_millis: int = int(os.path.getctime(jobs_path / job / "name") * 1000)
         pending_time_millis = int(read(jobs_path / "pendingtimemillis") or 0)
         run_start_time_millis: int = submit_time_millis + pending_time_millis
         end_time_millis: int = int(time.time() * 1000)
-        if (jobs_path / f"{job}.returncode").exists():
+        if (jobs_path / job / "returncode").exists():
             end_time_millis = int(
-                os.path.getctime(jobs_path / f"{job}.returncode") * 1000
+                os.path.getctime(jobs_path / job / "returncode") * 1000
             )
             if not args.l:
                 print("bhist says job is done")

--- a/tests/ert/unit_tests/scheduler/bin/bjobs.py
+++ b/tests/ert/unit_tests/scheduler/bin/bjobs.py
@@ -41,14 +41,14 @@ def main() -> None:
 
     # this is for the bjobs call looking for exit code
     if args.o.strip() == "exit_code":
-        returncode = read(jobs_path / f"{args.jobs[0]}.returncode")
+        returncode = read(jobs_path / args.jobs[0] / "returncode")
         print(returncode)
         return
 
     jobs_output: list[Job] = []
     for job in args.jobs:
-        pid = read(jobs_path / f"{job}.pid")
-        returncode = read(jobs_path / f"{job}.returncode")
+        pid = read(jobs_path / job / "pid")
+        returncode = read(jobs_path / job / "returncode")
 
         state: JobState = "PEND"
 

--- a/tests/ert/unit_tests/scheduler/bin/bkill.py
+++ b/tests/ert/unit_tests/scheduler/bin/bkill.py
@@ -20,7 +20,7 @@ def main() -> None:
     jobdir = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
     killsignal = getattr(signal, args.signal)
     for jobid in args.jobids:
-        pidfile = jobdir / f"{jobid}.pid"
+        pidfile = jobdir / jobid / "pid"
         if not pidfile.exists():
             sys.exit(1)
         pid = int(pidfile.read_text(encoding="utf-8").strip())

--- a/tests/ert/unit_tests/scheduler/bin/bsub
+++ b/tests/ert/unit_tests/scheduler/bin/bsub
@@ -3,7 +3,11 @@ set -e
 
 name="STDIN"
 
-while getopts "o:e:J:q:R:n:" opt
+jobid="${RANDOM}"
+jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
+mkdir -p "${jobdir}"
+
+while getopts "o:e:J:q:R:n:P:" opt
 do
     case "$opt" in
         o)
@@ -24,6 +28,9 @@ do
         R)
             resource_requirement=$OPTARG
             ;;
+        P)
+            project_code=$OPTARG
+            ;;
         *)
             echo "Unprocessed option ${opt}"
             ;;
@@ -31,14 +38,11 @@ do
 done
 shift $((OPTIND-1))
 
-jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
-jobid="${RANDOM}"
-job_env_file="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.env"
+job_env_file="${jobdir}/env"
 
-mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
-echo $@ > "${jobdir}/${jobid}.script"
-echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
-echo "$resource_requirement" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.resource_requirement"
+echo $@ > "${jobdir}/script"
+echo "$name" > "${jobdir}/name"
+echo "$resource_requirement" > "${jobdir}/resource_requirement"
 touch $job_env_file
 
 [ -n $num_cpu ] && echo "export LSB_MAX_NUM_PROCESSORS=$num_cpu" >> $job_env_file
@@ -46,7 +50,7 @@ touch $job_env_file
 [ -z $stdout ] && stdout="/dev/null"
 [ -z $stderr ] && stderr="/dev/null"
 
-bash "$(dirname $0)/lsfrunner" "${jobdir}/${jobid}" >$stdout 2>$stderr &
+bash "$(dirname $0)/lsfrunner" "${jobdir}" >$stdout 2>$stderr &
 disown
 
 echo "Job <$jobid> is submitted to default queue <normal>."

--- a/tests/ert/unit_tests/scheduler/bin/bsub
+++ b/tests/ert/unit_tests/scheduler/bin/bsub
@@ -6,8 +6,6 @@ name="STDIN"
 jobid="${RANDOM}"
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
 mkdir -p "${jobdir}"
-command_invocation_file="${jobdir}/complete_command_invocation"
-echo "$0 $@" > "$command_invocation_file"
 
 while getopts "o:e:J:q:R:n:P:" opt
 do

--- a/tests/ert/unit_tests/scheduler/bin/bsub
+++ b/tests/ert/unit_tests/scheduler/bin/bsub
@@ -6,6 +6,8 @@ name="STDIN"
 jobid="${RANDOM}"
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
 mkdir -p "${jobdir}"
+command_invocation_file="${jobdir}/complete_command_invocation"
+echo "$0 $@" > "$command_invocation_file"
 
 while getopts "o:e:J:q:R:n:P:" opt
 do

--- a/tests/ert/unit_tests/scheduler/bin/lsfrunner
+++ b/tests/ert/unit_tests/scheduler/bin/lsfrunner
@@ -4,7 +4,7 @@ job=$1  # NB: Includes full path
 function handle_sigterm {
     # LSF uses (128 + SIGNAL) as the returncode
     # SIGTERM=15
-    echo "143" > "${job}.returncode"
+    echo "143" > "${job}/returncode"
     for grandchild in $(pgrep -P $child_pid); do
         kill -s SIGTERM $grandchild
     done
@@ -14,17 +14,17 @@ function handle_sigterm {
 
 trap handle_sigterm SIGTERM
 
-echo "$$" > "${job}.pid"
-source "${job}.env"
-bash "${job}.script" > "${job}.stdout" 2> "${job}.stderr"  &
+echo "$$" > "${job}/pid"
+source "${job}/env"
+bash "${job}/script" > "${job}/stdout" 2> "${job}/stderr"  &
 child_pid=$!
 wait $child_pid
 
-echo "$?" > "${job}.returncode"
+echo "$?" > "${job}/returncode"
 echo "Sender: Mocked LSF system <$USER@$(hostname -s)"
 echo "Subject: Job $job:"
 echo "[..skipped in mock..]"
 echo "The output (if any) follows:"
-cat ${job}.stdout
+cat ${job}/stdout
 
-cat ${job}.stderr >&2
+cat ${job}/stderr >&2

--- a/tests/ert/unit_tests/scheduler/bin/qdel
+++ b/tests/ert/unit_tests/scheduler/bin/qdel
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid=$1
+jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
 
-if ! [ -f "${jobdir}/${jobid}.pid" ]
+if ! [ -f "${jobdir}/pid" ]
 then
     echo "No such job ${jobid}" >&2
     exit 1
 fi
 
-pid=$(cat "${jobdir}/${jobid}.pid")
+pid=$(cat "${jobdir}/pid")
 kill $pid

--- a/tests/ert/unit_tests/scheduler/bin/qstat.py
+++ b/tests/ert/unit_tests/scheduler/bin/qstat.py
@@ -42,11 +42,11 @@ def main() -> None:
         print(QSTAT_HEADER, end="")
 
     for job in args.jobs:
-        name = read(jobs_path / f"{job}.name")
+        name = read(jobs_path / f"{job}/name")
         assert name is not None
 
-        pid = read(jobs_path / f"{job}.pid")
-        returncode = read(jobs_path / f"{job}.returncode")
+        pid = read(jobs_path / f"{job}/pid")
+        returncode = read(jobs_path / f"{job}/returncode")
 
         state = "Q"
         if returncode is not None:

--- a/tests/ert/unit_tests/scheduler/bin/qsub
+++ b/tests/ert/unit_tests/scheduler/bin/qsub
@@ -7,8 +7,6 @@ jobid="test${RANDOM}.localhost"
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
 mkdir -p "${jobdir}"
 
-command_invocation_file="${jobdir}/complete_command_invocation"
-echo "$0 $@" > "$command_invocation_file"
 job_env_file="${jobdir}/env"
 touch $job_env_file
 

--- a/tests/ert/unit_tests/scheduler/bin/qsub
+++ b/tests/ert/unit_tests/scheduler/bin/qsub
@@ -7,6 +7,8 @@ jobid="test${RANDOM}.localhost"
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
 mkdir -p "${jobdir}"
 
+command_invocation_file="${jobdir}/complete_command_invocation"
+echo "$0 $@" > "$command_invocation_file"
 job_env_file="${jobdir}/env"
 touch $job_env_file
 

--- a/tests/ert/unit_tests/scheduler/bin/qsub
+++ b/tests/ert/unit_tests/scheduler/bin/qsub
@@ -3,7 +3,14 @@ set -e
 
 name="STDIN"
 
-while getopts "N:r:l:o:e:" opt
+jobid="test${RANDOM}.localhost"
+jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}"
+mkdir -p "${jobdir}"
+
+job_env_file="${jobdir}/env"
+touch $job_env_file
+
+while getopts "N:r:l:o:e:q:A:" opt
 do
     case "$opt" in
         N)
@@ -17,6 +24,12 @@ do
             ;;
         l)
             resource=$OPTARG
+            echo $resource >> $job_env_file
+            echo $resource >> "${jobdir}/resource_requirement"
+            ;;
+        q)
+            ;;
+        A)
             ;;
         *)
             echo "Unprocessed option ${opt}"
@@ -25,22 +38,16 @@ do
 done
 shift $((OPTIND-1))
 
-jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
-jobid="test${RANDOM}.localhost"
-job_env_file="${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.env"
 
-mkdir -p "${PYTEST_TMP_PATH:-.}/mock_jobs"
-cat <&0 > "${jobdir}/${jobid}.script"
-echo "$name" > "${PYTEST_TMP_PATH:-.}/mock_jobs/${jobid}.name"
-touch $job_env_file
+cat <&0 > "${jobdir}/script"
+echo "$name" > "${jobdir}/name"
 
-echo $resource >> $job_env_file
 num_cpu=$(echo $resource | sed 's/.*ncpus=\([[:digit:]]*\).*/\1/')
 
 [ -n $num_cpu ] && echo "export OMP_NUM_THREADS=$num_cpu" >> $job_env_file
 [ -n $num_cpu ] && echo "export NCPUS=$num_cpu" >> $job_env_file
 
-bash "$(dirname $0)/runner" "${jobdir}/${jobid}" >/dev/null 2>/dev/null &
+bash "$(dirname $0)/runner" "${jobdir}" >/dev/null 2>/dev/null &
 disown
 
 echo "$jobid"

--- a/tests/ert/unit_tests/scheduler/bin/runner
+++ b/tests/ert/unit_tests/scheduler/bin/runner
@@ -3,7 +3,7 @@ job=$1
 
 function handle_sigterm {
     # Torque uses (256 + SIGNAL) as the returncode
-    echo "271" > "${job}.returncode"
+    echo "271" > "${job}/returncode"
     for grandchild in $(pgrep -P $child_pid); do
         kill -s SIGTERM $grandchild
     done
@@ -13,13 +13,13 @@ function handle_sigterm {
 
 trap handle_sigterm SIGTERM
 
-echo "$$" > "${job}.pid"
-source "${job}.env"
-bash "${job}.script" > "${job}.stdout" 2> "${job}.stderr" &
+echo "$$" > "${job}/pid"
+source "${job}/env"
+bash "${job}/script" > "${job}/stdout" 2> "${job}/stderr" &
 child_pid=$!
 wait $child_pid
-echo $? > "${job}.returncode"
+echo $? > "${job}/returncode"
 
-cat ${job}.stdout
+cat ${job}/stdout
 
-cat ${job}.stderr >&2
+cat ${job}/stderr >&2

--- a/tests/ert/unit_tests/scheduler/bin/sacct.py
+++ b/tests/ert/unit_tests/scheduler/bin/sacct.py
@@ -6,7 +6,6 @@ This script partially mocks the Slurm provided utility sacct:
 """
 
 import argparse
-import glob
 import os
 from pathlib import Path
 from typing import Literal
@@ -35,13 +34,14 @@ def main() -> None:
 
     jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
 
-    for pidfile in glob.glob(f"{jobs_path}/*.pid"):
-        job = pidfile.split("/")[-1].split(".")[0]
+    for job_dir in jobs_path.iterdir():
+        pidfile = job_dir / "pid"
+        job = job_dir.name
         if args.j and job != args.j:
             continue
-        pid = read(Path(pidfile))
-        returncode = read(jobs_path / f"{job}.returncode")
-        cancelled = read(jobs_path / f"{job}.cancelled", default="no")
+        pid = read(pidfile)
+        returncode = read(job_dir / "returncode")
+        cancelled = read(job_dir / "cancelled", default="no")
         state: JobState = "PENDING"
 
         if pid is not None and returncode is None:

--- a/tests/ert/unit_tests/scheduler/bin/sbatch.py
+++ b/tests/ert/unit_tests/scheduler/bin/sbatch.py
@@ -40,6 +40,7 @@ def main() -> None:
     jobdir.mkdir(parents=True, exist_ok=True)
     (jobdir / "script").write_text(args.script, encoding="utf-8")
     (jobdir / "name").write_text(args.job_name, encoding="utf-8")
+    (jobdir / "complete_command_invocation").write_text(shlex.join(sys.argv))
     env_file = jobdir / "env"
     if args.ntasks:
         env_file.write_text(

--- a/tests/ert/unit_tests/scheduler/bin/sbatch.py
+++ b/tests/ert/unit_tests/scheduler/bin/sbatch.py
@@ -7,9 +7,7 @@ This script partially mocks the Slurm provided utility sbatch:
 import argparse
 import os
 import random
-import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 
@@ -40,7 +38,6 @@ def main() -> None:
     jobdir.mkdir(parents=True, exist_ok=True)
     (jobdir / "script").write_text(args.script, encoding="utf-8")
     (jobdir / "name").write_text(args.job_name, encoding="utf-8")
-    (jobdir / "complete_command_invocation").write_text(shlex.join(sys.argv))
     env_file = jobdir / "env"
     if args.ntasks:
         env_file.write_text(

--- a/tests/ert/unit_tests/scheduler/bin/scancel
+++ b/tests/ert/unit_tests/scheduler/bin/scancel
@@ -6,12 +6,12 @@ set -e
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid=$1
 
-if ! [ -f "${jobdir}/${jobid}.pid" ]
+if ! [ -f "${jobdir}/${jobid}/pid" ]
 then
     echo "No such job ${jobid}" >&2
     exit 1
 fi
 
-pid=$(cat "${jobdir}/${jobid}.pid")
+pid=$(cat "${jobdir}/${jobid}/pid")
 kill $pid
-echo "yes" > "${jobdir}/${jobid}.cancelled"
+echo "yes" > "${jobdir}/${jobid}/cancelled"

--- a/tests/ert/unit_tests/scheduler/bin/scontrol.py
+++ b/tests/ert/unit_tests/scheduler/bin/scontrol.py
@@ -6,7 +6,6 @@ This script partially mocks the Slurm provided utility scontrol:
 """
 
 import argparse
-import glob
 import os
 from pathlib import Path
 from typing import Literal
@@ -31,14 +30,15 @@ def main() -> None:
 
     jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
 
-    for pidfile in glob.glob(f"{jobs_path}/*.pid"):
-        job = pidfile.split("/")[-1].split(".")[0]
+    for job_dir in jobs_path.iterdir():
+        pidfile = job_dir / "pid"
+        job = job_dir.name
         if args.jobid and job != args.jobid:
             continue
-        pid = read(Path(pidfile))
-        returncode = read(jobs_path / f"{job}.returncode")
-        name = read(jobs_path / f"{job}.name")
-        cancelled = read(jobs_path / f"{job}.cancelled", default="no")
+        pid = read(pidfile)
+        returncode = read(job_dir / "returncode")
+        name = read(job_dir / "name")
+        cancelled = read(job_dir / "cancelled", default="no")
         state: JobState = "PENDING"
 
         if pid is not None and returncode is None:

--- a/tests/ert/unit_tests/scheduler/bin/squeue.py
+++ b/tests/ert/unit_tests/scheduler/bin/squeue.py
@@ -6,7 +6,6 @@ This script partially mocks the Slurm provided utility squeue:
 """
 
 import argparse
-import glob
 import os
 from pathlib import Path
 from typing import Literal
@@ -41,10 +40,11 @@ def main() -> None:
 
     jobs_path = Path(os.getenv("PYTEST_TMP_PATH", ".")) / "mock_jobs"
 
-    for pidfile in glob.glob(f"{jobs_path}/*.pid"):
-        job = pidfile.split("/")[-1].split(".")[0]
-        pid = read(Path(pidfile))
-        returncode = read(jobs_path / f"{job}.returncode")
+    for job_dir in jobs_path.iterdir():
+        pidfile = job_dir / "pid"
+        job = job_dir.name
+        pid = read(pidfile)
+        returncode = read(job_dir / "returncode")
 
         state: JobState = "PENDING"
 

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -14,6 +14,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from ert.cli.main import ErtCliError
+from ert.config.queue_config import _parse_realization_memory_str
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE
 from ert.scheduler.openpbs_driver import (
     JOB_STATES,
@@ -606,3 +607,45 @@ def test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_
             "poly.ert",
         )
     assert "RuntimeError: Status polling failed" in caplog.text
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("copy_poly_case")
+def test_queue_options_are_propagated_from_config_to_qsub(monkeypatch):
+    """
+    This end to end test is here to verify that queue_options are correctly
+    propagated all the way from ert config to the cluster.
+    """
+    mock_bin(monkeypatch, os.getcwd())
+    expected_queue = "foo_bar_queue"
+    expected_realization_memory = "9GB"
+    expected_project_code = "foo_bar_project"
+    expected_cluster_label = "foo_bar_cluster"
+    expected_num_cpu = 98
+    with open("poly.ert", "a", encoding="utf-8") as f:
+        f.write(
+            dedent(
+                f"""\
+                NUM_CPU {expected_num_cpu}
+                REALIZATION_MEMORY {expected_realization_memory}
+                QUEUE_SYSTEM TORQUE
+                QUEUE_OPTION TORQUE QUEUE {expected_queue}
+                QUEUE_OPTION TORQUE CLUSTER_LABEL {expected_cluster_label}
+                QUEUE_OPTION TORQUE PROJECT_CODE {expected_project_code}
+                NUM_REALIZATIONS 1
+                """
+            )
+        )
+    run_cli(ENSEMBLE_EXPERIMENT_MODE, "--disable-monitoring", "poly.ert")
+    mock_jobs_dir = Path(f"mock_jobs")
+    job_dir = next(
+        mock_jobs_dir.iterdir()
+    )  # There is only one realization in this test
+    complete_command_invocation = (job_dir / "complete_command_invocation").read_text(
+        encoding="utf-8"
+    )
+
+    assert f"-q {expected_queue}" in complete_command_invocation
+    assert f"-A {expected_project_code}" in complete_command_invocation
+    assert f"-l ncpus={expected_num_cpu}:mem={_parse_realization_memory_str(expected_realization_memory) // 1024**2}mb" in complete_command_invocation
+    assert f"-l {expected_cluster_label}" in complete_command_invocation


### PR DESCRIPTION
**Issue**
Resolves #10141



**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
