### PR TITLE
Sort time data explicitly before asof join

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -986,13 +986,17 @@ class LocalEnsemble(BaseMode):
                             )
                         )
                     elif "time" in pivoted:
-                        joined = observations_for_type.join_asof(
-                            pivoted,
-                            by=[
-                                "response_key",
-                                *[k for k in response_cls.primary_key if k != "time"],
-                            ],
+                        by_cols = [
+                            "response_key",
+                            *[k for k in response_cls.primary_key if k != "time"],
+                        ]
+                        joined = observations_for_type.sort(
+                            by=[*by_cols, "time"]
+                        ).join_asof(
+                            pivoted.sort(by=[*by_cols, "time"]),
+                            by=by_cols,
                             on="time",
+                            check_sortedness=False,  # Ref: https://github.com/pola-rs/polars/issues/21693
                             strategy="nearest",
                             tolerance="1s",
                         )


### PR DESCRIPTION
**Issue**
Resolves [#10492](https://github.com/equinor/ert/issues/10492)

Performance tests @ `test_obs_and_responses_performance.py` should catch performance regressions
