### PR TITLE
Merge heatbeat_task and publisher in EE

### DIFF
--- a/src/_ert/forward_model_runner/client.py
+++ b/src/_ert/forward_model_runner/client.py
@@ -114,11 +114,14 @@ class Client:
                 await asyncio.sleep(0)
                 self.socket.connect(self.url)
             except TimeoutError:
+                if not self._ack_event.is_set():
+                    continue  # We are already reconnecting
                 await self.socket.send_multipart([b"", CONNECT_MSG])
+                print("RECONNECT")
                 logger.warning(
-                    f"""{self.dealer_id} did not receive any events within the
-                    timeout period, there might be issues with the connection.
-                    Reconnecting..."""
+                    f"{self.dealer_id} did not receive any events within the "
+                    "timeout period - there might be issues with the connection. "
+                    "Reconnecting..."
                 )
 
     async def send(self, message: str | bytes, retries: int | None = None) -> None:

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -85,9 +85,10 @@ class EnsembleEvaluator:
         self._dispatchers_empty.set()
 
     async def _publisher(self) -> None:
+        event: Event | _HeartbeatEvent
         while True:
             try:
-                event: Event | _HeartbeatEvent = await asyncio.wait_for(
+                event = await asyncio.wait_for(
                     self._events_to_send.get(), timeout=HEARTBEAT_TIMEOUT
                 )
             except TimeoutError:

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_client.py
@@ -53,7 +53,9 @@ async def test_retry(unused_tcp_port):
     assert mock_server.messages.count("test_3") == 1
 
 
-async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
+async def test_reconnect_when_no_events_within_heartbeat_timeout(
+    unused_tcp_port, monkeypatch
+):
     host = "localhost"
     url = f"tcp://{host}:{unused_tcp_port}"
 
@@ -71,7 +73,7 @@ async def test_reconnect_when_missing_heartbeat(unused_tcp_port, monkeypatch):
     assert len(mock_server.dealers) == 0
 
     # when reconnection happens CONNECT message is sent again
-    assert mock_server.messages.count("CONNECT") == 2
+    assert mock_server.messages.count("CONNECT") > 2
     assert mock_server.messages.count("DISCONNECT") == 1
     assert "start" in mock_server.messages
     assert "stop" in mock_server.messages


### PR DESCRIPTION
**Issue**
Resolves #10251 


**Approach**
This commit merges the two tasks, by having publisher directly sending
heatbeat if there is not a new event in the event_to_send queue within
the `HEARTBEAT_TIMEOUT`. This means less messages being sent overall, as
we are now also using events as heartbeats, the same way that is being
done in monitor.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
