### PR TITLE
Remove outdated documentation reference

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -293,9 +293,6 @@ def check_non_utf_chars(file_path: str) -> None:
 def read_templates(config_dict) -> list[tuple[str, str]]:
     templates = []
     if ConfigKeys.DATA_FILE in config_dict and ConfigKeys.ECLBASE in config_dict:
-        # This replicates the behavior of the DATA_FILE implementation
-        # in C, it adds the .DATA extension and facilitates magic string
-        # replacement in the data file
         source_file = config_dict[ConfigKeys.DATA_FILE]
         target_file = config_dict[ConfigKeys.ECLBASE].replace("%d", "<IENS>") + ".DATA"
         check_non_utf_chars(source_file)


### PR DESCRIPTION
The C implementation is long gone, and the rest of the text in the comment is hopefully possible to extract from reading the source

**Issue**
Resolves 3 LOC


**Approach**
✂️ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
