### PR TITLE
Fix gui manual update validation

### DIFF
--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -52,7 +52,9 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         self._realizations_validator = EnsembleRealizationsArgument(
             self._ensemble_selector.selected_ensemble,
             max_value=ensemble_size,
-            required_realization_storage_state=RealizationStorageState.PARAMETERS_LOADED,
+            required_realization_storage_states=[
+                RealizationStorageState.PARAMETERS_LOADED
+            ],
         )
         self._active_realizations_field.setValidator(self._realizations_validator)
         self._realizations_from_fs()

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -77,7 +77,10 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         self._realizations_validator = EnsembleRealizationsArgument(
             self._ensemble_selector.selected_ensemble,
             max_value=ensemble_size,
-            required_realization_storage_state=RealizationStorageState.RESPONSES_LOADED,
+            required_realization_storage_states=[
+                RealizationStorageState.PARAMETERS_LOADED,
+                RealizationStorageState.RESPONSES_LOADED,
+            ],
         )
         self._active_realizations_field.setValidator(self._realizations_validator)
         self._realizations_from_fs()

--- a/src/ert/validation/ensemble_realizations_argument.py
+++ b/src/ert/validation/ensemble_realizations_argument.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from .range_string_argument import RangeStringArgument
@@ -18,13 +19,13 @@ class EnsembleRealizationsArgument(RangeStringArgument):
         self,
         ensemble: "Ensemble",
         max_value: int | None,
-        required_realization_storage_state: "RealizationStorageState",
+        required_realization_storage_states: Iterable["RealizationStorageState"],
         **kwargs: bool,
     ) -> None:
         super().__init__(max_value, **kwargs)
         self.__ensemble = ensemble
-        self._required_realization_storage_state: RealizationStorageState = (
-            required_realization_storage_state
+        self._required_realization_storage_states: Iterable[RealizationStorageState] = (
+            required_realization_storage_states
         )
 
     def set_ensemble(self, ensemble: "Ensemble") -> None:
@@ -40,7 +41,7 @@ class EnsembleRealizationsArgument(RangeStringArgument):
         found_realization_ids = [
             index
             for index, state in enumerate(self.__ensemble.get_ensemble_state())
-            if self._required_realization_storage_state in state
+            if set(self._required_realization_storage_states).issubset(state)
         ]
         for realization in attempted_realizations:
             if realization not in found_realization_ids:


### PR DESCRIPTION
**Issue**
There was an issue with the active realization validation for manual update, where the user was able to run manual update with only responses and no parameters. This caused a failure. 

**Approach**
This commit fixes the issue where there run button was enabled for ensembles where all realizations had `RealizationStorageState.RESPONSES_LOADED` when it also requires `RealizationStorageState.PARAMETERS_LOADED`.


(Screenshot of new behavior in GUI if applicable)

Uploading Screen Recording 2025-04-03 at 14.56.37.mov…



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
