### PR TITLE
Fixup asof join warnings

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -538,9 +538,9 @@ class EverestRunModel(BaseRunModel):
             # of our to-be-evaluated controls.
             for control_name in control_names:
                 left = (
-                    left.sort(["model_realization", control_name])
+                    left.sort([control_name, "model_realization"])
                     .join_asof(
-                        right.sort(["model_realization", control_name]),
+                        right.sort([control_name, "model_realization"]),
                         on=control_name,
                         by="model_realization",  # pre-join by model realization
                         tolerance=EPS,  # Same as np.allclose with atol=EPS

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -986,8 +986,13 @@ class LocalEnsemble(BaseMode):
                             )
                         )
                     elif "time" in pivoted:
-                        joined = observations_for_type.join_asof(
-                            pivoted,
+                        sort_by = [
+                            "time",
+                            "response_key",
+                            *[k for k in response_cls.primary_key if k != "time"],
+                        ]
+                        joined = observations_for_type.sort(by=sort_by).join_asof(
+                            pivoted.sort(sort_by),
                             by=[
                                 "response_key",
                                 *[k for k in response_cls.primary_key if k != "time"],

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -504,14 +504,14 @@ class EverestStorage:
             separator=":",
         )
 
-        realization_objectives = realization_objectives.pivot(  # type: ignore
+        realization_objectives = realization_objectives.pivot(
             values="objective_value",
             index=[
                 "batch_id",
                 "realization",
                 "simulation_id",
             ],
-            columns="objective_name",
+            on="objective_name",
         )
 
         return {


### PR DESCRIPTION
**Issue**
Resolves #10189

Sorts only by the `on` column, ref https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.join_asof.html

```
Both DataFrames must be sorted by the on key (within each by group, if specified).
```
Sorting "flat" only by `on` seems to not give the warning 