### PR TITLE
Reduce num realz for test

### DIFF
--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -187,6 +187,7 @@ def test_that_update_works_with_failed_realizations():
                 import numpy as np
                 import sys
                 import json
+                import os
 
                 def _load_coeffs(filename):
                     with open(filename, encoding="utf-8") as f:
@@ -196,7 +197,11 @@ def test_that_update_works_with_failed_realizations():
                     return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
 
                 if __name__ == "__main__":
-                    if np.random.random(1) > 0.5:
+                    # Kill one realization per iteration
+                    if (
+                        os.getenv("_ERT_REALIZATION_NUMBER") ==
+                        os.getenv("_ERT_ITERATION_NUMBER")
+                        ):
                         sys.exit(1)
                     coeffs = _load_coeffs("parameters.json")
                     output = [_evaluate(coeffs, x) for x in range(10)]
@@ -213,6 +218,8 @@ def test_that_update_works_with_failed_realizations():
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
         "--disable-monitoring",
+        "--realizations",
+        "0-2",
         "poly.ert",
     )
 


### PR DESCRIPTION
Reduce the number of realisations in test_that_update_works_with_failed_realizations. This test was one of the slower cli tests. goes from around 30s to 3s on my laptop

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
