### PR TITLE
Make Everviz work with old storages

### DIFF
--- a/src/ert/storage/migration/to12.py
+++ b/src/ert/storage/migration/to12.py
@@ -35,7 +35,7 @@ def migrate(path: Path) -> None:
                 "GenDataConfig": "gen_data",
                 "SummaryConfig": "summary",
                 "EverestConstraintsConfig": "everest_constraints",
-                "EverestObjectiveConfig": "everest_objective",
+                "EverestObjectivesConfig": "everest_objectives",
             },
         )
 

--- a/tests/ert/unit_tests/storage/migration/test_to12.py
+++ b/tests/ert/unit_tests/storage/migration/test_to12.py
@@ -1,0 +1,36 @@
+from ert.storage.migration.to12 import migrate_everest_param
+
+
+def test_migrate_everest_param_listkeys():
+    original = {"name": "supername", "input_keys": ["supername.2", "supername.3"]}
+    migrated = migrate_everest_param(original)
+
+    assert migrated["input_keys"] == original["input_keys"]
+
+
+def test_migrate_everest_param_dict_of_listkeys():
+    original = {
+        "name": "supername",
+        "input_keys": {
+            "WELL-1": ["1", "2", "3", "4"],
+            "WELL-2": ["1", "2", "3", "4"],
+            "WELL-3": ["1", "2", "3", "4"],
+        },
+    }
+
+    migrated = migrate_everest_param(original)
+
+    assert migrated["input_keys"] == [
+        "supername.WELL-1.1",
+        "supername.WELL-1.2",
+        "supername.WELL-1.3",
+        "supername.WELL-1.4",
+        "supername.WELL-2.1",
+        "supername.WELL-2.2",
+        "supername.WELL-2.3",
+        "supername.WELL-2.4",
+        "supername.WELL-3.1",
+        "supername.WELL-3.2",
+        "supername.WELL-3.3",
+        "supername.WELL-3.4",
+    ]

--- a/tests/everest/entry_points/test_visualization_entry.py
+++ b/tests/everest/entry_points/test_visualization_entry.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from unittest.mock import patch
 
 import pluggy
+import pytest
 
 from everest.bin.visualization_script import visualization_entry
 from everest.config import EverestConfig
-from everest.detached import ExperimentState
 from everest.plugins import hook_impl, hook_specs
 from everest.strings import EVEREST
 from tests.everest.utils import capture_streams
@@ -17,14 +18,14 @@ class MockPluginManager(pluggy.PluginManager):
         self.register(hook_impl)
 
 
-@patch(
-    "everest.bin.visualization_script.everserver_status",
-    return_value={"status": ExperimentState.completed},
-)
+@pytest.mark.xdist_group("math_func/config_advanced.yml")
 @patch("everest.bin.visualization_script.EverestPluginManager", MockPluginManager)
 def test_expected_message_when_no_visualisation_plugin_is_installed(
-    _, change_to_tmpdir, min_config
+    change_to_tmpdir, cached_example, min_config
 ):
+    config_path, config_file, _, _ = cached_example("math_func/config_advanced.yml")
+    config = EverestConfig.load_file(Path(config_path) / config_file)
+
     config_file = "test.yml"
     config = EverestConfig(**min_config)
     config.dump(config_file)


### PR DESCRIPTION
**Issue**
Resolves #11356 
Resolves #11353 


**Approach**
Use storage instead. Initiate storage migration only if storage is old. Attempt to open readonly storage to not interfere with writing in progress (if running simulation)