### PR TITLE
Don't parse old stdout/stderr files

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -140,7 +140,9 @@ class Job:
                 timeout_task = asyncio.create_task(self._max_runtime_task())
             if not self._scheduler.warnings_extracted:
                 self._scheduler.warnings_extracted = True
-                await log_warnings_from_forward_model(self.real)
+                await log_warnings_from_forward_model(
+                    self.real, file_modified_after=submit_time
+                )
 
             await self.returncode
 
@@ -367,7 +369,9 @@ def log_info_from_exit_file(exit_file_path: Path) -> None:
     )
 
 
-async def log_warnings_from_forward_model(real: Realization) -> None:
+async def log_warnings_from_forward_model(
+    real: Realization, file_modified_after: float
+) -> None:
     """Parse all stdout and stderr files from running the forward model
     for anything that looks like a Warning, and log it.
 
@@ -406,13 +410,19 @@ async def log_warnings_from_forward_model(real: Realization) -> None:
         for step_idx, step in enumerate(real.fm_steps):
             if step.stdout_file is not None:
                 stdout_file = runpath / f"{step.stdout_file}.{step_idx}"
-                if stdout_file.exists():
+                if (
+                    stdout_file.exists()
+                    and stdout_file.stat().st_mtime >= file_modified_after
+                ):
                     await log_warnings_from_file(
                         stdout_file, real.iens, step, step_idx, "stdout"
                     )
             if step.stderr_file is not None:
                 stderr_file = runpath / f"{step.stderr_file}.{step_idx}"
-                if stderr_file.exists():
+                if (
+                    stderr_file.exists()
+                    and stderr_file.stat().st_mtime >= file_modified_after
+                ):
                     await log_warnings_from_file(
                         stderr_file, real.iens, step, step_idx, "stderr"
                     )


### PR DESCRIPTION
If a runpath is reused, leftover stderr and stdout files might get parsed for warnings, this must be avoided.

**Issue**
Resolves #10916 


**Approach**
🕐 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
