### PR TITLE
Have just use correct justfile in testkomodo

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -13,7 +13,7 @@ copy_test_files() {
 }
 
 install_test_dependencies() {
-    pip install ".[dev]"
+    pip install ".[dev, types]"
 }
 
 run_ert_with_opm() {
@@ -115,7 +115,7 @@ start_tests() {
     export ERT_PYTEST_ARGS=--eclipse-simulator
 
     # Run all ert tests except tests evaluating memory consumption and tests requiring windows manager (GUI tests)
-    just check-all
+    just -f "${CI_SOURCE_ROOT}"/justfile check-all
     return_code_ert_main_tests=$?
 
     # Restricting the number of threads utilized by numpy to control memory consumption, as some tests evaluate memory usage and additional threads increase it.


### PR DESCRIPTION
Fixes the ci/testkomodo.sh by pointing at the right justfile and installing the types requirements.