### PR TITLE
Make ert exit with message when logs directory is nonwritable

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -635,8 +635,8 @@ def main() -> None:
         except ValueError as err:
             if "handler 'file'" in str(err):
                 exit_msg = (
-                    "Could not configure log handler for files. "
-                    "Check if you have write-access to the logs-directory."
+                    f"Could not configure log handler for files. "
+                    f"Check if you have write-access to the logs-directory ({log_dir})."
                 )
             else:
                 exit_msg = str(err)

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -630,7 +630,18 @@ def main() -> None:
                 handler_config["filename"] = "ert-log.txt"
             if "ert.logging.TimestampedFileHandler" in handler_config.values():
                 handler_config["config_filename"] = args.config
-        logging.config.dictConfig(config_dict)
+        try:
+            logging.config.dictConfig(config_dict)
+        except ValueError as err:
+            if "handler 'file'" in str(err):
+                exit_msg = (
+                    "Could not configure log handler for files. "
+                    "Check if you have write-access to the logs-directory."
+                )
+            else:
+                exit_msg = str(err)
+            os.environ.pop("ERT_LOG_DIR")
+            sys.exit(exit_msg)
 
     logger = logging.getLogger(__name__)
     if args.verbose:

--- a/tests/ert/unit_tests/shared/test_main_entry.py
+++ b/tests/ert/unit_tests/shared/test_main_entry.py
@@ -61,10 +61,11 @@ def test_non_writable_log_directory_exits_with_message(monkeypatch, use_tmpdir):
     os.mkdir(logs_dir)
     os.chmod(logs_dir, 0o444)  # Read only access mode
 
-    expected_exit_message = (
-        "Could not configure log handler for files. "
-        "Check if you have write-access to the logs-directory."
-    )
+    expected_exit_messages = [
+        "Could not configure log handler for files.",
+        "Check if you have write-access to the logs-directory",
+        logs_dir,
+    ]
 
     class ErtparserMock(MagicMock):
         logdir = logs_dir
@@ -73,4 +74,7 @@ def test_non_writable_log_directory_exits_with_message(monkeypatch, use_tmpdir):
 
     with pytest.raises(SystemExit) as exc_info:
         main.main()
-    assert expected_exit_message in str(exc_info)
+    assert all(
+        expected_exit_message in str(exc_info)
+        for expected_exit_message in expected_exit_messages
+    )


### PR DESCRIPTION
Should the logs directory be non-writable, the logger config setup fails with a valueerror, causing an ugly traceback in the command line. This commit will catch it and formulate it to the user.

**Issue**
Resolves #10386 


**Approach**
What happens:
- Main calls logging.config
- logging.config calls the `__init__` of `TimestampedFileHandler`
- `TimestampedFileHandler` inherits from logging classes, so these `__init__`s are called, which is where this crashed:
```py
open_func = self._builtin_open
return open_func(self.baseFilename, self.mode, encoding=self.encoding, errors=self.errors)
```
- This raises a `PermissionsError`
- `PermissionError` is caught as a normal `Exception` in the config method one level under main which is raised as a `ValueError`

Now - My handling of this `ValueError` is a bit extensive, but get the job done. Thought I would make some if else cases should there be other errors being raised from this step, which I am unsure of is realistic.

I also thought it could be nice to have it shown in the GUI together with validation errors, but this logging configuration step is before any GUI has been instantialized, so there would be some ugly logic to handle it based on selected runmodel. Thoughts? Can it be done clean, or better to not introduce any GUI logic in the `__main__` scope of ERT?


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
