### PR TITLE
Refactor ropt event interactions

### DIFF
--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -43,7 +43,6 @@ class EverestStatusEvent(BaseModel):
         "START_EVALUATOR_STEP",
         "FINISHED_EVALUATOR_STEP",
     ]
-    exit_code: str | None = None
 
 
 class EverestBatchResultEvent(BaseModel):
@@ -51,7 +50,6 @@ class EverestBatchResultEvent(BaseModel):
     event_type: Literal["EverestBatchResultEvent"] = "EverestBatchResultEvent"
     everest_event: Literal["FINISHED_EVALUATION", "FINISHED_SAMPLING_EVALUATION"]
     result_type: Literal["FunctionResult", "GradientResult"]
-    exit_code: str | None = None
 
 
 class RunModelTimeEvent(RunModelEvent):

--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -32,23 +32,20 @@ class RunModelStatusEvent(RunModelEvent):
 class EverestStatusEvent(BaseModel):
     batch: int | None
     event_type: Literal["EverestStatusEvent"] = "EverestStatusEvent"
-
-    # Reflects what is currently in ROPT,
-    # changes in ROPT should appear here accordingly
     everest_event: Literal[
-        "START_EVALUATION",
+        "START_OPTIMIZER_EVALUATION",
         "START_SAMPLING_EVALUATION",
-        "START_OPTIMIZER_STEP",
-        "FINISHED_OPTIMIZER_STEP",
-        "START_EVALUATOR_STEP",
-        "FINISHED_EVALUATOR_STEP",
     ]
 
 
 class EverestBatchResultEvent(BaseModel):
     batch: int
     event_type: Literal["EverestBatchResultEvent"] = "EverestBatchResultEvent"
-    everest_event: Literal["FINISHED_EVALUATION", "FINISHED_SAMPLING_EVALUATION"]
+    everest_event: Literal[
+        "OPTIMIZATION_RESULT",
+        "FINISHED_OPTIMIZER_EVALUATION",
+        "FINISHED_SAMPLING_EVALUATION",
+    ]
     result_type: Literal["FunctionResult", "GradientResult"]
 
 

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -348,7 +348,6 @@ class EverestRunModel(BaseRunModel):
                 EverestStatusEvent(
                     batch=None,  # Always 0, but omitting it for consistency
                     everest_event="START_SAMPLING_EVALUATION",
-                    exit_code=None,
                 )
             )
 
@@ -363,7 +362,6 @@ class EverestRunModel(BaseRunModel):
                     batch=self._batch_id,
                     everest_event="FINISHED_SAMPLING_EVALUATION",
                     result_type="FunctionResult",
-                    exit_code=None,
                 )
             )
 
@@ -407,10 +405,6 @@ class EverestRunModel(BaseRunModel):
             # The batch these results pertain to
             # If the event has results, they usually pertain to the
             # batch before self._batch_id, i.e., self._batch_id - 1
-            exit_code = everest_event.data.get("exit_code")
-            exit_code_name = (
-                None if exit_code is None else OptimizerExitCode(exit_code).name
-            )
 
             if has_results:
                 # A ROPT event may contain multiple results, here we send one
@@ -428,7 +422,6 @@ class EverestRunModel(BaseRunModel):
                                 if isinstance(r, FunctionResults)
                                 else "GradientResult"
                             ),
-                            exit_code=exit_code_name,
                         )
                     )
             else:
