### PR TITLE
Add more config validation for design matrix

### DIFF
--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -10,8 +10,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ert.cli.main import ErtCliError
 from ert.config import DESIGN_MATRIX_GROUP, ErtConfig
+from ert.config.parsing.config_errors import ConfigValidationError
 from ert.mode_definitions import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -132,7 +132,10 @@ def test_run_poly_example_with_design_matrix(caplog):
     "default_values, error_msg",
     [
         ([["b", 1], ["c", 2]], None),
-        ([["b", 1]], "Overlapping parameter names found in design matrix!"),
+        (
+            [["b", 1]],
+            "Only full overlaps of design matrix and one genkw group are supported.",
+        ),
     ],
 )
 def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, error_msg):
@@ -205,7 +208,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, err
     )
 
     if error_msg:
-        with pytest.raises(ErtCliError, match=error_msg):
+        with pytest.raises(ConfigValidationError, match=error_msg):
             run_cli(
                 ENSEMBLE_EXPERIMENT_MODE,
                 "--disable-monitoring",


### PR DESCRIPTION
We now raise ConfigValidationError if a genkw group is only partially overlapped by design matrix

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
