### PR TITLE
Refactor RunModel to use threading.Event for cancellation

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/conftest.py
@@ -5,7 +5,7 @@ import stat
 from collections.abc import Callable
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
 from pathlib import Path
-from queue import SimpleQueue
+from threading import Event
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -189,16 +189,16 @@ def evaluator_to_use(
 ) -> _AsyncGeneratorContextManager[EnsembleEvaluator, None]:
     @asynccontextmanager
     async def _evaluator_to_use(
-        end_queue: SimpleQueue | None = None,
+        end_event: Event | None = None,
         event_handler: Callable[[EEEvent], None] | None = None,
         ensemble: TestEnsemble | LegacyEnsemble | None = None,
     ):
-        if end_queue is None:
-            end_queue = SimpleQueue()
+        if end_event is None:
+            end_event = Event()
         if ensemble is None:
             ensemble = TestEnsemble(0, 2, 2, id_="0")
         evaluator = EnsembleEvaluator(
-            ensemble, make_ee_config(use_token=False), end_queue, event_handler
+            ensemble, make_ee_config(use_token=False), end_event, event_handler
         )
         evaluator._batching_interval = 0.5  # batching can be faster for tests
         run_task = asyncio.create_task(evaluator.run_and_get_successful_realizations())

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
 from functools import partial
-from queue import SimpleQueue
+from threading import Event
 
 import pytest
 import zmq.asyncio
@@ -58,7 +58,7 @@ async def test_when_task_fails_evaluator_raises_exception(
     evaluator = EnsembleEvaluator(
         TestEnsemble(0, 2, 2, id_="0"),
         make_ee_config(use_token=False),
-        end_queue=SimpleQueue(),
+        end_event=Event(),
     )
 
     monkeypatch.setattr(
@@ -74,7 +74,7 @@ async def test_evaluator_raises_on_invalid_dispatch_event(make_ee_config):
     evaluator = EnsembleEvaluator(
         TestEnsemble(0, 2, 2, id_="0"),
         make_ee_config(),
-        end_queue=SimpleQueue(),
+        end_event=Event(),
     )
 
     with pytest.raises(ValidationError):
@@ -87,7 +87,7 @@ async def test_evaluator_handles_dispatchers_connected(
     evaluator = EnsembleEvaluator(
         TestEnsemble(0, 2, 2, id_="0"),
         make_ee_config(),
-        end_queue=SimpleQueue(),
+        end_event=Event(),
     )
 
     await evaluator.handle_dispatch(b"dispatcher-1", CONNECT_MSG)
@@ -115,7 +115,7 @@ async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):
         evaluator = EnsembleEvaluator(
             TestEnsemble(0, 2, 2, id_="0"),
             ee_config,
-            end_queue=SimpleQueue(),
+            end_event=Event(),
         )
         with pytest.raises(
             zmq.error.ZMQBindError, match="Could not bind socket to random port"
@@ -130,7 +130,7 @@ async def test_no_config_raises_valueerror_when_running():
     evaluator = EnsembleEvaluator(
         TestEnsemble(0, 2, 2, id_="0"),
         None,
-        end_queue=SimpleQueue(),
+        end_event=Event(),
     )
     with pytest.raises(ValueError, match="no config for evaluator"):
         await evaluator.run_and_get_successful_realizations()
@@ -158,7 +158,7 @@ async def test_when_task_prematurely_ends_raises_exception(
     evaluator = EnsembleEvaluator(
         TestEnsemble(0, 2, 2, id_="0"),
         make_ee_config(),
-        end_queue=SimpleQueue(),
+        end_event=Event(),
         event_handler=event_handler,
     )
     monkeypatch.setattr(

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -57,7 +57,7 @@ async def test_run_and_cancel_legacy_ensemble(
 
         _ = await event_queue.get()
         # Cancel the ensemble upon the arrival of the first event
-        evaluator._end_queue.put("END")
+        evaluator._end_event.set()
         try:
             await evaluator.wait_for_evaluation_result()
             assert evaluator._ensemble.status == state.ENSEMBLE_STATE_STOPPED

--- a/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from queue import SimpleQueue
+from threading import Event
 from unittest.mock import AsyncMock
 
 import pytest
@@ -53,9 +53,7 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
 
         event_queue = asyncio.Queue()
 
-        evaluator = EnsembleEvaluator(
-            ensemble, config, SimpleQueue(), event_queue.put_nowait
-        )
+        evaluator = EnsembleEvaluator(ensemble, config, Event(), event_queue.put_nowait)
 
         async def mock_checksum_consumer(self, *args) -> None:
             event = await self._manifest_queue.get()

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -422,7 +422,7 @@ def test_get_number_of_active_realizations_varies_when_rerun_or_new_iteration(
 
 async def test_terminate_in_pre_evaluation(use_tmpdir):
     brm = create_run_model()
-    brm._end_queue.put("terminate")
+    brm._end_event.set()
     with pytest.raises(
         UserCancelled, match="Experiment cancelled by user in pre evaluation"
     ):
@@ -440,12 +440,12 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
     evaluator()._server_started = asyncio.Future()
     evaluator()._server_started.set_result(None)
 
-    async def send_terminate(end_queue) -> bool:
-        end_queue.put("terminate")
+    async def send_terminate(end_event) -> bool:
+        end_event.set()
         return True
 
     brm = create_run_model()
-    evaluator().wait_for_evaluation_result = MethodType(send_terminate, brm._end_queue)
+    evaluator().wait_for_evaluation_result = MethodType(send_terminate, brm._end_event)
     with pytest.raises(
         UserCancelled,
         match="Experiment cancelled by user in post evaluation",


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11340


**Approach**
This commit changes RunModel and EnsembleEvaluator to use threading.Event to cancel instead of queue.SimpleQueue.
Ideally, we would use asyncio.Event(), but that caused a lot of issues in everest.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
