### PR TITLE
Add parent to Suggestor windows

### DIFF
--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -90,6 +90,7 @@ class EnsembleSelector(QComboBox):
             Suggestor(
                 errors=[ErrorInfo(str(err))],
                 widget_info='<p style="font-size: 28px;">Error writing to storage</p>',
+                parent=self,
             ).show()
             return
 

--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -109,6 +109,7 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
             Suggestor(
                 errors=[ErrorInfo(str(err))],
                 widget_info='<p style="font-size: 28px;">Error reading storage</p>',
+                parent=self,
             ).show()
 
     @Slot(QWidget)

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -131,6 +131,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
             Suggestor(
                 errors=[ErrorInfo(str(err))],
                 widget_info='<p style="font-size: 28px;">Error reading storage</p>',
+                parent=self,
             ).show()
 
     @Slot(QWidget)

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -312,6 +312,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             Suggestor(
                 errors=[ErrorInfo(str(err))],
                 widget_info='<p style="font-size: 28px;">Error reading storage</p>',
+                parent=self,
             ).show()
 
 

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -493,6 +493,7 @@ class RunDialog(QFrame):
                     f"{'failed' if failed else 'succeeded'}!</p>"
                     f"<p>These {'errors' if failed else 'warnings'} were detected</p>"
                 ),
+                parent=self,
             )
             self.fail_msg_box.show()
         else:

--- a/src/ert/gui/suggestor/suggestor.py
+++ b/src/ert/gui/suggestor/suggestor.py
@@ -112,8 +112,9 @@ class Suggestor(QWidget):
         continue_action: Callable[[], None] | None = None,
         help_links: dict[str, str] | None = None,
         widget_info: str | None = None,
+        parent: QWidget | None = None,
     ) -> None:
-        super().__init__()
+        super().__init__(parent, flags=Qt.WindowType.Window)
         if errors is None:
             errors = []
         if warnings is None:

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -138,6 +138,7 @@ class LoadResultsPanel(QWidget):
                                <p style="font-size: 28px;">ERT experiment failed!</p>
                                <p>These errors were detected:</p>
                            """,
+                parent=self,
             )
             fail_msg_box.show()
 

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -212,4 +212,5 @@ class StorageWidget(QWidget):
                         '<p style="font-size: 28px;">'
                         "Error writing to storage, experiment not created</p>"
                     ),
+                    parent=self,
                 ).show()


### PR DESCRIPTION
The suggestor windows did not have parents and would therefore not die when the main window is closed. This caused them to stay up and accumulate between tests.
It was also harder to find the window in tests as you could not use findChildren.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
