### PR TITLE
Have ert use minimum of NUM_REALIZATIONS and DESIGN_MATRIX realizations

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -96,6 +96,14 @@ at least 2 realizations.
         -- Use 200 realizations/members
         NUM_REALIZATIONS 200
 
+
+.. note::
+         If used alongside :ref:`DESIGN_MATRIX <design_matrix>`, Ert will
+         compare the value of NUM_REALIZATIONS and the number of realizations
+         found in the design matrix, and use the minimum of the two as the
+         number of realizations to run. See :ref:`DESIGN_MATRIX notes <design_matrix_notes>`
+         for details on how the number of realizations is calculated in the design matrix.
+
 DEFINE
 ------
 .. _define:
@@ -281,6 +289,12 @@ In such cases consider to comment out GEN_KW definitions and thus only the desig
 
 In case there is no overlap with a GEN_KW group, the GEN_KW group will be sampled normally.
 
+.. _design_matrix_notes:
+.. note::
+    The number of realizations in the design matrix is calculated by the max realization id found in the
+    `REALS` column + 1. If the `REALS` column is missing some realizations, they will be set
+    as inactive in the ensemble and not run. For example, if the DESIGN_MATRIX only contains realization
+    id 3, then the ensemble_size will be four. Here the realizations 0, 1, and 2 will be marked as inactive and not run.
 
 ECLBASE
 -------

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -98,6 +98,17 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
     except ValueError as e:
         raise ErtCliError(f"{args.mode} was not valid, failed with: {e}") from e
 
+    if (
+        ert_config.analysis_config.design_matrix is not None
+        and ert_config.analysis_config.design_matrix.active_realizations is not None
+    ):
+        _log_if_num_realization_was_updated(
+            ert_config.runpath_config.num_realizations,
+            len(ert_config.analysis_config.design_matrix.active_realizations),
+            model.active_realizations.count(True),
+            hasattr(args, "realizations") and args.realizations is not None,
+        )
+
     if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
         # This is within the range for ephemeral ports as defined by
         # most unix flavors https://en.wikipedia.org/wiki/Ephemeral_port
@@ -154,3 +165,30 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
         # If monitor has not reported, give some info if the job failed
         msg = end_event.msg if args.disable_monitoring else ""
         raise ErtCliError(msg)
+
+
+def _log_if_num_realization_was_updated(
+    config_num_realizations: int,
+    dm_num_realizations: int,
+    active_realizations_count: int,
+    has_realizations_specified: bool = False,
+) -> None:
+    if dm_num_realizations == config_num_realizations:
+        return
+    if has_realizations_specified:
+        print(
+            "Using realizations intersected between realizations_specified "
+            f"and DESIGN_MATRIX ({active_realizations_count})"
+        )
+    else:
+        print(
+            f"NUM_REALIZATIONS ({config_num_realizations}) is "
+            + ("greater " if dm_num_realizations < config_num_realizations else "less ")
+            + f"than the number of realizations in DESIGN_MATRIX "
+            f"({dm_num_realizations}). Using the realizations from "
+            + (
+                f"DESIGN_MATRIX ({dm_num_realizations})"
+                if dm_num_realizations < config_num_realizations
+                else f"NUM_REALIZATIONS ({config_num_realizations})"
+            )
+        )


### PR DESCRIPTION
**Issue**
Resolves #10921 


**Approach**
This commit makes ert use the minimum of NUM_REALIZATIONS from config and design matrix. Now we can see in the logs which num_realization is being used, and it is also printed in the terminal when running CLI.

This commit also improves the error message for when a single test run fails due to the first active realization being inactive.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
