### PR TITLE
Backport Fix FlattenedControls to 14.4

### DIFF
--- a/src/everest/config/utils.py
+++ b/src/everest/config/utils.py
@@ -1,124 +1,92 @@
-from collections.abc import Generator
+from copy import deepcopy
 from typing import Any, Literal
 
 from .control_config import ControlConfig
-from .control_variable_config import (
-    ControlVariableConfig,
-    ControlVariableGuessListConfig,
-)
+from .control_variable_config import ControlVariableGuessListConfig
 from .sampler_config import SamplerConfig
 
 
 class FlattenedControls:
     def __init__(self, controls: list[ControlConfig]) -> None:
-        self._controls = []
-        self._samplers: list[SamplerConfig] = []
-
-        for control in controls:
-            control_sampler_idx = -1
-            variables = []
-            for variable in control.variables:
-                match variable:
-                    case ControlVariableConfig():
-                        var_dict, control_sampler_idx = self._add_variable(
-                            control, variable, control_sampler_idx
-                        )
-                        variables.append(var_dict)
-                    case ControlVariableGuessListConfig():
-                        var_dicts, control_sampler_idx = self._add_variable_guess_list(
-                            control, variable, control_sampler_idx
-                        )
-                        variables.extend(var_dicts)
-            self._inject_defaults(control, variables)
-            self._controls.extend(variables)
-
-        self.names = [control["name"] for control in self._controls]
+        control_dicts = _get_control_dicts(controls)
+        self.names = [control["name"] for control in control_dicts]
         self.types: list[Literal["real", "integer"]] = [
-            control["control_type"] for control in self._controls
+            control["control_type"] for control in control_dicts
         ]
-        self.initial_guesses = [control["initial_guess"] for control in self._controls]
-        self.lower_bounds = [control["min"] for control in self._controls]
-        self.upper_bounds = [control["max"] for control in self._controls]
-        self.scaled_ranges = [control["scaled_range"] for control in self._controls]
-        self.enabled = [control["enabled"] for control in self._controls]
+        self.initial_guesses = [control["initial_guess"] for control in control_dicts]
+        self.lower_bounds = [control["min"] for control in control_dicts]
+        self.upper_bounds = [control["max"] for control in control_dicts]
+        self.scaled_ranges = [control["scaled_range"] for control in control_dicts]
+        self.enabled = [control["enabled"] for control in control_dicts]
         self.perturbation_magnitudes = [
-            control["perturbation_magnitude"] for control in self._controls
+            control["perturbation_magnitude"] for control in control_dicts
         ]
         self.perturbation_types = [
-            control["perturbation_type"] for control in self._controls
+            control["perturbation_type"] for control in control_dicts
         ]
-        self.sampler_indices = [control["sampler_idx"] for control in self._controls]
-        self.samplers = self._samplers
+        self.samplers, self.sampler_indices = _get_samplers(controls)
 
-    def _add_variable(
-        self,
-        control: ControlConfig,
-        variable: ControlVariableConfig,
-        control_sampler_idx: int,
-    ) -> tuple[dict[str, Any], int]:
-        var_dict = {
-            key: getattr(variable, key)
-            for key in [
-                "control_type",
-                "enabled",
-                "scaled_range",
-                "min",
-                "max",
-                "perturbation_magnitude",
-                "initial_guess",
-            ]
-        }
-        var_dict["name"] = (
-            (control.name, variable.name)
-            if variable.index is None
-            else (control.name, variable.name, variable.index)
-        )
-        if variable.sampler is not None:
-            self._samplers.append(variable.sampler)
-            var_dict["sampler_idx"] = len(self._samplers) - 1
-        else:
-            if control.sampler is not None and control_sampler_idx < 0:
-                self._samplers.append(control.sampler)
-                control_sampler_idx = len(self._samplers) - 1
-            var_dict["sampler_idx"] = control_sampler_idx
-        return var_dict, control_sampler_idx
 
