### PR TITLE
Remove mention of IES in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@
 ert - Ensemble based Reservoir Tool - is designed for running
 ensembles of dynamical models such as reservoir models,
 in order to do sensitivity analysis and data assimilation.
-ert supports data assimilation using the Ensemble Smoother (ES),
-Ensemble Smoother with Multiple Data Assimilation (ES-MDA) and
-Iterative Ensemble Smoother (IES).
+ert supports data assimilation using the Ensemble Smoother (ES) and
+Ensemble Smoother with Multiple Data Assimilation (ES-MDA).
 
 ## Installation
 


### PR DESCRIPTION
IES was removed in commit b6285853e4050fb63f86f84d9a7206af0a0ac482

**Issue**
Resolves erroneous README

**Approach**
✂️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
