### PR TITLE
Fixup whitespace in error displayed to user

### DIFF
--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -270,15 +270,15 @@ class EnkfObs:
         except IndexError as err:
             raise ObservationConfigError.with_context(
                 f"Could not find {time} ({date_str}) in "
-                f"the time map for observations {obs_name}"
+                f"the time map for observations {obs_name}. "
                 + (
                     "The time map is set from the REFCASE keyword. Either "
                     "the REFCASE has an incorrect/missing date, or the observation "
                     "is given an incorrect date.)"
                     if has_refcase
-                    else " (The time map is set from the TIME_MAP "
+                    else "(The time map is set from the TIME_MAP "
                     "keyword. Either the time map file has an "
-                    "incorrect/missing date, or the  observation is given an "
+                    "incorrect/missing date, or the observation is given an "
                     "incorrect date."
                 ),
                 obs_name,


### PR DESCRIPTION
**Issue**
Resolves lack of dot and whitespace in error displayed to users.


**Approach**
do-it

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
