### PR TITLE
Prepare erts logger configuration to work with everest

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -625,9 +625,11 @@ def main() -> None:
 
     with open(LOGGING_CONFIG, encoding="utf-8") as conf_file:
         config_dict = yaml.safe_load(conf_file)
-        for _, v in config_dict["handlers"].items():
-            if "ert.logging.TimestampedFileHandler" in v.values():
-                v["ert_config"] = args.config
+        for handler_name, handler_config in config_dict["handlers"].items():
+            if handler_name == "file":
+                handler_config["filename"] = "ert-log.txt"
+            if "ert.logging.TimestampedFileHandler" in handler_config.values():
+                handler_config["config_filename"] = args.config
         logging.config.dictConfig(config_dict)
 
     logger = logging.getLogger(__name__)

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -38,8 +38,8 @@ class TimestampedFileHandler(logging.FileHandler):
         )
         filename, extension = os.path.splitext(filename)
 
-        if "ert_config" in kwargs:
-            config_file_path = pathlib.Path(kwargs.pop("ert_config"))
+        if "config_filename" in kwargs:
+            config_file_path = pathlib.Path(kwargs.pop("config_filename"))
             name, ext = os.path.splitext(config_file_path.name)
             config_filename = f"{name}-{ext[1:]}"
             filename = f"{filename}-{config_filename}-{timestamp}{extension}"

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -8,7 +8,6 @@ handlers:
   file:
     level: DEBUG
     formatter: simple_with_threading
-    filename: ert-log.txt
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
   terminal:


### PR DESCRIPTION
The file path must be set in code instead of in the config file such that the config file can be used for multiple applications

**Issue**
Resolves first step of #11027


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
