### PR TITLE
Change sorting in evaluate ensamble

### DIFF
--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -125,7 +125,8 @@ class EnsembleSelector(QComboBox):
             ensemble_list = [val for val in ensemble_list if val.id not in parents]
         return self.sort_ensembles(ensemble_list)
 
-    def sort_ensembles(self, ensemble_list: Iterable[Ensemble]) -> Iterable[Ensemble]:
+    @classmethod
+    def sort_ensembles(cls, ensemble_list: Iterable[Ensemble]) -> Iterable[Ensemble]:
         return sorted(
             ensemble_list,
             key=lambda e: (

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -108,14 +108,10 @@ def test_ensembles_are_sorted_failed_first_then_by_start_time(qtbot, notifier, s
     ensemble_c = storage.create_experiment().create_ensemble(
         name="default_a", ensemble_size=1
     )
-    notifier.set_storage(str(storage.path))
-    widget = EnsembleSelector(notifier)
-    qtbot.addWidget(widget)
-
-    ensemble_c.set_failure(0, RealizationStorageState.FAILURE_IN_CURRENT)
-    assert widget.sort_ensembles([ensemble_a, ensemble_b, ensemble_c]) == [
-        ensemble_c,
+    ensemble_b.set_failure(0, RealizationStorageState.FAILURE_IN_CURRENT)
+    assert EnsembleSelector.sort_ensembles([ensemble_a, ensemble_b, ensemble_c]) == [
         ensemble_b,
+        ensemble_c,
         ensemble_a,
     ]
 


### PR DESCRIPTION
**Issue**
Resolves #11405 

**Approach**
- Changed sorting in the drop down list of the Ensemble Evaluator panel, so that failed forward models appear first and all other ensembles appear chronologically, from newest to oldest.
- Changed indexing in the drop down list, so that the top most item appears first.
- Changed unit test to make it compatible with the new indexing (would like some feedback on whether this is risky behavior!).
- Tested the changes by running ert gui on poly_example, and by inducing failures in the forward model. 


https://github.com/user-attachments/assets/abaf0ee4-c4d1-458e-aed7-c57b34a9c76d


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
