### PR TITLE
Remove ensemble size from *experiment_panel, use active_realizations

### DIFF
--- a/src/ert/gui/simulation/ensemble_experiment_panel.py
+++ b/src/ert/gui/simulation/ensemble_experiment_panel.py
@@ -39,7 +39,6 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
     def __init__(
         self,
         analysis_config: AnalysisConfig,
-        ensemble_size: int,
         active_realizations: list[bool],
         config_num_realization: int,
         run_path: str,
@@ -82,7 +81,7 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         number_of_realizations_container = QWidget()
         number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
         number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
-        number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
+        number_of_realizations_label = QLabel(f"<b>{len(active_realizations)}</b>")
         number_of_realizations_label.setObjectName("num_reals_label")
         number_of_realizations_layout.addWidget(number_of_realizations_label)
 
@@ -91,7 +90,7 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         )
 
         self._active_realizations_field = StringBox(
-            ActiveRealizationsModel(ensemble_size),  # type: ignore
+            ActiveRealizationsModel(len(active_realizations)),  # type: ignore
             "config/simulation/active_realizations",
         )
         self._active_realizations_field.setValidator(

--- a/src/ert/gui/simulation/ensemble_information_filter_panel.py
+++ b/src/ert/gui/simulation/ensemble_information_filter_panel.py
@@ -44,7 +44,6 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         analysis_config: AnalysisConfig,
         run_path: str,
         notifier: ErtNotifier,
-        ensemble_size: int,
         active_realizations: list[bool],
         config_num_realization: int,
     ) -> None:
@@ -70,7 +69,7 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
-        number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
+        number_of_realizations_label = QLabel(f"<b>{len(active_realizations)}</b>")
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
         self._ensemble_format_model = TargetEnsembleModel(analysis_config, notifier)
@@ -83,7 +82,7 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         layout.addRow("Ensemble format:", self._ensemble_format_field)
 
         self._active_realizations_field = StringBox(
-            ActiveRealizationsModel(ensemble_size),  # type: ignore
+            ActiveRealizationsModel(len(active_realizations)),  # type: ignore
             "config/simulation/active_realizations",
         )
         self._active_realizations_field.setValidator(

--- a/src/ert/gui/simulation/ensemble_smoother_panel.py
+++ b/src/ert/gui/simulation/ensemble_smoother_panel.py
@@ -46,7 +46,6 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         analysis_config: AnalysisConfig,
         run_path: str,
         notifier: ErtNotifier,
-        ensemble_size: int,
         active_realizations: list[bool],
         config_num_realization: int,
     ) -> None:
@@ -78,7 +77,7 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         number_of_realizations_container = QWidget()
         number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
         number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
-        number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
+        number_of_realizations_label = QLabel(f"<b>{len(active_realizations)}</b>")
         number_of_realizations_label.setObjectName("num_reals_label")
         number_of_realizations_layout.addWidget(number_of_realizations_label)
 
@@ -96,13 +95,13 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         layout.addRow("Ensemble format:", self._ensemble_format_field)
 
         self._analysis_module_edit = AnalysisModuleEdit(
-            analysis_config.es_settings, ensemble_size
+            analysis_config.es_settings, len(active_realizations)
         )
         self._analysis_module_edit.setObjectName("ensemble_smoother_edit")
         layout.addRow("Analysis module:", self._analysis_module_edit)
 
         self._active_realizations_field = StringBox(
-            ActiveRealizationsModel(ensemble_size),  # type: ignore
+            ActiveRealizationsModel(len(active_realizations)),  # type: ignore
             "config/simulation/active_realizations",
         )
         self._active_realizations_field.setValidator(

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -159,7 +159,6 @@ class ExperimentPanel(QWidget):
         self.addExperimentConfigPanel(
             EnsembleExperimentPanel(
                 analysis_config,
-                ensemble_size,
                 active_realizations,
                 config_num_realization,
                 run_path,
@@ -181,7 +180,6 @@ class ExperimentPanel(QWidget):
                 analysis_config,
                 run_path,
                 notifier,
-                ensemble_size,
                 active_realizations,
                 config_num_realization,
             ),
@@ -192,7 +190,6 @@ class ExperimentPanel(QWidget):
                 analysis_config,
                 run_path,
                 notifier,
-                ensemble_size,
                 active_realizations,
                 config_num_realization,
             ),
@@ -203,7 +200,6 @@ class ExperimentPanel(QWidget):
                 analysis_config,
                 run_path,
                 notifier,
-                ensemble_size,
                 active_realizations,
                 config_num_realization,
             ),

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -58,7 +58,6 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         analysis_config: AnalysisConfig,
         run_path: str,
         notifier: ErtNotifier,
-        ensemble_size: int,
         active_realizations: list[bool],
         config_num_realization: int,
     ) -> None:
@@ -91,7 +90,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         number_of_realizations_container = QWidget()
         number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
         number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
-        number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
+        number_of_realizations_label = QLabel(f"<b>{len(active_realizations)}</b>")
         number_of_realizations_label.setObjectName("num_reals_label")
         number_of_realizations_layout.addWidget(number_of_realizations_label)
 
@@ -115,11 +114,11 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._createInputForWeights(layout)
 
         self._analysis_module_edit = AnalysisModuleEdit(
-            analysis_config.es_settings, ensemble_size
+            analysis_config.es_settings, len(active_realizations)
         )
         layout.addRow("Analysis module:", self._analysis_module_edit)
         self._active_realizations_field = StringBox(
-            ActiveRealizationsModel(ensemble_size),  # type: ignore
+            ActiveRealizationsModel(len(active_realizations)),  # type: ignore
             "config/simulation/active_realizations",
         )
         self._active_realizations_field.setValidator(


### PR DESCRIPTION
**Issue**
Resolves #11318 


**Approach**
Ensemble size is the length of active_realizations, so when we have this, use it.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
