### PR TITLE
Fix handling of time-outs for SLURM

### DIFF
--- a/tests/ert/unit_tests/scheduler/bin/scontrol.py
+++ b/tests/ert/unit_tests/scheduler/bin/scontrol.py
@@ -8,6 +8,7 @@ This script partially mocks the Slurm provided utility scontrol:
 import argparse
 import glob
 import os
+import signal
 from pathlib import Path
 from typing import Literal
 
@@ -51,6 +52,10 @@ def main() -> None:
                 state = "COMPLETED"
             if returncode != "0":
                 state = "FAILED"
+            # This is just to enable testing of time-out:
+            if returncode == f"{signal.SIGTERM + 128}":
+                state = "TERMINATED"
+                returncode = 0
 
         print(f"JobId={job} JobName={name}")
         print(f"   JobState={state}")


### PR DESCRIPTION
**Issue**
Resolves #11115


**Approach**
The SLURM drive did not handler time-out, these were detected as a failure, but not properly handled, leading to an infinite loop. This PR adds the TIMEOUT as a job status and handles it, reporting the job as failed with an appropriate exit code.

In addition, a test is added that works both with the SLURM test mock, as well as with a real SLURM cluster.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
