### PR TITLE
Revert moving of job_script into queue_options

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -707,7 +707,7 @@ class BaseRunModel(ABC):
                     max_runtime=self._queue_config.max_runtime,
                     run_arg=run_arg,
                     num_cpu=self._queue_config.queue_options.num_cpu,
-                    job_script=self._queue_config.queue_options.job_script,
+                    job_script=self._queue_config.job_script,
                     realization_memory=self._queue_config.queue_options.realization_memory,
                 )
             )

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -127,7 +127,7 @@ def test_that_job_script_can_be_set_in_site_config(monkeypatch):
 
     ert_config = ErtConfig.from_file(test_user_config)
 
-    assert Path(ert_config.queue_config.queue_options.job_script).resolve() == my_script
+    assert Path(ert_config.queue_config.job_script).resolve() == my_script
 
 
 @pytest.mark.parametrize(
@@ -482,9 +482,7 @@ def test_that_parsing_ert_config_result_in_expected_values(
         assert ert_config.ens_path == config_values.enspath
         assert ert_config.random_seed == config_values.random_seed
         assert ert_config.queue_config.max_submit == config_values.max_submit
-        assert (
-            ert_config.queue_config.queue_options.job_script == config_values.job_script
-        )
+        assert ert_config.queue_config.job_script == config_values.job_script
         assert ert_config.user_config_file == os.path.abspath(filename)
         assert ert_config.config_path == os.getcwd()
         assert str(ert_config.runpath_file) == os.path.abspath(


### PR DESCRIPTION



Makes sense to only have job_script in the global config not in the queue_options


(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
