### PR TITLE
Speed up scheduler tests

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_generic_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_generic_driver.py
@@ -55,6 +55,7 @@ def driver(request, pytestconfig, monkeypatch, tmp_path):
 @pytest.mark.integration_test
 async def test_submit(driver: Driver, tmp_path, job_name, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", f"echo test > {tmp_path}/test", name=job_name)
     await poll(driver, {0})
 
@@ -77,6 +78,7 @@ async def test_submit_something_that_fails(
         nonlocal finished_called
         finished_called = True
 
+    driver._poll_period = 0.01
     await driver.submit(
         0,
         "sh",
@@ -93,6 +95,7 @@ async def test_submit_something_that_fails(
 @pytest.mark.integration_test
 async def test_kill_gives_correct_state(driver: Driver, use_tmpdir, request):
     aborted_called = False
+    driver._poll_period = 0.01
 
     if isinstance(driver, SlurmDriver):
         expected_returncodes = [
@@ -157,6 +160,7 @@ async def test_repeated_submit_same_iens(driver: Driver, tmp_path, monkeypatch):
 async def test_kill_actually_kills(driver: Driver, tmp_path, pytestconfig, monkeypatch):
     monkeypatch.chdir(tmp_path)
     finished = False
+    driver._poll_period = 0.01
 
     async def kill_job_once_started(iens):
         nonlocal driver
@@ -191,6 +195,7 @@ async def test_num_cpu_sets_env_variables(
     if isinstance(driver, LocalDriver):
         pytest.skip("LocalDriver has no NUM_CPU concept")
     monkeypatch.chdir(tmp_path)
+    driver._poll_period = 0.01
     await driver.submit(
         0,
         "sh",

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -15,7 +15,7 @@ from typing import get_args, get_type_hints
 from unittest.mock import AsyncMock
 
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from ert.config import QueueConfig
@@ -96,9 +96,10 @@ async def test_exit_codes(tmp_path_factory, bjobs_script, bhist_script, exit_cod
 
 
 @given(
-    jobstate_sequence=st.lists(st.sampled_from(JobState.__args__)),
+    jobstate_sequence=st.lists(st.sampled_from(JobState.__args__), min_size=1),
     exit_code=st.integers(min_value=1, max_value=254),
 )
+@settings(max_examples=10)
 async def test_events_produced_from_jobstate_updates(
     tmp_path_factory, jobstate_sequence: list[str], exit_code: int
 ):
@@ -205,6 +206,7 @@ async def test_submit_with_project_code():
 @pytest.mark.usefixtures("capturing_bsub")
 async def test_submit_sets_stdout():
     driver = LsfDriver()
+    driver._poll_period = 0.01
     await driver.submit(0, "sleep", name="myjobname")
     expected_stdout_file = Path(os.getcwd()) / "myjobname.LSF-stdout"
     assert f"-o {expected_stdout_file}" in Path("captured_bsub_args").read_text(
@@ -1027,6 +1029,7 @@ def not_found_bjobs(monkeypatch, tmp_path):
 async def test_bjobs_exec_host_logs_only_once(use_tmpdir, job_name, caplog):
     caplog.set_level(logging.INFO)
     driver = LsfDriver()
+    driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", "sleep 1", name=job_name)
 
     job_id = next(iter(driver._jobs.keys()))
@@ -1040,6 +1043,7 @@ async def test_bjobs_exec_host_logs_only_once(use_tmpdir, job_name, caplog):
 @pytest.mark.integration_test
 async def test_lsf_stdout_file(use_tmpdir, job_name):
     driver = LsfDriver()
+    driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", "echo yay", name=job_name)
     await poll(driver, {0})
     lsf_stdout = Path(f"{job_name}.LSF-stdout").read_text(encoding="utf-8")
@@ -1055,6 +1059,7 @@ async def test_lsf_stdout_file(use_tmpdir, job_name):
 @pytest.mark.integration_test
 async def test_lsf_dumps_stderr_to_file(use_tmpdir, job_name):
     driver = LsfDriver()
+    driver._poll_period = 0.01
     failure_message = "failURE"
     await driver.submit(0, "sh", "-c", f"echo {failure_message} >&2", name=job_name)
     await poll(driver, {0})
@@ -1079,6 +1084,7 @@ async def test_lsf_can_retrieve_stdout_and_stderr(
     use_tmpdir, job_name, tail_chars_to_read
 ):
     driver = LsfDriver()
+    driver._poll_period = 0.01
     num_written_characters = 600
     out = generate_random_text(num_written_characters)
     err = generate_random_text(num_written_characters)
@@ -1100,6 +1106,7 @@ async def test_lsf_can_retrieve_stdout_and_stderr(
 @pytest.mark.integration_test
 async def test_lsf_cannot_retrieve_stdout_and_stderr(use_tmpdir, job_name):
     driver = LsfDriver()
+    driver._poll_period = 0.01
     num_written_characters = 600
     out = generate_random_text(num_written_characters)
     err = generate_random_text(num_written_characters)
@@ -1124,6 +1131,7 @@ async def test_lsf_info_file_in_runpath(
 ):
     monkeypatch.chdir(tmp_path)
     driver = LsfDriver()
+    driver._poll_period = 0.01
     (tmp_path / "some_runpath").mkdir()
     effective_runpath = tmp_path / "some_runpath" if explicit_runpath else tmp_path
     await driver.submit(
@@ -1152,6 +1160,7 @@ async def test_submit_to_named_queue(tmp_path, caplog, job_name, monkeypatch):
     test for success for the job."""
     monkeypatch.chdir(tmp_path)
     driver = LsfDriver(queue_name=os.getenv("_ERT_TESTS_ALTERNATIVE_QUEUE"))
+    driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", f"echo test > {tmp_path}/test", name=job_name)
     await poll(driver, {0})
 
@@ -1163,6 +1172,7 @@ async def test_submit_to_named_queue(tmp_path, caplog, job_name, monkeypatch):
 async def test_submit_with_resource_requirement(job_name):
     resource_requirement = "select[cs && x86_64Linux]"
     driver = LsfDriver(resource_requirement=resource_requirement)
+    driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", "echo test>test", name=job_name)
     await poll(driver, {0})
 
@@ -1261,6 +1271,8 @@ async def test_polling_bhist_fallback(not_found_bjobs, caplog, job_name):
     Path("mock_jobs/pendingtimemillis").write_text("100", encoding="utf-8")
     driver._poll_period = 0.01
 
+    driver._bhist_required_cache_age = 0.01
+    driver._sleep_time_between_cmd_retries = 0.01
     bhist_called = False
     original_bhist_method = driver._poll_once_by_bhist
 

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from ert.cli.main import ErtCliError
@@ -265,6 +265,7 @@ async def test_faulty_qstat(monkeypatch, tmp_path, qstat_script, started_expecte
 
 
 @given(st.integers(), st.integers(min_value=1), words)
+@settings(max_examples=10)
 @pytest.mark.usefixtures("capturing_qsub")
 async def test_full_resource_string(realization_memory, num_cpu, cluster_label):
     driver = OpenPBSDriver(
@@ -361,6 +362,7 @@ async def test_that_qsub_will_retry_and_succeed(
     )
     qsub_path.chmod(qsub_path.stat().st_mode | stat.S_IEXEC)
     driver = OpenPBSDriver()
+    driver._poll_period = 0.01
     driver._max_pbs_cmd_attempts = 2
     driver._sleep_time_between_cmd_retries = 0.2
     await driver.submit(0, "sleep 10")
@@ -401,7 +403,7 @@ async def test_that_qdel_will_retry_and_succeed(
     qdel_path.chmod(qdel_path.stat().st_mode | stat.S_IEXEC)
     driver = OpenPBSDriver()
     driver._max_pbs_cmd_attempts = 2
-    driver._retry_pbs_cmd_interval = 0.2
+    driver._sleep_time_between_cmd_retries = 0.2
     driver._iens2jobid[0] = 111
     await driver.kill(0)
     assert "TRIED" in (bin_path / "script_try").read_text()


### PR DESCRIPTION
**Approach**
This commit speeds up tests in ert/unit_tests/scheduler from 218s to 86s by limiting hypothesis cases to 10, and setting driver._pool_period to 0.01 from the default of 2.0.
Running `pytest tests/ert/unit_tests/scheduler --durations=40`

Before: 
```
17.71s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_events_produced_from_jobstate_updates
6.30s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_numcpu_sets_ntasks
6.12s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_full_resource_string
5.10s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_max_runtime_is_properly_formatted
5.03s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_realization_memory
4.86s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_exclude_is_set
4.81s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_project_code_is_set
4.71s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_queue_name_is_set
4.48s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_polling_bhist_fallback
4.45s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_include_is_set
2.65s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_slurm_stdout_file
2.60s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_actually_kills[LsfDriver]
2.55s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_kill_before_submit_is_finished
2.53s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit_something_that_fails[LsfDriver]
2.52s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_gives_correct_state[LsfDriver]
2.52s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_num_cpu_sets_env_variables[LsfDriver]
2.50s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_bjobs_exec_host_logs_only_once
2.50s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit[LsfDriver]
2.45s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_dumps_stderr_to_file
2.45s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_slurm_uses_sacct[true-0]
2.45s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_can_retrieve_stdout_and_stderr[700]
2.43s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_stdout_file
2.43s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_can_retrieve_stdout_and_stderr[500]
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_can_retrieve_stdout_and_stderr[50]
2.42s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_slurm_uses_sacct[false-1]
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_can_retrieve_stdout_and_stderr[5]
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_info_file_in_runpath[True]
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_cannot_retrieve_stdout_and_stderr
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_lsf_info_file_in_runpath[False]
2.42s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_submit_to_named_queue
2.40s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_submit_with_resource_requirement
2.31s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit[SlurmDriver]
2.31s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit_something_that_fails[SlurmDriver]
2.27s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_actually_kills[OpenPBSDriver]
2.27s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_gives_correct_state[SlurmDriver]
2.26s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_num_cpu_sets_env_variables[SlurmDriver]
2.26s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_submit_to_named_queue
2.26s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_that_qdel_will_retry_and_succeed[168-Request invalid for state of job]
2.26s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_gives_correct_state[OpenPBSDriver]
2.26s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_slurm_can_retrieve_stdout_and_stderr[50]
303 passed, 4 skipped, 22 warnings, 1 rerun in 212.28s (0:03:32) 
```
After:
```
2.49s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_kill_before_submit_is_finished
2.25s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_events_produced_from_jobstate_updates
2.21s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_max_runtime_while_killing
1.77s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_polling_bhist_fallback
1.48s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_bjobs_exec_host_logs_only_once
1.44s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep_with_max_running[0.15-0.1-1]
1.42s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep_with_max_running[0.15-0.35-5]
1.39s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep_with_max_running[0.15-0.1-10]
1.22s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[error_for_irrelevant_job_id]
1.22s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[exit-1]
1.21s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_faulty_bjobs[exit-1]
1.21s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[unparsable_output]
1.21s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[wrong-job-id]
1.20s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[unknown_jobstate_token_from_pbs]
1.20s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[all-good-properly-formatted]
1.19s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[empty_cluster]
1.19s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_faulty_bjobs[empty_cluster]
1.19s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_faulty_bjobs[wrong-job-id]
1.17s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_faulty_bjobs[unparsable_output]
1.17s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_faulty_bjobs[empty_cluster_specific_id]
1.17s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[empty_cluster_specific_id]
1.16s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_faulty_qstat[all-good]
1.12s call     tests/ert/unit_tests/scheduler/test_local_driver.py::test_kill_unresponsive_process
1.09s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_openpbs_driver_with_poly_example_failing_submit_fails_ert_and_propagates_exception_to_user
1.09s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_exception_to_user
1.02s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep[0.1-1-0.1]
1.01s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_no_resubmit_on_max_runtime_kill
1.01s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_max_runtime
0.92s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep[0.1-1-0]
0.92s call     tests/ert/unit_tests/scheduler/test_scheduler.py::test_submit_sleep[0.1-2-0]
0.86s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_that_openpbs_driver_ignores_qstat_flakiness[qstat: Invalid credential]
0.83s call     tests/ert/unit_tests/scheduler/test_openpbs_driver.py::test_that_openpbs_driver_ignores_qstat_flakiness[pbs_iff: cannot connect to host\npbs_iff: all reserved ports in use]
0.78s call     tests/ert/unit_tests/scheduler/test_lsf_driver.py::test_that_kill_before_submit_is_finished_works
0.60s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit[LsfDriver]
0.52s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_actually_kills[LsfDriver]
0.52s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_submit_something_that_fails[LsfDriver]
0.52s call     tests/ert/unit_tests/scheduler/test_local_driver.py::test_kill_when_job_completed[true-0]
0.52s call     tests/ert/unit_tests/scheduler/test_slurm_driver.py::test_exit_codes[echo 0-false-echo "COMPLETED|0:0"-0]
0.51s call     tests/ert/unit_tests/scheduler/test_local_driver.py::test_kill_when_job_completed[false-1]
0.50s call     tests/ert/unit_tests/scheduler/test_generic_driver.py::test_kill_gives_correct_state[LsfDriver]
303 passed, 4 skipped, 22 warnings in 84.46s (0:01:24)
```

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
