### PR TITLE
Fix flaky run dialog test

### DIFF
--- a/src/ert/config/forward_model_step.py
+++ b/src/ert/config/forward_model_step.py
@@ -185,7 +185,6 @@ class ForwardModelStep:
         Raises ConfigValidationError if not all required keywords are in
         private_args
         """
-        print(self.required_keywords)
         missing_keywords = set(self.required_keywords).difference(self.private_args)
         if missing_keywords:
             plural = "s" if len(missing_keywords) > 1 else ""

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -564,12 +564,10 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
     args_mock.config = config_file
 
     ert_config = ErtConfig.from_file(config_file)
-    with (
-        patch.object(
-            ert.run_models.SingleTestRun,
-            "run_experiment",
-            MagicMock(side_effect=ValueError("I failed :(")),
-        ),
+    with patch.object(
+        ert.run_models.SingleTestRun,
+        "run_experiment",
+        MagicMock(side_effect=ValueError("I failed :(")),
     ):
         gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
         qtbot.addWidget(gui)

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -575,7 +575,10 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
         qtbot.addWidget(gui)
         run_experiment = gui.findChild(QToolButton, name="run_experiment")
 
+        handler_done = False
+
         def handle_error_dialog(run_dialog):
+            nonlocal handler_done
             qtbot.waitUntil(
                 lambda: run_dialog.fail_msg_box is not None,
                 timeout=20000,
@@ -585,6 +588,7 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
             text = error_dialog.details_text.toPlainText()
             assert "I failed :(" in text
             qtbot.mouseClick(error_dialog.box.buttons()[0], Qt.MouseButton.LeftButton)
+            handler_done = True
 
         simulation_mode_combo = gui.findChild(QComboBox)
         simulation_mode_combo.setCurrentText("Single realization test-run")
@@ -593,6 +597,7 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, storage):
 
         QTimer.singleShot(100, lambda: handle_error_dialog(run_dialog))
         qtbot.waitUntil(lambda: run_dialog.is_simulation_done() == True, timeout=100000)
+        qtbot.waitUntil(lambda: handler_done, timeout=100000)
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
**Issue**
Resolves #10182


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release