### PR TITLE
[Backport version-14.1] Catch exceptions from unmatched quotes in config

### DIFF
--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -4,7 +4,15 @@ import os
 import os.path
 from typing import Self
 
-from lark import Discard, Lark, Token, Transformer, Tree, UnexpectedToken
+from lark import (
+    Discard,
+    Lark,
+    Token,
+    Transformer,
+    Tree,
+    UnexpectedCharacters,
+    UnexpectedToken,
+)
 
 from ._read_file import read_file
 from .config_dict import ConfigDict
@@ -424,6 +432,22 @@ def _parse_contents(content: str, file: str) -> Tree[Instruction]:
         unexpected_token = e.token
         allowed = e.expected
         message = f"Did not expect token: {unexpected_token}. Expected one of {allowed}"
+        raise ConfigValidationError.from_info(
+            ErrorInfo(
+                message=message,
+                line=e.line,
+                end_line=e.line + 1,
+                column=e.column,
+                end_column=e.column + 1,
+                filename=file,
+            )
+        ) from e
+    except UnexpectedCharacters as e:
+        unexpected_char = e.char
+        allowed = e.allowed
+        message = (
+            f"Did not expect character: {unexpected_char}. Expected one of {allowed}"
+        )
         raise ConfigValidationError.from_info(
             ErrorInfo(
                 message=message,

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -414,6 +414,19 @@ def test_that_quotations_in_forward_model_arglist_are_handled_correctly():
     assert res_config.forward_model_steps[2].private_args["<FILE>"] == "file.txt"
 
 
+@pytest.mark.parametrize("quote_mismatched_arg", ['"A', 'A"', '"A""', '"'])
+def test_unmatched_quotes_in_step_arg_gives_config_validation_error(
+    quote_mismatched_arg,
+):
+    with pytest.raises(ConfigValidationError, match="Did not expect character"):
+        ErtConfig.with_plugins().from_file_contents(
+            f"""
+            NUM_REALIZATIONS 1
+            FORWARD_MODEL COPY_FILE(<FROM>={quote_mismatched_arg})
+            """
+        )
+
+
 def test_that_positional_forward_model_args_gives_config_validation_error():
     with pytest.raises(ConfigValidationError, match="Did not expect token: <IENS>"):
         _ = ErtConfig.from_file_contents(


### PR DESCRIPTION
# Description
Backport of #10570 to `version-14.1`.