### PR TITLE
Log usage of forward_init with GEN_KW

### DIFF
--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -60,6 +60,10 @@ class EnsembleConfig:
             [p for p in self.parameter_configs.values() if isinstance(p, GenKwConfig)]
         )
 
+        self._check_for_forward_init_in_gen_kw(
+            [p for p in self.parameter_configs.values() if isinstance(p, GenKwConfig)]
+        )
+
         self.grid_file = _get_abs_path(self.grid_file)
 
     @staticmethod
@@ -92,6 +96,12 @@ class EnsembleConfig:
             logger.info(
                 f"Found duplicate GEN_KW parameter names: {duplicates_formatted}"
             )
+
+    @staticmethod
+    def _check_for_forward_init_in_gen_kw(gen_kw_list: list[GenKwConfig]) -> None:
+        for gen_kw in gen_kw_list:
+            if gen_kw.forward_init_file is not None:
+                logger.info(f"GEN_KW uses FORWARD_INIT: {gen_kw}")
 
     @no_type_check
     @classmethod


### PR DESCRIPTION
**Issue**
Resolves #10140 
 
Check for forward_init_file property in GenKwConfig, which should be None when forward_init is not used.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
