### PR TITLE
Check files specified in config with schema type EXISTING_PATH for read access

### DIFF
--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -166,7 +166,11 @@ def test_unopenable_observation_config_fails_gracefully():
     observation_config_abs_path = os.path.join(os.getcwd(), observation_config_rel_path)
     os.chmod(observation_config_abs_path, 0o000)
 
-    with pytest.raises(ConfigValidationError, match="Permission denied:"):
+    with pytest.raises(
+        ConfigValidationError,
+        match=f'File "{observation_config_abs_path}" '
+        f"is not readable; please check read access.",
+    ):
         run_cli(TEST_RUN_MODE, config_file_name)
 
 


### PR DESCRIPTION
**Issue**
Resolves #10716 


**Approach**
Should make sense that the arguments that we already define as "EXISTING_PATH" and "EXISTING_PATH_INLINE" should BOTH exist (checked today) and readable (not checked, altthough _INLINE will be validated due to a failing read_file). Now they fail "the same way".

TODO: Check for unintended other consequences, test, and make some new tests, for DATA_FILE, RUN_TEMPLATE and GEN_KW

![bilde](https://github.com/user-attachments/assets/0f8a6f26-cd10-4932-b4dd-5835275655e0)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
