### PR TITLE
Add lru cache to _get_machine_name

### DIFF
--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -13,7 +13,7 @@ import traceback
 import uuid
 from base64 import b64decode, b64encode
 from contextlib import asynccontextmanager
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path
 from queue import Empty, SimpleQueue
 from typing import Any
@@ -185,6 +185,7 @@ class Subscriber:
         self._event.clear()
 
 
+@lru_cache
 def _get_machine_name() -> str:
     """Returns a name that can be used to identify this machine in a network
 


### PR DESCRIPTION
Avoids two calls to it when starting up everserver, it goes over network and may be slow. 
Locally on macbook pro M1 max it takes about 5sec per invocation, so this reduces the startup delay by 5sec
