### PR TITLE
Fix fm_dispatch failing if terminating before started

### DIFF
--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -50,6 +50,7 @@ def _setup_reporters(
     dispatch_url: str | None,
     ee_token: str | None = None,
     experiment_id: str | None = None,
+    real_id: str | None = None,
 ) -> list[reporting.Reporter]:
     reporters: list[reporting.Reporter] = []
     if is_interactive_run:
@@ -58,7 +59,12 @@ def _setup_reporters(
         reporters.append(reporting.File())
         if dispatch_url is not None:
             reporters.append(
-                reporting.Event(evaluator_url=dispatch_url, token=ee_token)
+                reporting.Event(
+                    evaluator_url=dispatch_url,
+                    token=ee_token,
+                    real_id=real_id,
+                    ens_id=ens_id,
+                )
             )
     else:
         reporters.append(reporting.File())
@@ -202,14 +208,11 @@ def fm_dispatch(args: list[str]) -> None:
     ens_id = fm_description.get("ens_id")
     ee_token = fm_description.get("ee_token")
     dispatch_url = fm_description.get("dispatch_url")
+    real_id = fm_description.get("real_id")
 
     is_interactive_run = len(parsed_args.steps) > 0
     reporters = _setup_reporters(
-        is_interactive_run,
-        ens_id,
-        dispatch_url,
-        ee_token,
-        experiment_id,
+        is_interactive_run, ens_id, dispatch_url, ee_token, experiment_id, str(real_id)
     )
 
     fm_runner = ForwardModelRunner(fm_description)

--- a/src/_ert/forward_model_runner/reporting/statemachine.py
+++ b/src/_ert/forward_model_runner/reporting/statemachine.py
@@ -28,7 +28,7 @@ class StateMachine:
         finished = (Finish,)
         self._handler: dict[Any, Callable[[Any], None]] = {}
         self._transitions = {
-            None: initialized,
+            None: (*initialized, Exited),
             initialized: steps + checksum + finished,
             steps: steps + checksum + finished,
             checksum: checksum + finished,

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -34,7 +34,7 @@ class ForwardModelRunner:
         self.steps: list[ForwardModelStep] = []
         for index, step_data in enumerate(steps_data["jobList"]):
             self.steps.append(ForwardModelStep(step_data, index))
-
+        self._currently_running_step: ForwardModelStep | None = None
         self._set_environment()
 
     def _read_manifest(self) -> dict[str, Manifest] | None:


### PR DESCRIPTION
**Issue**
Resolves #11400 


**Approach**
This commit fixes the issue where fm_dispatcher fails ungracefully if we terminate before it has created the Init message, or no forward_model_step has started.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
