### PR TITLE
Make set_conn_info file writing atomic

### DIFF
--- a/src/ert/services/_base_service.py
+++ b/src/ert/services/_base_service.py
@@ -12,6 +12,7 @@ from logging import Logger, getLogger
 from pathlib import Path
 from select import PIPE_BUF, select
 from subprocess import Popen, TimeoutExpired
+from tempfile import NamedTemporaryFile
 from time import sleep
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
@@ -327,8 +328,10 @@ class BaseService:
             path = f"{self.service_name}_server.json"
 
         if isinstance(info, Mapping):
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(info, f, indent=4)
+            with NamedTemporaryFile(dir=f"{self._project}", delete=False) as f:
+                f.write(json.dumps(info, indent=4).encode("utf-8"))
+                f.flush()
+                os.rename(f.name, path)
 
         self._conn_info_event.set()
 

--- a/src/everest/config/server_config.py
+++ b/src/everest/config/server_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -71,19 +72,15 @@ class ServerConfig(BaseModel):
     @staticmethod
     def get_server_info(output_dir: str) -> dict[str, Any]:
         """Load server information from the hostfile"""
-        host_file_path = ServerConfig.get_hostfile_path(output_dir)
-        try:
-            with open(host_file_path, encoding="utf-8") as f:
-                json_string = f.read()
-
-            data = json.loads(json_string)
-            if not all(k in data for k in ("host", "port", "cert", "auth")):
-                raise RuntimeError("Malformed hostfile")
-        except FileNotFoundError:
-            # No host file
+        host_file_path = Path(ServerConfig.get_hostfile_path(output_dir))
+        if not host_file_path.exists():
             return {"host": None, "port": None, "cert": None, "auth": None}
-        else:
-            return data
+
+        data = json.loads(host_file_path.read_text(encoding="utf-8"))
+
+        if not all(k in data for k in ("host", "port", "cert", "auth")):
+            raise RuntimeError("Malformed hostfile")
+        return data
 
     @staticmethod
     def get_detached_node_dir(output_dir: str) -> str:


### PR DESCRIPTION
If not atomic, there is a possibility that another process can read a partially
written (typically length zero) file from disk.


**Issue**
Resolves #11581 


**Approach**

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
