### PR TITLE
Setup Qt resources directory for all test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
+from importlib.resources import files
 
 import pytest
+from PyQt6.QtCore import QDir
 
 
 def pytest_addoption(parser):
@@ -109,3 +111,10 @@ def env_save():
     ]
     set_xor = set(environment_pre).symmetric_difference(set(environment_post))
     assert len(set_xor) == 0, f"Detected differences in environment: {set_xor}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_svg_search_path():
+    QDir.addSearchPath(
+        "img", str(files("ert.gui").joinpath("../../ert/gui/resources/gui/img"))
+    )


### PR DESCRIPTION
This removes a lot of error messages on the terminal when running tests involving Qt, on 'No such file or directory' for svg files.

**Issue**
Resolves #11565 


**Approach**
➕ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
