### PR TITLE
Close model storage on run_model cancellation

### DIFF
--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -298,6 +298,7 @@ class ExperimentPanel(QWidget):
 
             msg_box_res = msg_box.exec()
             if msg_box_res == QMessageBox.StandardButton.No:
+                self._model._storage.close()
                 return
 
             if delete_runpath_checkbox.checkState() == Qt.CheckState.Checked:


### PR DESCRIPTION
There was a problem with run_experiment in the gui where the model is set up once the run experiment button is clicked, but only after everything is set up does the existing run_path dialog appear. If this is declined, the storage of the model is not properly closed, and ERT would crash on the next run experiment attempt.

**Issue**
Resolves #11239

Before:

https://github.com/user-attachments/assets/27c3c5a9-6d46-473c-a32a-56508781aefc

After:

https://github.com/user-attachments/assets/16e310ba-f910-4252-ba86-0b0ab74a1a68


# Problem
- [In run_experiment a model is generated](https://github.com/equinor/ert/blob/main/src/ert/gui/simulation/experiment_panel.py#L250)
- [When a new model is instantiated, the storage is opened](https://github.com/equinor/ert/blob/main/src/ert/run_models/run_model.py#L193)
- [Only after model is created is the runpath checked](https://github.com/equinor/ert/blob/main/src/ert/gui/simulation/experiment_panel.py#L268)
- On next attempt of running experiment, the storage was never closed properly, causing a `ErtStorageException: Failed to open storage`


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
