### PR TITLE
Refactor max_batch_num handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,8 +140,8 @@ everest = [
     "decorator",
     "resdata",
     "colorama",
-    "ropt[pandas]>=0.18,<0.19",
-    "ropt-dakota>=0.18,<0.19",
+    "ropt[pandas]>=0.19,<0.20",
+    "ropt-dakota>=0.19,<0.20",
 ]
 
 [tool.setuptools]

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -331,6 +331,8 @@ class EverestRunModel(BaseRunModel):
             match optimizer_exit_code:
                 case OptimizerExitCode.MAX_FUNCTIONS_REACHED:
                     self._exit_code = EverestExitCode.MAX_FUNCTIONS_REACHED
+                case OptimizerExitCode.MAX_BATCHES_REACHED:
+                    self._exit_code = EverestExitCode.MAX_BATCH_NUM_REACHED
                 case OptimizerExitCode.USER_ABORT:
                     self._exit_code = EverestExitCode.USER_ABORT
                 case OptimizerExitCode.TOO_FEW_REALIZATIONS:
@@ -403,14 +405,6 @@ class EverestRunModel(BaseRunModel):
 
     def _check_for_abort(self) -> bool:
         logging.getLogger(EVEREST).debug("Optimization callback called")
-        if (
-            self._everest_config.optimization is not None
-            and self._everest_config.optimization.max_batch_num is not None
-            and (self._batch_id >= self._everest_config.optimization.max_batch_num)
-        ):
-            self._exit_code = EverestExitCode.MAX_BATCH_NUM_REACHED
-            logging.getLogger(EVEREST).info("Maximum number of batches reached")
-            return True
         if (
             self._opt_callback is not None
             and self._opt_callback() == "stop_optimization"

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -197,8 +197,8 @@ def _parse_optimization(
     if alg_conv_tol := ever_opt.convergence_tolerance:
         ropt_optimizer["tolerance"] = alg_conv_tol
 
-    if alg_grad_spec := ever_opt.speculative:
-        ropt_optimizer["speculative"] = alg_grad_spec
+    if ever_opt.speculative:
+        ropt_gradient["evaluation_policy"] = "speculative"
 
     # Handle the backend options. Due to historical reasons there two keywords:
     # "options" is used to pass a list of string, "backend_options" is used to
@@ -272,7 +272,7 @@ def _parse_optimization(
             ropt_config["realization_filters"] = [cvar_config]
             # For efficiency, function and gradient evaluations should be split
             # so that no unnecessary gradients are calculated:
-            ropt_optimizer["split_evaluations"] = True
+            ropt_gradient["evaluation_policy"] = "separate"
 
 
 def _everest2ropt(ever_config: EverestConfig) -> dict[str, Any]:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -191,6 +191,9 @@ def _parse_optimization(
     if alg_max_eval := ever_opt.max_function_evaluations:
         ropt_optimizer["max_functions"] = alg_max_eval
 
+    if max_batches := ever_opt.max_batch_num:
+        ropt_optimizer["max_batches"] = max_batches
+
     if alg_conv_tol := ever_opt.convergence_tolerance:
         ropt_optimizer["tolerance"] = alg_conv_tol
 

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -11,6 +11,7 @@
       3,
       3
     ],
+    "evaluation_policy": "speculative",
     "merge_realizations": false,
     "number_of_perturbations": 7,
     "perturbation_magnitudes": [
@@ -71,8 +72,6 @@
     "options": {},
     "output_dir": "not_relevant",
     "parallel": true,
-    "speculative": true,
-    "split_evaluations": false,
     "stderr": "optimizer.stderr",
     "stdout": "optimizer.stdout",
     "tolerance": 0.005

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -64,6 +64,7 @@
     ]
   },
   "optimizer": {
+    "max_batches": null,
     "max_functions": null,
     "max_iterations": null,
     "method": "optpp_q_newton",

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -11,6 +11,7 @@
       3,
       3
     ],
+    "evaluation_policy": "auto",
     "merge_realizations": false,
     "number_of_perturbations": 5,
     "perturbation_magnitudes": [
@@ -48,8 +49,6 @@
     "options": {},
     "output_dir": "not_relevant",
     "parallel": true,
-    "speculative": false,
-    "split_evaluations": false,
     "stderr": "optimizer.stderr",
     "stdout": "optimizer.stdout",
     "tolerance": 0.001

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -41,6 +41,7 @@
     ]
   },
   "optimizer": {
+    "max_batches": 4,
     "max_functions": null,
     "max_iterations": null,
     "method": "optpp_q_newton",

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -11,6 +11,7 @@
       3,
       3
     ],
+    "evaluation_policy": "auto",
     "merge_realizations": false,
     "number_of_perturbations": 5,
     "perturbation_magnitudes": [
@@ -50,8 +51,6 @@
     "options": {},
     "output_dir": "not_relevant",
     "parallel": true,
-    "speculative": false,
-    "split_evaluations": false,
     "stderr": "optimizer.stderr",
     "stdout": "optimizer.stdout",
     "tolerance": 0.005

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -43,6 +43,7 @@
     ]
   },
   "optimizer": {
+    "max_batches": 3,
     "max_functions": null,
     "max_iterations": null,
     "method": "optpp_q_newton",

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -193,7 +193,7 @@ def test_math_func_auto_scaled_constraints(copy_math_func_test_data_to_tmp):
 
     # control number of batches, no need for full convergence:
     config_dict["optimization"]["convergence_tolerance"] = 1e-10
-    config_dict["optimization"]["max_batch_num"] = 3
+    config_dict["optimization"]["max_batch_num"] = 2
 
     # Run with auto_scaling:
     config_dict["environment"]["output_folder"] = "output_auto_scale"
@@ -209,8 +209,6 @@ def test_math_func_auto_scaled_constraints(copy_math_func_test_data_to_tmp):
     config_dict["environment"]["output_folder"] = "output_manual_scale"
     config_dict["output_constraints"][0]["auto_scale"] = False
     config_dict["output_constraints"][0]["scale"] = 0.25  # x(0)
-    # We need one batch less, no auto-scaling:
-    config_dict["optimization"]["max_batch_num"] -= 1
     config = EverestConfig.model_validate(config_dict)
     run_model = EverestRunModel.create(config)
     evaluator_server_config = EvaluatorServerConfig()

--- a/tests/everest/test_simulator_cache.py
+++ b/tests/everest/test_simulator_cache.py
@@ -24,7 +24,7 @@ def test_simulator_cache(copy_math_func_test_data_to_tmp, snapshot):
 
     config = EverestConfig.load_file("config_minimal.yml")
     config_dict = config.model_dump(exclude_none=True)
-    config_dict["optimization"]["max_batch_num"] = 5
+    config_dict["optimization"]["max_batch_num"] = 4
     config = EverestConfig.model_validate(config_dict)
 
     status_queue: SimpleQueue[StatusEvents] = SimpleQueue()

--- a/uv.lock
+++ b/uv.lock
@@ -3229,16 +3229,16 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/a5/ce636fe0f0af7f4cc66774ab5736f051afae8f3e8773cace2ee4ba859f7a/ropt-0.19.1.tar.gz", hash = "sha256:6021a472132e63697c7764f871b1ee41446702093909ebaea71fd853db9bbe9d", size = 144875 }
+sdist = { url = "https://files.pythonhosted.org/packages/54/d9/c7805ac8c10cc3703592d35cc5b2d72ae0a788f02b77688315275047864e/ropt-0.19.2.tar.gz", hash = "sha256:7f8f57176645cb7fa7b21b64d8a7e6c04a7f0c49b773ae5801521cc41c962732", size = 145440 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/c6/70e7b2f011b4aec4a23bbe51d8b708cd59a2d89d3a68ca9cd215b8a962c6/ropt-0.19.1-py3-none-any.whl", hash = "sha256:b6952eff2c7ec3bc74c9d0de8a065651a4ceaf802f09bcbb956cba66fb5fdfd0", size = 154573 },
+    { url = "https://files.pythonhosted.org/packages/a9/c0/95e7f9b376a7d50b4ee39837461480e0aafb06dab4cca1e991a378c644a5/ropt-0.19.2-py3-none-any.whl", hash = "sha256:980878983ce4a9932356c2718cd8a492d5736b7c9c8f64b399e1bfd2590bb282", size = 154850 },
 ]
 
 [package.optional-dependencies]
@@ -3248,15 +3248,15 @@ pandas = [
 
 [[package]]
 name = "ropt-dakota"
-version = "0.19.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/aa/5731453d2039a934a44388f5410434d08d60bcc9f717ae92be97437aa267/ropt_dakota-0.19.0.tar.gz", hash = "sha256:2487a41e804f06e32d77c7f8761bd96fd630bdf724912988e500f937592d897f", size = 28789 }
+sdist = { url = "https://files.pythonhosted.org/packages/75/8c/cb0c4b324a1d2ef32c7748e363b0a2007f4621d55675163e967f73f744ff/ropt_dakota-0.19.1.tar.gz", hash = "sha256:ee47d7cb537d20117206ce44654919c27eb69d679e477ae07be90901414b3d43", size = 28757 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/3b/69462c61c5239b0d5113b5762901702609ba8fc59f9470c6ae9d5090d0db/ropt_dakota-0.19.0-py3-none-any.whl", hash = "sha256:8b1046fea6098d99fa91b576c9507e5b0ee0cc20ca7ed559410393f6c817b0e8", size = 21443 },
+    { url = "https://files.pythonhosted.org/packages/66/73/c945773185a7305a2573a35d1703becae9a3457bb2bad873a837e5151799/ropt_dakota-0.19.1-py3-none-any.whl", hash = "sha256:1d974c04a7d3d803d40a0428b5e02d9caae5647f75d4df912b8173046628c31a", size = 21393 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -839,8 +839,8 @@ requires-dist = [
     { name = "resdata", marker = "extra == 'everest'" },
     { name = "resfo" },
     { name = "resfo", marker = "extra == 'dev'" },
-    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.18,<0.19" },
-    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.18,<0.19" },
+    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.19,<0.20" },
+    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.19,<0.20" },
     { name = "ruamel-yaml", marker = "extra == 'everest'" },
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1,<1.15" },
@@ -3229,16 +3229,16 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.18.1"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/f7/c3db84aa3fb678e4197023907ed722a85b1d2593ecdb269102e8187f0b17/ropt-0.18.1.tar.gz", hash = "sha256:a28d54df07ba218dd4902fad7edec059188cf7500f8e80a6dceca36728a73daa", size = 133006 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/a5/ce636fe0f0af7f4cc66774ab5736f051afae8f3e8773cace2ee4ba859f7a/ropt-0.19.1.tar.gz", hash = "sha256:6021a472132e63697c7764f871b1ee41446702093909ebaea71fd853db9bbe9d", size = 144875 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/8d/3c3493da1224bbc08c469fa82378b5d0cd4b12c1c11aaf094fd473a15783/ropt-0.18.1-py3-none-any.whl", hash = "sha256:e58836e8809c7cdaa97ec3253b4a62f484611d2ce8c232cd6196976dcaa6787b", size = 139014 },
+    { url = "https://files.pythonhosted.org/packages/03/c6/70e7b2f011b4aec4a23bbe51d8b708cd59a2d89d3a68ca9cd215b8a962c6/ropt-0.19.1-py3-none-any.whl", hash = "sha256:b6952eff2c7ec3bc74c9d0de8a065651a4ceaf802f09bcbb956cba66fb5fdfd0", size = 154573 },
 ]
 
 [package.optional-dependencies]
@@ -3248,15 +3248,15 @@ pandas = [
 
 [[package]]
 name = "ropt-dakota"
-version = "0.18.1"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/7f/a20e96c638cb224d5b2abfc3579b11817a8ca24851c54db4aaf3f1402c8e/ropt_dakota-0.18.1.tar.gz", hash = "sha256:0f3a725dced71a182f64047447df8f0068bab51c1bf812b59f7f4e38d86c9bbe", size = 28778 }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/aa/5731453d2039a934a44388f5410434d08d60bcc9f717ae92be97437aa267/ropt_dakota-0.19.0.tar.gz", hash = "sha256:2487a41e804f06e32d77c7f8761bd96fd630bdf724912988e500f937592d897f", size = 28789 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/93/d4c9bb1399ff592ecdf53e85936bb3596385182b48b29368cd8d1a8b1502/ropt_dakota-0.18.1-py3-none-any.whl", hash = "sha256:87f824e5b70739f89bab9cf89c70f8fb2c07985cd68b5deb2f6e88e06f5f7632", size = 21441 },
+    { url = "https://files.pythonhosted.org/packages/c2/3b/69462c61c5239b0d5113b5762901702609ba8fc59f9470c6ae9d5090d0db/ropt_dakota-0.19.0-py3-none-any.whl", hash = "sha256:8b1046fea6098d99fa91b576c9507e5b0ee0cc20ca7ed559410393f6c817b0e8", size = 21443 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue**
The handling of the `max_batch_num` keyword in Everest was sub-optimal:

1. It "mis-used" the user abort function of `ropt`, which makes it more difficult to distinguish between the two events for aborting optimization.
2. It included the potential extra batch run that is sometimes done at the beginning for auto-scaling purposes, meaning that enabling auto-scaling changes the meaning of `max_batch_num` somewhat.

**Approach**
`ropt` now supports stopping after a given number of batches directly, with a corresponding correct exit code. The custom handling of `max_batch_num` can be removed.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
