### PR TITLE
Tune everest logs

### DIFF
--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -38,6 +38,8 @@ loggers:
     level: INFO
   urllib3:
     level: WARNING
+  websockets:
+    level: WARNING
 
 
 root:

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -72,7 +72,7 @@ def everest_entry(args: list[str] | None = None) -> None:
         handler.setLevel(logging.DEBUG)
         root_logger.addHandler(handler)
 
-    logger.debug(version_info())
+    logger.info(version_info())
 
     if options.config.server_queue_system == QueueSystem.LOCAL:
         print(
@@ -163,11 +163,11 @@ async def run_everest(options: argparse.Namespace) -> None:
         )
     elif server_state["status"] == ServerStatus.never_run or options.new_run:
         config_dict = options.config.to_dict()
-        logger.debug("Running everest with the following config:")
-        logger.debug(json.dumps(config_dict, sort_keys=True, indent=2))
+        logger.info("Running everest with the following config:")
+        logger.info(json.dumps(config_dict, sort_keys=True, indent=2))
         for fm_job in options.config.forward_model_step_commands:
             job_name = fm_job.split()[0]
-            logger.debug(f"Everest forward model contains job {job_name}")
+            logger.info(f"Everest forward model contains job {job_name}")
 
         if (
             options.config.simulation_dir is not None
@@ -203,7 +203,7 @@ async def run_everest(options: argparse.Namespace) -> None:
         logger.debug("Waiting for response from everserver")
         wait_for_server(options.config.output_dir, timeout=600)
         print("Everest server found!")
-        logger.debug("Got response from everserver. Starting experiment")
+        logger.info("Got response from everserver. Starting experiment")
 
         start_experiment(
             server_context=ServerConfig.get_server_context(options.config.output_dir),
@@ -238,14 +238,14 @@ async def run_everest(options: argparse.Namespace) -> None:
                 )
             )
 
-        logger.debug("Everest experiment finished")
+        logger.info("Everest experiment finished")
 
         server_state = everserver_status(everserver_status_path)
         server_state_info = server_state["message"]
         if server_state["status"] == ServerStatus.failed:
             raise SystemExit(f"Everest run failed with: {server_state_info}")
         if server_state_info is not None:
-            logger.debug(f"Everest run finished with: {server_state_info}")
+            logger.info(f"Everest run finished with: {server_state_info}")
             print(server_state_info)
     else:
         report_on_previous_run(

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -68,7 +68,7 @@ async def start_server(config: EverestConfig, logging_level: int) -> Driver:
         raise ValueError(f"Everserver not started as expected, got status: {status}")
     poll_task.cancel()
     logger.debug(
-        f"Everserver started. Items left in queue: {driver.event_queue.qsize()}"
+        f"Everserver started. Events left in driver queue: {driver.event_queue.qsize()}"
     )
     return driver
 


### PR DESCRIPTION
**Issue**
Resolves noise from websockets and some of the lack of log level alignment ert vs everest.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
