### PR TITLE
Display error if ropt validation fails

### DIFF
--- a/src/everest/optimizer/utils.py
+++ b/src/everest/optimizer/utils.py
@@ -1,3 +1,5 @@
+import importlib
+
 from ropt.plugins import PluginManager
 
 
@@ -13,4 +15,15 @@ def get_ropt_plugin_manager() -> PluginManager:
     # Note: backends can also be added via the Python entrypoints mechanism,
     # these are detected by default and do not need to be added here.
 
-    return PluginManager()
+    try:
+        return PluginManager()
+    except Exception as exc:
+        ert_version = importlib.metadata.version("ert")
+        ropt_version = importlib.metadata.version("ropt")
+        msg = (
+            f"Error while initializing ropt:\n\n{exc}.\n\n"
+            "Check the everest installation, there may a be version mismatch.\n"
+            f"  (ERT: {ert_version}, ropt: {ropt_version})\n"
+            "If the everest installation is correct, please report this as a bug."
+        )
+        raise RuntimeError(msg) from exc


### PR DESCRIPTION
**Issue**
Resolves #10106


**Approach**
Validation errors in ropt should not occur if the everest configuration has been validated properly. Hence, if that occurs, it is either due to a version mismatch, or due to a bug. This PR adds an error message to communicate that.

The error report states that everest was hanging when this occurs, both locally and on lsf. Could not reproduce this locally and on SLURM. This error occurs within the server and is reported back properly. Hanging was possibly already resolved before this PR.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
