### PR TITLE
Backport: Make sure output has same dtype as input in save_parameters

### DIFF
--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -271,6 +271,7 @@ class Field(ParameterConfig):
             data=np.zeros(self.mask.size),
             mask=self.mask,
             fill_value=np.nan,
+            dtype=data.dtype,
         )
         ma[~ma.mask] = data
         ma = ma.reshape(self.mask.shape)  # type: ignore

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -220,6 +220,7 @@ def test_field_param_update_using_heat_equation(heat_equation_storage_es):
         assert len(prior_result.z) == param_config.nz
 
         posterior_result = posterior.load_parameters("COND")["values"]
+        assert posterior_result.dtype == np.float32
         prior_covariance = np.cov(
             prior_result.values.reshape(
                 prior.ensemble_size, param_config.nx * param_config.ny * param_config.nz


### PR DESCRIPTION
Backport of https://github.com/equinor/ert/pull/11497


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
