### PR TITLE
Do copy unupdated parameters only once in enif

### DIFF
--- a/src/ert/analysis/_enif_update.py
+++ b/src/ert/analysis/_enif_update.py
@@ -239,13 +239,13 @@ def analysis_EnIF(
             f"Storing data for {param_group} completed in "
             f"{(time.time() - start) / 60} minutes"
         )
-        _copy_unupdated_parameters(
-            list(source_ensemble.experiment.parameter_configuration.keys()),
-            parameters,
-            iens_active_index,
-            source_ensemble,
-            target_ensemble,
-        )
+    _copy_unupdated_parameters(
+        list(source_ensemble.experiment.parameter_configuration.keys()),
+        parameters,
+        iens_active_index,
+        source_ensemble,
+        target_ensemble,
+    )
 
     stop_enif = time.time()
     logger.info(f"EnIF total update time: {stop_enif - start_enif} seconds")


### PR DESCRIPTION
**Issue**
Unupdated parameters should be copied only once.


**Approach**
Fix wrong indentation.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
