### PR TITLE
Reduce max running everest tests

### DIFF
--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -79,3 +79,8 @@ environment:
   random_seed: 999
   simulation_folder: scratch/advanced/
   output_folder: everest_output/
+
+simulator:
+  queue_system:
+    name: local
+    max_running: 3

--- a/test-data/everest/math_func/config_minimal.yml
+++ b/test-data/everest/math_func/config_minimal.yml
@@ -37,3 +37,8 @@ environment:
   simulation_folder: sim_output
   log_level: info
   random_seed: 123
+
+simulator:
+  queue_system:
+    name: local
+    max_running: 3

--- a/test-data/everest/math_func/config_multiobj.yml
+++ b/test-data/everest/math_func/config_multiobj.yml
@@ -49,3 +49,8 @@ environment:
   output_folder: everest_output_multiobj
   log_level: debug
   random_seed: 999
+
+simulator:
+  queue_system:
+    name: local
+    max_running: 3

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -51,7 +51,6 @@ def test_everest_entry_run(cached_example):
 
     # Ensure no interference with plugins which may set queue system
     config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
-    config_content["simulator"] = {"queue_system": {"name": "local"}}
     Path(config_file).write_text(
         yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/array.yml
@@ -68,6 +68,11 @@ install_data:
     source: r{{configpath}}/../input/templates/
     target: templates
 
+simulator:
+  queue_system:
+    name: local
+    max_running: 3
+
 forward_model:
   - well_swapping --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
 

--- a/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
+++ b/tests/everest/test_data/open_shut_state_modifier/everest/model/index.yml
@@ -86,6 +86,11 @@ install_data:
     source: r{{configpath}}/../input/templates/
     target: templates
 
+simulator:
+  queue_system:
+    name: local
+    max_running: 3
+
 forward_model:
   - well_swapping --priorities well_priorities.json --constraints swapping_constraints.json --cases wells.json --output well_swap_output.json --config files/well_swap_config.yml
 

--- a/tests/everest/test_data/templating/config.yml
+++ b/tests/everest/test_data/templating/config.yml
@@ -26,6 +26,11 @@ optimization:
 model:
   realizations: [0]
 
+simulator:
+  queue_system:
+    name: local
+    max_running: 3
+
 environment:
   output_folder: everest_output
   simulation_folder: simulations_by_templating

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -157,7 +157,6 @@ def test_that_multiple_everest_clients_can_connect_to_server(cached_example):
 
     config_path = Path(path) / config_file
     config_content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    config_content["simulator"] = {"queue_system": {"name": "local"}}
     config_path.write_text(
         yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -157,7 +157,7 @@ def test_status_failed_job(_, change_to_tmpdir, mock_server):
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch("everest.detached.everserver._configure_loggers")
 async def test_status_exception(_, change_to_tmpdir, min_config):
-    min_config["simulator"] = {"queue_system": {"name": "local"}}
+    min_config["simulator"] = {"queue_system": {"name": "local", "max_running": 3}}
     config = EverestConfig(**min_config)
 
     await wait_for_server_to_complete(config)
@@ -178,7 +178,6 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
     }
     config = EverestConfig.model_validate(config_dict)
 
@@ -207,7 +206,6 @@ async def test_status_too_few_realizations_succeeded(copy_math_func_test_data_to
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
         "model": {"realizations": [0, 1]},
     }
     config_dict["install_jobs"].append(
@@ -236,7 +234,6 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
     }
     config_dict["install_jobs"].append({"name": "fail", "executable": which("false")})
     config_dict["forward_model"].append("fail")
@@ -258,7 +255,10 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
 @pytest.mark.timeout(240)
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 async def test_status_contains_max_runtime_failure(change_to_tmpdir, min_config):
-    min_config["simulator"] = {"queue_system": {"name": "local"}, "max_runtime": 1}
+    min_config["simulator"] = {
+        "queue_system": {"name": "local", "max_running": 3},
+        "max_runtime": 1,
+    }
     min_config["forward_model"] = ["sleep 5"]
     min_config["install_jobs"] = [{"name": "sleep", "executable": which("sleep")}]
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -20,7 +20,6 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     # Ensure no interference with plugins which may set queue system
     config_file = "config_minimal.yml"
     config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
-    config_content["simulator"] = {"queue_system": {"name": "local"}}
     Path(config_file).write_text(
         yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -71,7 +71,7 @@ def test_math_func_advanced(cached_example):
 def test_remove_run_path(copy_math_func_test_data_to_tmp):
     with open("config_minimal.yml", encoding="utf-8") as file:
         config_yaml = yaml.safe_load(file)
-        config_yaml["simulator"] = {"delete_run_path": True}
+        config_yaml["simulator"]["delete_run_path"] = True
         config_yaml["install_jobs"].append(
             {"name": "toggle_failure", "executable": "jobs/fail_simulation.py"}
         )


### PR DESCRIPTION
Try to fix overloading of cpus on for komodo testing.
Tests have failed with following loads:
```
System load after test failure (1/5/15min): 21.68, 15.73, 7.64, cpu_count=6
```

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
