### PR TITLE
Remove `rebuild_dataclass` in ErtConfig

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -16,7 +16,7 @@ import polars as pl
 from numpy.random import SeedSequence
 from pydantic import ValidationError as PydanticValidationError
 from pydantic import field_validator
-from pydantic.dataclasses import dataclass, rebuild_dataclass
+from pydantic.dataclasses import dataclass
 
 from ert.plugins import ErtPluginManager, fixtures_per_hook
 from ert.substitutions import Substitutions
@@ -1380,8 +1380,3 @@ def _forward_model_step_from_config_contents(
         required_keywords=content_dict.get("REQUIRED", []),
         default_mapping=default_mapping,
     )
-
-
-# Due to circular dependency in type annotations between
-# ErtConfig -> WorkflowJob -> ErtScript -> ErtConfig
-rebuild_dataclass(ErtConfig)


### PR DESCRIPTION
**Issue**
Resolves [#9587](https://github.com/equinor/ert/issues/9587)


**Approach**
Remove `rebuild_dataclass` in ErtConfig

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
