### PR TITLE
Silence sortedness warning for join_asof in everest_run_model.py

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -551,6 +551,7 @@ class EverestRunModel(BaseRunModel):
                         on=control_name,
                         by="model_realization",  # pre-join by model realization
                         tolerance=EPS,  # Same as np.allclose with atol=EPS
+                        check_sortedness=False,  # Ref: https://github.com/pola-rs/polars/issues/21693
                     )
                     .filter(pl.col("realization_right").is_not_null())
                 )


### PR DESCRIPTION
**Issue**
Resolves #10189

See https://github.com/pola-rs/polars/issues/21693

> If by is provided and check_sortedness is True, then we should provide a warning that sortedness cannot (currently) be checked.

