### PR TITLE
Run ensemble smoother for heat equation storage

### DIFF
--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -205,12 +205,12 @@ def test_field_param_update_using_heat_equation_enif_snapshot(
         )
 
 
-def test_field_param_update_using_heat_equation(heat_equation_storage):
+def test_field_param_update_using_heat_equation(heat_equation_storage_es):
     config = ErtConfig.from_file("config.ert")
     with open_storage(config.ens_path, mode="w") as storage:
-        experiment = storage.get_experiment_by_name("es-mda")
-        prior = experiment.get_ensemble_by_name("default_0")
-        posterior = experiment.get_ensemble_by_name("default_1")
+        experiment = storage.get_experiment_by_name("es")
+        prior = experiment.get_ensemble_by_name("iter-0")
+        posterior = experiment.get_ensemble_by_name("iter-1")
 
         prior_result = prior.load_parameters("COND")["values"]
 
@@ -408,7 +408,7 @@ if __name__ == "__main__":
 
 @pytest.mark.timeout(600)
 def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc(
-    heat_equation_storage, caplog
+    heat_equation_storage_es, caplog
 ):
     """Test field parameter updates with zero-variance regions and adaptive
     localization.
@@ -432,8 +432,8 @@ def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc
     """
     config = ErtConfig.from_file("config.ert")
     with open_storage(config.ens_path, mode="w") as storage:
-        experiment = storage.get_experiment_by_name("es-mda")
-        prior = experiment.get_ensemble_by_name("default_0")
+        experiment = storage.get_experiment_by_name("es")
+        prior = experiment.get_ensemble_by_name("iter-0")
         cond = prior.load_parameters("COND")
         init_temp_scale = prior.load_parameters("INIT_TEMP_SCALE")
         corr_length = prior.load_parameters("CORR_LENGTH")

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -42,7 +42,7 @@ from .conftest import get_child, wait_for_child
         ("SNAKE_OIL_WPR_DIFF@199", ENSEMBLE, "snake_oil"),
     ],
 )
-def plot_figure(qtbot, heat_equation_storage, snake_oil_case_storage, request):
+def plot_figure(qtbot, heat_equation_storage_esmda, snake_oil_case_storage, request):
     key, plot_name, storage_type = request.param
     args_mock = Mock()
 
@@ -50,7 +50,7 @@ def plot_figure(qtbot, heat_equation_storage, snake_oil_case_storage, request):
         storage_config = snake_oil_case_storage
         args_mock.config = "snake_oil.ert"
     else:
-        storage_config = heat_equation_storage
+        storage_config = heat_equation_storage_esmda
         args_mock.config = "config.ert"
 
     # For dark storage not to hang


### PR DESCRIPTION
Seems overkill to run 4 iterations of esmda when most tests, bar plotting of snake oil test, only uses the results from the first 2 iterations.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
