### PR TITLE
Use polars to save and load genkw parameters

### DIFF
--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -272,6 +272,7 @@ class Field(ParameterConfig):
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
     ) -> npt.NDArray[np.float64]:
         ds = ensemble.load_parameters(self.name, realizations)
+        assert isinstance(ds, xr.Dataset)
         ensemble_size = len(ds.realizations)
         da = xr.DataArray(
             [

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import networkx as nx
 import numpy as np
+import polars as pl
 import xarray as xr
 from pydantic import BaseModel
 
@@ -48,7 +49,7 @@ class ParameterConfig(ABC):
         real_nr: int,
         random_seed: int,
         ensemble_size: int,
-    ) -> xr.Dataset:
+    ) -> xr.Dataset | pl.DataFrame:
         return self.read_from_runpath(Path(), real_nr, 0)
 
     @property

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -144,7 +144,9 @@ class SurfaceConfig(ParameterConfig):
     def write_to_runpath(
         self, run_path: Path, real_nr: int, ensemble: Ensemble
     ) -> None:
-        data = ensemble.load_parameters(self.name, real_nr)["values"]
+        ds = ensemble.load_parameters(self.name, real_nr)
+        assert isinstance(ds, xr.Dataset)
+        data = ds["values"]
 
         surf = xtgeo.RegularSurface(
             ncol=self.ncol,
@@ -184,6 +186,7 @@ class SurfaceConfig(ParameterConfig):
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
     ) -> npt.NDArray[np.float64]:
         ds = ensemble.load_parameters(self.name, realizations)
+        assert isinstance(ds, xr.Dataset)
         ensemble_size = len(ds.realizations)
         return ds["values"].values.reshape(ensemble_size, -1).T
 

--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import operator
 import os
@@ -6,10 +5,8 @@ from collections.abc import Callable, Iterator
 from typing import Any
 from uuid import UUID
 
-import numpy as np
 import pandas as pd
 import polars as pl
-import xarray as xr
 from polars.exceptions import ColumnNotFoundError
 
 from ert.config import Field, GenDataConfig, GenKwConfig
