### PR TITLE
Rename job to step in documentation

### DIFF
--- a/docs/ert/developer_documentation/concepts.rst
+++ b/docs/ert/developer_documentation/concepts.rst
@@ -39,7 +39,7 @@ the cost of low ability to reason about the forward model, its internal data
 flow and to build tooling on top of it. Furthermore, an ERT forward model is
 today implemented as a sequential list of scripts that are executed in the same
 disk area such that data from one script can be dumped on disk and picked up by
-the next job. More on the current and future data model and run environment of
+the next step. More on the current and future data model and run environment of
 the forward model can be found in the :doc:`forward_model`.
 
 Realisation

--- a/docs/ert/developer_documentation/forward_model.rst
+++ b/docs/ert/developer_documentation/forward_model.rst
@@ -12,12 +12,12 @@ to :doc:`concepts`.
 ERT forward models
 ------------------
 
-Currently, an ERT forward model is a list of shell commands, called jobs, that
-are executed sequentially. There is some additional context surrounding each
-job that can be configured in the job configuration file, like environment
-variables and default argument values. However, it quickly boils down to
-sequential shell commands using the underlying file system for data
-communication.
+Currently, an ERT forward model is a list of shell commands, called steps
+(previously called jobs), that are executed sequentially. There is some
+additional context surrounding each step that can be configured in the step
+configuration file, like environment variables and default argument values.
+However, it quickly boils down to sequential shell commands using the
+underlying file system for data communication.
 
 The input to a forward model consists of:
 
@@ -28,7 +28,7 @@ The input to a forward model consists of:
 - surface and field parameters (2D and 3D parameters) persisted directly into
   the reservoir model.
 - A description of the forward model as *JSON* in the root of the runpath in a
-  file named :code:`jobs.json`.
+  file named :code:`jobs.json` (this filename is kept for legacy reasons)
 - The magic strings (string to string mapping for replacement) are being
   replaced in the runpath.
 
@@ -37,24 +37,25 @@ this entails that the script :code:`fm_dispatch.py` is executed with the runpath
 the forward model as an argument. It will locate the :code:`jobs.json` file and
 execute the forward model as prescribed. During execution the status of the
 forward model is dumped to the :code:`status.json` file. It contains information
-about whether each job was a success or failure, the start and end running
-time, memory usage and so forth. In addition, each job's standard out and
-standard error is piped to unique files for each job. Both the status
+about whether each step was a success or failure, the start and end running
+time, memory usage and so forth. In addition, each step's standard out and
+standard error is piped to unique files for each step. Both the status
 file and the log files are picked up again by the core for monitoring
 purposes.
 
 The run environment of the forward model using a plain ERT installation is the
-same as the core. That entails that environment
-variables are carried over and one assumes that the disk where the relevant
-environment is installed is also available when running the forward model.
-Furthermore, the system is configured in Equinor such that the named deploy
-used by the core is persisted to disk and then picked up again on the forward
-model side to ensure that upgrades are not impacting already launched runs.
+same as the core. That entails that environment variables are carried over and
+one assumes that the disk where the relevant environment is installed is also
+available when running the forward model. Furthermore, the system is configured
+in Equinor such that the named deploy used by the core is persisted to disk and
+then picked up again on the forward model side to ensure that upgrades are not
+impacting already launched runs.
 
-After the forward model is completed, the overall status of the forward model is
-signaled by either producing a file named :code:`OK` or one named :code:`ERROR` in the root
-of the runpath. After this, response loading is initiated by the core. In
-particular, summary data is loaded from the configured :code:`ECLBASE` and in
-addition the various :code:`GEN_DATA` etc. responses are loaded from their
-configured files. If the loading of responses is also successful, the forward
-model in its entirety is deemed successful by the core.
+After the forward model is completed, the overall status of the forward model
+is signaled by either producing a file named :code:`OK` or one named
+:code:`ERROR` in the root of the runpath. After this, response loading is
+initiated by the core. In particular, summary data is loaded from the
+configured :code:`ECLBASE` and in addition the various :code:`GEN_DATA` etc.
+responses are loaded from their configured files. If the loading of responses
+is also successful, the forward model in its entirety is deemed successful by
+the core.

--- a/docs/ert/developer_documentation/forward_model.rst
+++ b/docs/ert/developer_documentation/forward_model.rst
@@ -52,8 +52,8 @@ then picked up again on the forward model side to ensure that upgrades are not
 impacting already launched runs.
 
 After the forward model is completed, the overall status of the forward model
