### PR TITLE
Mark back as flaky test_that_multiple_everest_clients_can_connect_to_server

### DIFF
--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -146,6 +146,7 @@ def test_that_stop_errors_on_server_up_but_endpoint_down(
 
 @pytest.mark.integration_test
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
+@pytest.mark.flaky(rerun=3)
 def test_that_multiple_everest_clients_can_connect_to_server(cached_example):
     # We use a cached run for the reference list of received events
     path, config_file, _, server_events_list = cached_example(


### PR DESCRIPTION
The test is still failing.

Latest failure:

https://github.com/equinor/ert/actions/runs/14728444448/job/41336666927


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
