### PR TITLE
Merge observation warnings into one

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -305,8 +305,9 @@ def _load_observations_and_responses(
             )
         )
 
-    for missing_obs in obs_keys[~obs_mask]:
-        logger.warning(f"Deactivating observation: {missing_obs}")
+    missing_obs = sorted(set(obs_keys[~obs_mask]))
+    if missing_obs:
+        logger.warning("Deactivating observations: {missing_obs}")
 
     return S[obs_mask], (
         observations[obs_mask],


### PR DESCRIPTION
This log statement has been observed to be triggered thousands of times pr update in some scenarios, including some observations listed multiple times. Solved by only logging once, and list all unique observations sorted in one go.

**Issue**
Resolves #10280 


**Approach**
Merge and sort

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
