### PR TITLE
Add subprocess exception handling

### DIFF
--- a/src/ert/resources/forward_models/run_reservoirsimulator.py
+++ b/src/ert/resources/forward_models/run_reservoirsimulator.py
@@ -422,7 +422,7 @@ def run_reservoirsimulator(args: list[str]) -> None:
                 forwarded_args=forwarded_args,
             ).run_flow()
 
-    except EclError as msg:
+    except (EclError, subprocess.CalledProcessError) as msg:
         print(msg, file=sys.stderr)
         sys.exit(-1)
 


### PR DESCRIPTION
Before, given invalid .DATA, eclipse would throw uncaught subprocess.CalledProcessError, resulting in unintuitive traceback message for the user.

Resolves #10211 


**Approach**

- Edit polyexamble to run Eclipse on empty .DATA file to reproduce error
- Add additional exception found in traceback message
- Rerun polyexample and see the changes in stderr and gui message

**Before**

![image](https://github.com/user-attachments/assets/24545543-0ae2-449f-b462-5ce17731f202)
![image](https://github.com/user-attachments/assets/4343729e-e6fc-4f3e-a17b-e62bfa16641c)

**After**

![image](https://github.com/user-attachments/assets/0d278c97-b883-4532-a4a6-9ffb57d1ebb2)
![image](https://github.com/user-attachments/assets/ae3a8a89-76f4-4649-ab04-b6963fc80f01)

