### PR TITLE
Backport to Version 14.0

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -151,7 +151,7 @@ class DesignMatrix:
                 raise ConfigValidationError(
                     "Overlapping parameter names found in design matrix!\n"
                     f"{DESIGN_MATRIX_GROUP}:{design_keys}\n{parameter_group.name}:{existing_keys}"
-                    "\nThey need to much exactly or not at all."
+                    "\nThey need to match exactly or not at all."
                 )
             else:
                 new_param_config += [parameter_group]

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QFormLayout, QHBoxLayout, QLabel, QPushButton, QWidget
+from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
 
-from ert.config import AnalysisConfig, DesignMatrix
+from ert.config import AnalysisConfig
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import (
     ActiveRealizationsModel,
@@ -15,8 +15,7 @@ from ert.gui.ertwidgets import (
 from ert.gui.tools.design_matrix.design_matrix_panel import DesignMatrixPanel
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE
 from ert.run_models import EnsembleExperiment
-from ert.validation import ActiveRange, RangeStringArgument, RangeSubsetStringArgument
-from ert.validation.proper_name_argument import ExperimentValidation, ProperNameArgument
+from ert.validation import ExperimentValidation, ProperNameArgument, RangeStringArgument
 
 from .experiment_config_panel import ExperimentConfigPanel
 
@@ -37,8 +36,8 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         run_path: str,
         notifier: ErtNotifier,
     ):
-        self.notifier = notifier
         super().__init__(EnsembleExperiment)
+        self.notifier = notifier
         self.setObjectName("Ensemble_experiment_panel")
 
         layout = QFormLayout()
@@ -85,25 +84,11 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
 
         design_matrix = analysis_config.design_matrix
         if design_matrix is not None:
-            self._active_realizations_field.setText(
-                ActiveRange(design_matrix.active_realizations).rangestring
-            )
-            self._active_realizations_field.setValidator(
-                RangeSubsetStringArgument(
-                    ActiveRange(design_matrix.active_realizations)
-                )
-            )
-            show_dm_param_button = QPushButton("Show parameters")
-            show_dm_param_button.setObjectName("show-dm-parameters")
-            show_dm_param_button.setMinimumWidth(50)
-
-            button_layout = QHBoxLayout()
-            button_layout.addWidget(show_dm_param_button)
-            button_layout.addStretch()  # Add stretch to push the button to the left
-
-            layout.addRow("Design Matrix", button_layout)
-            show_dm_param_button.clicked.connect(
-                lambda: self.on_show_dm_params_clicked(design_matrix)
+            layout.addRow(
+                "Design Matrix",
+                DesignMatrixPanel.get_design_matrix_button(
+                    self._active_realizations_field, design_matrix
+                ),
             )
 
         self.setLayout(layout)
@@ -119,16 +104,6 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         )
 
         self.notifier.ertChanged.connect(self._update_experiment_name_placeholder)
-
-    def on_show_dm_params_clicked(self, design_matrix: DesignMatrix) -> None:
-        viewer = DesignMatrixPanel(
-            design_matrix.design_matrix_df,
-            design_matrix.xls_filename.name,
-        )
-        viewer.setMinimumHeight(500)
-        viewer.setMinimumWidth(1000)
-        viewer.adjustSize()
-        viewer.exec()
 
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 
 import numpy as np
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QFormLayout, QLabel
+from PyQt6.QtCore import pyqtSlot as Slot
+from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import (
@@ -91,3 +92,8 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
                 parameters, np.logical_or(missing_responses, failures)
             )
             self._active_realizations_field.model.setValueFromMask(mask)  # type: ignore
+
+    @Slot(QWidget)
+    def experimentTypeChanged(self, w: QWidget) -> None:
+        if isinstance(w, EvaluateEnsemblePanel):
+            self._realizations_from_fs()

--- a/src/ert/gui/simulation/experiment_config_panel.py
+++ b/src/ert/gui/simulation/experiment_config_panel.py
@@ -14,7 +14,7 @@ class ExperimentConfigPanel(QWidget):
     simulationConfigurationChanged = Signal()
 
     def __init__(self, simulation_model: type[BaseRunModel]):
-        QWidget.__init__(self)
+        super().__init__()
         self.setContentsMargins(10, 10, 10, 10)
         self.__simulation_model = simulation_model
 

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 
 import numpy as np
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QFormLayout, QLabel
+from PyQt6.QtCore import pyqtSlot as Slot
+from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
 
 from ert.config import AnalysisConfig
 from ert.gui.ertnotifier import ErtNotifier
@@ -113,3 +114,8 @@ class ManualUpdatePanel(ExperimentConfigPanel):
             responses = ensemble.get_realization_mask_with_responses()
             mask = np.logical_and(parameters, responses)
             self._active_realizations_field.model.setValueFromMask(mask)  # type: ignore
+
+    @Slot(QWidget)
+    def experimentTypeChanged(self, w: QWidget) -> None:
+        if isinstance(w, ManualUpdatePanel):
+            self._realizations_from_fs()

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -18,14 +18,15 @@ from ert.gui.ertwidgets import (
     TextModel,
     ValueModel,
 )
+from ert.gui.tools.design_matrix.design_matrix_panel import DesignMatrixPanel
 from ert.mode_definitions import ES_MDA_MODE
 from ert.run_models import MultipleDataAssimilation
 from ert.validation import (
+    ExperimentValidation,
     NumberListStringArgument,
     ProperNameFormatArgument,
     RangeStringArgument,
 )
-from ert.validation.proper_name_argument import ExperimentValidation
 
 from .experiment_config_panel import ExperimentConfigPanel
 
@@ -53,7 +54,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         notifier: ErtNotifier,
         ensemble_size: int,
     ) -> None:
