### PR TITLE
Ensure OpenMP parallelization will not take place in tests

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   UV_FROZEN: true
-
+  OMP_NUM_THREADS: 1
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   ERT_SHOW_BACKTRACE: 1
   UV_FROZEN: true
+  OMP_NUM_THREADS: 1
 
 jobs:
   run-ert-test-data:

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -16,6 +16,7 @@ env:
   ECL_SKIP_SIGNAL: 1
   ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
   UV_FROZEN: true
+  OMP_NUM_THREADS: 1
 
 jobs:
   tests-ert:

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -13,6 +13,7 @@ on:
 env:
   NO_PROJECT_RES: 1
   UV_FROZEN: true
+  OMP_NUM_THREADS: 1
 
 jobs:
   tests-everest:

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -9,6 +9,7 @@ on: [pull_request]
 
 env:
   UV_FROZEN: true
+  OMP_NUM_THREADS: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
In test workloads, we should assume that cpu cores are always saturated, and if any code partially oversubscribes to cpu resources, it will result in variable timings and stealing performance from other tests running simultaneously.

**Issue**
Resolves potential flakyness in test workflows in CI.

**Approach**
Make threading predictive.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
