### PR TITLE
Backport Handle running workflows without selected ensemble to 14.2

### DIFF
--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -128,9 +128,8 @@ class RunWorkflowWidget(QWidget):
         )
 
         workflow = self.config.workflows[self.getCurrentWorkflowName()]
-        ensemble = self.storage.get_ensemble(
-            self.source_ensemble_selector.currentData()
-        )
+        ensemble = self.source_ensemble_selector.selected_ensemble
+
         self._workflow_runner = WorkflowRunner(
             workflow=workflow,
             fixtures={

--- a/tests/ert/ui_tests/gui/test_workflow_tool.py
+++ b/tests/ert/ui_tests/gui/test_workflow_tool.py
@@ -78,3 +78,50 @@ def test_run_export_runpath_workflow(open_gui, qtbot, run_experiment):
     gui.workflows_tool.trigger()
 
     assert os.path.isfile(".ert_runpath_list")
+
+
+def test_run_workflow_with_no_ensemble_selected(qtbot, tmp_path, capsys):
+    os.chdir(tmp_path)
+    (tmp_path / "config.ert").write_text(
+        dedent("""
+            NUM_REALIZATIONS 1
+            LOAD_WORKFLOW_JOB print_job PRINT
+            LOAD_WORKFLOW print_workflow
+            """)
+    )
+
+    print_job_content = "EXECUTABLE echo"
+    (tmp_path / "print_job").write_text(print_job_content.strip())
+
+    print_workflow_content = "PRINT Hello world"
+    (tmp_path / "print_workflow").write_text(print_workflow_content.strip())
+
+    ert_config = ErtConfig.from_file("config.ert")
+
+    args_mock = Mock()
+    args_mock.config = "config.ert"
+    # handler defined here to ensure lifetime until end of function, if inlined
+    # it will cause the following error:
+    # RuntimeError: wrapped C/C++ object of type GUILogHandler
+    handler = GUILogHandler()
+    gui = _setup_main_window(ert_config, args_mock, handler, ert_config.ens_path)
+
+    def handle_run_workflow_tool():
+        dialog = wait_for_child(gui, qtbot, ClosableDialog)
+        workflow_widget = get_child(dialog, RunWorkflowWidget)
+        assert workflow_widget.notifier.current_ensemble is None
+        assert workflow_widget.run_button.isEnabled()
+
+        def close_all():
+            if running_dlg := workflow_widget._running_workflow_dialog:
+                running_dlg.accept()
+            dialog.close()
+
+        workflow_widget.workflowSucceeded.disconnect()
+        workflow_widget.workflowSucceeded.connect(close_all)
+        qtbot.mouseClick(workflow_widget.run_button, Qt.MouseButton.LeftButton)
+
+    QTimer.singleShot(1000, handle_run_workflow_tool)
+    gui.workflows_tool.trigger()
+    assert capsys.readouterr().out == "Hello world\n"
+    gui.close()


### PR DESCRIPTION
(cherry picked from commit afe5f703ede26c6a86ead4bb2d7910fcf89b836f)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
