### PR TITLE
Log when duration of forward model step is negative

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -69,6 +69,8 @@ _QCOLORS = {
     state.COLOR_NOT_ACTIVE: QColor(*state.COLOR_NOT_ACTIVE),
 }
 
+_warn_once = True
+
 
 def _estimate_duration(
     start_time: datetime, end_time: datetime | None = None
@@ -429,6 +431,16 @@ class SnapshotModel(QAbstractItemModel):
                 )
                 # There is no method for truncating microseconds, so we remove them
                 delta -= timedelta(microseconds=delta.microseconds)
+                if delta < timedelta():
+                    global _warn_once  # noqa: PLW0603
+                    if _warn_once:
+                        _warn_once = False
+                        logger.warning(
+                            "Negative duration in snapshot encountered. "
+                            f"start_time={start_time} end_time={node.data.get(ids.END_TIME)} "
+                            f"delta={delta}"
+                        )
+                    delta = timedelta()
                 return str(delta)
 
             return node.data.get(data_name)


### PR DESCRIPTION
Set negative durations to 0 in simulation status
Will also log warnings when encountering these issues.

**Issue**
Resolves #10150 

**Approach**


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
