### PR TITLE
Reduce timeouts for github workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     name: Check all workflow files
-    timeout-minutes: 60
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Download actionlint

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-wheels:
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       fail-fast: false
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,6 +18,7 @@ jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install_dependencies_qt

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -21,7 +21,7 @@ jobs:
   tests-ert:
     name: Run ert tests
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   tests-everest:
     name: Run everest tests
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test-semeio:
     name: Test Semeio
-    timeout-minutes: 40
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Broke the GUI tests on a recent pr of mine, and then they timed out after 60 minutes, which seems excessive.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
