### PR TITLE
Fix bug where rerunning failing subsets of realizations crashed ERT

### DIFF
--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -103,7 +103,6 @@ def test_active_realizations(initials, use_tmpdir):
         ([False, False], [False, False], False, [False, False]),
         ([False, False], [True, True], False, [False, False]),
         ([True, True], [False, True], True, [True, False]),
-        ([False, False], [], True, [True, True]),
     ],
 )
 def test_failed_realizations(initials, completed, any_failed, failures, use_tmpdir):
@@ -583,3 +582,22 @@ def test_check_if_runpath_exists(
     )
     run_model._run_paths.get_paths = get_run_path_mock
     assert run_model.check_if_runpath_exists() == expected
+
+
+def test_create_mask_from_failed_realizations_returns_initial_active_realizations_if_no_realization_succeeded():  # noqa
+    initial_active_realizations = [True, False]
+    active_realizations = initial_active_realizations.copy()
+    completed_realizations = [False, False]
+
+    brm = create_run_model(
+        start_iteration=0,
+        _total_iterations=1,
+        active_realizations=active_realizations,
+    )
+    brm._initial_realizations_mask = initial_active_realizations
+    brm.active_realizations = active_realizations
+    brm._completed_realizations_mask = completed_realizations
+
+    failed_realization_mask = brm._create_mask_from_failed_realizations()
+
+    assert failed_realization_mask == initial_active_realizations


### PR DESCRIPTION
**Issue**
Resolves #11143
Resolves #11230 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
