### PR TITLE
Fix copy_unupdated_parameters to copy them only once

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -378,13 +378,13 @@ def analysis_ES(
             f"{(time.time() - start) / 60} minutes"
         )
 
-        _copy_unupdated_parameters(
-            list(source_ensemble.experiment.parameter_configuration.keys()),
-            parameters,
-            iens_active_index,
-            source_ensemble,
-            target_ensemble,
-        )
+    _copy_unupdated_parameters(
+        list(source_ensemble.experiment.parameter_configuration.keys()),
+        parameters,
+        iens_active_index,
+        source_ensemble,
+        target_ensemble,
+    )
 
 
 def smoother_update(


### PR DESCRIPTION
**Issue**
The copy of parameters was wrongly indented and thus very copying over multiple times.


:car: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
