### PR TITLE
Add inline directive to config validation schema

### DIFF
--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -18,7 +18,6 @@ from .parsing import (
     ConfigValidationError,
     ConfigWarning,
     HistorySource,
-    read_file,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,15 +124,12 @@ class ModelConfig:
     @no_type_check
     @classmethod
     def from_dict(cls, config_dict: ConfigDict) -> ModelConfig:
-        time_map_file = config_dict.get(ConfigKeys.TIME_MAP)
-        time_map_file = (
-            os.path.abspath(time_map_file) if time_map_file is not None else None
-        )
+        time_map_args = config_dict.get(ConfigKeys.TIME_MAP)
         time_map = None
-        if time_map_file is not None:
-            file_contents = read_file(time_map_file)
+        if time_map_args is not None:
+            time_map_file, time_map_contents = time_map_args
             try:
-                time_map = _read_time_map(file_contents)
+                time_map = _read_time_map(time_map_contents)
             except ValueError as err:
                 raise ConfigValidationError.with_context(
                     f"Could not read timemap file {time_map_file}: {err}", time_map_file

--- a/src/ert/config/parsing/_option_dict.py
+++ b/src/ert/config/parsing/_option_dict.py
@@ -15,7 +15,12 @@ def parse_variable_options(
     of positional arguments vary.
     """
     offset = next(
-        (i for i, val in enumerate(line) if len(val.split(":")) == 2), max_positionals
+        (
+            i
+            for i, val in enumerate(line)
+            if isinstance(val, str) and len(val.split(":")) == 2
+        ),
+        max_positionals,
     )
     kwargs = option_dict(line, offset)
     args = line[:offset]

--- a/src/ert/config/parsing/_read_file.py
+++ b/src/ert/config/parsing/_read_file.py
@@ -1,0 +1,54 @@
+import os
+
+from .config_errors import ConfigValidationError, ErrorInfo
+
+
+def read_file(file: str) -> str:
+    file = os.path.normpath(os.path.abspath(file))
+    try:
+        with open(file, encoding="utf-8") as f:
+            return f.read()
+    except OSError as err:
+        raise ConfigValidationError.with_context(str(err), file) from err
+    except UnicodeDecodeError as e:
+        error_words = str(e).split(" ")
+        hex_str = error_words[error_words.index("byte") + 1]
+        try:
+            unknown_char = chr(int(hex_str, 16))
+        except ValueError:
+            unknown_char = f"hex:{hex_str}"
+
+        # Find the first line in the file with decode error
+        bad_byte_lines: list[int] = []
+        with open(file, "rb") as f:
+            all_lines = []
+            for line in f:
+                all_lines.append(line)
+
+        for i, line in enumerate(all_lines):
+            try:
+                line.decode("utf-8")
+            except UnicodeDecodeError:
+                # The error occurs on this line, so make this entire line red
+                # (Figuring column if it is not 0 is tricky and prob not necessary)
+                # Use 1-indexed lines like lark and for errors in ert
+                bad_byte_lines.append(i + 1)
+
+        assert len(bad_byte_lines) != -1
+
+        raise ConfigValidationError(
+            [
+                ErrorInfo(
+                    message=(
+                        f"Unsupported non UTF-8 character {unknown_char!r} "
+                        f"found in file: {file!r}"
+                    ),
+                    filename=str(file),
+                    column=0,
+                    line=bad_line,
+                    end_column=-1,
+                    end_line=bad_line,
+                )
+                for bad_line in bad_byte_lines
+            ]
+        ) from e

--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -4,6 +4,7 @@ from .config_schema_deprecations import deprecated_keywords_list
 from .config_schema_item import (
     SchemaItem,
     Varies,
+    existing_path_inline_keyword,
     existing_path_keyword,
     float_keyword,
     int_keyword,
@@ -349,7 +350,7 @@ def init_user_config_schema() -> ConfigSchemaDict:
         data_kw_keyword(),
         define_keyword(),
         existing_path_keyword(ConfigKeys.OBS_CONFIG),
-        existing_path_keyword(ConfigKeys.TIME_MAP),
+        existing_path_inline_keyword(ConfigKeys.TIME_MAP),
         single_arg_keyword(ConfigKeys.GEN_KW_EXPORT_NAME),
         history_source_keyword(),
         path_keyword(ConfigKeys.RUNPATH_FILE),

--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -188,9 +188,9 @@ def gen_kw_keyword() -> SchemaItem:
         options_after=Varies(4),
         type_map=[
             None,
-            SchemaItemType.EXISTING_PATH,
+            SchemaItemType.EXISTING_PATH_INLINE,
             SchemaItemType.STRING,
-            SchemaItemType.EXISTING_PATH,
+            SchemaItemType.EXISTING_PATH_INLINE,
         ],
         multi_occurrence=True,
     )

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -331,5 +331,9 @@ def existing_path_keyword(keyword: str) -> SchemaItem:
     return SchemaItem(kw=keyword, type_map=[SchemaItemType.EXISTING_PATH])
 
 
+def existing_path_inline_keyword(keyword: str) -> SchemaItem:
+    return SchemaItem(kw=keyword, type_map=[SchemaItemType.EXISTING_PATH_INLINE])
+
+
 def single_arg_keyword(keyword: str) -> SchemaItem:
     return SchemaItem(kw=keyword, argc_max=1, argc_min=1)

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from lark import Discard, Lark, Token, Transformer, Tree, UnexpectedToken
 
+from ._read_file import read_file
 from .config_dict import ConfigDict
 from .config_errors import ConfigValidationError, ConfigWarning
 from .config_schema import SchemaItem, define_keyword
@@ -432,57 +433,6 @@ def _parse_contents(content: str, file: str) -> Tree[Instruction]:
                 end_column=e.column + 1,
                 filename=file,
             )
-        ) from e
-
-
-def read_file(file: str) -> str:
-    file = os.path.normpath(os.path.abspath(file))
-    try:
-        with open(file, encoding="utf-8") as f:
-            return f.read()
-    except OSError as err:
-        raise ConfigValidationError.with_context(str(err), file) from err
-    except UnicodeDecodeError as e:
-        error_words = str(e).split(" ")
-        hex_str = error_words[error_words.index("byte") + 1]
-        try:
-            unknown_char = chr(int(hex_str, 16))
-        except ValueError:
-            unknown_char = f"hex:{hex_str}"
-
-        # Find the first line in the file with decode error
-        bad_byte_lines: list[int] = []
-        with open(file, "rb") as f:
-            all_lines = []
-            for line in f:
-                all_lines.append(line)
-
-        for i, line in enumerate(all_lines):
-            try:
-                line.decode("utf-8")
-            except UnicodeDecodeError:
-                # The error occurs on this line, so make this entire line red
-                # (Figuring column if it is not 0 is tricky and prob not necessary)
-                # Use 1-indexed lines like lark and for errors in ert
-                bad_byte_lines.append(i + 1)
-
-        assert len(bad_byte_lines) != -1
-
-        raise ConfigValidationError(
-            [
-                ErrorInfo(
-                    message=(
-                        f"Unsupported non UTF-8 character {unknown_char!r} "
-                        f"found in file: {file!r}"
-                    ),
-                    filename=str(file),
-                    column=0,
-                    line=bad_line,
-                    end_column=-1,
-                    end_line=bad_line,
-                )
-                for bad_line in bad_byte_lines
-            ]
         ) from e
 
 

--- a/src/ert/config/parsing/schema_item_type.py
+++ b/src/ert/config/parsing/schema_item_type.py
@@ -9,6 +9,10 @@ class SchemaItemType(StrEnum):
     POSITIVE_FLOAT = "POSITIVE_FLOAT"
     PATH = "PATH"
     EXISTING_PATH = "EXISTING_PATH"
+    # EXISTING_PATH_INLINE is a directive to the
+    # schema validation to inline the contents of
+    # the file.
+    EXISTING_PATH_INLINE = "EXISTING_PATH_INLINE"
     BOOL = "BOOL"
     CONFIG = "CONFIG"
     BYTESIZE = "BYTESIZE"

--- a/tests/ert/unit_tests/config/test_ensemble_config.py
+++ b/tests/ert/unit_tests/config/test_ensemble_config.py
@@ -113,7 +113,6 @@ def test_that_files_for_refcase_exists(existing_suffix, expected_suffix):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ensemble_config_duplicate_node_names():
     duplicate_name = "Test_name"
-    Path("MULTFLT.TXT").write_text("a UNIFORM 0 1", encoding="utf-8")
     Path("FAULT_TEMPLATE").write_text("", encoding="utf-8")
     config_dict = {
         ConfigKeys.GEN_DATA: [
@@ -129,9 +128,9 @@ def test_ensemble_config_duplicate_node_names():
         ConfigKeys.GEN_KW: [
             [
                 duplicate_name,
-                "FAULT_TEMPLATE",
+                ("FAULT_TEMPLATE", ""),
                 "MULTFLT.INC",
-                "MULTFLT.TXT",
+                ("MULTFLT.TXT", "a UNIFORM 0 1"),
                 {"FORWARD_INIT": "FALSE"},
             ]
         ],
@@ -169,23 +168,21 @@ def test_that_empty_grid_file_raises(tmpdir):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_logging_of_duplicate_gen_kw_parameter_names(caplog):
-    Path("MULTFLT1.TXT").write_text("a UNIFORM 0 1\nc UNIFORM 2 5", encoding="utf-8")
-    Path("MULTFLT2.TXT").write_text("a UNIFORM 0 1\nc UNIFORM 4 7", encoding="utf-8")
     Path("FAULT_TEMPLATE").write_text("", encoding="utf-8")
     config_dict = {
         ConfigKeys.GEN_KW: [
             [
                 "test_group1",
-                "FAULT_TEMPLATE",
+                ("FAULT_TEMPLATE", ""),
                 "MULTFLT.INC",
-                "MULTFLT1.TXT",
+                ("MULTFLT1.TXT", "a UNIFORM 0 1\nc UNIFORM 2 5"),
                 {"FORWARD_INIT": "FALSE"},
             ],
             [
                 "test_group2",
-                "FAULT_TEMPLATE",
+                ("FAULT_TEMPLATE", ""),
                 "MULTFLT.INC",
-                "MULTFLT2.TXT",
+                ("MULTFLT2.TXT", "a UNIFORM 0 1\nc UNIFORM 4 7"),
                 {"FORWARD_INIT": "FALSE"},
             ],
         ],

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -6,7 +6,7 @@ import xtgeo
 
 from ert.config import ConfigValidationError, ConfigWarning, Field
 from ert.config.field import TRANSFORM_FUNCTIONS
-from ert.config.parsing import init_user_config_schema, parse
+from ert.config.parsing import init_user_config_schema, parse_contents
 from ert.enkf_main import sample_prior
 from ert.field_utils import Shape, read_field
 
@@ -71,17 +71,17 @@ def egrid_file(tmp_path, grid_shape):
 
 
 @pytest.fixture
-def parse_field_line(tmp_path, grid_shape, egrid_file):
-    config_file = tmp_path / "test.ert"
-
+def parse_field_line(grid_shape, egrid_file):
     def make_field(field_line):
-        config_file.write_text(
-            "NUM_REALIZATIONS 1\nGRID " + egrid_file + "\n" + field_line + "\n",
-            encoding="utf-8",
+        return Field.from_config_list(
+            egrid_file,
+            grid_shape,
+            parse_contents(
+                f"NUM_REALIZATIONS 1\nGRID {egrid_file}\n" + field_line,
+                init_user_config_schema(),
+                "test.ert",
+            )["FIELD"][0],
         )
-        parsed = parse(str(config_file), init_user_config_schema(), None)
-
-        return Field.from_config_list(parsed["GRID"], grid_shape, parsed["FIELD"][0])
 
     return make_field
 

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -9,12 +9,11 @@ from lark import Token
 from ert.config import (
     ConfigValidationError,
     ConfigWarning,
-    EnsembleConfig,
     ErtConfig,
     GenKwConfig,
 )
 from ert.config.gen_kw_config import TransformFunctionDefinition
-from ert.config.parsing import ConfigKeys, ContextString
+from ert.config.parsing import ContextString
 from ert.config.parsing.file_context_token import FileContextToken
 from ert.enkf_main import create_run_path, sample_prior
 
@@ -263,22 +262,21 @@ def test_gen_kw_is_log_or_not(
 )
 def test_gen_kw_distribution_errors(tmpdir, distribution, mean, std, error):
     with tmpdir.as_cwd():
-        config = dedent(
-            """
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 1
-        GEN_KW KW_NAME template.txt kw.txt prior.txt
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
         with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w", encoding="utf-8") as fh:
-            if distribution == "TRUNCATED_NORMAL":
-                fh.writelines(f"MY_KEYWORD {distribution} {mean} {std} -1 1")
-            else:
-                fh.writelines(f"MY_KEYWORD {distribution} {mean} {std}")
+
+        if distribution == "TRUNCATED_NORMAL":
+            distribution_line = f"MY_KEYWORD {distribution} {mean} {std} -1 1"
+        else:
+            distribution_line = f"MY_KEYWORD {distribution} {mean} {std}"
+
+        config_list = [
+            "KW_NAME",
+            ("template.txt", "MY_KEYWORD <MY_KEYWORD>"),
+            "kw.txt",
+            ("prior.txt", distribution_line),
+            {},
+        ]
 
         if error:
             for e in error:
@@ -286,9 +284,9 @@ def test_gen_kw_distribution_errors(tmpdir, distribution, mean, std, error):
                     ConfigValidationError,
                     match=f"Negative {e} {mean if e == 'MEAN' else std}",
                 ):
-                    ErtConfig.from_file("config.ert")
+                    GenKwConfig.from_config_list(config_list)
         else:
-            ErtConfig.from_file("config.ert")
+            GenKwConfig.from_config_list(config_list)
 
 
 @pytest.mark.parametrize(
@@ -443,25 +441,18 @@ def test_gen_kw_trans_func(tmpdir, params, xinput, expected):
 
 def test_gen_kw_objects_equal(tmpdir):
     with tmpdir.as_cwd():
-        config = dedent(
-            """
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 1
-        GEN_KW KW_NAME template.txt kw.txt prior.txt
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
         with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w", encoding="utf-8") as fh:
-            fh.writelines("MY_KEYWORD UNIFORM 1 2")
-        with open("empty.txt", "w", encoding="utf-8") as fh:
-            fh.writelines("")
 
-        ert_config = ErtConfig.from_file("config.ert")
-
-        g1 = ert_config.ensemble_config["KW_NAME"]
+        g1 = GenKwConfig.from_config_list(
+            [
+                "KW_NAME",
+                ("template.txt", "MY_KEYWORD <MY_KEYWORD>"),
+                "kw.txt",
+                ("prior.txt", "MY_KEYWORD UNIFORM 1 2"),
+                {},
+            ]
+        )
         assert g1.transform_functions[0].name == "MY_KEYWORD"
 
         tfd = TransformFunctionDefinition(
@@ -549,31 +540,25 @@ def test_gen_kw_config_validation():
     with open("template.txt", "w", encoding="utf-8") as f:
         f.write("Hello")
 
-    EnsembleConfig.from_dict(
-        config_dict={
-            ConfigKeys.GEN_KW: [
-                [
-                    "KEY",
-                    ("template.txt", "Hello"),
-                    "nothing_here.txt",
-                    ("parameters.txt", "KEY  UNIFORM 0 1 \n"),
-                    {},
-                ]
-            ],
-        }
+    GenKwConfig.from_config_list(
+        [
+            "KEY",
+            ("template.txt", "Hello"),
+            "nothing_here.txt",
+            ("parameters.txt", "KEY  UNIFORM 0 1 \n"),
+            {},
+        ]
     )
 
-    EnsembleConfig.from_dict(
-        config_dict={
-            ConfigKeys.GEN_KW: [
-                [
-                    "KEY",
-                    ("template.txt", "hello.txt"),
-                    "nothing_here.txt",
-                    (
-                        "parameters_with_comments.txt",
-                        dedent(
-                            """\
+    GenKwConfig.from_config_list(
+        [
+            "KEY",
+            ("template.txt", "hello.txt"),
+            "nothing_here.txt",
+            (
+                "parameters_with_comments.txt",
+                dedent(
+                    """\
                             KEY1  UNIFORM 0 1 -- COMMENT
 
 
@@ -583,29 +568,23 @@ def test_gen_kw_config_validation():
                             ------------
                             KEY3  UNIFORM 0 1
                             """
-                        ),
-                    ),
-                    {},
-                ],
-            ]
-        }
+                ),
+            ),
+            {},
+        ],
     )
 
     with pytest.raises(
         ConfigValidationError, match=r"config.ert.* No such template file"
     ):
