### PR TITLE
Reduce logging of data access from storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ dependencies = [
     "openpyxl",                                # extra dependency for pandas (excel)
     "opentelemetry-api",
     "opentelemetry-sdk",
-    "opentelemetry-instrumentation-fastapi",
-    "opentelemetry-instrumentation-httpx",
     "opentelemetry-instrumentation-threading",
     "orjson",
     "packaging",

--- a/src/ert/dark_storage/app.py
+++ b/src/ert/dark_storage/app.py
@@ -6,7 +6,6 @@ from typing import Any
 from fastapi import FastAPI, Request, status
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from ert.dark_storage.endpoints import router as endpoints_router
 from ert.dark_storage.exceptions import ErtStorageError
@@ -108,5 +107,3 @@ async def healthcheck() -> str:
 
 
 app.include_router(endpoints_router)
-
-FastAPIInstrumentor.instrument_app(app)

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -6,13 +6,10 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import requests
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
 from ert.dark_storage.client import Client, ConnInfo
 from ert.services._base_service import BaseService, _Context, local_exec_args
 from ert.trace import get_traceparent
-
-HTTPXClientInstrumentor().instrument()
 
 
 class StorageService(BaseService):


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/scout/issues/1307

![Screenshot 2025-06-26 at 10 00 01](https://github.com/user-attachments/assets/e3d2807a-4f50-4fb2-9fe1-a5527fff321f)

I've found that most of the content in `AppDependencies` originate from the monitoring of HTTP requests.

![Screenshot 2025-06-27 at 09 38 09](https://github.com/user-attachments/assets/a1209c01-e549-406b-9480-536b944926df)

The logging seems to have been dramatically increased when we were conducting testing using `everest`.
Five runs accounted for most of the logging.


![Screenshot 2025-06-27 at 09 44 27](https://github.com/user-attachments/assets/293e8453-2ed5-4a59-babe-5b229bbb2dd4)


Related Kusto queries:

Graphs showing increase in volume:
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA03PTQ6CMBAF4L2neMs2IQp7YUE0xKURDzDQEZpAMaUNwXh4KYnocvK%252B%252BbuP1DB2b0wtW0apey7YsCXHChmoGUQSx0pu4ubIusCQpRhDMTwUzWKTEmQUzkat6PhvzDAJ%252BRt1GXPddVR1jDSFs56XaPR9T1a%252FGN%252FwRI6KHGmIxNWTcdrNEgcs6%252BI9qhmVNmK7K0KiZITQVc7P9TfLRrFFPXS%252BN3W7wA8DvIV%252F9wAAAA%253D%253D/limit/1000)


Numbers for logging and HTTP request related content:
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA6WST0%252BDQBDF73yKCSfQVanxYGJqUv%252Bk9WJ64G62MJaty%252Bxmd0nF9MO7tKWARk0slw3MvDc%252F3qxEB080Nyq7VxU5GMNE6wfUSDlSJtAG4J8NrAs0CIdCndYaIVPkuCAL4c4iBE45PPMSwTpunF0LV0A4fUzDvY2typIb8YEgSHvFS7afuj2jGBY1pKLEO0H%252B40JQ1LxNkdBwhzmDy6sivgmkp545p49inqXp%252FDtX4W2PoJpI%252BTtUN4lL%252Bc9BvYUFG1gp3%252F0mKB%252B%252FVlKqyqGB6JBODIpaz5%252BaW%252Bgvvbv8Wp5b4EsVja6TPPY1fHf%252Bz9otNqF54Giw1NNelj2JRpOh38ESvWKUJOcJnAx8LrpkOpVB2%252BTUZXb2xzRfWmHmWnzWSdng7rGejm3HsB7iJ%252Bp7rYYfAwAA/limit/1000)


TimeChart Percentage of HTTP request related content:
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA6VSTU%252BDQBC98ysmnECpUOPBxNSkfqT1YprI3WxhWrYuu2RZUjD98Q60FPCjB8uFwMx78%252Ba9EWjgRS60ih5VIQ1MYJplT5ihjFFGHHML6NnBNkGNcCxUYZUhREoaxmUO9p7CBiZjeGUpQm6YNvmWmwTs2XNoH2jyIk2Z5p8IXGaEeI8OU5u348KygpCn%252BMAl%252FVxy6dRfM5SomcHYg%252BubxL2zBKmeG5OdpXkehoufuhKiPUPVVIjTorpJTIh%252FDuoFZu1go6j7g8t4siqEUIVBDc7RHReUbDn%252Fam5Ff%252Bvd%252B9fquQe2Vs74NohdqmFpaLM2xdo0EuwMQr3sedmDZKgjpAzWSIhxEFwFcDHg8TtnOpTGvPap82x0cprv74CKG4xMu4DXgb3B9Xk9pNcM8noirV%252BIBlVdJ6zBUDFK6OibnJvDd6q0yTHwoEpZuV%252FXBd%252BHN7oUkyBUI1byHDST5MZKqxQCMKpu%252BwJFqd3%252FmAMAAA%253D%253D/limit/1000)


Find the worst "offenders":
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA3MsKHBJLUjNS0nNS85MLeaqUSguzc1NLMqsSgWxFGwVkvNL80o0NBWSKhX8C1KLEksy8%252FM8U4AK84tSUotAwiB1KanFyQBUhx18TAAAAA%253D%253D/timespan/P7D/limit/1000)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