-        ExperimentConfigPanel.__init__(self, MultipleDataAssimilation)
+        super().__init__(MultipleDataAssimilation)
         self.notifier = notifier
 
         layout = QFormLayout()
@@ -134,6 +135,15 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._relative_iteration_weights_box.getValidationSupport().validationChanged.connect(
             self.simulationConfigurationChanged
         )
+
+        design_matrix = analysis_config.design_matrix
+        if design_matrix is not None:
+            layout.addRow(
+                "Design Matrix",
+                DesignMatrixPanel.get_design_matrix_button(
+                    self._active_realizations_field, design_matrix
+                ),
+            )
 
         self.setLayout(layout)
 
@@ -271,7 +281,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
 
 class _ActiveLabel(QLabel):
     def __init__(self, model: ValueModel) -> None:
-        QLabel.__init__(self)
+        super().__init__()
 
         self._model = model
 

--- a/src/ert/gui/tools/design_matrix/design_matrix_panel.py
+++ b/src/ert/gui/tools/design_matrix/design_matrix_panel.py
@@ -1,6 +1,21 @@
+from typing import TYPE_CHECKING
+
 import pandas as pd
 from PyQt6.QtGui import QStandardItem, QStandardItemModel
-from PyQt6.QtWidgets import QDialog, QTableView, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QPushButton,
+    QTableView,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ert.gui.ertwidgets.stringbox import StringBox
+from ert.validation import ActiveRange, RangeSubsetStringArgument
+
+if TYPE_CHECKING:
+    from ert.config.design_matrix import DesignMatrix
 
 
 class DesignMatrixPanel(QDialog):
@@ -30,15 +45,13 @@ class DesignMatrixPanel(QDialog):
 
     @staticmethod
     def create_model(design_matrix_df: pd.DataFrame) -> QStandardItemModel:
-        model = QStandardItemModel()
-
         if isinstance(design_matrix_df.columns, pd.MultiIndex):
             header_labels = [str(col[-1]) for col in design_matrix_df.columns]
         else:
             header_labels = design_matrix_df.columns.astype(str).tolist()
 
+        model = QStandardItemModel()
         model.setHorizontalHeaderLabels(header_labels)
-
         for index, _ in design_matrix_df.iterrows():
             items = [
                 QStandardItem(str(design_matrix_df.at[index, col]))
@@ -46,3 +59,38 @@ class DesignMatrixPanel(QDialog):
             ]
             model.appendRow(items)
         return model
+
+    @staticmethod
+    def show_dm_params(design_matrix: "DesignMatrix") -> None:
+        viewer = DesignMatrixPanel(
+            design_matrix.design_matrix_df,
+            design_matrix.xls_filename.name,
+        )
+        viewer.setMinimumHeight(500)
+        viewer.setMinimumWidth(1000)
+        viewer.adjustSize()
+        viewer.exec()
+
+    @staticmethod
+    def get_design_matrix_button(
+        active_realizations_field: StringBox, design_matrix: "DesignMatrix"
+    ) -> QHBoxLayout:
+        active_realizations_field.setText(
+            ActiveRange(design_matrix.active_realizations).rangestring
+        )
+        active_realizations_field.setValidator(
+            RangeSubsetStringArgument(ActiveRange(design_matrix.active_realizations))
+        )
+        show_dm_param_button = QPushButton("Show parameters")
+        show_dm_param_button.setObjectName("show-dm-parameters")
+        show_dm_param_button.setMinimumWidth(50)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(show_dm_param_button)
+        button_layout.addStretch()  # Add stretch to push the button to the left
+
+        show_dm_param_button.clicked.connect(
+            lambda: DesignMatrixPanel.show_dm_params(design_matrix)
+        )
+
+        return button_layout

