### PR TITLE
Revert some of "Add import safety to CLI execution in restricted environments"

### DIFF
--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -33,6 +33,10 @@ jobs:
         fetch-depth: 0
         filter: tree:0
 
+    - uses: ./.github/actions/install_dependencies_qt
+      with:
+        os: ${{ matrix.os }}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -46,7 +50,6 @@ jobs:
 
     - name: Install ERT and dependencies
       run: |
-        # it should be possible to run this test without needing any qt dependencies
         uv sync
 
     - name: Test poly example

--- a/.github/workflows/test_ert_with_flow.yml
+++ b/.github/workflows/test_ert_with_flow.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: ./.github/actions/install_dependencies_qt
+      with:
+        os: ${{ inputs.os }}
+
     - uses: actions/setup-python@v5
       id: setup_python
       with:
@@ -31,7 +35,6 @@ jobs:
 
     - name: Install ert and everest
       run: |
-        # it should be possible to run this test without needing any qt dependencies
         uv sync --extra everest --extra dev
         uv pip install git+https://github.com/equinor/everest-models
 
@@ -50,7 +53,7 @@ jobs:
     - name: Run integration tests towards OPM flow without flowrun
       run: |
         set -e
-        uv run pytest tests/ert/unit_tests/resources/test_run_flow_simulator.py -p no:pytest-qt
+        uv run pytest tests/ert/unit_tests/resources/test_run_flow_simulator.py
 
     - name: Run Ert on an example configuration with flow
       run: |

--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: ./.github/actions/install_dependencies_qt
+      with:
+        os: ${{ inputs.os }}
+
     - uses: actions/setup-python@v5
       id: setup_python
       with:
@@ -31,7 +35,6 @@ jobs:
 
     - name: Install ert
       run: |
-        # it should be possible to run this test without needing any qt dependencies
         uv sync --extra dev
 
     - name: Install and setup slurm
@@ -84,11 +87,11 @@ jobs:
       run: |
         set -e
         export _ERT_TESTS_ALTERNATIVE_QUEUE=AlternativeQ
-        uv run pytest tests/ert/unit_tests/scheduler/test_{generic,slurm}_driver.py -sv -p no:pytest-qt --slurm \
+        uv run pytest tests/ert/unit_tests/scheduler/test_{generic,slurm}_driver.py -sv --slurm \
           -n 8 --durations=10 -k "not (LsfDriver or LocalDriver or OpenPBSDriver)"
         scontrol show job
 
-        uv run pytest tests/ert/ui_tests/cli/test_missing_runpath.py -p no:pytest-qt --slurm
+        uv run pytest tests/ert/ui_tests/cli/test_missing_runpath.py --slurm
 
     - name: Test poly-example on slurm
       run: |

--- a/src/ert/plugins/hook_implementations/workflows/gen_data_rft_export.py
+++ b/src/ert/plugins/hook_implementations/workflows/gen_data_rft_export.py
@@ -4,17 +4,15 @@ import contextlib
 import json
 import os
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import polars as pl
+from PyQt6.QtWidgets import QWidget
 
 from ert.plugins import CancelPluginException, ErtPlugin
 from ert.storage import Storage
-
-if TYPE_CHECKING:
-    from PyQt6.QtWidgets import QWidget
 
 
 def load_args(filename: str, column_names: list[str] | None = None) -> pd.DataFrame:


### PR DESCRIPTION
Puts the libegl install back in workflows, and restores code causing GUI to segfault in gendata rft export view to its previous state