### PR TITLE
Fix coverage data for unit tests being overwritten

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   ERT_SHOW_BACKTRACE: 1
-  ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
+  ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_main.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
   UV_FROZEN: true
   OMP_NUM_THREADS: 1
 
@@ -80,8 +80,8 @@ jobs:
         touch storage
         chmod 000 storage
         uv run just ert-unit-tests
-        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov2.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-doc-tests
-        uv run just ert-memory-tests
+        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_docs.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-doc-tests
+        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_mem.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-memory-tests
         chmod 700 storage
         rm storage
 
@@ -92,7 +92,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
-        files: cov1.xml,cov2.xml
+        files: cov_main.xml,cov_docs.xml,cov_mem.xml
         flags: ${{ inputs.test-type }}
     - name: codecov retry sleep
       if: steps.codecov1.outcome == 'failure'
@@ -103,7 +103,7 @@ jobs:
       if: steps.codecov1.outcome == 'failure'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: cov1.xml,cov2.xml
+        files: cov_main.xml,cov_docs.xml,cov_mem.xml
         flags: ${{ inputs.test-type }}
         fail_ci_if_error: ${{ github.ref == 'refs/heads/main' }}
 
@@ -128,7 +128,7 @@ jobs:
         # Remove things we have generated on purpose:
         ls -la
         rm -rf .coverage
-        rm -f coverage.xml cov1.xml cov2.xml junit.xml
+        rm -f coverage.xml cov_main.xml cov_docs.xml cov_mem.xml junit.xml
         rm -f ert.*.whl
         rm -f codecov.SHA*
         rm -f codecov


### PR DESCRIPTION
In https://github.com/equinor/ert/pull/11254 the cov1.xml file generated by unit tests was overwritten by the coverage generated by the memory tests. This PR makes sure that both files are uploaded to codecov.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)