### PR TITLE
Make flowbase definition passthrough to ertconfig

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -232,6 +232,20 @@ and environment variables are exposed in the form 'os.NAME', for example:
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     @model_validator(mode="after")
+    def validate_eclbase_flowbase(self) -> Self:  # pylint: disable=E0213
+        if self.definitions is None:
+            return self
+
+        if "eclbase" in self.definitions and "flowbase" in self.definitions:
+            raise ValueError(
+                "Found both eclbase and flowbase in definitions config. "
+                "Please use only one to point to the directory containing "
+                "reservoir simulator files."
+            )
+
+        return self
+
+    @model_validator(mode="after")
     def validate_queue_system(self) -> Self:  # pylint: disable=E0213
         assert self.server is not None
         assert self.simulator is not None

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -172,12 +172,8 @@ def _inject_simulation_defaults(
         if key not in ert_config:
             ert_config[key] = value
 
-    inject_default(
-        "ECLBASE",
-        (ever_config.definitions if ever_config.definitions is not None else {}).get(
-            "eclbase", "eclipse/ECL"
-        ),
-    )
+    defs = ever_config.definitions if ever_config.definitions is not None else {}
+    inject_default("ECLBASE", defs.get("eclbase", defs.get("flowbase", "eclipse/ECL")))
 
 
 def _extract_simulator(ever_config: EverestConfig, ert_config: dict[str, Any]) -> None:

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1186,3 +1186,10 @@ def test_export_deprecated_keys(key, value, min_config, change_to_tmpdir):
     )
     with pytest.warns(ConfigWarning, match=match_msg):
         EverestConfig.load_file_with_argparser("config.yml", parser)
+
+
+def test_that_definitions_eclbase_flowbase_are_mutually_exclusive():
+    with pytest.raises(
+        ValueError, match="Found both eclbase and flowbase in definitions config"
+    ):
+        EverestConfig.with_defaults(definitions={"eclbase": "heh", "flowbase": "hah"})

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -389,3 +389,10 @@ def test_user_config_jobs_precedence(tmp_path, monkeypatch):
     )
 
     assert installed_forward_model_steps_new.get(existing_job).executable == "echo"
+
+
+def test_that_definitions_passthrough_eclbase():
+    ever_config = EverestConfig.with_defaults(definitions={"eclbase": "blorgh"})
+
+    ert_config_dict = everest_to_ert_config_dict(ever_config)
+    assert ert_config_dict["ECLBASE"] == "blorgh"

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -391,6 +391,13 @@ def test_user_config_jobs_precedence(tmp_path, monkeypatch):
     assert installed_forward_model_steps_new.get(existing_job).executable == "echo"
 
 
+def test_that_definitions_passthrough_flowbase():
+    ever_config = EverestConfig.with_defaults(definitions={"flowbase": "blargh"})
+
+    ert_config_dict = everest_to_ert_config_dict(ever_config)
+    assert ert_config_dict["ECLBASE"] == "blargh"
+
+
 def test_that_definitions_passthrough_eclbase():
     ever_config = EverestConfig.with_defaults(definitions={"eclbase": "blorgh"})
 


### PR DESCRIPTION
**Issue**
Resolves [#10248](https://github.com/equinor/ert/issues/10248)

Passthrough `flowbase` as `ECLBASE` to ERT, and disallow both `flowbase` and `eclbase` in everest config simultaneously.

Discussion point maybe for another issue: We could rename the base directory to something not explicitly flow/eclipse