### PR TITLE
Add logging of num_params in run_model

### DIFF
--- a/src/ert/run_models/initial_ensemble_run_model.py
+++ b/src/ert/run_models/initial_ensemble_run_model.py
@@ -34,6 +34,7 @@ class InitialEnsembleRunModel(RunModel, ABC):
             Field(discriminator="type"),
         ]
     ]
+    num_params: int
     response_configuration: list[
         Annotated[
             (

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -163,6 +163,7 @@ def _setup_ensemble_experiment(
         queue_config=config.queue_config,
         observations=config.observations,
         status_queue=status_queue,
+        num_params=config.num_params,
     )
 
 


### PR DESCRIPTION
This approach went all the way from ErtConfig to properly include the num_params value in the settings_dict without manually adding it inside of run_model. Unsure if this is the way to go or if this should instead just be calculated closer to run_model as all the information is available there as well (param_configuration)

**Issue**
Resolves #11416 


**Approach**
_Short description of the approach_

Alternative approach to #11427 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
