### PR TITLE
Start storage server on KeyError from storage_server.json

### DIFF
--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -69,13 +69,13 @@ jobs:
     - name: Build Documentation
       if: inputs.test-type == 'doc'
       run: |
-        uv pip install git+https://github.com/equinor/everest-models.git
+        uv pip install git+https://github.com/equinor/everest-models.git@1.6.2
         uv run sphinx-build -n -v -E -W ./docs/everest ./everest_docs
 
     - name: Run tests requiring everest-models
       if: inputs.test-type == 'everest-models-test'
       run: |
-        uv pip install git+https://github.com/equinor/everest-models.git
+        uv pip install git+https://github.com/equinor/everest-models.git@1.6.2
         ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m everest_models_test' uv run just everest-tests
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/test_everest_models.yml
+++ b/.github/workflows/test_everest_models.yml
@@ -52,6 +52,9 @@ jobs:
         - name: Get everest-models
           run: |
             git clone https://github.com/equinor/everest-models.git
+            pushd everest-models
+            git checkout 1.6.2
+            popd
 
         - name: "Install and test everest-models"
           run: |

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -60,7 +60,7 @@ class StorageService(BaseService):
             service = cls.connect(timeout=0, project=kwargs.get("project", os.getcwd()))
             # Check the server is up and running
             _ = service.fetch_url()
-        except TimeoutError:
+        except (TimeoutError, KeyError):
             return cls.start_server(*args, **kwargs)
         return _Context(service)
 


### PR DESCRIPTION
**Issue**
Resolves manual backport of #11333 to 14.4


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
