### PR TITLE
Unpin sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ dev = [
     "resdata",
     "resfo",
     "rust-just",
-    "sphinx<8.2.0",
+    "sphinx",
     "sphinx-argparse",
     "sphinx-autoapi",
     "sphinx-copybutton",

--- a/uv.lock
+++ b/uv.lock
@@ -933,7 +933,7 @@ requires-dist = [
     { name = "rust-just", marker = "extra == 'dev'" },
     { name = "scipy", specifier = ">=1.10.1" },
     { name = "seaborn" },
-    { name = "sphinx", marker = "extra == 'dev'", specifier = "<8.2.0" },
+    { name = "sphinx", marker = "extra == 'dev'" },
     { name = "sphinx-argparse", marker = "extra == 'dev'" },
     { name = "sphinx-autoapi", marker = "extra == 'dev'" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'" },


### PR DESCRIPTION
This reverts commit 3bf3fee2a4fef0b3dfacdf0c9ddd2f56e853d299.

Upstream dependencies have fixed the issue, but new nbsphinx not released yet. 

Since everything passes without the pin, we don't need the pin anymore, and when nbsphinx is released, we will get an implicit bump.

**Issue**
Resolves 🎯 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