-is signaled by either producing a file named :code:`OK` or one named
-:code:`ERROR` in the root of the runpath. After this, response loading is
+is signaled back to the core through a network message. If it failed a file
+:code:`ERROR` is also produced at the root of the runpath. After this, response loading is
 initiated by the core. In particular, summary data is loaded from the
 configured :code:`ECLBASE` and in addition the various :code:`GEN_DATA` etc.
 responses are loaded from their configured files. If the loading of responses

--- a/docs/ert/developer_documentation/roadmap.rst
+++ b/docs/ert/developer_documentation/roadmap.rst
@@ -148,7 +148,7 @@ own elements that are to be part of the algorithmic pipeline in ERT.
 First class support for sensitivity analysis
 --------------------------------------------
 
-Today the sensitivity analysis done in ERT is done via external jobs added to
+Today the sensitivity analysis done in ERT is done via external steps added to
 the pipelines of ERT. Instead, we aim at making sensitivity analysis a first
 class citizen in ERT that lets users sample from the parameter distributions
 in a natural manner.

--- a/docs/ert/getting_started/configuration/poly_new/guide.rst
+++ b/docs/ert/getting_started/configuration/poly_new/guide.rst
@@ -99,11 +99,11 @@ In the ``simulations`` folder, you'll find folders for each realization, labeled
 
 * **OK**: Indicates success. If there's an error, an ``ERROR`` file will be created instead.
 * **STATUS**: A legacy status file.
