### PR TITLE
Allow non-utf-8 characters in PRT files

### DIFF
--- a/src/ert/resources/forward_models/run_reservoirsimulator.py
+++ b/src/ert/resources/forward_models/run_reservoirsimulator.py
@@ -37,7 +37,7 @@ class EclError(RuntimeError):
                     f"{ecl_case_dir}/{ecl_case_starts_with}*.PRT"
                 ):
                     if ecl_output_has_license_error(
-                        Path(prt_file).read_text(encoding="utf-8")
+                        Path(prt_file).read_text(encoding="utf-8", errors="ignore")
                     ):
                         return True
         return False
@@ -328,7 +328,7 @@ class RunReservoirSimulator:
 
         errors = None
         bugs = None
-        with open(report_file, encoding="utf-8") as filehandle:
+        with open(report_file, encoding="utf-8", errors="ignore") as filehandle:
             for line in filehandle.readlines():
                 error_match = re.match(error_regexp, line)
                 if error_match:
@@ -351,7 +351,7 @@ class RunReservoirSimulator:
         error_e300_regexp = re.compile(error_pattern_e300, re.MULTILINE)
         slave_started_regexp = re.compile(slave_started_pattern, re.MULTILINE)
 
-        content = self.prt_path.read_text(encoding="utf-8")
+        content = self.prt_path.read_text(encoding="utf-8", errors="ignore")
 
         for regexp in [error_e100_regexp, error_e300_regexp, slave_started_regexp]:
             offset = 0
@@ -371,7 +371,7 @@ class RunReservoirSimulator:
 def tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with open(file_path, encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8", errors="ignore") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)


### PR DESCRIPTION
If Eclipse made it through to this point, Ert should not crash at this point when looking for error counts etc from the PRT output file.

**Issue**
Backports #10208

**Approach**
🍒 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
