### PR TITLE
Split out memory tests

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -82,6 +82,7 @@ jobs:
         chmod 000 storage
         uv run just ert-unit-tests
         ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-doc-tests
+        uv run just ert-memory-tests
         chmod 700 storage
         rm storage
 

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ ert-cli-tests:
     pytest {{pytest_args}} tests/ert/ui_tests/cli
 
 ert-memory-tests:
-    _RJEM_MALLOC_CONF="dirty_decay_ms:100,muzzy_decay_ms:100" pytest {{pytest_args}} tests/ert -m "memory_test"
+    _RJEM_MALLOC_CONF="dirty_decay_ms:100,muzzy_decay_ms:100" pytest -n 2 {{pytest_args}} tests/ert -m "memory_test"
 
 ert-unit-tests:
     pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not memory_test"

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ pytest_args := env("ERT_PYTEST_ARGS", "--quiet")
 
 # execute rapid unittests
 rapid-tests:
-    pytest -n auto --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky)"
+    pytest -n auto --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky or memory_test)"
 
 ert-gui-tests:
     pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui
@@ -20,8 +20,11 @@ ert-gui-tests:
 ert-cli-tests:
     pytest {{pytest_args}} tests/ert/ui_tests/cli
 
+ert-memory-tests:
+    _RJEM_MALLOC_CONF="dirty_decay_ms:100,muzzy_decay_ms:100" pytest {{pytest_args}} tests/ert -m "memory_test"
+
 ert-unit-tests:
-    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests
+    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not memory_test"
 
 ert-doc-tests:
     pytest {{pytest_args}} --doctest-modules src/ --ignore src/ert/dark_storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ norecursedirs = [
     "tests/ert/unit_tests/scheduler/bin"
 ]
 markers = [
+    "memory_test",
     "integration_test",
     "out_of_memory",
     "quick_only",

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -46,6 +46,7 @@ def poly_template(monkeypatch):
     yield folder
 
 
+@pytest.mark.memory_test
 def test_memory_smoothing(poly_template):
     ert_config = ErtConfig.from_file("poly.ert")
     fill_storage_with_data(poly_template, ert_config)
@@ -73,6 +74,7 @@ def test_memory_smoothing(poly_template):
     assert stats.peak_memory_allocated < 1024**2 * 300
 
 
+@pytest.mark.memory_test
 def test_memory_enif_update(poly_template):
     ert_config = ErtConfig.from_file("poly.ert")
     fill_storage_with_data(poly_template, ert_config)
@@ -180,6 +182,7 @@ def make_summary_data(
     )
 
 
+@pytest.mark.memory_test
 @pytest.mark.limit_memory("130 MB")
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.skipif(

--- a/tests/ert/performance_tests/test_obs_and_responses_performance.py
+++ b/tests/ert/performance_tests/test_obs_and_responses_performance.py
@@ -408,6 +408,7 @@ def setup_benchmark(tmp_path, request):
         )
 
 
+@pytest.mark.memory_test
 def test_memory_performance_of_joining_observations_and_responses(
     setup_benchmark, tmp_path
 ):
@@ -500,6 +501,7 @@ def setup_es_benchmark(tmp_path, request):
         )
 
 
+@pytest.mark.memory_test
 def test_memory_performance_of_doing_es_update(setup_es_benchmark, tmp_path):
     _, prior, posterior, gen_kw_name, expected_performance = setup_es_benchmark
     with memray.Tracker(tmp_path / "memray.bin"):
@@ -536,6 +538,7 @@ def test_speed_performance_of_doing_es_update(setup_es_benchmark, benchmark):
     benchmark(run)
 
 
+@pytest.mark.memory_test
 def test_memory_performance_of_doing_enif_update(setup_es_benchmark, tmp_path):
     _, prior, posterior, gen_kw_name, expected_performance = setup_es_benchmark
     with memray.Tracker(tmp_path / "memray.bin"):


### PR DESCRIPTION
Background: Sometimes we need to set some env vars to configure OS memory collection (which affects the memory we measure from a python context).

Can be run as just ert-memory-tests
