### PR TITLE
Minor fixes to the suggestor GUI

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -163,8 +163,8 @@ def _start_initial_gui_window(
                 (plugin_manager.get_help_links() if plugin_manager is not None else {}),
                 widget_info="""\
                     <p style="font-size: 28px;">Some errors detected</p>
-                    <p> The following errors were detected while reading
-                    the ert configuration file. </p>
+                    <p style="font-size: 16px;">The following errors were detected
+                    while reading the ert configuration file. </p>
                 """,
             ),
             None,
@@ -202,8 +202,8 @@ def _start_initial_gui_window(
             plugin_manager.get_help_links() if plugin_manager is not None else {},
             widget_info="""\
                 <p style="font-size: 28px;">Some problems detected</p>
-                <p> The following problems were detected while reading
-                the ert configuration file. </p>
+                <p style="font-size: 16px;">The following problems were detected
+                while reading the ert configuration file. </p>
             """,
         )
         return (

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -491,7 +491,8 @@ class RunDialog(QFrame):
                 widget_info=(
                     f"<p style='font-size: 28px;' > ERT experiment "
                     f"{'failed' if failed else 'succeeded'}!</p>"
-                    f"<p>These {'errors' if failed else 'warnings'} were detected</p>"
+                    f"<p style='font-size: 16px;'>"
+                    f"These {'errors' if failed else 'warnings'} were detected</p>"
                 ),
                 parent=self,
             )

--- a/src/ert/gui/suggestor/suggestor.py
+++ b/src/ert/gui/suggestor/suggestor.py
@@ -124,26 +124,28 @@ class Suggestor(QWidget):
         if deprecations is None:
             deprecations = []
         self._continue_action = continue_action
+        self.setWindowTitle("ERT")
+
         self.__layout = QVBoxLayout()
         self.setLayout(self.__layout)
+        self.__layout.setContentsMargins(32, 16, 32, 16)
         self.__layout.addWidget(QLabel(widget_info))
-        self.setWindowTitle("ERT")
-        data_widget = QWidget(parent=self)
-        self.__layout.addWidget(data_widget)
-        self.__layout.setContentsMargins(32, 47, 32, 16)
-        self.__layout.setSpacing(32)
+        self.__layout.addSpacing(20)
 
         if not is_dark_mode():
             self.setStyleSheet(f"background-color: {LIGHT_GREY};")
 
+        data_widget = QWidget(parent=self)
         data_layout = QHBoxLayout()
         data_widget.setLayout(data_layout)
         data_layout.setSpacing(16)
         data_layout.setContentsMargins(0, 0, 0, 0)
-
         data_layout.addWidget(self._problem_area(errors, warnings, deprecations))
         if help_links:
             data_layout.addWidget(self._help_panel(help_links))
+        self.__layout.addWidget(data_widget)
+
+        self.__layout.addWidget(self._action_buttons())
 
     def _help_panel(self, help_links: dict[str, str]) -> QFrame:
         help_button_frame = QFrame(parent=self)
@@ -200,7 +202,6 @@ class Suggestor(QWidget):
         problem_area.setLayout(area_layout)
         area_layout.setContentsMargins(0, 0, 0, 0)
         area_layout.addWidget(self._messages(errors, warnings, deprecations))
-        area_layout.addWidget(self._action_buttons())
         return problem_area
 
     def _action_buttons(self) -> QWidget:

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -136,7 +136,8 @@ class LoadResultsPanel(QWidget):
                 continue_action=None,
                 widget_info="""\
                                <p style="font-size: 28px;">ERT experiment failed!</p>
-                               <p>These errors were detected:</p>
+                               <p style="font-size: 16px;">These errors were detected:
+                               </p>
                            """,
                 parent=self,
             )


### PR DESCRIPTION
**Issue**
Resolves #my_issue
Before:
<img width="1528" height="724" alt="image" src="https://github.com/user-attachments/assets/fb11aee8-81e7-419a-9515-ff1b8ae82f3c" />

After:
<img width="1504" height="724" alt="image" src="https://github.com/user-attachments/assets/25eff819-f093-48b6-b7a3-1003e292460e" />



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
