### PR TITLE
Remove redundant test_ert_context

### DIFF
--- a/tests/ert/unit_tests/test_enkf_main.py
+++ b/tests/ert/unit_tests/test_enkf_main.py
@@ -114,14 +114,3 @@ def test_assert_symlink_deleted(snake_oil_field_example, storage, run_paths):
 
     # ensure field symlink is replaced by file
     assert not os.path.islink(linkpath)
-
-
-@pytest.mark.usefixtures("use_tmpdir")
-def test_ert_context():
-    # Write a minimal config file with DEFINE
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
-        fout.write("NUM_REALIZATIONS 1\nDEFINE <MY_PATH> <CONFIG_PATH>")
-    ert_config = ErtConfig.from_file("config_file.ert")
-    context = ert_config.substitutions
-    my_path = context["<MY_PATH>"]
-    assert my_path == os.getcwd()


### PR DESCRIPTION
This test is nearly identical to
test_that_config_path_substitution_is_the_name_of_the_configs_directory

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
