### PR TITLE
Update to ropt 0.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,8 @@ everest = [
     "fastapi",
     "decorator",
     "colorama",
-    "ropt[pandas]>=0.21",
-    "ropt-dakota>=0.21",
+    "ropt[pandas]>=0.22",
+    "ropt-dakota>=0.22",
 ]
 
 [tool.setuptools]

--- a/src/everest/config/optimization_config.py
+++ b/src/everest/config/optimization_config.py
@@ -198,12 +198,16 @@ The default is to use parallel evaluation if supported.
 """,
     )
 
+    _optimization_plugin: str
+
     @model_validator(mode="after")
     def validate_backend_and_algorithm(self) -> Self:
         method = "default" if self.algorithm is None else self.algorithm
         plugin_manager = get_ropt_plugin_manager()
-        if not plugin_manager.is_supported("optimizer", method):
+        plugin_name = plugin_manager.get_plugin_name("optimizer", method)
+        if plugin_name is None:
             raise ValueError(f"Optimizer algorithm '{method}' not found")
+        self._optimization_plugin_name = plugin_name
 
         if self.backend is not None:
             message = (
@@ -229,3 +233,7 @@ The default is to use parallel evaluation if supported.
         )
 
         return self
+
+    @property
+    def optimization_plugin_name(self) -> str:
+        return self._optimization_plugin_name

--- a/src/everest/config/sampler_config.py
+++ b/src/everest/config/sampler_config.py
@@ -41,7 +41,10 @@ This dict of values is passed unchanged to the selected method in the backend.
 
     @model_validator(mode="after")
     def validate_backend_and_method(self) -> Self:
-        if not get_ropt_plugin_manager().is_supported("sampler", f"{self.method}"):
+        if (
+            get_ropt_plugin_manager().get_plugin_name("sampler", f"{self.method}")
+            is None
+        ):
             raise ValueError(f"Sampler '{self.method}' not found")
 
         if self.backend is not None:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -207,8 +207,13 @@ def _parse_optimization(
         if (
             has_output_constraints
             and ever_opt.constraint_tolerance is not None
-            and isinstance(options, list)
+            and ever_opt._optimization_plugin_name == "dakota"
+            and (
+                ever_opt.algorithm
+                in {"conmin_mfd", "conmin_frcg", "asynch_pattern_search"}
+            )
         ):
+            assert isinstance(options, list)
             options += [f"constraint_tolerance = {ever_opt.constraint_tolerance}"]
 
         if options:

--- a/tests/everest/test_repo_configs.py
+++ b/tests/everest/test_repo_configs.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from ropt.exceptions import ConfigError as ROptConfigError
 
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
 from everest.optimizer.utils import get_ropt_plugin_manager
@@ -46,7 +45,7 @@ def test_all_repo_configs():
 
     try:
         get_ropt_plugin_manager().get_plugin("optimizer", "scipy/default")
-    except ROptConfigError:
+    except ValueError:
         config_files = [f for f in config_files if "scipy" not in f]
 
     config_files = list(config_files)

--- a/uv.lock
+++ b/uv.lock
@@ -940,8 +940,8 @@ requires-dist = [
     { name = "resdata", marker = "extra == 'dev'" },
     { name = "resfo" },
     { name = "resfo", marker = "extra == 'dev'" },
-    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.21" },
-    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.21" },
+    { name = "ropt", extras = ["pandas"], marker = "extra == 'everest'", specifier = ">=0.22" },
+    { name = "ropt-dakota", marker = "extra == 'everest'", specifier = ">=0.22" },
     { name = "ruamel-yaml", marker = "extra == 'everest'" },
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1" },
@@ -3788,16 +3788,16 @@ wheels = [
 
 [[package]]
 name = "ropt"
-version = "0.21.3"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5c/64764b31cb5bc6c09bcbac19a718d77d91ef39d7c45943d9c264e29307f8/ropt-0.21.3.tar.gz", hash = "sha256:36f4554607b40a7b98a836f405ecdce52b019b41ede1cff5e9c796ac4a19bf38", size = 154478, upload-time = "2025-06-17T08:55:05.67Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2a/f0953433ee139fdabbc4fc344d4c91f184aa4aa337c3b4cd8e15bbc5fdaf/ropt-0.22.0.tar.gz", hash = "sha256:ad667759e571cbf66bb33c87ecac917076aa2a800421bfcfed50aed746f1f44b", size = 154616, upload-time = "2025-06-26T06:25:15.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/03/bcdae0c4071e1de7df3de32a30170c367e7a51ce89e123f28fbac73536ca/ropt-0.21.3-py3-none-any.whl", hash = "sha256:691718ac1be8520865eb8d983d807c9a90d088a391d8616cfebbd3204a266fdd", size = 165506, upload-time = "2025-06-17T08:55:04.167Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/78988ccb9c29621b16625edac2540141012f5107e12b900843b307ca7b09/ropt-0.22.0-py3-none-any.whl", hash = "sha256:e755c7edfd03d25833bb93eba40998306200bf6f4b3d782d0a0946dce5a6ac86", size = 165710, upload-time = "2025-06-26T06:25:12.73Z" },
 ]
 
 [package.optional-dependencies]
@@ -3807,15 +3807,15 @@ pandas = [
 
 [[package]]
 name = "ropt-dakota"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "carolina" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/c5/335cb6a69416268364cf0f5a0a8b2bf476520ff16ddeeaef828423fff8f1/ropt_dakota-0.21.0.tar.gz", hash = "sha256:44150e084ab994fd431427f46e37de314253f5e506cb4f5e8046cd61d70345d3", size = 30084, upload-time = "2025-06-05T11:17:11.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/e5/3e2d82fed08df9b5760ace7737636db6dbcec95a24414c533f8c3706a22e/ropt_dakota-0.22.0.tar.gz", hash = "sha256:60bf67be8e684e20e531e79f841271bdff7e9bc0abfe716b0bd582face76866b", size = 30068, upload-time = "2025-06-26T06:25:37.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/f4/2b5a52fc7e30fee8f35df0bf0192337490d03fa1bf88c2f1c4fdf3fadbb2/ropt_dakota-0.21.0-py3-none-any.whl", hash = "sha256:55ef9744ca609d052e9f0774e2ab480a71406c14d27ac441f56f423ad9c2fef2", size = 21277, upload-time = "2025-06-05T11:17:09.649Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/aa/125f00e3e7b308ec39a0cc81776e803c62c88652c4cdbaba6996296b336b/ropt_dakota-0.22.0-py3-none-any.whl", hash = "sha256:78acbacdfec76216ba9a1cacd39ae3e95cd433a4ca9e464d5fe8b7e55edcf3ce", size = 21262, upload-time = "2025-06-26T06:25:36.579Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

**Issue**
Resolves #11222


**Approach**
This issue appears to be resolved by the main branch of `ropt`, although it is not entirely clear to me why. Hence, I propose to update the ropt packages. This update includes a few other improvements.

Changes in Everest:
    1. `ConfigError` from `ropt` has been removed in favor of using `ValueError`, which plays more nicely with `pydantic`.
    2. Testing if optimization/sampler methods are supported uses now the `get_plugin_name` method from the `ropt` plugin manager. Needed to be able to retrieve the optimizer backend name, for the fix in the next point.
    3. Handling of Dakota-specific optimization options is improved. This fixes a bug when using other optimizer backends that would mistakenly receive those options.

Notes:
    - `ropt-0.22` is not backwards compatible with `ropt-0.21`.
    - Requires an update in komodo: https://github.com/equinor/komodo-releases/pull/7596

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
