### PR TITLE
Put name and num params in same log chunk (#11451)

### DIFF
--- a/src/ert/run_models/base_run_model.py
+++ b/src/ert/run_models/base_run_model.py
@@ -226,16 +226,16 @@ class BaseRunModel(BaseModelWithContextSupport, ABC):
             for key, value in self.__dict__.items()
             if key not in keys_to_drop
         }
-        num_params_log = ""
+        num_params_log = "with"
         if hasattr(self, "parameter_configuration"):
             num_params = sum(
                 len(param_config.parameter_keys)
                 for param_config in self.parameter_configuration
             )
-            num_params_log = f"\nExperiment has {num_params} parameters."
+            num_params_log = f"with {num_params} parameters and"
 
         logger.info(
-            f"Running '{self.name()}' with settings {settings_dict}{num_params_log}"
+            f"Running '{self.name()}' {num_params_log} settings {settings_dict}"
         )
 
     @classmethod

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -613,7 +613,7 @@ def test_run_model_logs_number_of_parameters_in_ensemble_experiment(use_tmpdir):
     rm = create_base_run_model(parameter_configuration=[parameters])
 
     def mock_logging(_, log_str):
-        regex = r"Experiment has (\d+) parameters\."
+        regex = r"Running '\w+' with (\d+) parameters"
         match = re.search(regex, log_str)
         num_param = int(match.group(1))
 


### PR DESCRIPTION
We wish to query for entries which have logged both the experiment type and num params. However, if logs gets too long, they get divided into chunks, which might separate experiment type and num params into different log chunks, which complicates the query logic.

This change will ensure the first chunk will always contain both of these properties.

(cherry picked from commit c0d5c5f1bc82a22224944e036e7766c6e4f2f637)

Manual Backport PR
