### PR TITLE
Unset unused depth option from fcluster

### DIFF
--- a/src/ert/analysis/misfit_preprocessor.py
+++ b/src/ert/analysis/misfit_preprocessor.py
@@ -61,7 +61,7 @@ def cluster_responses(
     if isinstance(correlation, np.float64):
         correlation = np.array([[1, correlation], [correlation, 1]])
     linkage_matrix = linkage(correlation, "average", "euclidean")
-    return fcluster(linkage_matrix, nr_clusters, criterion="maxclust", depth=2)
+    return fcluster(linkage_matrix, nr_clusters, criterion="maxclust")
 
 
 def main(


### PR DESCRIPTION
From docs:
The maximum depth to perform the inconsistency calculation. It has no meaning for the other criteria. Default is 2. (Note that we use the maxclust criterion)

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
