### PR TITLE
Make all BaseRunModels serializable

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -83,17 +83,15 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
                 f"All parameters are set to UPDATE:FALSE in {args.config}"
             )
 
-    storage = open_storage(ert_config.ens_path, "w")
-
     if args.mode == WORKFLOW_MODE:
-        execute_workflow(ert_config, storage, args.name)
+        with open_storage(ert_config.ens_path, "w") as storage:
+            execute_workflow(ert_config, storage, args.name)
         return
 
     status_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
     try:
         model = create_model(
             ert_config,
-            storage,
             args,
             status_queue,
         )
@@ -151,7 +149,6 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
             model.cancel()
 
     thread.join()
-    storage.close()
 
     if end_event is not None and end_event.failed:
         # If monitor has not reported, give some info if the job failed

--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -11,6 +11,8 @@ from ert.storage import Ensemble, Storage, open_storage
 
 class ErtNotifier(QObject):
     ertChanged = Signal()
+    simulationStarted = Signal()
+    simulationEnded = Signal()
     current_ensemble_changed = Signal(object, name="currentEnsembleChanged")
 
     def __init__(self) -> None:
@@ -91,3 +93,7 @@ class ErtNotifier(QObject):
     @Slot(bool)
     def set_is_simulation_running(self, is_running: bool) -> None:
         self._is_simulation_running = is_running
+        if self._is_simulation_running:
+            self.simulationStarted.emit()
+        else:
+            self.simulationEnded.emit()

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSignal as Signal
@@ -57,7 +58,6 @@ class EnsembleSelector(QComboBox):
             )
 
         notifier.ertChanged.connect(self.populate)
-        notifier.storage_changed.connect(self.populate)
 
         if notifier.is_storage_available:
             self.populate()
@@ -83,7 +83,7 @@ class EnsembleSelector(QComboBox):
             for ensemble in self._ensemble_list():
                 self.addItem(
                     f"{ensemble.experiment.name} : {ensemble.name}",
-                    userData=ensemble.id,
+                    userData=str(ensemble.id),
                 )
         except OSError as err:
             logger.error(str(err))
@@ -94,7 +94,9 @@ class EnsembleSelector(QComboBox):
             return
 
         current_index = (
-            self.findData(self.notifier.current_ensemble.id, Qt.ItemDataRole.UserRole)
+            self.findData(
+                str(self.notifier.current_ensemble.id), Qt.ItemDataRole.UserRole
+            )
             if self.notifier.current_ensemble is not None
             else -1
         )
@@ -126,7 +128,7 @@ class EnsembleSelector(QComboBox):
         return sorted(ensemble_list, key=lambda x: x.started_at, reverse=True)
 
     def _on_current_index_changed(self, index: int) -> None:
-        self.notifier.set_current_ensemble_id(self.itemData(index))
+        self.notifier.set_current_ensemble_id(UUID(self.itemData(index)))
 
-    def _on_global_current_ensemble_changed(self, data: Ensemble | None) -> None:
-        self.setCurrentIndex(max(self.findData(data, Qt.ItemDataRole.UserRole), 0))
+    def _on_global_current_ensemble_changed(self, data: UUID | None) -> None:
+        self.setCurrentIndex(max(self.findData(str(data), Qt.ItemDataRole.UserRole), 0))

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -249,7 +249,6 @@ class ExperimentPanel(QWidget):
         try:
             model = create_model(
                 self.config,
-                self._notifier.storage,
                 args,
                 event_queue,
             )

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -287,7 +287,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             mode=ES_MDA_MODE,
             target_ensemble=self._target_ensemble_format_model.getValue(),  # type: ignore
             realizations=self._active_realizations_field.text(),
-            weights=self.weights,  # type: ignore
+            weights=self.weights,
             restart_run=self._restart_box.isChecked(),
             prior_ensemble_id=(
                 str(self._ensemble_selector.selected_ensemble.id)

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -105,11 +105,14 @@ class LoadResultsPanel(QWidget):
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         messages: list[str] = []
         loaded: int = 0
-        with captured_logs(messages):
-            if ensemble := self._notifier.current_ensemble:
+        with captured_logs(messages), self._notifier.write_storage() as write_storage:
+            if self._notifier.current_ensemble is not None:
+                write_ensemble = write_storage.get_ensemble(
+                    self._notifier.current_ensemble.id
+                )
                 loaded = load_parameters_and_responses_from_runpath(
                     run_path_format=self._run_path_text.get_text,
-                    ensemble=ensemble,
+                    ensemble=write_ensemble,
                     active_realizations=active_realizations,
                 )
         QApplication.restoreOverrideCursor()

--- a/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
+++ b/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QEvent, QObject, Qt
+from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -163,8 +164,19 @@ class ManageExperimentsPanel(QTabWidget):
                     random_seed=self.ert_config.random_seed,
                 )
 
+        @Slot()
         def update_button_state() -> None:
-            initialize_button.setEnabled(ensemble_selector.count() > 0)
+            if self.notifier.is_simulation_running:
+                initialize_button.setEnabled(False)
+            else:
+                initialize_button.setEnabled(ensemble_selector.count() > 0)
+
+        @Slot()
+        def disableAdd() -> None:
+            initialize_button.setEnabled(False)
+
+        self.notifier.simulationStarted.connect(disableAdd)
+        self.notifier.simulationEnded.connect(update_button_state)
 
         update_button_state()
         ensemble_selector.ensemble_populated.connect(update_button_state)

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -10,6 +10,7 @@ from PyQt6.QtCore import (
     Qt,
 )
 from PyQt6.QtCore import pyqtSignal as Signal
