### PR TITLE
Use --dist loadgroup in pre-commit push and rapid-tests

### DIFF
--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -48,12 +48,12 @@ jobs:
     - name: Run Tests Linux
       if: ${{ inputs.test-type == 'test' && runner.os != 'macOS'}}
       run: |
-        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy --dist loadgroup -sv' uv run just everest-tests
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -sv' uv run just everest-tests
 
     - name: Run Tests macOS
       if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
-        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" --dist loadgroup -sv' uv run just everest-tests
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" -sv' uv run just everest-tests
 
     - name: Build Documentation
       if: inputs.test-type == 'doc'
@@ -65,7 +65,7 @@ jobs:
       if: inputs.test-type == 'everest-models-test'
       run: |
         uv pip install git+https://github.com/equinor/everest-models.git
-        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m everest_models_test --dist loadgroup' uv run just everest-tests
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m everest_models_test' uv run just everest-tests
 
     - name: Upload coverage to Codecov
       if: inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - id: pytest
     name: pytest
     entry: uv
-    args: [run, --all-extras, pytest, -n, auto, tests/ert/unit_tests, tests/everest, --hypothesis-profile=fast, -m, not integration_test]
+    args: [run, --all-extras, just, rapid-tests]
     language: system
     types: [python]
     stages: [pre-push]

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ pytest_args := env("ERT_PYTEST_ARGS", "--quiet")
 
 # execute rapid unittests
 rapid-tests:
-    nice pytest -n auto tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky)"
+    pytest -n auto --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky)"
 
 ert-gui-tests:
     pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui


### PR DESCRIPTION
To avoid race condition in everest cache.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
