### PR TITLE
Allow realization ranges in everest model config

### DIFF
--- a/src/everest/config/model_config.py
+++ b/src/everest/config/model_config.py
@@ -1,15 +1,17 @@
+from collections.abc import Iterator
 from typing import Any, Self
 
-from pydantic import BaseModel, Field, NonNegativeInt, model_validator
+from pydantic import BaseModel, Field, NonNegativeInt, field_validator, model_validator
 
 from ert.config import ConfigWarning
 
 
 class ModelConfig(BaseModel, extra="forbid"):
     realizations: list[NonNegativeInt] = Field(
-        description="""List of realizations to use in optimization ensemble.
+        description="""Realizations to use in optimization ensemble.
 
-Typically, this is a list [0, 1, ..., n-1] of all realizations in the ensemble.""",
+This is a list [0, 1, ..., n-1] of all realizations in the ensemble, or a string
+consisting of comma separated values and ranges, i.e '1, 2, 5-8, 10'.""",
         min_length=1,
     )
     realizations_weights: list[float] = Field(
@@ -31,6 +33,26 @@ If specified, it must be a list of numeric values, one per realization.""",
             )
             values.pop("report_steps")
         return values
+
+    @field_validator("realizations", mode="before")
+    @classmethod
+    def convert_realizations(cls, realizations: Any) -> list[int]:
+        def _parse_realizations(realizations: str) -> Iterator[int]:
+            msg = f"Invalid realizations specification: {realizations}"
+            for item in realizations.split(","):
+                first, sep, second = (part.strip() for part in item.partition("-"))
+                if not sep:
+                    second = first
+                if not first.isdigit() or not second.isdigit():
+                    raise ValueError(msg)
+                start, stop = int(first), int(second)
+                if start > stop:
+                    raise ValueError(msg)
+                yield from range(start, stop + 1)
+
+        if isinstance(realizations, str):
+            return sorted(dict.fromkeys(_parse_realizations(realizations)))
+        return realizations
 
     @model_validator(mode="after")
     def validate_realizations_weights_same_cardinaltiy(self) -> Self:

--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -60,7 +60,7 @@ forward_model:
 # - job: sleep --min 0.1 --max 5 --fail-chance 0.5
 
 model:
-  realizations: [0, 2]
+  realizations: 0, 2
   realizations_weights: [0.25, 0.75]
 
 


### PR DESCRIPTION
**Issue**
Resolves #10848


**Approach**
Adds a validator to ModelConfig that transforms strings consisting of a comma-separated list of integers and integer ranges of the form `min-max` into a list of integers.

Example: "1, 2, 5-8, 3" is transformed into [1, 2, 3, 5, 6, 7, 8] and stored in the realizations field.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
