### PR TITLE
[Backport version-14.4] Add num_params to log statement (#11427)

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -226,7 +226,17 @@ class BaseRunModel(BaseModelWithContextSupport, ABC):
             for key, value in self.__dict__.items()
             if key not in keys_to_drop
         }
-        logger.info(f"Running '{self.name()}' with settings {settings_dict}")
+        num_params_log = ""
+        if hasattr(self, "parameter_configuration"):
+            num_params = sum(
+                len(param_config.parameter_keys)
+                for param_config in self.parameter_configuration
+            )
+            num_params_log = f"\nExperiment has {num_params} parameters."
+
+        logger.info(
+            f"Running '{self.name()}' with settings {settings_dict}{num_params_log}"
+        )
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Add num_params specifically to log statement

(cherry picked from commit 663d61d4da8e05df933002bbbda2e633c9c0ff0e)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

My first time manually doing a backport. I am not familiar with git worktree as automatically suggested, so instead I:
- Created new branch from 14.4
- Cherry picked commit 
- Pushed to my fork per usual
- Made this PR to the 14.4 branch

Just need a sanity check that this is valid methology.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
