### PR TITLE
Revert "Deprecate QUEUE_OPTION SUBMIT_SLEEP (#10902)"

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -1768,7 +1768,7 @@ in :ref:`queue-system-chapter`. In brief, the queue systems have the following o
 * :ref:`LOCAL <local-queue>` — no queue options.
 * :ref:`LSF <lsf-systems>` — ``LSF_QUEUE``, ``LSF_RESOURCE``,
   ``BSUB_CMD``, ``BJOBS_CMD``, ``BKILL_CMD``,
-  ``BHIST_CMD``, ``PROJECT_CODE``, ``EXCLUDE_HOST``,
+  ``BHIST_CMD``, ``SUBMIT_SLEEP``, ``PROJECT_CODE``, ``EXCLUDE_HOST``,
   ``MAX_RUNNING``
 * :ref:`TORQUE <pbs-systems>` — ``QSUB_CMD``, ``QSTAT_CMD``, ``QDEL_CMD``,
   ``QUEUE``, ``CLUSTER_LABEL``, ``MAX_RUNNING``, ``KEEP_QSUB_OUTPUT``,

--- a/docs/ert/reference/configuration/queue.rst
+++ b/docs/ert/reference/configuration/queue.rst
@@ -140,6 +140,14 @@ The following is a list of available LSF configuration options:
 
     QUEUE_OPTION LSF BHIST_CMD command
 
+.. _submit_sleep:
+.. topic:: SUBMIT_SLEEP
+
+  Determines for how long in seconds the system will sleep between submitting jobs.
+  Default: ``0``. To change it to 1 second::
+
+    QUEUE_OPTION LSF SUBMIT_SLEEP 1
+
 .. _lsf_queue:
 .. topic:: LSF_QUEUE
 
@@ -278,6 +286,14 @@ The following is a list of all queue-specific configuration options:
 
     QUEUE_OPTION TORQUE KEEP_QSUB_OUTPUT 1
 
+.. _torque_submit_sleep:
+.. topic:: SUBMIT_SLEEP
+
+  To avoid stressing the TORQUE/PBS system you can instruct the driver to sleep
+  for every submit request. The argument to the SUBMIT_SLEEP is the number of
+  seconds to sleep for every submit, which can be a fraction like 0.5::
+
+    QUEUE_OPTION TORQUE SUBMIT_SLEEP 0.5
 
 .. _torque_project_code:
 .. topic:: PROJECT_CODE
@@ -435,8 +451,10 @@ the `GENERIC` keyword. ::
 
     QUEUE_SYSTEM LSF
     QUEUE_OPTION GENERIC MAX_RUNNING 10
+    QUEUE_OPTION GENERIC SUBMIT_SLEEP 2
 
 Is equivalent to::
 
     QUEUE_SYSTEM LSF
     QUEUE_OPTION LSF MAX_RUNNING 10
+    QUEUE_OPTION LSF SUBMIT_SLEEP 2

--- a/tests/ert/unit_tests/config/test_queue_config.py
+++ b/tests/ert/unit_tests/config/test_queue_config.py
@@ -1,10 +1,8 @@
 import logging
