### PR TITLE
Handle missing data in responses endpoint

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -116,10 +116,15 @@ def data_for_response(
     assert response_key is not None
     assert response_type is not None
 
+    realizations_with_responses = ensemble.get_realization_list_with_responses()
+
+    if len(realizations_with_responses) == 0:
+        return pd.DataFrame()
+
     if response_type == "summary":
         summary_data = ensemble.load_responses(
             response_key,
-            tuple(ensemble.get_realization_list_with_responses()),
+            tuple(realizations_with_responses),
         )
 
         df = (
@@ -136,9 +141,7 @@ def data_for_response(
         return data.astype(float)
 
     if response_type == "gen_data":
-        data = ensemble.load_responses(
-            response_key, tuple(ensemble.get_realization_list_with_responses())
-        )
+        data = ensemble.load_responses(response_key, tuple(realizations_with_responses))
 
         try:
             assert filter_on is not None

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -461,11 +461,8 @@ class LocalEnsemble(BaseMode):
             path = self._realization_dir(realization)
 
             def _has_response(key_: str) -> bool:
-                if key_ in self.experiment.response_key_to_response_type:
-                    response_type = self.experiment.response_key_to_response_type[key_]
-                    return (path / f"{response_type}.parquet").exists()
-
-                return (path / f"{key_}.parquet").exists()
+                df_key = self.experiment.response_key_to_response_type.get(key_, key_)
+                return (path / f"{df_key}.parquet").exists()
 
             if key:
                 return _has_response(key)

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -408,3 +408,27 @@ def test_that_observations_for_empty_ensemble_returns_empty_data(api_and_storage
     )
     ensemble = storage.create_ensemble(experiment.id, ensemble_size=1)
     assert api.observations_for_key([str(ensemble.id)], "NAIMFRAC").empty
+
+
+def test_data_for_response_no_realizations(api_and_storage):
+    api, storage = api_and_storage
+
+    experiment = storage.create_experiment(
+        parameters=[],
+        responses=[
+            SummaryConfig(
+                name="summary",
+                input_files=[],
+                keys=["FOPT"],
+                has_finalized_keys=True,
+            )
+        ],
+    )
+
+    ensemble = experiment.create_ensemble(
+        ensemble_size=1, name="ensemble_without_responses"
+    )
+
+    result_df = api.data_for_response(str(ensemble.id), "FOPT")
+
+    assert result_df.empty


### PR DESCRIPTION
**Issue**
Resolves [#11375](https://github.com/equinor/ert/issues/11375)


**Approach**
Return empty df when responses are missing (same behavior as currently/previously done for gen data)

