### PR TITLE
Make sure x509 OID COMMON NAME is at most 64 characters

### DIFF
--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -302,16 +302,15 @@ def _generate_certificate(cert_folder: str) -> tuple[str, str, bytes]:
     )
 
     # Generate the certificate and sign it with the private key
-    cert_name = get_machine_name()
     subject = issuer = x509.Name(
         [
             x509.NameAttribute(NameOID.COUNTRY_NAME, "NO"),
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Bergen"),
             x509.NameAttribute(NameOID.LOCALITY_NAME, "Sandsli"),
             x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Equinor"),
-            x509.NameAttribute(NameOID.COMMON_NAME, f"{cert_name}"),
         ]
     )
+    dns_name = get_machine_name()
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -323,7 +322,7 @@ def _generate_certificate(cert_folder: str) -> tuple[str, str, bytes]:
             datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=365)
         )  # 1 year
         .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(f"{cert_name}")]),
+            x509.SubjectAlternativeName([x509.DNSName(f"{dns_name}")]),
             critical=False,
         )
         .sign(key, hashes.SHA256(), default_backend())
@@ -331,10 +330,10 @@ def _generate_certificate(cert_folder: str) -> tuple[str, str, bytes]:
 
     # Write certificate and key to disk
     makedirs_if_needed(cert_folder)
-    cert_path = os.path.join(cert_folder, cert_name + ".crt")
+    cert_path = os.path.join(cert_folder, dns_name + ".crt")
     with open(cert_path, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.PEM))
-    key_path = os.path.join(cert_folder, cert_name + ".key")
+    key_path = os.path.join(cert_folder, dns_name + ".key")
     pw = bytes(os.urandom(28))
     with open(key_path, "wb") as f:
         f.write(

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -107,6 +107,25 @@ def test_certificate_generation(change_to_tmpdir):
     ctx.load_cert_chain(cert, key, pw)  # raise on error
 
 
+@pytest.mark.integration_test
+@patch(
+    "ert.shared.get_machine_name",
+    return_value="A" * 67,
+)
+def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
+    cert, key, pw = everserver._generate_certificate(
+        ServerConfig.get_certificate_dir("output")
+    )
+
+    # check that files are written
+    assert os.path.exists(cert)
+    assert os.path.exists(key)
+
+    # check certificate is readable
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.load_cert_chain(cert, key, pw)  # raise on error
+
+
 @patch("sys.argv", ["name", "--output-dir", "everest_output"])
 @patch(
     "everest.detached.everserver._configure_loggers",


### PR DESCRIPTION
The CN field is not required when SAN is given and CN can not be longer than 64 characters.

See https://stackoverflow.com/questions/5136198/what-strings-are-allowed-in-the-common-name-attribute-in-an-x-509-certificate and https://www.sectigo.com/knowledge-base/detail/64-Character-Limitation-on-Common-Name-CN-Field-in-X-509-Certificates/kA0Uj0000002kht

Also relevant to wether critical should now be set (it should not) https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6

**Issue**
Resolves #11583
Resolves #11584


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
