### PR TITLE
Disallow gen_kw group with name DESIGN_MATRIX when using DESIGN_MATRIX

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -28,6 +28,7 @@ from ert.substitutions import Substitutions
 
 from ._design_matrix_validator import DesignMatrixValidator
 from .analysis_config import AnalysisConfig
+from .design_matrix import DESIGN_MATRIX_GROUP
 from .ensemble_config import EnsembleConfig
 from .forward_model_step import (
     ForwardModelStep,
@@ -883,6 +884,12 @@ class ErtConfig:
                 if not isinstance(config, GenKwConfig):
                     continue
                 group_params = {x.name for x in config.transform_function_definitions}
+                if group_name == DESIGN_MATRIX_GROUP:
+                    dm_errors.append(
+                        ConfigValidationError(
+                            f"Cannot have GEN_KW with group name {DESIGN_MATRIX_GROUP} when using DESIGN_MATRIX keyword."
+                        )
+                    )
                 if dm_params == group_params:
                     ConfigWarning.warn(
                         f"Parameters {group_params} from GEN_KW group '{group_name}' "

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2152,3 +2152,30 @@ def test_queue_options_are_joined_after_option_name():
         ).queue_config.queue_options.lsf_resource
         == "select[bigmachine && Linux]"
     )
+
+
+def test_validation_error_on_gen_kw_with_design_matrix_group_name(tmp_path):
+    design_matrix_file = tmp_path / "my_design_matrix.xlsx"
+    _create_design_matrix(
+        design_matrix_file,
+        pd.DataFrame(
+            {
+                "REAL": [0, 1],
+                "letters": ["x", "y"],
+            }
+        ),
+        pd.DataFrame([["a", 1], ["c", 2]]),
+    )
+    with open(tmp_path / "coeffs_priors", mode="w", encoding="utf-8") as fh:
+        fh.write("a CONST 0")
+    with pytest.raises(
+        ConfigValidationError,
+        match="Cannot have GEN_KW with group name DESIGN_MATRIX when using DESIGN_MATRIX keyword\\.",
+    ):
+        ErtConfig.from_file_contents(
+            f"""\
+                NUM_REALIZATIONS 1
+                DESIGN_MATRIX {tmp_path}/my_design_matrix.xlsx
+                GEN_KW DESIGN_MATRIX {tmp_path}/coeffs_priors
+                """
+        )


### PR DESCRIPTION
**Issue**
Resolves #10525 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
