### PR TITLE
Add some logging for the queues

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -44,12 +44,17 @@ def everest_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
 
-    if options.debug:
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(DEFAULT_LOGGING_FORMAT)
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(DEFAULT_LOGGING_FORMAT)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.root
+    root_logger.addHandler(handler)
+    root_logger.setLevel(
+        logging.DEBUG if options.debug else options.config.logging_level
+    )
+
+    logger.setLevel(logging.DEBUG if options.debug else options.config.logging_level)
 
     logger.debug(version_info())
 


### PR DESCRIPTION
**Issue**
Resolves #9618

When running everest with the --debug flag we now provide logs from websockets with sizes of the events: 

```

2025-03-20 08:37:53,241 websockets.client DEBUG: < TEXT '{"batch":4,"event_type":"EverestBatchResultEven...e_names":["distance"]}}' [2342 bytes]
2025-03-20 08:37:53,342 websockets.client DEBUG: < TEXT '{"batch":5,"event_type":"EverestStatusEvent","e..._OPTIMIZER_EVALUATION"}' [90 bytes]

```
Also added a test for logging from plugins


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
