### PR TITLE
Make implicit masking of some parameter configs more explicit

### DIFF
--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -126,6 +126,11 @@ class ExtParamConfig(ParameterConfig):
     ) -> npt.NDArray[np.float64]:
         raise NotImplementedError()
 
+    def load_parameters_for_update(
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
+    ) -> npt.NDArray[np.float64]:
+        raise NotImplementedError()
+
     @staticmethod
     def to_dataset(data: DataType) -> xr.Dataset:
         """Flattens data to fit inside a dataset"""

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -268,7 +268,7 @@ class Field(ParameterConfig):
         ds = xr.Dataset({"values": (["x", "y", "z"], ma.filled())})  # type: ignore
         ensemble.save_parameters(self.name, realization, ds)
 
-    def load_parameters(
+    def load_parameters_for_update(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
     ) -> npt.NDArray[np.float64]:
         ds = ensemble.load_parameters(self.name, realizations)
@@ -280,6 +280,12 @@ class Field(ParameterConfig):
             ]
         )
         return da.T.to_numpy()
+
+    def load_parameters(
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
+    ) -> npt.NDArray[np.float64]:
+        ds = ensemble.load_parameters(self.name, realizations)
+        return ds["values"].T.to_numpy()
 
     def _fetch_from_ensemble(self, real_nr: int, ensemble: Ensemble) -> xr.DataArray:
         da = ensemble.load_parameters(self.name, real_nr)["values"]

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -383,6 +383,11 @@ class GenKwConfig(ParameterConfig):
     ) -> npt.NDArray[np.float64]:
         return ensemble.load_parameters(self.name, realizations)["values"].values.T
 
+    def load_parameters_for_update(
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
+    ) -> npt.NDArray[np.float64]:
+        return self.load_parameters(ensemble, realizations)
+
     def shouldUseLogScale(self, keyword: str) -> bool:
         for tf in self.transform_functions:
             if tf.name == keyword:

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -128,6 +128,15 @@ class ParameterConfig(ABC):
         """
 
     @abstractmethod
+    def load_parameters_for_update(
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
+    ) -> npt.NDArray[np.float64]:
+        """
+        Load parameters to update from internal storage for the given ensemble.
+        Must return array of shape (number of parameters, number of realizations).
+        """
+
+    @abstractmethod
     def load_parameter_graph(self) -> nx.Graph[int]:
         """
         Load the graph encoding Markov properties on the parameter `group`

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -180,6 +180,11 @@ class SurfaceConfig(ParameterConfig):
         )
         ensemble.save_parameters(self.name, realization, ds)
 
+    def load_parameters_for_update(
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
+    ) -> npt.NDArray[np.float64]:
+        return self.load_parameters(ensemble, realizations)
+
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
     ) -> npt.NDArray[np.float64]:

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -563,7 +563,7 @@ class LocalEnsemble(BaseMode):
         self, group: str, realizations: npt.NDArray[np.int_]
     ) -> npt.NDArray[np.float64]:
         config = self.experiment.parameter_configuration[group]
-        return config.load_parameters(self, realizations)
+        return config.load_parameters_for_update(self, realizations)
 
     def save_parameters_numpy(
         self,


### PR DESCRIPTION
Towards having numpy endpoint not be only silently "update only" by masking out excluded params