### PR TITLE
Disable monitoring of ert in testkomodo

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -22,7 +22,7 @@ run_ert_with_opm() {
     cp -r "${CI_SOURCE_ROOT}/test-data/ert/flow_example" ert_with_opm
     pushd ert_with_opm || exit 1
 
-    ert test_run flow.ert ||
+    ert test_run --disable-monitoring flow.ert ||
         (
             # In case ert fails, print log files if they are there:
             cat spe1_out/realization-0/iter-0/STATUS || true


### PR DESCRIPTION
**Issue**
Resolves uninteresting lines in logs. Also makes it easer to trace logs for the string "Failed".

**Approach**
`--disable-monitoring`

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
