### PR TITLE
Add design matrix support to manage experimenents UI

### DIFF
--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -133,11 +133,11 @@ def _setup_evaluate_ensemble(
     args: Namespace,
     status_queue: SimpleQueue[StatusEvents],
 ) -> EvaluateEnsemble:
-    active_realizations = _realizations(args, config.model_config.num_realizations)
+    active_realizations = _get_active_realizations_list(args, config)
 
     return EvaluateEnsemble(
         random_seed=config.random_seed,
-        active_realizations=active_realizations.tolist(),
+        active_realizations=active_realizations,
         ensemble_id=args.ensemble_id,
         minimum_required_realizations=config.analysis_config.minimum_required_realizations,
         config=config,

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -30,66 +30,17 @@ def _create_design_matrix(filename, design_sheet_df, default_sheet_df=None):
             )
 
 
-@pytest.mark.usefixtures("copy_poly_case")
-def test_run_poly_example_with_design_matrix(caplog):
+def test_run_poly_example_with_design_matrix(copy_poly_case_with_design_matrix, caplog):
     caplog.set_level(logging.INFO)
     num_realizations = 10
     a_values = list(range(num_realizations))
-    _create_design_matrix(
-        "poly_design.xlsx",
-        pd.DataFrame(
-            {
-                "REAL": list(range(num_realizations)),
-                "a": a_values,
-                "category": 5 * ["cat1"] + 5 * ["cat2"],
-            }
-        ),
-        pd.DataFrame([["b", 1], ["c", 2]]),
-    )
-
-    with open("poly.ert", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """\
-                QUEUE_OPTION LOCAL MAX_RUNNING 10
-                RUNPATH poly_out/realization-<IENS>/iter-<ITER>
-                NUM_REALIZATIONS 10
-                MIN_REALIZATIONS 1
-                GEN_DATA POLY_RES RESULT_FILE:poly.out
-                DESIGN_MATRIX poly_design.xlsx
-                INSTALL_JOB poly_eval POLY_EVAL
-                FORWARD_MODEL poly_eval
-                """
-            )
-        )
-
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
-                #!/usr/bin/env python
-                import json
-
-                def _load_coeffs(filename):
-                    with open(filename, encoding="utf-8") as f:
-                        return json.load(f)["DESIGN_MATRIX"]
-
-                def _evaluate(coeffs, x):
-                    assert coeffs["category"] in ["cat1", "cat2"]
-                    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
-
-                if __name__ == "__main__":
-                    coeffs = _load_coeffs("parameters.json")
-                    output = [_evaluate(coeffs, x) for x in range(10)]
-                    with open("poly.out", "w", encoding="utf-8") as f:
-                        f.write("\\n".join(map(str, output)))
-                """
-            )
-        )
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
-    )
+    design_dict = {
+        "REAL": list(range(num_realizations)),
+        "a": a_values,
+        "category": 5 * ["cat1"] + 5 * ["cat2"],
+    }
+    default_list = [["b", 1], ["c", 2]]
+    copy_poly_case_with_design_matrix(design_dict, default_list)
 
     run_cli(
         ENSEMBLE_EXPERIMENT_MODE,

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -352,17 +352,13 @@ def load_results_manually(qtbot, gui, ensemble_name="default"):
     gui.load_results_tool.trigger()
 
 
-def add_experiment_manually(
-    qtbot, gui, experiment_name="My_experiment", ensemble_name="default"
+def add_experiment_in_manage_experiment_dialog(
+    qtbot,
+    manage_experiment_dialog,
+    experiment_name="My_experiment",
+    ensemble_name="default",
 ):
-    button_manage_experiments = gui.findChild(QToolButton, "button_Manage_experiments")
-    assert button_manage_experiments
-    qtbot.mouseClick(button_manage_experiments, Qt.MouseButton.LeftButton)
-    experiments_panel = gui.findChild(ManageExperimentsPanel)
-
-    # Open the create new experiment tab
-    experiments_panel.setCurrentIndex(0)
-    current_tab = experiments_panel.currentWidget()
+    current_tab = manage_experiment_dialog.currentWidget()
     assert current_tab.objectName() == "create_new_ensemble_tab"
     storage_widget = get_child(current_tab, StorageWidget)
 
@@ -376,6 +372,20 @@ def add_experiment_manually(
     add_widget = get_child(storage_widget, AddWidget)
     qtbot.mouseClick(add_widget.addButton, Qt.MouseButton.LeftButton)
 
+
+def add_experiment_manually(
+    qtbot, gui, experiment_name="My_experiment", ensemble_name="default"
+):
+    button_manage_experiments = gui.findChild(QToolButton, "button_Manage_experiments")
+    assert button_manage_experiments
+    qtbot.mouseClick(button_manage_experiments, Qt.MouseButton.LeftButton)
+    experiments_panel = gui.findChild(ManageExperimentsPanel)
+
+    # Open the create new experiment tab
+    experiments_panel.setCurrentIndex(0)
+    add_experiment_in_manage_experiment_dialog(
+        qtbot, experiments_panel, experiment_name, ensemble_name
+    )
     experiments_panel.close()
 
 


### PR DESCRIPTION
**Issue**
Resolves #10355 


**Approach**
Provide saving design matrix on initialization from scratch in manage experiment panel.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
