### PR TITLE
Do not merge design matrix with parameters when restarting experiment

### DIFF
--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -86,7 +86,7 @@ class EnsembleExperiment(BaseRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -80,7 +80,7 @@ class EnsembleSmoother(UpdateRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -109,7 +109,7 @@ class MultipleDataAssimilation(UpdateRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)


### PR DESCRIPTION
**Issue**
Resolves #10625


**Approach**
When having DESIGN_MATRIX specified, the base run models that support restart can fail on merging design matrix parameters with gen_kw despite the parameters are only read from the storage. This commit fixes the issue by only merging design matrix with existing merging if it is not a restart of the experiment.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
