### PR TITLE
Save serialized experiment config in index.json

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -41,4 +41,4 @@ jobs:
           mode: simulation
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
-            uv run pytest tests/ert/performance_tests --codspeed --timeout=1200 -m "not memory_test"
+            uv run pytest tests/ert/performance_tests --codspeed --timeout=3000 -m "not memory_test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ log_cli = "false"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 360
-session_timeout = 1800
+session_timeout = 3000
 timeout_func_only = true # Do not apply timeout to fixtures which can be slow but cached
 
 [tool.setuptools_scm]

--- a/src/ert/config/everest_response.py
+++ b/src/ert/config/everest_response.py
@@ -79,8 +79,8 @@ class EverestResponse(ResponseConfig):
 class EverestConstraintsConfig(EverestResponse):
     type: Literal["everest_constraints"] = "everest_constraints"
     targets: list[float | None]
-    upper_bounds: list[float]
-    lower_bounds: list[float]
+    upper_bounds: list[float | None]
+    lower_bounds: list[float | None]
 
 
 responses_index.add_response_type(EverestConstraintsConfig)

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -70,10 +70,10 @@ class Field(ParameterConfig):
     dimensionality: Literal[3] = 3
     ertbox_params: ErtboxParameters
     file_format: FieldFileFormat
-    output_transformation: str | None
-    input_transformation: str | None
-    truncation_min: float | None
-    truncation_max: float | None
+    output_transformation: str | None = None
+    input_transformation: str | None = None
+    truncation_min: float | None = None
+    truncation_max: float | None = None
     forward_init_file: str
     output_file: Path
     grid_file: str

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, cast
+from typing import ClassVar
 from uuid import UUID
 
 from pydantic import PrivateAttr
 
 from ert.config import (
-    ParameterConfig,
     PostExperimentFixtures,
     PreExperimentFixtures,
-    ResponseConfig,
 )
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.initial_ensemble_run_model import (
@@ -54,11 +52,8 @@ class EnsembleExperiment(InitialEnsembleRunModel, EnsembleExperimentConfig):
         self.run_workflows(fixtures=PreExperimentFixtures(random_seed=self.random_seed))
 
         experiment_storage = self._storage.create_experiment(
-            parameters=cast(list[ParameterConfig], self.parameter_configuration),
-            observations=self.observation_dataframes(),
-            responses=cast(list[ResponseConfig], self.response_configuration),
+            experiment_config=self.model_dump(mode="json"),
             name=self.experiment_name,
-            templates=self.ert_templates,
         )
 
         ensemble_storage = self._storage.create_ensemble(

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import cast
 
 import numpy as np
 from pydantic import PrivateAttr
 
 from ert.config import (
-    ParameterConfig,
     PostExperimentFixtures,
     PreExperimentFixtures,
-    ResponseConfig,
 )
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.initial_ensemble_run_model import (
@@ -48,11 +45,8 @@ class EnsembleSmoother(InitialEnsembleRunModel, UpdateRunModel, EnsembleSmoother
         self.run_workflows(fixtures=PreExperimentFixtures(random_seed=self.random_seed))
 
         experiment_storage = self._storage.create_experiment(
-            parameters=cast(list[ParameterConfig], self.parameter_configuration),
-            observations=self.observation_dataframes(),
-            responses=cast(list[ResponseConfig], self.response_configuration),
+            experiment_config=self.model_dump(mode="json"),
             name=self.experiment_name,
-            templates=self.ert_templates,
         )
 
         prior = self._storage.create_ensemble(

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -46,13 +46,19 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
         self.set_env_key("_ERT_EXPERIMENT_ID", str(prior_experiment.id))
         self.set_env_key("_ERT_ENSEMBLE_ID", str(self._prior.id))
 
+        experiment_config = self.model_dump(mode="json") | {
+            "parameter_configuration": prior_experiment.experiment_config[
+                "parameter_configuration"
+            ],
+            "response_configuration": prior_experiment.experiment_config[
+                "response_configuration"
+            ],
+            "observations": prior_experiment.experiment_config["observations"],
+        }
+
         target_experiment = self._storage.create_experiment(
-            parameters=list(prior_experiment.parameter_configuration.values()),
-            responses=list(prior_experiment.response_configuration.values()),
-            observations=prior_experiment.observations,
-            simulation_arguments=prior_experiment.metadata,
+            experiment_config=experiment_config,
             name=f"Manual update of {self._prior.name}",
-            templates=self.ert_templates,
         )
         self.update(
             self._prior,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 from uuid import UUID
 
 from pydantic import PrivateAttr
 
 from ert.config import (
-    ParameterConfig,
     PostExperimentFixtures,
     PreExperimentFixtures,
-    ResponseConfig,
 )
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.initial_ensemble_run_model import (
@@ -97,12 +95,8 @@ class MultipleDataAssimilation(
                         f"restart iteration = {prior.iteration + 1}"
                     )
                 target_experiment = self._storage.create_experiment(
-                    parameters=list(prior.experiment.parameter_configuration.values()),
-                    responses=list(prior.experiment.response_configuration.values()),
-                    observations=prior.experiment.observations,
-                    simulation_arguments=prior.experiment.metadata,
+                    experiment_config=self.model_dump(mode="json"),
                     name=f"Restart from {prior.name}",
-                    templates=self.ert_templates,
                 )
 
             except (KeyError, ValueError) as err:
@@ -113,14 +107,9 @@ class MultipleDataAssimilation(
             self.run_workflows(
                 fixtures=PreExperimentFixtures(random_seed=self.random_seed),
             )
-            sim_args = {"weights": self.weights}
             experiment_storage = self._storage.create_experiment(
-                parameters=cast(list[ParameterConfig], self.parameter_configuration),
-                observations=self.observation_dataframes(),
-                responses=cast(list[ResponseConfig], self.response_configuration),
+                experiment_config=self.model_dump(mode="json"),
                 name=self.experiment_name,
-                templates=self.ert_templates,
-                simulation_arguments=sim_args,
             )
 
             prior = self._storage.create_ensemble(

--- a/src/ert/storage/migration/to25.py
+++ b/src/ert/storage/migration/to25.py
@@ -1,0 +1,91 @@
+import datetime
+import json
+import shutil
+from pathlib import Path
+from typing import Any, cast
+
+import polars as pl
+
+info = (
+    "Move parameters.json, responses.json, observations contents to be in "
+    "experiment index.json .experiment field"
+)
+
+
+def _observation_row_to_declaration(
+    row: dict[str, Any], response_type: str
+) -> dict[str, Any]:
+    observation, error = row.get("observations"), row.get("std")
+    decl = {
+        "name": row.get("observation_key"),
+        "value": float(observation) if observation is not None else None,
+        "error": float(error) if error is not None else None,
+    }
+    if response_type == "summary":
+        date_str = cast(datetime.datetime, row.get("time")).date().isoformat()
+        decl.update(
+            {
+                "type": "summary_observation",
+                "key": row.get("response_key"),
+                "date": date_str,
+            }
+        )
+        if row.get("east") is not None or row.get("north") is not None:
+            for f in ["east", "north", "radius"]:
+                if (val := row.get(f)) is not None:
+                    decl[f] = float(val)
+    elif response_type == "gen_data":
+        decl.update(
+            {
+                "type": "general_observation",
+                "data": row.get("response_key"),
+                "restart": int(row.get("report_step") or 0),
+                "index": int(row.get("index") or 0),
+            }
+        )
+    return decl
+
+
+def migrate_parameters_responses_and_observations_into_experiment_index(
+    path: Path,
+) -> None:
+    for exp_path in path.glob("experiments/*"):
+        if not exp_path.is_dir():
+            continue
+
+        meta = json.loads((exp_path / "metadata.json").read_text(encoding="utf-8"))
+        resps = json.loads((exp_path / "responses.json").read_text(encoding="utf-8"))
+        params = json.loads((exp_path / "parameter.json").read_text(encoding="utf-8"))
+
+        experiment_json = {
+            "response_configuration": list(resps.values()),
+            "parameter_configuration": list(params.values()),
+            "observations": [],
+        }
+        if "weights" in meta:
+            experiment_json["weights"] = meta["weights"]
+
+        obs_dir = exp_path / "observations"
+        if obs_dir.exists():
+            for obs_file in obs_dir.glob("*"):
+                df = pl.read_parquet(obs_file)
+                experiment_json["observations"].extend(
+                    [
+                        _observation_row_to_declaration(row, obs_file.stem)
+                        for row in df.to_dicts()
+                    ]
+                )
+
+        index_file = exp_path / "index.json"
+        index = json.loads(index_file.read_text(encoding="utf-8"))
+        index["experiment"] = experiment_json
+        index_file.write_text(json.dumps(index, indent=2), encoding="utf-8")
+
+        for f in ["metadata.json", "responses.json", "parameter.json"]:
+            (exp_path / f).unlink()
+        if obs_dir.exists():
+            shutil.rmtree(obs_dir)
+
+
+def migrate(path: Path) -> None:
+    migrate_parameters_responses_and_observations_into_experiment_index(path)

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -284,14 +284,15 @@ def test_plot_api_big_summary_memory_usage(
     )
 
     experiment = storage.create_experiment(
-        parameters=[],
-        responses=[
-            SummaryConfig(
-                name="summary",
-                input_files=["CASE.UNSMRY", "CASE.SMSPEC"],
-                keys=keys_df,
-            )
-        ],
+        experiment_config={
+            "response_configuration": [
+                SummaryConfig(
+                    name="summary",
+                    input_files=["CASE.UNSMRY", "CASE.SMSPEC"],
+                    keys=keys_df,
+                ).model_dump(mode="json")
+            ]
+        },
     )
 
     ensemble = experiment.create_ensemble(ensemble_size=num_reals, name="bigboi")

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -114,9 +114,20 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
             ert_config.observation_declarations, None
         )
         experiment_id = storage.create_experiment(
-            parameters=ens_config.parameter_configuration,
-            responses=ens_config.response_configuration,
-            observations=observations,
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json")
+                    for pc in ens_config.parameter_configuration
+                ],
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in ens_config.response_configuration
+                ],
+                "observations": [
+                    od.model_dump(mode="json")
+                    for od in ert_config.observation_declarations
+                ],
+            },
             name="test-experiment",
         )
         source = storage.create_ensemble(experiment_id, name="prior", ensemble_size=100)

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -651,7 +651,13 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
     num_realizations = ert_config.runpath_config.num_realizations
     with open_storage(ert_config.ens_path, mode="w") as storage:
         experiment_id = storage.create_experiment(
-            ert_config.ensemble_config.parameter_configuration, name="test-experiment"
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json")
+                    for pc in ert_config.ensemble_config.parameter_configuration
+                ]
+            },
+            name="test-experiment",
         )
         ensemble = storage.create_ensemble(
             experiment_id, name="iter-0", ensemble_size=num_realizations

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -15,7 +15,6 @@ import xtgeo
 
 from ert.analysis import smoother_update
 from ert.config import ErtConfig, ESSettings, ObservationSettings
-from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
 
@@ -434,11 +433,19 @@ def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc
         corr_length = prior.load_parameters("CORR_LENGTH")
 
         new_experiment = storage.create_experiment(
-            parameters=config.ensemble_config.parameter_configuration,
-            responses=config.ensemble_config.response_configuration,
-            observations=create_observation_dataframes(
-                config.observation_declarations, None
-            ),
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json")
+                    for pc in config.ensemble_config.parameter_configuration
+                ],
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in config.ensemble_config.response_configuration
+                ],
+                "observations": [
+                    od.model_dump(mode="json") for od in config.observation_declarations
+                ],
+            },
             name="exp-zero-var",
         )
         new_prior = storage.create_ensemble(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -436,7 +436,7 @@ def test_that_ert_config_is_serializable(tmp_path_factory, config_generator):
         ert_config = ErtConfig.from_dict(
             config_values.to_config_dict("config.ert", os.getcwd())
         )
-        config_json = json.loads(RootModel[ErtConfig](ert_config).model_dump_json())
+        config_json = RootModel[ErtConfig](ert_config).model_dump(mode="json")
         from_json = ErtConfig(**config_json)
         assert from_json == ert_config
 

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -28,7 +28,9 @@ def test_write_to_runpath_produces_the_transformed_field_in_storage(
 ):
     ensemble_config = snake_oil_field_example.ensemble_config
     experiment_id = storage.create_experiment(
-        parameters=ensemble_config.parameter_configuration
+        experiment_config={
+            "parameter_configuration": ensemble_config.parameter_configuration
+        }
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id, name="prior", ensemble_size=5

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -208,7 +208,11 @@ def test_gen_kw_is_log_or_not(
         gen_kw_config = ert_config.ensemble_config.parameter_configs["MY_KEYWORD"]
         assert isinstance(gen_kw_config, GenKwConfig)
         experiment_id = storage.create_experiment(
-            parameters=ert_config.ensemble_config.parameter_configuration
+            experiment_config={
+                "parameter_configuration": (
+                    ert_config.ensemble_config.parameter_configuration
+                )
+            }
         )
         prior_ensemble = storage.create_ensemble(
             experiment_id, name="prior", ensemble_size=1

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -45,9 +45,9 @@ def test_runpath_roundtrip(tmp_path, storage, surface):
         base_surface_path="base_surface",
         update=True,
     )
-    ensemble = storage.create_experiment(parameters=[config]).create_ensemble(
-        name="text", ensemble_size=1
-    )
+    ensemble = storage.create_experiment(
+        experiment_config={"parameter_configuration": [config]}
+    ).create_ensemble(name="text", ensemble_size=1)
     surface.to_file(tmp_path / "input_0", fformat="irap_ascii")
 
     # run_path -> storage

--- a/tests/ert/unit_tests/dark_storage/test_common.py
+++ b/tests/ert/unit_tests/dark_storage/test_common.py
@@ -29,9 +29,7 @@ def test_data_for_response_gives_mean_for_duplicate_values(tmp_path):
     with open_storage(tmp_path / "storage", mode="w") as storage:
         summary_config = SummaryConfig(name="summary", input_files=["CASE"], keys=["*"])
         experiment = storage.create_experiment(
-            observations={},
-            parameters=[],
-            responses=[summary_config],
+            experiment_config={"response_configuration": [summary_config]},
         )
         ensemble = experiment.create_ensemble(name="ensemble", ensemble_size=1)
         unsmry = Unsmry(
@@ -84,7 +82,9 @@ def test_data_for_response_doesnt_mistake_history_for_response(tmp_path):
         summary_config = SummaryConfig(
             name="summary", input_files=["CASE"], keys=["FGPR"]
         )
-        experiment = storage.create_experiment(responses=[summary_config])
+        experiment = storage.create_experiment(
+            experiment_config={"response_configuration": [summary_config]}
+        )
         ensemble = experiment.create_ensemble(name="ensemble", ensemble_size=1)
         ensemble.save_response(
             "summary",
@@ -109,9 +109,7 @@ def test_data_for_response_returns_empty_gen_data_config(tmp_path):
     with open_storage(tmp_path / "storage", mode="w") as storage:
         gen_data_config = GenDataConfig(keys=["response"])
         experiment = storage.create_experiment(
-            observations={},
-            parameters=[],
-            responses=[gen_data_config],
+            experiment_config={"response_configuration": [gen_data_config]},
         )
         ensemble = experiment.create_ensemble(name="ensemble", ensemble_size=1)
 

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -120,7 +120,11 @@ def test_show_only_no_parent(
     qtbot, notifier, storage, uniform_parameter, response, flag, expected
 ):
     experiment = storage.create_experiment(
-        parameters=[uniform_parameter], responses=[response], name="my-experiment"
+        experiment_config={
+            "parameter_configuration": [uniform_parameter.model_dump(mode="json")],
+            "response_configuration": [response.model_dump(mode="json")],
+        },
+        name="my-experiment",
     )
     ensemble = experiment.create_ensemble(name="parent", ensemble_size=1)
     experiment.create_ensemble(name="child", ensemble_size=1, prior_ensemble=ensemble)

--- a/tests/ert/unit_tests/resources/test_csv_export.py
+++ b/tests/ert/unit_tests/resources/test_csv_export.py
@@ -26,12 +26,11 @@ def test_that_csv_export_matches_snapshot(monkeypatch, tmp_path, snapshot):
 
     with open_storage(tmp_path / "storage", mode="w") as storage:
         experiment = storage.create_experiment(
-            responses=[info.gen_data_config, info.summary_config],
-            parameters=info.gen_kw_configs,
-            observations={
-                "gen_data": info.gen_data_observations,
-                "summary": info.summary_observations,
-            },
+            experiment_config={
+                "response_configuration": [info.gen_data_config, info.summary_config],
+                "parameter_configuration": info.gen_kw_configs,
+                "observations": info.gen_data_observations + info.summary_observations,
+            }
         )
         ens = experiment.create_ensemble(
             ensemble_size=num_realizations, name="BobKaareJohnny"

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -11,7 +11,6 @@ from resdata.summary import Summary
 
 from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, ESSettings, ObservationSettings
-from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.data import MeasuredData
 from ert.sample_prior import sample_prior
 from ert.storage.local_ensemble import load_parameters_and_responses_from_runpath
@@ -20,11 +19,20 @@ from ert.storage.local_ensemble import load_parameters_and_responses_from_runpat
 @pytest.fixture
 def prior_ensemble(storage, ert_config):
     return storage.create_experiment(
-        parameters=ert_config.ensemble_config.parameter_configuration,
-        responses=ert_config.ensemble_config.response_configuration,
-        observations=create_observation_dataframes(
-            ert_config.observation_declarations, None
-        ),
+        name="prior",
+        experiment_config={
+            "parameter_configuration": [
+                pc.model_dump(mode="json")
+                for pc in ert_config.ensemble_config.parameter_configuration
+            ],
+            "response_configuration": [
+                rc.model_dump(mode="json")
+                for rc in ert_config.ensemble_config.response_configuration
+            ],
+            "observations": [
+                od.model_dump(mode="json") for od in ert_config.observation_declarations
+            ],
+        },
     ).create_ensemble(ensemble_size=3, name="prior")
 
 

--- a/tests/ert/unit_tests/storage/create_runpath.py
+++ b/tests/ert/unit_tests/storage/create_runpath.py
@@ -18,9 +18,15 @@ def create_runpath(
     ert_config = ErtConfig.from_file(config)
 
     if ensemble is None:
+        parameter_config = [
+            pc.model_dump(mode="json")
+            for pc in ert_config.ensemble_config.parameter_configuration
+        ]
         experiment_id = storage.create_experiment(
-            ert_config.ensemble_config.parameter_configuration,
-            templates=ert_config.ert_templates,
+            experiment_config={
+                "parameter_configuration": parameter_config,
+                "ert_templates": ert_config.ert_templates,
+            }
         )
         ensemble = storage.create_ensemble(
             experiment_id,

--- a/tests/ert/unit_tests/storage/migration/test_to25.py
+++ b/tests/ert/unit_tests/storage/migration/test_to25.py
@@ -1,0 +1,244 @@
+import json
+from datetime import datetime
+
+import polars as pl
+
+from ert.storage.migration.to25 import migrate
+
+
+def test_that_migration_creates_experiment_index_with_params_responses_and_obs_configs(
+    tmp_path,
+):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    obs_path = exp_path / "observations"
+    obs_path.mkdir(parents=True)
+
+    (exp_path / "metadata.json").write_text(
+        json.dumps({"weights": [0.2, 0.8]}), encoding="utf-8"
+    )
+
+    (exp_path / "index.json").write_text(
+        json.dumps({"id": "test-id", "name": "test-experiment", "ensembles": []}),
+        encoding="utf-8",
+    )
+
+    responses = {
+        "summary": {
+            "type": "summary",
+            "name": "summary",
+            "keys": ["FOPR", "FGPR", "OVERLAP"],
+        },
+        "gen_data": {
+            "type": "gen_data",
+            "name": "gen_data",
+            "keys": ["SOME", "OTHER", "OVERLAP"],
+        },
+    }
+    parameters = {
+        "P1": {
+            "type": "gen_kw",
+            "name": "P1",
+            "distribution": {"name": "uniform", "min": 0, "max": 1},
+        }
+    }
+
+    (exp_path / "responses.json").write_text(json.dumps(responses), encoding="utf-8")
+    (exp_path / "parameter.json").write_text(json.dumps(parameters), encoding="utf-8")
+
+    gen_df = pl.from_dicts(
+        [
+            {
+                "response_key": "SOME",
+                "observation_key": "OBS1",
+                "report_step": 1,
+                "index": 0,
+                "observations": 1.23,
+                "std": 0.1,
+            },
+            {
+                "response_key": "SOME",
+                "observation_key": "OBS2",
+                "report_step": 2,
+                "index": 1,
+                "observations": 2.34,
+                "std": 0.2,
+            },
+        ]
+    )
+
+    summary_df = pl.from_dicts(
+        [
+            {
+                "response_key": "FOPR",
+                "observation_key": "FOPR",
+                "time": datetime(2020, 1, 1),
+                "observations": 3.21,
+                "std": 0.05,
+            }
+        ]
+    )
+
+    gen_df.write_parquet(obs_path / "gen_data")
+    summary_df.write_parquet(obs_path / "summary")
+
+    migrate(root)
+
+    updated_index = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+
+    expected_experiment = {
+        "weights": [0.2, 0.8],
+        "response_configuration": [
+            {
+                "type": "summary",
+                "name": "summary",
+                "keys": ["FOPR", "FGPR", "OVERLAP"],
+            },
+            {
+                "type": "gen_data",
+                "name": "gen_data",
+                "keys": ["SOME", "OTHER", "OVERLAP"],
+            },
+        ],
+        "parameter_configuration": [
+            {
+                "type": "gen_kw",
+                "name": "P1",
+                "distribution": {"name": "uniform", "min": 0, "max": 1},
+            }
+        ],
+        "observations": [
+            {
+                "type": "general_observation",
+                "name": name,
+                "data": "SOME",
+                "value": value,
+                "error": error,
+                "restart": restart,
+                "index": index,
+            }
+            for name, value, error, restart, index in [
+                ("OBS1", 1.23, 0.1, 1, 0),
+                ("OBS2", 2.34, 0.2, 2, 1),
+            ]
+        ]
+        + [
+            {
+                "type": "summary_observation",
+                "name": "FOPR",
+                "value": 3.21,
+                "error": 0.05,
+                "key": "FOPR",
+                "date": "2020-01-01",
+            },
+        ],
+    }
+
+    expected_index = {
+        "id": "test-id",
+        "name": "test-experiment",
+        "ensembles": [],
+        "experiment": expected_experiment,
+    }
+
+    assert updated_index == expected_index
+
+
+def test_that_experiment_config_migration_handles_empty_responses_json(tmp_path):
+    root = tmp_path / "project_no_responses"
+    root.mkdir()
+    exp = root / "experiments" / "no_responses"
+    exp.mkdir(parents=True)
+    obs = exp / "observations"
+    obs.mkdir()
+    (exp / "index.json").write_text(
+        json.dumps({"id": "test-id", "name": "test-experiment", "ensembles": []}),
+        encoding="utf-8",
+    )
+    (exp / "responses.json").write_text(json.dumps({}), encoding="utf-8")
+    (exp / "parameter.json").write_text(json.dumps({}), encoding="utf-8")
+    # metadata.json is assumed to always exist
+    (exp / "metadata.json").write_text(json.dumps({}), encoding="utf-8")
+
+    migrate(root)
+    updated = json.loads((exp / "index.json").read_text(encoding="utf-8"))
+    assert "experiment" in updated
+    exp_obj = updated["experiment"]
+    assert isinstance(exp_obj.get("response_configuration", []), list)
+    assert isinstance(exp_obj.get("parameter_configuration", []), list)
+
+
+def test_that_experiment_config_migration_handles_empty_parameter_json(tmp_path):
+    root = tmp_path / "project_no_parameters"
+    root.mkdir()
+    exp = root / "experiments" / "no_parameters"
+    exp.mkdir(parents=True)
+    obs = exp / "observations"
+    obs.mkdir()
+    (exp / "index.json").write_text(
+        json.dumps({"id": "test-id", "name": "test-experiment", "ensembles": []}),
+        encoding="utf-8",
+    )
+    (exp / "responses.json").write_text(
+        json.dumps({"summary": {"type": "summary", "name": "summary", "keys": []}}),
+        encoding="utf-8",
+    )
+    (exp / "parameter.json").write_text(json.dumps({}), encoding="utf-8")
+    # metadata.json is assumed to always exist
+    (exp / "metadata.json").write_text(json.dumps({}), encoding="utf-8")
+
+    migrate(root)
+    updated = json.loads((exp / "index.json").read_text(encoding="utf-8"))
+    assert "experiment" in updated
+    exp_obj = updated["experiment"]
+    assert isinstance(exp_obj.get("parameter_configuration", []), list)
+    assert isinstance(exp_obj.get("response_configuration", []), list)
+
+
+def test_that_experiment_config_migration_handles_missing_observations_directory(
+    tmp_path,
+):
+    root = tmp_path / "project_no_obs"
+    root.mkdir()
+    exp = root / "experiments" / "no_obs"
+    exp.mkdir(parents=True)
+    (exp / "index.json").write_text(
+        json.dumps({"id": "test-id", "name": "test-experiment", "ensembles": []}),
+        encoding="utf-8",
+    )
+    (exp / "responses.json").write_text(json.dumps({}), encoding="utf-8")
+    (exp / "parameter.json").write_text(json.dumps({}), encoding="utf-8")
+    # metadata.json is assumed to always exist
+    (exp / "metadata.json").write_text(json.dumps({}), encoding="utf-8")
+
+    migrate(root)
+    updated = json.loads((exp / "index.json").read_text(encoding="utf-8"))
+    assert "experiment" in updated
+    exp_obj = updated["experiment"]
+    assert isinstance(exp_obj.get("observations", []), list)
+
+
+def test_that_experiment_config_migration_does_not_add_weights_when_missing_in_metadata(
+    tmp_path,
+):
+    root = tmp_path / "project_meta_no_weights"
+    root.mkdir()
+    exp = root / "experiments" / "meta_no_weights"
+    exp.mkdir(parents=True)
+    obs = exp / "observations"
+    obs.mkdir()
+    (exp / "index.json").write_text(
+        json.dumps({"id": "test-id", "name": "test-experiment", "ensembles": []}),
+        encoding="utf-8",
+    )
+    (exp / "responses.json").write_text(json.dumps({}), encoding="utf-8")
+    (exp / "parameter.json").write_text(json.dumps({}), encoding="utf-8")
+    (exp / "metadata.json").write_text(json.dumps({"other": 1}), encoding="utf-8")
+
+    migrate(root)
+    updated = json.loads((exp / "index.json").read_text(encoding="utf-8"))
+    assert "experiment" in updated
+    exp_obj = updated["experiment"]
+    assert "weights" not in exp_obj

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -10,23 +10,25 @@ def test_that_load_scalar_keys_loads_all_parameters(tmp_path):
     """Test that load_scalar_keys loads all scalar parameters when keys=None."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-                GenKwConfig(
-                    name="param2",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-                GenKwConfig(
-                    name="param3",
-                    group="group2",
-                    distribution={"name": "normal", "mean": 0, "std": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                    GenKwConfig(
+                        name="param2",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                    GenKwConfig(
+                        name="param3",
+                        group="group2",
+                        distribution={"name": "normal", "mean": 0, "std": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 
@@ -56,23 +58,25 @@ def test_that_load_scalar_keys_loads_specific_parameters(tmp_path):
     """Test that load_scalar_keys loads only specified parameters."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-                GenKwConfig(
-                    name="param2",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-                GenKwConfig(
-                    name="param3",
-                    group="group2",
-                    distribution={"name": "normal", "mean": 0, "std": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                    GenKwConfig(
+                        name="param2",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                    GenKwConfig(
+                        name="param3",
+                        group="group2",
+                        distribution={"name": "normal", "mean": 0, "std": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 
@@ -100,13 +104,15 @@ def test_that_load_scalar_keys_filters_by_realizations(tmp_path):
     """Test that load_scalar_keys filters by specified realizations."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 
@@ -130,13 +136,15 @@ def test_that_load_scalar_keys_raises_key_error_for_missing_parameters(tmp_path)
     """Test that load_scalar_keys raises KeyError for non-existent parameters."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 
@@ -148,13 +156,15 @@ def test_that_load_scalar_keys_raises_key_error_for_unregistered_parameters(tmp_
     """Test that load_scalar_keys raises KeyError for parameters not in experiment."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 
@@ -178,13 +188,15 @@ def test_that_load_scalar_keys_raises_index_error_for_missing_realizations(tmp_p
     """Test that load_scalar_keys raises IndexError when no matching realizations."""
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
-            parameters=[
-                GenKwConfig(
-                    name="param1",
-                    group="group1",
-                    distribution={"name": "uniform", "min": 0, "max": 1},
-                ),
-            ]
+            experiment_config={
+                "parameter_configuration": [
+                    GenKwConfig(
+                        name="param1",
+                        group="group1",
+                        distribution={"name": "uniform", "min": 0, "max": 1},
+                    ).model_dump(mode="json"),
+                ]
+            }
         )
         ensemble = storage.create_ensemble(experiment.id, ensemble_size=5, name="test")
 

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -297,7 +297,13 @@ def test_that_sampling_is_fixed_from_name(
         with open("template.txt", "w", encoding="utf-8") as fh:
             fh.writelines(template)
         fs = storage.create_ensemble(
-            storage.create_experiment(parameters=scalars),
+            storage.create_experiment(
+                experiment_config={
+                    "parameter_configuration": [
+                        pc.model_dump(mode="json") for pc in scalars
+                    ]
+                }
+            ),
             name="prior",
             ensemble_size=num_realisations,
         )
@@ -364,7 +370,12 @@ def test_that_sub_sample_maintains_order(tmpdir, storage, mask, expected):
 
         fs = storage.create_ensemble(
             storage.create_experiment(
-                ert_config.ensemble_config.parameter_configuration
+                experiment_config={
+                    "parameter_configuration": [
+                        pc.model_dump(mode="json")
+                        for pc in ert_config.ensemble_config.parameter_configuration
+                    ]
+                }
             ),
             name="prior",
             ensemble_size=5,

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -23,7 +23,12 @@ def setup_case(storage, use_tmpdir, run_args):
         ert_config = ErtConfig.from_file_contents(config_text)
         prior_ensemble = storage.create_ensemble(
             storage.create_experiment(
-                responses=ert_config.ensemble_config.response_configuration
+                experiment_config={
+                    "response_configuration": [
+                        rc.model_dump(mode="json")
+                        for rc in ert_config.ensemble_config.response_configuration
+                    ],
+                }
             ),
             name="prior",
             ensemble_size=ert_config.runpath_config.num_realizations,
@@ -131,7 +136,12 @@ def test_load_forward_model_summary(
         """
     )
     experiment_id = storage.create_experiment(
-        responses=ert_config.ensemble_config.response_configuration
+        experiment_config={
+            "response_configuration": [
+                rc.model_dump(mode="json")
+                for rc in ert_config.ensemble_config.response_configuration
+            ]
+        }
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id, name="prior", ensemble_size=100
@@ -221,7 +231,12 @@ def test_loading_gen_data_without_restart(storage, run_args):
     )
     prior_ensemble = storage.create_ensemble(
         storage.create_experiment(
-            responses=ert_config.ensemble_config.response_configuration
+            experiment_config={
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in ert_config.ensemble_config.response_configuration
+                ],
+            }
         ),
         name="prior",
         ensemble_size=ert_config.runpath_config.num_realizations,
@@ -290,7 +305,12 @@ def test_loading_from_any_available_iter(storage, run_args, itr):
     )
     prior_ensemble = storage.create_ensemble(
         storage.create_experiment(
-            responses=ert_config.ensemble_config.response_configuration
+            experiment_config={
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in ert_config.ensemble_config.response_configuration
+                ],
+            }
         ),
         name="prior",
         ensemble_size=ert_config.runpath_config.num_realizations,

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -78,7 +78,11 @@ def test_that_create_run_path_overwrites_symlinks_by_file(
 ):
     ert_config = snake_oil_field_example
     experiment_id = storage.create_experiment(
-        parameters=ert_config.ensemble_config.parameter_configuration
+        experiment_config={
+            "parameter_configuration": (
+                ert_config.ensemble_config.parameter_configuration
+            )
+        },
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id,
@@ -149,8 +153,12 @@ ENSPATH storage
 def make_run_path(run_args, storage):
     def func(ert_config):
         experiment_id = storage.create_experiment(
-            parameters=ert_config.ensemble_config.parameter_configuration,
-            templates=ert_config.ert_templates,
+            experiment_config={
+                "parameter_configuration": (
+                    ert_config.ensemble_config.parameter_configuration
+                ),
+                "ert_templates": ert_config.ert_templates,
+            },
         )
         prior_ensemble = storage.create_ensemble(
             experiment_id, name="prior", ensemble_size=1
@@ -238,7 +246,9 @@ def test_that_run_template_replace_symlink_does_not_write_to_source(
             """
         )
     )
-    prior_ensemble = prior_ensemble_args(templates=ert_config.ert_templates)
+    prior_ensemble = prior_ensemble_args(
+        experiment_config={"ert_templates": ert_config.ert_templates}
+    )
     run_arg = run_args(ert_config, prior_ensemble)
     run_path = Path(run_arg[0].runpath)
     os.makedirs(run_path)
@@ -464,7 +474,11 @@ def test_that_sampling_prior_makes_initialized_fs(storage):
 
     prior_ensemble = storage.create_ensemble(
         storage.create_experiment(
-            parameters=ert_config.ensemble_config.parameter_configuration
+            experiment_config={
+                "parameter_configuration": (
+                    ert_config.ensemble_config.parameter_configuration
+                ),
+            },
         ),
         name="prior",
         ensemble_size=ert_config.runpath_config.num_realizations,
@@ -576,7 +590,11 @@ def test_write_runpath_file(storage, itr):
     )
     num_realizations = ert_config.runpath_config.num_realizations
     experiment_id = storage.create_experiment(
-        parameters=ert_config.ensemble_config.parameter_configuration
+        experiment_config={
+            "parameter_configuration": (
+                ert_config.ensemble_config.parameter_configuration
+            )
+        },
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id, name="prior", ensemble_size=num_realizations, iteration=itr
@@ -914,8 +932,10 @@ def test_when_manifest_files_are_written_loading_succeeds(storage, itr):
     )
 
     experiment_id = storage.create_experiment(
-        parameters=config.ensemble_config.parameter_configuration,
-        responses=config.ensemble_config.response_configuration,
+        experiment_config={
+            "parameter_configuration": config.ensemble_config.parameter_configuration,
+            "response_configuration": config.ensemble_config.response_configuration,
+        },
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id, name="prior", ensemble_size=num_realizations, iteration=itr
@@ -1009,8 +1029,10 @@ def test_that_contents_of_gridfile_is_logged(storage, caplog):
     )
 
     experiment_id = storage.create_experiment(
-        parameters=config.ensemble_config.parameter_configuration,
-        responses=config.ensemble_config.response_configuration,
+        experiment_config={
+            "parameter_configuration": config.ensemble_config.parameter_configuration,
+            "response_configuration": config.ensemble_config.response_configuration,
+        },
     )
     prior_ensemble = storage.create_ensemble(
         experiment_id, name="prior", ensemble_size=num_realizations, iteration=0

--- a/tests/ert/unit_tests/test_summary_response.py
+++ b/tests/ert/unit_tests/test_summary_response.py
@@ -41,7 +41,12 @@ def test_load_summary_response_restart_not_zero(
         ert_config = ErtConfig.from_file("config.ert")
 
         experiment_id = storage.create_experiment(
-            responses=ert_config.ensemble_config.response_configuration
+            experiment_config={
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in ert_config.ensemble_config.response_configuration
+                ]
+            },
         )
         ensemble = storage.create_ensemble(
             experiment_id,

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -1,4 +1,3 @@
-import json
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -119,13 +118,13 @@ def test_api_summary_snapshot(config_file, snapshot, cached_example):
         response_config = experiment.response_configuration
         response_config["summary"] = SummaryConfig(keys=["*"])
 
+        experiment.experiment_config["response_configuration"] = [
+            c.model_dump(mode="json") for c in response_config.values()
+        ]
+
         experiment._storage._write_transaction(
-            experiment._path / experiment._responses_file,
-            json.dumps(
-                {c.type: c.model_dump(mode="json") for c in response_config.values()},
-                default=str,
-                indent=2,
-            ).encode("utf-8"),
+            experiment._path / experiment._index_file,
+            experiment._index.model_dump_json(indent=2).encode("utf-8"),
         )
 
         smry_data = pl.DataFrame(
@@ -162,13 +161,13 @@ def test_api_summary_snapshot_missing_batch(snapshot, cached_example):
         response_config = experiment.response_configuration
         response_config["summary"] = SummaryConfig(keys=["*"])
 
+        experiment.experiment_config["response_configuration"] = [
+            c.model_dump(mode="json") for c in response_config.values()
+        ]
+
         experiment._storage._write_transaction(
-            experiment._path / experiment._responses_file,
-            json.dumps(
-                {c.type: c.model_dump(mode="json") for c in response_config.values()},
-                default=str,
-                indent=2,
-            ).encode("utf-8"),
+            experiment._path / experiment._index_file,
+            experiment._index.model_dump_json(indent=2).encode("utf-8"),
         )
 
         smry_data = pl.DataFrame(
@@ -211,13 +210,13 @@ def test_api_summary_snapshot_with_differing_columns_per_batch(
         response_config = experiment.response_configuration
         response_config["summary"] = SummaryConfig(keys=["*"])
 
+        experiment.experiment_config["response_configuration"] = [
+            c.model_dump(mode="json") for c in response_config.values()
+        ]
+
         experiment._storage._write_transaction(
-            experiment._path / experiment._responses_file,
-            json.dumps(
-                {c.type: c.model_dump(mode="json") for c in response_config.values()},
-                default=str,
-                indent=2,
-            ).encode("utf-8"),
+            experiment._path / experiment._index_file,
+            experiment._index.model_dump_json(indent=2).encode("utf-8"),
         )
 
         smry_data = pl.DataFrame(


### PR DESCRIPTION
Goes in with https://github.com/equinor/semeio/pull/866
**Issue**
Resolves https://github.com/equinor/ert/issues/11477

Made experiment config be cached, it is a performance hog, ref run [link] https://github.com/equinor/ert/issues/12804(https://codspeed.io/equinor/ert/branches/yngve-sk%3A25.08.save-runmodel-configs-in-storage?uri=tests%2Fert%2Fperformance_tests%2Ftest_obs_and_responses_performance.py%3A%3Atest_time_performance_of_joining_observations_and_responses%5Bsetup_benchmark0%5D&runnerMode=Simulation&utm_source=github&utm_medium=check&utm_content=benchmark&page=1)


Followup issues:
* Streamline / clarify / restructure cached getting of responses, parameters, observations from storage. Now it seems a bit ad-hoc, and is a potential performance hog especially if something is called many times with high frequency. https://github.com/equinor/ert/issues/12802
* Make LocalExperiment.experiment_config typed - split out experiment configs into own file so they can be imported from ERT storage and run models without introducing circular imports  https://github.com/equinor/ert/issues/12803