### PR TITLE
Convert ert config to basemodel

### DIFF
--- a/docs/ert/conf.py
+++ b/docs/ert/conf.py
@@ -179,6 +179,8 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 # Ignore unresolved references
 nitpick_ignore = [
     ("py:class", "ert.plugins.ert_script.ErtScript"),
+    ("py:class", "ErtScript"),
+    ("py:class", "ArgumentParser"),
     ("py:class", "Ensemble"),
     ("py:class", "ESSettings"),
     ("py:class", "Storage"),

--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -228,6 +228,7 @@ The configuration object and properties are as follows.
 .. autoclass:: ert.plugins.workflow_config.ErtScriptWorkflow
     :members:
     :undoc-members:
+    :exclude-members: model_config, validate_types
 
 Logging configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -1,5 +1,6 @@
 import dataclasses
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self, cast
@@ -45,7 +46,8 @@ class GenDataConfig(ResponseConfig):
 
     @classmethod
     def from_config_dict(cls, config_dict: ConfigDict) -> Self:
-        gen_data_list = config_dict.get("GEN_DATA", [])  # type: ignore
+        gen_data_list = config_dict.get("GEN_DATA", [])
+        assert isinstance(gen_data_list, Iterable)
 
         keys = []
         input_files = []

--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -6,8 +6,7 @@ import os.path
 import shutil
 from typing import no_type_check
 
-from pydantic import field_validator
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, field_validator
 
 from ert.shared.status.utils import byte_with_unit, get_mount_directory
 
@@ -32,8 +31,7 @@ MINIMUM_BYTES_LEFT_ON_DISK_THRESHOLD = 200 * 1000**3  # 200 GB
 # and used space in percentage is greater than FULL_DISK_PERCENTAGE_THRESHOLD
 
 
-@dataclass
-class ModelConfig:
+class ModelConfig(BaseModel):
     num_realizations: int = 1
     runpath_format_string: str = DEFAULT_RUNPATH
     jobname_format_string: str = DEFAULT_JOBNAME_FORMAT

--- a/src/ert/config/parsing/config_dict.py
+++ b/src/ert/config/parsing/config_dict.py
@@ -1,4 +1,4 @@
 from .context_values import ContextString
 from .types import MaybeWithContext
 
-ConfigDict = dict[ContextString, MaybeWithContext]
+ConfigDict = dict[ContextString | str, MaybeWithContext]

--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -89,9 +89,9 @@ class QueueOptions(
 
     def add_global_queue_options(self, config_dict: ConfigDict) -> None:
         for name, generic_option in QueueOptions.model_fields.items():
-            if (
-                generic_value := config_dict.get(name.upper(), None)  # type: ignore
-            ) and self.__dict__[name] == generic_option.default:
+            if (generic_value := config_dict.get(name.upper(), None)) and self.__dict__[
+                name
+            ] == generic_option.default:
                 try:
                     setattr(self, name, generic_value)
                 except pydantic.ValidationError as exception:

--- a/src/ert/config/refcase.py
+++ b/src/ert/config/refcase.py
@@ -35,11 +35,11 @@ class Refcase:
     @classmethod
     def from_config_dict(cls, config_dict: ConfigDict) -> Self | None:
         data = None
-        refcase_file_path = config_dict.get(ConfigKeys.REFCASE)  # type: ignore
+        refcase_file_path = config_dict.get(ConfigKeys.REFCASE)
         if refcase_file_path is not None:
             try:
                 start_date, refcase_keys, time_map, data = read_summary(
-                    refcase_file_path, ["*"]
+                    str(refcase_file_path), ["*"]
                 )
             except Exception as err:
                 raise ConfigValidationError(f"Could not read refcase: {err}") from err

--- a/src/ert/config/workflow.py
+++ b/src/ert/config/workflow.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
+
+from ert.substitutions import Substitutions
 
 from .parsing import ConfigValidationError, ErrorInfo, init_workflow_schema, parse
 from .parsing.types import Defines
-
-if TYPE_CHECKING:
-    from ert.substitutions import Substitutions
-
-    from .workflow_job import _WorkflowJob
+from .workflow_job import _WorkflowJob
 
 
 @dataclass

--- a/src/ert/config/workflow_job.py
+++ b/src/ert/config/workflow_job.py
@@ -41,21 +41,21 @@ def workflow_job_from_file(config_file: str, name: str | None = None) -> _Workfl
 
     content_dict = workflow_job_parser(config_file)
     arg_types_list = _WorkflowJob._make_arg_types_list(content_dict)
-    min_args = content_dict.get("MIN_ARG")  # type: ignore
-    max_args = content_dict.get("MAX_ARG")  # type: ignore
-    script = str(content_dict.get("SCRIPT")) if "SCRIPT" in content_dict else None  # type: ignore
+    min_args = content_dict.get("MIN_ARG")
+    max_args = content_dict.get("MAX_ARG")
+    script = str(content_dict.get("SCRIPT")) if "SCRIPT" in content_dict else None
     internal = (
-        bool(content_dict.get("INTERNAL")) if "INTERNAL" in content_dict else None  # type: ignore
+        bool(content_dict.get("INTERNAL")) if "INTERNAL" in content_dict else None
     )
     if internal is False:
         ConfigWarning.deprecation_warn(
             "INTERNAL FALSE has no effect and can be safely removed",
-            content_dict["INTERNAL"],  # type: ignore
+            content_dict["INTERNAL"],
         )
     if script and not internal:
         ConfigWarning.deprecation_warn(
             "SCRIPT has no effect and can be safely removed",
-            content_dict["SCRIPT"],  # type: ignore
+            content_dict["SCRIPT"],
         )
     if script is not None and internal:
         msg = (
@@ -63,7 +63,7 @@ def workflow_job_from_file(config_file: str, name: str | None = None) -> _Workfl
             f"for {name}, loading script {script}"
         )
         logger.warning(msg)
-        ConfigWarning.deprecation_warn(msg, content_dict["SCRIPT"])  # type: ignore
+        ConfigWarning.deprecation_warn(msg, content_dict["SCRIPT"])
         try:
             ert_script = ErtScript.loadScriptFromFile(script)
         # Bare Exception here as we have no control
@@ -76,7 +76,7 @@ def workflow_job_from_file(config_file: str, name: str | None = None) -> _Workfl
             min_args=min_args,
             max_args=max_args,
             arg_types=arg_types_list,
-            stop_on_fail=bool(content_dict.get("STOP_ON_FAIL")),  # type: ignore
+            stop_on_fail=bool(content_dict.get("STOP_ON_FAIL")),
         )
     else:
         return ExecutableWorkflow(
@@ -84,8 +84,8 @@ def workflow_job_from_file(config_file: str, name: str | None = None) -> _Workfl
             min_args=min_args,
             max_args=max_args,
             arg_types=arg_types_list,
-            executable=content_dict.get("EXECUTABLE"),  # type: ignore
-            stop_on_fail=bool(content_dict.get("STOP_ON_FAIL")),  # type: ignore
+            executable=content_dict.get("EXECUTABLE"),
+            stop_on_fail=bool(content_dict.get("STOP_ON_FAIL")),
         )
 
 

--- a/src/ert/config/workflow_job.py
+++ b/src/ert/config/workflow_job.py
@@ -94,7 +94,7 @@ class _WorkflowJob(BaseModel):
     min_args: int | None = None
     max_args: int | None = None
     arg_types: list[SchemaItemType] = field(default_factory=list)
-    stop_on_fail: bool | None = None  # If not None, overrides in-file specification
+    stop_on_fail: bool = False
 
     @staticmethod
     def _make_arg_types_list(content_dict: ConfigDict) -> list[SchemaItemType]:

--- a/src/ert/workflow_runner.py
+++ b/src/ert/workflow_runner.py
@@ -44,18 +44,14 @@ class WorkflowJobRunner:
 
         if isinstance(self.job, ErtScriptWorkflow):
             self.__script = self.job.ert_script()
-            if self.job.stop_on_fail is not None:
-                self.stop_on_fail = self.job.stop_on_fail
-            elif self.__script is not None:
-                self.stop_on_fail = self.__script.stop_on_fail or False
+            # We let stop on fail either from class or config take precedence
+            self.stop_on_fail = self.job.stop_on_fail or self.__script.stop_on_fail
 
         else:
             self.__script = ExternalErtScript(
                 self.job.executable,  # type: ignore
             )
-
-            if self.job.stop_on_fail is not None:
-                self.stop_on_fail = self.job.stop_on_fail
+            self.stop_on_fail = self.job.stop_on_fail
 
         result = self.__script.initializeAndRun(
             self.job.argument_types(), arguments, fixtures

--- a/tests/ert/unit_tests/config/test_ensemble_config.py
+++ b/tests/ert/unit_tests/config/test_ensemble_config.py
@@ -137,7 +137,7 @@ def test_ensemble_config_duplicate_node_names():
     }
     with (
         pytest.raises(
-            ConfigValidationError,
+            ValueError,
             match="GEN_KW and GEN_DATA contained duplicate name: Test_name",
         ),
         pytest.warns(match="The template file .* is empty"),

--- a/tests/ert/unit_tests/plugins/test_workflow_config.py
+++ b/tests/ert/unit_tests/plugins/test_workflow_config.py
@@ -3,8 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 
-import ert
-import ert.config.workflow_job
 from ert import ErtScript
 from ert.plugins import workflow_config
 from ert.plugins.workflow_config import WorkflowConfigs
@@ -12,7 +10,7 @@ from ert.plugins.workflow_config import WorkflowConfigs
 
 def test_workflow_config_duplicate_log_message(caplog, monkeypatch):
     def get_mock_config():
-        workflow_mock = Mock(spec=ert.config.workflow_job.ErtScriptWorkflow)
+        workflow_mock = Mock()
         workflow_mock.name = "same_name"
         return workflow_mock
 

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -34,7 +34,7 @@ def create_base_run_model(**kwargs):
         "user_config_file": MagicMock(spec=Path),
         "env_vars": MagicMock(spec=dict),
         "env_pr_fm_step": MagicMock(spec=dict),
-        "model_config": MagicMock(spec=ModelConfig),
+        "model_config": ModelConfig(),
         "queue_config": MagicMock(spec=SimpleQueue),
         "forward_model_steps": MagicMock(spec=dict),
         "status_queue": MagicMock(spec=SimpleQueue),


### PR DESCRIPTION
Allows us to do:

```python
ert_config.model_dump(exclude_defaults=True)
```

and get the user configured dict for potential reading of yaml down the line, for poly example:
```yaml
analysis_config:
    minimum_required_realizations: 1
config_path: /path/to/ert/test-data/ert/poly_example
enkf_obs:
    obs_vectors:
        POLY_OBS:
            data_key: POLY_RES
            observation_key: POLY_OBS
            observation_type: 3
            observations:
                '0':
                    indices:
                    - 0
                    - 2
                    - 4
                    - 6
                    - 8
                    std_scaling:
                    - 1.0
                    - 1.0
                    - 1.0
                    - 1.0
                    - 1.0
                    stds:
                    - 0.6
                    - 1.4
                    - 3.0
                    - 5.4
                    - 8.6
                    values:
                    - 2.1457049781272213
                    - 8.769219841380755
                    - 12.388014786122742
                    - 25.600464531354252
                    - 42.35204755970952
ens_path: /path/to/ert/test-data/ert/poly_example/storage
ensemble_config:
    parameter_configs:
       gen_kw:
         COEFFS:
            transform_function_definitions:
              a:
                param_name: UNIFORM
                values:
                - '0'
                - '1'
              b:
                distribution:
                   type: UNIFORM, 
                   min: 0, 
                   max:2
            c:
                param_name: UNIFORM
                values:
                - '0'
                - '5'
            update: true
    response_configs:
        gen_data:
            input_files:
            - poly.out
            keys:
            - POLY_RES
            report_steps_list:
            - null
forward_model_steps:
-   environment:
        _ERT_ITERATION_NUMBER: <ITER>
        _ERT_REALIZATION_NUMBER: <IENS>
        _ERT_RUNPATH: <RUNPATH>
    executable: /path/to/ert/test-data/ert/poly_example/poly_eval.py
    name: poly_eval
    stderr_file: poly_eval.stderr
    stdout_file: poly_eval.stdout
observation_config:
-   - POLY_OBS
    -   data: POLY_RES
        index_list: 0,2,4,6,8
        obs_file: /path/to/ert/test-data/ert/poly_example/poly_obs_data.txt
queue_config:
    queue_options:
        activate_script: source /path/to_env/ert/bin/activate
        max_running: 50
    realization_memory: 52428800
random_seed: 229541285455692126616861960897596451717
runpath_config:
    num_realizations: 100
    runpath_format_string: /path/to/ert/test-data/ert/poly_example/poly_out/realization-<IENS>/iter-<ITER>
runpath_file: /path/to/ert/test-data/ert/poly_example/.ert_runpath_list
substitutions:
    <CONFIG_FILE>: poly.ert
    <CONFIG_FILE_BASE>: poly
    <CONFIG_PATH>: /path/to/ert/test-data/ert/poly_example
    <CWD>: /path/to/ert/test-data/ert/poly_example
    <DATE>: '2025-05-05'
    <ECLBASE>: ECLBASE<IENS>
    <ECL_BASE>: ECLBASE<IENS>
    <NUM_CPU>: '1'
    <RUNPATH>: /path/to/ert/test-data/ert/poly_example/poly_out/realization-<IENS>/iter-<ITER>
    <RUNPATH_FILE>: /path/to/ert/test-data/ert/poly_example/.ert_runpath_list
user_config_file: /path/to/ert/test-data/ert/poly_example/poly.ert
```



**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
