### PR TITLE
Fix gui not working with high contrast mode

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -8,13 +8,20 @@ from pathlib import Path
 from PyQt6.QtCore import QCoreApplication, QEvent, QSize, Qt
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtGui import QAction, QCloseEvent, QCursor, QIcon, QMouseEvent
+from PyQt6.QtGui import (
+    QAction,
+    QCloseEvent,
+    QCursor,
+    QIcon,
+    QMouseEvent,
+)
 from PyQt6.QtWidgets import (
     QButtonGroup,
     QFrame,
     QHBoxLayout,
     QMainWindow,
     QMenu,
+    QMessageBox,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -27,6 +34,7 @@ from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.find_ert_info import find_ert_info
 from ert.gui.simulation import ExperimentPanel
+from ert.gui.simulation.experiment_panel import is_high_contrast_mode
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer import EventViewerTool, GUILogHandler
 from ert.gui.tools.export import ExportTool
@@ -109,11 +117,23 @@ class ErtMainWindow(QMainWindow):
         self.button_group = QButtonGroup(self.side_frame)
         self._external_plot_windows: list[PlotWindow] = []
 
+        self.setStyleSheet("QWidget { color: black; }")
         if self.is_dark_mode():
             self.side_frame.setStyleSheet("background-color: rgb(64, 64, 64);")
         else:
             self.side_frame.setStyleSheet("background-color: lightgray;")
 
+        if is_high_contrast_mode():
+            msg_box = QMessageBox()
+            msg_box.setText(
+                "High contrast mode detected. This is not supported by Ert and some features may not work as expected."
+            )
+            msg_box.setWindowTitle("Warning")
+            msg_box.setStyleSheet(
+                "QMessageBox {color: black; background-color: white;} QLabel {color: black;} QPushButton {color: black;}"
+            )
+            msg_box.update()
+            msg_box.exec()
         self.vbox_layout = QVBoxLayout(self.side_frame)
         self.side_frame.setLayout(self.vbox_layout)
 
@@ -141,6 +161,11 @@ class ErtMainWindow(QMainWindow):
         self.central_widget.setMinimumHeight(800)
         self.setCentralWidget(self.central_widget)
 
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        menu_bar.setStyleSheet(
+            "QMenuBar {color: black;} QMenuBar::item:selected {background-color: rgb(70, 140, 235); color: white;} QMenu::item:disabled {color: rgb(170,170,170);}  QMenu::item:selected {background-color: rgb(70, 140, 235); color: white;}"
+        )
         self.__add_tools_menu()
         self.__add_help_menu()
 
@@ -297,8 +322,9 @@ class ErtMainWindow(QMainWindow):
 
         button.setStyleSheet(
             BUTTON_STYLE_SHEET_DARK
-        ) if self.is_dark_mode() else button.setStyleSheet(BUTTON_STYLE_SHEET_LIGHT)
-
+        ) if self.is_dark_mode() and not is_high_contrast_mode() else button.setStyleSheet(
+            BUTTON_STYLE_SHEET_LIGHT
+        )
         pad = 45
         icon_size = QSize(button.size().width() - pad, button.size().height() - pad)
         button.setIconSize(icon_size)

--- a/src/ert/gui/simulation/combobox_with_description.py
+++ b/src/ert/gui/simulation/combobox_with_description.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from PyQt6.QtCore import QModelIndex, QPoint, QSize
 from PyQt6.QtGui import QColor, QRegion
@@ -32,12 +32,11 @@ class _ComboBoxItemWidget(QWidget):
         super().__init__(parent)
         layout = QVBoxLayout()
         layout.setSpacing(5)
-        self.setStyleSheet("background: rgba(0,0,0,1);")
-        self.label = QLabel(label)
-        color = "color: rgba(192,192,192,80);" if not enabled else ";"
+        self.label = QLabel(label, self)
+        color = "color: rgba(192,192,192,80);" if not enabled else "color: black;"
         pd_top = "0px" if group else "5px"
         if group:
-            self.group = QLabel(group)
+            self.group = QLabel(group, self)
             self.group.setStyleSheet(
                 f"""
                 {color}
@@ -60,7 +59,7 @@ class _ComboBoxItemWidget(QWidget):
             font-size: 13px;
         """
         )