-import warnings
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given
-from pydantic import ValidationError
 
 from ert.config import (
     ConfigValidationError,
@@ -266,32 +264,14 @@ def test_max_running_property():
 
 @pytest.mark.parametrize("queue_system", ["LSF", "GENERIC"])
 def test_multiple_submit_sleep_keywords(queue_system):
-    with warnings.catch_warnings(record=True) as all_warnings:
-        config = ErtConfig.from_file_contents(
-            "NUM_REALIZATIONS 1\n"
-            "QUEUE_SYSTEM LSF\n"
-            "QUEUE_OPTION LSF SUBMIT_SLEEP 10\n"
-            f"QUEUE_OPTION {queue_system} SUBMIT_SLEEP 42\n"
-            "QUEUE_OPTION TORQUE SUBMIT_SLEEP 22\n"
-        )
-        assert config.queue_config.submit_sleep == 42
-        assert len(all_warnings) > 0
-        assert all(issubclass(w.category, ConfigWarning) for w in all_warnings)
-        assert all(
-            str(w.message)
-            == (
-                "The SUBMIT_SLEEP keyword in QUEUE_OPTION is deprecated. "
-                "Put SUBMIT_SLEEP <seconds> on a separate line instead"
-            )
-            for w in all_warnings
-        )
-
-
-def test_multiple_submit_sleep_keywords_without_queue_system():
-    with warnings.catch_warnings(record=True) as all_warnings:
-        config = ErtConfig.from_file_contents("NUM_REALIZATIONS 1\nSUBMIT_SLEEP 3\n")
-        assert config.queue_config.submit_sleep == 3
-        assert len(all_warnings) == 0
+    config = ErtConfig.from_file_contents(
+        "NUM_REALIZATIONS 1\n"
+        "QUEUE_SYSTEM LSF\n"
+        "QUEUE_OPTION LSF SUBMIT_SLEEP 10\n"
+        f"QUEUE_OPTION {queue_system} SUBMIT_SLEEP 42\n"
+        "QUEUE_OPTION TORQUE SUBMIT_SLEEP 22\n"
+    )
+    assert config.queue_config.submit_sleep == 42
 
 
 def test_multiple_max_submit_keywords():
@@ -385,13 +365,6 @@ def test_global_config_key_does_not_overwrite_queue_options(queue_system, key, v
     )
 
 
-def test_negative_submit_sleep_raises_validation_error():
-    with pytest.raises(
-        ValidationError, match="Input should be greater than or equal to 0"
-    ):
-        ErtConfig.from_file_contents("NUM_REALIZATIONS 1\nSUBMIT_SLEEP -4.2\n")
-
-
 @pytest.mark.parametrize(
     "queue_system, key, value",
     [
@@ -405,8 +378,7 @@ def test_negative_submit_sleep_raises_validation_error():
 )
 def test_wrong_generic_queue_option_raises_validation_error(queue_system, key, value):
     with pytest.raises(
-        ConfigValidationError,
-        match=f"Input should be greater than or equal to 0. Got input '{value}'",
+        ConfigValidationError, match="Input should be greater than or equal to 0"
     ):
         ErtConfig.from_file_contents(
             "NUM_REALIZATIONS 1\n"
@@ -414,20 +386,15 @@ def test_wrong_generic_queue_option_raises_validation_error(queue_system, key, v
             f"QUEUE_OPTION GENERIC {key} {value}\n"
         )
 
-    if key == "SUBMIT_SLEEP":
-        with pytest.raises(
-            ValidationError, match="Input should be greater than or equal to 0"
-        ):
-            ErtConfig.from_file_contents(
-                f"NUM_REALIZATIONS 1\nQUEUE_SYSTEM {queue_system}\n{key} {value}\n"
-            )
-    else:
-        with pytest.raises(
-            ConfigValidationError, match="must have a positive integer value"
-        ):
-            ErtConfig.from_file_contents(
-                f"NUM_REALIZATIONS 1\nQUEUE_SYSTEM {queue_system}\n{key} {value}\n"
-            )
+    error_msg = (
+        "must have a positive integer value"
+        if key == "MAX_RUNNING"
+        else "Input should be greater than or equal to 0"
+    )
+    with pytest.raises(ConfigValidationError, match=error_msg):
+        ErtConfig.from_file_contents(
+            f"NUM_REALIZATIONS 1\nQUEUE_SYSTEM {queue_system}\n{key} {value}\n"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This reverts commit 10f48f9e5918e0924249b6a8f428e42ae7cf0212.

**Issue**
Relates to https://github.com/equinor/ert/issues/11421


**Approach**
Due to the issue above we need to rely on SUBMIT_SLEEP for the QUEUE_OPTION

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
