### PR TITLE
Backport Have ert use minimum of NUM_REALIZATIONS and DESIGN_MATRIX realizations

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -96,6 +96,14 @@ at least 2 realizations.
         -- Use 200 realizations/members
         NUM_REALIZATIONS 200
 
+
+.. note::
+         If used alongside :ref:`DESIGN_MATRIX <design_matrix>`, Ert will
+         compare the value of NUM_REALIZATIONS and the number of realizations
+         found in the design matrix, and use the minimum of the two as the
+         number of realizations to run. See :ref:`DESIGN_MATRIX notes <design_matrix_notes>`
+         for details on how the number of realizations is calculated in the design matrix.
+
 DEFINE
 ------
 .. _define:
@@ -281,6 +289,12 @@ In such cases consider to comment out GEN_KW definitions and thus only the desig
 
 In case there is no overlap with a GEN_KW group, the GEN_KW group will be sampled normally.
 
+.. _design_matrix_notes:
+.. note::
+    The number of realizations in the design matrix is calculated by the max realization id found in the
+    `REALS` column + 1. If the `REALS` column is missing some realizations, they will be set
+    as inactive in the ensemble and not run. For example, if the DESIGN_MATRIX only contains realization
+    id 3, then the ensemble_size will be four. Here the realizations 0, 1, and 2 will be marked as inactive and not run.
 
 ECLBASE
 -------

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -100,6 +100,17 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
     except ValueError as e:
         raise ErtCliError(f"{args.mode} was not valid, failed with: {e}") from e
 
+    if (
+        ert_config.analysis_config.design_matrix is not None
+        and ert_config.analysis_config.design_matrix.active_realizations is not None
+    ):
+        _log_if_num_realization_was_updated(
+            ert_config.runpath_config.num_realizations,
+            len(ert_config.analysis_config.design_matrix.active_realizations),
+            model.active_realizations.count(True),
+            hasattr(args, "realizations") and args.realizations is not None,
+        )
+
     if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
         # This is within the range for ephemeral ports as defined by
         # most unix flavors https://en.wikipedia.org/wiki/Ephemeral_port
@@ -157,3 +168,30 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
         # If monitor has not reported, give some info if the job failed
         msg = end_event.msg if args.disable_monitoring else ""
         raise ErtCliError(msg)
+
+
+def _log_if_num_realization_was_updated(
+    config_num_realizations: int,
+    dm_num_realizations: int,
+    active_realizations_count: int,
+    has_realizations_specified: bool = False,
+) -> None:
+    if dm_num_realizations == config_num_realizations:
+        return
+    if has_realizations_specified:
+        print(
+            "Using realizations intersected between realizations_specified "
+            f"and DESIGN_MATRIX ({active_realizations_count})"
+        )
+    else:
+        print(
+            f"NUM_REALIZATIONS ({config_num_realizations}) is "
+            + ("greater " if dm_num_realizations < config_num_realizations else "less ")
+            + f"than the number of realizations in DESIGN_MATRIX "
+            f"({dm_num_realizations}). Using the realizations from "
+            + (
+                f"DESIGN_MATRIX ({dm_num_realizations})"
+                if dm_num_realizations < config_num_realizations
+                else f"NUM_REALIZATIONS ({config_num_realizations})"
+            )
+        )

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from ert.run_models.event import StatusEvents
     from ert.storage import Storage
 
