### PR TITLE
Avoid copying existing poly storage to tmpdir

### DIFF
--- a/tests/ert/unit_tests/dark_storage/conftest.py
+++ b/tests/ert/unit_tests/dark_storage/conftest.py
@@ -1,6 +1,5 @@
 import contextlib
 import gc
-import os
 import shutil
 from argparse import ArgumentParser
 
@@ -21,10 +20,11 @@ def poly_example_tmp_dir_shared(
     source_root,
 ):
     tmpdir = tmp_path_factory.mktemp("my_poly_tmp")
-    poly_dir = path.local(os.path.join(str(tmpdir), "poly_example"))
+    poly_dir = path.local(tmpdir / "poly_example")
     shutil.copytree(
-        os.path.join(source_root, "test-data", "ert", "poly_example"),
+        source_root / "test-data" / "ert" / "poly_example",
         poly_dir,
+        ignore=shutil.ignore_patterns("*ipynb", "poly_out", "storage", "logs"),
     )
     with poly_dir.as_cwd():
         parser = ArgumentParser(prog="test_main")


### PR DESCRIPTION
Including storage in the copytree if it exists will fail some tests that assumes that this is a cleansed directory

**Issue**
Resolves #11310 


**Approach**
ignore certain files.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