-        EnsembleConfig.from_dict(
-            config_dict={
-                ConfigKeys.GEN_KW: [
-                    [
-                        "KEY",
-                        make_context_string("no_template_here.txt", "config.ert"),
-                        "nothing_here.txt",
-                        "parameters.txt",
-                        {},
-                    ]
-                ],
-            }
+        GenKwConfig.from_config_list(
+            [
+                "KEY",
+                make_context_string("no_template_here.txt", "config.ert"),
+                "nothing_here.txt",
+                "parameters.txt",
+                {},
+            ]
         )
 
 
@@ -627,24 +606,20 @@ def test_incorrect_values_in_forward_init_file_fails(tmp_path):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_suggestion_on_empty_parameter_file(tmp_path):
+def test_suggestion_on_empty_parameter_file():
     Path("empty_template.txt").write_text("", encoding="utf-8")
     with pytest.warns(UserWarning, match="GEN_KW KEY coeffs.txt"):
-        EnsembleConfig.from_dict(
-            config_dict={
-                ConfigKeys.GEN_KW: [
-                    [
-                        "KEY",
-                        ("empty_template.txt", ""),
-                        "output.txt",
-                        (
-                            make_context_string("coeffs.txt", "config.ert"),
-                            "a UNIFORM 0 1",
-                        ),
-                        {},
-                    ]
-                ],
-            }
+        GenKwConfig.from_config_list(
+            [
+                "KEY",
+                ("empty_template.txt", ""),
+                "output.txt",
+                (
+                    make_context_string("coeffs.txt", "config.ert"),
+                    "a UNIFORM 0 1",
+                ),
+                {},
+            ]
         )
 
 
@@ -680,28 +655,24 @@ def test_validation_triangular_distribution(
     tmpdir, distribution, min, mode, max, error
 ):
     with tmpdir.as_cwd():
-        config = dedent(
-            """
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 1
-        GEN_KW KW_NAME template.txt kw.txt prior.txt
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
         with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w", encoding="utf-8") as fh:
-            fh.writelines(f"MY_KEYWORD {distribution} {min} {mode} {max}")
+        config_list = [
+            "KW_NAME",
+            ("template.txt", "MY_KEYWORD <MY_KEYWORD>"),
+            "kw.txt",
+            ("prior.txt", f"MY_KEYWORD {distribution} {min} {mode} {max}"),
+            {},
+        ]
 
         if error:
             with pytest.raises(
                 ConfigValidationError,
                 match=error,
             ):
-                ErtConfig.from_file("config.ert")
+                GenKwConfig.from_config_list(config_list)
         else:
-            ErtConfig.from_file("config.ert")
+            GenKwConfig.from_config_list(config_list)
 
 
 @pytest.mark.parametrize(
@@ -797,27 +768,24 @@ def test_validation_derrf_distribution(
     tmpdir, distribution, nbins, min, max, skew, width, error
 ):
     with tmpdir.as_cwd():
-        config = dedent(
-            """
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 1
-        GEN_KW KW_NAME template.txt kw.txt prior.txt
-        """
-        )
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
         with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w", encoding="utf-8") as fh:
-            fh.writelines(
-                f"MY_KEYWORD {distribution} {nbins} {min} {max} {skew} {width}"
-            )
+        config_list = [
+            "KW_NAME",
+            ("template.txt", "MY_KEYWORD <MY_KEYWORD>"),
+            "kw.txt",
+            (
+                "prior.txt",
+                f"MY_KEYWORD {distribution} {nbins} {min} {max} {skew} {width}",
+            ),
+            {},
+        ]
 
         if error:
             with pytest.raises(
                 ConfigValidationError,
                 match=error,
             ):
-                ErtConfig.from_file("config.ert")
+                GenKwConfig.from_config_list(config_list)
         else:
-            ErtConfig.from_file("config.ert")
+            GenKwConfig.from_config_list(config_list)

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -411,10 +411,6 @@ def test_gen_kw_params_parsing(tmpdir, params, error):
     ],
 )
 def test_gen_kw_trans_func(tmpdir, params, xinput, expected):
-    """
-    This test data was generated using c++ transfer functions, and is used solely
-    to verify that implementation in python is equal to c++.
-    """
     args = params.split()[2:]
     float_args = []
     for a in args:

--- a/tests/ert/unit_tests/config/test_model_config.py
+++ b/tests/ert/unit_tests/config/test_model_config.py
@@ -57,13 +57,9 @@ def test_model_config_jobname_and_eclbase(extra_config, expected):
     assert ModelConfig.from_dict(config_dict).jobname_format_string == expected
 
 
-def test_that_invalid_time_map_file_raises_config_validation_error(tmpdir):
-    with tmpdir.as_cwd():
-        with open("time_map.txt", "w", encoding="utf-8") as fo:
-            fo.writelines("invalid")
-
-        with pytest.raises(ConfigValidationError, match="Could not read timemap file"):
-            _ = ModelConfig.from_dict({ConfigKeys.TIME_MAP: "time_map.txt"})
+def test_that_invalid_time_map_file_raises_config_validation_error():
+    with pytest.raises(ConfigValidationError, match="Could not read timemap file"):
+        _ = ModelConfig.from_dict({ConfigKeys.TIME_MAP: ("time_map.txt", "invalid")})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
By reading the files first, we avoid replicating logic for handling unicode and adding context in several places. 

This PR only add usage of EXISITING_FILE_INLINE to gen_kw and time_map, which shows how it can be used to 
avoid writing/reading of files in tests. 

The directive can also be used later to avoid the same IO in tests with observations and workflows.

Note: does not avoid writing gen_kw templates yet as that means migrating storage.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
