### PR TITLE
Align name of first argument in everest entry points

### DIFF
--- a/src/everest/bin/config_branch_script.py
+++ b/src/everest/bin/config_branch_script.py
@@ -29,7 +29,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
         usage="""everest branch <config_file> <new_config_file> -b #""",
     )
     arg_parser.add_argument(
-        "input_config",
+        "config",
         help="The path to the everest configuration file",
         type=partial(_yaml_config, parser=arg_parser),
     )
@@ -105,7 +105,7 @@ def _updated_initial_guess(
 def config_branch_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
-    _, optimization_dir, yml_config = options.input_config
+    _, optimization_dir, yml_config = options.config
 
     EverestStorage.check_for_deprecated_seba_storage(optimization_dir)
 

--- a/src/everest/bin/everexport_script.py
+++ b/src/everest/bin/everexport_script.py
@@ -17,12 +17,10 @@ def everexport_entry(args: list[str] | None = None) -> None:
         # Remove the null handler if set:
         logging.getLogger().removeHandler(logging.NullHandler())
 
-    config = options.config_file
-
     logger.info("Everexport deprecation warning seen")
     print(
         "Everexport is deprecated, optimization results "
-        f"already exist @ {config.optimization_output_dir}"
+        f"already exist @ {options.config.optimization_output_dir}"
     )
 
 
@@ -33,7 +31,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
         usage="everest export <config_file>",
     )
     arg_parser.add_argument(
-        "config_file",
+        "config",
         type=partial(EverestConfig.load_file_with_argparser, parser=arg_parser),
         help="The path to the everest configuration file",
     )

--- a/src/everest/bin/everlint_script.py
+++ b/src/everest/bin/everlint_script.py
@@ -15,7 +15,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
         usage="""everest lint <config_file>""",
     )
     arg_parser.add_argument(
-        "config_file",
+        "config",
         type=partial(EverestConfig.load_file_with_argparser, parser=arg_parser),
         help="The path to the everest configuration file",
     )
@@ -34,7 +34,7 @@ def lint_entry(args: list[str]) -> None:
         warnings.filterwarnings("default", category=ConfigWarning)
     parser = _build_args_parser()
     options = parser.parse_args(args)
-    parsed_config = options.config_file
+    parsed_config = options.config
     conf_file = parsed_config.config_path
 
     print(f"{conf_file} is valid")

--- a/src/everest/bin/visualization_script.py
+++ b/src/everest/bin/visualization_script.py
@@ -16,7 +16,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
         usage="""everest results <config_file>""",
     )
     arg_parser.add_argument(
-        "config_file",
+        "config",
         type=partial(EverestConfig.load_file_with_argparser, parser=arg_parser),
         help="The path to the everest configuration file",
     )
@@ -26,11 +26,12 @@ def _build_args_parser() -> argparse.ArgumentParser:
 def visualization_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
-    config = options.config_file
 
-    EverestStorage.check_for_deprecated_seba_storage(config.optimization_output_dir)
+    EverestStorage.check_for_deprecated_seba_storage(
+        options.config.optimization_output_dir
+    )
     server_state = everserver_status(
-        ServerConfig.get_everserver_status_path(config.output_dir)
+        ServerConfig.get_everserver_status_path(options.config.output_dir)
     )
     if server_state["status"] in {
         ServerStatus.failed,
@@ -38,7 +39,7 @@ def visualization_entry(args: list[str] | None = None) -> None:
         ServerStatus.completed,
     }:
         pm = EverestPluginManager()
-        pm.hook.visualize_data(api=EverestDataAPI(config))
+        pm.hook.visualize_data(api=EverestDataAPI(options.config))
     elif server_state["status"] in {
         ServerStatus.running,
         ServerStatus.starting,

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -63,6 +63,7 @@ def test_base_run_model_does_not_support_rerun_failed_realizations(minimum_case)
     assert not brm.supports_rerunning_failed_realizations
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_status_when_rerunning_on_non_rerunnable_model():
     brm = create_base_run_model()
     brm._status_queue = SimpleQueue()


### PR DESCRIPTION
Let this be "config" everywhere instead of a mixture of config, config_file and config_filename. Since this is the name of a positional argument, it will not imply user breaking changes but the help text generated by argparse will change.

**Issue**
Resolves preparatory work for solving #11146 


**Approach**
Align


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
