### PR TITLE
Skip test_that_killed_ert_does_not_leave_storage_server_process on mac

### DIFF
--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -921,6 +921,7 @@ def test_that_connection_errors_do_not_effect_final_result(
 
 
 @pytest.mark.usefixtures("copy_poly_case")
+@pytest.mark.skip_mac_ci
 async def test_that_killed_ert_does_not_leave_storage_server_process():
     ert_subprocess = Popen(["ert", "gui", "poly.ert"])
     assert ert_subprocess.is_running()


### PR DESCRIPTION
This blocks releases so we need to skip it until https://github.com/equinor/ert/issues/11493 is resolved.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
