### PR TITLE
Refactor setup of logging for everest entry points

### DIFF
--- a/src/everest/bin/config_branch_script.py
+++ b/src/everest/bin/config_branch_script.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
+from everest.bin.utils import setup_logging
 from everest.config import EverestConfig
 from everest.config_file_loader import load_yaml
 from everest.everest_storage import EverestStorage
@@ -105,6 +106,8 @@ def _updated_initial_guess(
 def config_branch_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
+    setup_logging(options)
+
     _, optimization_dir, yml_config = options.config
 
     EverestStorage.check_for_deprecated_seba_storage(optimization_dir)

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -6,17 +6,12 @@ import logging
 import logging.config
 import os
 import signal
-import sys
 import threading
 from functools import partial
-from pathlib import Path
-
-import yaml
 
 from _ert.threading import ErtThread
 from ert.config import QueueSystem
-from ert.logging import LOGGING_CONFIG
-from everest.bin.utils import show_scaled_controls_warning
+from everest.bin.utils import setup_logging, show_scaled_controls_warning
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
     ServerStatus,
@@ -47,31 +42,8 @@ def everest_entry(args: list[str] | None = None) -> None:
     """Entry point for running an optimization."""
     parser = _build_args_parser()
     options = parser.parse_args(args)
-
     makedirs_if_needed(options.config.output_dir, roll_if_exists=True)
-    log_dir = Path(options.config.output_dir) / "logs"
-    try:
-        log_dir.mkdir(exist_ok=True)
-    except PermissionError as err:
-        sys.exit(str(err))
-    os.environ["ERT_LOG_DIR"] = str(log_dir)
-
-    with open(LOGGING_CONFIG, encoding="utf-8") as log_conf_file:
-        config_dict = yaml.safe_load(log_conf_file)
-        if config_dict:
-            for handler_name, handler_config in config_dict["handlers"].items():
-                if handler_name == "file":
-                    handler_config["filename"] = "everest-log.txt"
-                if "ert.logging.TimestampedFileHandler" in handler_config.values():
-                    handler_config["config_filename"] = options.config.config_path.name
-            logging.config.dictConfig(config_dict)
-
-    if options.debug:
-        root_logger = logging.getLogger()
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(logging.DEBUG)
-        root_logger.addHandler(handler)
-
+    setup_logging(options)
     logger.info(version_info())
 
     if options.config.server_queue_system == QueueSystem.LOCAL:

--- a/src/everest/bin/everexport_script.py
+++ b/src/everest/bin/everexport_script.py
@@ -4,18 +4,17 @@ import argparse
 import logging
 from functools import partial
 
+from everest.bin.utils import setup_logging
 from everest.config import EverestConfig
 from everest.strings import EVEREST
+
+logger = logging.getLogger(EVEREST)
 
 
 def everexport_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
-    logger = logging.getLogger(EVEREST)
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
-        # Remove the null handler if set:
-        logging.getLogger().removeHandler(logging.NullHandler())
+    setup_logging(options)
 
     logger.info("Everexport deprecation warning seen")
     print(

--- a/src/everest/bin/kill_script.py
+++ b/src/everest/bin/kill_script.py
@@ -11,6 +11,7 @@ import traceback
 from functools import partial
 from typing import Any
 
+from everest.bin.utils import setup_logging
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import server_is_running, stop_server, wait_for_server_to_stop
 from everest.util import version_info
@@ -22,11 +23,7 @@ def kill_entry(args: list[str] | None = None) -> None:
     """Entry point for running an optimization."""
     parser = _build_args_parser()
     options = parser.parse_args(args)
-
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
-        # Remove the null handler if set:
-        logger.removeHandler(logging.NullHandler())
+    setup_logging(options)
 
     logger.info(version_info())
     logger.debug(json.dumps(options.config.to_dict(), sort_keys=True, indent=2))

--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -14,7 +14,6 @@ from everest.bin.everlint_script import lint_entry
 from everest.bin.kill_script import kill_entry
 from everest.bin.monitor_script import monitor_entry
 from everest.bin.visualization_script import visualization_entry
-from everest.plugins.everest_plugin_manager import EverestPluginManager
 
 
 def _build_args_parser() -> argparse.ArgumentParser:
@@ -45,11 +44,6 @@ class EverestMain:
         parsed_args = parser.parse_args(args[1:2])
         if not hasattr(self, parsed_args.command):
             parser.error("Unrecognized command")
-
-        # Setup logging from plugins:
-        plugin_manager = EverestPluginManager()
-        plugin_manager.add_log_handle_to_root()
-        plugin_manager.add_span_processor_to_trace_provider()
 
         # Use dispatch pattern to invoke method with same name
         getattr(self, parsed_args.command)(args[2:])

--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 import argparse
-import logging
 import signal
 import threading
 from functools import partial
 
+from everest.bin.utils import setup_logging
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import ServerStatus, everserver_status, server_is_running
 from everest.everest_storage import EverestStorage
@@ -22,10 +22,7 @@ def monitor_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
 
-    if options.debug:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Remove the null handler if set:
-        logging.getLogger().removeHandler(logging.NullHandler())
+    setup_logging(options)
 
     if threading.current_thread() is threading.main_thread():
         signal.signal(

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 from typing import Any, ClassVar
 
 import colorama
+import yaml
 from colorama import Fore
 
 from ert.config.parsing.queue_system import QueueSystem
@@ -21,6 +22,7 @@ from ert.ensemble_evaluator import (
     FullSnapshotEvent,
     SnapshotUpdateEvent,
 )
+from ert.logging import LOGGING_CONFIG
 from everest.config.server_config import ServerConfig
 from everest.detached import (
     ServerStatus,
@@ -29,8 +31,48 @@ from everest.detached import (
     start_monitor,
     stop_server,
 )
+from everest.plugins.everest_plugin_manager import EverestPluginManager
 from everest.simulator import JOB_FAILURE, JOB_RUNNING, JOB_SUCCESS
 from everest.strings import EVEREST, OPT_PROGRESS_ID, SIM_PROGRESS_ID
+from everest.util import makedirs_if_needed
+
+
+def setup_logging(options: argparse.Namespace) -> None:
+    if "output_dir" in options.config:
+        makedirs_if_needed(options.config.output_dir, roll_if_exists=False)
+        log_dir = Path(options.config.output_dir) / "logs"
+    else:
+        log_dir = Path("logs")
+
+    try:
+        log_dir.mkdir(exist_ok=True)
+    except PermissionError as err:
+        sys.exit(str(err))
+    os.environ["ERT_LOG_DIR"] = str(log_dir)
+
+    with open(LOGGING_CONFIG, encoding="utf-8") as log_conf_file:
+        config_dict = yaml.safe_load(log_conf_file)
+        if config_dict:
+            for handler_name, handler_config in config_dict["handlers"].items():
+                if handler_name == "file":
+                    handler_config["filename"] = "everest-log.txt"
+                if "ert.logging.TimestampedFileHandler" in handler_config.values():
+                    handler_config["config_filename"] = ""
+                    if "config_path" in options.config:
+                        handler_config["config_filename"] = (
+                            options.config.config_path.name
+                        )
+            logging.config.dictConfig(config_dict)
+
+    if "debug" in options and options.debug:
+        root_logger = logging.getLogger()
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(handler)
+
+    plugin_manager = EverestPluginManager()
+    plugin_manager.add_log_handle_to_root()
+    plugin_manager.add_span_processor_to_trace_provider()
 
 
 def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) -> None:

--- a/src/everest/bin/visualization_script.py
+++ b/src/everest/bin/visualization_script.py
@@ -4,6 +4,7 @@ import argparse
 from functools import partial
 
 from everest.api import EverestDataAPI
+from everest.bin.utils import setup_logging
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import ServerStatus, everserver_status
 from everest.everest_storage import EverestStorage
@@ -26,6 +27,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
 def visualization_entry(args: list[str] | None = None) -> None:
     parser = _build_args_parser()
     options = parser.parse_args(args)
+    setup_logging(options)
 
     EverestStorage.check_for_deprecated_seba_storage(
         options.config.optimization_output_dir

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -52,7 +52,7 @@ def test_everest_entry_debug(
     logger_conf = tmp_path / "dummy_logger.conf"
     logger_conf.write_text("", encoding="utf-8")
     with (
-        patch("everest.bin.everest_script.LOGGING_CONFIG", str(logger_conf)),
+        patch("everest.bin.utils.LOGGING_CONFIG", str(logger_conf)),
         caplog.at_level(logging.DEBUG),
     ):
         everest_entry([CONFIG_FILE_MINIMAL, "--debug", "--skip"])


### PR DESCRIPTION
As logging.config.dictConfig() resets all handlers, it is imperative to
load the plugin manager after having configured the loggers. This change
will solve missing plugin logging for the command 'everest run', and
will also use the same logger configuration for all Everest entry
points.

**Issue**
Resolves #11146


**Approach**
Make a utility function to setup logging, and let all entry points use this.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