--- a/src/ert/gui/tools/design_matrix/design_matrix_panel.py
+++ b/src/ert/gui/tools/design_matrix/design_matrix_panel.py
@@ -75,11 +75,11 @@ class DesignMatrixPanel(QDialog):
     def get_design_matrix_button(
         active_realizations_field: StringBox, design_matrix: "DesignMatrix"
     ) -> QHBoxLayout:
-        active_realizations_field.setText(
-            ActiveRange(design_matrix.active_realizations).rangestring
-        )
         active_realizations_field.setValidator(
             RangeSubsetStringArgument(ActiveRange(design_matrix.active_realizations))
+        )
+        active_realizations_field.model.setValueFromMask(  # type: ignore
+            design_matrix.active_realizations
         )
         show_dm_param_button = QPushButton("Show parameters")
         show_dm_param_button.setObjectName("show-dm-parameters")

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -93,7 +93,7 @@ def _setup_single_test_run(
 
 def validate_minimum_realizations(config: ErtConfig, args: Namespace) -> None:
     min_realizations_count = config.analysis_config.minimum_required_realizations
-    active_realizations = _realizations(args, config.model_config.num_realizations)
+    active_realizations = _get_active_realizations_list(args, config)
     active_realizations_count = int(np.sum(active_realizations))
     if active_realizations_count < min_realizations_count:
         config.analysis_config.minimum_required_realizations = active_realizations_count

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -148,12 +148,18 @@ def _setup_evaluate_ensemble(
 
 
 def _get_active_realizations_list(args: Namespace, config: ErtConfig) -> list[bool]:
-    return (
-        config.analysis_config.design_matrix.active_realizations
-        if config.analysis_config.design_matrix is not None
+    ensemble_size = config.model_config.num_realizations
+    if (
+        config.analysis_config.design_matrix is not None
         and config.analysis_config.design_matrix.active_realizations is not None
-        else _realizations(args, config.model_config.num_realizations).tolist()
-    )
+    ):
+        if args.realizations is None:
+            return config.analysis_config.design_matrix.active_realizations
+        else:
+            ensemble_size = len(
+                config.analysis_config.design_matrix.active_realizations
+            )
+    return _realizations(args, ensemble_size).tolist()
 
 
 def _setup_manual_update(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -9,7 +9,8 @@ from uuid import UUID
 import numpy as np
 
 from ert.config import ErtConfig, ESSettings, HookRuntime, UpdateSettings
-from ert.enkf_main import sample_prior
+from ert.config.parsing.config_errors import ConfigValidationError
+from ert.enkf_main import sample_prior, save_design_matrix_to_ensemble
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.storage import Ensemble, Storage
 from ert.trace import tracer
@@ -50,6 +51,8 @@ class MultipleDataAssimilation(UpdateRunModel):
         status_queue: SimpleQueue[StatusEvents],
     ):
         self._relative_weights = weights
+        self._parameter_configuration = config.ensemble_config.parameter_configuration
+        self._design_matrix = config.analysis_config.design_matrix
         self.weights = self.parse_weights(weights)
 
         self.target_ensemble_format = target_ensemble
@@ -97,6 +100,18 @@ class MultipleDataAssimilation(UpdateRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
+
+        parameters_config = self._parameter_configuration
+        design_matrix = self._design_matrix
+        design_matrix_group = None
+        if design_matrix is not None:
+            try:
+                parameters_config, design_matrix_group = (
+                    design_matrix.merge_with_existing_parameters(parameters_config)
+                )
+            except ConfigValidationError as exc:
+                raise ErtRunError(str(exc)) from exc
+
         self.restart = restart
         if self.restart_run:
             id = self.prior_ensemble_id
@@ -123,7 +138,8 @@ class MultipleDataAssimilation(UpdateRunModel):
             )
             sim_args = {"weights": self._relative_weights}
             experiment = self._storage.create_experiment(
-                parameters=self._parameter_configuration,
+                parameters=parameters_config
+                + ([design_matrix_group] if design_matrix_group else []),
                 observations=self._observations,
                 responses=self._response_configuration,
                 simulation_arguments=sim_args,
@@ -149,6 +165,14 @@ class MultipleDataAssimilation(UpdateRunModel):
                 np.where(self.active_realizations)[0],
                 random_seed=self.random_seed,
             )
+
+            if design_matrix_group is not None and design_matrix is not None:
+                save_design_matrix_to_ensemble(
+                    design_matrix.design_matrix_df,
+                    prior,
+                    np.where(self.active_realizations)[0],
+                    design_matrix_group.name,
+                )
             self._evaluate_and_postprocess(
                 prior_args,
                 prior,

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -4,12 +4,15 @@ import multiprocessing
 import os
 import resource
 import shutil
+import stat
 import sys
 from argparse import ArgumentParser
 from importlib.resources import files
 from pathlib import Path
+from textwrap import dedent
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 from hypothesis import HealthCheck, settings
 from hypothesis import strategies as st
@@ -184,11 +187,79 @@ def fixture_copy_case(tmp_path_factory, source_root, monkeypatch):
     yield _copy_case
 
 
+def _create_design_matrix(filename, design_sheet_df, default_sheet_df=None):
+    with pd.ExcelWriter(filename) as xl_write:
+        design_sheet_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
+        if default_sheet_df is not None:
+            default_sheet_df.to_excel(
+                xl_write, index=False, sheet_name="DefaultSheet", header=False
+            )
+
+
 @pytest.fixture()
 def copy_poly_case(copy_case):
     copy_case("poly_example")
     with open("poly.ert", "a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 12\n")
+
+
+@pytest.fixture()
+def copy_poly_case_with_design_matrix(copy_case):
+    def _create_poly_design_case(design_dict, default_list):
+        copy_case("poly_example")
+        num_realizations = len(design_dict["REAL"])
+        _create_design_matrix(
+            "poly_design.xlsx",
+            pd.DataFrame(design_dict),
+            pd.DataFrame(default_list),
+        )
+        with open("poly.ert", "w", encoding="utf-8") as fout:
+            fout.write(
+                dedent(
+                    f"""\
+                    QUEUE_OPTION LOCAL MAX_RUNNING 10
+                    RUNPATH poly_out/realization-<IENS>/iter-<ITER>
+                    NUM_REALIZATIONS {num_realizations}
+                    MIN_REALIZATIONS 1
+                    GEN_DATA POLY_RES RESULT_FILE:poly.out
+                    DESIGN_MATRIX poly_design.xlsx DESIGN_SHEET:DesignSheet DEFAULT_SHEET:DefaultSheet
+                    INSTALL_JOB poly_eval POLY_EVAL
+                    FORWARD_MODEL poly_eval
+                    """
+                )
+            )
+
+        with open("poly_eval.py", "w", encoding="utf-8") as f:
+            f.write(
+                dedent(
+                    """\
+                    #!/usr/bin/env python
+                    import json
+
+                    def _load_coeffs(filename):
+                        with open(filename, encoding="utf-8") as f:
+                            return json.load(f)["DESIGN_MATRIX"]
+
+                    def _evaluate(coeffs, x):
+                        return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+
+                    if __name__ == "__main__":
+                        coeffs = _load_coeffs("parameters.json")
+                        output = [_evaluate(coeffs, x) for x in range(10)]
+                        with open("poly.out", "w", encoding="utf-8") as f:
+                            f.write("\\n".join(map(str, output)))
+                    """
+                )
+            )
+        os.chmod(
+            "poly_eval.py",
+            os.stat("poly_eval.py").st_mode
+            | stat.S_IXUSR
+            | stat.S_IXGRP
+            | stat.S_IXOTH,
+        )
+
+    return _create_poly_design_case
 
 
 @pytest.fixture()

--- a/tests/ert/unit_tests/cli/test_model_hook_order.py
+++ b/tests/ert/unit_tests/cli/test_model_hook_order.py
@@ -168,6 +168,7 @@ def test_hook_call_order_es_mda(monkeypatch):
     test_class._storage = storage_mock
     test_class.restart_run = False
     test_class.run_ensemble_evaluator = MagicMock(return_value=[0])
+    test_class._design_matrix = None
     test_class.run_experiment(MagicMock())
 
     assert run_wfs_mock.mock_calls == EXPECTED_CALL_ORDER


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
This fixes the issue on 14.0 where ensemble experiment refuses to use specified realizations, and uses all realizations instead. Verified locally. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
