### PR TITLE
Upgrade pre-commits 0.11.1 -> 0.11.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         exclude: test-data/ert/eclipse/parse/ERROR.PRT # exact format is needed for testing
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.1
+    rev: v0.11.4
     hooks:
     - id: ruff
       args: [ --fix ]

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -157,17 +157,19 @@ async def test_job_run_sends_expected_events(
 
     await assert_scheduler_events(
         scheduler,
-        (
-            [
-                JobState.WAITING,
-                JobState.SUBMITTING,
-                JobState.PENDING,
-                JobState.RUNNING,
-                JobState.RESUBMITTING,
-            ]
-            * max_submit
-        )[:-1]
-        + [expected_final_event],
+        [
+            *(
+                [
+                    JobState.WAITING,
+                    JobState.SUBMITTING,
+                    JobState.PENDING,
+                    JobState.RUNNING,
+                    JobState.RESUBMITTING,
+                ]
+                * max_submit
+            )[:-1],
+            expected_final_event,
+        ],
     )
     scheduler.driver.submit.assert_called_with(
         realization.iens,


### PR DESCRIPTION

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
