### PR TITLE
Remove event_from_dict function and ZMQ client from LegacyEnsemble

### DIFF
--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -241,10 +241,6 @@ def event_from_json(raw_msg: str | bytes) -> Event:
     return EventAdapter.validate_json(raw_msg)
 
 
-def event_from_dict(dict_msg: dict[str, Any]) -> Event:
-    return EventAdapter.validate_python(dict_msg)
-
-
 def event_to_json(event: Event) -> str:
     return event.model_dump_json()
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -19,9 +19,8 @@ from _ert.events import (
     ForwardModelStepFailure,
     ForwardModelStepRunning,
     ForwardModelStepSuccess,
-    Id,
+    RealizationResubmit,
     RealizationSuccess,
-    event_from_dict,
     event_to_json,
 )
 from _ert.forward_model_runner.client import (
@@ -664,14 +663,14 @@ async def test_snapshot_on_resubmit_is_cleared(evaluator_to_use):
             assert (
                 snapshot.get_fm_step("0", "1")["status"] == FORWARD_MODEL_STATE_FAILURE
             )
-            event_dict = {
-                "ensemble": str(evaluator._ensemble.id_),
-                "event_type": Id.REALIZATION_RESUBMIT,
-                "queue_event_type": JobState.RESUBMITTING,
-                "real": "0",
-                "exec_hosts": "something",
-            }
-            await evaluator._events.put(event_from_dict(event_dict))
+            await evaluator._events.put(
+                RealizationResubmit(
+                    ensemble=evaluator.ensemble.id_,
+                    queue_event_type=JobState.RESUBMITTING,
+                    real="0",
+                    exec_hosts="something",
+                )
+            )
             event = await anext(events)
             snapshot = EnsembleSnapshot.from_nested_dict(event.snapshot)
             assert snapshot.get_fm_step("0", "0")["status"] == FORWARD_MODEL_STATE_INIT

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -114,14 +114,6 @@ async def test_queue_config_properties_propagated_to_scheduler(
     monkeypatch.setattr(QueueConfig, "max_running", 44)
     ensemble._queue_config.max_submit = 55
 
-    async def mock_send_event_method(*args, **kwargs):
-        return
-
-    monkeypatch.setattr(
-        "ert.ensemble_evaluator._ensemble.LegacyEnsemble.send_event",
-        mock_send_event_method,
-    )
-
     # The function under test:
     await ensemble.evaluate(config=MagicMock())
 


### PR DESCRIPTION
**Approach**
This first commit in this PR removes the event_from_dict function and makes the callers create the Events directly instead. This increases the readability and makes it easier to find where the events are actually being created without having to jump through hoops and doing eight spins. 

The second commit makes the LegacyEnsemble put events directly in the evaluator queue (which it has access to) instead of connecting to EE via ZMQ client and sending events. Before this commit, the client it used was also called dispatcher, which caused some confusion as to who was actually creating and sending Ensemble{Started,Cancelled,Stopped}.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
