### PR TITLE
Fix duplicate span entries created during everest tests

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -37,7 +37,7 @@ from ert.run_models.multiple_data_assimilation import MultipleDataAssimilation
 from ert.services import StorageService, WebvizErt
 from ert.shared.storage.command import add_parser_options as ert_api_add_parser_options
 from ert.storage import ErtStorageException
-from ert.trace import trace, tracer, tracer_provider
+from ert.trace import trace, tracer
 from ert.validation import (
     IntegerArgument,
     NumberListStringArgument,
@@ -637,9 +637,7 @@ def main() -> None:
         handler.setLevel(logging.INFO)
         root_logger.addHandler(handler)
     try:
-        with ErtPluginContext(
-            logger=logging.getLogger(), trace_provider=tracer_provider
-        ) as context:
+        with ErtPluginContext(logger=logging.getLogger()) as context:
             logger.info(f"Running ert with {args} in {os.getcwd()}")
             args.func(args, context.plugin_manager)
     except (ErtCliError, ErtStorageException) as err:

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -24,7 +24,7 @@ from ert.plugins import ErtPluginContext
 from ert.shared import __file__ as ert_shared_path
 from ert.shared import find_available_socket
 from ert.shared.storage.command import add_parser_options
-from ert.trace import tracer, tracer_provider
+from ert.trace import tracer
 
 DARK_STORAGE_APP = "ert.dark_storage.app:app"
 
@@ -193,7 +193,7 @@ def main() -> None:
     terminate_on_parent_death_thread = threading.Thread(
         target=terminate_on_parent_death, args=[stopped, args.parent_pid, 1.0]
     )
-    with ErtPluginContext(logger=logging.getLogger(), trace_provider=tracer_provider):
+    with ErtPluginContext(logger=logging.getLogger()):
         terminate_on_parent_death_thread.start()
         with tracer.start_as_current_span("run_storage_server", ctx):
             logger = logging.getLogger("ert.shared.storage.info")

--- a/src/ert/trace.py
+++ b/src/ert/trace.py
@@ -1,7 +1,7 @@
 from opentelemetry import trace
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import SpanLimits, TracerProvider
+from opentelemetry.sdk.trace import SpanLimits, SpanProcessor, TracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 ThreadingInstrumentor().instrument()
@@ -24,3 +24,10 @@ def get_traceparent() -> str | None:
     # Write the current context into the carrier.
     TraceContextTextMapPropagator().inject(carrier)
     return carrier.get("traceparent")
+
+
+def add_span_processor(span_processor: SpanProcessor) -> None:
+    # We don't want the same span processor registered multiple times,
+    # since this will cause duplicate span entries.
+    if span_processor not in tracer_provider._active_span_processor._span_processors:
+        tracer_provider.add_span_processor(span_processor)

--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -5,7 +5,7 @@ try:
     from ert.shared.version import __version__ as everest_version
 except ImportError:
     everest_version = "0.0.0"
-from ert.trace import tracer, tracer_provider
+from ert.trace import tracer
 from everest.bin.config_branch_script import config_branch_entry
 from everest.bin.everconfigdump_script import config_dump_entry
 from everest.bin.everest_script import everest_entry
@@ -49,7 +49,7 @@ class EverestMain:
         # Setup logging from plugins:
         plugin_manager = EverestPluginManager()
         plugin_manager.add_log_handle_to_root()
-        plugin_manager.add_span_processor_to_trace_provider(tracer_provider)
+        plugin_manager.add_span_processor_to_trace_provider()
 
         # Use dispatch pattern to invoke method with same name
         getattr(self, parsed_args.command)(args[2:])

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -63,7 +63,7 @@ from ert.run_models.everest_run_model import (
     EverestExitCode,
     EverestRunModel,
 )
-from ert.trace import tracer, tracer_provider
+from ert.trace import tracer
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
     ServerStatus,
@@ -522,7 +522,7 @@ def _configure_loggers(detached_dir: Path, log_dir: Path, logging_level: int) ->
 
     plugin_manager = EverestPluginManager()
     plugin_manager.add_log_handle_to_root()
-    plugin_manager.add_span_processor_to_trace_provider(tracer_provider)
+    plugin_manager.add_span_processor_to_trace_provider()
 
 
 def get_trace_context():

--- a/src/everest/plugins/everest_plugin_manager.py
+++ b/src/everest/plugins/everest_plugin_manager.py
@@ -2,8 +2,8 @@ import logging
 from typing import Any
 
 import pluggy
-from opentelemetry.sdk.trace import TracerProvider
 
+from ert.trace import add_span_processor
 from everest.plugins import hook_impl, hook_specs
 from everest.strings import EVEREST
 
@@ -28,9 +28,7 @@ class EverestPluginManager(pluggy.PluginManager):
         for handler in self.hook.add_log_handle_to_root():
             root_logger.addHandler(handler)
 
-    def add_span_processor_to_trace_provider(
-        self, trace_provider: TracerProvider
-    ) -> None:
+    def add_span_processor_to_trace_provider(self) -> None:
         span_processors = self.hook.add_span_processor()
         for span_processor in span_processors:
-            trace_provider.add_span_processor(span_processor)
+            add_span_processor(span_processor)

--- a/tests/ert/unit_tests/plugins/dummy_plugins.py
+++ b/tests/ert/unit_tests/plugins/dummy_plugins.py
@@ -86,11 +86,12 @@ def add_log_handle_to_root():
 
 
 span_output = StringIO()
+span_processor = BatchSpanProcessor(ConsoleSpanExporter(out=span_output))
 
 
 @plugin(name="dummy")
 def add_span_processor():
-    return BatchSpanProcessor(ConsoleSpanExporter(out=span_output))
+    return span_processor
 
 
 class DummyFMStep(ForwardModelStepPlugin):


### PR DESCRIPTION
**Issue**
Resolves #10843


**Approach**
During everest tests, the main entry point is called multiple times. This also causes the plugin hook for adding span processors to be called multiple times in the same process. Natively the OTel TracerProvider accepts adding the same span processor multiple times, which will again lead to duplicate span entries. This PR changes this behavior by adding a wrapper function (add_span_processor) that checks if a span processor is already registered before adding it to the TracerProvider.

For this solution to be effective the span processor returned from the plugin hook needs to be a singleton.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
