### PR TITLE
Change FileDialog to use Close button (with reject role)

### DIFF
--- a/src/ert/gui/tools/file/file_dialog.py
+++ b/src/ert/gui/tools/file/file_dialog.py
@@ -58,9 +58,10 @@ class FileDialog(QDialog):
         self._view.setWordWrapMode(QTextOption.WrapMode.NoWrap)
         # for moving the actual slider
         scroll_bar = self._view.verticalScrollBar()
-        scroll_bar.sliderMoved.connect(self._update_cursor)  # type: ignore
+        assert scroll_bar is not None
+        scroll_bar.sliderMoved.connect(self._update_cursor)
         # for mouse wheel and keyboard arrows
-        scroll_bar.valueChanged.connect(self._update_cursor)  # type: ignore
+        scroll_bar.valueChanged.connect(self._update_cursor)
 
         self._view.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
         self._search_bar = SearchBar(self._view)
@@ -77,21 +78,23 @@ class FileDialog(QDialog):
         self._file.close()
 
     def _init_layout(self) -> None:
-        dialog_buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
-        dialog_buttons.accepted.connect(self.accept)
+        dialog_buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        dialog_buttons.rejected.connect(self.reject)
 
         self._copy_all_button = dialog_buttons.addButton(
             "Copy all",
             QDialogButtonBox.ButtonRole.ActionRole,
         )
-        self._copy_all_button.clicked.connect(self._copy_all)  # type: ignore
+        assert self._copy_all_button is not None
+        self._copy_all_button.clicked.connect(self._copy_all)
 
         self._follow_button = dialog_buttons.addButton(
             "Follow",
             QDialogButtonBox.ButtonRole.ActionRole,
         )
-        self._follow_button.setCheckable(True)  # type: ignore
-        self._follow_button.toggled.connect(self._enable_follow_mode)  # type: ignore
+        assert self._follow_button is not None
+        self._follow_button.setCheckable(True)
+        self._follow_button.toggled.connect(self._enable_follow_mode)
         self._enable_follow_mode(self._follow_mode)
         layout = QVBoxLayout(self)
         layout.addLayout(self._search_bar.get_layout())
@@ -114,18 +117,22 @@ class FileDialog(QDialog):
 
     def _copy_all(self) -> None:
         text = self._view.toPlainText()
-        QApplication.clipboard().setText(text, QClipboard.Mode.Clipboard)  # type: ignore
+        clipboard = QApplication.clipboard()
+        assert clipboard is not None
+        clipboard.setText(text, QClipboard.Mode.Clipboard)
 
     def _update_cursor(self, value: int) -> None:
         if not self._view.textCursor().hasSelection():
             document = self._view.document()
-            block = document.findBlockByLineNumber(value)  # type: ignore
+            assert document is not None
+            block = document.findBlockByLineNumber(value)
             cursor = QTextCursor(block)
             self._view.setTextCursor(cursor)
 
     def _enable_follow_mode(self, enable: bool) -> None:
         vertical_scroll_bar = self._view.verticalScrollBar()
-        vertical_scroll_bar.setDisabled(enable)  # type: ignore
+        assert vertical_scroll_bar is not None
+        vertical_scroll_bar.setDisabled(enable)
         self._follow_mode = enable
         if enable:
             self._view.moveCursor(QTextCursor.MoveOperation.End)

--- a/src/ert/gui/tools/search_bar/search_bar.py
+++ b/src/ert/gui/tools/search_bar/search_bar.py
@@ -24,15 +24,16 @@ class SearchBar(QLineEdit):
             "Find next",
             QDialogButtonBox.ButtonRole.ActionRole,
         )
-
-        self._find_next_button.clicked.connect(self._find_next)  # type: ignore
+        assert self._find_next_button is not None
+        self._find_next_button.setDefault(True)
+        self._find_next_button.clicked.connect(self._find_next)
 
         self._highlight_all_button = dialog_buttons.addButton(
             "Highlight all",
             QDialogButtonBox.ButtonRole.ActionRole,
         )
-
-        self._highlight_all_button.clicked.connect(self._highlight_all)  # type: ignore
+        assert self._highlight_all_button is not None
+        self._highlight_all_button.clicked.connect(self._highlight_all)
 
     @Slot(str)
     def search_bar_changed(self, search_term: str) -> None:

--- a/tests/ert/unit_tests/gui/ertwidgets/test_file_dialog.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_file_dialog.py
@@ -1,0 +1,17 @@
+import tempfile
+
+from PyQt6 import QtCore
+from pytestqt.qtbot import QtBot
+
+from ert.gui.tools.file.file_dialog import FileDialog
+
+
+def test_file_dialog_default_keyclicks(qtbot: QtBot):
+    FileDialog._init_thread = lambda self: None
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as tmp_file:
+        dialog = FileDialog(tmp_file.name, "the_step", 0, 0, 0)
+        assert dialog.windowTitle() == "the_step # 0 Realization: 0 Iteration: 0"
+        qtbot.keyClick(dialog, QtCore.Qt.Key.Key_Return)
+        assert dialog.isVisible()
+        qtbot.keyClick(dialog, QtCore.Qt.Key.Key_Escape)
+        assert not dialog.isVisible()


### PR DESCRIPTION
- The OK button used today closes the window on enter
- We want to use enter for "find next"
- Re-introduce asserts to make type assumptions explicit (as per discussion with @eivindjahren )


**Issue**
Resolves #10954 

**Approach**
Change to using "Close" button (which have "reject") as default behaviour, meaning "Esc" closes it.
Enter will now be used for "find next"

(Screenshot of new behavior in GUI if applicable)
https://github.com/user-attachments/assets/890a726f-5ee4-4f01-bf77-5bd5d976cfc6



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
