### PR TITLE
Unskip test_that_multiple_everest_clients_can_connect_to_server

### DIFF
--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -149,7 +149,9 @@ def test_that_stop_errors_on_server_up_but_endpoint_down(
 @pytest.mark.integration_test
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
 @pytest.mark.flaky(rerun=3)
-@pytest.mark.skipif(sys.version_info[0:2] == (3, 13), reason="Fails on Python 3.13")
+@pytest.mark.skipif(
+    sys.version_info[0:3] == (3, 13, 6), reason="Fails on Python 3.13.6"
+)
 def test_that_multiple_everest_clients_can_connect_to_server(
     cached_example, change_to_tmpdir
 ):


### PR DESCRIPTION
python 3.13.7 is now default in runner images


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
