### PR TITLE
Mark slow tests as integration_test

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -204,6 +204,7 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
     assert len(mock_server.messages) == 0, "expected 0 Job running messages"
 
 
+@pytest.mark.integration_test
 def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
     # this is to show when the reporter fails but reconnects
     # reporter still manages to send events and completes fine

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -143,6 +143,7 @@ def test_configure_logger_failure(_, change_to_tmpdir):
     assert "Exception: Configuring logger failed" in status["message"]
 
 
+@pytest.mark.integration_test
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch("everest.detached.jobs.everserver._configure_loggers")
 def test_status_running_complete(_, change_to_tmpdir, mock_server):
@@ -172,6 +173,7 @@ def test_status_failed_job(_, change_to_tmpdir, mock_server):
     assert status["status"] == ServerStatus.failed
 
 
+@pytest.mark.integration_test
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch("everest.detached.jobs.everserver._configure_loggers")
 async def test_status_exception(_, change_to_tmpdir, min_config):


### PR DESCRIPTION
Maks some tests that were slow (>10s for `test_report_with_reconnected_reporter_but_finished_jobs` and >1s for the others) with integration_test to keep rapid tests rapid

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
