### PR TITLE
Use isoformat() instead of strftime()

### DIFF
--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -63,9 +63,9 @@ def _setup_logging(directory: str = "logs"):
     )
 
     filename = (
-        f"forward-model-runner-log-{datetime.now().strftime('%Y-%m-%dT%H%M')}.txt"
+        f"forward-model-runner-log-{datetime.now().isoformat(timespec='minutes')}.txt"
     )
-    csv_filename = f"memory-profile-{datetime.now().strftime('%Y-%m-%dT%H%M')}.csv"
+    csv_filename = f"memory-profile-{datetime.now().isoformat(timespec='minutes')}.csv"
 
     handler = logging.FileHandler(filename=directory + "/" + filename)
     handler.setFormatter(formatter)

--- a/src/ert/enkf_main.py
+++ b/src/ert/enkf_main.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from collections.abc import Iterable, Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 def _backup_if_existing(path: Path) -> None:
     if not path.exists():
         return
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%SZ")
+    timestamp = datetime.now(UTC).isoformat(timespec="seconds")
     new_path = path.parent / f"{path.name}_backup_{timestamp}"
     path.rename(new_path)
 

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -239,7 +239,9 @@ class ErtMainWindow(QMainWindow):
             widget.setVisible(False)
 
         run_dialog.setParent(self)
-        date_time = datetime.datetime.now(datetime.UTC).strftime("%Y-%d-%m %H:%M:%S")
+        date_time: str = datetime.datetime.now(datetime.UTC).isoformat(
+            timespec="seconds"
+        )
         experiment_type = run_dialog._run_model_api.experiment_name
         simulation_id = experiment_type + " : " + date_time
         self.central_panels_map[simulation_id] = run_dialog

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -33,9 +33,7 @@ _FORMATS = _FORMATS_ANSI if os.isatty(sys.stderr.fileno()) else _FORMATS_NO_COLO
 
 class TimestampedFileHandler(logging.FileHandler):
     def __init__(self, filename: str, *args: Any, **kwargs: Any) -> None:
-        timestamp = (
-            f"{datetime.now().strftime(datetime.now().strftime('%Y-%m-%dT%H%M'))}"
-        )
+        timestamp = f"{datetime.now().isoformat(timespec='minutes')}"
         filename, extension = os.path.splitext(filename)
 
         if "config_filename" in kwargs:

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -120,7 +120,7 @@ class LocalExperiment(BaseMode):
             Instance of the newly created experiment.
         """
         if name is None:
-            name = datetime.today().strftime("%Y-%m-%d")
+            name = datetime.today().isoformat()
 
         (path / "index.json").write_text(
             _Index(id=uuid, name=name).model_dump_json(indent=2)

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -45,6 +45,6 @@ def warn_user_that_runpath_is_nonempty() -> None:
 
 def _roll_dir(old_name: str) -> None:
     old_name = os.path.realpath(old_name)
-    new_name = old_name + datetime.now(UTC).strftime("__%Y-%m-%d_%H.%M.%S.%f")
+    new_name = f"{old_name}__{datetime.now(UTC).isoformat()}"
     os.rename(old_name, new_name)
     logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")

--- a/test-data/ert/snake_oil/forward_models/snake_oil_npv.py
+++ b/test-data/ert/snake_oil/forward_models/snake_oil_npv.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         date = date_ranges[index + 1]  # end of period
         production_sum = production_sums[index]
 
-        oil_price = OIL_PRICES[date.date().strftime("%Y-%m-%d")]
+        oil_price = OIL_PRICES[date.date().isoformat()]
 
         production_value = oil_price * production_sum
         npv += production_value

--- a/test-data/ert/snake_oil/forward_models/snake_oil_simulator.py
+++ b/test-data/ert/snake_oil/forward_models/snake_oil_simulator.py
@@ -50,9 +50,7 @@ def write_summary_data(
 
                 step = report_step * mini_step_count + mini_step
                 day = float(step)
-                time_map.append(
-                    (start_date + datetime.timedelta(days=day)).strftime("%Y-%m-%d")
-                )
+                time_map.append((start_date + datetime.timedelta(days=day)).isoformat())
                 values = [
                     simulator.fopt(),
                     simulator.fopr(),

--- a/test-data/ert/snake_oil_field/forward_models/snake_oil_npv.py
+++ b/test-data/ert/snake_oil_field/forward_models/snake_oil_npv.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         date = date_ranges[index + 1]  # end of period
         production_sum = production_sums[index]
 
-        oil_price = OIL_PRICES[date.date().strftime("%Y-%m-%d")]
+        oil_price = OIL_PRICES[date.date().isoformat()]
 
         production_value = oil_price * production_sum
         npv += production_value

--- a/test-data/ert/snake_oil_field/forward_models/snake_oil_simulator.py
+++ b/test-data/ert/snake_oil_field/forward_models/snake_oil_simulator.py
@@ -61,9 +61,7 @@ def write_summary_data(
 
                 step = report_step * mini_step_count + mini_step
                 day = float(step)
-                time_map.append(
-                    (start_date + datetime.timedelta(days=day)).strftime("%Y-%m-%d")
-                )
+                time_map.append((start_date + datetime.timedelta(days=day)).isoformat())
                 values = [
                     simulator.fopt(),
                     simulator.fopr(),

--- a/tests/ert/ui_tests/cli/test_observation_times.py
+++ b/tests/ert/ui_tests/cli/test_observation_times.py
@@ -51,7 +51,7 @@ observation_times = st.dates(
                     summary_keys=st.just("FOPR"),
                     std_cutoff=10.0,
                     names=st.just("FOPR_OBSERVATION"),
-                    dates=st.just(observation_time),
+                    datetimes=st.just(observation_time),
                     time_types=st.just("date"),
                 ),
             }


### PR DESCRIPTION
This avoids having to mentally parse the date format string for ISO8601 compliance, which is there mostly already in the repo.

Note that this commit still alters some strings ever so slightly, affecting log file names and ensemble identificators.

**Issue**
Resolves some usage of strftime.

Residual issue: https://github.com/equinor/ert/issues/11141

**Approach**
do-it


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
