### PR TITLE
Fix the resubmit_limit option

### DIFF
--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -106,7 +106,7 @@ def _extract_simulator(ever_config: EverestConfig, ert_config: dict[str, Any]) -
     ever_simulation = ever_config.simulator or SimulatorConfig()
 
     # Resubmit number (number of submission retries)
-    ert_config[ErtConfigKeys.MAX_SUBMIT] = ever_simulation.resubmit_limit
+    ert_config[ErtConfigKeys.MAX_SUBMIT] = ever_simulation.resubmit_limit + 1
 
     # Maximum number of seconds (MAX_RUNTIME) a forward model is allowed to run
     max_runtime = ever_simulation.max_runtime

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -477,7 +477,7 @@ def _generate_exp_ert_config(config_path, output_dir):
             os.path.realpath("everest/model"),
             "everest_output/.res_runpath_list",
         ),
-        ErtConfigKeys.MAX_SUBMIT: 1,
+        ErtConfigKeys.MAX_SUBMIT: 2,
         ErtConfigKeys.FORWARD_MODEL: [
             [
                 "copy_directory",

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -467,7 +467,7 @@ def test_that_queue_settings_are_taken_from_site_config(
     )
 
 
-def test_passthrough_explicit_summary_keys(change_to_tmpdir):
+def test_passthrough_explicit_summary_keys():
     custom_sum_keys = [
         "GOIR:PRODUC",
         "GOIT:INJECT",
@@ -538,7 +538,7 @@ def test_that_negative_max_memory_fails(max_memory) -> None:
     "max_memory",
     ["1x", "1 x", "1 xy", "foo"],
 )
-def test_that_invalid_max_memory_fails(change_to_tmpdir, max_memory) -> None:
+def test_that_invalid_max_memory_fails(max_memory) -> None:
     with pytest.raises(
         ValidationError, match=f"Could not understand byte unit in {max_memory}"
     ):
@@ -550,16 +550,21 @@ def test_that_invalid_max_memory_fails(change_to_tmpdir, max_memory) -> None:
     "max_memory",
     [0, 1, "0", "1", "1b", "1k", "1m", "1g", "1t", "1p", "1G", "1 G", "1Gb", "1 Gb"],
 )
-def test_that_max_memory_is_passed_to_ert_unchanged(
-    change_to_tmpdir, max_memory
-) -> None:
+def test_that_max_memory_is_passed_to_ert_unchanged(max_memory) -> None:
     ever_config = EverestConfig.with_defaults(simulator={"max_memory": max_memory})
     config_dict = everest_to_ert_config_dict(ever_config)
     assert config_dict[ErtConfigKeys.REALIZATION_MEMORY] == str(max_memory)
 
 
 @pytest.mark.usefixtures("no_plugins")
-def test_that_max_memory_none_is_not_passed_to_ert(change_to_tmpdir) -> None:
+def test_that_max_memory_none_is_not_passed_to_ert() -> None:
     ever_config = EverestConfig.with_defaults()
     config_dict = everest_to_ert_config_dict(ever_config)
     assert ErtConfigKeys.REALIZATION_MEMORY not in config_dict
+
+
+@pytest.mark.usefixtures("no_plugins")
+def test_that_resubmit_limit_is_set() -> None:
+    ever_config = EverestConfig.with_defaults(simulator={"resubmit_limit": 0})
+    config_dict = everest_to_ert_config_dict(ever_config)
+    assert config_dict[ErtConfigKeys.MAX_SUBMIT] == 1


### PR DESCRIPTION
**Issue**
Resolves #11089


**Approach**
ERT uses MAX_SUBMIT, therefore this should be set to resubmit_limit + 1

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
