### PR TITLE
Ensure everest tests use the local queue

### DIFF
--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import yaml
 from ruamel.yaml import YAML
 from tests.everest.utils import (
     capture_streams,
@@ -48,6 +49,14 @@ def test_everest_main_entry_bad_command():
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
 def test_everest_entry_run(cached_example):
     _, config_file, _, _ = cached_example("math_func/config_minimal.yml")
+
+    # Ensure no interference with plugins which may set queue system
+    config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
+    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    Path(config_file).write_text(
+        yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
+    )
+
     # Setup command line arguments
     with capture_streams():
         start_everest(["everest", "run", config_file, "--skip-prompt"])

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -7,6 +7,7 @@ from typing import Any
 import orjson
 import polars as pl
 import pytest
+import yaml
 
 from ert.config import SummaryConfig
 from ert.storage import open_storage
@@ -65,6 +66,11 @@ def make_api_snapshot(api) -> dict[str, Any]:
 def test_api_snapshots(config_file, snapshot, cached_example):
     config_path, config_file, optimal_result_json, _ = cached_example(
         f"math_func/{config_file}"
+    )
+    config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
+    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    Path(config_file).write_text(
+        yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )
     config = EverestConfig.load_file(Path(config_path) / config_file)
     api = EverestDataAPI(config)

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import requests
 import uvicorn
+import yaml
 from fastapi import FastAPI
 from starlette.responses import Response
 
@@ -155,6 +156,12 @@ def test_that_multiple_everest_clients_can_connect_to_server(cached_example):
     )
 
     config_path = Path(path) / config_file
+    config_content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    config_path.write_text(
+        yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
+    )
+
     ever_config = EverestConfig.load_file(config_path)
 
     # Run the case through everserver

--- a/tests/everest/test_everest_runmodel_events.py
+++ b/tests/everest/test_everest_runmodel_events.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import orjson
 import pytest
+import yaml
 
 from ert.ensemble_evaluator import FullSnapshotEvent
 from ert.run_models.event import EverestBatchResultEvent, EverestStatusEvent
@@ -35,6 +38,12 @@ def round_floats(obj, decimals=6):
 )
 def test_everest_events(config_file, snapshot, cached_example):
     _, config_file, _, events_list = cached_example(f"math_func/{config_file}")
+
+    config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
+    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    Path(config_file).write_text(
+        yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
+    )
 
     full_snapshots = [e for e in events_list if isinstance(e, FullSnapshotEvent)]
     everest_events = [

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -177,6 +177,7 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
+        "simulator": {"queue_system": {"name": "local"}},
     }
     config = EverestConfig.model_validate(config_dict)
 
@@ -201,7 +202,7 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
 @pytest.mark.timeout(240)
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 async def test_status_contains_max_runtime_failure(change_to_tmpdir, min_config):
-    min_config["simulator"] = {"max_runtime": 1}
+    min_config["simulator"] = {"queue_system": {"name": "local"}, "max_runtime": 1}
     min_config["forward_model"] = ["sleep 5"]
     min_config["install_jobs"] = [{"name": "sleep", "executable": which("sleep")}]
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+import yaml
 
 from everest.bin.main import start_everest
 from everest.config import (
@@ -16,7 +17,15 @@ from everest.config.install_job_config import InstallJobConfig
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 def test_logging_setup(copy_math_func_test_data_to_tmp):
-    everest_config = EverestConfig.load_file("config_minimal.yml")
+    # Ensure no interference with plugins which may set queue system
+    config_file = "config_minimal.yml"
+    config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
+    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    Path(config_file).write_text(
+        yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
+    )
+
+    everest_config = EverestConfig.load_file(config_file)
     everest_config.forward_model.append(
         ForwardModelStepConfig(job="toggle_failure --fail simulation_2")
     )


### PR DESCRIPTION
Not having simulator fixed in yaml files exposes the plugins to modify where these tests are run. We do not want to add this to the example test cases because interactively it can make sense to let plugins override.

**Issue**
Resolves #11188 


**Approach**
Patch only where needed.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