+from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import (
     QHBoxLayout,
@@ -126,6 +127,20 @@ class StorageWidget(QWidget):
         self._tree_view.setColumnWidth(2, 100)
 
         self._create_experiment_button = AddWidget(self._addItem)
+
+        @Slot()
+        def disableAdd() -> None:
+            self._create_experiment_button.setEnabled(False)
+
+        @Slot()
+        def enableAdd() -> None:
+            self._create_experiment_button.setEnabled(True)
+
+        if self._notifier.is_simulation_running:
+            disableAdd()
+
+        notifier.simulationStarted.connect(disableAdd)
+        notifier.simulationEnded.connect(enableAdd)
 
         layout = QVBoxLayout()
         layout.addWidget(search_bar)

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -387,6 +387,13 @@ class BaseRunModel(BaseModelWithContextSupport, ABC):
             self._stop_time = None
             with captured_logs(error_messages):
                 self._set_default_env_context()
+
+                if restart:
+                    self._storage = open_storage(self.storage_path, mode="w")
+                    self.active_realizations = (
+                        self._create_mask_from_failed_realizations()
+                    )
+
                 self.run_experiment(
                     evaluator_server_config=evaluator_server_config,
                     restart=restart,

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -16,7 +16,7 @@ from ert.config import (
 )
 from ert.enkf_main import sample_prior, save_design_matrix_to_ensemble
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.storage import Ensemble, Experiment, open_storage
+from ert.storage import Ensemble, Experiment
 from ert.trace import tracer
 
 from ..plugins import PostExperimentFixtures, PreExperimentFixtures
@@ -99,11 +99,6 @@ class EnsembleExperiment(BaseRunModel):
                 name=self.ensemble_name,
                 ensemble_size=self.ensemble_size,
             ).id
-        else:
-            # Storage is closed on completion of experiment
-            # If restart, we re-open it
-            self._storage = open_storage(self.storage_path, mode="w")
-            self.active_realizations = self._create_mask_from_failed_realizations()
 
         assert self._experiment
         assert self._ensemble

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -7,7 +7,6 @@ from uuid import UUID
 import numpy as np
 
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.storage import open_storage
 from ert.trace import tracer
 
 from ..run_arg import create_run_arguments
@@ -40,12 +39,6 @@ class EvaluateEnsemble(BaseRunModel):
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
-        self._restart = restart
-        if self._restart:
-            # Storage is closed on completion, hence it must be
-            # re-opened when restarting
-            self._storage = open_storage(self.storage_path, mode="w")
-            self.active_realizations = self._create_mask_from_failed_realizations()
         ensemble = self._storage.get_ensemble(UUID(self.ensemble_id))
         experiment = ensemble.experiment
         self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -1,80 +1,47 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from queue import SimpleQueue
-from typing import TYPE_CHECKING
+from typing import Any
 from uuid import UUID
 
-from ert.config import ErtConfig, ESSettings, ObservationSettings
+from pydantic import PrivateAttr
+
 from ert.ensemble_evaluator import EvaluatorServerConfig
-from ert.storage import Storage
+from ert.storage import Ensemble
 
-from .base_run_model import ErtRunError, StatusEvents, UpdateRunModel
-
-if TYPE_CHECKING:
-    from ert.config import QueueConfig
-
+from .base_run_model import ErtRunError, UpdateRunModel
 
 logger = logging.getLogger(__name__)
 
 
 class ManualUpdate(UpdateRunModel):
-    def __init__(
-        self,
-        ensemble_id: str,
-        target_ensemble: str,
-        active_realizations: list[bool],
-        minimum_required_realizations: int,
-        random_seed: int,
-        config: ErtConfig,
-        storage: Storage,
-        queue_config: QueueConfig,
-        es_settings: ESSettings,
-        update_settings: ObservationSettings,
-        status_queue: SimpleQueue[StatusEvents],
-    ) -> None:
+    ensemble_id: str
+    target_ensemble: str
+    support_restart: bool = False
+
+    _prior: Ensemble = PrivateAttr()
+
+    def model_post_init(self, ctx: Any) -> None:
+        super().model_post_init(ctx)
+
         try:
-            prior = storage.get_ensemble(UUID(ensemble_id))
+            self._prior = self._storage.get_ensemble(UUID(self.ensemble_id))
         except (KeyError, ValueError) as err:
             raise ErtRunError(
-                f"Prior ensemble with ID: {UUID(ensemble_id)} does not exists"
+                f"Prior ensemble with ID: {UUID(self.ensemble_id)} does not exist"
             ) from err
 
-        super().__init__(
-            es_settings,
-            update_settings,
-            storage,
-            config.runpath_file,
-            Path(config.user_config_file),
-            config.env_vars,
-            config.env_pr_fm_step,
-            config.runpath_config,
-            queue_config,
-            config.forward_model_steps,
-            status_queue,
-            config.substitutions,
-            config.hooked_workflows,
-            active_realizations=active_realizations,
-            total_iterations=1,
-            start_iteration=prior.iteration,
-            random_seed=random_seed,
-            minimum_required_realizations=minimum_required_realizations,
-            log_path=config.analysis_config.log_path,
-        )
-        self.prior = prior
-        self.target_ensemble_format = target_ensemble
         self.support_restart = False
 
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False
     ) -> None:
         self.log_at_startup()