+logger = logging.getLogger(__name__)
+
 
 def create_model(
     config: ErtConfig,
@@ -46,7 +48,6 @@ def create_model(
     args: Namespace,
     status_queue: SimpleQueue[StatusEvents],
 ) -> BaseRunModel:
-    logger = logging.getLogger(__name__)
     logger.info(
         "Initiating experiment",
         extra={
@@ -58,7 +59,6 @@ def create_model(
 
     if args.mode == TEST_RUN_MODE:
         return _setup_single_test_run(config, storage, args, status_queue)
-    validate_minimum_realizations(config, args)
     if args.mode == ENSEMBLE_EXPERIMENT_MODE:
         return _setup_ensemble_experiment(config, storage, args, status_queue)
     if args.mode == EVALUATE_ENSEMBLE_MODE:
@@ -91,7 +91,11 @@ def _setup_single_test_run(
     experiment_name = (
         "single-test-run" if args.experiment_name is None else args.experiment_name
     )
-
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    if not active_realizations[0]:
+        raise ConfigValidationError(
+            "Cannot run single test run when the first realization is inactive."
+        )
     return SingleTestRun(
         random_seed=config.random_seed,
         ensemble_name=args.current_ensemble,
@@ -102,9 +106,10 @@ def _setup_single_test_run(
     )
 
 
-def validate_minimum_realizations(config: ErtConfig, args: Namespace) -> None:
+def validate_minimum_realizations(
+    config: ErtConfig, active_realizations: list[bool]
+) -> None:
     min_realizations_count = config.analysis_config.minimum_required_realizations
-    active_realizations = _get_active_realizations_list(args, config)
     active_realizations_count = int(np.sum(active_realizations))
     if active_realizations_count < min_realizations_count:
         config.analysis_config.minimum_required_realizations = active_realizations_count
@@ -121,7 +126,8 @@ def _setup_ensemble_experiment(
     args: Namespace,
     status_queue: SimpleQueue[StatusEvents],
 ) -> EnsembleExperiment:
-    active_realizations = _get_active_realizations_list(args, config)
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    validate_minimum_realizations(config, active_realizations)
     experiment_name = args.experiment_name
     assert experiment_name is not None
 
@@ -144,8 +150,8 @@ def _setup_evaluate_ensemble(
     args: Namespace,
     status_queue: SimpleQueue[StatusEvents],
 ) -> EvaluateEnsemble:
-    active_realizations = _get_active_realizations_list(args, config)
-
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    validate_minimum_realizations(config, active_realizations)
     return EvaluateEnsemble(
         random_seed=config.random_seed,
         active_realizations=active_realizations,
@@ -158,18 +164,46 @@ def _setup_evaluate_ensemble(
     )
 
 
-def _get_active_realizations_list(args: Namespace, config: ErtConfig) -> list[bool]:
+def _get_and_validate_active_realizations_list(
+    args: Namespace, config: ErtConfig
+) -> list[bool]:
     ensemble_size = config.runpath_config.num_realizations
     if (
         config.analysis_config.design_matrix is not None
-        and config.analysis_config.design_matrix.active_realizations is not None
+        and (
+            dm_active_realizations
+            := config.analysis_config.design_matrix.active_realizations
+        )
+        is not None
     ):
-        if args.realizations is None:
-            return config.analysis_config.design_matrix.active_realizations
-        else:
-            ensemble_size = len(
-                config.analysis_config.design_matrix.active_realizations
+        if ensemble_size != len(dm_active_realizations):
+            ensemble_size = min(ensemble_size, len(dm_active_realizations))
+            logger.warning(
+                "The number of realizations in the design matrix "
+                f"({len(dm_active_realizations)}) differs from the configured "
+                f"ensemble size ({config.runpath_config.num_realizations}). "
+                f"Using the minimum of both ({ensemble_size})."
             )
+        if hasattr(args, "realizations") and args.realizations is not None:
+            intersected_realizations = np.array(
+                ActiveRange(
+                    rangestring=args.realizations,
+                    length=max(
+                        len(dm_active_realizations),
+                        config.runpath_config.num_realizations,
+                    ),
+                ).mask[:ensemble_size]
+            ) & np.array(dm_active_realizations[:ensemble_size])
+            if np.any(intersected_realizations):
+                return intersected_realizations.tolist()
+            else:
+                raise ConfigValidationError(
+                    "The specified realizations do not intersect "
+                    "with the active realizations in the design matrix "
+                    "and num_realizations."
+                )
+        return dm_active_realizations[:ensemble_size]
+
     return _realizations(args, ensemble_size).tolist()
 
 
@@ -181,7 +215,7 @@ def _setup_manual_update(
     status_queue: SimpleQueue[StatusEvents],
 ) -> ManualUpdate:
     active_realizations = _realizations(args, config.runpath_config.num_realizations)
-
+    validate_minimum_realizations(config, active_realizations.tolist())
     return ManualUpdate(
         random_seed=config.random_seed,
         active_realizations=active_realizations.tolist(),
@@ -204,7 +238,8 @@ def _setup_ensemble_smoother(
     update_settings: ObservationSettings,
     status_queue: SimpleQueue[StatusEvents],
 ) -> EnsembleSmoother:
-    active_realizations = _get_active_realizations_list(args, config)
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    validate_minimum_realizations(config, active_realizations)
     if len(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
@@ -232,7 +267,8 @@ def _setup_ensemble_information_filter(
     update_settings: ObservationSettings,
     status_queue: SimpleQueue[StatusEvents],
 ) -> EnsembleInformationFilter:
-    active_realizations = _get_active_realizations_list(args, config)
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    validate_minimum_realizations(config, active_realizations)
     if len(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
@@ -280,7 +316,8 @@ def _setup_multiple_data_assimilation(
     status_queue: SimpleQueue[StatusEvents],
 ) -> MultipleDataAssimilation:
     restart_run, prior_ensemble = _determine_restart_info(args)
-    active_realizations = _get_active_realizations_list(args, config)
+    active_realizations = _get_and_validate_active_realizations_list(args, config)
+    validate_minimum_realizations(config, active_realizations)
     if len(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
@@ -305,7 +342,7 @@ def _setup_multiple_data_assimilation(
 
 
 def _realizations(args: Namespace, ensemble_size: int) -> npt.NDArray[np.bool_]:
-    if args.realizations is None:
+    if not hasattr(args, "realizations") or args.realizations is None:
         return np.ones(ensemble_size, dtype=bool)
     return np.array(
         ActiveRange(rangestring=args.realizations, length=ensemble_size).mask

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -401,7 +401,7 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
 
 
 def test_run_poly_example_with_design_matrix_selective_realizations(
-    copy_poly_case_with_design_matrix,
+    copy_poly_case_with_design_matrix, capsys
 ):
     num_realizations = 5
     a_values = list(range(num_realizations))
@@ -426,10 +426,13 @@ def test_run_poly_example_with_design_matrix_selective_realizations(
     print(config_path)
 
     realizations_run = os.listdir(Path(config_path) / "poly_out")
-    assert len(realizations_run) == 2
+    assert len(realizations_run) == 1
     assert "realization-0" in realizations_run
-    assert "realization-10" in realizations_run
-    assert "realization-5" not in realizations_run
+
+    assert (
+        "Using realizations intersected between realizations_specified "
+        "and DESIGN_MATRIX (1)" in capsys.readouterr().out
+    )
 
 
 @pytest.mark.usefixtures("copy_poly_case")
@@ -470,3 +473,129 @@ def test_design_matrix_on_esmda_fail_without_updateable_parameters(
             "--experiment-name",
             "test-experiment",
         )
+
+
+@pytest.mark.parametrize(
+    "realizations_in_design_matrix, expected_message_format",
+    [
+        pytest.param(
+            5,
+            (
+                "NUM_REALIZATIONS ({num_realizations_in_user_config}) is greater than "
+                "the number of realizations in DESIGN_MATRIX "
+                "({realizations_in_design_matrix}). Using the realizations from "
+                "DESIGN_MATRIX ({realizations_in_design_matrix})"
+            ),
+        ),
+        pytest.param(
+            15,
+            (
+                "NUM_REALIZATIONS ({num_realizations_in_user_config}) is less than the "
+                "number of realizations in DESIGN_MATRIX "
+                "({realizations_in_design_matrix}). Using the realizations from "
+                "NUM_REALIZATIONS ({num_realizations_in_user_config})"
+            ),
+        ),
+    ],
+)
+def test_run_poly_example_with_different_realization_count_chooses_smaller_and_warns(
+    realizations_in_design_matrix,
+    expected_message_format,
+    copy_poly_case_with_design_matrix,
+    capsys,
+):
+    num_realizations_in_user_config = 10
+    expected_message = expected_message_format.format(
+        num_realizations_in_user_config=num_realizations_in_user_config,
+        realizations_in_design_matrix=realizations_in_design_matrix,
+    )
+
+    realization_list = list(range(realizations_in_design_matrix))
+    design_dict = {
+        "REAL": realization_list,
+        "a": [2 * a for a in realization_list],
+    }
+    default_list = [["b", 1], ["c", 2]]
+    copy_poly_case_with_design_matrix(design_dict, default_list)
+    with open("poly.ert", "a+", encoding="utf-8") as f:
+        f.write(f"\nNUM_REALIZATIONS {num_realizations_in_user_config}")
+    run_cli(
+        ENSEMBLE_EXPERIMENT_MODE,
+        "--disable-monitoring",
+        "poly.ert",
+        "--experiment-name",
+        "test-experiment",
+    )
+    config_path = ErtConfig.from_file("poly.ert").config_path
+
+    realizations_run = os.listdir(Path(config_path) / "poly_out")
+    assert len(realizations_run) == min(
+        realizations_in_design_matrix, num_realizations_in_user_config
+    )
+    assert expected_message in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "specified_realizations, intersected_realizations_count",
+    [
+        pytest.param(
+            "--realizations=3-6",
+            2,
+            id="specified_realizations_finds_and_uses_intersect",
+        ),
+        pytest.param(
+            "--realizations=0-4",
+            0,
+            id="specified_realizations_are_not_intersecting_and_raises",
+        ),
+    ],
+)
+def test_run_poly_example_with_specified_realizations_finds_intersection_and_warns(
+    specified_realizations: str,
+    intersected_realizations_count: int,
+    copy_poly_case_with_design_matrix,
+    capsys,
+):
+    realization_list = [5, 6, 7, 9, 10]
+    design_dict = {
+        "REAL": realization_list,
+        "a": [2 * a for a in realization_list],
+    }
+    default_list = [["b", 1], ["c", 2]]
+    copy_poly_case_with_design_matrix(design_dict, default_list)
+    with open("poly.ert", "a+", encoding="utf-8") as f:
+        f.write("\nNUM_REALIZATIONS 20")
+    if intersected_realizations_count > 0:
+        run_cli(
+            ENSEMBLE_EXPERIMENT_MODE,
+            specified_realizations,
+            "--disable-monitoring",
+            "poly.ert",
+            "--experiment-name",
+            "test-experiment",
+        )
+
+        assert (
+            "Using realizations intersected between realizations_specified and "
+            f"DESIGN_MATRIX ({intersected_realizations_count})"
+        ) in capsys.readouterr().out
+
+        config_path = ErtConfig.from_file("poly.ert").config_path
+        realizations_run = os.listdir(Path(config_path) / "poly_out")
+        assert len(realizations_run) == intersected_realizations_count
+    else:
+        with pytest.raises(
+            ErtCliError,
+            match=(
+                "The specified realizations do not intersect with the active "
+                r"realizations in the design matrix."
+            ),
+        ):
+            run_cli(
+                ENSEMBLE_EXPERIMENT_MODE,
+                specified_realizations,
+                "--disable-monitoring",
+                "poly.ert",
+                "--experiment-name",
+                "test-experiment",
+            )


### PR DESCRIPTION
This commit makes ert use the minimum of NUM_REALIZATIONS from config and design matrix. Now we can see in the logs which num_realization is being used, and it is also printed in the terminal when running CLI.

This commit also improves the error message for when a single test run fails due to the first active realization being inactive.



**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
