### PR TITLE
Remove priting of opt status when checking previous run

### DIFF
--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -26,7 +26,6 @@ from everest.config.server_config import ServerConfig
 from everest.detached import (
     ServerStatus,
     everserver_status,
-    get_opt_status_from_storage,
     server_is_running,
     start_monitor,
     stop_server,
@@ -367,11 +366,6 @@ def report_on_previous_run(
             f"`  everest run --new-run {config_file}`\n"
         )
     else:
-        opt_status = get_opt_status_from_storage(optimization_output_dir)
-        if opt_status.get("cli_monitor_data"):
-            monitor = _DetachedMonitor(show_all_jobs=False)
-            msg, _ = monitor.get_opt_progress(opt_status)
-            print(msg + "\n")
         print(
             f"Optimization completed.\n"
             "\nTo re-run the optimization use command:\n"

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -4,7 +4,6 @@ import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 import requests
 
@@ -26,7 +25,6 @@ from everest.detached import (
     PROXY,
     ServerStatus,
     everserver_status,
-    get_opt_status_from_storage,
     server_is_running,
     start_server,
     stop_server,
@@ -334,80 +332,3 @@ if __name__ == "__main__":
     driver = await start_server(everest_config, logging_level=logging.DEBUG)
     final_state = await server_running()
     assert final_state.returncode == 0
-
-
-@pytest.mark.xdist_group(name="math_func/config_multiobj.yml")
-def test_get_opt_status(cached_example):
-    _, config_file, _, _ = cached_example("math_func/config_multiobj.yml")
-    config = EverestConfig.load_file(config_file)
-
-    opts = get_opt_status_from_storage(config.optimization_output_dir)
-
-    assert np.allclose(
-        opts["objective_history"], [-2.3333, -2.3335, -2.0000], atol=1e-4
-    )
-
-    assert np.allclose(
-        opts["control_history"]["point.x"],
-        [0.0, -0.004202181916184627, -0.0021007888698514315],
-        atol=1e-4,
-    )
-    assert np.allclose(
-        opts["control_history"]["point.y"],
-        [0.0, -0.011298196942730383, -0.0056482862617779715],
-        atol=1e-4,
-    )
-    assert np.allclose(
-        opts["control_history"]["point.z"], [0.0, 1.0, 0.4999281115746754], atol=1e-4
-    )
-
-    assert np.allclose(
-        opts["objectives_history"]["distance_p"],
-        [-0.75, -0.7656459808349609, -0.5077850222587585],
-        atol=1e-4,
-    )
-    assert np.allclose(
-        opts["objectives_history"]["distance_q"],
-        [-4.75, -4.703639984130859, -4.476789951324463],
-        atol=1e-4,
-    )
-
-    assert opts["accepted_control_indices"] == [0, 2]
-
-    cmond = opts["cli_monitor_data"]
-
-    assert cmond["batches"] == [0, 1, 2]
-    assert cmond["controls"][0]["point.x"] == 0.0
-    assert cmond["controls"][0]["point.y"] == 0.0
-    assert cmond["controls"][0]["point.z"] == 0.0
-
-    assert np.allclose(
-        cmond["controls"][1]["point.x"], -0.004202181916184627, atol=1e-4
-    )
-    assert np.allclose(
-        cmond["controls"][1]["point.y"], -0.011298196942730383, atol=1e-4
-    )
-    assert np.allclose(cmond["controls"][1]["point.z"], 1.0, atol=1e-4)
-    assert np.allclose(
-        cmond["controls"][2]["point.x"], -0.0021007888698514315, atol=1e-4
-    )
-    assert np.allclose(
-        cmond["controls"][2]["point.y"], -0.0056482862617779715, atol=1e-4
-    )
-    assert np.allclose(cmond["controls"][2]["point.z"], 0.4999281115746754, atol=1e-4)
-
-    assert np.allclose(
-        cmond["objective_value"],
-        [-2.333333333333333, -2.333525975545247, -2.000048339366913],
-        atol=1e-4,
-    )
-    assert np.allclose(
-        cmond["expected_objectives"]["distance_p"],
-        [-0.75, -0.7656459808349609, -0.5077850222587585],
-        atol=1e-4,
-    )
-    assert np.allclose(
-        cmond["expected_objectives"]["distance_q"],
-        [-4.75, -4.703639984130859, -4.476789951324463],
-        atol=1e-4,
-    )


### PR DESCRIPTION
This feature made the client go into the server storage, and we need to have separation between between the frontend and the backend.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
