### PR TITLE
Fix flakiness in test_that_multiple_everest_clients_can_connect_to_server

### DIFF
--- a/src/everest/gui/everest_client.py
+++ b/src/everest/gui/everest_client.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import requests
 from pydantic import ValidationError
 from requests import HTTPError
+from websockets.exceptions import ConnectionClosedError
 from websockets.sync.client import connect
 
 from _ert.threading import ErtThread
@@ -108,6 +109,8 @@ class EverestClient:
                                 )
 
                         time.sleep(refresh_interval)
+            except ConnectionClosedError:
+                logger.debug("Connetion closed by server")
             except Exception:
                 logger.debug(traceback.format_exc())
 


### PR DESCRIPTION
**Issue**


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
