### PR TITLE
Let Everest use Erts logger.conf

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -625,9 +625,11 @@ def main() -> None:
 
     with open(LOGGING_CONFIG, encoding="utf-8") as conf_file:
         config_dict = yaml.safe_load(conf_file)
-        for _, v in config_dict["handlers"].items():
-            if "ert.logging.TimestampedFileHandler" in v.values():
-                v["ert_config"] = args.config
+        for handler_name, handler_config in config_dict["handlers"].items():
+            if handler_name == "file":
+                handler_config["filename"] = "ert-log.txt"
+            if "ert.logging.TimestampedFileHandler" in handler_config.values():
+                handler_config["config_filename"] = args.config
         logging.config.dictConfig(config_dict)
 
     logger = logging.getLogger(__name__)

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -38,8 +38,8 @@ class TimestampedFileHandler(logging.FileHandler):
         )
         filename, extension = os.path.splitext(filename)
 
-        if "ert_config" in kwargs:
-            config_file_path = pathlib.Path(kwargs.pop("ert_config"))
+        if "config_filename" in kwargs:
+            config_file_path = pathlib.Path(kwargs.pop("config_filename"))
             name, ext = os.path.splitext(config_file_path.name)
             config_filename = f"{name}-{ext[1:]}"
             filename = f"{filename}-{config_filename}-{timestamp}{extension}"

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -8,7 +8,6 @@ handlers:
   file:
     level: DEBUG
     formatter: simple_with_threading
-    filename: ert-log.txt
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
   terminal:

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python
-
 import argparse
 import asyncio
 import json
 import logging
+import logging.config
 import os
 import signal
+import sys
 import threading
 from functools import partial
 
+import yaml
+
 from _ert.threading import ErtThread
 from ert.config import QueueSystem
+from ert.logging import LOGGING_CONFIG
 from everest.bin.utils import show_scaled_controls_warning
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
@@ -22,7 +26,6 @@ from everest.detached import (
     wait_for_server,
 )
 from everest.everest_storage import EverestStorage
-from everest.strings import DEFAULT_LOGGING_FORMAT
 from everest.util import (
     makedirs_if_needed,
     version_info,
@@ -44,17 +47,27 @@ def everest_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
 
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter(DEFAULT_LOGGING_FORMAT)
-    handler.setFormatter(formatter)
+    log_dir = "logs"
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+    except PermissionError as err:
+        sys.exit(str(err))
+    os.environ["ERT_LOG_DIR"] = log_dir
 
-    root_logger = logging.root
-    root_logger.addHandler(handler)
-    root_logger.setLevel(
-        logging.DEBUG if options.debug else options.config.logging_level
-    )
+    with open(LOGGING_CONFIG, encoding="utf-8") as log_conf_file:
+        config_dict = yaml.safe_load(log_conf_file)
+        for handler_name, handler_config in config_dict["handlers"].items():
+            if handler_name == "file":
+                handler_config["filename"] = "everest-log.txt"
+            if "ert.logging.TimestampedFileHandler" in handler_config.values():
+                handler_config["config_filename"] = options.config.config_path.name
+        logging.config.dictConfig(config_dict)
 
-    logger.setLevel(logging.DEBUG if options.debug else options.config.logging_level)
+    if options.debug:
+        root_logger = logging.getLogger()
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(handler)
 
     logger.debug(version_info())
 


### PR DESCRIPTION
**Issue**
Resolves #11027 


**Approach**
    This aligns log levels for Everest and Ert (effectively muting some
    uninteresting INFO logs from auxiliary packages), and adds a logging
    feature to Everest to follow Erts pattern of writing to
    logs/everest-log-<config_filename>-<timestamp>.txt


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
