### PR TITLE
Fix error racecondition bug

### DIFF
--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -169,7 +169,7 @@ class File(Reporter):
 
     @staticmethod
     def _dump_error_file(fm_step, error_msg):
-        with open(ERROR_file, "a", encoding="utf-8") as file:
+        with open(ERROR_file, "w", encoding="utf-8") as file:
             file.write("<error>\n")
             file.write(
                 f"  <time>{time.strftime(TIME_FORMAT, time.localtime())}</time>\n"

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import os
 import socket
@@ -25,7 +24,6 @@ from _ert.forward_model_runner.util import data as data_util
 TIME_FORMAT = "%H:%M:%S"
 logger = logging.getLogger(__name__)
 memory_logger = logging.getLogger("_ert.forward_model_memory_profiler")
-append = functools.partial(open, mode="a")
 
 LOG_file = "JOB_LOG"
 ERROR_file = "ERROR"
@@ -128,7 +126,7 @@ class File(Reporter):
 
     @staticmethod
     def _write_status_file(msg: str) -> None:
-        with append(file=STATUS_file) as status_file:
+        with open(STATUS_file, "a", encoding="utf-8") as status_file:
             status_file.write(msg)
 
     def _init_status_file(self):
@@ -164,14 +162,14 @@ class File(Reporter):
 
     @staticmethod
     def _add_log_line(step):
-        with append(file=LOG_file) as f:
+        with open(LOG_file, "a", encoding="utf-8") as f:
             args = " ".join(step.step_data["argList"])
             time_str = time.strftime(TIME_FORMAT, time.localtime())
             f.write(f"{time_str}  Calling: {step.step_data['executable']} {args}\n")
 
     @staticmethod
     def _dump_error_file(fm_step, error_msg):
-        with append(ERROR_file) as file:
+        with open(ERROR_file, "a", encoding="utf-8") as file:
             file.write("<error>\n")
             file.write(
                 f"  <time>{time.strftime(TIME_FORMAT, time.localtime())}</time>\n"


### PR DESCRIPTION
**Issue**
Resolves #9366 


**Approach**

- Reproducing this error was troublesome and confusing at first.
- We figured out the error was due to a racecondition between different job submissions, where each submission is supposed to delete the ERROR file. However, this is not always done if the first submission is still writing when the new submission starts up. This happens in some cases and is difficult to reproduce.
- Why this happens is because the code appends text to the ERROR message. 
- We found this to be unnecessary, and that it should be changed to (over)writing the ERROR file instead of appending.
- Along the way, we also found an unnecessary alias for open() in append mode, which we found confusing. We chose to remove this in the same go.

