### PR TITLE
Stop resetting completed reals on error

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -366,7 +366,6 @@ class BaseRunModel(BaseModelWithContextSupport, ABC):
                     )
                 self._storage.close()
         except ErtRunError as e:
-            self._completed_realizations_mask = []
             failed = True
             exception = e
         except UserWarning as e:


### PR DESCRIPTION
This caused completed realizations to be rerun if trying to rerun after all active realizations failed.
For example if 1/2 fails initially, and you rerun just 1 and this fails again, 100% of realizations failed on that attempt causing an ErtRunError.
In these cases the completed realizations should not reset all those which were successful.

**Issue**
Resolves #11230 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
