### PR TITLE
Validate `DESIGN_MATRIX` when running `DESIGN2PARAMS`

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -33,7 +33,7 @@ class DesignMatrix:
                 self.active_realizations,
                 self.design_matrix_df,
                 self.parameter_configuration,
-            ) = self.read_design_matrix()
+            ) = self.read_and_validate_design_matrix()
         except (ValueError, AttributeError) as exc:
             raise ConfigValidationError.with_context(
                 f"Error reading design matrix {self.xls_filename}: {exc}",
@@ -157,7 +157,7 @@ class DesignMatrix:
                 new_param_config += [parameter_group]
         return new_param_config, design_parameter_group
 
-    def read_design_matrix(
+    def read_and_validate_design_matrix(
         self,
     ) -> tuple[list[bool], pd.DataFrame, GenKwConfig]:
         # Read the parameter names (first row) as strings to prevent pandas from modifying them.

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -23,6 +23,7 @@ from pydantic import ValidationError as PydanticValidationError
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass, rebuild_dataclass
 
+from ert.config.design_matrix import DesignMatrix
 from ert.config.parsing.context_values import ContextBoolEncoder
 from ert.plugins import ErtPluginManager
 from ert.plugins.workflow_config import ErtScriptWorkflow
@@ -459,7 +460,7 @@ def create_list_of_forward_model_steps_to_run(
     env_pr_fm_step: dict[str, dict[str, Any]],
 ) -> list[ForwardModelStep]:
     errors = []
-    fm_steps = []
+    fm_steps: list[ForwardModelStep] = []
 
     env_vars = {}
     for key, val in config_dict.get("SETENV", []):
@@ -510,7 +511,17 @@ def create_list_of_forward_model_steps_to_run(
         if should_add_step:
             fm_steps.append(fm_step)
 
+    design_matrices: list[DesignMatrix] = []
     for fm_step in fm_steps:
+        if fm_step.name == "DESIGN2PARAMS":
+            xls_filename = fm_step.private_args.get("<xls_filename>")
+            designsheet = fm_step.private_args.get("<designsheet>")
+            defaultsheet = fm_step.private_args.get("<defaultssheet>")
+            if design_matrix := validate_ert_design_matrix(
+                xls_filename, designsheet, defaultsheet
+            ):
+                design_matrices.append(design_matrix)
+
         if fm_step.name in preinstalled_forward_model_steps:
             try:
                 substituted_json = create_forward_model_json(
@@ -539,6 +550,15 @@ def create_list_of_forward_model_steps_to_run(
                     f"Unexpected plugin forward model exception: {e!s}",
                     context=fm_step.name,
                 )
+    try:
+        main_design_matrix: DesignMatrix | None = None
+        for design_matrix in design_matrices:
+            if main_design_matrix is None:
+                main_design_matrix = design_matrix
+            else:
+                main_design_matrix = main_design_matrix.merge_with_other(design_matrix)
+    except Exception as exc:
+        logger.warning(f"Design matrix merging would have failed due to: {exc}")
 
     if errors:
         raise ConfigValidationError.from_collected(errors)
@@ -1251,6 +1271,17 @@ def _forward_model_step_from_config_file(
         required_keywords=content_dict.get("REQUIRED", []),
         default_mapping=default_mapping,
     )
+
+
+def validate_ert_design_matrix(
+    xlsfilename, designsheetname, defaultssheetname
+) -> DesignMatrix | None:
+    try:
+        return DesignMatrix(xlsfilename, designsheetname, defaultssheetname)
+    except Exception as exc:
+        logger.warning(
+            f"DESIGN_MATRIX validation of DESIGN2PARAMS would have failed with: {exc!s}"
+        )
 
 
 # Due to circular dependency in type annotations between ErtConfig -> WorkflowJob -> ErtScript -> ErtConfig


### PR DESCRIPTION
**Issue**
Resolves #10271 


**Approach**
This commit makes us run validation for DESIGN_MATRIX when parsing configs using DESIGN2PARAMS, and log a warning if it would have failed.


(Screenshot of new behavior in GUI if applicable)
```
2025-03-14 09:02:28,837 - ert.config.ert_config - MainThread - WARNING - DESIGN_MATRIX validation of DESIGN2PARAMS would have failed with: Error reading design matrix dm.xlsx: Worksheet named 'default' not found

```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
