### PR TITLE
Turn distributions into pydantic class

### DIFF
--- a/src/ert/config/distribution.py
+++ b/src/ert/config/distribution.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import math
+import warnings
+from dataclasses import fields, is_dataclass
+from typing import Any, Literal, Self
+
+import numpy as np
+from pydantic import field_validator, model_validator
+from pydantic.dataclasses import dataclass
+from scipy.stats import norm
+
+from .parsing import ConfigValidationError, ErrorInfo
+
+
+class TransSettingsValidation:
+    @classmethod
+    def create(cls, *args: Any, **kwargs: Any) -> Self:
+        return cls(*args, **kwargs)
+
+    @classmethod
+    def get_param_names(cls) -> list[str]:
+        assert is_dataclass(cls), "This method should only be called on dataclasses"
+        return [f.name for f in fields(cls) if f.init and f.name != "name"]
+
+
+@dataclass
+class UnifSettings(TransSettingsValidation):
+    name: Literal["uniform"] = "uniform"
+    min: float = 0.0
+    max: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_unif_params(self) -> Self:
+        if not (self.min < self.max):
+            raise ConfigValidationError(
+                f"Minimum {self.min} must be strictly less than the maximum {self.max}"
+                " for uniform distribution"
+            )
+        return self
+
+    def transform(self, x: float) -> float:
+        y = float(norm.cdf(x))
+        return y * (self.max - self.min) + self.min
+
+
+@dataclass
+class LogUnifSettings(TransSettingsValidation):
+    name: Literal["logunif"] = "logunif"
+    min: float = 0.0
+    max: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_logunif_params(self) -> Self:
+        if not (self.min < self.max):
+            raise ConfigValidationError(
+                f"Minimum {self.min} must be strictly less than the maximum {self.max}"
+                " for log uniform distribution"
+            )
+        return self
+
+    def transform(self, x: float) -> float:
+        log_min, log_max = math.log(self.min), math.log(self.max)
+        tmp = norm.cdf(x)
+        # Shift according to max / min
+        return math.exp(log_min + tmp * (log_max - log_min))
+
+
+@dataclass
+class DUnifSettings(TransSettingsValidation):
+    name: Literal["dunif"] = "dunif"
+    steps: int = 1000
+    min: float = 0.0
+    max: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_dunif_params(self) -> Self:
+        errors = []
+        if not (self.min < self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly less"
+                    f" than the maximum {self.max} for duniform distribution"
+                )
+            )
+        if not self.steps > 1:
+            errors.append(
+                ErrorInfo(
+                    message=f"Number of steps {self.steps} must be larger"
+                    " than 1 for duniform distribution"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
+        return self
+
+    def transform(self, x: float) -> float:
+        y = norm.cdf(x)
+        return (math.floor(y * self.steps) / (self.steps - 1)) * (
+            self.max - self.min
+        ) + self.min
+
+
+@dataclass
+class NormalSettings(TransSettingsValidation):
+    name: Literal["normal"] = "normal"
+    mean: float = 0.0
+    std: float = 1.0
+
+    @field_validator("std")
+    @classmethod
+    def std_must_be_positive(cls, value: float) -> float:
+        if value < 0:
+            raise ConfigValidationError(f"Negative STD {value} for normal distribution")
+        return value
+
+    def transform(self, x: float) -> float:
+        return x * self.std + self.mean
+
+
+@dataclass
+class LogNormalSettings(TransSettingsValidation):
+    name: Literal["lognormal"] = "lognormal"
+    mean: float = 0.0
+    std: float = 1.0
+
+    @field_validator("std")
+    @classmethod
+    def std_must_be_positive(cls, value: float) -> float:
+        if value <= 0:
+            raise ConfigValidationError(
+                f"Negative STD {value} for lognormal distribution"
+            )
+        return value
+
+    def transform(self, x: float) -> float:
+        return math.exp(x * self.std + self.mean)
+
+
+@dataclass
+class TruncNormalSettings(TransSettingsValidation):
+    name: Literal["truncated_normal"] = "truncated_normal"
+    mean: float = 0.0
+    std: float = 1.0
+    min: float = 0.0
+    max: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_trunc_normal_params(self) -> Self:
+        errors = []
+        if not (self.min < self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly less than"
+                    f" the maximum {self.max} for truncated_normal distribution"
+                )
+            )
+        if self.std <= 0:
+            errors.append(
+                ErrorInfo(
+                    message=f"Negative STD {self.std} for truncated normal distribution"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
+        return self
+
+    def transform(self, x: float) -> float:
+        y = x * self.std + self.mean
+        return max(min(y, self.max), self.min)  # clamp
+
+
+@dataclass
+class RawSettings(TransSettingsValidation):
+    name: Literal["raw"] = "raw"
+
+    def transform(self, x: float) -> float:
+        return x
+
+
+@dataclass
+class ConstSettings(TransSettingsValidation):
+    name: Literal["const"] = "const"
+    value: float = 0.0
+
+    def transform(self, _: float) -> float:
+        return self.value
+
+
+@dataclass
+class TriangularSettings(TransSettingsValidation):
+    name: Literal["triangular"] = "triangular"
+    min: float = 0.0
+    mode: float = 0.5
+    max: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_triangular_params(self) -> Self:
+        errors = []
+        if not self.min < self.max:
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly less than"
+                    f" the maximum {self.max} for triangular distribution"
+                )
+            )
+        if not (self.min <= self.mode <= self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"The mode {self.mode} must be between the minimum"
+                    f" {self.min} and maximum {self.max} for triangular distribution"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
+        return self
+
+    def transform(self, x: float) -> float:
+        inv_norm_left = (self.max - self.min) * (self.mode - self.min)
+        inv_norm_right = (self.max - self.min) * (self.max - self.mode)
+        ymode = (self.mode - self.min) / (self.max - self.min)
+        y = norm.cdf(x)
+
+        if y < ymode:
+            return self.min + math.sqrt(y * inv_norm_left)
+        else:
+            return self.max - math.sqrt((1 - y) * inv_norm_right)
+
+
+@dataclass
+class ErrfSettings(TransSettingsValidation):
+    name: Literal["errf"] = "errf"
+    min: float = 0.0
+    max: float = 1.0
+    skewness: float = 0.0
+    width: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_errf_params(self) -> Self:
+        errors = []
+        if not self.width > 0:
+            errors.append(
+                ErrorInfo(
+                    message=f"The width {self.width} must be greater than"
+                    " 0 for errf distribution"
+                )
+            )
+        if not (self.min < self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly less"
+                    f" than the maximum {self.max} for errf distribution"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
+        return self
+
+    def transform(self, x: float) -> float:
+        y = norm(loc=0, scale=self.width).cdf(x + self.skewness)
+        if np.isnan(y):
+            raise ValueError(
+                "Output is nan, likely from triplet (x, skewness, width) "
+                "leading to low/high-probability in normal CDF."
+            )
+        return self.min + y * (self.max - self.min)
+
+
+@dataclass
+class DerrfSettings(TransSettingsValidation):
+    name: Literal["derrf"] = "derrf"
+    steps: float = 1000.0
+    min: float = 0.0
+    max: float = 1.0
+    skewness: float = 0.0
+    width: float = 1.0
+
+    @model_validator(mode="after")
+    def valid_derrf_params(self) -> Self:
+        errors = []
+        steps_float = float(self.steps)
+        if not steps_float.is_integer() or not (int(steps_float) >= 1):
+            errors.append(
+                ErrorInfo(
+                    message=f"NBINS {self.steps} must be a positive integer"
+                    " larger than 1 for DERRF distributed"
+                )
+            )
+        self.steps = int(self.steps)
+        if not (self.min < self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"The minimum {self.min} must be less than "
+                    f"the maximum {self.max} for DERRF distributed"
+                )
+            )
+        if not (self.width > 0):
+            errors.append(
+                ErrorInfo(
+                    message=f"The width {self.width} must be greater"
+                    " than 0 for DERRF distributed"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
+        return self
+
+    def transform(self, x: float) -> float:
+        q_values = np.linspace(start=0, stop=1, num=int(self.steps))
+        q_checks = np.linspace(start=0, stop=1, num=int(self.steps + 1))[1:]
+        y = ErrfSettings(
+            min=0, max=1, skewness=self.skewness, width=self.width
+        ).transform(x)
+        bin_index = np.digitize(y, q_checks, right=True)
+        y_binned = q_values[bin_index]
+        result = self.min + y_binned * (self.max - self.min)
+        if result > self.max or result < self.min:
+            warnings.warn(
+                "trans_derff suffered from catastrophic"
+                " loss of precision, clamping to min,max",
+                stacklevel=1,
+            )
+            return np.clip(result, self.min, self.max)
+        if np.isnan(result):
+            raise ValueError(
+                "trans_derrf returns nan, check that input arguments are reasonable"
+            )
+        return float(result)
+
+
+DISTRIBUTION_CLASSES: dict[str, type[TransSettingsValidation]] = {
+    "NORMAL": NormalSettings,
+    "LOGNORMAL": LogNormalSettings,
+    "UNIFORM": UnifSettings,
+    "LOGUNIF": LogUnifSettings,
+    "TRUNCATED_NORMAL": TruncNormalSettings,
+    "RAW": RawSettings,
+    "CONST": ConstSettings,
+    "DUNIF": DUnifSettings,
+    "TRIANGULAR": TriangularSettings,
+    "ERRF": ErrfSettings,
+    "DERRF": DerrfSettings,
+}
+
+
+def get_distribution(name: str, values: list[float]) -> Any:
+    cls = DISTRIBUTION_CLASSES[name]
+
+    param_names = cls.get_param_names()
+
+    kwargs = dict(zip(param_names, values, strict=False))
+
+    return cls.create(**kwargs)

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -2,22 +2,36 @@ from __future__ import annotations
 
 import math
 import os
-import warnings
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self, cast, overload
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast, overload
 
 import networkx as nx
 import numpy as np
 import pandas as pd
 import polars as pl
 import xarray as xr
-from scipy.stats import norm
+from pydantic import Field, ValidationError
 from typing_extensions import TypedDict
 
 from ._str_to_bool import str_to_bool
+from .distribution import (
+    DISTRIBUTION_CLASSES,
+    ConstSettings,
+    DerrfSettings,
+    DUnifSettings,
+    ErrfSettings,
+    LogNormalSettings,
+    LogUnifSettings,
+    NormalSettings,
+    RawSettings,
+    TriangularSettings,
+    TruncNormalSettings,
+    UnifSettings,
+    get_distribution,
+)
 from .parameter_config import ParameterConfig, ParameterMetadata
 from .parsing import ConfigValidationError, ConfigWarning, ErrorInfo
 
@@ -54,6 +68,30 @@ class TransformFunctionDefinition:
     name: str
     param_name: str
     values: list[Any]
+
+
+@dataclass
+class TransformFunction:
+    name: str
+    distribution: Annotated[
+        UnifSettings
+        | LogNormalSettings
+        | LogUnifSettings
+        | DUnifSettings
+        | RawSettings
+        | ConstSettings
+        | NormalSettings
+        | TruncNormalSettings
+        | ErrfSettings
+        | DerrfSettings
+        | TriangularSettings,
+        Field(discriminator="name"),
+    ]
+
+    @property
+    def parameter_list(self) -> dict[str, float]:
+        """Return the parameters of the distribution as a dictionary."""
+        return {k: v for k, v in asdict(self.distribution).items() if k != "name"}
 
 
 @dataclass
@@ -94,7 +132,7 @@ class GenKwConfig(ParameterConfig):
         return [
             ParameterMetadata(
                 key=f"{self.name}:{tf.name}",
-                transformation=tf.transform_function_name,
+                transformation=tf.distribution.name.upper(),
                 dimensionality=1,
                 userdata={"data_origin": "GEN_KW"},
             )
@@ -208,65 +246,6 @@ class GenKwConfig(ParameterConfig):
 
     def _validate(self) -> None:
         errors = []
-
-        def _check_non_negative_parameter(param: str, prior: PriorDict) -> None:
-            key = prior["key"]
-            dist = prior["function"]
-            param_val = prior["parameters"][param]
-            if param_val < 0:
-                errors.append(
-                    ErrorInfo(
-                        f"Negative {param} {param_val!r}"
-                        f" for {dist} distributed parameter {key!r}",
-                    ).set_context(self.name)
-                )
-
-        def _check_valid_triangular_parameters(prior: PriorDict) -> None:
-            key = prior["key"]
-            dist = prior["function"]
-            xmin, xmode, xmax = prior["parameters"].values()
-            if not (xmin < xmax):
-                errors.append(
-                    ErrorInfo(
-                        f"Minimum {xmin} must be strictly less than the maximum {xmax}"
-                        f" for {dist} distributed parameter {key}",
-                    ).set_context(self.name)
-                )
-            if not (xmin <= xmode <= xmax):
-                errors.append(
-                    ErrorInfo(
-                        f"The mode {xmode} must be between the minimum "
-                        f"{xmin} and maximum {xmax}"
-                        f" for {dist} distributed parameter {key}",
-                    ).set_context(self.name)
-                )
-
-        def _check_valid_derrf_parameters(prior: PriorDict) -> None:
-            key = prior["key"]
-            dist = prior["function"]
-            steps, min_, max_, _, width = prior["parameters"].values()
-            if not (steps >= 1 and steps.is_integer()):
-                errors.append(
-                    ErrorInfo(
-                        f"NBINS {steps} must be a positive integer larger than 1"
-                        f" for {dist} distributed parameter {key}",
-                    ).set_context(self.name)
-                )
-            if not (min_ < max_):
-                errors.append(
-                    ErrorInfo(
-                        f"The minimum {min_} must be less than the maximum {max_}"
-                        f" for {dist} distributed parameter {key}",
-                    ).set_context(self.name)
-                )
-            if not (width > 0):
-                errors.append(
-                    ErrorInfo(
-                        f"The width {width} must be greater than 0"
-                        f" for {dist} distributed parameter {key}",
-                    ).set_context(self.name)
-                )
-
         unique_keys = set()
         for prior in self.get_priors():
             key = prior["key"]
@@ -278,14 +257,6 @@ class GenKwConfig(ParameterConfig):
                 )
             unique_keys.add(key)
 
-            if prior["function"] == "LOGNORMAL":
-                _check_non_negative_parameter("STD", prior)
-            elif prior["function"] == "TRIANGULAR":
-                _check_valid_triangular_parameters(prior)
-            elif prior["function"] == "DERRF":
-                _check_valid_derrf_parameters(prior)
-            elif prior["function"] in {"NORMAL", "TRUNCATED_NORMAL"}:
-                _check_non_negative_parameter("STD", prior)
         if errors:
             raise ConfigValidationError.from_collected(errors)
 
@@ -346,7 +317,8 @@ class GenKwConfig(ParameterConfig):
         log10_data: dict[str, float | str] = {
             tf.name: math.log10(data[tf.name])
             for tf in self.transform_functions
-            if tf.use_log and isinstance(data[tf.name], (int, float))
+            if isinstance(tf.distribution, LogNormalSettings | LogUnifSettings)
+            and isinstance(data[tf.name], (int, float))
         }
 
         if log10_data:
@@ -397,7 +369,7 @@ class GenKwConfig(ParameterConfig):
     def shouldUseLogScale(self, keyword: str) -> bool:
         for tf in self.transform_functions:
             if tf.name == keyword:
-                return tf.use_log
+                return isinstance(tf.distribution, LogNormalSettings | LogUnifSettings)
         return False
 
     def get_priors(self) -> list[PriorDict]:
@@ -406,11 +378,14 @@ class GenKwConfig(ParameterConfig):
             priors.append(
                 {
                     "key": tf.name,
-                    "function": tf.transform_function_name,
-                    "parameters": tf.parameter_list,
+                    "function": tf.distribution.name.upper(),
+                    "parameters": {
+                        k.upper(): v
+                        for k, v in tf.parameter_list.items()
+                        if k != "name"
+                    },
                 }
             )
-
         return priors
 
     def transform(self, array: npt.ArrayLike) -> npt.NDArray[np.float64]:
@@ -424,7 +399,7 @@ class GenKwConfig(ParameterConfig):
         """
         array = np.array(array)
         for index, tf in enumerate(self.transform_functions):
-            array[index] = tf.calc_func(array[index], list(tf.parameter_list.values()))
+            array[index] = tf.distribution.transform(array[index])
         return array
 
     def transform_col(self, param_name: str) -> Callable[[float], float]:
@@ -433,8 +408,7 @@ class GenKwConfig(ParameterConfig):
             if tf.name == param_name:
                 break
         assert tf is not None, f"Transform function {param_name} not found"
-        arg = list(tf.parameter_list.values())
-        return lambda x: tf.calc_func(x, arg)
+        return tf.distribution.transform
 
     @staticmethod
     def _values_from_file(file_name: str, keys: list[str]) -> npt.NDArray[np.double]:
@@ -513,24 +487,20 @@ class GenKwConfig(ParameterConfig):
                 f"Too few instructions provided in: {t}", self.name
             )
 
-        if (
-            t.param_name not in DISTRIBUTION_PARAMETERS
-            or t.param_name not in PRIOR_FUNCTIONS
-        ):
+        if t.param_name not in DISTRIBUTION_CLASSES:
             raise ConfigValidationError(
                 f"Unknown distribution provided: {t.param_name}, for variable {t.name}",
                 self.name,
             )
 
-        param_names = DISTRIBUTION_PARAMETERS[t.param_name]
+        cls = DISTRIBUTION_CLASSES[t.param_name]
 
-        if len(t.values) != len(param_names):
+        if len(t.values) != len(cls.get_param_names()):
             raise ConfigValidationError.with_context(
                 f"Incorrect number of values: {t.values}, provided for variable "
                 f"{t.name} with distribution {t.param_name}.",
                 self.name,
             )
-
         param_floats = []
         for p in t.values:
             try:
@@ -541,167 +511,21 @@ class GenKwConfig(ParameterConfig):
                     f"{t.name} with distribution {t.param_name}.",
                     self.name,
                 ) from e
+        try:
+            dist = get_distribution(t.param_name, param_floats)
+        except ValidationError as e:
+            error_info = e.errors()[0]
+            ctx = error_info.get("ctx")
+            if ctx and "error" in ctx:
+                custom_error = ctx["error"].errors
+                if isinstance(custom_error, str):
+                    ctx["error"].errors += f" parameter {t.name}"
+                else:
+                    for err in custom_error:
+                        err.set_context(self.name)
+                        err.message += f" parameter {t.name}"
 
-        params = dict(zip(param_names, param_floats, strict=False))
+                    raise ConfigValidationError.from_collected(custom_error) from e
+            raise e
 
-        return TransformFunction(
-            name=t.name,
-            transform_function_name=t.param_name,
-            parameter_list=params,
-            calc_func=PRIOR_FUNCTIONS[t.param_name],
-        )
-
-
-@dataclass
-class TransformFunction:
-    name: str
-    transform_function_name: str
-    parameter_list: dict[str, float]
-    calc_func: Callable[[float, list[float]], float]
-    use_log: bool = False
-
-    def __post_init__(self) -> None:
-        if self.transform_function_name in {"LOGNORMAL", "LOGUNIF"}:
-            self.use_log = True
-
-    @staticmethod
-    def trans_errf(x: float, arg: list[float]) -> float:
-        """
-        Width  = 1 => uniform
-        Width  > 1 => unimodal peaked
-        Width  < 1 => bimodal peaks
-        Skewness < 0 => shifts towards the left
-        Skewness = 0 => symmetric
-        Skewness > 0 => Shifts towards the right
-        The width is a relavant scale for the value of skewness.
-        """
-        min_, max_, skew, width = arg[0], arg[1], arg[2], arg[3]
-        y = norm(loc=0, scale=width).cdf(x + skew)
-        if np.isnan(y):
-            raise ValueError(
-                "Output is nan, likely from triplet (x, skewness, width) "
-                "leading to low/high-probability in normal CDF."
-            )
-        return min_ + y * (max_ - min_)
-
-    @staticmethod
-    def trans_const(_: float, arg: list[float]) -> float:
-        return arg[0]
-
-    @staticmethod
-    def trans_raw(x: float, _: list[float]) -> float:
-        return x
-
-    @staticmethod
-    def trans_derrf(x: float, arg: list[float]) -> float:
-        """
-        Bin the result of `trans_errf` with `min=0` and `max=1` to closest of `nbins`
-        linearly spaced values on [0,1]. Finally map [0,1] to [min, max].
-        """
-        steps, min_, max_, skew, width = (
-            int(arg[0]),
-            arg[1],
-            arg[2],
-            arg[3],
-            arg[4],
-        )
-        q_values = np.linspace(start=0, stop=1, num=steps)
-        q_checks = np.linspace(start=0, stop=1, num=steps + 1)[1:]
-        y = TransformFunction.trans_errf(x, [0, 1, skew, width])
-        bin_index = np.digitize(y, q_checks, right=True)
-        y_binned = q_values[bin_index]
-        result = min_ + y_binned * (max_ - min_)
-        if result > max_ or result < min_:
-            warnings.warn(
-                "trans_derff suffered from catastrophic loss of precision, "
-                "clamping to min,max",
-                stacklevel=1,
-            )
-            return np.clip(result, min_, max_)
-        if np.isnan(result):
-            raise ValueError(
-                "trans_derrf returns nan, check that input arguments are reasonable"
-            )
-        return result
-
-    @staticmethod
-    def trans_unif(x: float, arg: list[float]) -> float:
-        min_, max_ = arg[0], arg[1]
-        y = norm.cdf(x)
-        return y * (max_ - min_) + min_
-
-    @staticmethod
-    def trans_dunif(x: float, arg: list[float]) -> float:
-        steps, min_, max_ = int(arg[0]), arg[1], arg[2]
-        y = norm.cdf(x)
-        return (math.floor(y * steps) / (steps - 1)) * (max_ - min_) + min_
-
-    @staticmethod
-    def trans_normal(x: float, arg: list[float]) -> float:
-        mean, std = arg[0], arg[1]
-        return x * std + mean
-
-    @staticmethod
-    def trans_truncated_normal(x: float, arg: list[float]) -> float:
-        mean, std, min_, max_ = arg[0], arg[1], arg[2], arg[3]
-        y = x * std + mean
-        return max(min(y, max_), min_)  # clamp
-
-    @staticmethod
-    def trans_lognormal(x: float, arg: list[float]) -> float:
-        # mean is the expectation of log( y )
-        mean, std = arg[0], arg[1]
-        return math.exp(x * std + mean)
-
-    @staticmethod
-    def trans_logunif(x: float, arg: list[float]) -> float:
-        log_min, log_max = math.log(arg[0]), math.log(arg[1])
-        tmp = norm.cdf(x)
-        log_y = log_min + tmp * (log_max - log_min)  # Shift according to max / min
-        return math.exp(log_y)
-
-    @staticmethod
-    def trans_triangular(x: float, arg: list[float]) -> float:
-        min_, mode, max_ = arg[0], arg[1], arg[2]
-        inv_norm_left = (max_ - min_) * (mode - min_)
-        inv_norm_right = (max_ - min_) * (max_ - mode)
-        ymode = (mode - min_) / (max_ - min_)
-        y = norm.cdf(x)
-
-        if y < ymode:
-            return min_ + math.sqrt(y * inv_norm_left)
-        else:
-            return max_ - math.sqrt((1 - y) * inv_norm_right)
-
-    def calculate(self, x: float, arg: list[float]) -> float:
-        return self.calc_func(x, arg)
-
-
-PRIOR_FUNCTIONS: dict[str, Callable[[float, list[float]], float]] = {
-    "NORMAL": TransformFunction.trans_normal,
-    "LOGNORMAL": TransformFunction.trans_lognormal,
-    "TRUNCATED_NORMAL": TransformFunction.trans_truncated_normal,
-    "TRIANGULAR": TransformFunction.trans_triangular,
-    "UNIFORM": TransformFunction.trans_unif,
-    "DUNIF": TransformFunction.trans_dunif,
-    "ERRF": TransformFunction.trans_errf,
-    "DERRF": TransformFunction.trans_derrf,
-    "LOGUNIF": TransformFunction.trans_logunif,
-    "CONST": TransformFunction.trans_const,
-    "RAW": TransformFunction.trans_raw,
-}
-
-
-DISTRIBUTION_PARAMETERS: dict[str, list[str]] = {
-    "NORMAL": ["MEAN", "STD"],
-    "LOGNORMAL": ["MEAN", "STD"],
-    "TRUNCATED_NORMAL": ["MEAN", "STD", "MIN", "MAX"],
-    "TRIANGULAR": ["MIN", "MODE", "MAX"],
-    "UNIFORM": ["MIN", "MAX"],
-    "DUNIF": ["STEPS", "MIN", "MAX"],
-    "ERRF": ["MIN", "MAX", "SKEWNESS", "WIDTH"],
-    "DERRF": ["STEPS", "MIN", "MAX", "SKEWNESS", "WIDTH"],
-    "LOGUNIF": ["MIN", "MAX"],
-    "CONST": ["VALUE"],
-    "RAW": [],
-}
+        return TransformFunction(name=t.name, distribution=dist)

--- a/src/ert/shared/storage/extraction.py
+++ b/src/ert/shared/storage/extraction.py
@@ -29,7 +29,7 @@ def create_priors(
         if isinstance(priors, GenKwConfig):
             for func in priors.transform_functions:
                 prior: dict[str, str | float] = {
-                    "function": _PRIOR_NAME_MAP[func.transform_function_name],
+                    "function": _PRIOR_NAME_MAP[func.distribution.name.upper()],
                 }
                 for name, value in func.parameter_list.items():
                     # Libres calls it steps, but normal stats uses bins

--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -11,7 +11,6 @@ from hypothesis import given, note, settings
 from pytest import MonkeyPatch, TempPathFactory
 
 from ert.cli.main import ErtCliError
-from ert.config.gen_kw_config import DISTRIBUTION_PARAMETERS
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
 
@@ -26,6 +25,20 @@ names = st.text(
         exclude_characters="\"'$,:%",  # These have specific meaning in configs
     ),
 )
+
+DISTRIBUTION_PARAMETERS: dict[str, list[str]] = {
+    "NORMAL": ["MEAN", "STD"],
+    "LOGNORMAL": ["MEAN", "STD"],
+    "TRUNCATED_NORMAL": ["MEAN", "STD", "MIN", "MAX"],
+    "TRIANGULAR": ["MIN", "MODE", "MAX"],
+    "UNIFORM": ["MIN", "MAX"],
+    "DUNIF": ["STEPS", "MIN", "MAX"],
+    "ERRF": ["MIN", "MAX", "SKEWNESS", "WIDTH"],
+    "DERRF": ["STEPS", "MIN", "MAX", "SKEWNESS", "WIDTH"],
+    "LOGUNIF": ["MIN", "MAX"],
+    "CONST": ["VALUE"],
+    "RAW": [],
+}
 
 
 @st.composite


### PR DESCRIPTION
Refactor distributions to become a pydantic class.
This provides a nicer validation and the actual transformation.

(Screenshot of new behavior in GUI if applicable)
![image](https://github.com/user-attachments/assets/10522908-9a8b-4d1e-bb75-cb4681fc9689)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
