### PR TITLE
Fix TARGET_FILE keyword not working

### DIFF
--- a/docs/ert/reference/configuration/forward_model.rst
+++ b/docs/ert/reference/configuration/forward_model.rst
@@ -66,8 +66,8 @@ By installing your own steps in this way, you can extend the capabilities of ERT
     REQUIRED    <ARG0> <ARG1>    -- A list of arguments required to be passed
                                  -- on to the executable
 
-Note
-____
+Notes
+_____
 When configuring ARGLIST for FORWARD_MODEL steps, "long-options" signified by a
 double dash, like :code:`--some-option`, is problematic for Ert as the double
 dash is treated as a comment. Enclose any such long options in quotes for this
@@ -88,6 +88,22 @@ Note that the following behaviour provides identical results:
     FORWARD_MODEL STEP_NAME(<ARG1>="something")
 
 see example :ref:`create_script`
+
+If the zero return code of the executable is not to be trusted, i.e. if the
+executable exits with a zero return code even in the case of failure, you may override Erts
+notion of a forward model step success by requiring the production of a
+certain file on the runpath. This is done through configuring a `TARGET_FILE`
+in the step configuration:
+
+.. code-block:: bash
+
+    EXECUTABLE   some_executable_with_flaky_return_code
+    TARGET_FILE  some_file_produced_on_success
+
+When this `TARGET_FILE` is present in the configuration, Ert will wait for this
+file to appear on disk before continuing on with the next step in the forward
+model. If the file is not present after 5 seconds, it will stop execution and
+notify about the failure.
 
 .. _Pre-configured steps:
 

--- a/docs/ert/reference/configuration/forward_model.rst
+++ b/docs/ert/reference/configuration/forward_model.rst
@@ -68,9 +68,10 @@ By installing your own steps in this way, you can extend the capabilities of ERT
 
 Note
 ____
-When configuring ARGLIST for FORWARD_MODEL steps it is not suitable to use
-:code:`--some-option` for named options as it treated as a comment by the
-configuration compiler. Single letter options, i.e. :code:`-s` are needed.
+When configuring ARGLIST for FORWARD_MODEL steps, "long-options" signified by a
+double dash, like :code:`--some-option`, is problematic for Ert as the double
+dash is treated as a comment. Enclose any such long options in quotes for this
+reason.
 
 Invoking the step is then done by including it in the ert config:
 


### PR DESCRIPTION
**Issue**
Resolves #11135


**Approach**
This commit fixes the issue where the target file is never checked in ForwardModelStep after running.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
