### PR TITLE
Change support_restart to default False

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import OrderedDict
 from pathlib import Path
 from queue import SimpleQueue
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
     from ert.config import ErtConfig
 
 EXPERIMENT_IS_MANUAL_UPDATE_MESSAGE = "Execute Selected"
+
+logger = logging.getLogger(__name__)
 
 
 def create_md_table(kv: dict[str, str], output: str) -> str:
@@ -350,6 +353,9 @@ class ExperimentPanel(QWidget):
             self._notifier.set_is_simulation_running(True)
 
         def restart() -> None:
+            logger.info(
+                f"Rerunning failed simulations for run model '{self._model.name()}'"
+            )
             start_simulation_thread(restart=True)
 
         self._dialog.restart_experiment.connect(restart)

--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -184,7 +184,7 @@ class BaseRunModel(BaseModelWithContextSupport, ABC):
     random_seed: int
     start_iteration: int = 0
     minimum_required_realizations: int = 0
-    support_restart: bool = True
+    support_restart: bool = False
 
     # Private attributes initialized in model_post_init
     _start_time: int | None = PrivateAttr(None)

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -42,6 +42,7 @@ class EnsembleExperiment(BaseRunModel):
     _observations: dict[str, pl.DataFrame] = PrivateAttr()
     _experiment_id: UUID | None = PrivateAttr(None)
     _ensemble_id: UUID | None = PrivateAttr(None)
+    support_restart: bool = True
 
     def __init__(self, **data: Any) -> None:
         observations = data.pop("observations", None)

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -25,6 +25,7 @@ class EvaluateEnsemble(BaseRunModel):
     """
 
     ensemble_id: str
+    support_restart: bool = True
 
     def model_post_init(self, ctx: Any) -> None:
         super().model_post_init(ctx)

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 class ManualUpdate(UpdateRunModel):
     ensemble_id: str
-    support_restart: bool = False
 
     _prior: Ensemble = PrivateAttr()
 
@@ -29,8 +28,6 @@ class ManualUpdate(UpdateRunModel):
             raise ErtRunError(
                 f"Prior ensemble with ID: {UUID(self.ensemble_id)} does not exist"
             ) from err
-
-        self.support_restart = False
 
     def run_experiment(
         self, evaluator_server_config: EvaluatorServerConfig, restart: bool = False

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -70,7 +70,6 @@ class MultipleDataAssimilation(UpdateRunModel):
 
         self.start_iteration = start_iteration
         self._total_iterations = total_iterations
-        self.support_restart = False
 
     @tracer.start_as_current_span(f"{__name__}.run_experiment")
     def run_experiment(

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -52,14 +52,14 @@ def create_base_run_model(**kwargs):
     return BaseRunModelWithMockSupport(**(default_args | kwargs))
 
 
-def test_base_run_model_supports_restart(minimum_case):
+def test_base_run_model_not_supports_restart(minimum_case):
     brm = create_base_run_model(
         storage_path=minimum_case.ens_path,
         queue_config=minimum_case.queue_config,
         active_realizations=[True],
         forward_model_steps=minimum_case.forward_model_steps,
     )
-    assert brm.support_restart
+    assert not brm.support_restart
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It doesn't work for most RunModels, and behaviour for "multistep" models/experiments must be clarified, and code refactored. If this is a desired feature.

It is already disabled for MDA, but does not work for Ensemble Smoother and IF. Leave enabled for "Evaluate Ensemble" and "Ensemble Experiment" since they work.

**Issue**
Resolves #11032 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
