### PR TITLE
Fix cli test taking 120s -> 1.5s

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -251,8 +251,10 @@ class Job:
     async def _verify_checksum(
         self,
         checksum_lock: asyncio.Lock,
-        timeout: int = DEFAULT_FILE_VERIFICATION_TIMEOUT,  # noqa: ASYNC109
+        timeout: int | None = None,  # noqa: ASYNC109
     ) -> None:
+        if timeout is None:
+            timeout = self.DEFAULT_FILE_VERIFICATION_TIMEOUT
         # Wait for job runpath to be in the checksum dictionary
         runpath = self.real.run_arg.runpath
         while runpath not in self._scheduler.checksum:

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -894,6 +894,7 @@ def test_tracking_missing_ecl(monkeypatch, tmp_path, caplog):
     ) in caplog.messages
 
 
+@pytest.mark.timeout(10)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_connection_errors_do_not_effect_final_result(
     monkeypatch: pytest.MonkeyPatch,
@@ -911,7 +912,7 @@ def test_that_connection_errors_do_not_effect_final_result(
         raise_connection_error,
     ):
         run_cli(
-            ENSEMBLE_EXPERIMENT_MODE,
+            TEST_RUN_MODE,
             "--disable-monitoring",
             "poly.ert",
         )


### PR DESCRIPTION

**Issue**
Resolves #[#11199](https://github.com/equinor/ert/issues/11199)


**Approach**
This commit fixes the `tests/ert/ui_tests/cli/test_cli.py::test_that_connection_errors_do_not_effect_final_result` hanging for 120s due to a mock not working in `Job`. The commit also adds a pytest.mark.timeout to ensure it will not hang in the future if the same situation happens again.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
