### PR TITLE
Resolve Pydantic 2.11 deprecation warning

### DIFF
--- a/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
+++ b/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
@@ -37,7 +37,7 @@ class AnalysisModuleVariablesPanel(QWidget):
 
         layout.addRow(QLabel("Inversion Algorithm"))
         dropdown = QComboBox(self)
-        options = analysis_module.model_fields["inversion"]
+        options = AnalysisModule.model_fields["inversion"]
         layout.addRow(QLabel(options.description))
         default_index = 0
         for i, option in enumerate(get_args(options.annotation)):
@@ -48,7 +48,7 @@ class AnalysisModuleVariablesPanel(QWidget):
         dropdown.currentTextChanged.connect(self.update_inversion_algorithm)
         layout.addRow(dropdown)
         var_name = "enkf_truncation"
-        metadata = analysis_module.model_fields[var_name]
+        metadata = AnalysisModule.model_fields[var_name]
         self.truncation_spinner = self.createDoubleSpinBox(
             var_name,
             analysis_module.enkf_truncation,
@@ -68,7 +68,7 @@ class AnalysisModuleVariablesPanel(QWidget):
         lf_layout = cast(QLayout, localization_frame.layout())
         lf_layout.setContentsMargins(0, 0, 0, 0)
 
-        metadata = analysis_module.model_fields["localization_correlation_threshold"]
+        metadata = AnalysisModule.model_fields["localization_correlation_threshold"]
         local_checkbox = QCheckBox(metadata.title)
         local_checkbox.setObjectName("localization")
         local_checkbox.clicked.connect(
@@ -79,7 +79,7 @@ class AnalysisModuleVariablesPanel(QWidget):
             )
         )
         var_name = "localization_correlation_threshold"
-        metadata = analysis_module.model_fields[var_name]
+        metadata = AnalysisModule.model_fields[var_name]
         self.local_spinner = self.createDoubleSpinBox(
             var_name,
             analysis_module.correlation_threshold(ensemble_size),


### PR DESCRIPTION
https://pydantic.dev/articles/pydantic-v2-11-release : Deprecation: Accessing model_fields on instances

**Issue**
Resolves #11011 


**Approach**
Read release notes

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