-        self.set_env_key("_ERT_EXPERIMENT_ID", str(self.prior.experiment.id))
-        self.set_env_key("_ERT_ENSEMBLE_ID", str(self.prior.id))
+        self.set_env_key("_ERT_EXPERIMENT_ID", str(self._prior.experiment.id))
+        self.set_env_key("_ERT_ENSEMBLE_ID", str(self._prior.id))
 
-        ensemble_format = self.target_ensemble_format
-        self.update(self.prior, ensemble_format % (self.prior.iteration + 1))
+        ensemble_format = self.target_ensemble
+        self.update(self._prior, ensemble_format % (self._prior.iteration + 1))
 
     @classmethod
     def name(cls) -> str:

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pydantic import Field
 
-from ert.config import ErtConfig
 from ert.run_models import EnsembleExperiment
-
-if TYPE_CHECKING:
-    from queue import SimpleQueue
-
-    from ert.storage import Storage
-
-    from .base_run_model import StatusEvents
 
 SINGLE_TEST_RUN_GROUP = "Forward model evaluation"
 
@@ -23,27 +15,8 @@ class SingleTestRun(EnsembleExperiment):
     2) Only a <b>single realization</b> (realization-0) is run<br>
     """
 
-    def __init__(
-        self,
-        ensemble_name: str,
-        experiment_name: str,
-        random_seed: int,
-        config: ErtConfig,
-        storage: Storage,
-        status_queue: SimpleQueue[StatusEvents],
-    ) -> None:
-        local_queue_config = config.queue_config.create_local_copy()
-        super().__init__(
-            ensemble_name=ensemble_name,
-            experiment_name=experiment_name,
-            active_realizations=[True],
-            minimum_required_realizations=1,
-            config=config,
-            storage=storage,
-            queue_config=local_queue_config,
-            status_queue=status_queue,
-            random_seed=random_seed,
-        )
+    active_realizations: list[bool] = Field(default_factory=lambda: [True])
+    minimum_required_realizations: int = 1
 
     @classmethod
     def name(cls) -> str:

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -292,11 +292,14 @@ class LocalStorage(BaseMode):
             return
 
         self._save_index()
-        self._release_lock()
+
+        if self.can_write:
+            self._release_lock()
 
     def _release_lock(self) -> None:
-        if self._lock.is_locked:
-            self._lock.release()
+        self._lock.release()
+
+        if (self.path / "storage.lock").exists():
             (self.path / "storage.lock").unlink()
 
     @require_write

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -145,7 +145,7 @@ class ExperimentRunner:
                 None,
                 lambda: run_model.start_simulations_thread(
                     EvaluatorServerConfig()
-                    if run_model._queue_config.queue_system == QueueSystem.LOCAL
+                    if run_model.queue_config.queue_system == QueueSystem.LOCAL
                     else EvaluatorServerConfig(
                         port_range=(49152, 51819), use_ipc_protocol=False
                     )

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -37,7 +37,7 @@ from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import AddWidget, StorageWidget
 from ert.plugins import ErtPluginContext
 from ert.run_models import EnsembleExperiment, MultipleDataAssimilation
-from ert.storage import Storage, open_storage
+from ert.storage import Storage
 from tests.ert.unit_tests.gui.simulation.test_run_path_dialog import (
     handle_run_path_dialog,
 )
@@ -87,11 +87,10 @@ def _open_main_window(path) -> Iterator[tuple[ErtMainWindow, Storage, ErtConfig]
     with ErtPluginContext():
         config = ErtConfig.with_plugins().from_file(path)
         with (
-            open_storage(config.ens_path, mode="w") as storage,
             add_gui_log_handler() as log_handler,
         ):
-            gui = _setup_main_window(config, args_mock, log_handler, storage)
-            yield gui, storage, config
+            gui = _setup_main_window(config, args_mock, log_handler, config.ens_path)
+            yield gui, config.ens_path, config
             gui.close()
 
 

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -77,15 +77,20 @@ def test_design_matrix_in_manage_experiments_panel(
     )
     experiments = list(storage.experiments)
     assert len(experiments) == 2
-    assert experiments[0].name == "my-experiment"
-    assert experiments[1].name == "my-experiment-2"
-    ensemble = experiments[1].get_ensemble_by_name("my-design-2")
-    assert "DESIGN_MATRIX" in experiments[1].parameter_configuration
+
+    # The write-storage writes the experiments,
+    # and the read-storage refreshes itself.
+    # There is no guarantee that the experiment UUIDs are in order-of-creation
+    # hence, we do not assert the order here
+    assert {e.name for e in experiments} == {"my-experiment", "my-experiment-2"}
+    exp2 = notifier.storage.get_experiment_by_name("my-experiment-2")
+    ensemble = exp2.get_ensemble_by_name("my-design-2")
+    assert "DESIGN_MATRIX" in exp2.parameter_configuration
     assert {
         t["name"]
-        for t in experiments[1]
-        .parameter_configuration["DESIGN_MATRIX"]
-        .transform_function_definitions
+        for t in exp2.parameter_configuration[
+            "DESIGN_MATRIX"
+        ].transform_function_definitions
     } == {"a", "b", "c"}
     assert all(
         RealizationStorageState.UNDEFINED in s for s in ensemble.get_ensemble_state()

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -40,7 +40,7 @@ def test_design_matrix_in_manage_experiments_panel(
     copy_poly_case_with_design_matrix(design_dict, default_list)
     config = ErtConfig.from_file("poly.ert")
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
     assert config.ensemble_config.parameter_configuration == []
     assert config.analysis_config.design_matrix is not None
     ensemble = storage.create_experiment(
@@ -97,7 +97,7 @@ def test_init_prior(qtbot, storage):
     config = ErtConfig.from_file("poly.ert")
     config.random_seed = 1234
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
     ensemble = storage.create_experiment(
         parameters=config.ensemble_config.parameter_configuration,
         responses=config.ensemble_config.response_configuration,
@@ -122,7 +122,7 @@ def test_init_prior(qtbot, storage):
         RealizationStorageState.PARAMETERS_LOADED in s
         for s in ensemble.get_ensemble_state()
     )
-    assert ensemble.load_parameters_numpy(
+    assert notifier.current_ensemble.load_parameters_numpy(
         "COEFFS", np.arange(ensemble.ensemble_size)
     ).mean() == pytest.approx(0.0458710649708845)
 
@@ -131,7 +131,7 @@ def test_init_prior(qtbot, storage):
 def test_that_init_updates_the_info_tab(qtbot, storage):
     config = ErtConfig.from_file("poly.ert")
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
 
     ensemble = storage.create_experiment(
         parameters=config.ensemble_config.parameter_configuration,
@@ -201,7 +201,7 @@ def test_experiment_view(
     storage = snake_oil_storage
 
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
 
     tool = ManageExperimentsPanel(
         config, notifier, config.runpath_config.num_realizations
@@ -233,7 +233,7 @@ def test_ensemble_view(
     storage = snake_oil_storage
 
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
 
     tool = ManageExperimentsPanel(
         config, notifier, config.runpath_config.num_realizations
@@ -373,7 +373,7 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
 
     notifier = ErtNotifier()
     with open_storage(config.ens_path, mode="w") as storage:
-        notifier.set_storage(storage)
+        notifier.set_storage(str(storage.path))
 
         tool = ManageExperimentsPanel(
             config, notifier, config.runpath_config.num_realizations
@@ -419,7 +419,7 @@ def test_ensemble_observations_view_on_empty_ensemble(qtbot):
     config = ErtConfig.from_file("poly.ert")
     notifier = ErtNotifier()
     with open_storage(config.ens_path, mode="w") as storage:
-        notifier.set_storage(storage)
+        notifier.set_storage(str(storage.path))
         storage.create_experiment(
             responses=[SummaryConfig(keys=["*"])],
             observations={
@@ -482,7 +482,7 @@ def test_realization_view(
     storage = snake_oil_storage
 
     notifier = ErtNotifier()
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
 
     tool = ManageExperimentsPanel(
         config, notifier, config.runpath_config.num_realizations

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -142,7 +142,7 @@ def test_that_all_plotter_filter_boxes_yield_expected_filter_results(
         gui = _setup_main_window(
             snake_oil_case_storage, args_mock, log_handler, storage
         )
-        gui.notifier.set_storage(storage)
+        gui.notifier.set_storage(str(storage.path))
         qtbot.addWidget(gui)
 
         button_plot_tool = gui.findChild(QToolButton, "button_Create_plot")

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -52,14 +52,17 @@ def plot_figure(qtbot, heat_equation_storage, snake_oil_case_storage, request):
         storage_config = heat_equation_storage
         args_mock.config = "config.ert"
 
+    # For dark storage not to hang
+    open_storage(storage_config.ens_path, mode="w")
     log_handler = GUILogHandler()
     with (
         StorageService.init_service(
             project=storage_config.ens_path,
         ),
-        open_storage(storage_config.ens_path) as storage,
     ):
-        gui = _setup_main_window(storage_config, args_mock, log_handler, storage)
+        gui = _setup_main_window(
+            storage_config, args_mock, log_handler, storage_config.ens_path
+        )
         qtbot.addWidget(gui)
 
         button_plot_tool = gui.findChild(QToolButton, "button_Create_plot")
@@ -137,12 +140,13 @@ def test_that_all_plotter_filter_boxes_yield_expected_filter_results(
         StorageService.init_service(
             project=snake_oil_case_storage.ens_path,
         ),
-        open_storage(snake_oil_case_storage.ens_path) as storage,
     ):
         gui = _setup_main_window(
-            snake_oil_case_storage, args_mock, log_handler, storage
+            snake_oil_case_storage,
+            args_mock,
+            log_handler,
+            snake_oil_case_storage.ens_path,
         )
-        gui.notifier.set_storage(str(storage.path))
         qtbot.addWidget(gui)
 
         button_plot_tool = gui.findChild(QToolButton, "button_Create_plot")

--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -17,7 +17,7 @@ from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.tools.event_viewer import GUILogHandler
 from ert.run_models import EnsembleExperiment
 from ert.run_models.evaluate_ensemble import EvaluateEnsemble
-from ert.storage import Storage, open_storage
+from ert.storage import Storage
 from ert.validation import rangestring_to_mask
 
 from .conftest import get_child
@@ -69,10 +69,9 @@ def _open_main_window(
     # it will cause the following error:
     # RuntimeError: wrapped C/C++ object of type GUILogHandler
     handler = GUILogHandler()
-    with open_storage(config.ens_path, mode="w") as storage:
-        gui = _setup_main_window(config, args_mock, handler, storage)
-        yield gui, storage, config
-        gui.close()
+    gui = _setup_main_window(config, args_mock, handler, config.ens_path)
+    yield gui, config.ens_path, config
+    gui.close()
 
 
 @pytest.fixture
@@ -88,7 +87,7 @@ def open_gui(tmp_path, monkeypatch, run_experiment, tmp_path_factory):
         yield gui
 
 
-def test_sensitivity_restart(open_gui, qtbot, run_experiment):
+def test_sensitivity_restart(open_gui, run_experiment):
     """This runs a full manual update workflow, first running ensemble experiment
     where some of the realizations fail, then doing an update before running an
     ensemble experiment again to calculate the forecast of the update.

