### PR TITLE
Fix storage write_transaction flakiness

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -572,6 +572,7 @@ class LocalStorage(BaseMode):
         self._swap_path.mkdir(parents=True, exist_ok=True)
         with NamedTemporaryFile(dir=self._swap_path, delete=False) as f:
             f.write(data)
+            f.flush()
             os.chmod(f.name, 0o660)
             os.rename(f.name, filename)
 


### PR DESCRIPTION
This commit makes the storage write_transaction method explicitly flush the temp file before renaming it into the destination_file. This fixes the issue where the destination-file would be empty, and cause flakiness in the cases where it would be read before automatically being flushed.

**Issue**
Resolves #[flaky gui test issue](https://github.com/equinor/ert/actions/runs/15411036517/job/43362892372)


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
