### PR TITLE
Triple httpx timeouts in dark_storage

### DIFF
--- a/src/ert/dark_storage/client/client.py
+++ b/src/ert/dark_storage/client/client.py
@@ -18,5 +18,8 @@ class Client(httpx.Client):
             headers = {"Token": conn_info.auth_token}
 
         super().__init__(
-            base_url=conn_info.base_url, headers=headers, verify=conn_info.cert
+            base_url=conn_info.base_url,
+            headers=headers,
+            verify=conn_info.cert,
+            timeout=15,
         )


### PR DESCRIPTION
The default for httpx is 5 seconds, which is seemingly too small for production filesystem (shared network disks) when hammered with file requests.

**Issue**
Resolves #11543 
Resolves #11542
Resolves #11520


**Approach**
➕ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
