### PR TITLE
Move imports to the top, and enforce it

### DIFF
--- a/docs/everest/conf.py
+++ b/docs/everest/conf.py
@@ -15,6 +15,11 @@ import os
 import sys
 from importlib import metadata
 
+from json_schema_for_humans.generate import generate_from_filename
+from json_schema_for_humans.generation_configuration import GenerationConfiguration
+
+from everest.config import EverestConfig
+
 sys.path.append(os.path.abspath("_ext"))
 
 # -- Project information -----------------------------------------------------
@@ -34,10 +39,6 @@ version = ".".join(dist_version.split(".")[:2])
 # The full version, including alpha/beta/rc tags
 release = dist_version
 
-from json_schema_for_humans.generate import generate_from_filename
-from json_schema_for_humans.generation_configuration import GenerationConfiguration
-
-from everest.config import EverestConfig
 
 config = GenerationConfiguration(
     copy_css=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
+    "E",     # pycodestyle
     "W",     # pycodestyle
     "I",     # isort
     "B",     # flake-8-bugbear
@@ -210,6 +211,7 @@ select = [
 ]
 preview = true
 ignore = [
+    "E501",    # line-too-long
     "FURB103", # write-hole-file
     "FURB101", # read-whole-file
     "G004",    # logging-f-string
@@ -241,6 +243,7 @@ allowed-confusables = ["–"]
 ]
 "src/ert/dark_storage/json_schema/__init__.py" = ["F401"]
 "src/ert/dark_storage/*" = ["RUF029"] # unused-async
+"*.ipynb" = ["E402"]
 
 
 [tool.ruff.lint.pylint]

--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandas.api.types import is_integer_dtype
 
 from ert.config.gen_kw_config import GenKwConfig, TransformFunctionDefinition
+from ert.shared.status.utils import convert_to_numeric
 
 from .parsing import ConfigValidationError, ErrorInfo
 
@@ -16,8 +17,6 @@ if TYPE_CHECKING:
     from ert.config import ParameterConfig
 
 DESIGN_MATRIX_GROUP = "DESIGN_MATRIX"
-
-from ert.shared.status.utils import convert_to_numeric
 
 
 @dataclass

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, no_type_check
 
+import polars as pl
+
 from ert.substitutions import substitute_runpath_name
 
 from ._read_summary import read_summary
@@ -15,7 +17,6 @@ from .response_config import InvalidResponseFile, ResponseConfig
 from .responses_index import responses_index
 
 logger = logging.getLogger(__name__)
-import polars as pl
 
 
 @dataclass

--- a/src/ert/gui/ertwidgets/__init__.py
+++ b/src/ert/gui/ertwidgets/__init__.py
@@ -6,20 +6,6 @@ from typing import Any
 from collections.abc import Callable
 
 
-def showWaitCursorWhileWaiting(func: Callable[..., Any]) -> Callable[..., Any]:
-    """A function decorator to show the wait cursor while the function is working."""
-
-    def wrapper(*arg: Any) -> Any:
-        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
-        try:
-            res = func(*arg)
-            return res
-        finally:
-            QApplication.restoreOverrideCursor()
-
-    return wrapper
-
-
 from .closabledialog import ClosableDialog
 from .analysismoduleedit import AnalysisModuleEdit
 from .searchbox import SearchBox
@@ -41,6 +27,21 @@ from .models import (
 from .copyablelabel import CopyableLabel
 from .message_box import ErtMessageBox
 from .copy_button import CopyButton
+
+
+def showWaitCursorWhileWaiting(func: Callable[..., Any]) -> Callable[..., Any]:
+    """A function decorator to show the wait cursor while the function is working."""
+
+    def wrapper(*arg: Any) -> Any:
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
+        try:
+            res = func(*arg)
+            return res
+        finally:
+            QApplication.restoreOverrideCursor()
+
+    return wrapper
+
 
 __all__ = [
     "ActiveRealizationsModel",

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -9,9 +9,20 @@ from httpx import RequestError
 from pandas import DataFrame
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QDockWidget, QMainWindow, QTabWidget, QWidget
+from PyQt6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QDockWidget,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
-from ert.gui.ertwidgets import showWaitCursorWhileWaiting
+from ert.gui.ertwidgets import CopyButton, showWaitCursorWhileWaiting
 from ert.utils import log_duration
 
 from .customize import PlotCustomizer
@@ -42,18 +53,8 @@ RESPONSE_DEFAULT = 0
 GEN_KW_DEFAULT = 2
 STD_DEV_DEFAULT = 6
 
+
 logger = logging.getLogger(__name__)
-
-from PyQt6.QtWidgets import (
-    QApplication,
-    QDialog,
-    QHBoxLayout,
-    QLabel,
-    QTextEdit,
-    QVBoxLayout,
-)
-
-from ert.gui.ertwidgets import CopyButton
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/ert/gui/tools/plot/plottery/__init__.py
+++ b/src/ert/gui/tools/plot/plottery/__init__.py
@@ -1,4 +1,4 @@
-# isort: skip_file
+# ruff: noqa: E402
 
 # At least for some combinations of pandas and matplotlib the numpy.datetime64
 # dates coming from pandas are not correctly recognized/converted by matplotlib.
@@ -7,12 +7,12 @@ from pandas.plotting import register_matplotlib_converters
 
 register_matplotlib_converters()
 
-from .plot_style import PlotStyle
-from .plot_limits import PlotLimits
 from .plot_config import PlotConfig
-from .plot_context import PlotContext
-from .plot_config_history import PlotConfigHistory
 from .plot_config_factory import PlotConfigFactory
+from .plot_config_history import PlotConfigHistory
+from .plot_context import PlotContext
+from .plot_limits import PlotLimits
+from .plot_style import PlotStyle
 
 __all__ = [
     "PlotConfig",

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -12,9 +13,6 @@ from ert.services._base_service import BaseService, _Context, local_exec_args
 from ert.trace import get_traceparent
 
 HTTPXClientInstrumentor().instrument()
-
-
-import os
 
 
 class StorageService(BaseService):

--- a/src/ert/shared/__init__.py
+++ b/src/ert/shared/__init__.py
@@ -6,6 +6,8 @@ except ImportError:
 import importlib.util
 from pathlib import Path
 
+from .net_utils import find_available_socket, get_machine_name
+
 
 def ert_share_path() -> str:
     spec = importlib.util.find_spec("ert.shared")
@@ -15,7 +17,5 @@ def ert_share_path() -> str:
     assert spec_origin
     return str(Path(spec_origin).parent.parent / "resources")
 
-
-from .net_utils import find_available_socket, get_machine_name
 
 __all__ = ["__version__", "ert_share_path", "find_available_socket", "get_machine_name"]

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import xarray as xr
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -28,8 +29,6 @@ if TYPE_CHECKING:
     from ert.storage.local_storage import LocalStorage
 
 logger = logging.getLogger(__name__)
-
-import polars as pl
 
 
 class EverestRealizationInfo(TypedDict):

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 from ert.config import ExtParamConfig, Field, GenKwConfig, ResponseConfig, SurfaceConfig
 from ert.config.parsing.context_values import ContextBoolEncoder
+from ert.config.responses_index import responses_index
 from ert.storage.mode import BaseMode, Mode, require_write
 
 if TYPE_CHECKING:
@@ -28,8 +29,6 @@ _KNOWN_PARAMETER_TYPES = {
     Field.__name__: Field,
     ExtParamConfig.__name__: ExtParamConfig,
 }
-
-from ert.config.responses_index import responses_index
 
 
 class _Index(BaseModel):

--- a/src/ert/substitutions.py
+++ b/src/ert/substitutions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import UserDict
 from collections.abc import Mapping
 from typing import Any
 
@@ -11,9 +12,6 @@ from pydantic_core import core_schema
 
 logger = logging.getLogger(__name__)
 _PATTERN = re.compile(r"<[^<>]+>")
-
-
-from collections import UserDict
 
 
 class Substitutions(UserDict[str, str]):

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -7,9 +7,9 @@ import pytest
 from ert.config import ErtConfig
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
+from tests.ert.ui_tests.cli.run_cli import run_cli
 
 random_seed_line = "RANDOM_SEED 1234\n\n"
-from tests.ert.ui_tests.cli.run_cli import run_cli
 
 
 def run_cli_ES_with_case(poly_config):

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -31,6 +31,7 @@ from ert.mode_definitions import (
     ES_MDA_MODE,
     TEST_RUN_MODE,
 )
+from ert.scheduler.driver import Driver
 from ert.scheduler.job import Job
 from ert.storage import open_storage
 
@@ -712,9 +713,6 @@ def test_exclude_parameter_from_update():
     assert log_paths
     assert (log_paths[0] / "Report.report").exists()
     assert (log_paths[0] / "Report.csv").exists()
-
-
-from ert.scheduler.driver import Driver
 
 
 @pytest.mark.timeout(15)

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -1,11 +1,12 @@
-from __future__ import annotations
-
 """
 The following test generates different kind of parameters
 and places their configuration in the config file. Then an
 ensemble experiment is ran and we assert that each realization
 was passed the parameters correctly in the runpath.
 """
+
+from __future__ import annotations
+
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime

--- a/tests/ert/ui_tests/gui/test_csv_export.py
+++ b/tests/ert/ui_tests/gui/test_csv_export.py
@@ -15,6 +15,7 @@ from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.export.export_panel import ExportDialog
 from ert.libres_facade import LibresFacade
 from ert.run_models import EnsembleExperiment
+from ert.storage import open_storage
 
 from .conftest import get_child, wait_for_child
 
@@ -104,9 +105,6 @@ def run_experiment_via_gui(gui, qtbot):
     run_dialog = wait_for_child(gui, qtbot, RunDialog)
     qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=20000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-
-
-from ert.storage import open_storage
 
 
 def test_that_export_tool_does_not_produce_duplicate_data(

--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -1,3 +1,4 @@
+from array import array
 from datetime import datetime, timedelta
 from itertools import zip_longest
 
@@ -357,9 +358,6 @@ def test_empty_keywords_in_summary_files_raises_informative_errors(tmp_path):
 
     with pytest.raises(InvalidResponseFile, match="Got empty summary keyword"):
         read_summary(str(tmp_path / "test"), ["*"])
-
-
-from array import array
 
 
 def test_missing_names_keywords_in_summary_files_raises_informative_errors(

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -6,6 +6,7 @@ from functools import partial
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi.encoders import jsonable_encoder
 from websockets.sync.client import ClientConnection
 
 import everest
@@ -26,9 +27,6 @@ METADATA = EnsembleSnapshotMetadata(
     sorted_real_ids=[],
     sorted_fm_step_ids=defaultdict(list),
 )
-
-
-from fastapi.encoders import jsonable_encoder
 
 
 @pytest.fixture


### PR DESCRIPTION
**Issue**
Resolves import statements not being at the top of the source code.


**Approach**
🚚 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
