### PR TITLE
Improve naming and asserts of autoscale test

### DIFF
--- a/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
+++ b/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
@@ -142,18 +142,32 @@ def test_that_correlated_and_independent_observations_are_grouped_separately(
 
 
 @pytest.mark.parametrize("nr_observations", [0, 1, 2])
-def test_misfit_preprocessor_single(nr_observations):
-    """We create nr_observations responses using the linear function y = ax.
-    We don`t have enough information to cluster properly, so we don`t try
-    to scale"""
-    rng = np.random.default_rng(1234)
+def test_edge_cases_with_few_observations_return_default_values(nr_observations):
+    """Test that edge cases with 0-2 observations return default scaling values.
+    We do not know why this is the case.
+    """
     nr_realizations = 1000
     Y = np.ones((nr_observations, nr_realizations))
+
+    rng = np.random.default_rng(1234)
     parameters_a = rng.normal(10, 1, nr_realizations)
+
     for i in range(nr_observations):
         Y[i] = (i + 1) * parameters_a
-    result, *_ = main(Y, Y.mean(axis=1))
+
+    scale_factors, clusters, nr_components = main(Y, Y.mean(axis=1))
+
     np.testing.assert_equal(
-        result,
+        scale_factors,
+        np.array(nr_observations * [1.0]),
+    )
+
+    np.testing.assert_equal(
+        clusters,
+        np.array(nr_observations * [1.0]),
+    )
+
+    np.testing.assert_equal(
+        nr_components,
         np.array(nr_observations * [1.0]),
     )


### PR DESCRIPTION
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
