### PR TITLE
Mark slow tests as integration_test

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -228,6 +228,7 @@ def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
     assert len(mock_server.messages) == 3, "expected 3 Job running messages"
 
 
+@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "mocked_server_signal, expected_message",
     [

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -297,6 +297,7 @@ def test_processtree_timer(
     assert timer.total_cpu_seconds() == expected_total_seconds
 
 
+@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "command, exit_code, expected_error_message, target_file_name",


### PR DESCRIPTION
Marks tests that are slower than 1s as integration_test as per CONTRIBUTING.md

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
