### PR TITLE
Add logging for overlaps between parameter names and magic strings

### DIFF
--- a/src/ert/substitutions.py
+++ b/src/ert/substitutions.py
@@ -40,6 +40,12 @@ class Substitutions(UserDict[str, str]):
                 else:
                     formatted_value = str(value)
                 to_substitute = to_substitute.replace(f"<{key}>", formatted_value)
+                if f"<{key}>" in self:
+                    logger.warning(
+                        f"Tried to substitute <{key}> for '{formatted_value}' "
+                        f"from parameters, but it was already set to "
+                        f"'{self.get(f'<{key}>')}' from user config"
+                    )
         return to_substitute
 
     def substitute_real_iter(
@@ -115,10 +121,12 @@ def _substitute(
     """
     substituted_string = to_substitute
     for _ in range(max_iterations):
+        # print(f"pre replacing - {substituted_string=}")
         substituted_tmp_string = _replace_strings(substitutions, substituted_string)
         if substituted_tmp_string is None:
             break
         substituted_string = substituted_tmp_string
+    # print(f"post replacing - {substituted_string=}")
     else:
         if warn_max_iter:
             warning_message = (


### PR DESCRIPTION
This commit makes substitutions log warning if we try to substitute in parameter names that are already substituted from ert config

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
