### PR TITLE
Update select_wells job arguments in valid_config_maintained_forward_models.yml

### DIFF
--- a/tests/everest/test_data/valid_config_file/forward_models/valid_config_maintained_forward_models.yml
+++ b/tests/everest/test_data/valid_config_file/forward_models/valid_config_maintained_forward_models.yml
@@ -61,7 +61,7 @@ install_data:
 
 forward_model:
   - drill_planner -i wells.json -c drill_planner_config.yml -opt well_order.json -o wells_dp_result.json
-  - select_wells -i wells_dp_result.json -o wells_sw_result.json file well_number.json -r 0 6 -s 0 1
+  - select_wells -i wells_dp_result.json -o wells_sw_result.json file well_number.json
   - add_templates -i wells_sw_result.json -c configs/template_config.yml -o wells_tmpl_result.json
   - schmerge -i wells_tmpl_result.json -s input/model/WELLSELECT.SCH -o input/model/SCHEDULE_OPT.SCH
   - npv -s something.UNSMRY -o npv_0 -c prices.yml -sd 2022-10-01 -ed 2040-01-01 -i files/a7_readydate.json'


### PR DESCRIPTION
**Issue**
Update select_wells job arguments in valid_config_maintained_forward_models.yml to match the autoscaling changes in everest-models. 


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
