### PR TITLE
Have gui notify user if high contrast mode is enabled

### DIFF
--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -4,17 +4,20 @@ import datetime
 import functools
 import webbrowser
 from pathlib import Path
+from typing import cast
 
 from PyQt6.QtCore import QCoreApplication, QEvent, QSize, Qt
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtGui import QAction, QCloseEvent, QCursor, QIcon, QMouseEvent
+from PyQt6.QtGui import QAction, QCloseEvent, QCursor, QIcon, QMouseEvent, QPalette
 from PyQt6.QtWidgets import (
+    QApplication,
     QButtonGroup,
     QFrame,
     QHBoxLayout,
     QMainWindow,
     QMenu,
+    QMessageBox,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -113,6 +116,18 @@ class ErtMainWindow(QMainWindow):
             self.side_frame.setStyleSheet("background-color: rgb(64, 64, 64);")
         else:
             self.side_frame.setStyleSheet("background-color: lightgray;")
+
+        if is_high_contrast_mode():
+            msg_box = QMessageBox()
+            msg_box.setText(
+                "High contrast mode detected. This is not supported by Ert and some features may not work as expected."
+            )
+            msg_box.setWindowTitle("Warning")
+            msg_box.setStyleSheet(
+                "QMessageBox {color: black; background-color: white;} QLabel {color: black;} QPushButton {color: black;}"
+            )
+            msg_box.update()
+            msg_box.exec()
 
         self.vbox_layout = QVBoxLayout(self.side_frame)
         self.side_frame.setLayout(self.vbox_layout)
@@ -380,3 +395,8 @@ class ErtMainWindow(QMainWindow):
     def __showAboutMessage(self) -> None:
         diag = AboutDialog(self)
         diag.show()
+
+
+def is_high_contrast_mode() -> bool:
+    app = cast(QWidget, QApplication.instance())
+    return app.palette().color(QPalette.ColorRole.Window).lightness() > 245


### PR DESCRIPTION
**Issue**
Resolves #10336 


**Approach**
This commit makes the gui emit a QMessageBox on startup, stating that the user has high contrast mode enabled, and that it is not by ert and some features might not work as expected.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/f1439a31-9db5-4f18-af44-96f1e9791b96)

The gui still looks like this, but the previous fix failed (e37a8389f144ef5f219e74d9aa8f6df1775dca6c), so this is the simplest solution for now. 
![image](https://github.com/user-attachments/assets/2f402d5b-573a-4094-9df9-b3272a9c256a)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
