### PR TITLE
Rerun memory tests once on failures

### DIFF
--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -258,6 +258,7 @@ def api_and_snake_oil_storage(snake_oil_case_storage, monkeypatch):
     gc.collect()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "num_reals, num_dates, num_keys, max_memory_mb",
     [  # Tested 24.11.22 on macbook pro M1 max


### PR DESCRIPTION
Measured memory usage is apparently not fully deterministic. Probably some lazy cleanup that sometimes not happens in time.

**Issue**
Resolves https://github.com/equinor/komodo-releases/actions/runs/15961767235/job/45016096166


**Approach**
♻️ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
