### PR TITLE
Limit local queue to 2 simultaneous realizations when running Everest tests

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -17,6 +17,7 @@ import yaml
 
 import ert
 import everest
+from ert.config.queue_config import LocalQueueOptions
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models import StatusEvents
 from ert.run_models.event import status_event_from_json, status_event_to_json
@@ -200,6 +201,7 @@ def cached_example(pytestconfig):
 
             shutil.copytree(config_path.parent, my_tmpdir / "everest")
             config = EverestConfig.load_file(my_tmpdir / "everest" / config_file)
+            config.simulator.queue_system = LocalQueueOptions(max_running=2)
             status_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
             run_model = EverestRunModel.create(config, status_queue=status_queue)
             evaluator_server_config = EvaluatorServerConfig()

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -51,7 +51,7 @@ def test_everest_entry_run(cached_example):
 
     # Ensure no interference with plugins which may set queue system
     config_content = yaml.safe_load(Path(config_file).read_text(encoding="utf-8"))
-    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    config_content["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
     Path(config_file).write_text(
         yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -158,7 +158,7 @@ def test_that_multiple_everest_clients_can_connect_to_server(
 
     config_path = Path(path) / config_file
     config_content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    config_content["simulator"] = {"queue_system": {"name": "local"}}
+    config_content["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
     config_path.write_text(
         yaml.dump(config_content, default_flow_style=False), encoding="utf-8"
     )

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -178,7 +178,7 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
+        "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
     config = EverestConfig.model_validate(config_dict)
 
@@ -207,7 +207,7 @@ async def test_status_too_few_realizations_succeeded(copy_math_func_test_data_to
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
+        "simulator": {"queue_system": {"name": "local", "max_running": 2}},
         "model": {"realizations": [0, 1]},
     }
     config_dict["install_jobs"].append(
@@ -236,7 +236,7 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
     config_dict = {
         **config.model_dump(exclude_none=True),
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
-        "simulator": {"queue_system": {"name": "local"}},
+        "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
     config_dict["install_jobs"].append({"name": "fail", "executable": which("false")})
     config_dict["forward_model"].append("fail")
@@ -258,7 +258,10 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
 @pytest.mark.timeout(240)
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 async def test_status_contains_max_runtime_failure(change_to_tmpdir, min_config):
-    min_config["simulator"] = {"queue_system": {"name": "local"}, "max_runtime": 1}
+    min_config["simulator"] = {
+        "queue_system": {"name": "local", "max_running": 2},
+        "max_runtime": 1,
+    }
     min_config["forward_model"] = ["sleep 5"]
     min_config["install_jobs"] = [{"name": "sleep", "executable": which("sleep")}]
 

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -140,6 +140,7 @@ def test_math_func_auto_scaled_controls(copy_math_func_test_data_to_tmp):
                 "upper_bound": 0.5,
             }
         ],
+        "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
     config = EverestConfig.model_validate(config_dict)
 
@@ -168,11 +169,12 @@ def test_math_func_auto_scaled_objectives(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file("config_multiobj.yml")
     config_dict = config.model_dump(exclude_none=True)
 
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
+
     # Normalize only distance_p:
     config_dict["objective_functions"][0]["auto_scale"] = True
     config_dict["objective_functions"][0]["scale"] = 1.0
     config_dict["optimization"]["max_batch_num"] = 1
-
     config = EverestConfig.model_validate(config_dict)
     run_model = EverestRunModel.create(config)
     evaluator_server_config = EvaluatorServerConfig()
@@ -191,6 +193,8 @@ def test_math_func_auto_scaled_objectives(copy_math_func_test_data_to_tmp):
 def test_math_func_auto_scaled_constraints(copy_math_func_test_data_to_tmp):
     config = EverestConfig.load_file("config_advanced.yml")
     config_dict = config.model_dump(exclude_none=True)
+
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
 
     # control number of batches, no need for full convergence:
     config_dict["optimization"]["convergence_tolerance"] = 1e-10
@@ -239,6 +243,8 @@ def test_that_math_func_violating_output_constraints_has_no_result(
     config = EverestConfig.load_file("config_advanced.yml")
     config_dict = config.model_dump(exclude_none=True)
 
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
+
     # The first batch violates the output constraint:
     config_dict["optimization"]["max_batch_num"] = 1
     config_dict["controls"][0]["initial_guess"] = 0.05
@@ -257,6 +263,8 @@ def test_that_math_func_violating_output_constraints_has_a_result(
 ):
     config = EverestConfig.load_file("config_advanced.yml")
     config_dict = config.model_dump(exclude_none=True)
+
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
 
     # The second batch does not violate the output constraint:
     config_dict["optimization"]["max_batch_num"] = 2
@@ -277,6 +285,8 @@ def test_that_math_func_violating_input_constraints_has_no_result(
     config = EverestConfig.load_file("config_advanced.yml")
     config_dict = config.model_dump(exclude_none=True)
 
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
+
     # The first batch violates the input constraint:
     config_dict["optimization"]["max_batch_num"] = 1
     config_dict["controls"][0]["initial_guess"] = 0.5
@@ -295,6 +305,8 @@ def test_that_math_func_violating_input_constraints_has_a_result(
 ):
     config = EverestConfig.load_file("config_advanced.yml")
     config_dict = config.model_dump(exclude_none=True)
+
+    config_dict["simulator"] = {"queue_system": {"name": "local", "max_running": 2}}
 
     # The second batch does not violate the input constraint:
     config_dict["optimization"]["max_batch_num"] = 2

--- a/tests/everest/test_objective_type.py
+++ b/tests/everest/test_objective_type.py
@@ -27,6 +27,7 @@ def test_objective_type(copy_math_func_test_data_to_tmp):
                 "--target 0.5 0.5 0.5 --out stddev"
             ),
         ],
+        "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
     config = EverestConfig.model_validate(config_dict)
     # Act


### PR DESCRIPTION
When the test suite is running, one should assume that pytest takes care of parallelization and saturation of CPUs, thus one should not try to run everest with an arbitrary default (currently 8) as other cpus should be assumed busy with other tasks.

It is more fair to set this to 1, but since the relevant example in the test suite is not computationally heavy, each realization is mostly waiting for IO when going through fm_dispatch, and we allow for some slight overbooking

**Issue**
Resolves #11505 


**Approach**
Explicit runtime modification of the config file. 

Tried patching `SimulatorConfig.default_local_queue` to always return a LsfQueueOption object with requested max_running, but it seemed to be more complex to get working.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
