### PR TITLE
Add qtbot fixture parameter to test

### DIFF
--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -87,7 +87,7 @@ def open_gui(tmp_path, monkeypatch, run_experiment, tmp_path_factory):
         yield gui
 
 
-def test_sensitivity_restart(open_gui, run_experiment):
+def test_sensitivity_restart(open_gui, qtbot, run_experiment):
     """This runs a full manual update workflow, first running ensemble experiment
     where some of the realizations fail, then doing an update before running an
     ensemble experiment again to calculate the forecast of the update.


### PR DESCRIPTION
What I believe caused this test to fail locally is that a QApplication was never made, which caused MainWindow init to never be called. qtbot will handle this for us.

I am still uncertain why this test passed without issues on github CI pipeline.

**Issue**
Resolves #11399 

https://github.com/user-attachments/assets/8b890e99-4367-4347-9d24-e6a9b2392958


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
