### PR TITLE
Backport: Fix issue where tooltip was not possible on realization visuals

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 UserRole = Qt.ItemDataRole.UserRole
 NodeRole = UserRole + 1
 FMStepColorHint = UserRole + 2
-RealLabelHint = UserRole + 4
 ProgressRole = UserRole + 5
 FileRole = UserRole + 6
 RealIens = UserRole + 7
@@ -365,8 +364,6 @@ class SnapshotModel(QAbstractItemModel):
 
             queue_color = node.data.real_status_color
             return queue_color, finished_count, total_count
-        if role == RealLabelHint:
-            return node.id_
         if role == RealIens:
             return node.id_
         if role == IterNum:

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -6,12 +6,12 @@ from PyQt6.QtCore import (
     QItemSelectionModel,
     QModelIndex,
     QObject,
-    QPointF,
+    QPoint,
     QSize,
     Qt,
 )
 from PyQt6.QtCore import pyqtSignal as Signal
-from PyQt6.QtGui import QColor, QMouseEvent, QPainter, QPalette, QPen
+from PyQt6.QtGui import QColor, QHelpEvent, QPainter, QPalette, QPen
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QListView,
@@ -28,7 +28,7 @@ from ert.gui.model.snapshot import (
     CallbackStatusMessageRole,
     FMStepColorHint,
     MemoryUsageRole,
-    RealLabelHint,
+    RealIens,
 )
 from ert.shared.status.utils import byte_with_unit
 
@@ -96,7 +96,7 @@ class RealizationDelegate(QStyledItemDelegate):
         super().__init__(parent)
         self._size = size
         parent.installEventFilter(self)
-        self.adjustment_point_for_job_rect_margin = QPointF(-20, -20)
+        self.adjustment_point_for_job_rect_margin = QPoint(-20, -20)
         self._color_black = QColor(0, 0, 0, 180)
         self._color_progress = QColor(50, 173, 230, 200)
         self._color_lightgray = QColor("LightGray").lighter(120)
@@ -107,7 +107,7 @@ class RealizationDelegate(QStyledItemDelegate):
     ) -> None:
         if painter is None:
             return
-        text = index.data(RealLabelHint)
+        text = index.data(RealIens)
         selected_color, finished_count, total_count = tuple(index.data(FMStepColorHint))
 
         painter.save()
@@ -154,10 +154,8 @@ class RealizationDelegate(QStyledItemDelegate):
         return self._size
 
     def eventFilter(self, object: QObject | None, event: QEvent | None) -> bool:
-        if event and event.type() == QEvent.Type.ToolTip and type(event) is QMouseEvent:
-            mouse_pos = (
-                event.position() + self.adjustment_point_for_job_rect_margin
-            ).toPoint()
+        if isinstance(event, QHelpEvent) and event.type() == QEvent.Type.ToolTip:
+            mouse_pos = event.pos() + self.adjustment_point_for_job_rect_margin
             parent: RealizationWidget = cast(RealizationWidget, self.parent())
             view = parent._real_view
             index = view.indexAt(mouse_pos)


### PR DESCRIPTION
Backport of 565b090a2dabd2854be56eac3eb3db000e266a91

* Replace RealLabelHint duplicate
* Show tooltips on hover realizations

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
