### PR TITLE
Rename inaccurate test title

### DIFF
--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -605,7 +605,7 @@ def test_create_mask_from_failed_realizations_returns_initial_active_realization
     assert failed_realization_mask == initial_active_realizations
 
 
-def test_run_model_logs_number_of_parameters_in_ensemble_experiment(use_tmpdir):
+def test_run_model_logs_number_of_parameters(use_tmpdir):
     tfds = [
         TransformFunctionDefinition(name="a", param_name="NORMAL", values=[1, 2]),
         TransformFunctionDefinition(name="b", param_name="NORMAL", values=[1, 2]),


### PR DESCRIPTION
When opening this, I am not certain if this is worth merging in as an own commit, please provide feedback.

The test title was created before the test, before the realization that no specific subclass of run_model was necessary to test the logging feature.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
