### PR TITLE
Emit a specific error if all realizations fail during optimization

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -92,11 +92,12 @@ class OptimizerCallback(Protocol):
 
 
 class EverestExitCode(IntEnum):
-    COMPLETED = 1
-    TOO_FEW_REALIZATIONS = 2
-    MAX_FUNCTIONS_REACHED = 3
-    MAX_BATCH_NUM_REACHED = 4
-    USER_ABORT = 5
+    COMPLETED = auto()
+    TOO_FEW_REALIZATIONS = auto()
+    ALL_REALIZATIONS_FAILED = auto()
+    MAX_FUNCTIONS_REACHED = auto()
+    MAX_BATCH_NUM_REACHED = auto()
+    USER_ABORT = auto()
 
 
 class _EvaluationStatus(IntEnum):
@@ -403,7 +404,11 @@ class EverestRunModel(RunModel):
                 case RoptExitCode.USER_ABORT:
                     self._exit_code = EverestExitCode.USER_ABORT
                 case RoptExitCode.TOO_FEW_REALIZATIONS:
-                    self._exit_code = EverestExitCode.TOO_FEW_REALIZATIONS
+                    self._exit_code = (
+                        EverestExitCode.TOO_FEW_REALIZATIONS
+                        if self.get_number_of_successful_realizations() > 0
+                        else EverestExitCode.ALL_REALIZATIONS_FAILED
+                    )
                 case _:
                     self._exit_code = EverestExitCode.COMPLETED
 

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -19,6 +19,7 @@ OPT_PROGRESS_ID = "optimization_progress"
 OPT_FAILURE_REALIZATIONS = (
     "Optimization failed: not enough successful realizations to proceed."
 )
+OPT_FAILURE_ALL_REALIZATIONS = "Optimization failed: all realizations failed."
 
 SESSION_DIR = ".session"
 SERVER_STATUS = "status"


### PR DESCRIPTION
**Issue**
Resolves #11235


**Approach**
This adds a new exit code to return if the optimization fails because all realizations failed. A specific error message for that case is emitted. There are two new tests: for the case that all realizations fail and for the case that some fail, which yield different errors.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
