### PR TITLE
Try fix flaky test

### DIFF
--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -1,5 +1,4 @@
 import os
-import signal
 import threading
 import time
 from pathlib import Path
@@ -179,7 +178,9 @@ def test_stopping_local_queue_with_ctrl_c(capsys, setup_minimal_everest_case):
                     ServerConfig.get_everserver_status_path(config.output_dir)
                 )
                 if status.get("status") == ExperimentState.running:
-                    os.kill(os.getpid(), signal.SIGINT)
+                    import _thread  # noqa: PLC0415
+
+                    _thread.interrupt_main()
                     return
                 time.sleep(1)
 


### PR DESCRIPTION
`pytest tests/everest/functional/test_main_everest_entry.py -k test_stopping_local_queue_with_ctrl_c --count=100 -n auto`

Running PR (without reruns) parallel:
![Screenshot 2025-07-09 at 13 47 21](https://github.com/user-attachments/assets/768d4e97-70a8-40d3-bffa-903f23f32d07)

Running PR (with reruns) parallel:
![Screenshot 2025-07-09 at 13 53 28](https://github.com/user-attachments/assets/32ec43d0-99a4-4e8b-9dc1-efcc10ad7a22)

Running main (5 reruns) parallel:
![Screenshot 2025-07-09 at 14 13 54](https://github.com/user-attachments/assets/abd4cecc-8927-4272-a42f-3ebb7ab221b4)

