### PR TITLE
Add correct formatting when doing parameter substitution

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -299,7 +299,7 @@ class GenKwConfig(ParameterConfig):
         run_path: Path,
         real_nr: int,
         ensemble: Ensemble,
-    ) -> dict[str, dict[str, float]]:
+    ) -> dict[str, dict[str, float | str]]:
         array = ensemble.load_parameters(self.name, real_nr)["transformed_values"]
         assert isinstance(array, xr.DataArray)
         if not array.size == len(self.transform_functions):
@@ -327,10 +327,10 @@ class GenKwConfig(ParameterConfig):
             )
         )
 
-        log10_data = {
+        log10_data: dict[str, float | str] = {
             tf.name: math.log10(data[tf.name])
             for tf in self.transform_functions
-            if tf.use_log
+            if tf.use_log and isinstance(data[tf.name], (int, float))
         }
 
         if log10_data:

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -61,7 +61,7 @@ class ParameterConfig(ABC):
     @abstractmethod
     def write_to_runpath(
         self, run_path: Path, real_nr: int, ensemble: Ensemble
-    ) -> dict[str, dict[str, float]] | None:
+    ) -> dict[str, dict[str, float | str]] | None:
         """
         This function is responsible for converting the parameter
         from the internal ert format to the format the forward model

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -43,7 +43,9 @@ def _backup_if_existing(path: Path) -> None:
 
 
 def _value_export_txt(
-    run_path: Path, export_base_name: str, values: Mapping[str, Mapping[str, float]]
+    run_path: Path,
+    export_base_name: str,
+    values: Mapping[str, Mapping[str, float | str]],
 ) -> None:
     path = run_path / f"{export_base_name}.txt"
     _backup_if_existing(path)
@@ -61,7 +63,9 @@ def _value_export_txt(
 
 
 def _value_export_json(
-    run_path: Path, export_base_name: str, values: Mapping[str, Mapping[str, float]]
+    run_path: Path,
+    export_base_name: str,
+    values: Mapping[str, Mapping[str, float | str]],
 ) -> None:
     path = run_path / f"{export_base_name}.json"
     _backup_if_existing(path)
@@ -70,7 +74,7 @@ def _value_export_json(
         return
 
     # Hierarchical
-    json_out: dict[str, float | dict[str, float]] = {
+    json_out: dict[str, float | dict[str, float | str]] = {
         key: dict(param_map.items()) for key, param_map in values.items()
     }
 
@@ -90,7 +94,7 @@ def _generate_parameter_files(
     iens: int,
     fs: Ensemble,
     iteration: int,
-) -> dict[str, dict[str, float]]:
+) -> dict[str, dict[str, float | str]]:
     """
     Generate parameter files that are placed in each runtime directory for
     forward-model jobs to consume.
@@ -104,7 +108,7 @@ def _generate_parameter_files(
         iens: Realisation index
         fs: Ensemble from which to load parameter data
     """
-    exports: dict[str, dict[str, float]] = {}
+    exports: dict[str, dict[str, float | str]] = {}
 
     for node in parameter_configs:
         # For the first iteration we do not write the parameter

--- a/src/ert/substitutions.py
+++ b/src/ert/substitutions.py
@@ -31,11 +31,15 @@ class Substitutions(UserDict[str, str]):
         return _substitute(self, to_substitute, context, max_iterations, warn_max_iter)
 
     def substitute_parameters(
-        self, to_substitute: str, data: dict[str, dict[str, float]]
+        self, to_substitute: str, data: dict[str, dict[str, float | str]]
     ) -> str:
         for values in data.values():
             for key, value in values.items():
-                to_substitute = to_substitute.replace(f"<{key}>", f"{value:.6g}")
+                if isinstance(value, (int, float)):
+                    formatted_value = f"{value:.6g}"
+                else:
+                    formatted_value = str(value)
+                to_substitute = to_substitute.replace(f"<{key}>", formatted_value)
         return to_substitute
 
     def substitute_real_iter(

--- a/tests/ert/unit_tests/test_substitution_list.py
+++ b/tests/ert/unit_tests/test_substitution_list.py
@@ -48,6 +48,16 @@ def test_subst_list_reads_correct_values():
     assert substitutions["keyD"] == "valD"
 
 
+def test_substitutions_with_hybrid_parameter_types():
+    subst_list = Substitutions()
+    params: dict[str, dict[str, float | str]] = {
+        "GROUP1": {"a": 1.01},
+        "GROUP2": {"b": "value"},
+    }
+    to_substitute = "<a> and <b>"
+    assert subst_list.substitute_parameters(to_substitute, params) == "1.01 and value"
+
+
 def test_substitutions():
     subst_list = Substitutions()
 


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/10772

The follow up issue: https://github.com/equinor/ert/issues/10779

**Approach**

When using DESIGN_MATRIX internally it is still represented as GENKW and thus parameters might be of type str. This resolves the formatting error.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
