### PR TITLE
Solve deprecation warning from httpx, use create_default_context

### DIFF
--- a/src/ert/dark_storage/client/_session.py
+++ b/src/ert/dark_storage/client/_session.py
@@ -54,7 +54,7 @@ def find_conn_info() -> ConnInfo:
         raise RuntimeError("No Storage connection configuration found")
 
     try:
-        conn_info = ConnInfo.parse_obj(json.loads(conn_str))
+        conn_info = ConnInfo.model_validate_json(conn_str)
     except (json.JSONDecodeError, ValidationError) as e:
         raise RuntimeError("Invalid storage connection configuration") from e
     else:

--- a/src/ert/dark_storage/client/client.py
+++ b/src/ert/dark_storage/client/client.py
@@ -1,3 +1,5 @@
+import ssl
+
 import httpx
 
 from ._session import ConnInfo, find_conn_info
@@ -16,10 +18,11 @@ class Client(httpx.Client):
         headers = {}
         if conn_info.auth_token is not None:
             headers = {"Token": conn_info.auth_token}
-
         super().__init__(
             base_url=conn_info.base_url,
             headers=headers,
-            verify=conn_info.cert,
+            verify=ssl.create_default_context(cafile=conn_info.cert)
+            if isinstance(conn_info.cert, str)
+            else conn_info.cert,
             timeout=15,
         )


### PR DESCRIPTION
Solves the warning:
```
  /home/runner/work/ert/ert/.venv/lib/python3.11/site-packages/httpx/_config.py:51: DeprecationWarning: `verify=<str>` is deprecated. Use `verify=ssl.create_default_context(cafile=...)` or `verify=ssl.create_default_context(capath=...)` instead.
    warnings.warn(message, DeprecationWarning)
```


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