--- a/tests/ert/ui_tests/gui/test_rft_export_plugin.py
+++ b/tests/ert/ui_tests/gui/test_rft_export_plugin.py
@@ -10,7 +10,6 @@ from ert.config import ErtConfig
 from ert.gui.ertwidgets import CustomDialog, ListEditBox, PathChooser
 from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.plugins import ErtPluginContext
-from ert.storage import open_storage
 
 from .conftest import (
     add_experiment_manually,
@@ -78,10 +77,7 @@ def test_rft_csv_export_plugin_exports_rft_data(
     output_file = Path("output.csv")
     with ErtPluginContext():
         ert_config = ErtConfig.with_plugins().from_file(args.config)
-    with (
-        open_storage(ert_config.ens_path, mode="w") as storage,
-    ):
-        gui = _setup_main_window(ert_config, args, GUILogHandler(), storage)
+        gui = _setup_main_window(ert_config, args, GUILogHandler(), ert_config.ens_path)
         qtbot.addWidget(gui)
 
         add_experiment_manually(qtbot, gui)

--- a/tests/ert/ui_tests/gui/test_workflow_tool.py
+++ b/tests/ert/ui_tests/gui/test_workflow_tool.py
@@ -15,7 +15,7 @@ from ert.gui.tools.event_viewer import GUILogHandler
 from ert.gui.tools.workflows import RunWorkflowWidget
 from ert.plugins import ErtPluginContext
 from ert.run_models import EnsembleExperiment
-from ert.storage import Storage, open_storage
+from ert.storage import Storage
 
 from .conftest import get_child, wait_for_child
 
@@ -43,21 +43,16 @@ def _open_main_window(
         # it will cause the following error:
         # RuntimeError: wrapped C/C++ object of type GUILogHandler
         handler = GUILogHandler()
-        with open_storage(config.ens_path, mode="w") as storage:
-            gui = _setup_main_window(config, args_mock, handler, storage)
-            yield gui, storage, config
-            gui.close()
+        gui = _setup_main_window(config, args_mock, handler, config.ens_path)
+        yield gui
+        gui.close()
 
 
 @pytest.fixture
 def open_gui(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     with (
-        _open_main_window(tmp_path) as (
-            gui,
-            _,
-            __,
-        ),
+        _open_main_window(tmp_path) as (gui),
     ):
         yield gui
 

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -45,16 +45,16 @@ def test_current_ensemble(qtbot, notifier, storage):
     qtbot.addWidget(widget)
     assert widget.count() == 0
 
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
     notifier.set_current_ensemble_id(ensemble.id)
     assert widget.count() == 1
-    assert widget.currentData() == ensemble.id
+    assert widget.currentData() == str(ensemble.id)
 
     # Creating EnsembleSelector after storage has been created populates it
     widget = EnsembleSelector(notifier)
     qtbot.addWidget(widget)
     assert widget.count() == 1
-    assert widget.currentData() == ensemble.id
+    assert widget.currentData() == str(ensemble.id)
 
 
 def test_changing_ensemble(qtbot, notifier, storage):
@@ -65,7 +65,7 @@ def test_changing_ensemble(qtbot, notifier, storage):
         name="default_b", ensemble_size=1
     )
 
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
     notifier.set_current_ensemble_id(ensemble_a.id)
     widget_a = EnsembleSelector(notifier)
     widget_b = EnsembleSelector(notifier)
@@ -76,23 +76,23 @@ def test_changing_ensemble(qtbot, notifier, storage):
     assert widget_b.count() == 2
 
     # First ensemble is selected in both
-    assert widget_a.currentData() == ensemble_a.id
-    assert widget_b.currentData() == ensemble_a.id
+    assert widget_a.currentData() == str(ensemble_a.id)
+    assert widget_b.currentData() == str(ensemble_a.id)
 
     # Second ensemble is selected via signal, changing both widgets'
     # selections
     notifier.set_current_ensemble_id(ensemble_b.id)
-    assert widget_a.currentData() == ensemble_b.id
-    assert widget_b.currentData() == ensemble_b.id
+    assert widget_a.currentData() == str(ensemble_b.id)
+    assert widget_b.currentData() == str(ensemble_b.id)
 
     # Changing back to first ensemble via widget sets the global current_ensemble
     qtbot.keyClicks(
         widget_a,
-        widget_a.itemText(widget_a.findData(ensemble_a.id)),
+        widget_a.itemText(widget_a.findData(str(ensemble_a.id))),
     )
     assert notifier.current_ensemble.id == ensemble_a.id
-    assert widget_a.currentData() == ensemble_a.id
-    assert widget_b.currentData() == ensemble_a.id
+    assert widget_a.currentData() == str(ensemble_a.id)
+    assert widget_b.currentData() == str(ensemble_a.id)
 
 
 @pytest.mark.parametrize(
@@ -111,7 +111,7 @@ def test_show_only_no_parent(
     ensemble = experiment.create_ensemble(name="parent", ensemble_size=1)
     experiment.create_ensemble(name="child", ensemble_size=1, prior_ensemble=ensemble)
 
-    notifier.set_storage(storage)
+    notifier.set_storage(str(storage.path))
     notifier.set_current_ensemble_id(ensemble.id)
 
     widget = EnsembleSelector(notifier, show_only_no_children=flag)

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -128,9 +128,7 @@ def run_dialog(qtbot: QtBot, use_tmpdir, mock_set_env_key):
     args_mock = Mock()
     args_mock.config = config_file
     ert_config = ErtConfig.from_file(config_file)
-    gui = _setup_main_window(
-        ert_config, args_mock, GUILogHandler(), use_tmpdir / "storage"
-    )
+    gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), "storage")
     qtbot.addWidget(gui)
     experiment_panel = gui.findChild(ExperimentPanel)
     assert experiment_panel
@@ -599,9 +597,7 @@ def test_that_exception_in_base_run_model_is_handled(qtbot: QtBot, use_tmpdir):
         "run_experiment",
         MagicMock(side_effect=ValueError("I failed :(")),
     ):
-        gui = _setup_main_window(
-            ert_config, args_mock, GUILogHandler(), use_tmpdir / "storage"
-        )
+        gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), "storage")
         qtbot.addWidget(gui)
         run_experiment = gui.findChild(QToolButton, name="run_experiment")
 
