### PR TITLE
Ensure everest tests are run locally

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -144,6 +144,12 @@ def cached_example(pytestconfig):
                 Path(__file__) / f"../../../test-data/everest/{test_data_case}"
             ).resolve()
             config_file = config_path.name
+            # Ensure tests are run locally, avoiding interference with plugins:
+            config_content = yaml.safe_load(config_path.open())
+            config_content["simulator"]["queue_system"] = {"name": "local"}
+            config_path.write_text(
+                yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
+            )
 
             # This assumes no parallel runs for the same example,
             # which must be ensured by using xdist loadgroups


### PR DESCRIPTION
Not having simulator fixed in yaml files exposes the plugins to modify where these tests are run. We do not want to add this to the example test cases because interactively it can make sense to let plugins override.

**Issue**
Resolves #11188 


**Approach**
Hack the config files while testing

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
