### PR TITLE
Fix defaults in Everest config

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -121,7 +121,6 @@ class EverestRunModel(BaseRunModel):
     ):
         Path(everest_config.log_dir).mkdir(parents=True, exist_ok=True)
         Path(everest_config.optimization_output_dir).mkdir(parents=True, exist_ok=True)
-        assert everest_config.environment is not None
         logging.getLogger(EVEREST).info(
             "Using random seed: %d. To deterministically reproduce this experiment, "
             "add the above random seed to your configuration file.",

--- a/src/everest/config/environment_config.py
+++ b/src/everest/config/environment_config.py
@@ -7,7 +7,7 @@ from everest.config.validation_utils import check_path_valid
 
 
 class EnvironmentConfig(BaseModel, extra="forbid"):
-    simulation_folder: str | None = Field(
+    simulation_folder: str = Field(
         default="simulation_folder", description="Folder used for simulation by Everest"
     )
     output_folder: str | None = Field(

--- a/src/everest/config/environment_config.py
+++ b/src/everest/config/environment_config.py
@@ -10,7 +10,7 @@ class EnvironmentConfig(BaseModel, extra="forbid"):
     simulation_folder: str = Field(
         default="simulation_folder", description="Folder used for simulation by Everest"
     )
-    output_folder: str | None = Field(
+    output_folder: str = Field(
         default="everest_output", description="Folder for outputs of Everest"
     )
     log_level: Literal["debug", "info", "warning", "error", "critical"] | None = Field(

--- a/src/everest/config/environment_config.py
+++ b/src/everest/config/environment_config.py
@@ -13,7 +13,7 @@ class EnvironmentConfig(BaseModel, extra="forbid"):
     output_folder: str = Field(
         default="everest_output", description="Folder for outputs of Everest"
     )
-    log_level: Literal["debug", "info", "warning", "error", "critical"] | None = Field(
+    log_level: Literal["debug", "info", "warning", "error", "critical"] = Field(
         default="info",
         description="""Defines the verbosity of logs output by Everest.
 

--- a/src/everest/config/environment_config.py
+++ b/src/everest/config/environment_config.py
@@ -35,9 +35,7 @@ critical: A serious error, indicating that the program itself may be unable to
 continue running.
 """,
     )
-    random_seed: int | None = Field(
-        default=None, description="Random seed (must be positive)"
-    )
+    random_seed: int = Field(default=None, description="Random seed (must be positive)")  # type: ignore
 
     @field_validator("output_folder", mode="before")
     @classmethod
@@ -50,5 +48,5 @@ continue running.
     @model_validator(mode="after")
     def validate_random_seed(self) -> Self:
         if self.random_seed is None:
-            self.random_seed = SeedSequence().entropy  # type: ignore
+            self.random_seed = SeedSequence().entropy
         return self

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -477,7 +477,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
         if environment is None or config_path is None:
             return self
 
-        check_writeable_path(environment.simulation_folder, Path(config_path))  # type: ignore
+        check_writeable_path(environment.simulation_folder, Path(config_path))
         return self
 
     # pylint: disable=E0213
@@ -569,14 +569,14 @@ and environment variables are exposed in the form 'os.NAME', for example:
     def simulation_dir(self) -> str | None:
         path = self.environment.simulation_folder
 
-        if os.path.isabs(path):  # type: ignore
+        if os.path.isabs(path):
             return path
 
         cfgdir = self.output_dir
         if cfgdir is None:
             return path
 
-        return os.path.join(cfgdir, path)  # type: ignore
+        return os.path.join(cfgdir, path)
 
     def _get_output_subdirectory(self, subdirname: str) -> str:
         return os.path.join(os.path.abspath(self.output_dir), subdirname)

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -135,7 +135,7 @@ class EverestConfig(BaseModel):
     model: ModelConfig = Field(
         description="Configuration of the Everest model",
     )
-    environment: EnvironmentConfig | None = Field(
+    environment: EnvironmentConfig = Field(
         default_factory=EnvironmentConfig,
         description="The environment of Everest, specifies which folders are used "
         "for simulation and output, as well as the level of detail in Everest-logs",
@@ -529,10 +529,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @property
     def logging_level(self) -> int:
-        level = self.environment.log_level if self.environment is not None else "info"
-
-        if level is None:
-            level = "info"
+        level = self.environment.log_level
 
         levels = {
             "debug": logging.DEBUG,  # 10
@@ -553,7 +550,6 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @property
     def output_dir(self) -> str:
-        assert self.environment is not None
         path = self.environment.output_folder
 
         if path is None:
@@ -571,7 +567,6 @@ and environment variables are exposed in the form 'os.NAME', for example:
 
     @property
     def simulation_dir(self) -> str | None:
-        assert self.environment is not None
         path = self.environment.simulation_folder
 
         if os.path.isabs(path):  # type: ignore

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -128,7 +128,7 @@ class EverestConfig(BaseModel):
     objective_functions: list[ObjectiveFunctionConfig] = Field(
         description="List of objective function specifications", min_length=1
     )
-    optimization: OptimizationConfig | None = Field(
+    optimization: OptimizationConfig = Field(
         default_factory=OptimizationConfig,
         description="Optimizer options",
     )

--- a/src/everest/config/model_config.py
+++ b/src/everest/config/model_config.py
@@ -43,8 +43,10 @@ If specified, it must be a list of numeric values, one per realization.""",
     def validate_realizations_weights_same_cardinaltiy(self) -> Self:
         weights = self.realizations_weights
         if not weights:
+            self.realizations_weights = [1.0 / len(self.realizations)] * len(
+                self.realizations
+            )
             return self
-
         if len(weights) != len(self.realizations):
             raise ValueError(
                 "Specified realizations_weights must have one"

--- a/src/everest/config/model_config.py
+++ b/src/everest/config/model_config.py
@@ -19,8 +19,8 @@ Typically, this is a list [0, 1, ..., n-1] of all realizations in the ensemble."
 
 NOTE: Without a data file no well or group specific summary data will be exported.""",
     )
-    realizations_weights: list[float] | None = Field(
-        default=None,
+    realizations_weights: list[float] = Field(
+        default_factory=list,
         description="""List of weights, one per realization.
 
 If specified, it must be a list of numeric values, one per realization.""",

--- a/src/everest/config/optimization_config.py
+++ b/src/everest/config/optimization_config.py
@@ -9,7 +9,7 @@ from everest.strings import EVEREST
 
 
 class OptimizationConfig(BaseModel, extra="forbid"):
-    algorithm: str | None = Field(
+    algorithm: str = Field(
         default="optpp_q_newton",
         description="""Algorithm used by Everest.  Defaults to
 optpp_q_newton, a quasi-Newton algorithm in Dakota's OPT PP library.

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -285,10 +285,12 @@ def _parse_model(
     if not ever_model:
         return
 
-    ever_reals = ever_model.realizations or []
-    ever_reals_weights = ever_model.realizations_weights
-    if ever_reals_weights is None:
-        ever_reals_weights = [1.0 / len(ever_reals)] * len(ever_reals)
+    ever_reals = ever_model.realizations
+    ever_reals_weights = (
+        [1.0 / len(ever_reals)] * len(ever_reals)
+        if not ever_model.realizations_weights
+        else ever_model.realizations_weights
+    )
 
     ropt_config["realizations"] = {
         "weights": ever_reals_weights,

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -279,7 +279,7 @@ def _parse_optimization(
 
 def _parse_model(
     ever_model: ModelConfig | None,
-    ever_opt: OptimizationConfig | None,
+    ever_opt: OptimizationConfig,
     ropt_config: dict[str, Any],
 ) -> None:
     if not ever_model:
@@ -293,8 +293,8 @@ def _parse_model(
     ropt_config["realizations"] = {
         "weights": ever_reals_weights,
     }
-    min_real_succ = ever_opt.min_realizations_success if ever_opt else None
-    if min_real_succ is not None:
+
+    if min_real_succ := ever_opt.min_realizations_success:
         ropt_config["realizations"]["realization_min_success"] = min_real_succ
 
 

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -338,9 +338,7 @@ def _everest2ropt(
     )
     _parse_environment(
         optimization_output_dir=ever_config.optimization_output_dir,
-        random_seed=ever_config.environment.random_seed
-        if ever_config.environment
-        else None,
+        random_seed=ever_config.environment.random_seed,
         ropt_config=ropt_config,
     )
 

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -277,7 +277,7 @@ def _parse_optimization(
 
 
 def _parse_model(
-    ever_model: ModelConfig | None,
+    ever_model: ModelConfig,
     ever_opt: OptimizationConfig,
     ropt_config: dict[str, Any],
 ) -> None:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -185,20 +185,16 @@ def _parse_optimization(
 
     ropt_optimizer["method"] = ever_opt.algorithm
 
-    alg_max_iter = ever_opt.max_iterations
-    if alg_max_iter:
+    if alg_max_iter := ever_opt.max_iterations:
         ropt_optimizer["max_iterations"] = alg_max_iter
 
-    alg_max_eval = ever_opt.max_function_evaluations
-    if alg_max_eval:
+    if alg_max_eval := ever_opt.max_function_evaluations:
         ropt_optimizer["max_functions"] = alg_max_eval
 
-    alg_conv_tol = ever_opt.convergence_tolerance or None
-    if alg_conv_tol:
+    if alg_conv_tol := ever_opt.convergence_tolerance:
         ropt_optimizer["tolerance"] = alg_conv_tol
 
-    alg_grad_spec = ever_opt.speculative or None
-    if alg_grad_spec:
+    if alg_grad_spec := ever_opt.speculative:
         ropt_optimizer["speculative"] = alg_grad_spec
 
     # Handle the backend options. Due to historical reasons there two keywords:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -183,8 +183,7 @@ def _parse_optimization(
     ropt_optimizer = ropt_config["optimizer"]
     ropt_gradient = ropt_config["gradient"]
 
-    algorithm = ever_opt.algorithm or "optpp_q_newton"
-    ropt_optimizer["method"] = f"{algorithm}"
+    ropt_optimizer["method"] = ever_opt.algorithm
 
     alg_max_iter = ever_opt.max_iterations
     if alg_max_iter:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -284,15 +284,8 @@ def _parse_model(
     if not ever_model:
         return
 
-    ever_reals = ever_model.realizations
-    ever_reals_weights = (
-        [1.0 / len(ever_reals)] * len(ever_reals)
-        if not ever_model.realizations_weights
-        else ever_model.realizations_weights
-    )
-
     ropt_config["realizations"] = {
-        "weights": ever_reals_weights,
+        "weights": ever_model.realizations_weights,
     }
 
     if min_real_succ := ever_opt.min_realizations_success:

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -389,7 +389,6 @@ def _extract_model(ever_config: EverestConfig, ert_config: dict[str, Any]) -> No
 
 
 def _extract_seed(ever_config: EverestConfig, ert_config: dict[str, Any]) -> None:
-    assert ever_config.environment is not None
     random_seed = ever_config.environment.random_seed
 
     if random_seed:

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -245,12 +245,9 @@ def test_everest2ropt_arbitrary_backend_options():
     assert ropt_config.optimizer.options["a"] == [1]
 
 
-def test_everest2ropt_no_algorithm_name(copy_test_data_to_tmp):
-    config = EverestConfig.load_file(
-        os.path.join("valid_config_file", "valid_yaml_config_no_algorithm.yml")
-    )
-
-    config.optimization.algorithm = None
+def test_everest2ropt_default_algorithm_name(min_config):
+    config = EverestConfig(**min_config)
+    assert not min_config.get("optimization")
     ropt_config = everest2ropt(config)
     assert ropt_config.optimizer.method == "optpp_q_newton"
 


### PR DESCRIPTION
Many of these are optional, but the default value should not be None. This has the positive side effect that the docs become much more readable.


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
