### PR TITLE
Ensure a tmpdir is used in test

### DIFF
--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -63,6 +63,7 @@ def test_base_run_model_does_not_support_rerun_failed_realizations(minimum_case)
     assert not brm.supports_rerunning_failed_realizations
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_status_when_rerunning_on_non_rerunnable_model():
     brm = create_base_run_model()
     brm._status_queue = SimpleQueue()


### PR DESCRIPTION
Otherwise this will taint the source repo with a directory `storage`. 

To observe failure, do `touch storage; chmod 000 storage` and then run test in the root of the checked out repository.

**Issue**
Resolves test failures (seemingly flaky), example https://github.com/equinor/ert/actions/runs/15734201589/job/44352020731?pr=11157


**Approach**
`cd`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
