### PR TITLE
Skip failing ci tests on mac

### DIFF
--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -289,6 +289,7 @@ def test_that_ert_changes_to_config_directory(qtbot):
         assert gui.windowTitle().startswith("ERT - snake_oil_surface.ert")
 
 
+@pytest.mark.skip_mac_ci
 def test_that_the_plot_window_contains_the_expected_elements(
     esmda_has_run: ErtMainWindow, qtbot
 ):
@@ -618,6 +619,7 @@ def test_that_a_failing_job_shows_error_message_with_context(
     qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=100000)
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.usefixtures("set_site_config")
 def test_that_gui_plotter_works_when_no_data(qtbot, monkeypatch, use_tmpdir):
     monkeypatch.setattr(PlotApi, "get_all_ensembles", lambda _: [])
@@ -652,6 +654,7 @@ def test_that_gui_plotter_works_when_no_data(qtbot, monkeypatch, use_tmpdir):
         assert len(ensemble_plot_names) == 0
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
 def test_right_click_plot_button_opens_external_plotter(qtbot, use_tmpdir, monkeypatch):
     monkeypatch.setattr(PlotApi, "get_all_ensembles", lambda _: [])

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -130,6 +130,7 @@ def test_that_all_snake_oil_visualisations_matches_snapshot(plot_figure):
     return plot_figure
 
 
+@pytest.mark.skip_mac_ci
 def test_that_all_plotter_filter_boxes_yield_expected_filter_results(
     qtbot, snake_oil_case_storage
 ):

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -164,6 +164,7 @@ def test_everest_main_configdump_entry(copy_egg_test_data_to_tmp):
     )
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.timeout(60)
 @pytest.mark.integration_test

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -146,6 +146,7 @@ def test_that_stop_errors_on_server_up_but_endpoint_down(
     )
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
 @pytest.mark.flaky(rerun=3)

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -152,6 +152,7 @@ def test_status_failed_job(_, change_to_tmpdir, mock_server):
     assert status["status"] == ExperimentState.failed
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
@@ -169,6 +170,7 @@ async def test_status_exception(_, change_to_tmpdir, min_config):
     assert "Optimization failed:" in status["message"]
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.timeout(240)
@@ -198,6 +200,7 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
     assert {b.batch_id for b in storage.data.batches} == {0}
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.timeout(240)
@@ -227,6 +230,7 @@ async def test_status_too_few_realizations_succeeded(copy_math_func_test_data_to
     assert OPT_FAILURE_REALIZATIONS in status["message"]
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.timeout(240)
@@ -253,6 +257,7 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
     assert OPT_FAILURE_ALL_REALIZATIONS in status["message"]
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.timeout(240)

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -13,6 +13,7 @@ from everest.config.forward_model_config import ForwardModelStepConfig
 from everest.config.install_job_config import InstallJobConfig
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.timeout(240)  # Simulation might not finish
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")


### PR DESCRIPTION
Skips tests which time out on main branch and version branches following the upgrade to macos 15.5. There is an issue to unskip these here: https://github.com/equinor/ert/issues/11573


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