@@ -736,9 +732,7 @@ def test_that_design_matrix_show_parameters_button_is_visible(
     args_mock.config = config_file
 
     ert_config = ErtConfig.from_file(config_file)
-    gui = _setup_main_window(
-        ert_config, args_mock, GUILogHandler(), use_tmpdir / "storage"
-    )
+    gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), "storage")
     experiment_panel = gui.findChild(ExperimentPanel)
     assert experiment_panel
 
@@ -883,9 +877,7 @@ def test_that_design_matrix_alters_num_realizations_field(
     args_mock.config = config_file
 
     ert_config = ErtConfig.from_file(config_file)
-    gui = _setup_main_window(
-        ert_config, args_mock, GUILogHandler(), use_tmpdir / "storage"
-    )
+    gui = _setup_main_window(ert_config, args_mock, GUILogHandler(), "storage")
     experiment_panel = gui.findChild(ExperimentPanel)
     assert experiment_panel
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_path_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_path_dialog.py
@@ -15,7 +15,6 @@ from ert.gui.simulation.experiment_panel import ExperimentPanel
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.gui.tools.event_viewer.panel import GUILogHandler
 from ert.run_models.ensemble_experiment import EnsembleExperiment
-from ert.storage import open_storage
 
 
 def handle_run_path_dialog(
@@ -57,44 +56,43 @@ def test_run_path_deleted_error(
     args_mock = Mock()
     args_mock.config = "snake_oil.ert"
 
-    with (
-        open_storage(snake_oil_case.ens_path, mode="w") as storage,
-    ):
-        gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
-        experiment_panel = gui.findChild(ExperimentPanel)
+    gui = _setup_main_window(
+        snake_oil_case, args_mock, GUILogHandler(), snake_oil_case.ens_path
+    )
+    experiment_panel = gui.findChild(ExperimentPanel)
 
-        assert isinstance(experiment_panel, ExperimentPanel)
-        simulation_mode_combo = experiment_panel.findChild(QComboBox)
-        assert isinstance(simulation_mode_combo, QComboBox)
-        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
-        simulation_settings = gui.findChild(EnsembleExperimentPanel)
-        simulation_settings._experiment_name_field.setText("new_experiment_name")
+    assert isinstance(experiment_panel, ExperimentPanel)
+    simulation_mode_combo = experiment_panel.findChild(QComboBox)
+    assert isinstance(simulation_mode_combo, QComboBox)
+    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+    simulation_settings = gui.findChild(EnsembleExperimentPanel)
+    simulation_settings._experiment_name_field.setText("new_experiment_name")
 
-        # Click start simulation and agree to the message
-        run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
-        assert run_experiment
-        assert isinstance(run_experiment, QToolButton)
+    # Click start simulation and agree to the message
+    run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
+    assert run_experiment
+    assert isinstance(run_experiment, QToolButton)
 
-        # Add something to the runpath
-        run_path = Path(
-            snake_oil_case.runpath_config.runpath_format_string.replace(
-                "<IENS>", "0"
-            ).replace("<ITER>", "0")
-        )
-        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-            dummy_file.close()
+    # Add something to the runpath
+    run_path = Path(
+        snake_oil_case.runpath_config.runpath_format_string.replace(
+            "<IENS>", "0"
+        ).replace("<ITER>", "0")
+    )
+    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+        dummy_file.close()
 
-        QTimer.singleShot(
-            1000, lambda: handle_run_path_dialog(gui, qtbot, expect_error=True)
-        )
-        with patch("shutil.rmtree", side_effect=PermissionError("Not allowed!")):
-            qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
+    QTimer.singleShot(
+        1000, lambda: handle_run_path_dialog(gui, qtbot, expect_error=True)
+    )
+    with patch("shutil.rmtree", side_effect=PermissionError("Not allowed!")):
+        qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
 
-            qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
-        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-        assert os.path.exists(run_path / dummy_file.name)
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
+    qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+    assert os.path.exists(run_path / dummy_file.name)
 
 
 @pytest.mark.integration_test
@@ -103,42 +101,41 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
     args_mock = Mock()
     args_mock.config = "snake_oil.ert"
 
-    with (
-        open_storage(snake_oil_case.ens_path, mode="w") as storage,
-    ):
-        gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
-        experiment_panel = gui.findChild(ExperimentPanel)
+    gui = _setup_main_window(
+        snake_oil_case, args_mock, GUILogHandler(), snake_oil_case.ens_path
+    )
+    experiment_panel = gui.findChild(ExperimentPanel)
 
-        assert isinstance(experiment_panel, ExperimentPanel)
-        simulation_mode_combo = experiment_panel.findChild(QComboBox)
-        assert isinstance(simulation_mode_combo, QComboBox)
-        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
-        simulation_settings = gui.findChild(EnsembleExperimentPanel)
-        simulation_settings._experiment_name_field.setText("new_experiment_name")
+    assert isinstance(experiment_panel, ExperimentPanel)
+    simulation_mode_combo = experiment_panel.findChild(QComboBox)
+    assert isinstance(simulation_mode_combo, QComboBox)
+    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+    simulation_settings = gui.findChild(EnsembleExperimentPanel)
+    simulation_settings._experiment_name_field.setText("new_experiment_name")
 
-        # Click start simulation and agree to the message
-        run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
-        assert run_experiment
-        assert isinstance(run_experiment, QToolButton)
+    # Click start simulation and agree to the message
+    run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
+    assert run_experiment
+    assert isinstance(run_experiment, QToolButton)
 
-        run_path = Path(
-            snake_oil_case.runpath_config.runpath_format_string.replace(
-                "<IENS>", "0"
-            ).replace("<ITER>", "0")
-        )
-        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-            dummy_file.close()
+    run_path = Path(
+        snake_oil_case.runpath_config.runpath_format_string.replace(
+            "<IENS>", "0"
+        ).replace("<ITER>", "0")
+    )
+    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+        dummy_file.close()
 
-        QTimer.singleShot(
-            1000, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
-        )
-        qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
+    QTimer.singleShot(
+        1000, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
+    )
+    qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
 
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
-        run_dialog = gui.findChild(RunDialog)
-        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
-        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-        assert not os.path.exists(run_path / dummy_file.name)
+    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
+    qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+    assert not os.path.exists(run_path / dummy_file.name)
 
 
 @pytest.mark.integration_test
@@ -147,37 +144,36 @@ def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot
     args_mock = Mock()
     args_mock.config = "snake_oil.ert"
 
-    with (
-        open_storage(snake_oil_case.ens_path, mode="w") as storage,
-    ):
-        gui = _setup_main_window(snake_oil_case, args_mock, GUILogHandler(), storage)
-        experiment_panel = gui.findChild(ExperimentPanel)
+    gui = _setup_main_window(
+        snake_oil_case, args_mock, GUILogHandler(), snake_oil_case.ens_path
+    )
+    experiment_panel = gui.findChild(ExperimentPanel)
 
-        assert isinstance(experiment_panel, ExperimentPanel)
-        simulation_mode_combo = experiment_panel.findChild(QComboBox)
-        assert isinstance(simulation_mode_combo, QComboBox)
-        simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
-        simulation_settings = gui.findChild(EnsembleExperimentPanel)
-        simulation_settings._experiment_name_field.setText("new_experiment_name")
+    assert isinstance(experiment_panel, ExperimentPanel)
+    simulation_mode_combo = experiment_panel.findChild(QComboBox)
+    assert isinstance(simulation_mode_combo, QComboBox)
+    simulation_mode_combo.setCurrentText(EnsembleExperiment.name())
+    simulation_settings = gui.findChild(EnsembleExperimentPanel)
+    simulation_settings._experiment_name_field.setText("new_experiment_name")
 
-        # Click start simulation and agree to the message
-        run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
-        assert run_experiment
-        assert isinstance(run_experiment, QToolButton)
+    # Click start simulation and agree to the message
+    run_experiment = experiment_panel.findChild(QWidget, name="run_experiment")
+    assert run_experiment
+    assert isinstance(run_experiment, QToolButton)
 
-        run_path = Path(
-            snake_oil_case.runpath_config.runpath_format_string.replace("<IENS>", "0")
-        ).parent
-        with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-            dummy_file.close()
+    run_path = Path(
+        snake_oil_case.runpath_config.runpath_format_string.replace("<IENS>", "0")
+    ).parent
+    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
+        dummy_file.close()
 
-        QTimer.singleShot(
-            500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False)
-        )
-        qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
+    QTimer.singleShot(
+        500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False)
+    )
+    qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
 
-        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=10000)
-        run_dialog = gui.findChild(RunDialog)
-        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
-        qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-        assert os.path.exists(run_path / dummy_file.name)
+    qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=10000)
+    run_dialog = gui.findChild(RunDialog)
+    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
+    qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
+    assert os.path.exists(run_path / dummy_file.name)

