### PR TITLE
Fix gui realization selector using magic string as default

### DIFF
--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -108,7 +108,9 @@ class StringBox(QLineEdit):
         return self._validation
 
     def isValid(self) -> bool:
-        return self._validation.isValid()
+        return (
+            bool(self.text() or self.placeholderText()) and self._validation.isValid()
+        )
 
     @property
     def get_text(self) -> str:

--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -47,7 +47,6 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
 
         self._active_realizations_field = StringBox(
             ActiveRealizationsModel(ensemble_size, show_default=False),  # type: ignore
-            "config/simulation/active_realizations",
             continuous_update=True,
         )
         self._realizations_validator = EnsembleRealizationsArgument(

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -72,7 +72,6 @@ class ManualUpdatePanel(ExperimentConfigPanel):
 
         self._active_realizations_field = StringBox(
             ActiveRealizationsModel(ensemble_size, show_default=False),  # type: ignore
-            "config/simulation/active_realizations",
             continuous_update=True,
         )
         self._realizations_validator = EnsembleRealizationsArgument(


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
This commit fixes the issue where the active realization selector for manual update / evaluate ensemble panel used the magic string `config/simulation/active_realizations` as default. 

(Screenshot of new behavior in GUI if applicable)

https://github.com/user-attachments/assets/fb00f8b2-1d23-469e-9eb7-6a05781a70cc



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
