### PR TITLE
Add deprecation warnings for non-iso data formats

### DIFF
--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -2,7 +2,6 @@ from enum import StrEnum
 
 CERTIFICATE_DIR = "cert"
 
-DATE_FORMAT = "%Y-%m-%d"
 DETACHED_NODE_DIR = "detached_node_output"
 DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -8,19 +8,11 @@ try:
     from ert.shared.version import version as ert_version
 except ImportError:
     ert_version = "0.0.0"
-from everest.strings import DATE_FORMAT, EVEREST
+from everest.strings import EVEREST
 
 
 def version_info() -> str:
     return f"everest:{ert_version}, ropt:{ropt_version}, ert:{ert_version}"
-
-
-def date2str(date: datetime) -> str:
-    return datetime.strftime(date, DATE_FORMAT)
-
-
-def str2date(date_str: str) -> datetime:
-    return datetime.strptime(date_str, DATE_FORMAT)
 
 
 def makedirs_if_needed(path: str, roll_if_exists: bool = False) -> None:

--- a/tests/everest/test_wells.py
+++ b/tests/everest/test_wells.py
@@ -32,7 +32,7 @@ from everest.simulator.everest_to_ert import everest_to_ert_config_dict
         ),
         (
             {"name": "a.b"},
-            pytest.raises(ValueError, match=r"Well name can not contain any dots (.)"),
+            pytest.raises(ValueError, match=r"Well name cannot contain any dots (.)"),
         ),
         (
             {"name": "well_well", "drill_time": -4},


### PR DESCRIPTION
**Issue**
Resolves #11141 


**Approach**
None-iso dates of this form: "2000-1-1" will be accepted, but will emit a configuration warning.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
