### PR TITLE
Fix model_factory realization_list validation returning np array and GUI not showing correct NUM_REALIZATIONS when using designmatrix

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -99,14 +99,16 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
         raise ErtCliError(f"{args.mode} was not valid, failed with: {e}") from e
 
     if (
-        ert_config.analysis_config.design_matrix is not None
-        and ert_config.analysis_config.design_matrix.active_realizations is not None
+        (
+            ert_config.analysis_config.design_matrix is not None
+            and ert_config.analysis_config.design_matrix.active_realizations is not None
+        )
+        and hasattr(args, "realizations")
+        and args.realizations is not None
     ):
-        _log_if_num_realization_was_updated(
-            ert_config.runpath_config.num_realizations,
-            len(ert_config.analysis_config.design_matrix.active_realizations),
-            model.active_realizations.count(True),
-            hasattr(args, "realizations") and args.realizations is not None,
+        print(
+            "Using realizations intersected between realizations specified "
+            f"and DESIGN_MATRIX ({model.active_realizations.count(True)})"
         )
 
     if args.port_range is None and model.queue_system == QueueSystem.LOCAL:
@@ -165,30 +167,3 @@ def run_cli(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
         # If monitor has not reported, give some info if the job failed
         msg = end_event.msg if args.disable_monitoring else ""
         raise ErtCliError(msg)
-
-
-def _log_if_num_realization_was_updated(
-    config_num_realizations: int,
-    dm_num_realizations: int,
-    active_realizations_count: int,
-    has_realizations_specified: bool = False,
-) -> None:
-    if dm_num_realizations == config_num_realizations:
-        return
-    if has_realizations_specified:
-        print(
-            "Using realizations intersected between realizations_specified "
-            f"and DESIGN_MATRIX ({active_realizations_count})"
-        )
-    else:
-        print(
-            f"NUM_REALIZATIONS ({config_num_realizations}) is "
-            + ("greater " if dm_num_realizations < config_num_realizations else "less ")
-            + f"than the number of realizations in DESIGN_MATRIX "
-            f"({dm_num_realizations}). Using the realizations from "
-            + (
-                f"DESIGN_MATRIX ({dm_num_realizations})"
-                if dm_num_realizations < config_num_realizations
-                else f"NUM_REALIZATIONS ({config_num_realizations})"
-            )
-        )

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -7,6 +7,7 @@ import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime
+from functools import cached_property
 from os import path
 from pathlib import Path
 from typing import Any, ClassVar, Self, no_type_check, overload
@@ -1160,6 +1161,51 @@ class ErtConfig(BaseModel):
                 )
         else:
             logger.info(f"Content of the config_dict: {config_dict_content}")
+
+    @cached_property
+    def ensemble_size(self) -> int:
+        config_num_realizations = self.runpath_config.num_realizations
+        if (
+            self.analysis_config.design_matrix is not None
+            and (
+                dm_active_realizations
+                := self.analysis_config.design_matrix.active_realizations
+            )
+            is not None
+        ) and (
+            dm_num_realizations := len(dm_active_realizations)
+        ) != config_num_realizations:
+            msg = (
+                f"NUM_REALIZATIONS ({config_num_realizations}) is "
+                + (
+                    "greater "
+                    if dm_num_realizations < config_num_realizations
+                    else "less "
+                )
+                + f"than the number of realizations in DESIGN_MATRIX "
+                f"({dm_num_realizations}). Using the realizations from "
+                + (
+                    f"DESIGN_MATRIX ({dm_num_realizations})"
+                    if dm_num_realizations < config_num_realizations
+                    else f"NUM_REALIZATIONS ({config_num_realizations})"
+                )
+            )
+            ConfigWarning.warn(msg)
+            return min(config_num_realizations, dm_num_realizations)
+        return config_num_realizations
+
+    @cached_property
+    def active_realizations(self) -> list[bool]:
+        if (
+            self.analysis_config.design_matrix is not None
+            and (
+                dm_active_realizations
+                := self.analysis_config.design_matrix.active_realizations
+            )
+            is not None
+        ):
+            return dm_active_realizations[: self.ensemble_size]
+        return [True for _ in range(self.ensemble_size)]
 
     @classmethod
     def _log_custom_forward_model_steps(cls, user_config: ConfigDict) -> None:

--- a/src/ert/gui/simulation/_design_matrix_panel.py
+++ b/src/ert/gui/simulation/_design_matrix_panel.py
@@ -15,9 +15,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from ert.gui.ertwidgets.stringbox import StringBox
-from ert.validation import ActiveRange, RangeSubsetStringArgument
-
 if TYPE_CHECKING:
     from ert.config import DesignMatrix
 
@@ -75,17 +72,10 @@ class DesignMatrixPanel(QDialog):
 
     @staticmethod
     def get_design_matrix_button(
-        active_realizations_field: StringBox,
         design_matrix: "DesignMatrix",
         number_of_realizations_label: QLabel,
-        ensemble_size: int,
+        config_num_realization: int,
     ) -> QHBoxLayout:
-        active_realizations_field.setValidator(
-            RangeSubsetStringArgument(ActiveRange(design_matrix.active_realizations))
-        )
-        active_realizations_field.model.setValueFromMask(  # type: ignore
-            design_matrix.active_realizations
-        )
         show_dm_param_button = QPushButton("Show parameters")
         show_dm_param_button.setObjectName("show-dm-parameters")
         show_dm_param_button.setMinimumWidth(50)
@@ -97,9 +87,7 @@ class DesignMatrixPanel(QDialog):
         show_dm_param_button.clicked.connect(
             lambda: DesignMatrixPanel.show_dm_params(design_matrix)
         )
-        dm_num_reals = len(design_matrix.active_realizations)
-        if dm_num_reals != ensemble_size:
-            number_of_realizations_label.setText(f"<b>{dm_num_reals}</b>")
+        if len(design_matrix.active_realizations) != config_num_realization:
             parent_widget = number_of_realizations_label.parent()
 
             if isinstance(parent_widget, QWidget) and (
@@ -121,8 +109,15 @@ class DesignMatrixPanel(QDialog):
                 layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
                 warning_icon.setToolTip(
-                    f"Number of realizations changed from {ensemble_size} "
-                    f"to {dm_num_reals} due to 'REAL' column in design matrix"
+                    "Number of realizations was set to "
+                    + str(
+                        min(
+                            config_num_realization,
+                            len(design_matrix.active_realizations),
+                        )
+                    )
+                    + " due to different number of realizations in the design matrix "
+                    "and NUM_REALIZATIONS in config"
                 )
                 warning_icon.show()
 

--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -19,7 +19,9 @@ from ert.gui.ertwidgets import (
 )
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE
 from ert.run_models import EnsembleExperiment
-from ert.validation import ExperimentValidation, ProperNameArgument, RangeStringArgument
+from ert.validation import ExperimentValidation, ProperNameArgument
+from ert.validation.active_range import ActiveRange
+from ert.validation.range_string_argument import RangeSubsetStringArgument
 
 from ._design_matrix_panel import DesignMatrixPanel
 from .experiment_config_panel import ExperimentConfigPanel
@@ -38,6 +40,8 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         self,
         analysis_config: AnalysisConfig,
         ensemble_size: int,
+        active_realizations: list[bool],
+        config_num_realization: int,
         run_path: str,
         notifier: ErtNotifier,
     ) -> None:
@@ -91,7 +95,10 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
             "config/simulation/active_realizations",
         )
         self._active_realizations_field.setValidator(
-            RangeStringArgument(ensemble_size),
+            RangeSubsetStringArgument(ActiveRange(active_realizations)),
+        )
+        self._active_realizations_field.model.setValueFromMask(  # type: ignore
+            active_realizations
         )
         layout.addRow("Active realizations", self._active_realizations_field)
 
