### PR TITLE
Don't claim a warning is an exception to user

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -28,6 +28,7 @@ from .forward_model_step import (
     ForwardModelStepJSON,
     ForwardModelStepPlugin,
     ForwardModelStepValidationError,
+    ForwardModelStepWarning,
 )
 from .gen_kw_config import GenKwConfig
 from .model_config import ModelConfig
@@ -646,6 +647,12 @@ def create_list_of_forward_model_steps_to_run(
                         context=fm_step.name,
                     ),
                 )
+            except ForwardModelStepWarning as err:
+                ConfigWarning.warn(
+                    f"Forward model step validation: {err!s}",
+                    context=fm_step.name,
+                )
+
             except Exception as e:  # type: ignore
                 ConfigWarning.warn(
                     f"Unexpected plugin forward model exception: {e!s}",


### PR DESCRIPTION
Catch the warning explicitly.

**Issue**
Resolves claiming a warning is an exception.

Before and after in one screenshot: 

![image](https://github.com/user-attachments/assets/218cc42b-d053-4d91-ac7d-9f034b50c092)



**Approach**
🎣 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
