### PR TITLE
Add exponential backoff for flaky reruns

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -4,7 +4,6 @@ import os
 import random
 import stat
 import string
-import sys
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 
@@ -370,19 +369,14 @@ async def test_submit_with_num_cpu(pytestconfig, job_name):
 
 
 @pytest.mark.integration_test
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=4)
 async def test_kill_before_submit_is_finished(
-    tmp_path, monkeypatch, caplog, pytestconfig
+    tmp_path, monkeypatch, caplog, pytestconfig, request
 ):
     os.chdir(tmp_path)
 
-    if sys.platform.startswith("darwin"):
-        # Mitigate flakiness on low-power test nodes
-        job_kill_window = 5
-        test_grace_time = 10
-    else:
-        job_kill_window = 1
-        test_grace_time = 2
+    job_kill_window = 1 * 2 ** (request.node.execution_count - 1)
+    test_grace_time = 2 * 2 ** (request.node.execution_count - 1)
 
     bin_path = tmp_path / "bin"
     bin_path.mkdir()


### PR DESCRIPTION
**Issue**
Resolves flakyness in this function observed on Azure.


**Approach**
Use the retry count from pytest-rerunfailures to calculate grace times.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
