### PR TITLE
Improve selected failed realizations color

### DIFF
--- a/src/ert/gui/simulation/view/realization.py
+++ b/src/ert/gui/simulation/view/realization.py
@@ -134,7 +134,12 @@ class RealizationDelegate(QStyledItemDelegate):
             painter.drawPie(adjusted_rect, 1440, -int(percentage_done * 57.6))
 
         if option.state & QStyle.StateFlag.State_Selected:
-            selected_color = selected_color.lighter(125)
+            factor: int = (
+                125
+                if selected_color.lighter(125).getRgb() != (255, 255, 255, 255)
+                else 110
+            )
+            selected_color = selected_color.lighter(factor)
 
         painter.setBrush(selected_color)
         adjusted_rect = option.rect.adjusted(7, 7, -7, -7)


### PR DESCRIPTION
**Issue**
Resolves #11240


**Approach**
The selected realization was turning white because `selected_color.lighter(125)` reached the cap of rgb and became (255, 255, 255, 255) which is white. The approach was to check if the lightened color would be white and, if yes, reduce the lightening factor to 110 instead of 125. Now the selected failed realization is as below:
<br>
<img width="180" height="92" alt="lighter_110" src="https://github.com/user-attachments/assets/c4d7fceb-8ca5-40e4-a377-90abee237f21" />

I've also tried with 105, 115 and 120 but only 115 made sense, since 105 was barely lighter and 120 was nearly white. With factor =  115, the result was this:
<br>
<img width="183" height="90" alt="lighter_115" src="https://github.com/user-attachments/assets/df7d3ca0-b536-48b6-a9ea-ecc99119aa20" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
