### PR TITLE
Fix tests failing when site config was installed

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -30,11 +30,9 @@ NonEmptyString = Annotated[str, pydantic.StringConstraints(min_length=1)]
 
 
 def activate_script() -> str:
-    venv = os.environ.get("VIRTUAL_ENV")
-    if venv:
+    if venv := os.environ.get("VIRTUAL_ENV"):
         return f"source {venv}/bin/activate"
-    conda_env = os.environ.get("CONDA_ENV")
-    if conda_env:
+    if conda_env := os.environ.get("CONDA_ENV"):
         return f'eval "$(conda shell.bash hook)" && conda activate {conda_env}'
     return ""
 

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -736,6 +736,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
     @classmethod
     def with_plugins(cls, config_dict: dict[str, Any] | ConfigDict) -> Self:
         site_config = ErtConfig.read_site_config()
+        has_site_config = bool(site_config)  # site_config gets mutated by next call
         ert_config: ErtConfig = ErtConfig.with_plugins().from_dict(
             config_dict=site_config
         )
@@ -743,7 +744,7 @@ and environment variables are exposed in the form 'os.NAME', for example:
             "install_jobs": ert_config.installed_forward_model_steps,
         }
         activate_script = ErtPluginManager().activate_script()
-        if site_config:
+        if has_site_config:
             context["queue_system"] = QueueConfig.from_dict(site_config).queue_options
         if activate_script:
             context["activate_script"] = activate_script

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 import ert
+import everest
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models import StatusEvents
 from ert.run_models.event import status_event_from_json, status_event_to_json
@@ -244,5 +245,11 @@ def mock_server(monkeypatch):
 @pytest.fixture()
 def no_plugins():
     patched = partial(ert.config.ert_config.ErtPluginManager, plugins=[])
-    with patch("ert.config.ert_config.ErtPluginManager", patched):
+    patched_everest = partial(
+        everest.config.everest_config.ErtPluginManager, plugins=[]
+    )
+    with (
+        patch("ert.config.ert_config.ErtPluginManager", patched),
+        patch("everest.config.everest_config.ErtPluginManager", patched_everest),
+    ):
         yield


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/10528


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
