### PR TITLE
Remove setting of env var ECL_SKIP_SIGNAL

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   ERT_SHOW_BACKTRACE: 1
-  ECL_SKIP_SIGNAL: 1
   ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
   UV_FROZEN: true
   OMP_NUM_THREADS: 1

--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -93,7 +93,6 @@ run_everest_egg_test() {
 
 start_tests() {
     export NO_PROXY=localhost,127.0.0.1
-    export ECL_SKIP_SIGNAL=ON
     export ERT_PYTEST_ARGS=--eclipse-simulator
     # Restricting the number of threads utilized by numpy to control memory consumption
     #, as some tests evaluate memory usage and additional threads increase it.


### PR DESCRIPTION
This was an environment variable that would change how resdata (previously ecl and libecl) set up signal handlers. In resdata, this has changed name to RD_SKIP_SIGNAL. Since it is not needed anymore for Ert, it should just be removed.

**Issue**
Resolves gruff

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