@@ -439,7 +432,6 @@ class EverestRunModel(BaseRunModel):
                     EverestStatusEvent(
                         batch=None,
                         everest_event=everest_event.event_type.name,
-                        exit_code=exit_code_name,
                     )
                 )
 

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -128,14 +128,14 @@ class EverestConfig(BaseModel):
         description="List of objective function specifications", min_length=1
     )
     optimization: OptimizationConfig | None = Field(
-        default=OptimizationConfig(),
+        default_factory=OptimizationConfig,
         description="Optimizer options",
     )
     model: ModelConfig = Field(
         description="Configuration of the Everest model",
     )
     environment: EnvironmentConfig | None = Field(
-        default=EnvironmentConfig(),
+        default_factory=EnvironmentConfig,
         description="The environment of Everest, specifies which folders are used "
         "for simulation and output, as well as the level of detail in Everest-logs",
     )

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
@@ -3,134 +3,114 @@
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP",
-      "exit_code": null
+      "everest_event": "START_OPTIMIZER_STEP"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 5,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 5,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP",
-      "exit_code": "OPTIMIZER_STEP_FINISHED"
+      "everest_event": "FINISHED_OPTIMIZER_STEP"
     }
   ],
   "num_full_snapshots": 6

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
@@ -1,116 +1,142 @@
 {
   "everest_events": [
     {
-      "batch": null,
+      "batch": 0,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP"
-    },
-    {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 0,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 1,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 1,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 2,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 2,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 3,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 3,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 4,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 4,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 5,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 5,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 5,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
-      "result_type": "GradientResult"
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
     },
     {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP"
+      "batch": 5,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "GradientResult"
     }
   ],
   "num_full_snapshots": 6

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
@@ -3,73 +3,62 @@
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP",
-      "exit_code": null
+      "everest_event": "START_OPTIMIZER_STEP"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP",
-      "exit_code": "USER_ABORT"
+      "everest_event": "FINISHED_OPTIMIZER_STEP"
     }
   ],
   "num_full_snapshots": 4

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
@@ -1,64 +1,78 @@
 {
   "everest_events": [
     {
-      "batch": null,
+      "batch": 0,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP"
-    },
-    {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 0,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 1,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
-      "batch": null,
+      "batch": 1,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 2,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
-      "batch": null,
+      "batch": 2,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 3,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
-      "result_type": "GradientResult"
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
+      "result_type": "FunctionResult"
     },
     {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP"
+      "batch": 3,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "GradientResult"
     }
   ],
   "num_full_snapshots": 4

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
@@ -3,60 +3,51 @@
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP",
-      "exit_code": null
+      "everest_event": "START_OPTIMIZER_STEP"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "GradientResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION",
-      "exit_code": null
+      "everest_event": "START_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "FINISHED_EVALUATION",
-      "exit_code": null,
       "result_type": "FunctionResult"
     },
     {
       "batch": null,
       "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP",
-      "exit_code": "USER_ABORT"
+      "everest_event": "FINISHED_OPTIMIZER_STEP"
     }
   ],
   "num_full_snapshots": 3

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
@@ -1,53 +1,61 @@
 {
   "everest_events": [
     {
-      "batch": null,
+      "batch": 0,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_OPTIMIZER_STEP"
-    },
-    {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 0,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
       "result_type": "GradientResult"
     },
     {
-      "batch": null,
+      "batch": 1,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
-      "batch": null,
+      "batch": 1,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
+    },
+    {
+      "batch": 2,
       "event_type": "EverestStatusEvent",
-      "everest_event": "START_EVALUATION"
+      "everest_event": "START_OPTIMIZER_EVALUATION"
     },
     {
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
-      "everest_event": "FINISHED_EVALUATION",
+      "everest_event": "FINISHED_OPTIMIZER_EVALUATION",
       "result_type": "FunctionResult"
     },
     {
-      "batch": null,
-      "event_type": "EverestStatusEvent",
-      "everest_event": "FINISHED_OPTIMIZER_STEP"
+      "batch": 2,
+      "event_type": "EverestBatchResultEvent",
+      "everest_event": "OPTIMIZATION_RESULT",
+      "result_type": "FunctionResult"
     }
   ],
   "num_full_snapshots": 3


### PR DESCRIPTION
**Issue**
This PR resolves some issues on how the Everest run model interacts with the `ropt `optimizer (and fixes an unrelated bug). There are three commits:


* Fix a bug in the Everest configuration code.
* Remove the `exit_code` field from the events. There is no need for the exit code to be in the events, and this will be removed from the `ropt` events in the near future.
* Change the way the `ropt` events are forwarded. Currently all events are forwarded blindly, except for events that produce resutls, which are split up in multiple events. First of all, I do not think we should forward them blindly if we don't need them. They may not currently have any meaning in Everest. Secondly, by splitting the results into separate events we are not mirroring `ropt` events, but creating new ones with a slightly different meaning (the `ropt` events send results of a whole batch, the new events send one result per batch.) Therefore I suggest here not to mirror `ropt` events, but create new Everest optimization events and emit those when appropriate.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
