### PR TITLE
Stop loading plugins to avoid conflict with site config

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -4,13 +4,15 @@ import shutil
 import tempfile
 from collections.abc import Callable, Iterator
 from copy import deepcopy
+from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
 
+import ert
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models import StatusEvents
 from ert.run_models.event import status_event_from_json, status_event_to_json
@@ -237,3 +239,10 @@ def mock_server(monkeypatch):
     monkeypatch.setattr(everserver, "_find_open_port", lambda *args, **kwargs: 42)
     monkeypatch.setattr(everserver, "_write_hostfile", MagicMock())
     monkeypatch.setattr(everserver, "_everserver_thread", MagicMock())
+
+
+@pytest.fixture()
+def no_plugins():
+    patched = partial(ert.config.ert_config.ErtPluginManager, plugins=[])
+    with patch("ert.config.ert_config.ErtPluginManager", patched):
+        yield

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -144,6 +144,7 @@ def test_wait_for_server(server_is_running_mock, caplog):
     assert not caplog.messages
 
 
+@pytest.mark.usefixtures("no_plugins")
 def test_detached_mode_config_base(min_config, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     with open("config.yml", "w", encoding="utf-8") as fout:
@@ -247,6 +248,7 @@ def test_generate_queue_options_use_simulator_values(
     assert config.server.queue_system == expected_result
 
 
+@pytest.mark.usefixtures("no_plugins")
 @pytest.mark.parametrize("use_plugin", (True, False))
 @pytest.mark.parametrize(
     "queue_options",

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -34,6 +34,7 @@ from everest.simulator.everest_to_ert import (
 from tests.everest.utils import skipif_no_everest_models
 
 
+@pytest.mark.usefixtures("no_plugins")
 @pytest.mark.parametrize(
     "config, config_class",
     [
@@ -363,6 +364,7 @@ def test_user_config_jobs_precedence(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.usefixtures("no_plugins")
 def test_that_queue_settings_are_taken_from_site_config(
     min_config, monkeypatch, tmp_path
 ):


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/10528


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
