### PR TITLE
Use runpath for disk usage widget

### DIFF
--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os.path
 import shutil
+from pathlib import Path
 from typing import no_type_check
 
 from pydantic import BaseModel, field_validator
@@ -71,7 +72,7 @@ class ModelConfig(BaseModel):
             ConfigWarning.warn(msg)
             logger.warning(msg)
         with contextlib.suppress(Exception):
-            mount_dir = get_mount_directory(runpath_format_string)
+            mount_dir = get_mount_directory(Path(runpath_format_string))
             total_space, used_space, free_space = shutil.disk_usage(mount_dir)
             percentage_used = used_space / total_space
             if (

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from pathlib import Path
 from queue import SimpleQueue
 from typing import TYPE_CHECKING, Any
 
@@ -330,6 +331,7 @@ class ExperimentPanel(QWidget):
             self._notifier,
             self.parent(),  # type: ignore
             output_path=self.config.analysis_config.log_path,
+            run_path=Path(self.config.runpath_config.runpath_format_string),
         )
         self._dialog.set_queue_system_name(model.queue_system)
         self.experiment_started.emit(self._dialog)

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -201,8 +201,10 @@ class RunDialog(QFrame):
         parent: QWidget | None = None,
         output_path: Path | None = None,
         is_everest: bool | None = False,
+        run_path: Path | None = None,
     ):
         super().__init__(parent)
+        self.run_path = run_path or Path()
         self.output_path = output_path
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setWindowFlags(Qt.WindowType.Window)
@@ -250,9 +252,6 @@ class RunDialog(QFrame):
         self.running_time = QLabel("")
         self.queue_system = QLabel("")
         self.memory_usage = QLabel("")
-        self.disk_space = DiskSpaceWidget(
-            get_mount_directory(self._run_model_api.runpath_format_string)
-        )
 
         self.kill_button = QPushButton("Terminate experiment")
         self.restart_button = QPushButton("Rerun failed")
@@ -280,6 +279,9 @@ class RunDialog(QFrame):
 
         footer_layout.addStretch()
         footer_layout.addWidget(self.memory_usage)
+        self.disk_space = DiskSpaceWidget(
+            get_mount_directory(self.run_path),
+        )
         footer_layout.addWidget(self.disk_space)
 
         footer_layout.addStretch()

--- a/src/ert/shared/status/utils.py
+++ b/src/ert/shared/status/utils.py
@@ -87,7 +87,7 @@ def get_ert_memory_usage() -> int:
     return usage.ru_maxrss // rss_scale
 
 
-def get_mount_directory(runpath: str) -> Path:
+def get_mount_directory(runpath: Path) -> Path:
     path = Path(runpath).absolute()
 
     while not path.is_mount():

--- a/tests/ert/unit_tests/gui/simulation/view/test_disk_space_widget.py
+++ b/tests/ert/unit_tests/gui/simulation/view/test_disk_space_widget.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from ert.gui.simulation.view import DiskSpaceWidget
@@ -9,7 +10,7 @@ from ert.gui.simulation.view.disk_space_widget import (
 
 
 def test_disk_space_widget(qtbot):
-    disk_space_widget = DiskSpaceWidget("/tmp")
+    disk_space_widget = DiskSpaceWidget(Path("/tmp"))
     qtbot.addWidget(disk_space_widget)
     disk_space_widget._get_status = MagicMock()
 


### PR DESCRIPTION
**Issue**
Resolves #10517 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
