### PR TITLE
Disable auto-scaling for discrete controls

### DIFF
--- a/src/everest/config/control_config.py
+++ b/src/everest/config/control_config.py
@@ -150,7 +150,7 @@ NOTE: In most cases this should not be configured, and the default value should 
 Can be used to set the range of the control values
 after scaling (default = [0, 1]).
 
-This option has no effect if auto_scale is not set.
+This option has no effect on discrete controls.
         """,
         )
     )

--- a/src/everest/config/control_variable_config.py
+++ b/src/everest/config/control_variable_config.py
@@ -38,7 +38,7 @@ initial value.
         default=None,
         description="""
 Can be set to true to re-scale variable from the range
-defined by [min, max] to the range defined by scaled_range (default [0, 1])
+defined by [min, max] to the range defined by scaled_range (default [0, 1]).
 """,
     )
     scaled_range: Annotated[tuple[float, float] | None, AfterValidator(valid_range)] = (
@@ -48,7 +48,7 @@ defined by [min, max] to the range defined by scaled_range (default [0, 1])
 Can be used to set the range of the variable values
 after scaling (default = [0, 1]).
 
-This option has no effect if auto_scale is not set.
+This option has no effect on discrete controls.
 """,
         )
     )

--- a/src/everest/config/utils.py
+++ b/src/everest/config/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from typing import Any
+from typing import Any, Literal
 
 from .control_config import ControlConfig
 from .control_variable_config import (
@@ -33,8 +33,8 @@ class FlattenedControls:
             self._controls.extend(variables)
 
         self.names = [control["name"] for control in self._controls]
-        self.types = [
-            None if control["control_type"] is None else control["control_type"]
+        self.types: list[Literal["real", "integer"]] = [
+            "real" if control["control_type"] is None else control["control_type"]
             for control in self._controls
         ]
         self.initial_guesses = [control["initial_guess"] for control in self._controls]

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -22,10 +22,7 @@ from everest.strings import EVEREST
 
 
 def _parse_controls(controls: FlattenedControls, ropt_config: dict[str, Any]) -> None:
-    control_types = [
-        None if type_ is None else VariableType[type_.upper()]
-        for type_ in controls.types
-    ]
+    control_types = [VariableType[type_.upper()] for type_ in controls.types]
     ropt_config["variables"] = {
         "types": None if all(item is None for item in control_types) else control_types,
         "initial_values": controls.initial_guesses,

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -24,7 +24,6 @@ def test_discrete_optimizer(copy_math_func_test_data_to_tmp):
                 "type": "generic_control",
                 "min": 0,
                 "max": 10,
-                "scaled_range": [0, 10],
                 "control_type": "integer",
                 "initial_guess": 0,
                 "variables": [{"name": "x"}, {"name": "y"}],


### PR DESCRIPTION
**Issue**
Resolves #10298


**Approach**
Disable scaling for discrete controls, since scaling does not make sense in this case.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
