### PR TITLE
Assert that LSF job names can include spaces

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1297,6 +1297,15 @@ async def test_no_exception_when_no_access_to_bjobs_executable(
     assert "Permission denied" in caplog.text
 
 
+async def test_jobname_with_spaces(tmp_path, pytestconfig):
+    if not pytestconfig.getoption("lsf"):
+        pytest.skip("Mocked LSF driver does not support spaces")
+    os.chdir(tmp_path)
+    driver = LsfDriver()
+    await driver.submit(0, "sh", "-c", "sleep 1", name="I have spaces")
+    await poll(driver, {0})
+
+
 @pytest.mark.integration_test
 async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, caplog):
     """This test asserts that it is possible to issue a kill command


### PR DESCRIPTION
**Issue**
Resolves #9564 

**Approach**
Avoid testing the mock.

This added test will be integration tested on the line:
https://github.com/equinor/ert/blob/437292ef7dec7eb216671c6d6539f3b5641a2d91/ci/testkomodo.sh#L119


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
