### PR TITLE
Remove start experiment from run dialog

### DIFF
--- a/tests/ert/performance_tests/test_snapshot.py
+++ b/tests/ert/performance_tests/test_snapshot.py
@@ -14,19 +14,6 @@ from ert.ensemble_evaluator.snapshot import (
     FMStepSnapshot,
     RealizationSnapshot,
 )
-from tests.ert.ui_tests.gui.conftest import (  # noqa: F401
-    active_realizations_fixture,
-)
-from tests.ert.unit_tests.gui.conftest import (  # noqa: F401
-    large_snapshot,
-)
-from tests.ert.unit_tests.gui.simulation.test_run_dialog import (  # noqa: F401
-    event_queue,
-    notifier,
-    run_dialog,
-    run_model_api,
-    test_large_snapshot,
-)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #10234 


**Approach**
Move the logic from RunDialog `run_experiment` inside `ExperimentPanel`  `run_experiment`.

Adjust RunDialog tests

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
