### PR TITLE
Narrow down RunDialog init args

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -26,6 +26,7 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.gui.ertnotifier import ErtNotifier
 from ert.run_models import BaseRunModel, StatusEvents, create_model
 
+from ..find_ert_info import find_ert_info
 from ..summarypanel import SummaryPanel
 from .combobox_with_description import QComboBoxWithDescription
 from .ensemble_experiment_panel import EnsembleExperimentPanel
@@ -313,7 +314,7 @@ class ExperimentPanel(QWidget):
                 QApplication.restoreOverrideCursor()
 
         self._dialog = RunDialog(
-            self._config_file,
+            f"Experiment - {self._config_file} {find_ert_info()}",
             model.api,
             event_queue,
             self._notifier,

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -52,10 +52,10 @@ def create_md_table(kv: dict[str, str], output: str) -> str:
     return output
 
 
-def get_simulation_thread(model: Any, restart: bool = False) -> ErtThread:
-    evaluator_server_config = EvaluatorServerConfig(
-        use_ipc_protocol=model.api.queue_system == QueueSystem.LOCAL
-    )
+def get_simulation_thread(
+    model: Any, restart: bool = False, use_ipc_protocol: bool = False
+) -> ErtThread:
+    evaluator_server_config = EvaluatorServerConfig(use_ipc_protocol=use_ipc_protocol)
 
     def run() -> None:
         model.api.start_simulations_thread(
@@ -326,7 +326,12 @@ class ExperimentPanel(QWidget):
         self.run_button.setEnabled(self._simulation_done)
 
         def start_simulation_thread(restart: bool = False) -> None:
-            simulation_thread = get_simulation_thread(self._model, restart)
+            simulation_thread = get_simulation_thread(
+                self._model,
+                restart,
+                use_ipc_protocol=self.config.queue_config.queue_system
+                == QueueSystem.LOCAL,
+            )
             self._dialog.setup_event_monitoring(restart)
             simulation_thread.start()
             self._notifier.set_is_simulation_running(True)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -67,7 +67,6 @@ from ert.shared.status.utils import (
     get_mount_directory,
 )
 
-from ..find_ert_info import find_ert_info
 from .queue_emitter import QueueEmitter
 from .view import DiskSpaceWidget, ProgressWidget, RealizationWidget, UpdateWidget
 
@@ -194,7 +193,7 @@ class RunDialog(QFrame):
 
     def __init__(
         self,
-        config_file: str,
+        title: str,
         run_model_api: BaseRunModelAPI,
         event_queue: SimpleQueue[StatusEvents],
         notifier: ErtNotifier,
@@ -207,7 +206,7 @@ class RunDialog(QFrame):
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setWindowFlags(Qt.WindowType.Window)
         self.setWindowFlag(Qt.WindowType.WindowContextHelpButtonHint, False)
-        self.setWindowTitle(f"Experiment - {config_file} {find_ert_info()}")
+        self.setWindowTitle(title)
 
         self._run_model_api = run_model_api
         self._queue_system = run_model_api.queue_system

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -209,7 +209,6 @@ class RunDialog(QFrame):
         self.setWindowTitle(title)
 
         self._run_model_api = run_model_api
-        self._queue_system = run_model_api.queue_system
         self._snapshot_model = SnapshotModel(self)
         self._event_queue = event_queue
         self._notifier = notifier

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -138,7 +138,6 @@ class StartSimulationsThreadFn(Protocol):
 @dataclasses.dataclass
 class BaseRunModelAPI:
     experiment_name: str
-    queue_system: str
     runpath_format_string: str
     support_restart: bool
     start_simulations_thread: StartSimulationsThreadFn
@@ -219,7 +218,6 @@ class BaseRunModel(ABC):
     def api(self) -> BaseRunModelAPI:
         return BaseRunModelAPI(
             experiment_name=self.name(),
-            queue_system=self._queue_config.queue_system,
             runpath_format_string=str(self._runpath_file),
             get_runtime=self.get_runtime,
             start_simulations_thread=self.start_simulations_thread,

--- a/src/everest/gui/everest_client.py
+++ b/src/everest/gui/everest_client.py
@@ -91,9 +91,7 @@ class EverestClient:
 
         return event_queue, monitor_thread
 
-    def create_run_model_api(
-        self, queue_system: str, runpath_format_string: str
-    ) -> BaseRunModelAPI:
+    def create_run_model_api(self, runpath_format_string: str) -> BaseRunModelAPI:
         def start_fn(
             evaluator_server_config: EvaluatorServerConfig, restart: bool = False
         ) -> None:
@@ -101,7 +99,6 @@ class EverestClient:
 
         return BaseRunModelAPI(
             experiment_name="Everest Experiment",
-            queue_system=queue_system,
             runpath_format_string=runpath_format_string,
             support_restart=False,
             start_simulations_thread=start_fn,

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -66,9 +66,7 @@ class EverestMainWindow(QMainWindow):
         sim_dir = ever_config.simulation_dir
 
         assert sim_dir is not None
-        run_model_api = client.create_run_model_api(
-            ever_config.simulator.queue_system.name, runpath_format_string=sim_dir
-        )
+        run_model_api = client.create_run_model_api(runpath_format_string=sim_dir)
         event_queue, event_monitor_thread = client.setup_event_queue_from_ws_endpoint(
             refresh_interval=0.02, open_timeout=40, websocket_recv_timeout=1.0
         )

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -74,7 +74,7 @@ class EverestMainWindow(QMainWindow):
         )
 
         run_dialog = RunDialog(
-            config_file=self.config_file,
+            title=self.config_file,
             run_model_api=run_model_api,
             event_queue=event_queue,
             is_everest=True,


### PR DESCRIPTION
Disconnects RunDialog from it, redirects `experiment_panel` getter to get from config instead