### PR TITLE
Use personal access token to create backport PR

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,3 +27,4 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           add_author_as_assignee: true
+          github_token: ${{ secrets.LOCKFILE_UPDATE_TOKEN }}


### PR DESCRIPTION
When a PR is created using the default github.token, workflows are not triggered on the new PR and prevents necessary checks to complete. Using a personal access token or an app token will allow workflows to be triggered. This commit uses the already existing LOCKFILE_UPDATE_TOKEN as a temporary fix until we have a Github app in place to acquire an app token.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
