### PR TITLE
Fix dynamic sizes of hamburger icon

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -140,9 +140,16 @@ class CustomItemDelegate(QStyledItemDelegate):
 
         painter.drawRect(rect)
 
-        text_rect = rect.adjusted(self.swap_pixmap.width() + 4, 4, -4, -4)
+        icon_logical_width = int(
+            self.swap_pixmap.width() / self.swap_pixmap.devicePixelRatio()
+        )
+        icon_logical_height = int(
+            self.swap_pixmap.height() / self.swap_pixmap.devicePixelRatio()
+        )
+
+        text_rect = rect.adjusted(2 * icon_logical_width, 4, -4, -4)
         painter.drawText(text_rect, Qt.AlignmentFlag.AlignLeft, index.data())
 
-        cursor_x = option.rect.left() + self.swap_pixmap.width() - 14
-        cursor_y = int(option.rect.center().y() - (self.swap_pixmap.height() / 2))
+        cursor_x = int(option.rect.left() + icon_logical_width / 2)
+        cursor_y = int(option.rect.center().y() - (icon_logical_height / 2))
         painter.drawPixmap(cursor_x, cursor_y, self.swap_pixmap)


### PR DESCRIPTION
What I learnt is that self.swap_pixmap.width()/height() is a reference to how it is displayed which depends on your monitor.

To calculate the logical dimensions for the icon, one can do what is done in this commit, which makes it easier to work with dynamic sizes instead of hardcoding padding.

**Issue**
Resolves #11153 


**Approach**

TGX BEFORE:
![image](https://github.com/user-attachments/assets/8d4d21c4-836b-4017-85e8-d9a42ef22f13)
MAC BEFORE:
![image](https://github.com/user-attachments/assets/ca342b08-4070-46ae-b36b-5a0b7d543203)
TGX AFTER:
![image](https://github.com/user-attachments/assets/5c887ebe-7312-47a9-b210-883b3a76bdfb)
MAC AFTER:
![image](https://github.com/user-attachments/assets/448059d5-7d6a-4024-982e-ab7c8a7e4332)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
