### PR TITLE
Revert "Enable memory test on Mac. Problem not reproducible locally."

### DIFF
--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import sys
 import tempfile
 from multiprocessing import Process
 from pathlib import Path
@@ -181,6 +182,9 @@ def make_summary_data(
 
 @pytest.mark.limit_memory("130 MB")
 @pytest.mark.flaky(reruns=5)
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Currently failing on mac"
+)
 def test_field_param_memory(tmpdir):
     with tmpdir.as_cwd():
         # Setup is done in a subprocess so that memray does not pick up the allocations


### PR DESCRIPTION
This reverts commit d40841dec9dc662affdbb22301bff5d913447b25.

The Mac test fails constantly again, prohibiting us from releasing at all.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
