### PR TITLE
Disable pytest benchmarks on parallel runs

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ pytest_args := env("ERT_PYTEST_ARGS", "--quiet")
 
 # execute rapid unittests
 rapid-tests:
-    OMP_NUM_THREADS=1 pytest -n auto --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky or memory_test or limit_memory)"
+    OMP_NUM_THREADS=1 pytest -n auto --benchmark-disable --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky or memory_test or limit_memory)"
 
 ert-gui-tests:
     pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui
@@ -26,13 +26,13 @@ ert-memory-tests:
     _RJEM_MALLOC_CONF="dirty_decay_ms:100,muzzy_decay_ms:100" pytest -n 2 {{pytest_args}} tests/ert -m "limit_memory" --memray
 
 ert-unit-tests:
-    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not (memory_test or limit_memory)"
+    pytest {{pytest_args}} -n 4 --benchmark-disable --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not (memory_test or limit_memory)"
 
 ert-doc-tests:
     pytest {{pytest_args}} --doctest-modules src/ --ignore src/ert/dark_storage
 
 everest-tests:
-    pytest -n 4 --dist loadgroup {{pytest_args}} tests/everest
+    pytest -n 4 --benchmark-disable --dist loadgroup {{pytest_args}} tests/everest
 
 build-everest-docs:
     sphinx-build -n -v -E -W ./docs/everest ./everest_docs


### PR DESCRIPTION
This avoid the warning from pytest:

```
  PytestBenchmarkWarning: Benchmarks are automatically disabled because
  xdist plugin is active.Benchmarks cannot be performed reliably in a
  parallelized environment.
```

**Issue**
Resolves printed warning

**Approach**
Be explicit


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