@@ -100,10 +107,9 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
             layout.addRow(
                 "Design Matrix",
                 DesignMatrixPanel.get_design_matrix_button(
-                    self._active_realizations_field,
                     design_matrix,
                     number_of_realizations_label,
-                    ensemble_size,
+                    config_num_realization,
                 ),
             )
 

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -152,10 +152,19 @@ class ExperimentPanel(QWidget):
             True,
         )
 
-        ensemble_size = config.runpath_config.num_realizations
+        ensemble_size = config.ensemble_size
+        active_realizations = config.active_realizations
         analysis_config = config.analysis_config
+        config_num_realization = config.runpath_config.num_realizations
         self.addExperimentConfigPanel(
-            EnsembleExperimentPanel(analysis_config, ensemble_size, run_path, notifier),
+            EnsembleExperimentPanel(
+                analysis_config,
+                ensemble_size,
+                active_realizations,
+                config_num_realization,
+                run_path,
+                notifier,
+            ),
             True,
         )
         self.addExperimentConfigPanel(
@@ -169,17 +178,34 @@ class ExperimentPanel(QWidget):
 
         self.addExperimentConfigPanel(
             MultipleDataAssimilationPanel(
-                analysis_config, run_path, notifier, ensemble_size
+                analysis_config,
+                run_path,
+                notifier,
+                ensemble_size,
+                active_realizations,
+                config_num_realization,
             ),
             experiment_type_valid,
         )
         self.addExperimentConfigPanel(
-            EnsembleSmootherPanel(analysis_config, run_path, notifier, ensemble_size),
+            EnsembleSmootherPanel(
+                analysis_config,
+                run_path,
+                notifier,
+                ensemble_size,
+                active_realizations,
+                config_num_realization,
+            ),
             experiment_type_valid,
         )
         self.addExperimentConfigPanel(
             EnsembleInformationFilterPanel(
-                analysis_config, run_path, notifier, ensemble_size
+                analysis_config,
+                run_path,
+                notifier,
+                ensemble_size,
+                active_realizations,
+                config_num_realization,
             ),
             experiment_type_valid,
         )

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -228,7 +228,7 @@ def _get_and_validate_active_realizations_list(
                 ).mask[:ensemble_size]
             ) & np.array(dm_active_realizations[:ensemble_size])
             if np.any(intersected_realizations):
