### PR TITLE
Replace is_initialized function with get_ensemble_state

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -266,31 +266,6 @@ class LocalEnsemble(BaseMode):
             ]
         )
 
-    def is_initalized(self) -> list[int]:
-        """
-        Return the realization numbers where all parameters are internalized. In
-        cases where there are parameters which are read from the forward model, an
-        ensemble is considered initialized if all other parameters are present
-
-        Returns
-        -------
-        exists : list[int]
-            Returns the realization numbers with parameters
-        """
-
-        return [
-            i
-            for i in range(self.ensemble_size)
-            if all(
-                (
-                    self._realization_dir(i)
-                    / (_escape_filename(parameter.name) + ".nc")
-                ).exists()
-                for parameter in self.experiment.parameter_configuration.values()
-                if not parameter.forward_init
-            )
-        ]
-
     def has_data(self) -> list[int]:
         """
         Return the realization numbers where all responses are internalized

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -12,7 +12,10 @@ from ert.config import ErtConfig
 from ert.enkf_main import create_run_path
 from ert.libres_facade import LibresFacade
 from ert.storage import open_storage
-from ert.storage.local_ensemble import load_parameters_and_responses_from_runpath
+from ert.storage.local_ensemble import (
+    RealizationStorageState,
+    load_parameters_and_responses_from_runpath,
+)
 
 
 @pytest.fixture()
@@ -286,7 +289,12 @@ def test_that_the_states_are_set_correctly():
     load_parameters_and_responses_from_runpath(
         facade.run_path, new_ensemble, list(range(ensemble_size))
     )
-    assert not new_ensemble.is_initalized()
+
+    assert all(
+        RealizationStorageState.PARAMETERS_LOADED not in state
+        for state in new_ensemble.get_ensemble_state()
+    )
+
     assert new_ensemble.has_data()
 
 

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -20,7 +20,7 @@ from ert.enkf_main import create_run_path, sample_prior
 from ert.run_arg import create_run_arguments
 from ert.runpaths import Runpaths
 from ert.storage.load_status import LoadStatus
-from ert.storage.local_ensemble import forward_model_ok
+from ert.storage.local_ensemble import RealizationStorageState, forward_model_ok
 from tests.ert.unit_tests.config.egrid_generator import simple_grid
 from tests.ert.unit_tests.config.summary_generator import simple_smspec, simple_unsmry
 
@@ -354,9 +354,15 @@ def test_that_sampling_prior_makes_initialized_fs(storage):
         ensemble_size=ert_config.runpath_config.num_realizations,
     )
 
-    assert not prior_ensemble.is_initalized()
+    assert (
+        RealizationStorageState.PARAMETERS_LOADED
+        not in prior_ensemble.get_ensemble_state()[0]
+    )
     sample_prior(prior_ensemble, [0], 123)
-    assert prior_ensemble.is_initalized()
+    assert (
+        RealizationStorageState.PARAMETERS_LOADED
+        in prior_ensemble.get_ensemble_state()[0]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -340,7 +340,7 @@ def test_that_sampling_prior_makes_initialized_fs(storage):
     ert_config = ErtConfig.from_file_contents(
         dedent(
             """\
-            NUM_REALIZATIONS 1
+            NUM_REALIZATIONS 2
             GEN_KW KW_NAME template.txt kw.txt prior.txt FORWARD_INIT:False
             """
         )
@@ -358,10 +358,19 @@ def test_that_sampling_prior_makes_initialized_fs(storage):
         RealizationStorageState.PARAMETERS_LOADED
         not in prior_ensemble.get_ensemble_state()[0]
     )
+    assert (
+        RealizationStorageState.PARAMETERS_LOADED
+        not in prior_ensemble.get_ensemble_state()[1]
+    )
     sample_prior(prior_ensemble, [0], 123)
+    # Realization 0 state now contains PARAMETERS_LOADED
     assert (
         RealizationStorageState.PARAMETERS_LOADED
         in prior_ensemble.get_ensemble_state()[0]
+    )
+    assert (
+        RealizationStorageState.PARAMETERS_LOADED
+        not in prior_ensemble.get_ensemble_state()[1]
     )
 
 


### PR DESCRIPTION
**Issue**
Function is_initialized is not used anymore and the functionality can be replaced by get_ensemble_state.


**Approach**
:scissors: 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
