### PR TITLE
Align simulation panel contents to the left

### DIFF
--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import QFormLayout, QHBoxLayout, QLabel, QWidget
 
@@ -48,9 +49,13 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
     ) -> None:
         super().__init__(EnsembleSmoother)
         self.notifier = notifier
+        self.setObjectName("ensemble_smoother_panel")
 
         layout = QFormLayout()
-        self.setObjectName("ensemble_smoother_panel")
+        lab = QLabel(" ".join(EnsembleSmoother.__doc__.split()))  # type: ignore
+        lab.setWordWrap(True)
+        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        layout.addRow(lab)
 
         self._experiment_name_field = StringBox(
             TextModel(""),

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -52,8 +52,7 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         self.setObjectName("ensemble_smoother_panel")
 
         layout = QFormLayout()
-        lab = QLabel(" ".join(EnsembleSmoother.__doc__.split()))  # type: ignore
-        lab.setWordWrap(True)
+        lab = QLabel(EnsembleSmoother.name())
         lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
         layout.addRow(lab)
 

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -43,8 +43,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         self.setObjectName("Manual_update_panel")
 
         layout = QFormLayout()
-        lab = QLabel(" ".join(ManualUpdate.__doc__.split()))  # type: ignore
-        lab.setWordWrap(True)
+        lab = QLabel(ManualUpdate.name())
         lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
         layout.addRow(lab)
         self._ensemble_selector = EnsembleSelector(notifier)

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QCheckBox, QFormLayout, QHBoxLayout, QLabel, QWidget
@@ -58,6 +59,10 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self.notifier = notifier
 
         layout = QFormLayout()
+        lab = QLabel(" ".join(MultipleDataAssimilation.__doc__.split()))  # type: ignore
+        lab.setWordWrap(True)
+        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        layout.addRow(lab)
         self.setObjectName("ES_MDA_panel")
 
         self._experiment_name_field = StringBox(

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -26,6 +26,10 @@ logger = logging.getLogger(__name__)
 
 
 class EnsembleSmoother(UpdateRunModel):
+    """
+    Ensemble Smoother
+    """
+
     def __init__(
         self,
         target_ensemble: str,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -26,10 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class EnsembleSmoother(UpdateRunModel):
-    """
-    Ensemble Smoother
-    """
-
     def __init__(
         self,
         target_ensemble: str,

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class ManualUpdate(UpdateRunModel):
-    """Manual update"""
-
     def __init__(
         self,
         ensemble_id: str,


### PR DESCRIPTION
**Issue**
Resolves #10543 

This was only present on macOS, although there is no guarantee this won't surface on RHEL later on.
The fix will make the panels more consistent in that they all will show the `__doc__` as a label at the top.

https://github.com/user-attachments/assets/accfec9e-cc63-4474-8aa1-c339586a1ead

https://github.com/user-attachments/assets/fd4fa663-caef-4919-954f-301f6c3df74a



**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
