### PR TITLE
Revert "Set OMP_NUM_THREADS=1 for testkomodo.sh"

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -95,10 +95,6 @@ start_tests() {
     export NO_PROXY=localhost,127.0.0.1
     export ECL_SKIP_SIGNAL=ON
     export ERT_PYTEST_ARGS=--eclipse-simulator
-    # Restricting the number of threads utilized by numpy to control memory consumption
-    #, as some tests evaluate memory usage and additional threads increase it.
-    # Also reduces cpu usage, since we run most tests in parallell anyway.
-    export OMP_NUM_THREADS=1
 
     pushd "${CI_TEST_ROOT}"/tests/ert || exit 1
 
@@ -112,6 +108,9 @@ start_tests() {
       run_everest_egg_test
       return $?
     elif [ "$CI_SUBSYSTEM_TEST" == "ert-limit-memory" ]; then
+      # Restricting the number of threads utilized by numpy to control memory consumption, as some tests evaluate memory usage and additional threads increase it.
+      export OMP_NUM_THREADS=1
+
       # Run ert tests that evaluates memory consumption
       just -f "${CI_SOURCE_ROOT}"/justfile ert-memory-tests
       return $?


### PR DESCRIPTION
This reverts commit 4b2f0014a2c58c026e7b0de786c3c659f5f9fbcb.

**Issue**
Resolves #11378 


**Approach**
Revert offending commit. This is not a permanent solution, as there should not be any such dependency on this variable. 



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
