### PR TITLE
Ensure logging directory exists for everest

### DIFF
--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 from collections.abc import Callable
 from datetime import datetime
+from pathlib import Path
 from types import TracebackType
 from typing import Any
 
@@ -47,6 +48,7 @@ class TimestampedFileHandler(logging.FileHandler):
         if kwargs.pop("use_log_dir_from_env", False) and "ERT_LOG_DIR" in os.environ:
             log_dir = os.environ["ERT_LOG_DIR"]
             filename = log_dir + "/" + filename
+            Path(filename).parent.mkdir(exist_ok=True, parents=True)
 
         super().__init__(filename, *args, **kwargs)
 


### PR DESCRIPTION
Everserver at least does not check the ERT_LOG_DIR environment variable, and will fail if it points to a directory that does not already exists.

**Issue**
Resolves #11170 


**Approach**
`mkdir`. Potentially shifting responsibility for who should take care of the logging directory, maybe not good?

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
