### PR TITLE
Use github_token for uv lockfile workflow

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 8 * * 1"
-
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -14,6 +16,12 @@ jobs:
         python-version: ['3.12']
     steps:
       - uses: actions/checkout@v4
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.SCOUT_TEAM_APP_ID }}
+          private-key: ${{ secrets.SCOUT_TEAM_APP_PRIVATE_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,7 +41,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.LOCKFILE_UPDATE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Update uv lockfile
           title: Update uv lockfile
           body-path: uv_output.md


### PR DESCRIPTION
Fixup for lockfile workflow.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
