### PR TITLE
Let initialization of Everest plugin manager be lazy

### DIFF
--- a/src/everest/util/forward_models.py
+++ b/src/everest/util/forward_models.py
@@ -1,11 +1,25 @@
 from collections.abc import Sequence
 from typing import Any
 
+import pluggy
 from pydantic import BaseModel, ValidationError
 
 from everest.plugins.everest_plugin_manager import EverestPluginManager
 
-pm = EverestPluginManager()
+
+class LazyEverestPluginManager:
+    def __init__(self) -> None:
+        self.everest_plugin_manager: EverestPluginManager | None = None
+
+    @property
+    def hook(self) -> pluggy.HookRelay:
+        if self.everest_plugin_manager is None:
+            self.everest_plugin_manager = EverestPluginManager()
+
+        return self.everest_plugin_manager.hook
+
+
+pm = LazyEverestPluginManager()
 
 
 def collect_forward_model_schemas() -> dict[str, Any] | None:


### PR DESCRIPTION
This module is imported also upon invocations of Ert where we do not want the Everest plugin manager to start up and load the Everest plugins.

**Issue**
Resolves https://github.com/equinor/scout/issues/1291
Resolves https://github.com/equinor/fmu-site-configuration/issues/169


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
