### PR TITLE
Validate gen_kw parameter name cannot be IENS,ITER, or realization

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -666,6 +666,9 @@ def create_list_of_forward_model_steps_to_run(
     return fm_steps
 
 
+RESERVED_KEYWORDS = ["realization", "IENS", "ITER"]
+
+
 class ErtConfig(BaseModel):
     DEFAULT_ENSPATH: ClassVar[str] = "storage"
     DEFAULT_RUNPATH_FILE: ClassVar[str] = ".ert_runpath_list"
@@ -673,6 +676,7 @@ class ErtConfig(BaseModel):
     PREINSTALLED_WORKFLOWS: ClassVar[dict[str, ErtScriptWorkflow]] = {}
     ENV_PR_FM_STEP: ClassVar[dict[str, dict[str, Any]]] = {}
     ACTIVATE_SCRIPT: ClassVar[str | None] = None
+    RESERVED_KEYWORDS: ClassVar[list[str]] = RESERVED_KEYWORDS
 
     substitutions: Substitutions = Field(default_factory=Substitutions)
     ensemble_config: EnsembleConfig = Field(default_factory=EnsembleConfig)
@@ -687,6 +691,7 @@ class ErtConfig(BaseModel):
         default_factory=lambda: defaultdict(list)
     )
     runpath_file: Path = Path(DEFAULT_RUNPATH_FILE)
+
     ert_templates: list[tuple[str, str]] = Field(default_factory=list)
     installed_forward_model_steps: dict[str, ForwardModelStep] = Field(
         default_factory=dict
@@ -716,6 +721,7 @@ class ErtConfig(BaseModel):
             parameter_name
             for parameter_name in self.ensemble_config.get_all_gen_kw_parameter_names()
             if f"<{parameter_name}>" in self.substitutions
+            or parameter_name in ErtConfig.RESERVED_KEYWORDS
         ]
         if overlapping_parameter_names:
             raise ConfigValidationError(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2378,6 +2378,9 @@ def test_validation_error_on_gen_kw_with_design_matrix_group_name(tmp_path):
     "invalid_parameter_definition_name",
     [
         pytest.param("CWD UNIFORM 0 1", id="already_a_magic_string"),
+        pytest.param("realization UNIFORM 0 1", id="realization_is_reserved"),
+        pytest.param("ITER UNIFORM 0 1", id="ITER_is_reserved"),
+        pytest.param("IENS UNIFORM 0 1", id="IENS_is_reserved"),
         pytest.param("a UNIFORM 0 1", id="already_defined_in_user_config"),
     ],
 )


### PR DESCRIPTION
**Issue**
Resolves #11069
Resolves #11070 


**Approach**
This commit makes ert_config validate for IENS,ITER, and realization gen_kw parameter name.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
