### PR TITLE
Fix Event reporter not exiting after failed retries

### DIFF
--- a/src/_ert/forward_model_runner/client.py
+++ b/src/_ert/forward_model_runner/client.py
@@ -55,7 +55,13 @@ class Client:
         self._receiver_task: asyncio.Task[None] | None = None
 
     async def __aenter__(self) -> Self:
-        await self.connect()
+        try:
+            await self.connect()
+        except ClientConnectionError:
+            logger.error(
+                "No ack for dealer connection. Connection was not established!"
+            )
+            raise
         return self
 
     async def __aexit__(
@@ -162,5 +168,5 @@ class Client:
                 backoff = min(backoff * 2, 10)  # Exponential backoff
             retries -= 1
         raise ClientConnectionError(
-            f"{self.dealer_id} Failed to send {message!r} to {self.url} after retries!"
+            f"{self.dealer_id} Failed to send {message!r} to {self.url} after retrying!"
         )

--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -75,7 +75,9 @@ class Event(Reporter):
         self._ens_id = None
         self._real_id = None
         self._event_queue: queue.Queue[events.Event | EventSentinel] = queue.Queue()
-        self._event_publisher_thread = ErtThread(target=self._event_publisher)
+        self._event_publisher_thread = ErtThread(
+            target=self._event_publisher, should_raise=False
+        )
         self._done = threading.Event()
         self._ack_timeout = ack_timeout
         self._max_retries = max_retries
@@ -124,6 +126,7 @@ class Event(Reporter):
                         return
                     except ClientConnectionError as exc:
                         logger.error(f"Failed to send event: {exc}")
+                        raise exc
 
         try:
             asyncio.run(publisher())


### PR DESCRIPTION
**Approach**
This commit fixes the issue where the fm_dispatch event reporter would be stuck forever trying to resend events/CONNECT/DISCONNECT if it didn't get ACK messages from the dealer.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
