### PR TITLE
Reintroduce possibility to log from Everest with pluggins

### DIFF
--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -13,7 +13,8 @@ from everest.bin.everlint_script import lint_entry
 from everest.bin.kill_script import kill_entry
 from everest.bin.monitor_script import monitor_entry
 from everest.bin.visualization_script import visualization_entry
-from everest.trace import tracer
+from everest.plugins.everest_plugin_manager import EverestPluginManager
+from everest.trace import tracer, tracer_provider
 
 
 def _build_args_parser() -> argparse.ArgumentParser:
@@ -44,6 +45,11 @@ class EverestMain:
         parsed_args = parser.parse_args(args[1:2])
         if not hasattr(self, parsed_args.command):
             parser.error("Unrecognized command")
+
+        # Setup logging from plugins:
+        plugin_manager = EverestPluginManager()
+        plugin_manager.add_log_handle_to_root()
+        plugin_manager.add_span_processor_to_trace_provider(tracer_provider)
 
         # Use dispatch pattern to invoke method with same name
         getattr(self, parsed_args.command)(args[2:])


### PR DESCRIPTION
Reintroduces possibility to add log handlers and span processors through plugins

This was removed in commit: 087b9b8100faea908b58727de00131278dcf1847

**Issue**
Resolves #10725 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
