### PR TITLE
Solve and enforce flake8-builtins via ruff

### DIFF
--- a/docs/everest/conf.py
+++ b/docs/everest/conf.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.abspath("_ext"))
 # -- Project information -----------------------------------------------------
 
 project = "Everest"
-copyright = "2024, Equinor & TNO"
+copyright = "2024, Equinor & TNO"  # noqa: A001
 author = "Equinor & TNO"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
+    "A",     # flake8-builtins
     "E",     # pycodestyle
     "W",     # pycodestyle
     "I",     # isort

--- a/src/ert/callbacks.py
+++ b/src/ert/callbacks.py
@@ -94,7 +94,7 @@ async def _write_responses_to_storage(
 async def forward_model_ok(
     run_path: str,
     realization: int,
-    iter: int,
+    iter_: int,
     ensemble: Ensemble,
 ) -> LoadResult:
     parameters_result = LoadResult(LoadStatus.LOAD_SUCCESSFUL, "")
@@ -102,11 +102,11 @@ async def forward_model_ok(
     try:
         # We only read parameters after the prior, after that, ERT
         # handles parameters
-        if iter == 0:
+        if iter_ == 0:
             parameters_result = await _read_parameters(
                 run_path,
                 realization,
-                iter,
+                iter_,
                 ensemble,
             )
 

--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -206,15 +206,17 @@ def _is_smspec(base: str, path: str) -> bool:
 def _find_file_matching(
     kind: str, case: str, predicate: Callable[[str, str], bool]
 ) -> str:
-    dir, base = os.path.split(case)
-    candidates = list(filter(lambda x: predicate(base, x), os.listdir(dir or ".")))
+    directory, base = os.path.split(case)
+    candidates = list(
+        filter(lambda x: predicate(base, x), os.listdir(directory or "."))
+    )
     if not candidates:
         raise FileNotFoundError(f"Could not find any {kind} matching case path {case}")
     if len(candidates) > 1:
         raise FileNotFoundError(
             f"Ambiguous reference to {kind} in {case}, could be any of {candidates}"
         )
-    return os.path.join(dir, candidates[0])
+    return os.path.join(directory, candidates[0])
 
 
 def _get_summary_filenames(filepath: str) -> tuple[str, str]:
@@ -297,13 +299,13 @@ def _read_spec(
     )
     if spec.lower().endswith("fsmspec"):
         mode = "rt"
-        format = resfo.Format.FORMATTED
+        assumed_format = resfo.Format.FORMATTED
     else:
         mode = "rb"
-        format = resfo.Format.UNFORMATTED
+        assumed_format = resfo.Format.UNFORMATTED
 
     with open(spec, mode) as fp:
-        for entry in resfo.lazy_read(fp, format):
+        for entry in resfo.lazy_read(fp, assumed_format):
             if all(p is not None for p in [date, n, nx, ny, *arrays.values()]):
                 break
             kw = entry.read_keyword()
@@ -450,10 +452,10 @@ def _read_summary(
 ) -> tuple[npt.NDArray[np.float32], list[datetime]]:
     if summary.lower().endswith("funsmry"):
         mode = "rt"
-        format = resfo.Format.FORMATTED
+        assumed_format = resfo.Format.FORMATTED
     else:
         mode = "rb"
-        format = resfo.Format.UNFORMATTED
+        assumed_format = resfo.Format.UNFORMATTED
 
     last_params = None
     values: list[npt.NDArray[np.float32]] = []
@@ -477,7 +479,7 @@ def _read_summary(
             last_params = None
 
     with open(summary, mode) as fp:
-        for entry in resfo.lazy_read(fp, format):
+        for entry in resfo.lazy_read(fp, assumed_format):
             kw = entry.read_keyword()
             if kw == "PARAMS  ":
                 last_params = entry

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1288,7 +1288,7 @@ class ErtConfig:
         return EnkfObs(obs_vectors, obs_time_list)
 
 
-def _split_string_into_sections(input: str, section_length: int) -> list[str]:
+def _split_string_into_sections(string: str, section_length: int) -> list[str]:
     """
     Splits a string into sections of length section_length and returns it as a list.
 
@@ -1296,8 +1296,10 @@ def _split_string_into_sections(input: str, section_length: int) -> list[str]:
     input string is returned as one section in a list
     """
     if section_length < 1:
-        return [input]
-    return [input[i : i + section_length] for i in range(0, len(input), section_length)]
+        return [string]
+    return [
+        string[i : i + section_length] for i in range(0, len(string), section_length)
+    ]
 
 
 def _get_files_in_directory(job_path, errors):

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -109,7 +109,7 @@ class GenDataConfig(ResponseConfig):
             report_steps_list=report_steps,
         )
 
-    def read_from_file(self, run_path: str, iens: int, iter: int) -> pl.DataFrame:
+    def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         def _read_file(filename: Path, report_step: int) -> pl.DataFrame:
             try:
                 data = np.loadtxt(filename, ndmin=1)
@@ -143,14 +143,14 @@ class GenDataConfig(ResponseConfig):
             datasets_per_report_step = []
             if report_steps is None:
                 try:
-                    filename = substitute_runpath_name(input_file, iens, iter)
+                    filename = substitute_runpath_name(input_file, iens, iter_)
                     datasets_per_report_step.append(_read_file(run_path_ / filename, 0))
                 except (InvalidResponseFile, FileNotFoundError) as err:
                     errors.append(err)
             else:
                 for report_step in report_steps:
                     filename = substitute_runpath_name(
-                        input_file % report_step, iens, iter
+                        input_file % report_step, iens, iter_
                     )
                     try:
                         datasets_per_report_step.append(

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -23,7 +23,7 @@ class ResponseConfig(ABC):
     has_finalized_keys: bool = False
 
     @abstractmethod
-    def read_from_file(self, run_path: str, iens: int, iter: int) -> pl.DataFrame:
+    def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         """Reads the data for the response from run_path.
 
         Raises:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -37,8 +37,8 @@ class SummaryConfig(ResponseConfig):
         base = self.input_files[0]
         return [f"{base}.UNSMRY", f"{base}.SMSPEC"]
 
-    def read_from_file(self, run_path: str, iens: int, iter: int) -> pl.DataFrame:
-        filename = substitute_runpath_name(self.input_files[0], iens, iter)
+    def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
+        filename = substitute_runpath_name(self.input_files[0], iens, iter_)
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
         if len(data) == 0 or len(keys) == 0:
             # https://github.com/equinor/ert/issues/6974

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -121,7 +121,7 @@ def _generate_parameter_files(
     _value_export_json(run_path, export_base_name, exports)
 
 
-def _manifest_to_json(ensemble: Ensemble, iens: int, iter: int) -> dict[str, Any]:
+def _manifest_to_json(ensemble: Ensemble, iens: int, iter_: int) -> dict[str, Any]:
     manifest = {}
     # Add expected parameter files to manifest
     for param_config in ensemble.experiment.parameter_configuration.values():
@@ -132,14 +132,14 @@ def _manifest_to_json(ensemble: Ensemble, iens: int, iter: int) -> dict[str, Any
         if param_config.forward_init and ensemble.iteration == 0:
             assert param_config.forward_init_file is not None
             file_path = substitute_runpath_name(
-                param_config.forward_init_file, iens, iter
+                param_config.forward_init_file, iens, iter_
             )
             manifest[param_config.name] = file_path
     # Add expected response files to manifest
     for response_config in ensemble.experiment.response_configuration.values():
         for input_file in response_config.expected_input_files:
             manifest[f"{response_config.response_type}_{input_file}"] = (
-                substitute_runpath_name(input_file, iens, iter)
+                substitute_runpath_name(input_file, iens, iter_)
             )
 
     return manifest

--- a/src/ert/ensemble_evaluator/snapshot.py
+++ b/src/ert/ensemble_evaluator/snapshot.py
@@ -466,5 +466,5 @@ def _realization_dict_to_realization_snapshot(
 T = TypeVar("T", RealizationSnapshot, FMStepSnapshot)
 
 
-def _filter_nones(input: T) -> T:
-    return cast(T, {k: v for k, v in input.items() if v is not None})
+def _filter_nones(data: T) -> T:
+    return cast(T, {k: v for k, v in data.items() if v is not None})

--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -156,7 +156,7 @@ class RealizationDelegate(QStyledItemDelegate):
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         return self._size
 
-    def eventFilter(self, object: QObject | None, event: QEvent | None) -> bool:
+    def eventFilter(self, object: QObject | None, event: QEvent | None) -> bool:  # noqa: A002
         if isinstance(event, QHelpEvent) and event.type() == QEvent.Type.ToolTip:
             mouse_pos = event.pos() + self.adjustment_point_for_job_rect_margin
             parent: RealizationWidget = cast(RealizationWidget, self.parent())

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -49,9 +49,9 @@ class PlotApi:
     def escape(s: str) -> str:
         return quote(quote(s, safe=""))
 
-    def _get_ensemble_by_id(self, id: str) -> EnsembleObject | None:
+    def _get_ensemble_by_id(self, id_: str) -> EnsembleObject | None:
         for ensemble in self.get_all_ensembles():
-            if ensemble.id == id:
+            if ensemble.id == id_:
                 return ensemble
         return None
 

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -80,10 +80,10 @@ class TerminalFormatter(logging.Formatter):
 def suppress_logs(logs_to_suppress: list[str]) -> Callable[[logging.LogRecord], bool]:
     """Suppresses logs from loggers listed in logs_to_suppress"""
 
-    def filter(record: logging.LogRecord) -> bool:
+    def log_filter(record: logging.LogRecord) -> bool:
         for log_name in logs_to_suppress:
             if record.name.startswith(log_name):
                 return False
         return True
 
-    return filter
+    return log_filter

--- a/src/ert/plugins/hook_implementations/workflows/export_runpath.py
+++ b/src/ert/plugins/hook_implementations/workflows/export_runpath.py
@@ -38,12 +38,12 @@ class ExportRunpathJob(ErtScript):
     ) -> None:
         args = " ".join(workflow_args).split()  # Make sure args is a list of words
         assert ensemble
-        iter = ensemble.iteration
+        iter_ = ensemble.iteration
         reals = ensemble.ensemble_size
         run_paths.write_runpath_list(
             *self.get_ranges(
                 args,
-                iter,
+                iter_,
                 reals,
             )
         )

--- a/src/ert/resources/forward_models/template_render.py
+++ b/src/ert/resources/forward_models/template_render.py
@@ -99,8 +99,8 @@ def render_template(
 
     _assert_input(all_input_files, template_file, output_file)
 
-    if dir := os.path.dirname(output_file):
-        os.makedirs(dir, exist_ok=True)
+    if directory := os.path.dirname(output_file):
+        os.makedirs(directory, exist_ok=True)
 
     template = _load_template(template_file)
     data = _load_input(all_input_files)

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -124,9 +124,9 @@ class MultipleDataAssimilation(UpdateRunModel):
 
         self.restart = restart
         if self.restart_run:
-            id = self.prior_ensemble_id
+            id_ = self.prior_ensemble_id
             try:
-                ensemble_id = UUID(id)
+                ensemble_id = UUID(id_)
                 prior = self._storage.get_ensemble(ensemble_id)
                 experiment = prior.experiment
                 self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
@@ -140,7 +140,7 @@ class MultipleDataAssimilation(UpdateRunModel):
                     )
             except (KeyError, ValueError) as err:
                 raise ErtRunError(
-                    f"Prior ensemble with ID: {id} does not exists"
+                    f"Prior ensemble with ID: {id_} does not exists"
                 ) from err
         else:
             self.run_workflows(

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -261,7 +261,7 @@ class Job:
         callback_status, status_msg = await forward_model_ok(
             run_path=self.real.run_arg.runpath,
             realization=self.real.run_arg.iens,
-            iter=self.real.run_arg.itr,
+            iter_=self.real.run_arg.itr,
             ensemble=self.real.run_arg.ensemble_storage,
         )
         if self._message:

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -446,8 +446,8 @@ def _tail_textfile(file_path: Path, num_chars: int) -> str:
 def _parse_squeue_output(output: str) -> Iterator[tuple[str, SqueueInfo]]:
     for line in output.split("\n"):
         if line:
-            id, status = line.split()
-            yield id, SqueueInfo(JobStatus[status])
+            id_, status = line.split()
+            yield id_, SqueueInfo(JobStatus[status])
 
 
 def _seconds_to_slurm_time_format(seconds: float) -> str:

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -476,8 +476,8 @@ class LocalStorage(BaseMode):
                 bkup_path = self.path / "_blockfs_backup"
                 dirs = set(os.listdir(self.path)) - {"storage.lock"}
                 os.mkdir(bkup_path)
-                for dir in dirs:
-                    shutil.move(self.path / dir, bkup_path / dir)
+                for directory in dirs:
+                    shutil.move(self.path / directory, bkup_path / directory)
 
                 self._index = self._load_index()
 

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -552,7 +552,7 @@ def test_es_mda(snapshot):
             data.append(ensemble.load_all_gen_kw_data())
     result = pd.concat(
         data,
-        keys=[f"iter-{iter}" for iter in range(len(data))],
+        keys=[f"iter-{iter_}" for iter_ in range(len(data))],
         names=("Iteration", "Realization"),
     )
 

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -65,25 +65,25 @@ class IoLibrary(Enum):
     RESDATA = auto()
 
 
-def extension(format: FieldFileFormat):
+def extension(format_: FieldFileFormat):
     """The file extension of a given field file format"""
-    if format in ROFF_FORMATS:
+    if format_ in ROFF_FORMATS:
         return "roff"
-    return format.value
+    return format_.value
 
 
 def xtgeo_fformat(
-    format: FieldFileFormat,
+    format_: FieldFileFormat,
 ) -> Literal["roff", "roffasc", "grdecl", "bgrdecl"]:
     """Converts the FieldFileFormat to the corresponding xtgeo 'fformat' value.
 
     See xtgeo.GridProperty.to_file
     """
-    if format == FieldFileFormat.ROFF_BINARY:
+    if format_ == FieldFileFormat.ROFF_BINARY:
         return "roff"
-    elif format == FieldFileFormat.ROFF_ASCII:
+    elif format_ == FieldFileFormat.ROFF_ASCII:
         return "roffasc"
-    return format.value
+    return format_.value
 
 
 class IoProvider:

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1857,15 +1857,15 @@ def test_warning_is_emitted_when_malformatted_runpath():
     )
 
 
-@given(input=st.text(), section_length=st.integers())
-def test_split_string_into_sections(input, section_length):
-    split_string = _split_string_into_sections(input, section_length)
-    assert "".join(split_string) == input
+@given(string=st.text(), section_length=st.integers())
+def test_split_string_into_sections(string, section_length):
+    split_string = _split_string_into_sections(string, section_length)
+    assert "".join(split_string) == string
     if section_length > 0:
         for section in split_string:
             assert len(section) <= section_length
     else:
-        split_string = [input]
+        split_string = [string]
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -622,7 +622,7 @@ def test_suggestion_on_empty_parameter_file():
 
 
 @pytest.mark.parametrize(
-    "distribution, min, mode, max, error",
+    "distribution, minimum, mode, maximum, error",
     [
         ("TRIANGULAR", "0", "2", "3", None),
         (
@@ -650,7 +650,7 @@ def test_suggestion_on_empty_parameter_file():
     ],
 )
 def test_validation_triangular_distribution(
-    tmpdir, distribution, min, mode, max, error
+    tmpdir, distribution, minimum, mode, maximum, error
 ):
     with tmpdir.as_cwd():
         with open("template.txt", "w", encoding="utf-8") as fh:
@@ -659,7 +659,7 @@ def test_validation_triangular_distribution(
             "KW_NAME",
             ("template.txt", "MY_KEYWORD <MY_KEYWORD>"),
             "kw.txt",
-            ("prior.txt", f"MY_KEYWORD {distribution} {min} {mode} {max}"),
+            ("prior.txt", f"MY_KEYWORD {distribution} {minimum} {mode} {maximum}"),
             {},
         ]
 
@@ -674,7 +674,7 @@ def test_validation_triangular_distribution(
 
 
 @pytest.mark.parametrize(
-    "distribution, nbins, min, max, skew, width, error",
+    "distribution, nbins, minimum, maximum, skew, width, error",
     [
         ("DERRF", "10", "-1", "3", "-1", "2", None),
         ("DERRF", "100", "-10", "10", "0", "1", None),
@@ -770,7 +770,7 @@ def test_validation_triangular_distribution(
     ],
 )
 def test_validation_derrf_distribution(
-    tmpdir, distribution, nbins, min, max, skew, width, error
+    tmpdir, distribution, nbins, minimum, maximum, skew, width, error
 ):
     with tmpdir.as_cwd():
         with open("template.txt", "w", encoding="utf-8") as fh:
@@ -781,7 +781,7 @@ def test_validation_derrf_distribution(
             "kw.txt",
             (
                 "prior.txt",
-                f"MY_KEYWORD {distribution} {nbins} {min} {max} {skew} {width}",
+                f"MY_KEYWORD {distribution} {nbins} {minimum} {maximum} {skew} {width}",
             ),
             {},
         ]

--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -251,13 +251,13 @@ def test_local_well_summary_format_have_cell_index_and_name(keyword, name, lgr_n
 
 @given(summaries(), st.sampled_from(resfo.Format))
 def test_that_reading_summaries_returns_the_contents_of_the_file(
-    tmp_path_factory, summary, format
+    tmp_path_factory, summary, format_
 ):
     tmp_path = tmp_path_factory.mktemp("summary")
-    format_specifier = "F" if format == resfo.Format.FORMATTED else ""
+    format_specifier = "F" if format_ == resfo.Format.FORMATTED else ""
     smspec, unsmry = summary
-    unsmry.to_file(tmp_path / f"TEST.{format_specifier}UNSMRY", format)
-    smspec.to_file(tmp_path / f"TEST.{format_specifier}SMSPEC", format)
+    unsmry.to_file(tmp_path / f"TEST.{format_specifier}UNSMRY", format_)
+    smspec.to_file(tmp_path / f"TEST.{format_specifier}SMSPEC", format_)
     (_, keys, time_map, data) = read_summary(str(tmp_path / "TEST"), ["*"])
 
     local_name = smspec.lgrs or []

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -543,8 +543,8 @@ def test_that_non_existing_install_job_errors_deprecated(
     )
 
     with pytest.raises(ConfigValidationError, match="No such file or directory:"):
-        dict = everest_to_ert_config_dict(config)
-        ErtConfig.from_dict(dict)
+        dictionary = everest_to_ert_config_dict(config)
+        ErtConfig.from_dict(dictionary)
 
 
 @pytest.mark.parametrize(
@@ -585,8 +585,8 @@ def test_that_existing_install_job_with_malformed_executable_errors_deprecated(
     with pytest.raises(
         ConfigValidationError, match="EXECUTABLE must have at least 1 arguments"
     ):
-        dict = everest_to_ert_config_dict(config)
-        ErtConfig.from_dict(dict)
+        dictionary = everest_to_ert_config_dict(config)
+        ErtConfig.from_dict(dictionary)
 
 
 @pytest.mark.parametrize(
@@ -624,8 +624,8 @@ def test_that_existing_install_job_with_non_executable_executable_errors_depreca
     )
 
     with pytest.raises(ConfigValidationError, match="File not executable"):
-        dict = everest_to_ert_config_dict(config)
-        ErtConfig.from_dict(dict)
+        dictionary = everest_to_ert_config_dict(config)
+        ErtConfig.from_dict(dictionary)
 
 
 @pytest.mark.parametrize(
@@ -689,8 +689,8 @@ def test_that_existing_install_job_with_non_existing_executable_errors_deprecate
     )
 
     with pytest.raises(ConfigValidationError, match="Could not find executable"):
-        dict = everest_to_ert_config_dict(config)
-        ErtConfig.from_dict(dict)
+        dictionary = everest_to_ert_config_dict(config)
+        ErtConfig.from_dict(dictionary)
 
 
 @pytest.mark.parametrize(

--- a/tests/everest/test_data/mocked_test_case/jobs/npv_function_mock.py
+++ b/tests/everest/test_data/mocked_test_case/jobs/npv_function_mock.py
@@ -26,12 +26,12 @@ sum_mock["TIME"] = [
 ]
 
 
-def compute_npv(sum):
-    fopt = sum.get("FOPT")
-    fwpt = sum.get("FWPT")
-    fgpt = sum.get("FGPT")
-    fwit = sum.get("FWIT")
-    elapsedtime = sum.get("TIME")
+def compute_npv(summary):
+    fopt = summary.get("FOPT")
+    fwpt = summary.get("FWPT")
+    fgpt = summary.get("FGPT")
+    fwit = summary.get("FWIT")
+    elapsedtime = summary.get("TIME")
 
     with open("debug.txt", "w", encoding="utf-8") as f:
         DCF = compute_dcf(fopt[0], fwpt[0], fgpt[0], fwit[0], elapsedtime[0])

--- a/tests/everest/test_data/mocked_test_case/jobs/oil_prod_rate_mock.py
+++ b/tests/everest/test_data/mocked_test_case/jobs/oil_prod_rate_mock.py
@@ -17,11 +17,11 @@ def main(argv):
     # Main script starts here
     times = sys.argv[2:]
 
-    sum = {}
-    sum["FOPR"] = 17 * [6000]
+    summary = {}
+    summary["FOPR"] = 17 * [6000]
 
     for i in range(len(times)):
-        val = sum.get("FOPR")[i]
+        val = summary.get("FOPR")[i]
         save_return_value(val, f"oil_prod_rate_{i:03d}")
 
     with open("OIL_PROD_RATE_OK", "w", encoding="utf-8") as f:

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -20,14 +20,14 @@ def test_random_seed(tmp_path, monkeypatch, random_seed):
     if random_seed:
         config["environment"] = {"random_seed": random_seed}
     ever_config = EverestConfig.with_defaults(**config)
-    dict = everest_to_ert_config_dict(ever_config)
+    dictionary = everest_to_ert_config_dict(ever_config)
 
     if random_seed is None:
         assert ever_config.environment.random_seed > 0
-        assert dict[ErtConfigKeys.RANDOM_SEED] > 0
+        assert dictionary[ErtConfigKeys.RANDOM_SEED] > 0
     else:
         assert ever_config.environment.random_seed == random_seed
-        assert dict[ErtConfigKeys.RANDOM_SEED] == random_seed
+        assert dictionary[ErtConfigKeys.RANDOM_SEED] == random_seed
 
 
 def test_read_file(tmp_path, monkeypatch):


### PR DESCRIPTION
Mostly this ruff rule:

Derived from the **flake8-builtins** linter.

Checks for variable (and function) assignments that use the same names as builtins.

Reusing a builtin name for the name of a variable increases the difficulty of reading and maintaining the code, and can cause non-obvious errors, as readers may mistake the variable for the builtin and vice versa.

Builtins can be marked as exceptions to this rule via the [`lint.flake8-builtins.ignorelist`] configuration option.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
