### PR TITLE
Add back default recurse dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,8 @@ everest = ["data/**/*", "*.tmpl", "detached/jobs/everserver"]
 [tool.pytest.ini_options]
 addopts = "-ra --strict-markers"
 norecursedirs = [
+    "*.egg",
+    ".*",
     "tests/ert/unit_tests/gui/plottery/baseline",
     "tests/ert/unit_tests/storage/snapshots",
     "tests/ert/unit_tests/snapshots",


### PR DESCRIPTION
In 57a80a77eac5c29c5ccaf242567edb61b3380793 norecursedirs was set, which overwrote the defaults. We still want to have ".*" and "*.egg" from the defaults.


Skims ~1 second off the rapid tests.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
