### PR TITLE
Fix a bug where join_after=2 was erronously removed

### DIFF
--- a/src/ert/config/parsing/config_schema.py
+++ b/src/ert/config/parsing/config_schema.py
@@ -169,6 +169,7 @@ def queue_option_keyword() -> SchemaItem:
         kw=ConfigKeys.QUEUE_OPTION,
         argc_min=2,
         argc_max=None,
+        join_after=2,
         type_map=[QueueSystemWithGeneric, SchemaItemType.STRING, SchemaItemType.STRING],
         multi_occurrence=True,
     )

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2175,3 +2175,16 @@ def test_run_template_raises_configvalidationerror_with_more_than_two_arguments(
             """
             )
         )
+
+
+def test_queue_options_are_joined_after_option_name():
+    assert (
+        ErtConfig.from_file_contents(
+            """
+            NUM_REALIZATIONS 1
+            QUEUE_SYSTEM LSF
+            QUEUE_OPTION LSF LSF_RESOURCE select[bigmachine && Linux]
+            """
+        ).queue_config.queue_options.lsf_resource
+        == "select[bigmachine && Linux]"
+    )


### PR DESCRIPTION
Fixes an issue where QueueOption was no longer joined after the option name.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
