### PR TITLE
Remove experiment-type column from Manage experiments

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_model.py
+++ b/src/ert/gui/tools/manage_experiments/storage_model.py
@@ -92,7 +92,6 @@ class ExperimentModel:
         self._parent = parent
         self._id = experiment.id
         self._name = experiment.name
-        self._experiment_type = experiment.metadata.get("ensemble_type")
         self._children: list[EnsembleModel] = []
 
     def add_ensemble(self, ensemble: EnsembleModel) -> None:

--- a/src/ert/gui/tools/manage_experiments/storage_model.py
+++ b/src/ert/gui/tools/manage_experiments/storage_model.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import humanize
 from PyQt6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QApplication
 from typing_extensions import override
 
 from ert.storage import Ensemble, Experiment, Storage
@@ -14,14 +13,12 @@ from ert.storage import Ensemble, Experiment, Storage
 class _Column(IntEnum):
     NAME = 0
     TIME = 1
-    TYPE = 2
 
 
 _NUM_COLUMNS = max(_Column).value + 1
 _COLUMN_TEXT = {
     0: "Name",
     1: "Created at",
-    2: "Type",
 }
 
 
@@ -122,13 +119,6 @@ class ExperimentModel:
                     if self._children
                     else "None"
                 )
-            if col == _Column.TYPE:
-                return self._experiment_type or "None"
-        elif role == Qt.ItemDataRole.ForegroundRole:
-            if col == _Column.TYPE and not self._experiment_type:
-                qapp = QApplication.instance()
-                assert isinstance(qapp, QApplication)
-                return qapp.palette().mid()
 
         return None
 


### PR DESCRIPTION
Ref discussion in #10470
The ForegroundRole conditional statement's purpose is to get a specific color from the palette for the type column when experiment_type is undefined.

**Issue**
Resolves #10470 


**Approach**

As the issue discussion concluded in removing the column, my approach was to:

- Find and remove definition of the Type column
- Remove code which references and depends to the Type property of the class being present

GUI before:

![image](https://github.com/user-attachments/assets/46ea515c-8216-40d7-bdbf-ac55133693d0)

GUI after:

![image](https://github.com/user-attachments/assets/221fce3f-9ef5-411b-b44a-e7f3b79138f5)



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
