### PR TITLE
Fix deprecation warning from polars

### DIFF
--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -504,14 +504,14 @@ class EverestStorage:
             separator=":",
         )
 
-        realization_objectives = realization_objectives.pivot(  # type: ignore
+        realization_objectives = realization_objectives.pivot(
+            on="objective_name",
             values="objective_value",
             index=[
                 "batch_id",
                 "realization",
                 "simulation_id",
             ],
-            columns="objective_name",
         )
 
         return {


### PR DESCRIPTION
Fixes the warning `everest_storage.py:507: DeprecationWarning: The argument `columns` for `DataFrame.pivot` is deprecated. It has been renamed to `on``


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
