### PR TITLE
Reduce mac os flakyness for Everest tests

### DIFF
--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Run Tests macOS
       if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
-        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" -v' uv run just everest-tests
+        ERT_PYTEST_ARGS='-n 3 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" -v' uv run just everest-tests
 
     - name: Build Documentation
       if: inputs.test-type == 'doc'

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ ert-doc-tests:
     pytest {{pytest_args}} --doctest-modules src/ --ignore src/ert/dark_storage
 
 everest-tests:
-    pytest {{pytest_args}} tests/everest -n 4 --dist loadgroup
+    pytest -n 4 --dist loadgroup {{pytest_args}} tests/everest
 
 build-everest-docs:
     sphinx-build -n -v -E -W ./docs/everest ./everest_docs


### PR DESCRIPTION
Mac runners are not powerful enough to run 4 simulataneous tests, resulting in flaky behaviour.

Pytest allows specifying '-n' twice, and the latest will take precedence

**Issue**
Resolves flakyness, e.g in 
https://github.com/equinor/ert/actions/runs/15926842342/attempts/1
(this blocked deploy to Pypi)


**Approach**
Reduce load on test node

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
