### PR TITLE
Update active realization mask when panel changed

### DIFF
--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -70,7 +70,6 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         return (
             self._active_realizations_field.isValid()
             and self._ensemble_selector.currentIndex() != -1
-            and self._active_realizations_field.isValid()
         )
 
     def get_experiment_arguments(self) -> Arguments:

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -94,7 +94,6 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         return (
             self._active_realizations_field.isValid()
             and self._ensemble_selector.currentIndex() != -1
-            and self._active_realizations_field.isValid()
         )
 
     def get_experiment_arguments(self) -> Arguments:


### PR DESCRIPTION
For experiment types that uses a previous ensemble, one should ensure that the active realizations are set when clicking on the panel.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
