### PR TITLE
Internalize ert_templates into storage

### DIFF
--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -214,7 +214,6 @@ def create_run_path(
     env_pr_fm_step: dict[str, dict[str, Any]],
     forward_model_steps: list[ForwardModelStep],
     substitutions: Substitutions,
-    templates: list[tuple[str, str]],
     parameters_file: str,
     runpaths: Runpaths,
     context_env: dict[str, str] | None = None,
@@ -226,19 +225,15 @@ def create_run_path(
         run_path = Path(run_arg.runpath)
         if run_arg.active:
             run_path.mkdir(parents=True, exist_ok=True)
-            for source_file, target_file in templates:
+            for (
+                source_file_content,
+                target_file,
+            ) in ensemble.experiment.templates_configuration:
                 target_file = substitutions.substitute_real_iter(
                     target_file, run_arg.iens, ensemble.iteration
                 )
-                try:
-                    file_content = Path(source_file).read_text("utf-8")
-                except UnicodeDecodeError as e:
-                    raise ValueError(
-                        f"Unsupported non UTF-8 character found in file: {source_file}"
-                    ) from e
-
                 result = substitutions.substitute_real_iter(
-                    file_content,
+                    source_file_content,
                     run_arg.iens,
                     ensemble.iteration,
                 )

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -176,6 +176,7 @@ class StorageWidget(QWidget):
                 responses=self._ert_config.ensemble_config.response_configuration,
                 observations=self._ert_config.enkf_obs.datasets,
                 name=create_experiment_dialog.experiment_name,
+                templates=self._ert_config.ert_templates,
             ).create_ensemble(
                 name=create_experiment_dialog.ensemble_name,
                 ensemble_size=self._ensemble_size,

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -183,7 +183,6 @@ class BaseRunModel(ABC):
         forward_model_steps: list[ForwardModelStep],
         status_queue: SimpleQueue[StatusEvents],
         substitutions: Substitutions,
-        templates: list[tuple[str, str]],
         hooked_workflows: defaultdict[HookRuntime, list[Workflow]],
         active_realizations: list[bool],
         log_path: Path,
@@ -213,7 +212,6 @@ class BaseRunModel(ABC):
         self._runpath_file: Path = runpath_file
         self._forward_model_steps: list[ForwardModelStep] = forward_model_steps
         self._user_config_file: Path = user_config_file
-        self._templates: list[tuple[str, str]] = templates
         self._hooked_workflows: defaultdict[HookRuntime, list[Workflow]] = (
             hooked_workflows
         )
@@ -788,7 +786,6 @@ class BaseRunModel(ABC):
             env_pr_fm_step=self._env_pr_fm_step,
             forward_model_steps=self._forward_model_steps,
             substitutions=self._substitutions,
-            templates=self._templates,
             parameters_file=self._model_config.gen_kw_export_name,
             runpaths=self.run_paths,
             context_env=self._context_env,
@@ -861,7 +858,6 @@ class UpdateRunModel(BaseRunModel):
         forward_model_steps: list[ForwardModelStep],
         status_queue: SimpleQueue[StatusEvents],
         substitutions: Substitutions,
-        templates: list[tuple[str, str]],
         hooked_workflows: defaultdict[HookRuntime, list[Workflow]],
         active_realizations: list[bool],
         total_iterations: int,
@@ -884,7 +880,6 @@ class UpdateRunModel(BaseRunModel):
             forward_model_steps,
             status_queue,
             substitutions,
-            templates,
             hooked_workflows,
             active_realizations=active_realizations,
             total_iterations=total_iterations,

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -52,6 +52,7 @@ class EnsembleExperiment(BaseRunModel):
         self._observations = config.observations
         self._parameter_configuration = config.ensemble_config.parameter_configuration
         self._response_configuration = config.ensemble_config.response_configuration
+        self._templates = config.ert_templates
 
         super().__init__(
             storage,
@@ -64,7 +65,6 @@ class EnsembleExperiment(BaseRunModel):
             config.forward_model_steps,
             status_queue,
             config.substitutions,
-            config.ert_templates,
             config.hooked_workflows,
             total_iterations=1,
             log_path=config.analysis_config.log_path,
@@ -107,6 +107,7 @@ class EnsembleExperiment(BaseRunModel):
                 ),
                 observations=self._observations,
                 responses=self._response_configuration,
+                templates=self._templates,
             )
             self.ensemble = self._storage.create_ensemble(
                 self.experiment,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -53,7 +53,6 @@ class EnsembleSmoother(UpdateRunModel):
             config.forward_model_steps,
             status_queue,
             config.substitutions,
-            config.ert_templates,
             config.hooked_workflows,
             active_realizations=active_realizations,
             start_iteration=0,
@@ -71,6 +70,7 @@ class EnsembleSmoother(UpdateRunModel):
         self._design_matrix = config.analysis_config.design_matrix
         self._observations = config.observations
         self._response_configuration = config.ensemble_config.response_configuration
+        self._templates = config.ert_templates
 
     @tracer.start_as_current_span(f"{__name__}.run_experiment")
     def run_experiment(
@@ -104,6 +104,7 @@ class EnsembleSmoother(UpdateRunModel):
             observations=self._observations,
             responses=self._response_configuration,
             name=self.experiment_name,
+            templates=self._templates,
         )
 
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -60,7 +60,6 @@ class EvaluateEnsemble(BaseRunModel):
             config.forward_model_steps,
             status_queue,
             config.substitutions,
-            config.ert_templates,
             config.hooked_workflows,
             start_iteration=self.ensemble.iteration,
             total_iterations=1,

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -192,6 +192,7 @@ class EverestRunModel(BaseRunModel):
         self._parameter_configuration = ensemble_config.parameter_configuration
         self._parameter_configs = ensemble_config.parameter_configs
         self._response_configuration = ensemble_config.response_configuration
+        self._templates = ert_templates
 
         super().__init__(
             storage,
@@ -204,7 +205,6 @@ class EverestRunModel(BaseRunModel):
             forward_model_steps,
             status_queue,
             substitutions,
-            ert_templates,
             hooked_workflows,
             random_seed=123,  # No-op as far as Everest is concerned
             active_realizations=[],  # Set dynamically in run_forward_model()

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -56,7 +56,6 @@ class ManualUpdate(UpdateRunModel):
             config.forward_model_steps,
             status_queue,
             config.substitutions,
-            config.ert_templates,
             config.hooked_workflows,
             active_realizations=active_realizations,
             total_iterations=1,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -86,7 +86,6 @@ class MultipleDataAssimilation(UpdateRunModel):
             config.forward_model_steps,
             status_queue,
             config.substitutions,
-            config.ert_templates,
             config.hooked_workflows,
             active_realizations=active_realizations,
             total_iterations=total_iterations,
@@ -99,6 +98,7 @@ class MultipleDataAssimilation(UpdateRunModel):
         self._observations = config.observations
         self._parameter_configuration = config.ensemble_config.parameter_configuration
         self._response_configuration = config.ensemble_config.response_configuration
+        self._templates = config.ert_templates
 
     @tracer.start_as_current_span(f"{__name__}.run_experiment")
     def run_experiment(
@@ -154,6 +154,7 @@ class MultipleDataAssimilation(UpdateRunModel):
                 responses=self._response_configuration,
                 simulation_arguments=sim_args,
                 name=self.experiment_name,
+                templates=self._templates,
             )
 
             prior = self._storage.create_ensemble(

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -307,6 +307,7 @@ class LocalStorage(BaseMode):
         observations: dict[str, pl.DataFrame] | None = None,
         simulation_arguments: dict[Any, Any] | None = None,
         name: str | None = None,
+        templates: list[tuple[str, str]] | None = None,
     ) -> LocalExperiment:
         """
         Creates a new experiment in the storage.
@@ -323,6 +324,8 @@ class LocalStorage(BaseMode):
             The simulation arguments for the experiment.
         name : str, optional
             The name of the experiment.
+        templates : list of tuple[str, str], optional
+            Run templates for the experiment. Defaults to None.
 
         Returns
         -------
@@ -343,6 +346,7 @@ class LocalStorage(BaseMode):
             observations=observations,
             simulation_arguments=simulation_arguments,
             name=name,
+            templates=templates,
         )
 
         self._experiments[exp.id] = exp
@@ -459,6 +463,7 @@ class LocalStorage(BaseMode):
             to7,
             to8,
             to9,
+            to10,
         )
 
         try:
@@ -478,7 +483,8 @@ class LocalStorage(BaseMode):
 
                 logger.info("Blockfs storage backed up")
                 print(
-                    dedent(f"""
+                    dedent(
+                        f"""
                     Detected outdated storage (blockfs), which is no longer supported
                     by ERT. Its contents are copied to:
 
@@ -497,13 +503,14 @@ class LocalStorage(BaseMode):
                     This is not guaranteed to work. Other than setting the custom
                     ENSPATH, the ERT config should ideally be the same as it was
                     when the old blockfs storage was created.
-                """)
+                """
+                    )
                 )
                 return None
 
             elif version < _LOCAL_STORAGE_VERSION:
                 migrations = list(
-                    enumerate([to2, to3, to4, to5, to6, to7, to8, to9], start=1)
+                    enumerate([to2, to3, to4, to5, to6, to7, to8, to9, to10], start=1)
                 )
                 for from_version, migration in migrations[version - 1 :]:
                     print(f"* Updating storage to version: {from_version + 1}")

--- a/src/ert/storage/migration/to10.py
+++ b/src/ert/storage/migration/to10.py
@@ -1,0 +1,25 @@
+import json
+import shutil
+from pathlib import Path
+
+from ert.storage.local_storage import local_storage_get_ert_config
+
+info = "Internalizes run templates in to the storage"
+
+
+def migrate(path: Path) -> None:
+    ert_config = local_storage_get_ert_config()
+    if ert_config.ert_templates:
+        for experiment in path.glob("experiments/*"):
+            templates_abs: list[tuple[str, str]] = []
+            templates_path = experiment / "templates"
+            templates_path.mkdir(parents=True, exist_ok=True)
+            for src, dst in ert_config.ert_templates:
+                incoming_template_file_path = Path(src)
+                template_file_path = Path(
+                    templates_path / incoming_template_file_path.name
+                )
+                shutil.copyfile(incoming_template_file_path, template_file_path)
+                templates_abs.append((str(template_file_path.resolve()), dst))
+            with open(experiment / "templates.json", "w", encoding="utf-8") as fout:
+                fout.write(json.dumps(templates_abs))

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -235,7 +235,6 @@ def test_gen_kw_is_log_or_not(
             env_vars=ert_config.env_vars,
             env_pr_fm_step=ert_config.env_pr_fm_step,
             substitutions=ert_config.substitutions,
-            templates=ert_config.ert_templates,
             parameters_file="parameters",
         )
         assert re.match(

--- a/tests/ert/unit_tests/conftest.py
+++ b/tests/ert/unit_tests/conftest.py
@@ -34,6 +34,19 @@ def prior_ensemble(storage):
 
 
 @pytest.fixture
+def prior_ensemble_args(storage):
+    def _create_prior_ensemble(
+        ensemble_name="prior", ensemble_size=100, **experiment_params
+    ):
+        experiment_id = storage.create_experiment(**experiment_params)
+        return storage.create_ensemble(
+            experiment_id, name=ensemble_name, ensemble_size=ensemble_size
+        )
+
+    return _create_prior_ensemble
+
+
+@pytest.fixture
 def run_paths():
     def func(ert_config: ErtConfig):
         return Runpaths(

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -38,7 +38,6 @@ def create_base_run_model(**kwargs):
         "forward_model_steps": MagicMock(spec=dict),
         "status_queue": MagicMock(spec=SimpleQueue),
         "substitutions": MagicMock(spec=Substitutions),
-        "templates": MagicMock(spec=dict),
         "hooked_workflows": MagicMock(spec=dict),
         "active_realizations": MagicMock(spec=list),
         "random_seed": 123,

--- a/tests/ert/unit_tests/storage/create_runpath.py
+++ b/tests/ert/unit_tests/storage/create_runpath.py
@@ -48,7 +48,6 @@ def create_runpath(
         env_pr_fm_step=ert_config.env_pr_fm_step,
         forward_model_steps=ert_config.forward_model_steps,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=runpaths,
     )

--- a/tests/ert/unit_tests/test_enkf_main.py
+++ b/tests/ert/unit_tests/test_enkf_main.py
@@ -90,7 +90,6 @@ def test_assert_symlink_deleted(snake_oil_field_example, storage, run_paths):
         env_vars=ert_config.env_vars,
         env_pr_fm_step=ert_config.env_pr_fm_step,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=runpaths,
     )
@@ -112,7 +111,6 @@ def test_assert_symlink_deleted(snake_oil_field_example, storage, run_paths):
         env_vars=ert_config.env_vars,
         env_pr_fm_step=ert_config.env_pr_fm_step,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=runpaths,
     )

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -35,7 +35,6 @@ def setup_case(storage, use_tmpdir, run_args, run_paths):
             env_pr_fm_step=ert_config.env_pr_fm_step,
             forward_model_steps=ert_config.forward_model_steps,
             substitutions=ert_config.substitutions,
-            templates=ert_config.ert_templates,
             parameters_file="parameters",
             runpaths=run_paths(ert_config),
         )
@@ -148,7 +147,6 @@ def test_load_forward_model_summary(
         env_pr_fm_step=ert_config.env_pr_fm_step,
         forward_model_steps=ert_config.forward_model_steps,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=run_paths(ert_config),
     )
@@ -253,7 +251,6 @@ def test_loading_gen_data_without_restart(storage, run_paths, run_args):
         env_pr_fm_step=ert_config.env_pr_fm_step,
         forward_model_steps=ert_config.forward_model_steps,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=run_paths(ert_config),
     )
@@ -318,7 +315,6 @@ def test_loading_from_any_available_iter(storage, run_paths, run_args, itr):
         env_pr_fm_step=ert_config.env_pr_fm_step,
         forward_model_steps=ert_config.forward_model_steps,
         substitutions=ert_config.substitutions,
-        templates=ert_config.ert_templates,
         parameters_file="parameters",
         runpaths=run_paths(ert_config),
     )

--- a/tests/ert/unit_tests/test_summary_response.py
+++ b/tests/ert/unit_tests/test_summary_response.py
@@ -47,7 +47,6 @@ def test_load_summary_response_restart_not_zero(
             env_vars=ert_config.env_vars,
             env_pr_fm_step=ert_config.env_pr_fm_step,
             substitutions=ert_config.substitutions,
-            templates=ert_config.ert_templates,
             parameters_file="parameters",
             runpaths=run_paths(ert_config),
         )


### PR DESCRIPTION
**Issue**
This is a necessary pre-work related to https://github.com/equinor/ert/issues/10180

 All templates will be part of storage and thus for instance restart would
 rely only on templates from the storage. Additionally, this removes templates
 param from create_run_path, but it needs to be specified directly when calling
 create_experiment.
 Templates are stored in the experiment.mount_point / templates folder
 Example: [["templates/seed_template_0.txt", "seed.txt"]]

 It requires storage migration for run_templates.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
