### PR TITLE
Move responsibility to save parameters into Ensemble

### DIFF
--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Iterator
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import networkx as nx
 import numpy as np
+import polars as pl
 import xarray as xr
 from pydantic import BaseModel
 
@@ -85,14 +87,14 @@ class ParameterConfig(BaseModel):
         """
 
     @abstractmethod
-    def save_parameters(
+    def create_storage_datasets(
         self,
-        ensemble: Ensemble,
-        realization: int,
-        data: npt.NDArray[np.float64],
-    ) -> None:
+        from_data: npt.NDArray[np.float64],
+        iens_active_index: npt.NDArray[np.int_],
+    ) -> Iterator[tuple[int | None, pl.DataFrame | xr.Dataset]]:
         """
-        Save the parameter in internal storage for the given ensemble
+        Iterates over realization. It creates an xarray Dataset
+        or polars DataFrame from the numpy data
         """
 
     def copy_parameters(

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -509,10 +509,10 @@ class EverestRunModel(RunModel):
                 n_param_keys = len(ext_param_config.parameter_keys)
 
                 # Save controls to ensemble
-                ext_param_config.save_parameters(
-                    ensemble,
-                    realization=sim_id,
-                    data=sim_controls[offset : (offset + n_param_keys)],
+                ensemble.save_parameters_numpy(
+                    sim_controls[offset : (offset + n_param_keys)].reshape(-1, 1),
+                    ext_param_config.name,
+                    np.array([sim_id]),
                 )
                 offset += n_param_keys
 

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -613,21 +613,10 @@ class LocalEnsemble(BaseMode):
         iens_active_index: npt.NDArray[np.int_],
     ) -> None:
         config_node = self.experiment.parameter_configuration[param_group]
-        if isinstance(config_node, GenKwConfig):
-            df = pl.DataFrame(
-                {
-                    "realization": iens_active_index,
-                }
-            ).with_columns(
-                [
-                    pl.Series(parameters[i, :]).alias(param_name.name)
-                    for i, param_name in enumerate(config_node.transform_functions)
-                ]
-            )
-            self.save_parameters(param_group, None, df)
-        else:
-            for i, realization in enumerate(iens_active_index):
-                config_node.save_parameters(self, int(realization), parameters[:, i])
+        for real, ds in config_node.create_storage_datasets(
+            parameters, iens_active_index
+        ):
+            self.save_parameters(config_node.name, real, ds)
 
     def load_scalars(
         self, group: str | None = None, realizations: npt.NDArray[np.int_] | None = None

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -647,15 +647,23 @@ def save_zeros(prior_ensemble, num_realizations, dim_size):
     for config_node in parameter_configs.values():
         for realization_nr in range(num_realizations):
             if isinstance(config_node, SurfaceConfig):
-                config_node.save_parameters(
-                    prior_ensemble, realization_nr, np.zeros(dim_size**2)
+                prior_ensemble.save_parameters_numpy(
+                    np.zeros(dim_size**2).reshape(-1, 1),
+                    config_node.name,
+                    np.array([realization_nr]),
                 )
             elif isinstance(config_node, Field):
-                config_node.save_parameters(
-                    prior_ensemble, realization_nr, np.zeros(dim_size**3)
+                prior_ensemble.save_parameters_numpy(
+                    np.zeros(dim_size**3).reshape(-1, 1),
+                    config_node.name,
+                    np.array([realization_nr]),
                 )
             elif isinstance(config_node, GenKwConfig):
-                config_node.save_parameters(prior_ensemble, realization_nr, np.zeros(1))
+                prior_ensemble.save_parameters_numpy(
+                    np.zeros(1).reshape(-1, 1),
+                    config_node.name,
+                    np.array([realization_nr]),
+                )
             else:
                 raise ValueError(f"unexpected {config_node}")
 


### PR DESCRIPTION
In order to make scalars more actionable, we need to move saving of parameters one level higher to get the proper abstraction.


**Approach**
ParameterConfig gets create_storage_datasets iterator, which prepares
the datasets (xr.Dataset or pl.Dataframe), which then gets saved into
the storage by the ensemble. This allows us to handle hybrid ways of
storing data; ie. either per realization or per ensemble.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
