### PR TITLE
Add warning icon when ensemble_size is changed due to design matrix

### DIFF
--- a/src/ert/gui/simulation/_design_matrix_panel.py
+++ b/src/ert/gui/simulation/_design_matrix_panel.py
@@ -1,11 +1,15 @@
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QStandardItem, QStandardItemModel
 from PyQt6.QtWidgets import (
+    QApplication,
     QDialog,
     QHBoxLayout,
+    QLabel,
     QPushButton,
+    QStyle,
     QTableView,
     QVBoxLayout,
     QWidget,
@@ -71,7 +75,10 @@ class DesignMatrixPanel(QDialog):
 
     @staticmethod
     def get_design_matrix_button(
-        active_realizations_field: StringBox, design_matrix: "DesignMatrix"
+        active_realizations_field: StringBox,
+        design_matrix: "DesignMatrix",
+        number_of_realizations_label: QLabel,
+        ensemble_size: int,
     ) -> QHBoxLayout:
         active_realizations_field.setValidator(
             RangeSubsetStringArgument(ActiveRange(design_matrix.active_realizations))
@@ -90,5 +97,32 @@ class DesignMatrixPanel(QDialog):
         show_dm_param_button.clicked.connect(
             lambda: DesignMatrixPanel.show_dm_params(design_matrix)
         )
+        dm_num_reals = len(design_matrix.active_realizations)
+        if dm_num_reals != ensemble_size:
+            number_of_realizations_label.setText(f"<b>{dm_num_reals}</b>")
+            parent_widget = number_of_realizations_label.parent()
+
+            if isinstance(parent_widget, QWidget) and (
+                layout := parent_widget.layout()
+            ):
+                warning_icon = QLabel()
+                warning_icon.setObjectName(
+                    "warning_icon_num_realizations_design_matrix"
+                )
+                style = QApplication.style()
+                if style is not None:
+                    warning_icon.setPixmap(
+                        style.standardIcon(
+                            QStyle.StandardPixmap.SP_MessageBoxWarning
+                        ).pixmap(16, 16)
+                    )
+                layout.addWidget(warning_icon)
+                layout.setSpacing(2)
+                layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
+
+                warning_icon.setToolTip(
+                    f"Number of realizations changed from {ensemble_size} to {dm_num_reals} due to 'REAL' column in design matrix"
+                )
+                warning_icon.show()
 
         return button_layout

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
+from PyQt6.QtWidgets import (
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QWidget,
+)
 
 from ert.config import AnalysisConfig
 from ert.gui.ertnotifier import ErtNotifier
@@ -70,8 +75,16 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
+        number_of_realizations_container = QWidget()
+        number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
+        number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
         number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+        number_of_realizations_label.setObjectName("num_reals_label")
+        number_of_realizations_layout.addWidget(number_of_realizations_label)
+
+        layout.addRow(
+            QLabel("Number of realizations:"), number_of_realizations_container
+        )
 
         self._active_realizations_field = StringBox(
             ActiveRealizationsModel(ensemble_size),  # type: ignore
@@ -87,7 +100,10 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
             layout.addRow(
                 "Design Matrix",
                 DesignMatrixPanel.get_design_matrix_button(
-                    self._active_realizations_field, design_matrix
+                    self._active_realizations_field,
+                    design_matrix,
+                    number_of_realizations_label,
+                    ensemble_size,
                 ),
             )
 

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
+from PyQt6.QtWidgets import QFormLayout, QHBoxLayout, QLabel, QWidget
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import (
@@ -68,8 +68,16 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
+        number_of_realizations_container = QWidget()
+        number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
+        number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
         number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+        number_of_realizations_label.setObjectName("num_reals_label")
+        number_of_realizations_layout.addWidget(number_of_realizations_label)
+
+        layout.addRow(
+            QLabel("Number of realizations:"), number_of_realizations_container
+        )
 
         self._ensemble_format_model = TargetEnsembleModel(analysis_config, notifier)
         self._ensemble_format_field = StringBox(
@@ -99,7 +107,10 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
             layout.addRow(
                 "Design Matrix",
                 DesignMatrixPanel.get_design_matrix_button(
-                    self._active_realizations_field, design_matrix
+                    self._active_realizations_field,
+                    design_matrix,
+                    number_of_realizations_label,
+                    ensemble_size,
                 ),
             )
 

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QFont
-from PyQt6.QtWidgets import QCheckBox, QFormLayout, QLabel, QWidget
+from PyQt6.QtWidgets import QCheckBox, QFormLayout, QHBoxLayout, QLabel, QWidget
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import (
@@ -76,8 +76,16 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
+        number_of_realizations_container = QWidget()
+        number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
+        number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
         number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+        number_of_realizations_label.setObjectName("num_reals_label")
+        number_of_realizations_layout.addWidget(number_of_realizations_label)
+
+        layout.addRow(
+            QLabel("Number of realizations:"), number_of_realizations_container
+        )
 
         self._target_ensemble_format_model = TargetEnsembleModel(
             analysis_config, notifier
@@ -141,7 +149,10 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             layout.addRow(
                 "Design Matrix",
                 DesignMatrixPanel.get_design_matrix_button(
-                    self._active_realizations_field, design_matrix
+                    self._active_realizations_field,
+                    design_matrix,
+                    number_of_realizations_label,
+                    ensemble_size,
                 ),
             )
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QPushButton,
     QToolButton,
+    QWidget,
 )
 from pytestqt.qtbot import QtBot
 
@@ -24,11 +25,19 @@ from ert.ensemble_evaluator.event import (
 )
 from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.gui.simulation.ensemble_experiment_panel import EnsembleExperimentPanel
+from ert.gui.simulation.ensemble_smoother_panel import EnsembleSmootherPanel
 from ert.gui.simulation.experiment_panel import ExperimentPanel
+from ert.gui.simulation.multiple_data_assimilation_panel import (
+    MultipleDataAssimilationPanel,
+)
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.simulation.view.realization import RealizationWidget
 from ert.gui.tools.file import FileDialog
-from ert.run_models.ensemble_experiment import EnsembleExperiment
+from ert.run_models import (
+    EnsembleExperiment,
+    EnsembleSmoother,
+    MultipleDataAssimilation,
+)
 from ert.storage import open_storage
 from tests.ert import SnapshotBuilder
 from tests.ert.ui_tests.gui.conftest import wait_for_child
@@ -811,3 +820,60 @@ def test_forward_model_overview_label_selected_on_tab_change(
 
     qt_bot_click_tab_index(1)
     assert "Realization id 1 in iteration 1" in fm_step_label.text()
+
+
+@pytest.mark.integration_test
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "experiment_mode, experiment_mode_panel",
+    [
+        (EnsembleExperiment, EnsembleExperimentPanel),
+        (EnsembleSmoother, EnsembleSmootherPanel),
+        (MultipleDataAssimilation, MultipleDataAssimilationPanel),
+    ],
+)
+def test_that_design_matrix_alters_num_realizations_field(
+    qtbot: QtBot, storage, experiment_mode, experiment_mode_panel
+):
+    xls_filename = "design_matrix.xlsx"
+    design_matrix_df = pd.DataFrame(
+        {
+            "REAL": list(range(3)),
+            "a": [0, 1, 2],
+        }
+    )
+    default_sheet_df = pd.DataFrame([["b", 1], ["c", 2]])
+    with pd.ExcelWriter(xls_filename) as xl_write:
+        design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
+        default_sheet_df.to_excel(
+            xl_write, index=False, sheet_name="DefaultSheet", header=False
+        )
+
+    config_file = "minimal_config.ert"
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write("NUM_REALIZATIONS 10")
+        f.write(f"\nDESIGN_MATRIX {xls_filename}")
+
+    args_mock = Mock()
+    args_mock.config = config_file
+
+    ert_config = ErtConfig.from_file(config_file)
+    gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), storage)
+    experiment_panel = gui.findChild(ExperimentPanel)
+    assert experiment_panel
+
+    simulation_mode_combo = experiment_panel.findChild(QComboBox)
+    assert simulation_mode_combo
+
+    simulation_mode_combo.setCurrentText(experiment_mode.name())
+    simulation_settings = gui.findChild(experiment_mode_panel)
+    num_realizations_label = simulation_settings.findChild(QWidget, "num_reals_label")
+    assert num_realizations_label
+    assert num_realizations_label.text() == "<b>3</b>"
+
+    # Verify that the warning icon has the correct tooltip
+    warning_icon = gui.findChild(QLabel, "warning_icon_num_realizations_design_matrix")
+    assert (
+        warning_icon.toolTip()
+        == "Number of realizations changed from 10 to 3 due to 'REAL' column in design matrix"
+    )


### PR DESCRIPTION
Resolves #10296 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