-    def _add_variable_guess_list(
-        self,
-        control: ControlConfig,
-        variable: ControlVariableGuessListConfig,
-        control_sampler_idx: int,
-    ) -> tuple[Generator[dict[str, Any], None, None], int]:
-        if control.sampler is not None and control_sampler_idx < 0:
-            self._samplers.append(control.sampler)
-            control_sampler_idx = len(self._samplers) - 1
-        return (
-            (
-                {
-                    "name": (control.name, variable.name, index + 1),
-                    "initial_guess": guess,
-                    "sampler_idx": control_sampler_idx,
-                }
-                for index, guess in enumerate(variable.initial_guess)
-            ),
-            control_sampler_idx,
-        )
+def _get_control_dicts(controls: list[ControlConfig]) -> list[dict[str, Any]]:
+    def _inject_defaults(control: ControlConfig, var_dict: dict[str, Any]) -> None:
+        for key in [
+            "type",
+            "initial_guess",
+            "control_type",
+            "enabled",
+            "min",
+            "max",
+            "perturbation_type",
+            "perturbation_magnitude",
+            "scaled_range",
+        ]:
+            if var_dict.get(key) is None:
+                var_dict[key] = getattr(control, key)
 
-    @staticmethod
-    def _inject_defaults(
-        control: ControlConfig, variables: list[dict[str, Any]]
-    ) -> None:
-        for var_dict in variables:
-            for key in [
-                "type",
-                "initial_guess",
-                "control_type",
-                "enabled",
-                "min",
-                "max",
-                "perturbation_type",
-                "perturbation_magnitude",
-                "scaled_range",
-            ]:
-                if var_dict.get(key) is None:
-                    var_dict[key] = getattr(control, key)
+    control_dicts: list[dict[str, Any]] = []
+    for control in controls:
+        for variable in control.variables:
+            if isinstance(variable, ControlVariableGuessListConfig):
+                for index, guess in enumerate(variable.initial_guess, start=1):
+                    var_dict = deepcopy(variable.model_dump())
+                    var_dict["name"] = (control.name, variable.name, index)
+                    var_dict["initial_guess"] = guess
+                    _inject_defaults(control, var_dict)
+                    control_dicts.append(var_dict)
+            else:
+                var_dict = deepcopy(variable.model_dump())
+                var_dict["name"] = (
+                    (control.name, variable.name)
+                    if variable.index is None
+                    else (control.name, variable.name, variable.index)
+                )
+                _inject_defaults(control, var_dict)
+                control_dicts.append(var_dict)
+    return control_dicts
+
+
+def _get_samplers(
+    controls: list[ControlConfig],
+) -> tuple[list[SamplerConfig | None], list[int]]:
+    samplers: list[SamplerConfig | None] = []
+    sampler_indices: list[int] = []
+    for control in controls:
+        control_sampler_idx: int | None = None
+        for variable in control.variables:
+            if variable.sampler is None:
+                if control_sampler_idx is None:
+                    samplers.append(control.sampler)
+                    control_sampler_idx = len(samplers) - 1
+                sampler_index = control_sampler_idx
+            else:
+                samplers.append(variable.sampler)
+                sampler_index = len(samplers) - 1
+            if isinstance(variable, ControlVariableGuessListConfig):
+                sampler_indices.extend([sampler_index] * len(variable.initial_guess))
+            else:
+                sampler_indices.append(sampler_index)
+    return samplers, sampler_indices
+
+
+def flatten_controls(controls: list[ControlConfig]) -> FlattenedControls:
+    return FlattenedControls(controls)

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -38,17 +38,17 @@ def _parse_controls(
         for perturbation_type in controls.perturbation_types
     ]
 
-    ropt_samplers: list[dict[str, Any]] = []
-    if any(item >= 0 for item in controls.sampler_indices):
-        ropt_samplers = [
-            {
-                "method": sampler.method,
-                "options": {} if sampler.options is None else sampler.options,
-                "shared": False if sampler.shared is None else sampler.shared,
-            }
-            for sampler in controls.samplers
-        ]
-        ropt_variables["samplers"] = controls.sampler_indices
+    ropt_variables["samplers"] = controls.sampler_indices
+    ropt_samplers = [
+        {}
+        if sampler is None
+        else {
+            "method": sampler.method,
+            "options": {} if sampler.options is None else sampler.options,
+            "shared": False if sampler.shared is None else sampler.shared,
+        }
+        for sampler in controls.samplers
+    ]
 
     return ropt_variables, ropt_samplers
 

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -71,6 +71,9 @@
       0.75
     ]
   },
