### PR TITLE
Adjust logger level for azure.monitor

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -21,6 +21,8 @@ loggers:
     level: INFO
   azure.core:
     level: WARNING
+  azure.monitor:
+    level: WARNING
   ert.storage.migration:
     level: DEBUG
     handlers: [terminal]


### PR DESCRIPTION
This is to avoid log statements like 'Transmission succeded' at INFO level from azure.monitor.opentelemetry.exporter.export_base

**Issue**
Resolves #10282 

**Approach**
Adjust logger configuration based on the logger name in the logged records (logs from bleeding includes the logger name). This is an educated guess. Not confirmed to work.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
