### PR TITLE
Ignore OSError when handling failure

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import logging
 import time
@@ -291,9 +292,10 @@ class Job:
             self.real.run_arg.runpath, self.real.run_arg.job_name
         )
 
-        self.real.run_arg.ensemble_storage.set_failure(
-            self.real.run_arg.iens, RealizationStorageState.LOAD_FAILURE, error_msg
-        )
+        with contextlib.suppress(OSError):
+            self.real.run_arg.ensemble_storage.set_failure(
+                self.real.run_arg.iens, RealizationStorageState.LOAD_FAILURE, error_msg
+            )
         logger.error(error_msg)
         log_info_from_exit_file(Path(self.real.run_arg.runpath) / ERROR_file)
 


### PR DESCRIPTION
If e.g. a job fails in internalization stage due to a PermissionError then we should ignore that the same PermissionError will occur when we try to set the job state to failed in the same storage that has permission issues.

**Issue**
Resolves one of many exceptions logged when there are permission issues in storage.

See operation id bc4e0a221fea6fb1af2d4ce00222399e

**Approach**
Close ears.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
