### PR TITLE
Have evaluator send terminate message instead of driver kill

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -167,6 +167,7 @@ class EnsembleEvaluator:
                 logger.debug("Run model cancelled - during evaluation")
                 await self._signal_cancel()
                 logger.debug("Run model cancelled - during evaluation - cancel sent")
+                self._end_event.clear()
             await asyncio.sleep(0.1)
 
     async def _append_message(self, snapshot_update_event: EnsembleSnapshot) -> None:

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -553,10 +553,12 @@ class RunModel(BaseModel, ABC):
         evaluator_task = asyncio.create_task(
             evaluator.run_and_get_successful_realizations()
         )
-
-        if await evaluator.wait_for_evaluation_result() is not True:
+        try:
+            if (await evaluator.wait_for_evaluation_result()) is not True:
+                await evaluator_task
+                return []
+        finally:
             await evaluator_task
-            return []
 
         logger.debug("tasks complete")
 

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -130,6 +130,16 @@ class Scheduler:
         for task in pending:
             logger.debug(f"Task {task.get_name()} was not killed properly!")
 
+    def mark_job_as_being_killed_by_evaluator(self, real_id: int) -> None:
+        """Mark the job as being killed by the evaluator"""
+        self._jobs[real_id]._started_killing_by_evaluator = True
+
+    def confirm_job_killed_by_evaluator(self, real_id: int) -> None:
+        """Set the job as killed by the evaluator, if the flag for \
+            evaluator started killing job is already set."""
+        if self._jobs[real_id]._started_killing_by_evaluator:
+            self._jobs[int(real_id)]._was_killed_by_evaluator.set()
+
     async def _update_avg_job_runtime(self) -> None:
         while True:
             iens = await self.completed_jobs.get()

--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -236,7 +236,7 @@ def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
         pytest.param(1, "Failed to send event", id="failed_to_send_event"),
     ],
 )
-def test_event_reporter_does_not_hang_after_failed_JONAK(
+def test_event_reporter_does_not_hang_after_failed(
     mocked_server_signal, expected_message, unused_tcp_port, monkeypatch, caplog
 ):
     host = "localhost"

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -44,6 +44,7 @@ from ert.run_models import (
     EnsembleSmoother,
     MultipleDataAssimilation,
 )
+from ert.scheduler.job import Job
 from tests.ert import SnapshotBuilder
 from tests.ert.ui_tests.gui.conftest import wait_for_attribute, wait_for_child
 from tests.ert.unit_tests.gui.simulation.test_run_path_dialog import (
@@ -152,7 +153,10 @@ def run_dialog(qtbot: QtBot, use_tmpdir, mock_set_env_key):
 
 
 @pytest.mark.integration_test
-def test_terminating_experiment_shows_a_confirmation_dialog(qtbot: QtBot, run_dialog):
+def test_terminating_experiment_shows_a_confirmation_dialog(
+    qtbot: QtBot, run_dialog, monkeypatch
+):
+    monkeypatch.setattr(Job, "WAIT_PERIOD_FOR_TERM_MESSAGE_TO_CANCEL", 0)
     with qtbot.waitSignal(run_dialog.simulation_done, timeout=10000):
 
         def handle_dialog():

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -33,6 +33,7 @@ def create_scheduler():
     sch.driver = AsyncMock()
     sch._manifest_queue = None
     sch._cancelled = False
+    sch._cancelled_by_evaluator = False
     return sch
 
 
@@ -77,6 +78,7 @@ async def assert_scheduler_events(
 async def test_submitted_job_is_cancelled(realization, mock_event):
     scheduler = create_scheduler()
     job = Job(scheduler, realization)
+    job.WAIT_PERIOD_FOR_TERM_MESSAGE_TO_CANCEL = 0
     job._requested_max_submit = 1
     job.started = mock_event()
     job.returncode.cancel()

--- a/tests/ert/utils.py
+++ b/tests/ert/utils.py
@@ -14,6 +14,7 @@ from _ert.forward_model_runner.client import (
     CONNECT_MSG,
     DISCONNECT_MSG,
     HEARTBEAT_MSG,
+    TERMINATE_MSG,
 )
 from _ert.threading import ErtThread
 from ert.scheduler.event import FinishedEvent, StartedEvent
@@ -134,6 +135,10 @@ class MockZMQServer:
     async def do_heartbeat(self):
         for dealer in self.dealers:
             await self.router_socket.send_multipart([dealer, b"", HEARTBEAT_MSG])
+
+    async def send_terminate_message(self):
+        for dealer in self.dealers:
+            await self.router_socket.send_multipart([dealer, b"", TERMINATE_MSG])
 
     async def _handler(self):
         while True:


### PR DESCRIPTION
**Issue**
Improves #9832


**Approach**
This commit makes it so that the evaluator sends a `TERMINATE_MSG`
to the connected dispatchers, letting them know it is time to shut down.
The corresponding task in the dispatcher calls SIGTERM on the pgroup,
which would look the same as if we used the queue specific commands
from the driver (bkill, qdel). The evaluator waits five seconds
after sending the message, then calls `scheduler.killAllJobs()`
that forcefully kills all jobs that did not exit gracefully within
the set sleep period. This should improve the issue with too many open
files, as we do not call the shell commands for stopping jobs as often
(only if graceful shutdown did not succeeed).

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
