### PR TITLE
Use app token when creating backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,8 +23,14 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v4
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.SCOUT_TEAM_APP_ID }}
+          private-key: ${{ secrets.SCOUT_TEAM_APP_PRIVATE_KEY }}
       - name: Create backport pull requests
         uses: korthout/backport-action@v3
         with:
           add_author_as_assignee: true
-          github_token: ${{ secrets.LOCKFILE_UPDATE_TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
When a PR is created using the default github.token, workflows are not triggered on the new PR and prevents necessary checks to complete. Using an app token instead will allow workflows to be triggered.

**Issue**
Resolves #10483 

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
