### PR TITLE
Extend error message for NoPortsInRangeException

### DIFF
--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -86,7 +86,10 @@ def find_available_socket(
         except PortAlreadyInUseException:
             continue
 
-    raise NoPortsInRangeException(f"No available ports in range {port_range}.")
+    raise NoPortsInRangeException(
+        f"No available ports in range {port_range}. "
+        "Perhaps you are running too many instances of Ert."
+    )
 
 
 def _bind_socket(host: str, port: int) -> socket.socket:


### PR DESCRIPTION
**Issue**
Resolves #10573


**Approach**
Extend error message

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