-        self.description = QLabel(description)
+        self.description = QLabel(description, self)
         self.description.setStyleSheet(
             f"""
             {color}
@@ -78,6 +77,9 @@ class _ComboBoxItemWidget(QWidget):
 
 
 class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
+    def __init__(self, parent: Any) -> None:
+        super().__init__(parent)
+
     def paint(self, painter: Any, option: Any, index: Any) -> None:
         painter.save()
 
@@ -92,11 +94,20 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
             or option.state & QStyle.StateFlag.State_MouseOver
         ):
             color = COLOR_HIGHLIGHT_LIGHT
-            if option.palette.text().color().value() > 150:
+            if (
+                option.palette.text().color().value() > 150
+                or option.palette.window().color().lightness() > 245
+            ):
                 color = COLOR_HIGHLIGHT_DARK
             painter.fillRect(option.rect, color)
 
-        widget = _ComboBoxItemWidget(label, description, is_enabled, group=group)
+        widget = _ComboBoxItemWidget(
+            label,
+            description,
+            is_enabled,
+            group=group,
+            parent=cast(QWidget, self.parent()),
+        )
         widget.setStyle(option.widget.style())
         widget.resize(option.rect.size())
 
@@ -110,14 +121,16 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         group = index.data(GROUP_TITLE_ROLE)
         adjustment = QSize(0, 20) if group else QSize(0, 0)
 
-        widget = _ComboBoxItemWidget(label, description, group)
+        widget = _ComboBoxItemWidget(
+            label, description, group=group, parent=cast(QWidget, self.parent())
+        )
         return widget.sizeHint() + adjustment
 
 
 class QComboBoxWithDescription(QComboBox):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setItemDelegate(_ComboBoxWithDescriptionDelegate(self))
+        self.setItemDelegate(_ComboBoxWithDescriptionDelegate(parent))
 
     def addDescriptionItem(
         self, label: str, description: Any, group: str | None = None

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -230,6 +230,9 @@ class RunDialog(QFrame):
         )
 
         self._total_progress_bar = QProgressBar(self)
+        self._total_progress_bar.setStyleSheet(
+            "QProgressBar::chunk {background-color: rgb(70,140,230);}"
+        )
         self._total_progress_bar.setRange(0, 100)
         self._total_progress_bar.setTextVisible(False)
 

--- a/src/ert/gui/tools/manage_experiments/storage_model.py
+++ b/src/ert/gui/tools/manage_experiments/storage_model.py
@@ -5,7 +5,7 @@ from uuid import UUID
 import humanize
 from PyQt6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtGui import QBrush, QColor
 from typing_extensions import override
 
 from ert.storage import Ensemble, Experiment, Storage
@@ -126,9 +126,7 @@ class ExperimentModel:
                 return self._experiment_type or "None"
         elif role == Qt.ItemDataRole.ForegroundRole:
             if col == _Column.TYPE and not self._experiment_type:
-                qapp = QApplication.instance()
-                assert isinstance(qapp, QApplication)
-                return qapp.palette().mid()
+                return QBrush(QColor("transparent"))
 
         return None
 

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -99,6 +99,12 @@ class StorageWidget(QWidget):
         self.setMinimumWidth(500)
 
         self._tree_view = QTreeView(self)
+        self._tree_view.setStyleSheet("""
+                                      QTreeView::item::selected {
+                                          background-color: rgb(70,140,230);
+                                          color: white;
+                                      }
+                                      """)
         storage_model = StorageModel(self._notifier.storage)
         notifier.storage_changed.connect(storage_model.reloadStorage)
         notifier.ertChanged.connect(

--- a/src/ert/gui/tools/plugins/plugins_tool.py
+++ b/src/ert/gui/tools/plugins/plugins_tool.py
@@ -35,6 +35,9 @@ class PluginsTool(Tool):
         self.__plugins = {}
 
         self.menu = QMenu("&Plugins")
+        self.menu.setStyleSheet(
+            "QMenu {color: black;} QMenu::item:selected {background-color: rgb(70,140,230); color: white;} QMenu::item:disabled {color: rgb(170,170,170);}"
+        )
         for plugin in plugin_handler:
             plugin_runner = PluginRunner(plugin, ert_config, notifier.storage)
             plugin_runner.setPluginFinishedCallback(self.trigger)


### PR DESCRIPTION
**Issue**
Resolves #10336 
Resolves #10419 

**Approach**
This commit fixes the issue with high contrast mode by emitting a warning message box stating that there might be unexpected behavior when using high contrast mode, and also changing the gui to be as similar to normal contrast mode as possible.
It also fixes the issue where we use a bad text color for ManageExperiment QTreeView "Type" column. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
