### PR TITLE
Mark batch_objective_gradient as optional for GradientBatchStorageData

### DIFF
--- a/src/everest/api/everest_data_api.py
+++ b/src/everest/api/everest_data_api.py
@@ -174,7 +174,8 @@ class EverestDataAPI:
         all_batch_data = [
             b.batch_objective_gradient
             for b in self._ever_storage.data.batches_with_gradient_results
-            if b.is_improvement  # Note: This part might not be sensible
+            if b.batch_objective_gradient is not None
+            and b.is_improvement  # Note: This part might not be sensible
         ]
         if not all_batch_data:
             return []

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -187,12 +187,6 @@ class FunctionBatchStorageData(BatchStorageData):
 
 class GradientBatchStorageData(BatchStorageData):
     @property
-    def batch_objective_gradient(self) -> pl.DataFrame:
-        df = super().batch_objective_gradient
-        assert df is not None
-        return df
-
-    @property
     def perturbation_objectives(self) -> pl.DataFrame:
         df = super().perturbation_objectives
         assert df is not None


### PR DESCRIPTION
Fixes wrong assumption made in https://github.com/equinor/ert/commit/cd3c9bf99723445172ca619d4520cac6267b3ab4
A batch may compute all the perturbations, but fail to compute the gradient, so it may be None
