### PR TITLE
Fix qwarning from QApplication after migration to pyqt6

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -6,7 +6,7 @@ from collections import Counter
 from importlib.resources import files
 from signal import SIG_DFL, SIGINT, signal
 
-from PyQt6.QtCore import QDir
+from PyQt6.QtCore import QDir, QLoggingCategory
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication, QWidget
 
@@ -40,8 +40,11 @@ def run_gui(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
     signal(SIGINT, SIG_DFL)
 
     QDir.addSearchPath("img", str(files("ert.gui").joinpath("resources/gui/img")))
-
+    # silence "QColorSpace attempted constructed from invalid primaries" warning
+    qcolor_space_category = QLoggingCategory("QColorSpace")
+    qcolor_space_category.setFilterRules("*.warning=false")
     app = QApplication(["ert"])  # Early so that QT is initialized before other imports
+    qcolor_space_category.setFilterRules("")  # Reset the filter to re-enable warnings
     app.setWindowIcon(QIcon("img:ert_icon.svg"))
 
     with add_gui_log_handler() as log_handler:


### PR DESCRIPTION
**Issue**
Resolves #10114 

**Approach**
This is a quickfix that resolves the issue where creating QApplication would print out a qwarning `QColorSpace attempted constructed from invalid primaries: QPointF(0,0) QPointF(0,0) QPointF(0,0) QPointF(0,0)`. This started occuring on some systems after the migration to pyqt6, and this workaround should be removed in the future.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
