### PR TITLE
Prohibit CPU overspending warning on localqueue

### DIFF
--- a/src/ert/ensemble_evaluator/_ensemble.py
+++ b/src/ert/ensemble_evaluator/_ensemble.py
@@ -17,7 +17,7 @@ from _ert.events import (
     ForwardModelStepFailure,
     ForwardModelStepSuccess,
 )
-from ert.config import ForwardModelStep, QueueConfig
+from ert.config import ForwardModelStep, QueueConfig, QueueSystem
 from ert.run_arg import RunArg
 from ert.scheduler import Scheduler, create_driver
 
@@ -266,6 +266,10 @@ class LegacyEnsemble:
         if self._scheduler is not None:
             await self._scheduler.kill_all_jobs()
         logger.debug("evaluator cancelled")
+
+    @property
+    def queue_system(self) -> QueueSystem:
+        return self._queue_config.queue_system
 
 
 @dataclass

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -36,6 +36,7 @@ from _ert.forward_model_runner.client import (
 )
 from ert.ensemble_evaluator import identifiers as ids
 
+from ..config import QueueSystem
 from ._ensemble import FMStepSnapshot
 from ._ensemble import LegacyEnsemble as Ensemble
 from .config import EvaluatorServerConfig
@@ -176,9 +177,10 @@ class EnsembleEvaluator:
             memory_usage = fm_step.get(ids.MAX_MEMORY_USAGE) or "-1"
             max_memory_usage = max(int(memory_usage), max_memory_usage)
 
-            if cpu_message := detect_overspent_cpu(
+            cpu_message = detect_overspent_cpu(
                 self.ensemble.reals[int(real_id)].num_cpu, real_id, fm_step
-            ):
+            )
+            if self.ensemble.queue_system != QueueSystem.LOCAL and cpu_message:
                 logger.warning(cpu_message)
 
         logger.info(


### PR DESCRIPTION
**Issue**
Resolves #10780 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
