### PR TITLE
Increase test timeout for macOS 15.5

### DIFF
--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -3,6 +3,7 @@ import fileinput
 import json
 import logging
 import os
+import platform
 import stat
 import threading
 import warnings
@@ -934,7 +935,9 @@ async def test_that_killed_ert_does_not_leave_storage_server_process():
             await asyncio.sleep(0.05)
 
     storage_process_pid = await asyncio.wait_for(
-        _find_storage_process_pid(), timeout=120
+        _find_storage_process_pid(),
+        # Increased timeout for version branch 14.4 due to flaky mac tests
+        timeout=240 if platform.mac_ver()[0] == "15.5" else 120,
     )
     # wait for storage server to have connected to ert
     await asyncio.sleep(5)


### PR DESCRIPTION
This test have become flaky for our mac runners, which stalls deployment to pypi. This fix will not be added to main, but is added here to speed up new releases for version 14.4.

**Issue**
Doesn't solve, but is related to #11493 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