+  "samplers": [
+    {}
+  ],
   "variables": {
     "lower_bounds": [
       -1.0,
@@ -91,6 +94,11 @@
       1,
       1,
       1
+    ],
+    "samplers": [
+      0,
+      0,
+      0
     ],
     "seed": 999,
     "types": [

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -40,6 +40,9 @@
       1.0
     ]
   },
+  "samplers": [
+    {}
+  ],
   "variables": {
     "lower_bounds": [
       -1.0,
@@ -60,6 +63,11 @@
       1,
       1,
       1
+    ],
+    "samplers": [
+      0,
+      0,
+      0
     ],
     "seed": 123,
     "types": [

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -47,6 +47,9 @@
       1.0
     ]
   },
+  "samplers": [
+    {}
+  ],
   "variables": {
     "lower_bounds": [
       -1.0,
@@ -67,6 +70,11 @@
       1,
       1,
       1
+    ],
+    "samplers": [
+      0,
+      0,
+      0
     ],
     "seed": 999,
     "types": [

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -256,3 +256,73 @@ def test_control_bad_variables(variables, control_data_no_variables: dict):
     data["variables"] = variables
     with pytest.raises(ValidationError, match="3 validation errors"):
         ControlConfig.model_validate(data)
+
+
+def test_control_variable_guess_list():
+    controls1 = ControlConfig(
+        name="controls",
+        type="generic_control",
+        variables=[
+            {"name": "var", "initial_guess": [0.1, 0.2, 0.3]},
+        ],
+        control_type="real",
+        min=0.0,
+        max=1.0,
+        perturbation_type="relative",
+        perturbation_magnitude=5,
+        scaled_range=[1.0, 2.0],
+        enabled=False,
+    )
+
+    controls2 = ControlConfig(
+        name="controls",
+        type="generic_control",
+        variables=[
+            {"name": "var", "initial_guess": 0.1, "index": 1},
+            {"name": "var", "initial_guess": 0.2, "index": 2},
+            {"name": "var", "initial_guess": 0.3, "index": 3},
+        ],
+        control_type="real",
+        min=0.0,
+        max=1.0,
+        perturbation_type="relative",
+        perturbation_magnitude=5,
+        scaled_range=[1.0, 2.0],
+        enabled=False,
+    )
+
+    ever_config1 = EverestConfig.with_defaults(controls=[controls1])
+    ever_config2 = EverestConfig.with_defaults(controls=[controls2])
+
+    ropt_config1, initial1 = everest2ropt(
+        ever_config1.controls,
+        ever_config1.objective_functions,
+        ever_config1.input_constraints,
+        ever_config1.output_constraints,
+        ever_config1.optimization,
+        ever_config1.model,
+        1234,
+        "dummy",
+    )
+
+    ropt_config2, initial2 = everest2ropt(
+        ever_config2.controls,
+        ever_config2.objective_functions,
+        ever_config2.input_constraints,
+        ever_config2.output_constraints,
+        ever_config2.optimization,
+        ever_config2.model,
+        1234,
+        "dummy",
+    )
+
+    assert initial1 == initial2
+    assert ropt_config1["names"]["variable"] == ropt_config2["names"]["variable"]
+    for key in [
+        "lower_bounds",
+        "upper_bounds",
+        "perturbation_magnitudes",
+        "perturbation_types",
+        "mask",
+    ]:
+        assert ropt_config1["variables"][key] == ropt_config2["variables"][key]


### PR DESCRIPTION
The original code was buggy, since it did not handle all fields in the case the variable field has class `ControlVariableGuessListConfig `. The result was that some fields would fall back to the values in the control section, or to defaults. The code has been rewritten such that the parsing of all fields is shared by the  `ControlVariableGuessListConfig` and `ControlVariableConfig` cases. A test to check this has been added.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
