### PR TITLE
Remove default value of eclbase and replace with validation

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -144,7 +144,7 @@ class EverestConfig(BaseModel):
         default_factory=list,
         description="A list of well configurations, all with unique names.",
     )
-    definitions: dict[str, Any] | None = Field(
+    definitions: dict[str, Any] = Field(
         default_factory=dict[str, Any],
         description="""Section for specifying variables.
 

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1115,3 +1115,13 @@ def test_export_deprecated_keys(key, value, min_config, change_to_tmpdir):
     )
     with pytest.warns(ConfigWarning, match=match_msg):
         EverestConfig.load_file_with_argparser("config.yml", parser)
+
+
+def test_valid_init_of_summary_loading(tmp_path):
+    a_file = tmp_path / "a_file"
+    a_file.touch()
+    config = EverestConfig.with_defaults(
+        model={"data_file": str(a_file), "realizations": [0]}
+    )
+    with pytest.raises(ValueError, match="definitions -> eclbase"):
+        everest_to_ert_config_dict(config)


### PR DESCRIPTION
Note! This also removes the default value, which means that without eclbase in definitions, the user will get a validation error. Previously this would almost always cause an exception in the callbacks, unless their ecl file was located in the same location, with the same name as the default.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
