### PR TITLE
Bump timeout for a flaky test

### DIFF
--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -180,7 +180,7 @@ def test_terminating_experiment_shows_a_confirmation_dialog(
 def test_run_dialog_polls_run_model_for_runtime(
     qtbot, mock_set_is_simulation_running, mock_get_runtime, run_dialog: RunDialog
 ):
-    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True)
+    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=10000)
     mock_get_runtime.assert_any_call()
     mock_set_is_simulation_running.assert_has_calls([call(True), call(False)])
 


### PR DESCRIPTION
Has been observed to fail with a timeout when timeout was 5000ms

**Issue**
Resolves #11589 🙏🏻 


**Approach**
🕐 ➕ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
