### PR TITLE
Remove line with no effect

### DIFF
--- a/tests/ert/ui_tests/cli/test_missing_runpath.py
+++ b/tests/ert/ui_tests/cli/test_missing_runpath.py
@@ -78,7 +78,6 @@ def patch_raising_named_temporary_file(queue_system):
     )
 
 
-@pytest.mark.usefixtures()
 def test_failing_writes_lead_to_isolated_failures(tmp_path, monkeypatch, pytestconfig):
     monkeypatch.chdir(tmp_path)
     queue_system = None


### PR DESCRIPTION
Solves warning from pytest while testing: 
`PytestWarning: usefixtures() in tests/ert/ui_tests/cli/test_missing_runpath.py::test_failing_writes_lead_to_isolated_failures without arguments has no effect
`
**Issue**
Resolves warning from pytest emitted while running tests.


**Approach*
Do as pytest suggests.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
