### PR TITLE
Avoid claiming misconfigured NUM_CPU for short jobs

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -466,12 +466,14 @@ def detect_overspent_cpu(num_cpu: int, real_id: str, fm_step: FMStepSnapshot) ->
     """Produces a message warning about misconfiguration of NUM_CPU if
     so is detected. Returns an empty string if everything is ok."""
     allowed_overspending = 1.05
+    minimum_wallclock_time_seconds = 30  # Information is only polled every 5 sec
+
     start_time = fm_step.get(ids.START_TIME)
     end_time = fm_step.get(ids.END_TIME)
     if start_time is None or end_time is None:
         return ""
     duration = (end_time - start_time).total_seconds()
-    if duration <= 0:
+    if duration <= minimum_wallclock_time_seconds:
         return ""
     cpu_seconds = fm_step.get(ids.CPU_SECONDS) or 0.0
     parallelization_obtained = cpu_seconds / duration

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -608,7 +608,7 @@ def test_overspent_cpu_is_logged(
             cpu_seconds=cpu_seconds,
         ),
     )
-    if duration > 0 and cpu_seconds / duration > num_cpu * 1.05:
+    if duration > 30 and cpu_seconds / duration > num_cpu * 1.05:
         assert "Misconfigured NUM_CPU" in message
     else:
         assert "NUM_CPU" not in message


### PR DESCRIPTION
**Issue**
Resolves #10744 


**Approach**
🕐 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
