### PR TITLE
Make rapid tests rapid again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,14 @@ everest = ["data/**/*", "*.tmpl", "detached/jobs/everserver"]
 
 [tool.pytest.ini_options]
 addopts = "-ra --strict-markers"
+norecursedirs = [
+    "tests/ert/unit_tests/gui/plottery/baseline",
+    "tests/ert/unit_tests/storage/snapshots",
+    "tests/ert/unit_tests/snapshots",
+    "tests/everest/snapshots",
+    "tests/everest/test_data",
+    "tests/ert/unit_tests/scheduler/bin"
+]
 markers = [
     "integration_test",
     "out_of_memory",

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -76,7 +76,7 @@ settings.register_profile(
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
     print_blob=True,
-    max_examples=10,
+    max_examples=1,
 )
 
 

--- a/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
+++ b/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
@@ -52,6 +52,7 @@ def test_that_get_nr_primary_components_is_according_to_theory():
 
 
 @pytest.mark.parametrize("nr_observations", [4, 10, 100])
+@pytest.mark.integration_test
 def test_misfit_preprocessor(nr_observations):
     """We create two independent parameters, a and b.
     Using the linear function y = ax.

--- a/tests/ert/unit_tests/config/test_analysis_config.py
+++ b/tests/ert/unit_tests/config/test_analysis_config.py
@@ -16,6 +16,7 @@ from ert.config import (
 from ert.config.parsing import ConfigKeys, ConfigWarning
 
 
+@pytest.mark.integration_test
 def test_analysis_config_from_file_is_same_as_from_dict(monkeypatch, tmp_path):
     with pd.ExcelWriter(tmp_path / "my_design_matrix.xlsx") as xl_write:
         design_matrix_df = pd.DataFrame(

--- a/tests/ert/unit_tests/ensemble_evaluator/test_async_queue_execution.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_async_queue_execution.py
@@ -5,6 +5,7 @@ from ert.scheduler import Scheduler, create_driver
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
+@pytest.mark.integration_test
 async def test_happy_path(
     tmpdir,
     make_ensemble,

--- a/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_monitor.py
@@ -126,6 +126,7 @@ async def test_unexpected_close_after_connection_successful(
     await websocket_server_task
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "correct_server_key",
     [

--- a/tests/ert/unit_tests/resources/test_run_eclipse_simulator.py
+++ b/tests/ert/unit_tests/resources/test_run_eclipse_simulator.py
@@ -350,6 +350,7 @@ def test_find_unsmry(paths_to_touch, basepath, expectation):
         assert str(run_reservoirsimulator.find_unsmry(Path(basepath))) == expectation
 
 
+@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_await_completed_summary_file_will_timeout_on_missing_smry():
     assert (
@@ -361,6 +362,7 @@ def test_await_completed_summary_file_will_timeout_on_missing_smry():
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_await_completed_summary_file_will_return_asap():
     resfo.write("FOO.UNSMRY", [("INTEHEAD", np.array([1], dtype=np.int32))])

--- a/tests/ert/unit_tests/resources/test_run_reservoirsimulator.py
+++ b/tests/ert/unit_tests/resources/test_run_reservoirsimulator.py
@@ -104,17 +104,6 @@ def test_runner_can_extract_base_name(data_path: str, expected: str):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_await_completed_summary_file_will_timeout_on_missing_smry():
-    assert (
-        # Expected wait time is 0.3
-        run_reservoirsimulator.await_completed_unsmry_file(
-            "SPE1.UNSMRY", max_wait=0.3, poll_interval=0.1
-        )
-        > 0.3
-    )
-
-
-@pytest.mark.usefixtures("use_tmpdir")
 def test_await_completed_summary_file_will_return_asap():
     resfo.write("FOO.UNSMRY", [("INTEHEAD", np.array([1], dtype=np.int32))])
     assert (

--- a/tests/ert/unit_tests/resources/test_templating.py
+++ b/tests/ert/unit_tests/resources/test_templating.py
@@ -195,6 +195,7 @@ def test_no_parameters_json():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.integration_test
 def test_template_executable():
     with open("template", "w", encoding="utf-8") as template_file:
         template_file.write(

--- a/tests/ert/unit_tests/scheduler/test_generic_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_generic_driver.py
@@ -177,6 +177,7 @@ async def test_kill_actually_kills(driver: Driver, tmp_path, pytestconfig):
     assert not Path("survived").exists(), "Job should have been killed"
 
 
+@pytest.mark.integration_test
 async def test_num_cpu_sets_env_variables(driver: Driver, tmp_path, job_name):
     """The intention of this check is to verify that the driver sets up
     the num_cpu requirement correctly for the relevant queue system.

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1028,6 +1028,7 @@ async def test_bjobs_exec_host_logs_only_once(tmp_path, job_name, caplog):
     assert caplog.text.count("was assigned to host:") == 1
 
 
+@pytest.mark.integration_test
 async def test_lsf_stdout_file(tmp_path, job_name):
     os.chdir(tmp_path)
     driver = LsfDriver()
@@ -1043,6 +1044,7 @@ async def test_lsf_stdout_file(tmp_path, job_name):
     assert "yay" in lsf_stdout
 
 
+@pytest.mark.integration_test
 async def test_lsf_dumps_stderr_to_file(tmp_path, job_name):
     os.chdir(tmp_path)
     driver = LsfDriver()

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -301,6 +301,7 @@ def generate_random_text(size):
 
 
 @pytest.mark.parametrize("tail_chars_to_read", [(5), (50), (500), (700)])
+@pytest.mark.integration_test
 async def test_slurm_can_retrieve_stdout_and_stderr(
     tmp_path, job_name, tail_chars_to_read
 ):

--- a/tests/ert/unit_tests/test_enkf_main.py
+++ b/tests/ert/unit_tests/test_enkf_main.py
@@ -57,6 +57,7 @@ def test_create_run_args_separate_base_and_name(prior_ensemble, run_paths):
     assert substitutions.get("<ECLBASE>") == "base<IENS>"
 
 
+@pytest.mark.integration_test
 def test_assert_symlink_deleted(snake_oil_field_example, storage, run_paths):
     ert_config = snake_oil_field_example
     experiment_id = storage.create_experiment(

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -270,6 +270,7 @@ def test_loading_gen_data_without_restart(storage, run_paths, run_args):
 
 
 @pytest.mark.usefixtures("copy_snake_oil_case_storage")
+@pytest.mark.integration_test
 def test_that_the_states_are_set_correctly():
     """
     When creating a new ensemble and loading results manually (load_from_forward_model)

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -189,6 +189,7 @@ def test_api_summary_snapshot_missing_batch(snapshot, cached_example):
     )
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "config_file",
     [

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -159,6 +159,7 @@ def test_status_running_complete(_, change_to_tmpdir, mock_server):
     assert status["message"] == "Optimization completed."
 
 
+@pytest.mark.integration_test
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch("everest.detached.jobs.everserver._configure_loggers")
 def test_status_failed_job(_, change_to_tmpdir, mock_server):

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -187,6 +187,7 @@ def test_failed_jobs_monitor(
     assert output.endswith("Failed")
 
 
+@pytest.mark.integration_test
 def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys):
     server_mock = MagicMock()
     connection_mock = MagicMock(spec=ClientConnection)

--- a/tests/everest/test_repo_configs.py
+++ b/tests/everest/test_repo_configs.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from ropt.exceptions import ConfigError as ROptConfigError
 
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
@@ -14,6 +15,7 @@ def _get_all_files(folder):
     ]
 
 
+@pytest.mark.integration_test
 def test_all_repo_configs():
     repo_dir = os.path.join(os.path.dirname(__file__), "..")
     repo_dir = os.path.realpath(repo_dir)


### PR DESCRIPTION
Goes from 59.0-43.4 to 41.9-41.2s on my machine while number of tests ran goes from 2388 to 2360

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
