### PR TITLE
Add queue system name to run_dialog

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -323,6 +323,7 @@ class ExperimentPanel(QWidget):
             self.parent(),  # type: ignore
             output_path=self.config.analysis_config.log_path,
         )
+        self._dialog.set_queue_system_name(model.queue_system)
         self.experiment_started.emit(self._dialog)
         self._simulation_done = False
         self.run_button.setEnabled(self._simulation_done)


### PR DESCRIPTION
**Issue**
Resolves #10255 


**Approach**
This commit makes the GUI show what queue_system is being used, in the footer of the RunDialog.

(Screenshot of new behavior in GUI if applicable)
Before:
![image](https://github.com/user-attachments/assets/7afc1b61-c5e3-4272-b29f-3f3e25801468)

After:
![image](https://github.com/user-attachments/assets/31cd9423-b25b-453a-b031-11f48ec10e5b)


https://github.com/user-attachments/assets/6d2baa82-faaa-4bcf-a495-d7111d9fcefd



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
