### PR TITLE
Everest job runners needs to use the same ports as ert

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -240,9 +240,7 @@ class ExperimentRunner:
                 lambda: run_model.start_simulations_thread(
                     EvaluatorServerConfig()
                     if run_model.queue_config.queue_system == QueueSystem.LOCAL
-                    else EvaluatorServerConfig(
-                        port_range=(49152, 51819), use_ipc_protocol=False
-                    )
+                    else EvaluatorServerConfig(use_ipc_protocol=False)
                 ),
             )
             while True:


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11424


**Approach**
Let port range for evaluator to be default.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