-                return intersected_realizations
+                return intersected_realizations.tolist()
             else:
                 raise ConfigValidationError(
                     "The specified realizations do not intersect "

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -434,17 +434,16 @@ def test_run_poly_example_with_design_matrix_selective_realizations(
         "--experiment-name",
         "test-experiment",
         "--realizations",
-        "0,10",
+        "0,4",
     )
     config_path = ErtConfig.from_file("poly.ert").config_path
-    print(config_path)
 
     realizations_run = os.listdir(Path(config_path) / "poly_out")
     assert len(realizations_run) == 1
     assert "realization-0" in realizations_run
 
     assert (
-        "Using realizations intersected between realizations_specified "
+        "Using realizations intersected between realizations specified "
         "and DESIGN_MATRIX (1)" in capsys.readouterr().out
     )
 
@@ -502,20 +501,22 @@ def test_design_matrix_on_esmda_fail_without_updateable_parameters(
         pytest.param(
             5,
             (
-                "NUM_REALIZATIONS ({num_realizations_in_user_config}) is greater than "
-                "the number of realizations in DESIGN_MATRIX "
-                "({realizations_in_design_matrix}). Using the realizations from "
-                "DESIGN_MATRIX ({realizations_in_design_matrix})"
+                r"NUM_REALIZATIONS \({num_realizations_in_user_config}\) is "
+                "greater than the number of realizations in DESIGN_MATRIX "
+                r"\({realizations_in_design_matrix}\)\. Using the realizations from "
+                r"DESIGN_MATRIX \({realizations_in_design_matrix}\)"
             ),
+            id="num_reals_greater_than_design_matrix",
         ),
         pytest.param(
             15,
             (
-                "NUM_REALIZATIONS ({num_realizations_in_user_config}) is less than the "
-                "number of realizations in DESIGN_MATRIX "
-                "({realizations_in_design_matrix}). Using the realizations from "
-                "NUM_REALIZATIONS ({num_realizations_in_user_config})"
+                r"NUM_REALIZATIONS \({num_realizations_in_user_config}\) is "
+                "less than the number of realizations in DESIGN_MATRIX "
+                r"\({realizations_in_design_matrix}\). Using the realizations from "
+                r"NUM_REALIZATIONS \({num_realizations_in_user_config}\)"
             ),
+            id="num_reals_less_than_design_matrix",
         ),
     ],
 )
@@ -523,7 +524,6 @@ def test_run_poly_example_with_different_realization_count_chooses_smaller_and_w
     realizations_in_design_matrix,
     expected_message_format,
     copy_poly_case_with_design_matrix,
