### PR TITLE
Use property to simplify remember logic in remaining verification time

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -448,7 +448,17 @@ async def log_warnings_from_forward_model(
     for anything that looks like a Warning, and log it.
 
     This is not a critical task to perform, but it is critical not to crash
-    during this process."""
+    during this process.
+
+    Args:
+        real: The realization to look for warnings in
+        job_submission_time: The time the job for the given realization was last
+            started. Files not changed after the job started are not read. There is
+            a retry used to wait for file sync.
+        timeout_seconds: Time to wait for stdout and stderr to appear if missing.
+    Returns:
+        The seconds left of the given timeout_seconds.
+    """
 
     max_length = 2048  # Lines will be truncated in length when logged
 


### PR DESCRIPTION
Also adds documentation of parameters and return value to log_warnings_from_file

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
