### PR TITLE
Fix fm_runner not yielding Finish message when early exit

### DIFF
--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -73,6 +73,9 @@ class ForwardModelRunner:
                 f"Available forward_model steps: {[step.name() for step in self.steps]}"
             )
             yield init_message
+            yield Finish().with_error(
+                "Not all forward model steps completed successfully."
+            )
             return
         else:
             yield init_message


### PR DESCRIPTION
**Issue**
Might be related to #11001 


**Approach**
This commit fixes the bug where an early exit in the fm_runner (if the file with all the job steps no longer exists) did not yield a finish message, but only a init message with an error. This caused the event reporter to never shut down.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
