### PR TITLE
Specify polars return_dtype in test

### DIFF
--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -11,6 +11,7 @@ import polars as pl
 import pytest
 import resfo
 import xtgeo
+from polars import Float32
 
 from ert.analysis import (
     smoother_update,
@@ -94,7 +95,8 @@ def _compare_ensemble_params(
                 pl.col(c).map_elements(
                     lambda x: 0.0
                     if abs(x) < outlier_threshold
-                    else (abs(x) - outlier_threshold)
+                    else (abs(x) - outlier_threshold),
+                    return_dtype=Float32,
                 )
             ).alias(c)
             for c in columns
@@ -105,7 +107,10 @@ def _compare_ensemble_params(
     outlier_percentage = truncated_df.select(
         [
             pl.concat_list(columns)
-            .map_elements(lambda row: sum(1 for x in row if x != 0.0) / len(row))
+            .map_elements(
+                lambda row: sum(1 for x in row if x != 0.0) / len(row),
+                return_dtype=Float32,
+            )
             .alias("outlier_percentage")
         ]
     )["outlier_percentage"]
@@ -113,7 +118,7 @@ def _compare_ensemble_params(
     max_deviance = truncated_df.select(
         [
             pl.concat_list(columns)
-            .map_elements(lambda row: max(x for x in row))
+            .map_elements(lambda row: max(x for x in row), return_dtype=Float32)
             .alias("max_deviance")
         ]
     )["max_deviance"]


### PR DESCRIPTION
By reading the documentation, .map_element is expected to throw a warning whenever the user does not specify the return_dtype, as it conciders it a bug in the user's query.

The decision of choosing Float32 as datatype was simply picking the smallest possible value which suffices for the test to limit memory footprint.

**Issue**
Resolves #11429 


**Approach**
Define the return_dtype to reduce the number of warnings.

Warnings reduced from 5712 to 1.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
