### PR TITLE
Change base class of EventViewPanel to QDialog

### DIFF
--- a/src/ert/gui/tools/event_viewer/panel.py
+++ b/src/ert/gui/tools/event_viewer/panel.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from PyQt6.QtCore import QObject
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QPlainTextEdit, QVBoxLayout
+from PyQt6.QtWidgets import QDialog, QPlainTextEdit, QVBoxLayout
 
 from ert.gui.tools.search_bar import SearchBar
 
@@ -49,10 +49,10 @@ class GUILogHandler(_Signaler):
         return self.handler.handle(record)
 
 
-class EventViewerPanel(QPlainTextEdit):
+class EventViewerPanel(QDialog):
     def __init__(self, log_handler: GUILogHandler) -> None:
+        super().__init__()
         self.log_handler = log_handler
-        QPlainTextEdit.__init__(self)
 
         self.setMinimumWidth(500)
         self.setMinimumHeight(800)


### PR DESCRIPTION
It shouldn't _be_ a QPlainTextEdit when it _contains_ a QPlainTextEdit

**Issue**
Resolves #10960 


**Approach**
The EventViewPanel was (inherited) QPlainTextEdit, _and_ contained a QPlainTextEdit. So we had "two" edit fields, could be seen by a cursor appearing, and text "next to" the main text edit field being possible to write into. 

Now it is gone, and the behaviour is similar to the file_dialog that is used to show stdout from forward jobs. Enter searches next and Esc closes window.

![bilde](https://github.com/user-attachments/assets/4466a2e4-8605-4f22-845e-a99bb11f6ca0)



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
