### PR TITLE
Remove objective/constraint forward model types

### DIFF
--- a/src/everest/config/forward_model_config.py
+++ b/src/everest/config/forward_model_config.py
@@ -21,14 +21,6 @@ class SummaryResults(ForwardModelResult):
     )
 
 
-class ObjectiveResult(ForwardModelResult):
-    type: Literal["objective"] = "objective"
-
-
-class ConstraintResult(ForwardModelResult):
-    type: Literal["constraint"] = "constraint"
-
-
 class GenDataResults(ForwardModelResult):
     type: Literal["gen_data"] = "gen_data"
 
@@ -40,7 +32,7 @@ class ForwardModelStepConfig(BaseModelWithContextSupport):
     results: (
         (
             Annotated[
-                SummaryResults | GenDataResults | ObjectiveResult | ConstraintResult,
+                SummaryResults | GenDataResults,
                 Discriminator("type"),
             ]
         )

--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -45,10 +45,6 @@ install_jobs:
 forward_model:
   # Compute distance (squared and negated) between 2 points
   - job: adv_distance3 --point-file point.json --target-file data/r{{ realization}}/target.json --out distance
-    results:
-      file_name: distance
-      type: objective
-      keys: "*"
   # Expect no objective, but should generate gen_data in ERT storage
   - job: adv_distance3 --point-file point.json --target-file data/r{{ realization}}/target.json --out distance_nonobj
     results:


### PR DESCRIPTION
The `objective` and `constraint` types in the `results:` section of the `forward_model:` list in the Everest configuration are currently not used. The necessary information for ERT is derived directly from the `objective_functions` and `output_constraints` sections. Since no other additional info needs to be provided, these types are not needed in the `results:` sections.

**Issue**
Resolves #10995


**Approach**
Remove the corresponding entries in the everest config. Update test config file.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
