### PR TITLE
Avoid using exc_info in logger.warning

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -1163,7 +1163,10 @@ async def _read_parameters(
         except Exception as err:
             error_msg += str(err)
             result = LoadResult(LoadStatus.LOAD_FAILURE, error_msg)
-            logger.warning(f"Failed to load: {realization}", exc_info=err)
+            logger.warning(
+                "Failed to load parameters in storage "
+                f"for realization {realization}: {err}"
+            )
     return result
 
 


### PR DESCRIPTION
The exc_info data is picked up by OpenTelemetry and logged as an exception in addition to the intended, while the point of this try block is to degrade this exception to a warning



**Issue**
Resolves source of 3000 logged exceptions on 2025-05-08.

**Approach**
`str`

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
