### PR TITLE
Update ropt to 0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,8 +140,8 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.16,<0.17",
-    "ropt-dakota>=0.16,<0.17",
+    "ropt[pandas]>=0.17,<0.18",
+    "ropt-dakota>=0.17,<0.18",
 ]
 
 [tool.setuptools]

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -7,9 +7,7 @@ import logging
 import os
 import queue
 import shutil
-import sys
-from collections.abc import Callable, Generator, MutableSequence
-from contextlib import contextmanager
+from collections.abc import Callable, MutableSequence
 from enum import IntEnum, auto
 from pathlib import Path
 from types import TracebackType
@@ -316,12 +314,7 @@ class EverestRunModel(BaseRunModel):
         optimizer.set_results_callback(self._handle_optimizer_results)
 
         # Run the optimization:
-        output_dir = Path(self._everest_config.optimization_output_dir)
-        with redirect_optimizer_output(
-            stdout=output_dir / "optimizer_output.stdout",
-            stderr=output_dir / "optimizer_output.stderr",
-        ):
-            optimizer_exit_code = optimizer.run().exit_code
+        optimizer_exit_code = optimizer.run().exit_code
 
         # Store some final results.
         self.ever_storage.on_optimization_finished()
@@ -946,60 +939,3 @@ class EverestRunModel(BaseRunModel):
             and os.path.exists(self._everest_config.simulation_dir)
             and any(os.listdir(self._everest_config.simulation_dir))
         )
-
-
-@contextmanager
-def redirect_optimizer_output(
-    stdout: Path | None, stderr: Path | None = None
-) -> Generator[None, None, None]:
-    """This context manager redirects stdout and stderr to the given files.
-
-    The standard Python approach would be to redirect sys.stdout and sys.stderr,
-    or use contextlib.redirect_stdout/err. However, these may fail in cases
-    where the output is produced by C or Fortran code, as commonly used in
-    optimization backends. Therefore, the stdout and stderr file descriptors are
-    directly manipulated. It should be noted that this is not thread-safe, i.e.
-    standard output/errors may be affected in other threads in the same process.
-    However, this should not be an issue since the Everest run model does not
-    send output to stdout/stderr directly. (Note that manipulating sys.stdout or
-    using contextlib.redirect_stdout would also not be thread-safe.)
-    """
-    if stderr is None:
-        stderr = stdout
-
-    old_stdout: int | None = None
-    old_stderr: int | None = None
-    new_stdout: int | None = None
-    new_stderr: int | None = None
-
-    try:
-        sys.stdout.flush()
-        sys.stderr.flush()
-        old_stdout = os.dup(1)
-        old_stderr = os.dup(2)
-        new_stdout = (
-            os.open(os.devnull, os.O_WRONLY)
-            if stdout is None
-            else os.open(stdout, os.O_WRONLY | os.O_CREAT)
-        )
-        os.dup2(new_stdout, 1)
-        if stderr == stdout:
-            os.dup2(new_stdout, 2)
-            new_stderr = None
-        else:
-            new_stderr = (
-                os.open(os.devnull, os.O_WRONLY)
-                if stderr is None
-                else os.open(stderr, os.O_WRONLY | os.O_CREAT)
-            )
-            os.dup2(new_stderr, 2)
-        yield
-    finally:
-        if old_stdout is not None:
-            os.dup2(old_stdout, 1)
-        if old_stderr is not None:
-            os.dup2(old_stderr, 2)
-        if new_stdout is not None:
-            os.close(new_stdout)
-        if new_stderr is not None:
-            os.close(new_stderr)

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -325,7 +325,7 @@ class EverestStorage:
             "perturbed_variables": "perturbed_control_value",
             "perturbed_objectives": "perturbed_objective_value",
             "perturbed_constraints": "perturbed_constraint_value",
-            "evaluation_ids": "simulation_id",
+            "evaluation_info.sim_ids": "simulation_id",
         }
         return df.rename({k: v for k, v in renames.items() if k in df.columns})
 
