### PR TITLE
Include string_type errors in EverestConfig lint from file

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -787,7 +787,10 @@ to read summary data from forward model, do:
             for e in error.errors(
                 include_context=True, include_input=True, include_url=False
             ):
-                if e["type"] in {"missing", "value_error"} or e["input"] is None:
+                if (
+                    e["type"] in {"missing", "value_error", "string_type"}
+                    or e["input"] is None
+                ):
                     exp.errors.append((e, None))
                 else:
                     for index, line in enumerate(file_content):

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -1,13 +1,38 @@
 import logging
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
-from everest.config import EverestConfig, ServerConfig, SimulatorConfig
+from everest.config import (
+    EverestConfig,
+    EverestValidationError,
+    ServerConfig,
+    SimulatorConfig,
+)
 from everest.config.control_config import ControlConfig
 from everest.config.control_variable_config import ControlVariableConfig
 from everest.config.cvar_config import CVaRConfig
 from everest.config.optimization_config import OptimizationConfig
+
+
+def test_that_str_type_failures_are_propagated(tmp_path, monkeypatch):
+    monkeypatch.chdir(str(tmp_path))
+    Path("everest_config.yml").write_text(
+        dedent("""
+        objective_functions:
+            - name:
+                job: distance
+    """),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EverestValidationError) as err:
+        EverestConfig.load_file("everest_config.yml")
+
+    assert any(
+        e for e in err.value.error if "Input should be a valid string" in e[0]["msg"]
+    )
 
 
 def test_that_control_config_is_initialized_with_control_variables():


### PR DESCRIPTION
**Issue**
Resolves [11039](https://github.com/equinor/ert/issues/11039)


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
