### PR TITLE
Fix test_fm_step_config_via_plugin_ends_up_json_data assumption

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -803,7 +803,7 @@ def test_that_include_statements_with_multiple_values_raises_error():
 @pytest.mark.usefixtures("use_tmpdir")
 @given(anystring=st.text())
 def test_fm_step_config_via_plugin_ends_up_json_data(monkeypatch, anystring):
-    assume(not (anystring and anystring[0] == "<" and anystring[-1] == ">"))
+    assume(all(bracket not in anystring for bracket in "<>"))
     monkeypatch.setattr(
         ErtPluginManager,
         "get_forward_model_configuration",


### PR DESCRIPTION
The assumption was not strong enough as `anystring=0<IENS>` is a counterexample.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
