### PR TITLE
Make cached everest example persist deletion of tmpdirs

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -141,8 +141,9 @@ def cached_example(pytestconfig):
     cache = pytestconfig.cache
 
     def run_config(test_data_case: str):
+        test_data_name = test_data_case.replace("/", ".")
         if cache.get(f"cached_example:{test_data_case}", None) is None:
-            my_tmpdir = Path(tempfile.mkdtemp())
+            my_tmpdir = cache.mkdir("cached_example_case" + test_data_name)
             config_path = (
                 Path(__file__) / f"../../../test-data/everest/{test_data_case}"
             ).resolve()


### PR DESCRIPTION
Avoids using tmpdir for everest cache which will be deleted on reboot on most systems.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
