### PR TITLE
Set index to design matrix index in parameter viewer

### DIFF
--- a/src/ert/gui/simulation/_design_matrix_panel.py
+++ b/src/ert/gui/simulation/_design_matrix_panel.py
@@ -45,10 +45,7 @@ class DesignMatrixPanel(QDialog):
 
     @staticmethod
     def create_model(design_matrix_df: pd.DataFrame) -> QStandardItemModel:
-        if isinstance(design_matrix_df.columns, pd.MultiIndex):
-            header_labels = [str(col[-1]) for col in design_matrix_df.columns]
-        else:
-            header_labels = design_matrix_df.columns.astype(str).tolist()
+        header_labels = design_matrix_df.columns.astype(str).tolist()
 
         model = QStandardItemModel()
         model.setHorizontalHeaderLabels(header_labels)
@@ -58,6 +55,7 @@ class DesignMatrixPanel(QDialog):
                 for col in design_matrix_df.columns
             ]
             model.appendRow(items)
+        model.setVerticalHeaderLabels(design_matrix_df.index.astype(str).tolist())
         return model
 
     @staticmethod


### PR DESCRIPTION
Fixup so that the column index matches the actual REAL index from the design matrix


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
