### PR TITLE
Add max_memory keyword to the Everest config

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -280,7 +280,7 @@ class QueueConfig:
         job_script: str = config_dict.get(
             "JOB_SCRIPT", shutil.which("fm_dispatch.py") or "fm_dispatch.py"
         )
-        realization_memory: int = _parse_realization_memory_str(
+        realization_memory: int = parse_realization_memory_str(
             config_dict.get(ConfigKeys.REALIZATION_MEMORY, "0b")
         )
         max_submit: int = config_dict.get(ConfigKeys.MAX_SUBMIT, 1)
@@ -361,7 +361,7 @@ class QueueConfig:
         return self.queue_options.submit_sleep
 
 
-def _parse_realization_memory_str(realization_memory_str: str) -> int:
+def parse_realization_memory_str(realization_memory_str: str) -> int:
     if "-" in realization_memory_str:
         raise ConfigValidationError.with_context(
             f"Negative memory does not make sense in {realization_memory_str}",

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -119,6 +119,11 @@ def _extract_simulator(ever_config: EverestConfig, ert_config: dict[str, Any]) -
     if max_runtime is not None:
         ert_config[ErtConfigKeys.MAX_RUNTIME] = max_runtime or 0
 
+    # Maximum amount of memory (REALIZATION_MEMORY) a forward model is allowed to use
+    max_memory = ever_simulation.max_memory
+    if max_memory is not None:
+        ert_config[ErtConfigKeys.REALIZATION_MEMORY] = max_memory or 0
+
     # Number of cores reserved on queue nodes (NUM_CPU)
     num_fm_cpu = ever_simulation.cores_per_node
     if num_fm_cpu is not None:


### PR DESCRIPTION
**Issue**
Resolves #10624 
Resolves #9569


**Approach**
Add the keyword, add to generated ert config

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
