### PR TITLE
Use pprint to log config dict in a readable manner

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1,8 +1,8 @@
 # mypy: ignore-errors
 import copy
-import json
 import logging
 import os
+import pprint
 import re
 from collections import defaultdict
 from collections.abc import Sequence
@@ -60,7 +60,6 @@ from .parsing import (
 from .parsing import (
     parse as parse_config,
 )
-from .parsing.context_values import ContextBoolEncoder
 from .parsing.observations_parser import (
     GenObsValues,
     HistoryValues,
@@ -955,9 +954,7 @@ class ErtConfig:
         # of MAX_MESSAGE_LENGTH_APP_INSIGHTS = 32768
         SAFE_MESSAGE_LENGTH_LIMIT = 26214  # <= MAX_MESSAGE_LENGTH_APP_INSIGHTS * 0.8
         try:
-            config_dict_content = json.dumps(
-                content_dict, indent=2, cls=ContextBoolEncoder
-            )
+            config_dict_content = pprint.pformat(content_dict)
         except Exception as err:
             config_dict_content = str(content_dict)
             logger.warning(

--- a/src/ert/config/parsing/config_keywords.py
+++ b/src/ert/config/parsing/config_keywords.py
@@ -56,3 +56,6 @@ class ConfigKeys(StrEnum):
     CONFIG_DIRECTORY = "CONFIG_DIRECTORY"
     SUBMIT_SLEEP = "SUBMIT_SLEEP"
     MAX_RUNNING = "MAX_RUNNING"
+
+    def __repr__(self) -> str:
+        return f"{self.value!r}"

--- a/src/ert/config/parsing/context_values.py
+++ b/src/ert/config/parsing/context_values.py
@@ -25,6 +25,11 @@ class ContextBool:
     def __eq__(self, other: object) -> bool:
         return bool(self) == bool(other)
 
+    def __repr__(self) -> str:
+        if bool(self.val):
+            return "True"
+        return "False"
+
     @no_type_check
     def __deepcopy__(self, memo):
         new_instance = ContextBool(bool(self), self.token, self.keyword_token)


### PR DESCRIPTION
**Issue**
Resolves #10293 


**Approach**
`pprint` plus some fixes for booleans and strenum.

How it was logged before this PR (see belof for after)
```
'{
  "DEFINE": [
    [
      "<CONFIG_PATH>",
      "/tmp/tmpu_wk7vxm"
    ],
    [
      "<CONFIG_FILE_BASE>",
      "site-config"
    ],
    [
      "<DATE>",
      "2025-03-20"
    ],
    [
      "<CWD>",
      "/tmp/tmpu_wk7vxm"
    ],
    [
      "<CONFIG_FILE>",
      "site-config"
    ],
    [
      "<CONFIG_PATH>",
      "/data/projects/ert/test-data/ert/poly_example"
    ],
    [
      "<CONFIG_FILE_BASE>",
      "poly"
    ],
    [
      "<DATE>",
      "2025-03-20"
    ],
    [
      "<CWD>",
      "/data/projects/ert/test-data/ert/poly_example"
    ],
    [
      "<CONFIG_FILE>",
      "poly.ert"
    ]
  ],
  "QUEUE_SYSTEM": "local",
  "QUEUE_OPTION": [
    [
      "lsf",
      "LSF_RESOURCE",
      "select[cs && x86_64Linux]"
    ],
    [
      "lsf",
      "LSF_QUEUE",
      "mr8"
    ],
    [
      "lsf",
      "MAX_RUNNING",
      "10000"
    ],
    [
      "lsf",
      "SUBMIT_SLEEP",
      "1"
    ],
    [
      "local",
      "MAX_RUNNING",
      "12"
    ],
    [
      "local",
      "MAX_RUNNING",
      "50"
    ]
  ],
  "STOP_LONG_RUNNING": true,
  "RUNPATH": "/data/projects/ert/test-data/ert/poly_example/poly_out/realization-<IENS>/iter-<ITER>",
  "OBS_CONFIG": "/data/projects/ert/test-data/ert/poly_example/observations",
  "REALIZATION_MEMORY": "50mb",
  "NUM_REALIZATIONS": 100,
  "MIN_REALIZATIONS": "1",
  "GEN_KW": [
    [
      "COEFFS",
      "/data/projects/ert/test-data/ert/poly_example/coeff_priors"
    ]
  ],
  "GEN_DATA": [
    [
      "POLY_RES",
      "RESULT_FILE:poly.out"
    ]
  ],
  "INSTALL_JOB": [
    [
      "STEA",
      "/data/venv/lib64/python3.12/site-packages/stea/fm_stea/STEA_CONFIG"
    ],
    [
      "CO2_CONTAINMENT",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_CONTAINMENT"
    ],
    [
      "CO2_MASS_MAP",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_MASS_MAP"
    ],
    [
      "CO2_PLUME_AREA",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_PLUME_AREA"
    ],
    [
      "CO2_PLUME_EXTENT",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_PLUME_EXTENT"
    ],
    [
      "GRID3D_AGGREGATE_MAP",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/GRID3D_AGGREGATE_MAP"
    ],
    [
      "GRID3D_MIGRATION_TIME",
      "/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/GRID3D_MIGRATION_TIME"
    ],
    [
      "poly_eval",
      "/data/projects/ert/test-data/ert/poly_example/POLY_EVAL"
    ]
  ],
  "FORWARD_MODEL": [
    [
      "poly_eval"
    ]
  ],
  "SETENV": [
    [
      "OMP_NUM_THREADS",
      "<NUM_CPU>"
    ],
    [
      "MKL_NUM_THREADS",
      "<NUM_CPU>"
    ],
    [
      "NUMEXPR_NUM_THREADS",
      "<NUM_CPU>"
    ]
  ],
  "MAX_SUBMIT": 1,
  "LOAD_WORKFLOW_JOB": [
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/CAREFUL_COPY_FILE"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/COPY_DIRECTORY"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/COPY_FILE"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/DELETE_DIRECTORY"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/DELETE_FILE"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/MAKE_DIRECTORY"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/MAKE_SYMLINK"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/MOVE_DIRECTORY"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/MOVE_FILE"
    ],
    [
      "/data/projects/ert/src/ert/resources/workflows/jobs/shell/SYMLINK"
    ]
  ],
  "ENSPATH": "/data/projects/ert/test-data/ert/poly_example/storage",
  "RUNPATH_FILE": "/data/projects/ert/test-data/ert/poly_example/.ert_runpath_list"
}
```

After this PR: (note the formatting of the boolean for STOP_LONG_RUNNING)
```
{'DEFINE': [['<CONFIG_PATH>', '/tmp/tmpu_wk7vxm'],
            ['<CONFIG_FILE_BASE>', 'site-config'],
            ['<DATE>', '2025-03-20'],
            ['<CWD>', '/tmp/tmpu_wk7vxm'],
            ['<CONFIG_FILE>', 'site-config'],
            ['<CONFIG_PATH>', '/data/projects/ert/test-data/ert/poly_example'],
            ['<CONFIG_FILE_BASE>', 'poly'],
            ['<DATE>', '2025-03-20'],
            ['<CWD>', '/data/projects/ert/test-data/ert/poly_example'],
            ['<CONFIG_FILE>', 'poly.ert']],
 'ENSPATH': '/data/projects/ert/test-data/ert/poly_example/storage',
 'FORWARD_MODEL': [['poly_eval']],
 'GEN_DATA': [['POLY_RES', 'RESULT_FILE:poly.out']],
 'GEN_KW': [['COEFFS',
             '/data/projects/ert/test-data/ert/poly_example/coeff_priors']],
 'INSTALL_JOB': [['STEA',
                  '/data/venv/lib64/python3.12/site-packages/stea/fm_stea/STEA_CONFIG'],
                 ['CO2_CONTAINMENT',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_CONTAINMENT'],
                 ['CO2_MASS_MAP',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_MASS_MAP'],
                 ['CO2_PLUME_AREA',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_PLUME_AREA'],
                 ['CO2_PLUME_EXTENT',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/CO2_PLUME_EXTENT'],
                 ['GRID3D_AGGREGATE_MAP',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/GRID3D_AGGREGATE_MAP'],
                 ['GRID3D_MIGRATION_TIME',
                  '/data/projects/ccs-scripts/src/ccs_scripts/config_jobs/GRID3D_MIGRATION_TIME'],
                 ['poly_eval',
                  '/data/projects/ert/test-data/ert/poly_example/POLY_EVAL']],
 'LOAD_WORKFLOW_JOB': [['/data/projects/ert/src/ert/resources/workflows/jobs/shell/CAREFUL_COPY_FILE'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/COPY_DIRECTORY'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/COPY_FILE'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/DELETE_DIRECTORY'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/DELETE_FILE'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/MAKE_DIRECTORY'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/MAKE_SYMLINK'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/MOVE_DIRECTORY'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/MOVE_FILE'],
                       ['/data/projects/ert/src/ert/resources/workflows/jobs/shell/SYMLINK']],
 'MAX_SUBMIT': 1,
 'MIN_REALIZATIONS': '1',
 'NUM_REALIZATIONS': 100,
 'OBS_CONFIG': '/data/projects/ert/test-data/ert/poly_example/observations',
 'QUEUE_OPTION': [[<QueueSystemWithGeneric.LSF: 'lsf'>,
                   'LSF_RESOURCE',
                   'select[cs && x86_64Linux]'],
                  [<QueueSystemWithGeneric.LSF: 'lsf'>, 'LSF_QUEUE', 'mr8'],
                  [<QueueSystemWithGeneric.LSF: 'lsf'>, 'MAX_RUNNING', '10000'],
                  [<QueueSystemWithGeneric.LSF: 'lsf'>, 'SUBMIT_SLEEP', '1'],
                  [<QueueSystemWithGeneric.LOCAL: 'local'>,
                   'MAX_RUNNING',
                   '12'],
                  [<QueueSystemWithGeneric.LOCAL: 'local'>,
                   'MAX_RUNNING',
                   '50']],
 'QUEUE_SYSTEM': <QueueSystem.LOCAL: 'local'>,
 'REALIZATION_MEMORY': '50mb',
 'RUNPATH': '/data/projects/ert/test-data/ert/poly_example/poly_out/realization-<IENS>/iter-<ITER>',
 'RUNPATH_FILE': '/data/projects/ert/test-data/ert/poly_example/.ert_runpath_list',
 'SETENV': [['OMP_NUM_THREADS', '<NUM_CPU>'],
            ['MKL_NUM_THREADS', '<NUM_CPU>'],
            ['NUMEXPR_NUM_THREADS', '<NUM_CPU>']],
 'STOP_LONG_RUNNING': True}

```



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