@@ -338,7 +338,6 @@ class EverestStorage:
             # -1 is used as a value in simulator cache.
             # thus we need signed, otherwise we could do unsigned
             "simulation_id": pl.Int32,
-            "perturbed_evaluation_ids": pl.Int32,
             "objective_name": pl.String,
             "control_name": pl.String,
             "constraint_name": pl.String,
@@ -496,7 +495,7 @@ class EverestStorage:
         realization_objectives = self._ropt_to_df(
             results,
             "evaluations",
-            values=["objectives", "evaluation_ids"],
+            values=["objectives", "evaluation_info.sim_ids"],
             select=["batch_id", "realization", "objective"],
         )
 
@@ -504,7 +503,7 @@ class EverestStorage:
             realization_constraints = self._ropt_to_df(
                 results,
                 "evaluations",
-                values=["constraints", "evaluation_ids"],
+                values=["constraints", "evaluation_info.sim_ids"],
                 select=["batch_id", "realization", "nonlinear_constraint"],
             )
 
@@ -539,7 +538,7 @@ class EverestStorage:
         realization_controls = self._ropt_to_df(
             results,
             "evaluations",
-            values=["variables", "evaluation_ids"],
+            values=["variables", "evaluation_info.sim_ids"],
             select=["batch_id", "variable", "realization"],
         )
 
@@ -585,7 +584,7 @@ class EverestStorage:
                     "variables",
                     "perturbed_variables",
                     "perturbed_objectives",
-                    "perturbed_evaluation_ids",
+                    "evaluation_info.sim_ids",
                 ]
                 + (["perturbed_constraints"] if have_perturbed_constraints else [])
             ),
