### PR TITLE
[Backport] Skip test_that_multiple_everest_clients_can_connect_to_server python 3.13

### DIFF
--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -1,5 +1,6 @@
 import logging
 import ssl
+import sys
 import threading
 from pathlib import Path
 
@@ -149,7 +150,10 @@ def test_that_stop_errors_on_server_up_but_endpoint_down(
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.flaky(rerun=3)
-def test_that_multiple_everest_clients_can_connect_to_server(cached_example):
+@pytest.mark.skipif(sys.version_info[0:2] == (3, 13), reason="Fails on Python 3.13")
+def test_that_multiple_everest_clients_can_connect_to_server(
+    cached_example, change_to_tmpdir
+):
     # We use a cached run for the reference list of received events
     path, config_file, _, server_events_list = cached_example(
         "math_func/config_minimal.yml"


### PR DESCRIPTION
Skip test_that_multiple_everest_clients_can_connect_to_server python 3.13

Backport of 1c03dbd23cbae4a371c0a0bcaef6c93a06dd1563
Backport of https://github.com/equinor/ert/commit/a743c41daf05d26315ca820502207b3f0807287a

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
