### PR TITLE
Add deprecation warning for init_files with GEN_KW

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -195,4 +195,11 @@ deprecated_keywords_list = [
         "FORWARD_MODEL. Please use FORWARD_MODEL keyword instead:\n"
         f"FORWARD_MODEL {' '.join(args) if args else ''}",
     ),
+    DeprecationInfo(
+        keyword="GEN_KW",
+        message=(
+            "GEN_KW with INIT_FILES is deprecated, and will be removed in the next version. "
+        ),
+        check=lambda line: any("INIT_FILES" in str(v) for v in line),
+    ),
 ]

--- a/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -1,4 +1,5 @@
 import warnings
+from pathlib import Path
 
 import pytest
 
@@ -194,4 +195,17 @@ def test_that_suggester_gives_job_prefix_migration():
     ):
         ErtConfig.from_file_contents(
             "NUM_REALIZATIONS 1\nQUEUE_OPTION TORQUE JOB_PREFIX foo\n"
+        )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_gen_kw_with_init_files_warns():
+    Path("coeff_priors").write_text("a UNIFORM 0 1", encoding="utf-8")
+    Path("init_file").write_text("a 0.4", encoding="utf-8")
+    with pytest.warns(
+        ConfigWarning,
+        match="GEN_KW with INIT_FILES is deprecated, and will be removed in the next version.",
+    ):
+        ErtConfig.from_file_contents(
+            "NUM_REALIZATIONS 1\nGEN_KW COEFFS coeff_priors INIT_FILES:init_file%d"
         )


### PR DESCRIPTION
**Issue**
Resolves #10358


**Approach**
Add deprecation warning for init_files with GEN_KW

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
