### PR TITLE
Use None for LOG10 of gen_kw params if value  <= 0

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -337,18 +336,7 @@ class GenKwConfig(ParameterConfig):
             )
 
         data = df.to_dicts()[0]
-
-        log10_data: dict[str, float | str] = {
-            tf.name: math.log10(data[tf.name])
-            for tf in self.transform_functions
-            if isinstance(tf.distribution, LogNormalSettings | LogUnifSettings)
-            and isinstance(data[tf.name], (int, float))
-        }
-
-        if log10_data:
-            return {self.name: data, f"LOG10_{self.name}": log10_data}
-        else:
-            return {self.name: data}
+        return {self.name: data}
 
     def save_parameters(
         self,

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -186,30 +186,14 @@ number_regex = r"[-+]?(?:\d*\.\d+|\d+)"
     "distribution, expect_log, parameters_regex",
     [
         ("NORMAL 0 1", False, r"KW_NAME:MY_KEYWORD " + number_regex),
-        (
-            "LOGNORMAL 0 1",
-            True,
-            r"KW_NAME:MY_KEYWORD "
-            + number_regex
-            + r"\n"
-            + r"LOG10_KW_NAME:MY_KEYWORD "
-            + number_regex,
-        ),
+        ("LOGNORMAL 0 1", True, r"KW_NAME:MY_KEYWORD " + number_regex + r"\n"),
         ("UNIFORM 0 1", False, r"KW_NAME:MY_KEYWORD " + number_regex),
         (
             "TRUNCATED_NORMAL 1 0.25 0 10",
             False,
             r"KW_NAME:MY_KEYWORD " + number_regex,
         ),
-        (
-            "LOGUNIF 0.0001 1",
-            True,
-            r"KW_NAME:MY_KEYWORD "
-            + number_regex
-            + r"\n"
-            + r"LOG10_KW_NAME:MY_KEYWORD "
-            + number_regex,
-        ),
+        ("LOGUNIF 0.0001 1", True, r"KW_NAME:MY_KEYWORD " + number_regex),
         ("CONST 1.0", False, "KW_NAME:MY_KEYWORD 1\n"),
         ("DUNIF 5 1 5", False, r"KW_NAME:MY_KEYWORD " + number_regex),
         ("ERRF 1 2 0.1 0.1", False, r"KW_NAME:MY_KEYWORD " + number_regex),


### PR DESCRIPTION
If the raw (updated) params are 0 or negative, we avoid exception.

**Issue**
Resolves #9585 


**Approach**
in gen_kw_config.py the function write_to_runpath (not a perfect name, anymore) takes log10 of parameters (for writing to parameters.{txt|json}) if they are of the log distributions, and this fails if the values are <= 0. 

Suggestion: Use None as log10 value if raw gen_kw params is <=0

Note: Also handle the "on the fly" log10 of the same values in the plotting department (causes an exception in the terminal output)

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