@@ -668,7 +667,7 @@ class EverestStorage:
             perturbation_constraints = None
 
         perturbation_objectives = perturbation_objectives.drop(
-            "perturbed_evaluation_ids", "control_value"
+            "simulation_id", "control_value"
         )
 
         perturbation_objectives = perturbation_objectives.pivot(

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -176,7 +176,10 @@ def _parse_optimization(
     has_output_constraints: bool,
     ropt_config: dict[str, Any],
 ) -> None:
-    ropt_config["optimizer"] = {}
+    ropt_config["optimizer"] = {
+        "stdout": "optimizer.stdout",
+        "stderr": "optimizer.stderr",
+    }
     if not ever_opt:
         return
 

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
@@ -68,10 +68,12 @@
               0.25
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -6.1875
@@ -99,9 +101,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -125,6 +124,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -171,26 +192,6 @@
               [
                 0.246149
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -348,9 +349,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -429,10 +427,12 @@
               0.259045
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -5.88373
@@ -460,9 +460,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -486,6 +483,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -532,26 +551,6 @@
               [
                 0.258075
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -709,9 +708,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -790,10 +786,12 @@
               0.318636
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -5.70666
@@ -821,9 +819,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -847,6 +842,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -893,26 +910,6 @@
               [
                 0.319148
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -1070,9 +1067,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1151,10 +1145,12 @@
               0.241178
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -5.43767
@@ -1182,9 +1178,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1208,6 +1201,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -1254,26 +1269,6 @@
               [
                 0.244028
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -1431,9 +1426,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1512,10 +1504,12 @@
               0.150915
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -4.9807
@@ -1543,9 +1537,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1569,6 +1560,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -1615,26 +1628,6 @@
               [
                 0.156554
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -1792,9 +1785,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1873,10 +1863,12 @@
               0.114527
             ]
           ],
-          "evaluation_ids": [
-            0,
-            1
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0,
+              1
+            ]
+          },
           "objectives": [
             [
               -4.88825
@@ -1904,9 +1896,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -1930,6 +1919,28 @@
           "point.x.2"
         ],
         "evaluations": {
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            ]
+          },
           "perturbed_constraints": [
             [
               [
@@ -1976,26 +1987,6 @@
               [
                 0.119971
               ]
-            ]
-          ],
-          "perturbed_evaluation_ids": [
-            [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
-            [
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15
             ]
           ],
           "perturbed_objectives": [
@@ -2152,9 +2143,6 @@
         "metadata": {},
         "objective_names": [
           "distance"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
@@ -49,9 +49,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.48
@@ -73,9 +75,6 @@
         "metadata": {},
         "objective_names": [
           "distance"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,
@@ -99,16 +98,18 @@
           "point.z"
         ],
         "evaluations": {
-          "perturbed_constraints": null,
-          "perturbed_evaluation_ids": [
-            [
-              1,
-              2,
-              3,
-              4,
-              5
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                1,
+                2,
+                3,
+                4,
+                5
+              ]
             ]
-          ],
+          },
+          "perturbed_constraints": null,
           "perturbed_objectives": [
             [
               [
@@ -182,9 +183,6 @@
         "objective_names": [
           "distance"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -243,9 +241,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.480218
@@ -267,9 +267,6 @@
         "metadata": {},
         "objective_names": [
           "distance"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,
@@ -329,9 +326,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.0
@@ -353,9 +352,6 @@
         "metadata": {},
         "objective_names": [
           "distance"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,
@@ -391,16 +387,18 @@
           "point.z"
         ],
         "evaluations": {
-          "perturbed_constraints": null,
-          "perturbed_evaluation_ids": [
-            [
-              0,
-              1,
-              2,
-              3,
-              4
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                0,
+                1,
+                2,
+                3,
+                4
+              ]
             ]
-          ],
+          },
+          "perturbed_constraints": null,
           "perturbed_objectives": [
             [
               [
@@ -473,9 +471,6 @@
         "metadata": {},
         "objective_names": [
           "distance"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
@@ -49,9 +49,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.75,
@@ -77,9 +79,6 @@
           "distance_p",
           "distance_q"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -102,16 +101,18 @@
           "point.z"
         ],
         "evaluations": {
-          "perturbed_constraints": null,
-          "perturbed_evaluation_ids": [
-            [
-              1,
-              2,
-              3,
-              4,
-              5
+          "evaluation_info": {
+            "sim_ids": [
+              [
+                1,
+                2,
+                3,
+                4,
+                5
+              ]
             ]
-          ],
+          },
+          "perturbed_constraints": null,
           "perturbed_objectives": [
             [
               [
@@ -196,9 +197,6 @@
           "distance_p",
           "distance_q"
         ],
-        "plan_id": [
-          0
-        ],
         "realizations": {
           "constraint_weights": null,
           "failed_realizations": [
@@ -257,9 +255,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.765646,
@@ -284,9 +284,6 @@
         "objective_names": [
           "distance_p",
           "distance_q"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,
@@ -346,9 +343,11 @@
         ],
         "evaluations": {
           "constraints": null,
-          "evaluation_ids": [
-            0
-          ],
+          "evaluation_info": {
+            "sim_ids": [
+              0
+            ]
+          },
           "objectives": [
             [
               -0.507785,
@@ -373,9 +372,6 @@
         "objective_names": [
           "distance_p",
           "distance_q"
-        ],
-        "plan_id": [
-          0
         ],
         "realizations": {
           "constraint_weights": null,

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -72,6 +72,8 @@
     "parallel": true,
     "speculative": true,
     "split_evaluations": false,
+    "stderr": "optimizer.stderr",
+    "stdout": "optimizer.stdout",
     "tolerance": 0.005
   },
   "realization_filters": [],

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -49,6 +49,8 @@
     "parallel": true,
     "speculative": false,
     "split_evaluations": false,
+    "stderr": "optimizer.stderr",
+    "stdout": "optimizer.stdout",
     "tolerance": 0.001
   },
   "realization_filters": [],

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -51,6 +51,8 @@
     "parallel": true,
     "speculative": false,
     "split_evaluations": false,
+    "stderr": "optimizer.stderr",
+    "stdout": "optimizer.stdout",
     "tolerance": 0.005
   },
   "realization_filters": [],

--- a/uv.lock
+++ b/uv.lock
@@ -841,8 +841,8 @@ requires-dist = [
     { name = "resdata", marker = "extra == 'everest'" },
     { name = "resfo" },
     { name = "resfo", marker = "extra == 'dev'" },
-    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.16,<0.17" },
-    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.16,<0.17" },
+    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.17,<0.18" },
+    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.17,<0.18" },
     { name = "ruamel-yaml", marker = "extra == 'everest'" },
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1,<1.15" },
@@ -3216,16 +3216,16 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.16.2"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/59/f5e109afd70cae278b7acb83789919d7d8592f29717d49c5e7d4537c7d61/ropt-0.16.2.tar.gz", hash = "sha256:6ba2299a1888c1b20c236a09c80bec0f8df06546c3d9bbc86206e9809be0705a", size = 121483 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ae/bf53b24301e6aca81fc0c5302ba4172bad11344e0145ce1af949d6b6e43d/ropt-0.17.0.tar.gz", hash = "sha256:b52139119158ea519db3b17f0db35cfb2d3edf491064bc9d9fe898c018416d03", size = 120203 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/ab/b267dd8394b3325afd4aafc715934d19f570d63491ae4e576347a544bb4c/ropt-0.16.2-py3-none-any.whl", hash = "sha256:8b71d08037b33a4581297738a6c6f51bcd4da30a69f425ba6ed7bea5488b289e", size = 127429 },
+    { url = "https://files.pythonhosted.org/packages/dd/00/d7396e9a34a48358ec5bc9747a37eb1d71fd320986ede8dd0a701deb7b9a/ropt-0.17.0-py3-none-any.whl", hash = "sha256:b5d04c77e139d0101c85ecb8b3c68d08ca53801c24e6526cbc4fa91d11cdc3e4", size = 125186 },
 ]
 
 [package.optional-dependencies]
@@ -3235,15 +3235,15 @@ pandas = [
 
 [[package]]
 name = "ropt-dakota"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/19/2e53dda227e1a4877b200b768bcc473488ad59692e8dc0fe4d4dc37ff62f/ropt_dakota-0.16.0.tar.gz", hash = "sha256:c93a1fc5b23299f62463777ba2e5861258d30d56371345b0c8893e7104666261", size = 23922 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/4b/ebf6efb1f67bed1b3b4d13e1728a79c3bb1c501f9702a83ffc81b38115c6/ropt_dakota-0.17.0.tar.gz", hash = "sha256:5497cefbae1dcb19bd2f12b2f768f030f73372dced130e726a591b0b9dd1abbc", size = 23892 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/93/e487daa2b0c01b17e583c937543922a5aa6074319235627ed95c79f610b7/ropt_dakota-0.16.0-py3-none-any.whl", hash = "sha256:ebf4e0aabe3fd1c1a250c3405da773090dae5bab3eea4f87cb508de7b31054d8", size = 19623 },
+    { url = "https://files.pythonhosted.org/packages/88/10/6ccd25b822b11a2d30fbfc48f9d09187f8aebba91bb344ce2a2b6bb1879d/ropt_dakota-0.17.0-py3-none-any.whl", hash = "sha256:8ab465087b71ee08ef0db503353995ce35cbe1814b2e6617aa63f1daf2d18935", size = 19622 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue**
This PR updates `ropt` to version `0.17.0`. This provides the following improvements to Everest:
1. The code that redirects optimizer output is removed. That is now done at a lower level in `ropt` in a less broad manner. Everest should not have to deal with the shortcomings in the optimizers that this code was fixing.
2. Instead of `evaluations_ids` the evaluation results now may return a dictionary with additional info on each evaluation. That is now used to reproduce the current behavior with `evaluation_ids`, but is intended to allow passing more information in the future, for instance to indicate which bath cached results originate from.

The `ropt` packages in bleeding will need to bumped after merging this.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
