### PR TITLE
Fix  backend handling in the optimization config

### DIFF
--- a/src/everest/config/sampler_config.py
+++ b/src/everest/config/sampler_config.py
@@ -28,6 +28,7 @@ This dict of values is passed unchanged to the selected method in the backend.
 """,
     )
     method: str = Field(
+        default="norm",
         description="""The sampling method or distribution used by the sampler backend.
 """,
     )
@@ -50,14 +51,22 @@ This dict of values is passed unchanged to the selected method in the backend.
             print(message)
             logging.getLogger(EVEREST).warning(message)
 
+        # Update the default for backends that are not scipy:
+        if (
+            self.backend not in {None, "scipy"}
+            and "method" not in self.model_fields_set
+        ):
+            self.method = "default"
+
         if self.backend is not None:
             self.method = f"{self.backend}/{self.method}"
-            self.backend = None
 
         if (
             get_ropt_plugin_manager().get_plugin_name("sampler", f"{self.method}")
             is None
         ):
-            raise ValueError(f"Sampler '{self.method}' not found")
+            raise ValueError(f"Sampler method '{self.method}' not found")
+
+        self.backend = None
 
         return self

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -207,7 +207,7 @@ def _parse_optimization(
         if (
             has_output_constraints
             and ever_opt.constraint_tolerance is not None
-            and ever_opt._optimization_plugin_name == "dakota"
+            and ever_opt.optimization_plugin_name == "dakota"
             and (
                 ever_opt.algorithm
                 in {"conmin_mfd", "conmin_frcg", "asynch_pattern_search"}

--- a/tests/everest/test_cvar.py
+++ b/tests/everest/test_cvar.py
@@ -12,8 +12,7 @@ def test_mathfunc_cvar(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {
-            "backend": "scipy",
-            "algorithm": "slsqp",
+            "algorithm": "scipy/slsqp",
             "cvar": {"percentile": 0.5},
             "max_batch_num": 5,
         },

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -13,8 +13,7 @@ def test_discrete_optimizer(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {
-            "backend": "scipy",
-            "algorithm": "differential_evolution",
+            "algorithm": "scipy/differential_evolution",
             "max_function_evaluations": 4,
             "parallel": False,
             "backend_options": {"rng": 4},

--- a/tests/everest/test_optimization_config.py
+++ b/tests/everest/test_optimization_config.py
@@ -38,3 +38,26 @@ def test_optimization_config_options_unknown_options_error():
                 "merit_function el_bakry",
             ]
         )
+
+
+@pytest.mark.parametrize(
+    "backend, algorithm, expected",
+    [
+        (None, None, "optpp_q_newton"),
+        ("dakota", None, "dakota/optpp_q_newton"),
+        (None, "conmin_mfd", "conmin_mfd"),
+        ("dakota", "conmin_mfd", "dakota/conmin_mfd"),
+        (None, "slsqp", "slsqp"),
+        ("scipy", None, "scipy/default"),
+        ("scipy", "slsqp", "scipy/slsqp"),
+    ],
+)
+def test_optimization_config_backend_and_algorithm(backend, algorithm, expected):
+    config_dict = {}
+    if backend is not None:
+        config_dict["backend"] = backend
+    if algorithm is not None:
+        config_dict["algorithm"] = algorithm
+    config = OptimizationConfig.model_validate(config_dict)
+    assert config.backend is None
+    assert config.algorithm == expected

--- a/tests/everest/test_optimization_config.py
+++ b/tests/everest/test_optimization_config.py
@@ -61,3 +61,22 @@ def test_optimization_config_backend_and_algorithm(backend, algorithm, expected)
     config = OptimizationConfig.model_validate(config_dict)
     assert config.backend is None
     assert config.algorithm == expected
+
+
+@pytest.mark.parametrize(
+    "backend, algorithm, expected",
+    [
+        (None, "foo", "Optimizer algorithm 'foo' not found"),
+        (None, "default", "Cannot specify 'default' method without a plugin name"),
+        ("foo", None, "Optimizer algorithm 'foo/default' not found"),
+        ("foo", "optpp_q_newton", "Optimizer algorithm 'foo/optpp_q_newton' not found"),
+    ],
+)
+def test_optimization_config_backend_and_algorithm_errors(backend, algorithm, expected):
+    config_dict = {}
+    if backend is not None:
+        config_dict["backend"] = backend
+    if algorithm is not None:
+        config_dict["algorithm"] = algorithm
+    with pytest.raises(ValueError, match=expected):
+        OptimizationConfig.model_validate(config_dict)

--- a/tests/everest/test_sampler_config.py
+++ b/tests/everest/test_sampler_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from everest.config import SamplerConfig
+
+
+@pytest.mark.parametrize(
+    "backend, method, expected",
+    [
+        (None, "norm", "norm"),
+        ("scipy", None, "scipy/norm"),
+        ("scipy", "norm", "scipy/norm"),
+    ],
+)
+def test_sampler_config_backend_and_method(backend, method, expected):
+    config_dict = {}
+    if backend is not None:
+        config_dict["backend"] = backend
+    if method is not None:
+        config_dict["method"] = method
+    config = SamplerConfig.model_validate(config_dict)
+    assert config.backend is None
+    assert config.method == expected
+
+
+@pytest.mark.parametrize(
+    "backend, method, expected",
+    [
+        (None, "foo", "Sampler method 'foo' not found"),
+        (None, "default", "Cannot specify 'default' method without a plugin name"),
+        ("foo", None, "Sampler method 'foo/default' not found"),
+        ("foo", "bar", "Sampler method 'foo/bar' not found"),
+    ],
+)
+def test_sampler_config_backend_and_method_errors(backend, method, expected):
+    config_dict = {}
+    if backend is not None:
+        config_dict["backend"] = backend
+    if method is not None:
+        config_dict["method"] = method
+    with pytest.raises(ValueError, match=expected):
+        SamplerConfig.model_validate(config_dict)


### PR DESCRIPTION
**Issue**
Resolves #11313


**Approach**
- Fixes handling of the backend keyword.
- Added a test for this.
- Small fix of a method name in everest2ropt.
- Fix deprecate usage of "backend" in two tests.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
