### PR TITLE
[Backport version-14.2]: Format elapsed time in a human-readable way

### DIFF
--- a/src/ert/gui/simulation/view/update.py
+++ b/src/ert/gui/simulation/view/update.py
@@ -188,7 +188,8 @@ class UpdateWidget(QWidget):
                 self._insert_status_message(msg)
             case RunModelTimeEvent(remaining_time=remaining_time):
                 self._progress_msg.setText(
-                    f"Estimated remaining time for current step {remaining_time:.2f}s"
+                    f"Estimated remaining time for current step "
+                    f"{humanize.precisedelta(int(remaining_time))}"
                 )
 
     @Slot(RunModelErrorEvent)


### PR DESCRIPTION
Approach:
🍒 bc08c26a7d


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
