### PR TITLE
Add signal 15 SIGTERM to accepted returncodes for LSF state test

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_generic_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_generic_driver.py
@@ -101,8 +101,9 @@ async def test_kill_gives_correct_state(driver: Driver, use_tmpdir, request):
         ]
     else:
         expected_returncodes = [
-            SIGNAL_OFFSET + signal.SIGTERM,
+            signal.SIGTERM,
             SIGNAL_OFFSET + signal.SIGINT,
+            SIGNAL_OFFSET + signal.SIGTERM,
             256 + signal.SIGKILL,
             256 + signal.SIGTERM,
         ]


### PR DESCRIPTION
**Issue**
Resolves #11290

Allow SIGTERM (signal error code 15) to expected return codes.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
