### PR TITLE
Keep the data as is since the conversion happens elsewhere

### DIFF
--- a/src/ert/dark_storage/endpoints/parameters.py
+++ b/src/ert/dark_storage/endpoints/parameters.py
@@ -8,9 +8,7 @@ import pandas as pd
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
 from fastapi.responses import Response
 
-from ert.dark_storage.common import (
-    get_storage,
-)
+from ert.dark_storage.common import get_storage
 from ert.storage import Ensemble, Storage
 
 router = APIRouter(tags=["ensemble"])
@@ -116,4 +114,4 @@ def data_for_parameter(ensemble: Ensemble, key: str) -> pd.DataFrame:
         return pd.DataFrame()
     data = data[key].to_frame().dropna()
     data.columns = pd.Index([0])
-    return data.astype(float)
+    return data

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -14,6 +14,7 @@ import httpx
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 from pandas.errors import ParserError
 
 from ert.config.parameter_config import ParameterMetadata
@@ -233,10 +234,10 @@ class PlotApi:
             except (ParserError, ValueError):
                 df.columns = [int(s) for s in df.columns]
 
-            try:
-                return df.astype(float)
-            except ValueError:
-                return df
+            for col in df.columns:
+                if is_numeric_dtype(df[col]):
+                    df[col] = df[col].astype(float)
+            return df
 
     def observations_for_key(self, ensemble_ids: list[str], key: str) -> pd.DataFrame:
         """Returns a pandas DataFrame with the datapoints for a given observation key


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11302


**Approach**
This will keep the parameter types, since the conversion to float happens down the line in plot_api. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
