### PR TITLE
Move closing of filedialogs to when simulation panel is closed

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -9,7 +9,7 @@ import humanize
 from PyQt6.QtCore import QModelIndex, QSize, Qt, QThread, QTimer
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtGui import QMouseEvent, QMovie, QTextCursor, QTextOption
+from PyQt6.QtGui import QHideEvent, QMouseEvent, QMovie, QTextCursor, QTextOption
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QDialog,
@@ -486,8 +486,6 @@ class RunDialog(QFrame):
             self.fail_msg_box.show()
         else:
             self.update_total_progress(1.0, "Experiment completed.")
-        for file_dialog in self.findChildren(FileDialog):
-            file_dialog.close()
 
     @Slot()
     def _on_ticker(self) -> None:
@@ -630,6 +628,10 @@ class RunDialog(QFrame):
             case QueueSystem.SLURM:
                 formatted_queue_system = "Slurm"
         self.queue_system.setText(f"Queue system:\n{formatted_queue_system}")
+
+    def hideEvent(self, event: QHideEvent | None) -> None:
+        for file_dialog in self.findChildren(FileDialog):
+            file_dialog.close()
 
 
 # Cannot use a non-static method here as

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -1,3 +1,4 @@
+import tempfile
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pandas as pd
@@ -896,3 +897,19 @@ def test_that_design_matrix_alters_num_realizations_field(
         "Number of realizations changed from 10 to 3 due "
         "to 'REAL' column in design matrix"
     )
+
+
+@pytest.mark.integration_test
+def test_that_file_dialog_close_when_run_dialog_hidden(qtbot: QtBot, run_dialog):
+    with qtbot.waitSignal(run_dialog.simulation_done, timeout=10000):
+        assert not run_dialog.findChild(FileDialog)  # No file dialog from fixture setup
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as tmp_file:
+            FileDialog._init_thread = (
+                lambda self: None
+            )  # To avoid firing up the file watcher
+            file_dialog = FileDialog(tmp_file.name, "the_step", 0, 0, 0, run_dialog)
+            assert run_dialog.findChild(FileDialog)
+            assert file_dialog.isVisible()
+            run_dialog.setVisible(False)
+            assert not file_dialog.isVisible()


### PR DESCRIPTION
The current behaviour is to close file dialogs (the stdout file viewer) when simulation is finished. 
This behaviour appears disturbing, one may be in the middle of reading. Moving it to when the run dialog is hidden

**Issue**
Resolves #10953


**Approach**
Simply remove the closing of the filedialog(s) when simulation ends, move it to when the simulation result/run dialog is hidden.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