-* **jobs.json**: Defines the jobs to run.
+* **jobs.json**: Defines the forward model steps to run.
 * **logs/**: Log files useful for debugging
 * **status.json**: Used to communicate the status to ERT.
 
-Do not modify these files, either manually or through your experiments' jobs.
+Do not modify these files, either manually or through your experiments' steps.
 
 Adding a forward model
 ----------------------
@@ -162,39 +162,39 @@ The ``poly_eval.py`` script must be marked as executable to allow it to be invok
    This command changes the permissions of the file, allowing it to be executed like a program.
    Once you have run this command, the script can be run directly from the terminal or used within ERT as needed.
 
-Adding a job to the forward model
-*********************************
-To add a job to the forward model, you need to define the job in a separate file and then reference it in your configuration.
-Here's how to do it:
+Adding a step to the forward model
+**********************************
+To add a step to the forward model, you need to define the step in a separate
+file and then reference it in your configuration. Here's how to do it:
 
-1. **Define the job**: Create a file named ``POLY_EVAL`` with the following content to specify the executable:
+1. **Define the step**: Create a file named ``POLY_EVAL`` with the following content to specify the executable:
 
 .. include:: with_simple_script/POLY_EVAL
     :code:
 
-2. **Reference the job in configuration**: Open your configuration file and add these lines:
+2. **Reference the step in configuration**: Open your configuration file and add these lines:
 
 .. code-block:: shell
 
     INSTALL_JOB poly_eval POLY_EVAL
     FORWARD_MODEL poly_eval
 
-The :ref:`INSTALL_JOB <install_job>` line informs ERT about the job named ``poly_eval``
-and the file containing details of how to execute the job.
-The :ref:`FORWARD_MODEL <forward_model>` line instructs ERT to include the job as part of the forward model.
+The :ref:`INSTALL_JOB <install_job>` line informs ERT about the step named ``poly_eval``
+and the file containing details of how to execute the step.
+The :ref:`FORWARD_MODEL <forward_model>` line instructs ERT to include the step as part of the forward model.
 
 3. **Complete Configuration**: Your final configuration file should now look like this:
 
 .. include:: with_simple_script/poly.ert
     :code:
 
-For more details on configuring your own jobs, see the corresponding section on :ref:`configure_own_jobs`.
+For more details on configuring your own steps, see the corresponding section on :ref:`configure_own_steps`.
 
-By following these steps, you have added a job to the forward model, allowing ERT to execute the ``poly_eval.py`` script as part of the forward model.
+By following these steps, you have added a step to the forward model, allowing ERT to execute the ``poly_eval.py`` script as part of the forward model.
 
-Running with the new job
-************************
-With the new job added, follow these steps to run ERT and observe the results:
+Running with the new step
+*************************
+With the new step added, follow these steps to run ERT and observe the results:
 
 1. **Delete old output files**: To clear any previous results, execute the following command:
 
@@ -210,7 +210,7 @@ With the new job added, follow these steps to run ERT and observe the results:
 
 .. image:: with_simple_script/ert.png
 
-You will notice the updated configuration summary, including the newly defined job and the customized runpath.
+You will notice the updated configuration summary, including the newly defined step and the customized runpath.
 
 3. **Run the experiment**: Execute the ensemble experiment as before. Once it's complete, close all ERT windows.
 

--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -47,6 +47,8 @@ Forward models
 To install forward model steps that you want to have available in ERT you can either
 use the simplified :code:`installable_jobs` function name, or
 :code:`installable_forward_model_steps` which gives a lot more control.
+The individual steps in a forward model were previously called "jobs" in Ert,
+and this is still partly present in the source code.
 
 .. code-block:: python
 
@@ -105,7 +107,7 @@ validated pre-experiment, you can use the ``ForwardModelStepWarning.warn(...)`` 
 
 To provide documentation for a forward model step given with
 ``installable_jobs``, use the :code:`job_documentation` name. If you are the
-plugin that provided the job with the name :code:`job_name`, then you respond
+plugin that provided the step with the name :code:`step_name`, then you respond
 with the documentation as specified, else respond with :code:`None`.
 
 .. code-block:: python
@@ -113,12 +115,12 @@ with the documentation as specified, else respond with :code:`None`.
    import ert
 
    @ert.plugin(name="my_plugin")
-   def job_documentation(job_name: str):
-       if job_name == "my_job":
+   def job_documentation(step_name: str):
+       if step_name == "my_step":
             return {
-                "description": "job description",
+                "description": "step description",
                 "examples": "...",
-                "category": "test.category.for.job",
+                "category": "test.category.for.step",
             }
 
 When creating documentation in ERT, forward model steps will be grouped by their

--- a/docs/ert/reference/configuration/forward_model.rst
+++ b/docs/ert/reference/configuration/forward_model.rst
@@ -11,56 +11,56 @@ The model is called "forward" because it predicts the future state of the system
 on the current state and a set of input parameters.
 The predictive model may include pre-processing and post-processing steps in addition
 to the physics simulator itself.
-In ERT, we think of a forward model as a sequence of jobs such as making directories,
+In ERT, we think of a forward model as a sequence of steps such as making directories,
 copying files, executing simulators etc.
 
 Consider a scenario in reservoir management.
 Here, a forward model might encompass reservoir modeling software like RMS,
-a fluid simulator like Eclipse or Flow, and custom jobs like relative permeability interpolation
+a fluid simulator like Eclipse or Flow, and custom steps like relative permeability interpolation
 and water saturation calculation.
 
-To add a job to the forward model, use the :code:`FORWARD_MODEL` keyword.
+To add a step to the forward model, use the :code:`FORWARD_MODEL` keyword.
 Each :code:`FORWARD_MODEL` keyword instructs ERT to run a specific executable.
-You can build a series of jobs by listing multiple :code:`FORWARD_MODEL` keywords.
+You can build a series of steps by listing multiple :code:`FORWARD_MODEL` keywords.
 
-You can find all pre-configured jobs to define your forward models :ref:`here <Pre-configured jobs>`.
+You can find all pre-configured steps to define your forward models :ref:`here <Pre-configured steps>`.
 These jobs form the building blocks for your custom forward models in ERT.
 
-.. _configure_own_jobs:
+.. _configure_own_steps:
 
-Configuring your own jobs
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Configuring your own steps
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ERT imposes no restrictions on the programming language used to write a job.
+ERT imposes no restrictions on the programming language used to write a step.
 The only requirement is that it should be an executable that can be run.
 Consequently, it is possible to create a program or script performing any desired function,
-and then have ERT run it as one of the jobs in the :code:`FORWARD_MODEL`.
+and then have ERT run it as one of the steps in the :code:`FORWARD_MODEL`.
 
-However, for ERT to recognize a job, it must be installed. All predefined
-jobs are already installed and may be invoked by using the
+However, for ERT to recognize a step, it must be installed. All predefined
+steps are already installed and may be invoked by using the
 :code:`FORWARD_MODEL` keyword in the configuration file.
-If you need to include a custom job, it must first be installed using :code:`INSTALL_JOB`,
+If you need to include a custom step, it must first be installed using :code:`INSTALL_JOB`,
 as follows:
 
 .. code-block:: bash
 
-    INSTALL_JOB JOB_NAME JOB_CONFIG
+    INSTALL_JOB STEP_NAME STEP_CONFIG
 
-In this command, JOB_NAME is a name of your choice that you can later use in
-the ERT configuration file to call upon the job.
-:code:`JOB_CONFIG` is a file that specifies the location of the executable
+In this command, STEP_NAME is a name of your choice that you can later use in
+the ERT configuration file to call upon the step.
+:code:`STEP_CONFIG` is a file that specifies the location of the executable
 and provides rules for the behavior of any arguments.
 
-By installing your own jobs in this way, you can extend the capabilities of ERT to meet your specific needs and scenarios.
+By installing your own steps in this way, you can extend the capabilities of ERT to meet your specific needs and scenarios.
 
 .. code-block:: bash
 
     EXECUTABLE  path/to/program
 
     STDERR      prog.stderr      -- Name of stderr file (defaults to
-                                 -- name_of_file.stderr.<job_nr>)
+                                 -- name_of_file.stderr.<step_nr>)
     STDOUT      prog.stdout      -- Name of stdout file (defaults to
-                                 -- name_of_file.stdout.<job_nr>)
+                                 -- name_of_file.stdout.<step_nr>)
     ARGLIST     <ARG0> <ARG1>    -- A list of arguments to pass on to the
                                  --  executable
     REQUIRED    <ARG0> <ARG1>    -- A list of arguments required to be passed
@@ -68,15 +68,15 @@ By installing your own jobs in this way, you can extend the capabilities of ERT 
 
 Note
 ____
-When configuring ARGLIST for FORWARD_MODEL jobs it is not suitable to use
+When configuring ARGLIST for FORWARD_MODEL steps it is not suitable to use
 :code:`--some-option` for named options as it treated as a comment by the
 configuration compiler. Single letter options, i.e. :code:`-s` are needed.
 
-Invoking the job is then done by including it in the ert config:
+Invoking the step is then done by including it in the ert config:
 
 .. code-block:: bash
 
-    FORWARD_MODEL JOB_NAME(<ARG0>=3, <ARG1>="something")
+    FORWARD_MODEL STEP_NAME(<ARG0>=3, <ARG1>="something")
 
 
 Note that the following behaviour provides identical results:
@@ -84,11 +84,11 @@ Note that the following behaviour provides identical results:
 .. code-block:: bash
 
     DEFINE <ARG0> 3
-    FORWARD_MODEL JOB_NAME(<ARG1>="something")
+    FORWARD_MODEL STEP_NAME(<ARG1>="something")
 
 see example :ref:`create_script`
 
-.. _Pre-configured jobs:
+.. _Pre-configured steps:
 
 Pre-configured forward models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -307,7 +307,7 @@ ECLIPSE data file. For instance, it can be used to insert include paths.
 
         -- Define the alias MY_PATH using DATA_KW. Any instances of <MY_PATH> (yes, with brackets)
         -- in the ECLIPSE data file will now be replaced with /mnt/my_own_disk/my_reservoir_model
-        -- when running the ECLIPSE jobs.
+        -- when running the ECLIPSE step.
         DATA_KW  MY_PATH  /mnt/my_own_disk/my_reservoir_model
 
 The DATA_KW keyword is optional. Note also that ERT has some built in magic strings.
@@ -420,26 +420,26 @@ INSTALL_JOB
 .. _install_job:
 
 The INSTALL_JOB keyword is used to instruct ERT how to run
-external applications and scripts, i.e. defining a job. After a job has been
+external applications and scripts, i.e. defining a step. After a step has been
 defined with INSTALL_JOB, it can be used with the FORWARD_MODEL keyword. For
 example, if you have a script which generates relative permeability curves
-from a set of parameters, it can be added as a job, allowing you to do history
+from a set of parameters, it can be added as a step, allowing you to do history
 matching and sensitivity analysis on the parameters defining the relative
 permeability curves.
 
-The INSTALL_JOB keyword takes two arguments, a job name and the name of a
-configuration file for that particular job.
+The INSTALL_JOB keyword takes two arguments, a step name and the name of a
+configuration file for that particular step.
 
 *Example:*
 
 ::
 
-        -- Define a Lomeland relative permeabilty job.
-        -- The file jobs/lomeland.txt contains a detailed
-        -- specification of the job.
-        INSTALL_JOB LOMELAND jobs/lomeland.txt
+        -- Define a Lomeland relative permeabilty step.
+        -- The file lomeland.txt contains a detailed
+        -- specification of the step.
+        INSTALL_JOB LOMELAND lomeland.txt
 
-The configuration file used to specify an external job is easy to use and very
+The configuration file used to specify an external step is easy to use and very
 flexible. It is documented in Customizing the simulation workflow in ERT.
 
 The INSTALL_JOB keyword is optional.
@@ -844,7 +844,7 @@ field as it comes out from ERT. The typical way to achieve this is:
 2. In the first iteration ERT will *not* output a file ``poro.grdecl``, but in
    the second and subsequent iterations a ``poro.grdecl`` file will be created
    by ERT - this is at the core of the ``FORWARD_INIT:True`` functionality.
-3. In the forward model there should be a job ``CAREFUL_COPY_FILE`` which will copy
+3. In the forward model there should be a step ``CAREFUL_COPY_FILE`` which will copy
    ``tmp_poro.grdecl`` *only if* ``poro.grdecl`` does not already exist. The
    rest of the forward model components should use ``poro.grdecl``.
 
@@ -1365,8 +1365,8 @@ initialize PERMX and PORO nodes from these files:
 Observe that forward model has created the file petro.grdecl and the nodes
 PORO and PERMX create the ECLIPSE input files poro.grdecl and permx.grdecl, to
 ensure that ECLIPSE finds the input files poro.grdecl and permx.grdecl the
-forward model should contain a job which will copy/convert petro.grdecl ->
-(poro.grdecl,permx.grdecl), this job should not overwrite existing versions of
+forward model should contain a step which will copy/convert petro.grdecl ->
+(poro.grdecl,permx.grdecl), this step should not overwrite existing versions of
 permx.grdecl and poro.grdecl. This extra hoops is not strictly needed in all
 cases, but strongly recommended to ensure that you have control over which
 data is used, and that everything is consistent in the case where the forward
@@ -1656,9 +1656,9 @@ FORWARD_MODEL
 
     The FORWARD_MODEL keyword is used to define how the simulations are executed.
     E.g., which version of ECLIPSE to use, which rel.perm script to run, which
-    rock physics model to use etc. Jobs (i.e. programs and scripts) that are to be
+    rock physics model to use etc. Steps (i.e. programs and scripts) that are to be
     used in the FORWARD_MODEL keyword must be defined using the INSTALL_JOB
-    keyword. A set of default jobs is available, and by default FORWARD_MODEL
+    keyword. A set of default steps is available, and by default FORWARD_MODEL
     takes the value ECLIPSE100.
 
     The FORWARD_MODEL keyword expects one keyword defined with INSTALL_JOB.
@@ -1673,7 +1673,7 @@ FORWARD_MODEL
             FORWARD_MODEL MY_RELPERM_SCRIPT
             FORWARD_MODEL ECLIPSE100
 
-    In available jobs in ERT you can see a list of the jobs which are available.
+    In available steps in ERT you can see a list of the steps which are available.
 
 JOB_SCRIPT
 ----------
@@ -1700,7 +1700,7 @@ QUEUE_SYSTEM
 ------------
 .. _queue_system:
 
-The keyword QUEUE_SYSTEM can be used to control where the simulation jobs are
+The keyword QUEUE_SYSTEM can be used to control where the forward model is
 executed. It can take the values LSF, TORQUE, SLURM and LOCAL.
 
 ::
@@ -1854,6 +1854,6 @@ forward models.
         SETENV  MY_OTHER_VAR    Hello$MY_VAR
 
 This will result in two environment variables being set in the compute side
-and available to all jobs. MY_VAR will be "World", and MY_OTHER_VAR will be
+and available to all step. MY_VAR will be "World", and MY_OTHER_VAR will be
 "HelloWorld". The variables are expanded in order on the compute side, so
 the environment where ERT is running has no impact, and is not changed.


### PR DESCRIPTION
The job concept has been renamed to step in the source code some years ago, and this change should now be reflected in the docuementation.

The API of Ert is not changed, that means there will be inconsistencies still left in Ert and its docs (jobs.json f.ex).

The term job in Ert should only mean the entire forward model as submitted to the queue system, or a workflow job.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
