### PR TITLE
Have DESIGN_MATRIX  not require design_sheet and default_sheet

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -43,8 +43,8 @@ class DesignMatrix:
     def from_config_list(cls, config_list: list[str | dict[str, str]]) -> DesignMatrix:
         filename = Path(cast(str, config_list[0]))
         options = cast(dict[str, str], config_list[1])
-        design_sheet = options.get("DESIGN_SHEET")
-        default_sheet = options.get("DEFAULT_SHEET")
+        design_sheet = options.get("DESIGN_SHEET", "DesignSheet")
+        default_sheet = options.get("DEFAULT_SHEET", "DefaultSheet")
         errors = []
         if filename.suffix not in {
             ".xlsx",
@@ -54,14 +54,6 @@ class DesignMatrix:
                 ErrorInfo(
                     f"DESIGN_MATRIX must be of format .xls or .xlsx; is '{filename}'"
                 ).set_context(config_list)
-            )
-        if design_sheet is None:
-            errors.append(
-                ErrorInfo("Missing required DESIGN_SHEET").set_context(config_list)
-            )
-        if default_sheet is None:
-            errors.append(
-                ErrorInfo("Missing required DEFAULT_SHEET").set_context(config_list)
             )
         if design_sheet is not None and design_sheet == default_sheet:
             errors.append(

--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -261,8 +261,8 @@ def install_job_directory_keyword() -> SchemaItem:
 def design_matrix_keyword() -> SchemaItem:
     return SchemaItem(
         kw=ConfigKeys.DESIGN_MATRIX,
-        argc_min=2,
-        argc_max=2,
+        argc_min=1,
+        argc_max=3,
         type_map=[
             SchemaItemType.EXISTING_PATH,
             SchemaItemType.STRING,

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -22,7 +22,7 @@ from tests.ert.ui_tests.cli.run_cli import run_cli
 
 def _create_design_matrix(filename, design_sheet_df, default_sheet_df=None):
     with pd.ExcelWriter(filename) as xl_write:
-        design_sheet_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_sheet_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         if default_sheet_df is not None:
             default_sheet_df.to_excel(
                 xl_write, index=False, sheet_name="DefaultSheet", header=False
@@ -54,7 +54,7 @@ def test_run_poly_example_with_design_matrix():
                 NUM_REALIZATIONS 10
                 MIN_REALIZATIONS 1
                 GEN_DATA POLY_RES RESULT_FILE:poly.out
-                DESIGN_MATRIX poly_design.xlsx DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet
+                DESIGN_MATRIX poly_design.xlsx
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
@@ -156,7 +156,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, err
                 MIN_REALIZATIONS 1
                 GEN_DATA POLY_RES RESULT_FILE:poly.out
                 GEN_KW COEFFS my_template my_output coeff_priors
-                DESIGN_MATRIX poly_design.xlsx DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet
+                DESIGN_MATRIX poly_design.xlsx DESIGN_SHEET:DesignSheet DEFAULT_SHEET:DefaultSheet
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
@@ -268,8 +268,8 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
                 NUM_REALIZATIONS 10
                 MIN_REALIZATIONS 1
                 GEN_DATA POLY_RES RESULT_FILE:poly.out
-                DESIGN_MATRIX poly_design_1.xlsx DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet
-                DESIGN_MATRIX poly_design_2.xlsx DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet
+                DESIGN_MATRIX poly_design_1.xlsx
+                DESIGN_MATRIX poly_design_2.xlsx
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
@@ -358,7 +358,7 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
                 GEN_KW COEFFS_B coeff_priors_b
                 GEN_KW COEFFS_C coeff_priors_c
                 GEN_DATA POLY_RES RESULT_FILE:poly.out
-                DESIGN_MATRIX design_matrix.xlsx DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet
+                DESIGN_MATRIX design_matrix.xlsx
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """

--- a/tests/ert/unit_tests/config/test_analysis_config.py
+++ b/tests/ert/unit_tests/config/test_analysis_config.py
@@ -126,40 +126,6 @@ def test_invalid_design_matrix_format_raises_validation_error():
         )
 
 
-def test_design_matrix_without_design_sheet_raises_validation_error():
-    with pytest.raises(ConfigValidationError, match="Missing required DESIGN_SHEET"):
-        AnalysisConfig.from_dict(
-            {
-                ConfigKeys.DESIGN_MATRIX: [
-                    [
-                        "my_matrix.xlsx",
-                        {
-                            "DESIGN_": "design",
-                            "DEFAULT_SHEET": "default",
-                        },
-                    ]
-                ],
-            }
-        )
-
-
-def test_design_matrix_without_default_sheet_raises_validation_error():
-    with pytest.raises(ConfigValidationError, match="Missing required DEFAULT_SHEET"):
-        AnalysisConfig.from_dict(
-            {
-                ConfigKeys.DESIGN_MATRIX: [
-                    [
-                        "my_matrix.xlsx",
-                        {
-                            "DESIGN_SHEET": "design",
-                            "DEFAULT_": "default",
-                        },
-                    ]
-                ],
-            }
-        )
-
-
 def test_invalid_min_realization_percentage_raises_config_validation_error():
     with pytest.raises(
         ConfigValidationError,

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -684,7 +684,7 @@ def test_that_design_matrix_show_parameters_button_is_visible(
     )
     default_sheet_df = pd.DataFrame([["b", 1], ["c", 2]])
     with pd.ExcelWriter(xls_filename) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
             xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
@@ -693,9 +693,7 @@ def test_that_design_matrix_show_parameters_button_is_visible(
     with open(config_file, "w", encoding="utf-8") as f:
         f.write("NUM_REALIZATIONS 1")
         if design_matrix_entry:
-            f.write(
-                f"\nDESIGN_MATRIX {xls_filename} DESIGN_SHEET:DesignSheet01 DEFAULT_SHEET:DefaultSheet"
-            )
+            f.write(f"\nDESIGN_MATRIX {xls_filename}")
 
     args_mock = Mock()
     args_mock.config = config_file

--- a/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
+++ b/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
@@ -12,11 +12,11 @@ from ert.config.gen_kw_config import TransformFunctionDefinition
 
 def _create_design_matrix(xls_path, design_matrix_df, default_sheet_df) -> DesignMatrix:
     with pd.ExcelWriter(xls_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
-    return DesignMatrix(xls_path, "DesignSheet01", "DefaultValues")
+    return DesignMatrix(xls_path, "DesignSheet", "DefaultSheet")
 
 
 @pytest.mark.parametrize(
@@ -145,11 +145,11 @@ def test_read_and_merge_with_existing_parameters(tmp_path, parameters, error_msg
     )
     default_sheet_df = pd.DataFrame([["a", 1], ["b", 4]])
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
-    design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+    design_matrix = DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
     if error_msg:
         with pytest.raises(ValueError, match=error_msg):
             design_matrix.merge_with_existing_parameters(extra_genkw_config)
@@ -180,11 +180,11 @@ def test_reading_design_matrix(tmp_path):
     )
     default_sheet_df = pd.DataFrame([["one", 1], ["b", 4], ["d", "case_name"]])
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
-    design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+    design_matrix = DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
     design_params = design_matrix.parameter_configuration
     assert all(param in design_params for param in ("a", "b", "c", "one", "d"))
     assert design_matrix.active_realizations == [True, True, False, False, True]
@@ -218,13 +218,13 @@ def test_reading_design_matrix_validate_reals(tmp_path, real_column, error_msg):
     )
     default_sheet_df = pd.DataFrame()
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
 
     with pytest.raises(ValueError, match=error_msg):
-        DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+        DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
 
 
 @pytest.mark.parametrize(
@@ -270,13 +270,13 @@ def test_reading_design_matrix_validate_headers(tmp_path, column_names, error_ms
     )
     default_sheet_df = pd.DataFrame([["one", 1], ["b", 4], ["d", 6]])
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
 
     with pytest.raises(ValueError, match=error_msg):
-        DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+        DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
 
 
 @pytest.mark.parametrize(
@@ -306,13 +306,13 @@ def test_reading_design_matrix_validate_cells(tmp_path, values, error_msg):
     )
     default_sheet_df = pd.DataFrame()
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
 
     with pytest.raises(ValueError, match=error_msg):
-        DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+        DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
 
 
 @pytest.mark.parametrize(
@@ -352,13 +352,13 @@ def test_reading_default_sheet_validation(tmp_path, data, error_msg):
     )
     default_sheet_df = pd.DataFrame(data)
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
 
     with pytest.raises(ValueError, match=error_msg):
-        DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+        DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
 
 
 def test_default_values_used(tmp_path):
@@ -373,11 +373,11 @@ def test_default_values_used(tmp_path):
     )
     default_sheet_df = pd.DataFrame([["one", 1], ["b", 4], ["d", "case_name"]])
     with pd.ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         default_sheet_df.to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
-    design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+    design_matrix = DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
     df = design_matrix.design_matrix_df
     np.testing.assert_equal(df["one"], np.array([1, 1, 1, 1]))
     np.testing.assert_equal(df["b"], np.array([0, 2, 0, 1]))

--- a/tests/ert/unit_tests/test_libres_facade.py
+++ b/tests/ert/unit_tests/test_libres_facade.py
@@ -276,11 +276,11 @@ def test_save_parameters_to_storage_from_design_dataframe(
     c_values = np.random.default_rng().uniform(-5, 5, 10)
     design_matrix_df = DataFrame({"a": a_values, "b": b_values, "c": c_values})
     with ExcelWriter(design_path) as xl_write:
-        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet01")
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
         DataFrame().to_excel(
-            xl_write, index=False, sheet_name="DefaultValues", header=False
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
-    design_matrix = DesignMatrix(design_path, "DesignSheet01", "DefaultValues")
+    design_matrix = DesignMatrix(design_path, "DesignSheet", "DefaultSheet")
     with open_storage(tmp_path / "storage", mode="w") as storage:
         experiment_id = storage.create_experiment(
             parameters=[design_matrix.parameter_configuration]


### PR DESCRIPTION
**Issue**
Resolves #10270


**Approach**
This commit makes the DESIGN_MATRIX keyword not require arguments for design and default sheet. Now DESIGN_SHEET defaults to `DesignSheet` and `DEFAULT_SHEET` defaults to "DefaultSheet"

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
