### PR TITLE
Fix ome arkmode color issues

### DIFF
--- a/src/ert/gui/model/snapshot.py
+++ b/src/ert/gui/model/snapshot.py
@@ -15,6 +15,7 @@ from ert.ensemble_evaluator.snapshot import (
     EnsembleSnapshotMetadata,
     convert_iso8601_to_datetime,
 )
+from ert.gui import is_dark_mode
 from ert.gui.model.node import (
     ForwardModelStepNode,
     IterNode,
@@ -400,6 +401,8 @@ class SnapshotModel(QAbstractItemModel):
                 index.data(FileRole)
             ):
                 return QColor(Qt.GlobalColor.blue)
+            elif is_dark_mode():
+                return QColor(Qt.GlobalColor.black)
 
         if role == Qt.ItemDataRole.BackgroundRole:
             return (

--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -4,6 +4,8 @@ from PyQt6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from PyQt6.QtGui import QColor, QIcon
 from typing_extensions import override
 
+from ert.gui import is_dark_mode
+
 from .plot_api import PlotApiKeyDefinition
 
 
@@ -52,6 +54,12 @@ class DataTypeKeysListModel(QAbstractItemModel):
                 return item.key
             elif role == Qt.ItemDataRole.BackgroundRole and item.observations:
                 return self.HAS_OBSERVATIONS
+            elif (
+                role == Qt.ItemDataRole.ForegroundRole
+                and item.observations
+                and is_dark_mode()
+            ):
+                return QColor(Qt.GlobalColor.black)
 
         return None
 


### PR DESCRIPTION
Fixed for observations in the plotter
Fixed for fm_step_data

**Issue**
Resolves #my_issue
<img width="746" height="1058" alt="image" src="https://github.com/user-attachments/assets/f2abf458-b020-43bf-9318-1b2af21cc45b" />

<img width="746" height="1058" alt="image" src="https://github.com/user-attachments/assets/e1e5c527-5ec6-45e8-8f51-8af526735a93" />



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
