### PR TITLE
Fix duplicate log entries in storage log

### DIFF
--- a/src/ert/logging/storage_log.conf
+++ b/src/ert/logging/storage_log.conf
@@ -37,7 +37,7 @@ loggers:
     ert.shared.storage.info:
       level: INFO
       handlers: [file]
-      propagate: True
+      propagate: False
     ert.shared.status:
       level: INFO
     res:

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -69,14 +69,6 @@ def test_storage_logging(change_to_tmpdir):
         assert len(logfiles) == 1, "Expected exactly one log file"
         with open(logfiles[0], encoding="utf-8") as logfile:
             contents = logfile.readlines()
-            assert (
-                "[INFO] ert.shared.storage.info: Starting dark storage" in contents[0]
-            )
-            assert (
-                "[INFO] ert.shared.storage.info: "
-                f"Started dark storage with parent {os.getpid()}"
-            ) in contents[1]
-            assert (
-                "[INFO] ert.shared.storage.info: "
-                "Storage server is ready to accept requests. Listening on:"
-            ) in contents[2]
+
+        # check for duplicated log entries
+        assert len(contents) == len(set(contents)), "Found duplicated log entries"

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -71,4 +71,10 @@ def test_storage_logging(change_to_tmpdir):
             contents = logfile.readlines()
 
         # check for duplicated log entries
-        assert len(contents) == len(set(contents)), "Found duplicated log entries"
+        assert (
+            sum(
+                "[INFO] ert.shared.storage.info: Starting dark storage" in e
+                for e in contents
+            )
+            == 1
+        ), "Found duplicated log entries"


### PR DESCRIPTION
**Issue**
Resolves #11099 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