@@ -129,41 +126,22 @@ def _extract_parameter_group_and_key(key: str) -> tuple[str, str] | tuple[None, 
 
 def data_for_parameter(ensemble: Ensemble, key: str) -> pd.DataFrame:
     group, _ = _extract_parameter_group_and_key(key)
-    parameters = ensemble.experiment.parameter_configuration
-    if group in parameters and isinstance(gen_kw := parameters[group], GenKwConfig):
-        dataframes: list[pd.DataFrame] = []
+    df = ensemble.load_scalars(group)
+    if df.is_empty():
+        return pd.DataFrame()
 
-        with contextlib.suppress(KeyError):
-            try:
-                da = ensemble.load_parameters(group, transformed=True)["values"]
-            except ValueError as err:
-                print(f"Could not load parameter {group}: {err}")
-                return pd.DataFrame()
-
-            assert isinstance(da, xr.DataArray)
-            da["names"] = np.char.add(f"{gen_kw.name}:", da["names"].astype(np.str_))
-            df = da.to_dataframe().unstack(level="names")
-            df.columns = df.columns.droplevel()
-            for parameter in df.columns:
-                if gen_kw.shouldUseLogScale(parameter.split(":")[1]):
-                    df[f"LOG10_{parameter}"] = np.log10(df[parameter])
-            dataframes.append(df)
-        if not dataframes:
-            return pd.DataFrame()
-
-        dataframe = pd.concat(dataframes, axis=1)
-        dataframe.columns.name = None
-        dataframe.index.name = "Realization"
-
-        data = dataframe.sort_index(axis=1)
-        if data.empty or key not in data:
-            return pd.DataFrame()
-        data = data[key].to_frame().dropna()
-        data.columns = pd.Index([0])
-        try:
-            return data.astype(float)
-        except ValueError:
-            return data
+    dataframe = df.to_pandas().set_index("realization")
+    dataframe.columns.name = None
+    dataframe.index.name = "Realization"
+    data = dataframe.sort_index(axis=1)
+    if data.empty or key not in data:
+        return pd.DataFrame()
+    data = data[key].to_frame().dropna()
+    data.columns = pd.Index([0])
+    try:
+        return data.astype(float)
+    except ValueError:
+        return data
 
 
 def _extract_response_type_and_key(

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 import pandas as pd
-import xarray as xr
+import polars as pl
 
 from ert.substitutions import Substitutions, substitute_runpath_name
 from ert.utils import log_duration
@@ -158,19 +158,16 @@ def save_design_matrix_to_ensemble(
     design_group_name: str = DESIGN_MATRIX_GROUP,
 ) -> None:
     assert not design_matrix_df.empty
-    for realization_nr in active_realizations:
-        row = design_matrix_df.loc[realization_nr]
-        ds = xr.Dataset(
-            {
-                "values": ("names", list(row.values)),
-                "names": list(row.keys()),
-            }
-        )
-        ensemble.save_parameters(
-            design_group_name,
-            realization_nr,
-            ds,
-        )
+    df = design_matrix_df.copy()
+    df["realization"] = df.index
+    pl_df = pl.from_pandas(df.reset_index(drop=True))
+    if not set(active_realizations) <= set(pl_df["realization"].to_list()):
+        raise KeyError("Active realization mask is not in design matrix!")
+    ensemble.save_parameters(
+        design_group_name,
+        realization=None,
+        dataset=pl_df.filter(pl.col("realization").is_in(list(active_realizations))),
+    )
 
 
 @log_duration(
@@ -199,13 +196,29 @@ def sample_prior(
             f"Sampling parameter {config_node.name} "
             f"for realizations {active_realizations}"
         )
-        for realization_nr in active_realizations:
-            ds = config_node.sample_or_load(
-                realization_nr,
-                random_seed=random_seed,
-                ensemble_size=ensemble.ensemble_size,
-            )
-            ensemble.save_parameters(parameter, realization_nr, ds)
+        if isinstance(config_node, GenKwConfig):
+            datasets = [
+                config_node.sample_or_load(
+                    realization_nr,
+                    random_seed=random_seed,
+                    ensemble_size=ensemble.ensemble_size,
+                )
+                for realization_nr in active_realizations
+            ]
+            if datasets:
+                ensemble.save_parameters(
+                    parameter,
+                    realization=None,
+                    dataset=pl.concat(datasets, how="vertical"),
+                )
+        else:
+            for realization_nr in active_realizations:
+                ds = config_node.sample_or_load(
+                    realization_nr,
+                    random_seed=random_seed,
+                    ensemble_size=ensemble.ensemble_size,
+                )
+                ensemble.save_parameters(parameter, realization_nr, ds)
 
     ensemble.refresh_ensemble_state()
 

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -306,6 +306,7 @@ class _EnsembleWidget(QWidget):
             self._state_text_edit.clear()
             html = "<table>"
             assert self._ensemble is not None
+            self._ensemble.refresh_ensemble_state()
             for state_index, state in enumerate(self._ensemble.get_ensemble_state()):
                 html += (
                     f"<tr><td width=30>{state_index:d}.</td>"

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -29,7 +29,7 @@ from ert.storage.realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 10
+_LOCAL_STORAGE_VERSION = 11
 
 
 class _Migrations(BaseModel):
@@ -467,6 +467,7 @@ class LocalStorage(BaseMode):
             to8,
             to9,
             to10,
+            to11,
         )
 
         try:
@@ -513,7 +514,9 @@ class LocalStorage(BaseMode):
 
             elif version < _LOCAL_STORAGE_VERSION:
                 migrations = list(
-                    enumerate([to2, to3, to4, to5, to6, to7, to8, to9, to10], start=1)
+                    enumerate(
+                        [to2, to3, to4, to5, to6, to7, to8, to9, to10, to11], start=1
+                    )
                 )
                 for from_version, migration in migrations[version - 1 :]:
                     print(f"* Updating storage to version: {from_version + 1}")

--- a/src/ert/storage/migration/to11.py
+++ b/src/ert/storage/migration/to11.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import Path
+
+import polars as pl
+import xarray as xr
+
+from ert.storage.local_ensemble import _escape_filename
+
+info = "Converting xr.Dataset to pl.Dataframe for genkw parameters"
+
+
+def migrate(path: Path) -> None:
+    for experiment in path.glob("experiments/*"):
+        ensembles = path.glob("ensembles/*")
+
+        experiment_id = None
+        with open(experiment / "index.json", encoding="utf-8") as f:
+            exp_index = json.load(f)
+            experiment_id = exp_index["id"]
+
+        with open(experiment / "parameter.json", encoding="utf-8") as fin:
+            parameters_json = json.load(fin)
+
+        for ens in ensembles:
+            with open(ens / "index.json", encoding="utf-8") as f:
+                ens_file = json.load(f)
+                if ens_file["experiment_id"] != experiment_id:
+                    continue
+
+            real_dirs = [*ens.glob("realization-*")]
+            for param_config in parameters_json.values():
+                if param_config["_ert_kind"] == "GenKwConfig":
+                    group = param_config["name"]
+                    datasets = {
+                        real_dir: xr.open_dataset(
+                            real_dir / f"{_escape_filename(group)}.nc",
+                            engine="scipy",
+                        )
+                        for real_dir in real_dirs
+                        if (real_dir / f"{_escape_filename(group)}.nc").exists()
+                    }
+                    records = []
+                    for real_dir, ds in datasets.items():
+                        array = ds.isel(realizations=0, drop=True)["values"]
+                        realization = int(real_dir.name.split("-")[1])
+
+                        def parse_value(value: float | int | str) -> float | int | str:
+                            if isinstance(value, float | int):
+                                return value
+                            try:
+                                return int(value)
+                            except ValueError:
+                                try:
+                                    return float(value)
+                                except ValueError:
+                                    return value
+
+                        data_dict = dict(
+                            zip(
+                                array["names"].values.tolist(),
+                                [parse_value(i) for i in array.values],
+                                strict=False,
+                            )
+                        )
+                        data_dict["realization"] = realization
+                        records.append(data_dict)
+                    if records:
+                        df = pl.DataFrame(records).sort("realization")
+                        group_path = ens / f"{_escape_filename(group)}.parquet"
+                        df.write_parquet(group_path)
+                        for real_dir in real_dirs:
+                            if (real_dir / f"{_escape_filename(group)}.nc").exists():
+                                os.remove(real_dir / f"{_escape_filename(group)}.nc")

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -27,7 +27,7 @@ def run_cli_ES_with_case(poly_config):
         experiment = storage.get_experiment_by_name("test-experiment")
         prior_ensemble = experiment.get_ensemble_by_name("iter-0")
         posterior_ensemble = experiment.get_ensemble_by_name("iter-1")
-    return prior_ensemble, posterior_ensemble
+    return prior_ensemble.id, posterior_ensemble.id, storage_path
 
 
 @pytest.mark.timeout(600)
@@ -47,12 +47,19 @@ def test_that_adaptive_localization_with_cutoff_1_equals_ensemble_prior():
 
     with open("poly_localization_1.ert", "w", encoding="utf-8") as f:
         f.writelines(lines)
-    prior_ensemble, posterior_ensemble = run_cli_ES_with_case("poly_localization_1.ert")
+    prior_ensemble_id, posterior_ensemble_id, storage_path = run_cli_ES_with_case(
+        "poly_localization_1.ert"
+    )
 
-    prior_sample = prior_ensemble.load_parameters("COEFFS")["values"]
-    posterior_sample = posterior_ensemble.load_parameters("COEFFS")["values"]
-    # Check prior and posterior samples are equal
-    assert np.allclose(posterior_sample, prior_sample)
+    with open_storage(storage_path) as storage:
+        prior_sample = storage.get_ensemble(prior_ensemble_id).load_parameters_numpy(
+            "COEFFS", np.arange(100)
+        )
+        posterior_sample = storage.get_ensemble(
+            posterior_ensemble_id
+        ).load_parameters_numpy("COEFFS", np.arange(100))
+        # Check prior and posterior samples are equal
+        assert np.allclose(posterior_sample, prior_sample)
 
 
 @pytest.mark.timeout(600)
@@ -89,7 +96,7 @@ def test_that_adaptive_localization_works_with_a_single_observation():
     with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
         f.writelines(lines)
 
-    _, _ = run_cli_ES_with_case("poly_localization_0.ert")
+    _, _, _ = run_cli_ES_with_case("poly_localization_0.ert")
 
 
 @pytest.mark.timeout(600)
@@ -205,11 +212,15 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
         ("POLY_OBS1_*", "POLY_OBS1_2", "0, 4"),
     }
 
-    prior_ens, _ = run_cli_ES_with_case("poly_localization_0.ert")
-    sf = prior_ens.load_observation_scaling_factors()
-    records_from_pl = sf.select(["input_group", "obs_key", "index"]).to_numpy().tolist()
+    prior_ens_id, _, storage_path = run_cli_ES_with_case("poly_localization_0.ert")
+    with open_storage(storage_path) as storage:
+        sf = storage.get_ensemble(prior_ens_id).load_observation_scaling_factors()
+        assert sf is not None
+        records_from_pl = (
+            sf.select(["input_group", "obs_key", "index"]).to_numpy().tolist()
+        )
 
-    assert set(map(tuple, records_from_pl)) == expected_records
+        assert set(map(tuple, records_from_pl)) == expected_records
 
 
 @pytest.mark.timeout(600)
@@ -238,13 +249,21 @@ def test_that_adaptive_localization_with_cutoff_0_equals_ESupdate():
     with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
         f.writelines(lines)
 
-    _, posterior_ensemble_loc0 = run_cli_ES_with_case("poly_localization_0.ert")
-    _, posterior_ensemble_noloc = run_cli_ES_with_case("poly_no_localization.ert")
+    _, posterior_ensemble_loc0_id, storage_loc = run_cli_ES_with_case(
+        "poly_localization_0.ert"
+    )
+    _, posterior_ensemble_noloc_id, storage_noloc = run_cli_ES_with_case(
+        "poly_no_localization.ert"
+    )
 
-    posterior_sample_loc0 = posterior_ensemble_loc0.load_parameters("COEFFS")["values"]
-    posterior_sample_noloc = posterior_ensemble_noloc.load_parameters("COEFFS")[
-        "values"
-    ]
+    with open_storage(storage_loc) as storage:
+        posterior_sample_loc0 = storage.get_ensemble(
+            posterior_ensemble_loc0_id
+        ).load_parameters_numpy("COEFFS", np.arange(100))
+    with open_storage(storage_noloc) as storage:
+        posterior_sample_noloc = storage.get_ensemble(
+            posterior_ensemble_noloc_id
+        ).load_parameters_numpy("COEFFS", np.arange(100))
 
     # Check posterior sample without adaptive localization and with cut-off 0 are equal
     assert np.allclose(posterior_sample_loc0, posterior_sample_noloc, atol=1e-6)
@@ -287,31 +306,44 @@ def test_that_posterior_generalized_variance_increases_in_cutoff():
     with open("poly_localization_cutoff2.ert", "w", encoding="utf-8") as f:
         f.writelines(lines)
 
-    prior_ensemble_cutoff1, posterior_ensemble_cutoff1 = run_cli_ES_with_case(
-        "poly_localization_cutoff1.ert"
+    prior_ensemble_cutoff1_id, posterior_ensemble_cutoff1_id, storage_cutoff1 = (
+        run_cli_ES_with_case("poly_localization_cutoff1.ert")
     )
-    _, posterior_ensemble_cutoff2 = run_cli_ES_with_case(
+    _, posterior_ensemble_cutoff2_id, storage_cutoff2 = run_cli_ES_with_case(
         "poly_localization_cutoff2.ert"
     )
+    with open_storage(storage_cutoff1) as storage:
+        cross_correlations = storage.get_ensemble(
+            prior_ensemble_cutoff1_id
+        ).load_cross_correlations()
+        assert all(cross_correlations.parameter.to_numpy() == ["a", "b", "c"])
+        assert cross_correlations["COEFFS"].values.shape == (3, 5)
+        assert (
+            (cross_correlations["COEFFS"].values >= -1)
+            & (cross_correlations["COEFFS"].values <= 1)
+        ).all()
 
-    cross_correlations = prior_ensemble_cutoff1.load_cross_correlations()
-    assert all(cross_correlations.parameter.to_numpy() == ["a", "b", "c"])
-    assert cross_correlations["COEFFS"].values.shape == (3, 5)
-    assert (
-        (cross_correlations["COEFFS"].values >= -1)
-        & (cross_correlations["COEFFS"].values <= 1)
-    ).all()
+        prior_sample_cutoff1 = (
+            storage.get_ensemble(prior_ensemble_cutoff1_id)
+            .load_parameters_numpy("COEFFS", np.arange(200))
+            .T
+        )
+        prior_cov = np.cov(prior_sample_cutoff1, rowvar=False)
 
-    prior_sample_cutoff1 = prior_ensemble_cutoff1.load_parameters("COEFFS")["values"]
-    prior_cov = np.cov(prior_sample_cutoff1, rowvar=False)
-    posterior_sample_cutoff1 = posterior_ensemble_cutoff1.load_parameters("COEFFS")[
-        "values"
-    ]
-    posterior_cutoff1_cov = np.cov(posterior_sample_cutoff1, rowvar=False)
-    posterior_sample_cutoff2 = posterior_ensemble_cutoff2.load_parameters("COEFFS")[
-        "values"
-    ]
-    posterior_cutoff2_cov = np.cov(posterior_sample_cutoff2, rowvar=False)
+        posterior_sample_cutoff1 = (
+            storage.get_ensemble(posterior_ensemble_cutoff1_id)
+            .load_parameters_numpy("COEFFS", np.arange(200))
+            .T
+        )
+        posterior_cutoff1_cov = np.cov(posterior_sample_cutoff1, rowvar=False)
+
+    with open_storage(storage_cutoff2) as storage:
+        posterior_sample_cutoff2 = (
+            storage.get_ensemble(posterior_ensemble_cutoff2_id)
+            .load_parameters_numpy("COEFFS", np.arange(200))
+            .T
+        )
+        posterior_cutoff2_cov = np.cov(posterior_sample_cutoff2, rowvar=False)
 
     generalized_variance_1 = np.linalg.det(posterior_cutoff1_cov)
     generalized_variance_2 = np.linalg.det(posterior_cutoff2_cov)

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -58,11 +58,13 @@ def test_run_poly_example_with_design_matrix(copy_poly_case_with_design_matrix, 
         experiment = storage.get_experiment_by_name("test-experiment")
         params = experiment.get_ensemble_by_name("default").load_parameters(
             "DESIGN_MATRIX"
-        )["values"]
-        np.testing.assert_array_equal(params[:, 0], [str(idx) for idx in a_values])
-        np.testing.assert_array_equal(params[:, 1], 5 * ["cat1"] + 5 * ["cat2"])
-        np.testing.assert_array_equal(params[:, 2], 10 * ["1"])
-        np.testing.assert_array_equal(params[:, 3], 10 * ["2"])
+        )
+        np.testing.assert_array_equal(params["a"].to_list(), a_values)
+        np.testing.assert_array_equal(
+            params["category"].to_list(), 5 * ["cat1"] + 5 * ["cat2"]
+        )
+        np.testing.assert_array_equal(params["b"].to_list(), 10 * [1])
+        np.testing.assert_array_equal(params["c"].to_list(), 10 * [2])
 
     real_0_iter_0_parameters_json_path = (
         Path(config_path) / "poly_out" / "realization-0" / "iter-0" / "parameters.json"
@@ -193,13 +195,13 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values, err
     storage_path = ErtConfig.from_file("poly.ert").ens_path
     with open_storage(storage_path) as storage:
         experiment = storage.get_experiment_by_name("test-experiment")
-        params = experiment.get_ensemble_by_name("default").load_parameters("COEFFS")[
-            "values"
-        ]
-        np.testing.assert_array_equal(params[:, 0], [str(idx) for idx in a_values])
-        np.testing.assert_array_equal(params[:, 2], 10 * ["1"])
-        np.testing.assert_array_equal(params[:, 3], 10 * ["2"])
-        np.testing.assert_array_equal(params[:, 1], 5 * ["cat1"] + 5 * ["cat2"])
+        params = experiment.get_ensemble_by_name("default").load_parameters("COEFFS")
+        np.testing.assert_array_equal(params["a"].to_list(), a_values)
+        np.testing.assert_array_equal(
+            params["category"].to_list(), 5 * ["cat1"] + 5 * ["cat2"]
+        )
+        np.testing.assert_array_equal(params["b"].to_list(), 10 * [1])
+        np.testing.assert_array_equal(params["c"].to_list(), 10 * [2])
     with open("poly_out/realization-0/iter-0/my_output", encoding="utf-8") as f:
         output = [line.strip() for line in f]
         assert output[0] == "a: 0"
@@ -295,12 +297,12 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
         experiment = storage.get_experiment_by_name("test-experiment")
         params = experiment.get_ensemble_by_name("default").load_parameters(
             "DESIGN_MATRIX"
-        )["values"]
-        np.testing.assert_array_equal(params[:, 0], a_values)
-        np.testing.assert_array_equal(params[:, 1], 10 * [1])
-        np.testing.assert_array_equal(params[:, 2], 10 * [2])
-        np.testing.assert_array_equal(params[:, 3], 10 * [3])
-        np.testing.assert_array_equal(params[:, 4], 10 * [4])
+        )
+        np.testing.assert_array_equal(params["a"].to_list(), a_values)
+        np.testing.assert_array_equal(params["b"].to_list(), 10 * [1])
+        np.testing.assert_array_equal(params["c"].to_list(), 10 * [2])
+        np.testing.assert_array_equal(params["d"].to_list(), 10 * [3])
+        np.testing.assert_array_equal(params["g"].to_list(), 10 * [4])
 
 
 @pytest.mark.usefixtures("copy_poly_case")
@@ -400,14 +402,15 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
             ensemble = experiment.get_ensemble_by_name(f"{ensemble_name}{i}")
 
             # coeffs_a should be different in all realizations
-            coeffs_a = ensemble.load_parameters("COEFFS_A")["values"].values.flatten()
+            coeffs_a = ensemble.load_parameters("COEFFS_A")["a"].to_list()
+
             if coeffs_a_previous is not None:
                 assert not np.array_equal(coeffs_a, coeffs_a_previous)
             coeffs_a_previous = coeffs_a
 
             # coeffs_b should be overridden by design matrix and be the
             # same for all realizations
-            coeffs_b = ensemble.load_parameters("COEFFS_B")["values"].values.flatten()
+            coeffs_b = ensemble.load_parameters("COEFFS_B")["b"].to_list()
             assert values == pytest.approx(coeffs_b, 0.0001)
 
 

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -673,9 +673,9 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
         )
         sample_prior(ensemble, prior_mask, ert_config.random_seed)
         experiment = storage.get_experiment_by_name("test-experiment")
-        prior_values = experiment.get_ensemble_by_name(ensemble.name).load_parameters(
-            "COEFFS"
-        )["values"]
+        prior_values = experiment.get_ensemble_by_name(
+            ensemble.name
+        ).load_parameters_numpy("COEFFS", np.arange(num_realizations))
     with caplog.at_level(logging.INFO):
         run_cli(
             ENSEMBLE_EXPERIMENT_MODE,
@@ -687,9 +687,9 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
         )
 
     with open_storage(ert_config.ens_path, mode="w") as storage:
-        parameter_values = storage.get_ensemble(ensemble.id).load_parameters("COEFFS")[
-            "values"
-        ]
+        parameter_values = storage.get_ensemble(ensemble.id).load_parameters_numpy(
+            "COEFFS", np.arange(num_realizations)
+        )
         np.testing.assert_array_equal(parameter_values, prior_values)
     assert len([msg for msg in caplog.messages if "RANDOM_SEED" in msg]) == 1
 
@@ -740,9 +740,10 @@ def test_exclude_parameter_from_update():
         experiment = storage.get_experiment_by_name("es")
         prior = experiment.get_ensemble_by_name("iter-0")
         posterior = experiment.get_ensemble_by_name("iter-1")
-        assert prior.load_parameters(
-            "ANOTHER_KW", tuple(range(5))
-        ) == posterior.load_parameters("ANOTHER_KW", tuple(range(5)))
+        np.allclose(
+            prior.load_parameters_numpy("ANOTHER_KW", np.arange(6)),
+            posterior.load_parameters_numpy("ANOTHER_KW", np.arange(6)),
+        )
 
     log_paths = list(Path("update_log").iterdir())
     assert log_paths

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -77,10 +77,11 @@ def test_design_matrix_in_manage_experiments_panel(
         RealizationStorageState.PARAMETERS_LOADED in s
         for s in ensemble.get_ensemble_state()
     )
-    params = ensemble.load_parameters("DESIGN_MATRIX")["values"]
-    np.testing.assert_array_equal(params[:, 0], a_values)
-    np.testing.assert_array_equal(params[:, 1], np.ones(num_realizations))
-    np.testing.assert_array_equal(params[:, 2], 2 * np.ones(num_realizations))
+
+    params = ensemble.load_parameters("DESIGN_MATRIX").drop("realization")
+    np.testing.assert_array_equal(params["a"].to_list(), a_values)
+    np.testing.assert_array_equal(params["b"].to_list(), np.ones(num_realizations))
+    np.testing.assert_array_equal(params["c"].to_list(), 2 * np.ones(num_realizations))
 
     add_experiment_in_manage_experiment_dialog(
         qtbot, tool, experiment_name="my-experiment-2", ensemble_name="my-design-2"
@@ -389,7 +390,7 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
 """
         )
 
-    prior_ens, _ = run_cli_ES_with_case("poly_localization_0.ert")
+    prior_ens_id, _, _ = run_cli_ES_with_case("poly_localization_0.ert")
     config = ErtConfig.from_file("poly_localization_0.ert")
 
     notifier = ErtNotifier()
@@ -400,7 +401,7 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
             config, notifier, config.runpath_config.num_realizations
         )
 
-        assert prior_ens.name
+        assert storage.get_ensemble(prior_ens_id).name
 
         # select the ensemble
         storage_widget = tool.findChild(StorageWidget)

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -8,11 +8,7 @@ import xarray as xr
 import xtgeo
 from tabulate import tabulate
 
-from ert.analysis import (
-    ErtAnalysisError,
-    ObservationStatus,
-    smoother_update,
-)
+from ert.analysis import ErtAnalysisError, ObservationStatus, smoother_update
 from ert.analysis._update_commons import (
     _compute_observation_statuses,
     _OutlierColumns,
@@ -496,11 +492,11 @@ def test_update_snapshot(
     )
 
     sim_gen_kw = list(
-        prior_ens.load_parameters("SNAKE_OIL_PARAM", 0)["values"].values.flatten()
+        prior_ens.load_parameters_numpy("SNAKE_OIL_PARAM", np.array([0])).flatten()
     )
 
     target_gen_kw = list(
-        posterior_ens.load_parameters("SNAKE_OIL_PARAM", 0)["values"].values.flatten()
+        posterior_ens.load_parameters_numpy("SNAKE_OIL_PARAM", np.array([0])).flatten()
     )
 
     # Check that prior is not equal to posterior after updationg
@@ -577,10 +573,10 @@ def test_smoother_snapshot_alpha(
         prior_storage.save_parameters(
             "PARAMETER",
             iens,
-            xr.Dataset(
+            pl.DataFrame(
                 {
-                    "values": ("names", [data]),
-                    "names": ["KEY_1"],
+                    "KEY_1": [data],
+                    "realization": iens,
                 }
             ),
         )
@@ -1064,10 +1060,10 @@ def test_gen_data_obs_data_mismatch(storage, uniform_parameter):
         prior.save_parameters(
             "PARAMETER",
             iens,
-            xr.Dataset(
+            pl.DataFrame(
                 {
-                    "values": ("names", [data]),
-                    "names": ["KEY_1"],
+                    "KEY_1": [data],
+                    "realization": iens,
                 }
             ),
         )
@@ -1126,10 +1122,10 @@ def test_gen_data_missing(storage, uniform_parameter, obs):
         prior.save_parameters(
             "PARAMETER",
             iens,
-            xr.Dataset(
+            pl.DataFrame(
                 {
-                    "values": ("names", [data]),
-                    "names": ["KEY_1"],
+                    "KEY_1": [data],
+                    "realization": iens,
                 }
             ),
         )
@@ -1200,20 +1196,20 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
         prior.save_parameters(
             "PARAMETER",
             iens,
-            xr.Dataset(
+            pl.DataFrame(
                 {
-                    "values": ("names", [data]),
-                    "names": ["KEY_1"],
+                    "KEY_1": [data],
+                    "realization": iens,
                 }
             ),
         )
         prior.save_parameters(
             "EXTRA_PARAMETER",
             iens,
-            xr.Dataset(
+            pl.DataFrame(
                 {
-                    "values": ("names", [data]),
-                    "names": ["KEY_1"],
+                    "KEY_1": [data],
+                    "realization": iens,
                 }
             ),
         )
@@ -1246,9 +1242,12 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
         ObservationSettings(),
         ESSettings(),
     )
-    assert prior.load_parameters("EXTRA_PARAMETER", 0)["values"].equals(
-        posterior_ens.load_parameters("EXTRA_PARAMETER", 0)["values"]
+
+    assert (
+        prior.load_parameters("EXTRA_PARAMETER", 0).rows()
+        == posterior_ens.load_parameters("EXTRA_PARAMETER", 0).rows()
     )
-    assert not prior.load_parameters("PARAMETER", 0)["values"].equals(
-        posterior_ens.load_parameters("PARAMETER", 0)["values"]
+    assert (
+        prior.load_parameters("PARAMETER", 0).rows()
+        != posterior_ens.load_parameters("PARAMETER", 0).rows()
     )

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -279,11 +279,11 @@ def test_plot_api_handles_empty_gen_kw(api_and_storage):
     assert api.data_for_key(str(ensemble.id), key).empty
     ensemble.save_parameters(
         key,
-        1,
-        xr.Dataset(
+        realization=None,
+        dataset=pl.DataFrame(
             {
-                "values": ("names", [1.0]),
-                "names": [name],
+                name: [1.0],
+                "realization": 1,
             }
         ),
     )

--- a/tests/ert/unit_tests/storage/snapshots/test_storage_migration/test_migration_to_genkw_with_polars_and_design_matrix/14.2/design_matrix_snapshot.json
+++ b/tests/ert/unit_tests/storage/snapshots/test_storage_migration/test_migration_to_genkw_with_polars_and_design_matrix/14.2/design_matrix_snapshot.json
@@ -1,0 +1,72 @@
+[
+  {
+    "a": 0,
+    "category": "cat1",
+    "b": 1,
+    "c": 2,
+    "realization": 0
+  },
+  {
+    "a": 1,
+    "category": "cat1",
+    "b": 1,
+    "c": 2,
+    "realization": 1
+  },
+  {
+    "a": 2,
+    "category": "cat1",
+    "b": 1,
+    "c": 2,
+    "realization": 2
+  },
+  {
+    "a": 3,
+    "category": "cat1",
+    "b": 1,
+    "c": 2,
+    "realization": 3
+  },
+  {
+    "a": 4,
+    "category": "cat1",
+    "b": 1,
+    "c": 2,
+    "realization": 4
+  },
+  {
+    "a": 5,
+    "category": "cat2",
+    "b": 1,
+    "c": 2,
+    "realization": 5
+  },
+  {
+    "a": 6,
+    "category": "cat2",
+    "b": 1,
+    "c": 2,
+    "realization": 6
+  },
+  {
+    "a": 7,
+    "category": "cat2",
+    "b": 1,
+    "c": 2,
+    "realization": 7
+  },
+  {
+    "a": 8,
+    "category": "cat2",
+    "b": 1,
+    "c": 2,
+    "realization": 8
+  },
+  {
+    "a": 9,
+    "category": "cat2",
+    "b": 1,
+    "c": 2,
+    "realization": 9
+  }
+]

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -1243,7 +1243,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         parameter_names = [p.name for p in self.model[experiment_id].parameters]
         assume(parameter not in parameter_names)
         with pytest.raises(
-            KeyError, match=f"No dataset '{parameter}' in storage for realization 0"
+            KeyError, match=f"{parameter} is not registered to the experiment"
         ):
             _ = storage_ensemble.load_parameters(parameter, self.iens_to_edit)
 

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -423,6 +423,40 @@ def test_gen_kw(storage, tmpdir, config_str, expected, extra_files, expectation)
             )
 
 
+@pytest.mark.parametrize(
+    "active_reals, expectation",
+    [
+        (
+            [False, False],
+            pytest.raises(
+                KeyError, match="No KW_NAME dataset in storage for ensemble default"
+            ),
+        ),
+        (
+            [False, True],
+            pytest.raises(
+                IndexError, match=r"No matching realizations \[0\] found for KW_NAME"
+            ),
+        ),
+    ],
+)
+def test_gen_kw_missing_in_storage(storage, tmpdir, active_reals, expectation):
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        NUM_REALIZATIONS 2
+        GEN_KW KW_NAME prior.txt
+        """
+        )
+        with open("config.ert", mode="w", encoding="utf-8") as fh:
+            fh.writelines(config)
+        with open("prior.txt", mode="w", encoding="utf-8") as fh:
+            fh.writelines("MY_KEYWORD NORMAL 0 1")
+        with expectation:
+            _, ensemble = create_runpath(storage, "config.ert", active_reals)
+            ensemble.load_parameters("KW_NAME", 0)
+
+
 @pytest.mark.usefixtures("set_site_config")
 @pytest.mark.parametrize(
     "config_str, expected, extra_files",

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
+import polars as pl
 import pytest
 from resdata.geometry import Surface
 
@@ -221,7 +222,7 @@ def test_that_first_three_parameters_sampled_snapshot(tmpdir, storage):
         with open("prior.txt", mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD NORMAL 0 1")
         _, fs = create_runpath(storage, "config.ert", [True] * 3)
-        prior = fs.load_parameters("KW_NAME", range(3))["values"].values.ravel()
+        prior = fs.load_parameters_numpy("KW_NAME", np.arange(3)).flatten()
         expected = np.array([-0.8814228, 1.5847818, 1.009956])
         np.testing.assert_almost_equal(prior, expected)
 
@@ -279,9 +280,9 @@ def test_that_sampling_is_fixed_from_name(
         key_hash = sha256(b"1234" + b"KW_NAME:MY_KEYWORD")
         seed = np.frombuffer(key_hash.digest(), dtype="uint32")
         expected = np.random.default_rng(seed).standard_normal(num_realisations)
-        assert fs.load_parameters("KW_NAME").sel(names="MY_KEYWORD")[
-            "values"
-        ].values.ravel().tolist() == list(expected)
+        df = fs.load_parameters("KW_NAME")
+        assert isinstance(df, pl.DataFrame)
+        assert df.select("MY_KEYWORD").to_numpy().ravel().tolist() == list(expected)
 
 
 @pytest.mark.parametrize(
@@ -341,13 +342,9 @@ def test_that_sub_sample_maintains_order(tmpdir, storage, mask, expected):
             fs, [i for i, active in enumerate(mask) if active], random_seed=1234
         )
 
-        assert (
-            fs.load_parameters("KW_NAME")["values"]
-            .sel(names="MY_KEYWORD")
-            .values.ravel()
-            .tolist()
-            == expected
-        )
+        df = fs.load_parameters("KW_NAME")
+        assert isinstance(df, pl.DataFrame)
+        assert df.select("MY_KEYWORD").to_numpy().ravel().tolist() == expected
 
 
 @pytest.mark.usefixtures("set_site_config")
@@ -375,9 +372,10 @@ def test_gen_kw_optional_template(storage, tmpdir, config_str, expected):
             fh.writelines("MY_KEYWORD NORMAL 0 1")
 
         create_runpath(storage, "config.ert")
-        assert next(iter(storage.ensembles)).load_parameters("KW_NAME")[
-            "values"
-        ].values.flatten().tolist() == pytest.approx([expected])
+
+        assert next(iter(storage.ensembles)).load_parameters_numpy(
+            "KW_NAME", np.array([0])
+        ).ravel().tolist() == pytest.approx([expected])
 
 
 def write_file(fname, contents):

--- a/tests/ert/unit_tests/test_libres_facade.py
+++ b/tests/ert/unit_tests/test_libres_facade.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from textwrap import dedent
 
 import numpy as np
+import polars as pl
 import pytest
 from pandas import ExcelWriter
 from pandas.core.frame import DataFrame
@@ -237,8 +238,9 @@ def test_save_parameters_to_storage_from_design_dataframe(
             save_design_matrix_to_ensemble(
                 design_matrix.design_matrix_df, ensemble, reals
             )
-            params = ensemble.load_parameters(DESIGN_MATRIX_GROUP)["values"]
-            all(params.names.values == ["a", "b", "c"])
-            np.testing.assert_array_almost_equal(params[:, 0], a_values)
-            np.testing.assert_array_almost_equal(params[:, 1], b_values)
-            np.testing.assert_array_almost_equal(params[:, 2], c_values)
+            params = ensemble.load_parameters(DESIGN_MATRIX_GROUP).drop("realization")
+            assert isinstance(params, pl.DataFrame)
+            assert params.columns == ["a", "b", "c"]
+            np.testing.assert_array_almost_equal(params["a"].to_list(), a_values)
+            np.testing.assert_array_almost_equal(params["b"].to_list(), b_values)
+            np.testing.assert_array_almost_equal(params["c"].to_list(), c_values)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/10794


**Approach**
Internal data format for GenKw (scalar) parameters changes from xr.Dataset to polars.Dataframe. There are several advantages, which includes storing hybrid data types, faster i/o operations, data handling and manipulation. Additionally it represents a necessary step to implement scalar parameters.

 Each parameter is stored in a column where realizations are the represented as rows. Column realization then defines realizations for which the parameters are defined. 
```python
df = pl.DataFrame({
    "realization": [0, 1],
    "a": [1.0, 4.0],
    "b": [2.0, 5.0],
    "c": [3.0, 6.0],
})
```
One downside is that the load_parameters in LocalEnsemble will now return pl.Dataframe | xr.Dataset. This needs to remain while fields and surfaces rely on xr.Dataset.
In order to determine realization state, the parquet file needs to be open to retrieve the present realizations.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
