### PR TITLE
Add setting summary log statement to run_model

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -230,16 +230,25 @@ class RunModel(BaseModel, ABC):
             for key, value in self.__dict__.items()
             if key not in keys_to_drop
         }
-        num_params_log = "with"
-        if hasattr(self, "parameter_configuration"):
-            num_params = sum(
+        settings_summary = {
+            "run_model": self.name(),
+            "num_realizations": self.runpath_config.num_realizations,
+            "num_active_realizations": self.active_realizations.count(True),
+            "num_parameters": sum(
                 len(param_config.parameter_keys)
                 for param_config in self.parameter_configuration
             )
-            num_params_log = f"with {num_params} parameters and"
+            if hasattr(self, "parameter_configuration")
+            else "NA",
+            "localization": getattr(
+                settings_dict.get("analysis_settings", {}), "localization", "NA"
+            ),
+        }
 
         logger.info(
-            f"Running '{self.name()}' {num_params_log} settings {settings_dict}"
+            f"Running '{self.name()}'\n\n"
+            f"Settings summary: {settings_summary}\n\n"
+            f"Settings: {settings_dict}"
         )
 
     @classmethod

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -624,7 +624,7 @@ def test_run_model_logs_number_of_parameters(use_tmpdir):
     rm = create_run_model(parameter_configuration=[parameters])
 
     def mock_logging(_, log_str):
-        regex = r"Running '\w+' with (\d+) parameters"
+        regex = r"'num_parameters': (\d+)"
         match = re.search(regex, log_str)
         num_param = int(match.group(1))
 


### PR DESCRIPTION
Logs are chunked if their message becomes too long. To be able to query logs for conditions based on multiple of these values, we need to ensure they are in the same log chunk.

This will make a short summary of properties (to be amended?) we wish to query for in the first chunk of the log.

**Issue**
Resolves #11518 

Log examples:
<img width="837" height="72" alt="image" src="https://github.com/user-attachments/assets/77933dff-b83e-49ce-bec2-cf34f0d32924" />
<img width="812" height="68" alt="image" src="https://github.com/user-attachments/assets/d98d033d-29ac-4d5e-8799-e5c9fd30f689" />

Note: `evaluate_ensemble` have `num_parameters: NA` because `EvaluateEnsemble` doesn't have the `parameter_config` property as it's not inheriting `InitialEnsembleRunModel`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
