### PR TITLE
Remove integration with OPM for reading well names

### DIFF
--- a/src/everest/config/export_config.py
+++ b/src/everest/config/export_config.py
@@ -18,8 +18,8 @@ class ExportConfig(BaseModel, extra="forbid"):
         default=None,
         description="'discard_rejected' key is deprecated. You can safely remove it from the config file",
     )
-    keywords: list[str] | None = Field(
-        default=None,
+    keywords: list[str] = Field(
+        default_factory=list,
         description="List of eclipse keywords to be exported.",
     )
     batches: list[int] | None = Field(

--- a/src/everest/simulator/__init__.py
+++ b/src/everest/simulator/__init__.py
@@ -4,10 +4,10 @@ JOB_RUNNING = "Running"
 JOB_FAILURE = "Failed"
 
 
-DEFAULT_DATA_SUMMARY_KEYS = ("YEAR", "YEARS", "TCPU", "TCPUDAY", "MONTH", "DAY")
+DEFAULT_DATA_SUMMARY_KEYS = ["YEAR", "YEARS", "TCPU", "TCPUDAY", "MONTH", "DAY"]
 
 
-DEFAULT_FIELD_SUMMARY_KEYS = (
+DEFAULT_FIELD_SUMMARY_KEYS = [
     "FOPR",
     "FOPT",
     "FOIR",
@@ -39,33 +39,10 @@ DEFAULT_FIELD_SUMMARY_KEYS = (
     "FAQT",
     "FAQTG",
     "FWGR",
-)
+]
 
 
-DEFAULT_GROUP_SUMMARY_KEYS = (
-    "GOPR",
-    "GOPT",
-    "GOIR",
-    "GOIT",
-    "GWPR",
-    "GWPT",
-    "GWIR",
-    "GWIT",
-    "GGPR",
-    "GGPT",
-    "GGIR",
-    "GGIT",
-    "GVPR",
-    "GVPT",
-    "GVIR",
-    "GVIT",
-    "GWCT",
-    "GGOR",
-    "GWGR",
-)
-
-
-_DEFAULT_WELL_SUMMARY_KEYS = (
+_DEFAULT_WELL_SUMMARY_KEYS = [
     "WOPR",
     "WOPT",
     "WOIR",
@@ -88,19 +65,20 @@ _DEFAULT_WELL_SUMMARY_KEYS = (
     "WBHP",
     "WTHP",
     "WPI",
-)
+]
 
 _EXCLUDED_TARGET_KEYS = "WGOR"
 
-_DEFAULT_WELL_TARGET_SUMMARY_KEYS = (
+_DEFAULT_WELL_TARGET_SUMMARY_KEYS = [
     well_key + "T"
     for well_key in _DEFAULT_WELL_SUMMARY_KEYS
     if well_key.endswith("R") and well_key not in _EXCLUDED_TARGET_KEYS
+]
+
+DEFAULT_WELL_SUMMARY_KEYS = (
+    _DEFAULT_WELL_SUMMARY_KEYS + _DEFAULT_WELL_TARGET_SUMMARY_KEYS
 )
 
-DEFAULT_WELL_SUMMARY_KEYS = _DEFAULT_WELL_SUMMARY_KEYS + tuple(
-    _DEFAULT_WELL_TARGET_SUMMARY_KEYS
-)
 
 __all__ = [
     "JOB_FAILURE",

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -68,15 +68,8 @@ def _extract_summary_keys(
     field_keys = everest.simulator.DEFAULT_FIELD_SUMMARY_KEYS
     well_sum_keys = everest.simulator.DEFAULT_WELL_SUMMARY_KEYS
     user_specified_keys = (
-        []
-        if ever_config.export is None or ever_config.export.keywords is None
-        else ever_config.export.keywords
+        [] if ever_config.export is None else ever_config.export.keywords
     )
-
-    # Makes it work w/ new config setup, default will be empty list
-    # when old way of doing it is phased out
-    if user_specified_keys is None:
-        user_specified_keys = []
 
     wells = [well.name for well in ever_config.wells]
 

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -10,19 +10,6 @@ except ImportError:
     ert_version = "0.0.0"
 from everest.strings import DATE_FORMAT, EVEREST
 
-try:
-    import opm.io
-    from opm.io.ecl_state import EclipseState
-    from opm.io.schedule import Schedule
-
-    def has_opm() -> bool:
-        return True
-
-except ImportError:
-
-    def has_opm() -> bool:
-        return False
-
 
 def version_info() -> str:
     return f"everest:{ert_version}, ropt:{ropt_version}, ert:{ert_version}"
@@ -61,53 +48,3 @@ def _roll_dir(old_name: str) -> None:
     new_name = old_name + datetime.now(UTC).strftime("__%Y-%m-%d_%H.%M.%S.%f")
     os.rename(old_name, new_name)
     logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")
-
-
-def load_deck(fname: str):  # type: ignore
-    """Take a .DATA file and return an opm.io.Deck."""
-    if not os.path.exists(fname):
-        raise OSError(f'No such data file "{fname}".')
-
-    if not has_opm():
-        raise RuntimeError("Cannot load ECL files, opm could not be imported")
-
-    # OPM parser will fail with different errors on corrupted Eclipse input files.
-    # We should ignore these as we just want to extract the wells, we don't
-    # care about anything else in the file (for now).
-    errors_to_ignore = [
-        "INTERNAL_ERROR_UNINITIALIZED_THPRES",
-        "PARSE_EXTRA_DATA",
-        "PARSE_MISSING_DIMS_KEYWORD",
-        "PARSE_MISSING_INCLUDE",
-        "PARSE_RANDOM_SLASH",
-        "PARSE_RANDOM_TEXT",
-        "PARSE_UNKNOWN_KEYWORD",
-        "SUMMARY_UNKNOWN_GROUP",
-        "SUMMARY_UNKNOWN_WELL",
-        "UNSUPPORTED_COMPORD_TYPE",
-        "UNSUPPORTED_INITIAL_THPRES",
-        "UNSUPPORTED_SCHEDULE_GEO_MODIFIER",
-        "UNSUPPORTED_TERMINATE_IF_BHP",
-    ]
-    parse_context = opm.io.ParseContext(
-        [(err_name, opm.io.action.ignore) for err_name in errors_to_ignore]
-    )
-    return opm.io.Parser().parse(fname, parse_context)
-
-
-def read_wellnames(fname: str) -> list[str]:
-    """Take a .DATA file and return the list of well
-    names at time the first timestep from deck."""
-    deck = load_deck(fname)
-    state = EclipseState(deck)
-    schedule = Schedule(deck, state)
-    return [str(well.name) for well in schedule.get_wells(0)]
-
-
-def read_groupnames(fname: str) -> list[str]:
-    """Take a .DATA file and return the list of group
-    names at the first timestep from deck."""
-    deck = load_deck(fname)
-    state = EclipseState(deck)
-    schedule = Schedule(deck, state)
-    return [str(group.name) for group in schedule._groups(0)]

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -13,9 +13,7 @@ from everest.config import EverestConfig
 from everest.simulator.everest_to_ert import _everest_to_ert_config_dict
 from tests.everest.utils import (
     everest_default_jobs,
-    hide_opm,
     skipif_no_everest_models,
-    skipif_no_opm,
 )
 
 CONFIG_FILE = "everest/model/config.yml"
@@ -552,23 +550,6 @@ def _generate_exp_ert_config(config_path, output_dir):
     }
 
 
-@pytest.mark.integration_test
-@skipif_no_opm
-def test_egg_model_convert(copy_egg_test_data_to_tmp):
-    config = EverestConfig.load_file(CONFIG_FILE)
-    ert_config = _everest_to_ert_config_dict(config)
-
-    # configpath isn't specified in config_file so it should be inferred
-    # to be at the directory of the config file.
-    output_dir = config.output_dir
-    config_path = os.path.dirname(os.path.abspath(CONFIG_FILE))
-    exp_ert_config = _generate_exp_ert_config(config_path, output_dir)
-    sort_res_summary(exp_ert_config)
-    sort_res_summary(ert_config)
-    assert exp_ert_config == ert_config
-
-
-@hide_opm
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 def test_egg_model_convert_no_opm(copy_egg_test_data_to_tmp):
@@ -613,7 +594,6 @@ def test_opm_fail_default_summary_keys(copy_egg_test_data_to_tmp):
 
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
-@skipif_no_opm
 def test_opm_fail_explicit_summary_keys(copy_egg_test_data_to_tmp):
     extra_sum_keys = [
         "GOIR:PRODUC",
@@ -671,7 +651,6 @@ def test_init_egg_model(copy_egg_test_data_to_tmp):
 @pytest.mark.integration_test
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
-@skipif_no_opm
 def test_egg_model_wells_json_output_no_none(copy_egg_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
     _ = _everest_to_ert_config_dict(config)

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -30,11 +30,7 @@ from everest.simulator.everest_to_ert import (
     get_forward_model_steps,
     get_substitutions,
 )
-from tests.everest.utils import (
-    hide_opm,
-    skipif_no_everest_models,
-    skipif_no_opm,
-)
+from tests.everest.utils import skipif_no_everest_models
 
 
 @pytest.mark.parametrize(
@@ -209,40 +205,7 @@ def test_install_data_no_init(tmp_path, source, target, symlink, cmd, monkeypatc
     assert expected_fm.arglist == [f"./{source}", target]
 
 
-@skipif_no_opm
-@skipif_no_everest_models
-@pytest.mark.everest_models_test
 @pytest.mark.integration_test
-def test_summary_default(copy_egg_test_data_to_tmp):
-    config_dir = "everest/model"
-    config_file = os.path.join(config_dir, "config.yml")
-    everconf = EverestConfig.load_file(config_file)
-
-    data_file = everconf.model.data_file
-    if not os.path.isabs(data_file):
-        data_file = os.path.join(config_dir, data_file)
-    data_file = data_file.replace("<GEO_ID>", "0")
-
-    wells = everest.util.read_wellnames(data_file)
-    groups = everest.util.read_groupnames(data_file)
-
-    sum_keys = list(everest.simulator.DEFAULT_DATA_SUMMARY_KEYS) + list(
-        everest.simulator.DEFAULT_FIELD_SUMMARY_KEYS
-    )
-
-    key_name_lists = (
-        (everest.simulator.DEFAULT_GROUP_SUMMARY_KEYS, groups),
-        (everest.simulator.DEFAULT_WELL_SUMMARY_KEYS, wells),
-    )
-    for keys, names in key_name_lists:
-        sum_keys += [f"{key}:{name}" for key, name in itertools.product(keys, names)]
-
-    res_conf = _everest_to_ert_config_dict(everconf)
-    assert set(sum_keys) == set(res_conf[ErtConfigKeys.SUMMARY][0])
-
-
-@pytest.mark.integration_test
-@hide_opm
 @skipif_no_everest_models
 @pytest.mark.everest_models_test
 @pytest.mark.skip_mac_ci

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -13,9 +13,7 @@ from everest.detached import ServerStatus
 from everest.strings import EVEREST, SERVER_STATUS
 from tests.everest.utils import (
     capture_streams,
-    hide_opm,
     relpath,
-    skipif_no_opm,
 )
 
 EGG_DATA = relpath(
@@ -23,30 +21,6 @@ EGG_DATA = relpath(
     "realizations/realization-0/eclipse/model/EGG.DATA",
 )
 SPE1_DATA = relpath("test_data/eclipse/SPE1.DATA")
-
-
-@skipif_no_opm
-def test_loadwells():
-    wells = util.read_wellnames(SPE1_DATA)
-    assert wells == ["PROD", "INJ"]
-
-
-@skipif_no_opm
-def test_loadgroups():
-    groups = util.read_groupnames(EGG_DATA)
-    assert {"FIELD", "PRODUC", "INJECT"} == set(groups)
-
-
-@hide_opm
-def test_loadwells_no_opm():
-    with pytest.raises(RuntimeError):
-        util.read_wellnames(SPE1_DATA)
-
-
-@hide_opm
-def test_loadgroups_no_opm():
-    with pytest.raises(RuntimeError):
-        util.read_groupnames(EGG_DATA)
 
 
 def test_get_values(change_to_tmpdir):

--- a/tests/everest/utils/__init__.py
+++ b/tests/everest/utils/__init__.py
@@ -5,26 +5,13 @@ import pathlib
 import shutil
 import sys
 from io import StringIO
-from unittest import mock
 
-import decorator
 import pytest
 
 from everest.bin.main import start_everest
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import ServerStatus, everserver_status
 from everest.jobs import script_names
-from everest.util import has_opm
-
-
-def skipif_no_opm(function):
-    """Decorator to skip a test if opm is not available
-
-    If this decorator is used on a test, there should be a corresponding
-    test that verifies the expected behavior in case opm is not available
-    (use the hide_opm decorator)
-    """
-    return pytest.mark.skipif(not has_opm(), reason="OPM not found")(function)
 
 
 def skipif_no_everest_models(function):
@@ -32,16 +19,6 @@ def skipif_no_everest_models(function):
     spec = importlib.util.find_spec("everest_models")
     not_found = spec is None
     return pytest.mark.skipif(not_found, reason="everest-models not found")(function)
-
-
-def hide_opm(function):
-    """Decorator for faking that the opm module is not present"""
-
-    def wrapper(function, *args, **kwargs):
-        with mock.patch("everest.util.has_opm", return_value=False):
-            return function(*args, **kwargs)
-
-    return decorator.decorator(wrapper, function)
 
 
 def relpath(*path):


### PR DESCRIPTION
**Issue**
Resolves #10260 

While very useful on paper, this turned out to not work very
well in real cases, where the input deck to the simulator was not
complete before it hit runpath. Most users always got a warning,
and just ignored it.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Create Backport PR to latest release

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
