### PR TITLE
Adapt setup_logging for everest branch entry point

### DIFF
--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -23,6 +23,7 @@ from ert.ensemble_evaluator import (
     SnapshotUpdateEvent,
 )
 from ert.logging import LOGGING_CONFIG
+from everest.config import EverestConfig
 from everest.config.server_config import ServerConfig
 from everest.detached import (
     ExperimentState,
@@ -38,10 +39,11 @@ from everest.util import makedirs_if_needed
 
 
 def setup_logging(options: argparse.Namespace) -> None:
-    if "output_dir" in options.config:
+    if isinstance(options.config, EverestConfig):
         makedirs_if_needed(options.config.output_dir, roll_if_exists=False)
         log_dir = Path(options.config.output_dir) / "logs"
     else:
+        # `everest branch` gives a tuple object here.
         log_dir = Path("logs")
 
     try:
@@ -58,10 +60,13 @@ def setup_logging(options: argparse.Namespace) -> None:
                     handler_config["filename"] = "everest-log.txt"
                 if "ert.logging.TimestampedFileHandler" in handler_config.values():
                     handler_config["config_filename"] = ""
-                    if "config_path" in options.config:
+                    if isinstance(options.config, EverestConfig):
                         handler_config["config_filename"] = (
                             options.config.config_path.name
                         )
+                    else:
+                        # `everest branch`
+                        handler_config["config_filename"] = options.config[0]
             logging.config.dictConfig(config_dict)
 
     if "debug" in options and options.debug:


### PR DESCRIPTION
The entry point for everest branch parses the config file differently than the other entry points, and thus requires adaptations in setup_logging.

**Issue**
Resolves #11174

**Approach**
`isinstance`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
