### PR TITLE
Remove superfluous log statement

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -298,8 +298,6 @@ class LegacyEnsemble:
             await event_unary_send(event_creator(Id.ENSEMBLE_FAILED))
             return
 
-        logger.info(f"Experiment ran on QUEUESYSTEM: {self._queue_config.queue_system}")
-
         # Dispatch final result from evaluator - FAILED, CANCEL or STOPPED
         await event_unary_send(event_creator(result))
 


### PR DESCRIPTION
Exactly the same line is logged in base_run_model.py

**Issue**
Resolves double logging:

https://github.com/equinor/ert/blob/acc432cf72c25109981f13cbb5815b79fbfec232/src/ert/run_models/base_run_model.py#L814
https://github.com/equinor/ert/blob/acc432cf72c25109981f13cbb5815b79fbfec232/src/ert/ensemble_evaluator/_ensemble.py#L301


**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
