### PR TITLE
Fix flaky tests in test_run_dialog

### DIFF
--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -115,7 +115,14 @@ def mock_get_runtime():
 
 
 @pytest.fixture
-def run_dialog(qtbot: QtBot, use_tmpdir, storage):
+def mock_set_env_key():
+    mock = MagicMock()
+    with patch("ert.run_models.base_run_model.BaseRunModel.set_env_key", mock) as _mock:
+        yield _mock
+
+
+@pytest.fixture
+def run_dialog(qtbot: QtBot, use_tmpdir, storage, mock_set_env_key):
     config_file = "minimal_config.ert"
     with open(config_file, "w", encoding="utf-8") as f:
         f.write("NUM_REALIZATIONS 1")


### PR DESCRIPTION
**Issue**
Resolves #10503 


**Approach**
Avoid env var changes for running experiments in the run dialogue tests. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
