### PR TITLE
[Backport version-14.1] Do not merge design matrix with parameters when restarting experiment

### DIFF
--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -85,7 +85,7 @@ class EnsembleExperiment(BaseRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -80,7 +80,7 @@ class EnsembleSmoother(UpdateRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -109,7 +109,7 @@ class MultipleDataAssimilation(UpdateRunModel):
         parameters_config = self._parameter_configuration
         design_matrix = self._design_matrix
         design_matrix_group = None
-        if design_matrix is not None:
+        if design_matrix is not None and not restart:
             try:
                 parameters_config, design_matrix_group = (
                     design_matrix.merge_with_existing_parameters(parameters_config)


### PR DESCRIPTION
# Description
Backport of #10626 to `version-14.1`.