### PR TITLE
Consolidate history key

### DIFF
--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 
+from ert.summary_key_type import history_key
 from ert.validation import rangestring_to_list
 
 from .gen_data_config import GenDataConfig
@@ -30,11 +31,6 @@ if TYPE_CHECKING:
     from .ensemble_config import EnsembleConfig
 
 DEFAULT_TIME_DELTA = timedelta(seconds=30)
-
-
-def history_key(key: str) -> str:
-    keyword, *rest = key.split(":")
-    return ":".join([keyword + "H", *rest])
 
 
 @dataclass

--- a/src/ert/summary_key_type.py
+++ b/src/ert/summary_key_type.py
@@ -133,7 +133,28 @@ def is_rate(summary_variable: str) -> bool:
     return False
 
 
-__all__ = ["SummaryKeyType", "is_rate"]
+def history_key(key: str) -> str:
+    """The history summary key responding to given summary key
+
+    See :ref:`SUMMARY  <summary>` and :ref:`HISTORY_SOURCE <history_source>`
+    for in keywords.rst for details.
+
+    >>> history_key("FOPR")
+    'FOPRH'
+    >>> history_key("BPR:1,3,8")
+    'BPRH:1,3,8'
+    >>> history_key("LWWIT:WNAME:LGRNAME")
+    'LWWITH:WNAME:LGRNAME'
+    """
+
+    # Note that this function is not idempotent and only ad-hoc.
+    # It is possible to create to make a better version by looking
+    # at opm-flow-manual 2023-04 table 11.8, 11.9, 11.14 11.9
+    keyword, *rest = key.split(":")
+    return ":".join([keyword + "H", *rest])
+
+
+__all__ = ["SummaryKeyType", "history_key", "is_rate"]
 
 
 _rate_roots = [  # see opm-flow-manual 2023-04 table 11.8, 11.9 & 11.14


### PR DESCRIPTION
Finding the history key of a summary key was computed differently in two places. This just extracts and calls a function in those two places.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
