### PR TITLE
Log overlaps between parameter names and pre-defines/magic strings

### DIFF
--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -66,6 +66,15 @@ class EnsembleConfig:
 
         self.grid_file = _get_abs_path(self.grid_file)
 
+    def get_all_parameter_names(self) -> list[str]:
+        gen_kw_list = [
+            p for p in self.parameter_configs.values() if isinstance(p, GenKwConfig)
+        ]
+        param_names = [
+            keyword.name for p in gen_kw_list for keyword in p.transform_functions
+        ]
+        return param_names
+
     @staticmethod
     def _check_for_duplicate_names(
         parameter_list: list[str], gen_data_list: list[str]

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2362,3 +2362,27 @@ def test_validation_error_on_gen_kw_with_design_matrix_group_name(tmp_path):
                 GEN_KW DESIGN_MATRIX {tmp_path}/coeffs_priors
                 """
         )
+
+
+@pytest.mark.parametrize(
+    "invalid_parameter_definition_name",
+    [
+        pytest.param("CWD UNIFORM 0 1", id="already_a_magic_string"),
+        pytest.param("a UNIFORM 0 1", id="already_defined_in_user_config"),
+    ],
+)
+def test_validation_error_on_invalid_parameter_name(
+    invalid_parameter_definition_name, tmp_path, caplog
+):
+    caplog.set_level(logging.INFO)
+    with open(tmp_path / "coeffs_priors", mode="w", encoding="utf-8") as fh:
+        fh.write(invalid_parameter_definition_name)
+
+    ErtConfig.from_file_contents(
+        f"""\
+            DEFINE <a> 3
+            NUM_REALIZATIONS 1
+            GEN_KW COEFFS {tmp_path}/coeffs_priors
+            """
+    )
+    assert "Found reserved parameter name" in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #10784 


**Approach**
This commit adds logging of cases where the user has a parameter name that is already a user config defines or magic string.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