--- a/tests/ert/unit_tests/test_tracking.py
+++ b/tests/ert/unit_tests/test_tracking.py
@@ -187,7 +187,6 @@ def test_tracking(
     queue = Events()
     model = create_model(
         ert_config,
-        storage,
         parsed,
         queue,
     )
@@ -274,7 +273,6 @@ def test_setting_env_context_during_run(
     queue = Events()
     model = create_model(
         ert_config,
-        storage,
         parsed,
         queue,
     )
@@ -344,7 +342,7 @@ def test_run_information_present_as_env_var_in_fm_context(
 
     evaluator_server_config = EvaluatorServerConfig(use_token=False)
     queue = Events()
-    model = create_model(ert_config, storage, parsed, queue)
+    model = create_model(ert_config, parsed, queue)
 
     thread = ErtThread(
         name="ert_cli_simulation_thread",

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -670,7 +670,7 @@ def test_egg_snapshot(snapshot, copy_egg_test_data_to_tmp):
     evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
-    best_batch = [b for b in run_model.ever_storage.data.batches if b.is_improvement][
+    best_batch = [b for b in run_model._ever_storage.data.batches if b.is_improvement][
         -1
     ]
 

--- a/tests/everest/test_environment.py
+++ b/tests/everest/test_environment.py
@@ -17,9 +17,6 @@ def test_seed(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
     config.environment.random_seed = random_seed
 
-    run_model = EverestRunModel.create(config)
-    assert random_seed == run_model._everest_config.environment.random_seed
-
     # Res
     ert_config = _everest_to_ert_config_dict(config)
     assert random_seed == ert_config["RANDOM_SEED"]
@@ -29,15 +26,13 @@ def test_seed(copy_math_func_test_data_to_tmp):
 def test_loglevel(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file(CONFIG_FILE)
     config.environment.log_level = "info"
-    run_model = EverestRunModel.create(config)
-    config = run_model._everest_config
     assert len(EverestConfig.lint_config_dict(config.to_dict())) == 0
 
 
 @pytest.mark.parametrize("iteration", [0, 1, 2])
 def test_run_path(tmp_path, min_config, iteration, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(ert.run_models.everest_run_model, "open_storage", MagicMock())
+    monkeypatch.setattr(ert.run_models.base_run_model, "open_storage", MagicMock())
 
     model_realizations = [0, 2]
     config = EverestConfig(**min_config)

--- a/tests/everest/test_everest_initialization.py
+++ b/tests/everest/test_everest_initialization.py
@@ -46,5 +46,5 @@ def test_site_config_with_substitutions(monkeypatch, copy_math_func_test_data_to
     config = EverestConfig.load_file("config_minimal.yml")
     everest_run_model = EverestRunModel.create(config)
 
-    assert ("<NUM_CPU>", "1") in everest_run_model._substitutions.items()
-    assert everest_run_model._env_vars["HOW_MANY_CPU"] == "1"
+    assert ("<NUM_CPU>", "1") in everest_run_model.substitutions.items()
+    assert everest_run_model.env_vars["HOW_MANY_CPU"] == "1"


### PR DESCRIPTION
Main motivation: Having an experiment config specified, and reusing commonalities in it between `BaseRunModel` and its inheriting subclasses. 

Approach: 
* Each BaseRunModel is a pydantic BaseModel
* Private / stateful attributes exempt from serialization/initialization are `PrivateAttr`s, making it explicit that these are purely for internal state management during execution
* Attributes that should be serializable, but are not are stored as `PrivateAttr`s (`observations` for ERT runmodels, `transforms` / `opt_callback` for Everest runmodels), making it explicit that these variables should be replaced / revised.
* Storage is made serializable by passing the storage path instead of the storage, a write storage is initialized at the `BaseRunModel` level, meaning all fixtures that create write-storages have to be revised to at most create read-only storages

Benefits:
* An experiment can be serialized, giving us all the information to re-run the experiment (currently disregarding observations, but that can be a TODO)
* Brings us closer to a uniform way of submitting an experiment, whether it is an Everest or ERT experiment
* Confines the lengthy initialization to `EverestConfig.create` and the functions in `model_factory` (imo this initialization could be streamlined so that each `BaseRunModel` implementation implements its own `create` function, letting us delete model_factory and instead just holding a list of available runmodels.
* Less verbosity/repetition with lengthy argument lists
* No direct access to ERT config / EverestConfig from within the BaseRunModel implementations


Cons:
* Pydantic is a bit strict so mocking becomes a bit more tricky for tests, but still not impossible.