-    capsys,
 ):
     num_realizations_in_user_config = 10
     expected_message = expected_message_format.format(
@@ -540,20 +540,20 @@ def test_run_poly_example_with_different_realization_count_chooses_smaller_and_w
     copy_poly_case_with_design_matrix(design_dict, default_list)
     with open("poly.ert", "a+", encoding="utf-8") as f:
         f.write(f"\nNUM_REALIZATIONS {num_realizations_in_user_config}")
-    run_cli(
-        ENSEMBLE_EXPERIMENT_MODE,
-        "--disable-monitoring",
-        "poly.ert",
-        "--experiment-name",
-        "test-experiment",
-    )
+    with pytest.warns(ConfigWarning, match=expected_message):
+        run_cli(
+            ENSEMBLE_EXPERIMENT_MODE,
+            "--disable-monitoring",
+            "poly.ert",
+            "--experiment-name",
+            "test-experiment",
+        )
     config_path = ErtConfig.from_file("poly.ert").config_path
 
     realizations_run = os.listdir(Path(config_path) / "poly_out")
     assert len(realizations_run) == min(
         realizations_in_design_matrix, num_realizations_in_user_config
     )
-    assert expected_message in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -597,7 +597,7 @@ def test_run_poly_example_with_specified_realizations_finds_intersection_and_war
         )
 
         assert (
-            "Using realizations intersected between realizations_specified and "
+            "Using realizations intersected between realizations specified and "
             f"DESIGN_MATRIX ({intersected_realizations_count})"
         ) in capsys.readouterr().out
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -845,21 +845,24 @@ def test_forward_model_overview_label_selected_on_tab_change(
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
-    "experiment_mode, experiment_mode_panel",
+    "experiment_mode, experiment_mode_panel, dm_realizations",
     [
-        (EnsembleExperiment, EnsembleExperimentPanel),
-        (EnsembleSmoother, EnsembleSmootherPanel),
-        (MultipleDataAssimilation, MultipleDataAssimilationPanel),
+        (EnsembleExperiment, EnsembleExperimentPanel, 5),
+        (EnsembleExperiment, EnsembleExperimentPanel, 15),
+        (EnsembleSmoother, EnsembleSmootherPanel, 5),
+        (EnsembleSmoother, EnsembleSmootherPanel, 15),
+        (MultipleDataAssimilation, MultipleDataAssimilationPanel, 5),
+        (MultipleDataAssimilation, MultipleDataAssimilationPanel, 15),
     ],
 )
-def test_that_design_matrix_alters_num_realizations_field(
-    qtbot: QtBot, experiment_mode, experiment_mode_panel, use_tmpdir
+def test_that_ert_chooses_minimum_realization_with_design_matrix(
+    qtbot: QtBot, experiment_mode, dm_realizations, experiment_mode_panel, use_tmpdir
 ):
     xls_filename = "design_matrix.xlsx"
     design_matrix_df = pd.DataFrame(
         {
-            "REAL": list(range(3)),
-            "a": [0, 1, 2],
+            "REAL": list(range(dm_realizations)),
+            "a": list(range(dm_realizations)),
         }
     )
     default_sheet_df = pd.DataFrame([["b", 1], ["c", 2]])
@@ -869,9 +872,11 @@ def test_that_design_matrix_alters_num_realizations_field(
             xl_write, index=False, sheet_name="DefaultSheet", header=False
         )
 
+    config_num_realizations = 10
+    expected_num_realizations = min(dm_realizations, config_num_realizations)
     config_file = "minimal_config.ert"
     with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 10")
+        f.write(f"NUM_REALIZATIONS {config_num_realizations}")
         f.write(f"\nDESIGN_MATRIX {xls_filename}")
 
     args_mock = Mock()
@@ -889,13 +894,15 @@ def test_that_design_matrix_alters_num_realizations_field(
     simulation_settings = gui.findChild(experiment_mode_panel)
     num_realizations_label = simulation_settings.findChild(QWidget, "num_reals_label")
     assert num_realizations_label
-    assert num_realizations_label.text() == "<b>3</b>"
+
+    assert num_realizations_label.text() == f"<b>{expected_num_realizations}</b>"
 
     # Verify that the warning icon has the correct tooltip
     warning_icon = gui.findChild(QLabel, "warning_icon_num_realizations_design_matrix")
     assert warning_icon.toolTip() == (
-        "Number of realizations changed from 10 to 3 due "
-        "to 'REAL' column in design matrix"
+        f"Number of realizations was set to {expected_num_realizations} "
+        "due to different number of realizations in the design matrix "
+        "and NUM_REALIZATIONS in config"
     )
 
 


### PR DESCRIPTION
**Issue**
Resolves #11136 
The first commit fixes the issue where the `_get_and_validate_active_realization_list` might return a numpy array instead of a `list[bool]` for one of the code paths.

The second commit fixes the issue where the GUI would always show active realizations from design_matrix, even if it was greater than NUM_REALIZATIONS. Ert chooses the minimum of the two, and would run the correct realizations.

**Approach**
🚗 

(Screenshot of new behavior in GUI if applicable)
DM Realizations: 201
NUM_REALIZATIONS 100
In this case, `number of realizations` should show 100, and `Active realizations` should NOT show realization 200. 
**Before**
![Image](https://github.com/user-attachments/assets/8f703b8b-5538-45ae-8c98-d62cd3900e83)

**After**
![image](https://github.com/user-attachments/assets/75794558-b083-4909-9079-15c75ed8140a)


![Image](https://github.com/user-attachments/assets/5571a3eb-adc6-488f-8923-212f574a856f)

![Image](https://github.com/user-attachments/assets/408e80a9-06e8-4107-815b-29c322c12b13)

(This is with 201 realizations in design matrix and NUM_REALIZATIONS set to 100.)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
