### PR TITLE
Remove dead logic from endpoint

### DIFF
--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -17,14 +17,13 @@ from ert.ensemble_evaluator import (
 )
 from ert.resources import all_shell_script_fm_steps
 from everest.detached import (
-    OPT_PROGRESS_ID,
     ServerStatus,
     everserver_status,
     get_opt_status,
     start_monitor,
 )
 from everest.simulator import JOB_FAILURE, JOB_RUNNING, JOB_SUCCESS
-from everest.strings import EVEREST, SIM_PROGRESS_ID
+from everest.strings import EVEREST, OPT_PROGRESS_ID, SIM_PROGRESS_ID
 
 
 def handle_keyboard_interrupt(signal, frame, options):

--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -28,7 +28,6 @@ from everest.everest_storage import EverestStorage
 from everest.strings import (
     EVEREST_SERVER_CONFIG,
     OPT_PROGRESS_ENDPOINT,
-    OPT_PROGRESS_ID,
     SIM_PROGRESS_ID,
     START_EXPERIMENT_ENDPOINT,
     STOP_ENDPOINT,
@@ -252,14 +251,13 @@ def server_is_running(url: str, cert: str, auth: tuple[str, str]) -> bool:
 
 def start_monitor(
     server_context: tuple[str, str, tuple[str, str]],
-    callback: Callable[..., dict[str, Any]],
+    callback: Callable[..., None],
     polling_interval: float = 0.1,
 ) -> None:
     """
     Checks status on Everest server and calls callback when status changes
 
-    Monitoring stops when the server stops answering. It can also be
-    interrupted by returning True from the callback
+    Monitoring stops when the server stops answering.
     """
     url, cert, auth = server_context
     opt_endpoint = "/".join([url, OPT_PROGRESS_ENDPOINT])
@@ -295,8 +293,6 @@ def start_monitor(
                 new_opt_status = _query_server(cert, auth, opt_endpoint)
                 if new_opt_status != opt_status:
                     opt_status = new_opt_status
-                    ret = bool(callback({OPT_PROGRESS_ID: opt_status}))
-                    stop |= ret
                 time.sleep(polling_interval)
     except:
         logging.debug(traceback.format_exc())


### PR DESCRIPTION
Callback does not currently return anything, don't think we plan to let the callback interrupt the websocket from running anyway?