### PR TITLE
Reduce LSF logging with removal of low value log statements

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -369,7 +369,7 @@ class LsfDriver(Driver):
                     f"Could not understand '{process_message}' from bsub"
                 )
             job_id = match[1]
-            logger.info(f"Realization {iens} accepted by LSF, got id {job_id}")
+            logger.debug(f"Realization {iens} accepted by LSF, got id {job_id}")
 
             (Path(runpath) / LSF_INFO_JSON_FILENAME).write_text(
                 json.dumps({"job_id": job_id}), encoding="utf-8"
@@ -521,7 +521,7 @@ class LsfDriver(Driver):
                 exec_hosts=self._jobs[job_id].exec_hosts,
             )
         elif isinstance(new_state, FinishedJobSuccess):
-            logger.info(
+            logger.debug(
                 f"Realization {iens} (LSF-id: {self._iens2jobid[iens]}) succeeded"
             )
             event = FinishedEvent(
@@ -644,7 +644,7 @@ class LsfDriver(Driver):
     def update_and_log_exec_hosts(self, bjobs_exec_hosts: dict[str, str]) -> None:
         for job_id, exec_hosts in bjobs_exec_hosts.items():
             if self._jobs[job_id].exec_hosts == "-" and exec_hosts != "-":
-                logger.info(
+                logger.debug(
                     f"Realization {self._jobs[job_id].iens} "
                     f"was assigned to host: {exec_hosts}"
                 )

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1001,7 +1001,7 @@ def not_found_bjobs(monkeypatch, tmp_path):
 
 @pytest.mark.integration_test
 async def test_bjobs_exec_host_logs_only_once(use_tmpdir, job_name, caplog):
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     driver = LsfDriver()
     driver._poll_period = 0.01
     await driver.submit(0, "sh", "-c", "sleep 1", name=job_name)


### PR DESCRIPTION
**Issue**
Resolves #11603 

Altering these insignificant log statements should reduce our logging by approx 27 %.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
