### PR TITLE
Ensure the status test is run on a local queue

### DIFF
--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -157,6 +157,7 @@ def test_status_failed_job(_, change_to_tmpdir, mock_server):
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch("everest.detached.everserver._configure_loggers")
 async def test_status_exception(_, change_to_tmpdir, min_config):
+    min_config["simulator"] = {"queue_system": {"name": "local"}}
     config = EverestConfig(**min_config)
 
     await wait_for_server_to_complete(config)


### PR DESCRIPTION
If not explicitly defined, site-config can override. When overridden by site-config, this test will take much longer to go through but it would still pass since it takes longer for the realizations to fail.

**Issue**
Resolves slow tests. Related to #11188 

**Approach**
Explicit queue.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
