### PR TITLE
Disable QDockWidget features

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -333,10 +333,7 @@ class PlotWindow(QMainWindow):
         dock_widget.setObjectName(f"{name}Dock")
         dock_widget.setWidget(widget)
         dock_widget.setAllowedAreas(allowed_areas)
-        dock_widget.setFeatures(
-            QDockWidget.DockWidgetFeature.DockWidgetFloatable
-            | QDockWidget.DockWidgetFeature.DockWidgetMovable
-        )
+        dock_widget.setFeatures(QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
 
         self.addDockWidget(area, dock_widget)
         return dock_widget


### PR DESCRIPTION
To disallow the user to move around the dock sections, a quick fix is to disable the features of the QDockWidget.

However, we should perhaps consider using something else than a dock widget if we are not going to use the docking features anyway.

**Issue**
Resolves #11066 


**Approach**
Played around with dock features until it was immovable. However, we should consider moving away from the docking class if we are not going to utilize the docking features.

The GUI looks exactly the same, but the windows cannot be undocked.
![image](https://github.com/user-attachments/assets/fcf52d48-c764-4b91-95c2-60693c90bab1)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
