### PR TITLE
Adapt `well_swapping` tests to unscaled values

### DIFF
--- a/tests/everest/test_data/open_shut_state_modifier/everest/input/files/well_swap_config.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/input/files/well_swap_config.yml
@@ -1,9 +1,3 @@
-constraints:
-  state_duration:
-    scaling:
-      source: [0.0, 1.0]
-      target: [0, 500]
-
 start_date: 2022-06-01
 
 state:

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
@@ -36,10 +36,10 @@ controls:
   - name: swapping_constraints
     type: generic_control
     min: 0.0
-    max: 1.0
-    perturbation_magnitude: 0.05
+    max: 500.0
+    perturbation_magnitude: 25.0
     variables:
-      - { name: state_duration, initial_guess: [0.5, 0.5, 0.5, 0.5] }
+      - { name: state_duration, initial_guess: [250.0, 250.0, 250.0, 250.0] }
 
 objective_functions:
   - name: npv

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
@@ -51,13 +51,13 @@ controls:
   - name: swapping_constraints
     type: generic_control
     min: 0.0
-    max: 1.0
-    perturbation_magnitude: 0.05
+    max: 500
+    perturbation_magnitude: 25
     variables:
-      - { name: state_duration, index: 1, initial_guess: 0.5 }
-      - { name: state_duration, index: 2, initial_guess: 0.5 }
-      - { name: state_duration, index: 3, initial_guess: 0.5 }
-      - { name: state_duration, index: 4, initial_guess: 0.5 }
+      - { name: state_duration, index: 1, initial_guess: 250 }
+      - { name: state_duration, index: 2, initial_guess: 250 }
+      - { name: state_duration, index: 3, initial_guess: 250 }
+      - { name: state_duration, index: 4, initial_guess: 250 }
 
 objective_functions:
   - name: npv


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/everest-models/issues/137


**Approach**
`well_swapping` forward model is no longer scaling values to days (after this is in: https://github.com/equinor/everest-models/pull/138), so need to adjust config for the tests.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
