### PR TITLE
Move evaluate from ensemble to EnsembleEvaluator

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -91,7 +91,7 @@ class Job:
     def unschedule(self, msg: str) -> None:
         self.state = JobState.ABORTED
         self.real.run_arg.ensemble_storage.set_failure(
-            self.real.run_arg.iens,
+            self.real.iens,
             RealizationStorageState.LOAD_FAILURE,
             f"Job not scheduled due to {msg}",
         )

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_legacy.py
@@ -1,14 +1,13 @@
 import asyncio
 import os
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from _ert.events import EEEvent
-from ert.config import QueueConfig
 from ert.ensemble_evaluator import EnsembleEvaluator, state
 from ert.ensemble_evaluator.evaluator import UserCancelled
-from ert.scheduler import Scheduler, job
+from ert.scheduler import job
 from ert.scheduler.job import Job
 
 
@@ -66,28 +65,3 @@ async def test_run_and_cancel_legacy_ensemble(
         # realisations should not finish, thus not creating a status-file
         for i in range(num_reals):
             assert not os.path.isfile(f"real_{i}/status.txt")
-
-
-async def test_queue_config_properties_propagated_to_scheduler(
-    tmpdir, make_ensemble, monkeypatch
-):
-    num_reals = 1
-    mocked_scheduler = MagicMock()
-    mocked_scheduler.__class__ = Scheduler
-    monkeypatch.setattr(Scheduler, "__init__", mocked_scheduler)
-    ensemble = make_ensemble(monkeypatch, tmpdir, num_reals, 2)
-    ensemble._config = MagicMock()
-    ensemble._scheduler = mocked_scheduler
-
-    # The properties we want to propagate from QueueConfig to the Scheduler object:
-    monkeypatch.setattr(QueueConfig, "submit_sleep", 33)
-    monkeypatch.setattr(QueueConfig, "max_running", 44)
-    ensemble._queue_config.max_submit = 55
-
-    # The function under test:
-    await ensemble.evaluate(config=MagicMock())
-
-    # Assert properties successfully propagated:
-    assert Scheduler.__init__.call_args.kwargs["submit_sleep"] == 33
-    assert Scheduler.__init__.call_args.kwargs["max_running"] == 44
-    assert Scheduler.__init__.call_args.kwargs["max_submit"] == 55


### PR DESCRIPTION
**Approach**
It makes more sense that evaluate be in EnsembleEVALUATOR instead of ensemble. This also moves scheduler and driver from ensemble to evaluator, so we don't have to do as nested method calls anymore (still nested, but slightly better).
 
(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
