### PR TITLE
Fix error messages for drivers.kill

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -383,15 +383,16 @@ class LsfDriver(Driver):
 
     async def kill(self, iens: int) -> None:
         if iens not in self._submit_locks:
-            logger.error(
-                f"LSF kill failed, realization {iens} has never been submitted"
+            logger.debug(
+                f"LSF kill was not run, realization {iens} has never been submitted"
             )
             return
 
         async with self._submit_locks[iens]:
             if iens not in self._iens2jobid:
-                logger.error(
-                    f"LSF kill failed, realization {iens} was not submitted properly"
+                logger.warning(
+                    f"LSF kill failed, realization {iens} was not submitted properly, "
+                    "or it has already finished"
                 )
                 return
 

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -238,7 +238,10 @@ class OpenPBSDriver(Driver):
             return
 
         if iens not in self._iens2jobid:
-            logger.info(f"PBS kill failed due to missing jobid for realization {iens}")
+            logger.warning(
+                f"PBS kill failed due to missing jobid for realization {iens}. "
+                "It might have already finished"
+            )
             return
 
         job_id = self._iens2jobid[iens]

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -217,13 +217,16 @@ class SlurmDriver(Driver):
 
     async def kill(self, iens: int) -> None:
         if iens not in self._submit_locks:
-            logger.error(f"scancel failed, realization {iens} has never been submitted")
+            logger.debug(
+                f"scancel was not run, realization {iens} has never been submitted"
+            )
             return
 
         async with self._submit_locks[iens]:
             if iens not in self._iens2jobid:
-                logger.error(
-                    f"scancel failed, realization {iens} was not submitted properly"
+                logger.warning(
+                    f"scancel failed, realization {iens} was not submitted properly, "
+                    "or it has already finished"
                 )
                 return
 

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -991,10 +991,11 @@ def test_filter_job_ids_on_submission_time(time_submitted_modifier, expected_res
 
 
 async def test_kill_before_submit_logs_error(caplog):
+    caplog.set_level(logging.DEBUG)
     driver = LsfDriver()
     await driver.kill(0)
-    assert "ERROR" in caplog.text
-    assert "realization 0 has never been submitted" in caplog.text
+    assert "DEBUG" in caplog.text
+    assert "LSF kill was not run, realization 0 has never been submitted" in caplog.text
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -256,10 +256,11 @@ async def test_faulty_sbatch_produces_error_log(monkeypatch, tmp_path):
 
 
 async def test_kill_before_submit_logs_error(caplog):
+    caplog.set_level(logging.DEBUG)
     driver = SlurmDriver()
     await driver.kill(0)
-    assert "ERROR" in caplog.text
-    assert "realization 0 has never been submitted" in caplog.text
+    assert "DEBUG" in caplog.text
+    assert "scancel was not run, realization 0 has never been submitted" in caplog.text
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
**Issue**
Resolves #10467 


**Approach**
This commit makes the error message for drivers.kill when it has not been submitted into a warning instead. It also changes the error stating the job has not been submitted properly into a warning, and adds that it might have already finished.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
