### PR TITLE
Start storage server on KeyError from storage_server.json

### DIFF
--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -60,7 +60,7 @@ class StorageService(BaseService):
             service = cls.connect(timeout=0, project=kwargs.get("project", os.getcwd()))
             # Check the server is up and running
             _ = service.fetch_url()
-        except TimeoutError:
+        except (TimeoutError, KeyError):
             return cls.start_server(*args, **kwargs)
         return _Context(service)
 

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import socket
+from unittest.mock import patch
 
 import pytest
 
@@ -49,6 +50,35 @@ def test_that_service_can_be_started_with_existing_conn_info_json(tmp_path):
     with open(tmp_path / "storage_server.json", mode="w", encoding="utf-8") as f:
         json.dump(connection_info, f)
     StorageService.connect(project=tmp_path)
+
+
+@patch("ert.services.StorageService.start_server")
+def test_that_service_can_be_started_with_missing_cert_in_conn_info_json(
+    start_server_mock, tmp_path
+):
+    """
+    This is a regression test for a bug with the following reproduction steps:
+
+        1. run `ert gui poly.ert` with an ert 14.3
+        2. kill that process, meaning `storage_service_server.json` is not cleaned up.
+        3. run `ert gui poly.ert` with ert 14.4.0, which
+           looks for a 'cert' key present in storage_server.json
+    """
+    connection_info = {
+        "urls": [
+            f"http://{host}:51839"
+            for host in (
+                "127.0.0.1",
+                socket.gethostname(),
+                socket.getfqdn(),
+            )
+        ],
+        "authtoken": "dummytoken",
+    }
+    with open(tmp_path / "storage_server.json", mode="w", encoding="utf-8") as f:
+        json.dump(connection_info, f)
+    StorageService.init_service(project=str(tmp_path))
+    start_server_mock.assert_called_once()
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
If KeyErrors occurs while trying to connect to the server, then storage_server.json is malformed and should be regarded the same as a TimeoutError, i.e. a new server will be started and storage_server.json is overwritten

**Issue**
Resolves #11325 


**Approach**
catch

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
