### PR TITLE
Fix warnings in the Everest tests

### DIFF
--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -796,6 +796,7 @@ def test_that_existing_install_job_with_non_existing_executable_errors(
         ("normalization", 0.1, None),
     ],
 )
+@pytest.mark.filterwarnings("ignore:normalization key is deprecated")
 def test_that_objective_function_attrs_are_valid(key, value, expected_error):
     if expected_error:
         with pytest.raises(ValueError) as e:
@@ -1035,6 +1036,8 @@ def test_deprecated_objective_function_auto_normalize():
         (0.42, 0.24, True, False),
     ],
 )
+@pytest.mark.filterwarnings("ignore:normalization key is deprecated")
+@pytest.mark.filterwarnings("ignore:auto_normalize key is deprecated")
 def test_objective_function_scaling_is_backward_compatible_with_scaling(
     normalization, scale, auto_normalize, auto_scale
 ):

--- a/tests/everest/test_data/mocked_test_case/config_full_gradient_info.yml
+++ b/tests/everest/test_data/mocked_test_case/config_full_gradient_info.yml
@@ -33,7 +33,7 @@ install_jobs:
     source: jobs/RES_MOCK
 
 optimization:
-  algorithm: conmin_mfd
+  algorithm: optpp_q_newton
   perturbation_num: 20
   max_iterations: 10
   max_function_evaluations: 1000

--- a/tests/everest/test_data/mocked_test_case/config_output_constraints.yml
+++ b/tests/everest/test_data/mocked_test_case/config_output_constraints.yml
@@ -143,7 +143,7 @@ install_jobs:
 
 
 optimization:
-  algorithm: conmin_mfd
+  algorithm: optpp_q_newton
   max_iterations: 2
   max_function_evaluations: 2
   perturbation_num: 2

--- a/tests/everest/test_data/mocked_test_case/config_samplers.yml
+++ b/tests/everest/test_data/mocked_test_case/config_samplers.yml
@@ -73,7 +73,7 @@ install_jobs:
     source: jobs/RES_MOCK
 
 optimization:
-  algorithm: conmin_mfd
+  algorithm: optpp_q_newton
   perturbation_num: 20
   max_iterations: 10
   max_function_evaluations: 1000

--- a/tests/everest/test_data/mocked_test_case/mocked_test_case.yml
+++ b/tests/everest/test_data/mocked_test_case/mocked_test_case.yml
@@ -5,7 +5,6 @@ definitions:
 
 export:
   keywords: ['FOIP', 'FOPT']
-  csv_output_filepath: path/to/relative/folder
 
 wells:
   - { name: w00}

--- a/tests/everest/test_data/templating/config.yml
+++ b/tests/everest/test_data/templating/config.yml
@@ -19,7 +19,7 @@ objective_functions:
 
 
 optimization:
-  algorithm: conmin_mfd
+  algorithm: optpp_q_newton
   max_iterations: 1
 
 

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -129,7 +129,7 @@ def test_math_func_auto_scaled_controls(copy_math_func_test_data_to_tmp):
     # Arrange
     config = EverestConfig.load_file("config_minimal.yml")
     config.controls[0].auto_scale = True
-    config.controls[0].scaled_range = [0.3, 0.7]
+    config.controls[0].scaled_range = (0.3, 0.7)
 
     # Convergence is slower that's why more batches and start closer to final solution?
     config.controls[0].initial_guess = 0.2

--- a/tests/everest/test_optimization_config.py
+++ b/tests/everest/test_optimization_config.py
@@ -11,7 +11,7 @@ def test_optimization_config(copy_test_data_to_tmp):
     full_config_dict = EverestConfig.load_file(cfg)
 
     optim_config = full_config_dict.optimization
-    assert optim_config.algorithm == "conmin_mfd"
+    assert optim_config.algorithm == "optpp_q_newton"
     assert optim_config.perturbation_num == 20
     assert optim_config.max_iterations == 10
     assert optim_config.max_function_evaluations == 1000

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -150,6 +150,9 @@ def test_default_installed_jobs(tmp_path, monkeypatch):
     assert [c.name for c in forward_model_steps[1:]] == jobs
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Config contains a SUMMARY key but no forward model steps"
+)
 def test_combined_wells_everest_to_ert(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     Path("my_file").touch()

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -141,7 +141,7 @@ def test_everest2ropt_controls_optimizer_setting():
     config = EverestConfig.load_file(config)
     ropt_config = everest2ropt(config)
     assert len(ropt_config.realizations.weights) == 15
-    assert ropt_config.optimizer.method == "conmin_mfd"
+    assert ropt_config.optimizer.method == "optpp_q_newton"
     assert ropt_config.gradient.number_of_perturbations == 20
 
 


### PR DESCRIPTION
**Issue**
This removes a number of warnings and unnecessary output from the Everest tests.

**Approach**
- A wrong data type produced a pydantic warning
- One config contained a deprecated key that was not relevant for the test
- All instances of the `conmin `algorithm are replaced with `optpp_q_newton`, since `conmin `algorithm produce output that with pytest cannot be suppressed. In normal use it is suppressed, but pytest interferes with that mechanism. All off the affected tests work fine with `optpp_q_newton`.
- A number of warnings that are expected but not of interest are filtered

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
