### PR TITLE
Fix experiment_panel validation error on simulation done

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -347,8 +347,8 @@ class ExperimentPanel(QWidget):
         def simulation_done_handler() -> None:
             self._simulation_done = True
             self.run_button.setEnabled(self._simulation_done)
-            self.toggleExperimentType()
             self._notifier.emitErtChange()
+            self.toggleExperimentType()
 
         self._dialog.simulation_done.connect(simulation_done_handler)
 


### PR DESCRIPTION
**Issue**
Resolves #10468 


**Approach**
This commit fixes the issue where we would get validation failed due to duplicate experiment name when
simulation was done in experiment_panel. This was due to validation running before emitting the ertChanged signal.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
