### PR TITLE
Mute warning on SUMMARY key in tests

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1387,6 +1387,7 @@ def test_that_defines_in_included_files_has_immediate_effect():
 
 
 @pytest.mark.usefixtures("use_tmpdir", "set_site_config")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_multiple_errors_are_shown_for_forward_model():
     with pytest.raises(ConfigValidationError) as err:
         _ = ErtConfig.from_file_contents(
@@ -1680,6 +1681,7 @@ def test_that_multiple_errors_are_shown_when_validating_observation_config():
 
 
 @pytest.mark.usefixtures("copy_snake_oil_case")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_multiple_errors_are_shown_when_generating_observations():
     injected_errors = {
         7: "    RESTART = 0;",

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -13,6 +13,7 @@ from ert.field_utils import FieldFileFormat, Shape, read_field
 from ert.sample_prior import sample_prior
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_write_to_runpath_produces_the_transformed_field_in_storage(
     snake_oil_field_example, storage
 ):

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -52,6 +52,7 @@ def run_simulator():
     ],
 )
 @pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_correct_key_observation_is_loaded(extra_config, expected):
     run_simulator()
     observations = ErtConfig.from_dict(
@@ -75,6 +76,7 @@ def test_that_correct_key_observation_is_loaded(extra_config, expected):
     ],
 )
 @pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_date_parsing_in_observations(datestring, errors):
     config_dict = {
         "ECLBASE": "my_case%d",
@@ -173,6 +175,7 @@ def test_that_empty_observations_file_causes_exception():
         ErtConfig.from_dict({"OBS_CONFIG": ("obs_conf", "")})
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_having_no_refcase_but_history_observations_causes_exception():
     with pytest.raises(
         expected_exception=ConfigValidationError,
@@ -419,6 +422,7 @@ def run_sim(start_date, keys=None, values=None, days=None):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_loading_summary_obs_with_days_is_within_tolerance(
     tmpdir,
     time_delta,
@@ -451,6 +455,7 @@ def test_that_loading_summary_obs_with_days_is_within_tolerance(
             )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_having_observations_on_starting_date_errors(tmpdir):
     date = datetime(2014, 9, 10)
     with tmpdir.as_cwd():
@@ -516,6 +521,7 @@ def test_that_having_observations_on_starting_date_errors(tmpdir):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_out_of_bounds_segments_are_truncated(tmpdir, start, stop, message):
     with tmpdir.as_cwd():
         run_sim(
@@ -559,6 +565,7 @@ def test_that_out_of_bounds_segments_are_truncated(tmpdir, start, stop, message)
         [("WWIR", "SM3/DAY", "WNAME"), ("WWIRH", "SM3/DAY", "WNAME")],
     ],
 )
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_history_observations_are_loaded(tmpdir, keys, with_ext):
     with tmpdir.as_cwd():
         key, _, wname = keys[0]
@@ -671,6 +678,7 @@ def test_that_report_step_mismatch_warns():
         )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
     with tmpdir.as_cwd():
         run_sim(
@@ -755,6 +763,7 @@ def test_validation_of_duplicate_names(tmpdir):
             )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_segment_defaults_are_applied(tmpdir):
     with tmpdir.as_cwd():
         run_sim(
@@ -797,6 +806,7 @@ def test_that_segment_defaults_are_applied(tmpdir):
             ].std == pytest.approx(0.1)
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_summary_default_error_min_is_applied(tmpdir):
     with tmpdir.as_cwd():
         run_sim(

--- a/tests/ert/unit_tests/gui/ertwidgets/models/test_ertsummary.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/models/test_ertsummary.py
@@ -90,6 +90,7 @@ def test_getParameters(mock_ert):
     assert parameter_count == 223
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_snake_oil(snake_oil_case):
     summary = ErtSummary(snake_oil_case)
 

--- a/tests/ert/unit_tests/plugins/test_export_runpath.py
+++ b/tests/ert/unit_tests/plugins/test_export_runpath.py
@@ -40,6 +40,7 @@ def writing_setup(setup_case):
         )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_empty_range(writing_setup):
     writing_setup, run_paths = writing_setup
 
@@ -53,6 +54,7 @@ def test_export_runpath_empty_range(writing_setup):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_star_parameter(writing_setup):
     writing_setup, run_paths = writing_setup
 
@@ -67,6 +69,7 @@ def test_export_runpath_star_parameter(writing_setup):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_range_parameter(writing_setup):
     writing_setup, run_paths = writing_setup
 
@@ -81,6 +84,7 @@ def test_export_runpath_range_parameter(writing_setup):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_comma_parameter(writing_setup):
     writing_setup, run_paths = writing_setup
 
@@ -95,6 +99,7 @@ def test_export_runpath_comma_parameter(writing_setup):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_combination_parameter(writing_setup):
     writing_setup, run_paths = writing_setup
 
@@ -109,6 +114,7 @@ def test_export_runpath_combination_parameter(writing_setup):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_export_runpath_bad_arguments(writing_setup):
     writing_setup, run_paths = writing_setup
 

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -81,6 +81,7 @@ def create_responses(prior_ensemble, response_times):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_reading_matching_time_is_ok(ert_config, storage, prior_ensemble):
     sample_prior(prior_ensemble, range(prior_ensemble.ensemble_size), 123)
 
@@ -107,6 +108,7 @@ def test_that_reading_matching_time_is_ok(ert_config, storage, prior_ensemble):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_mismatched_responses_give_error(ert_config, storage, prior_ensemble):
     sample_prior(prior_ensemble, range(prior_ensemble.ensemble_size), 123)
 
@@ -136,6 +138,7 @@ def test_that_mismatched_responses_give_error(ert_config, storage, prior_ensembl
         )
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_different_length_is_ok_as_long_as_observation_time_exists(
     ert_config,
     storage,
@@ -184,6 +187,7 @@ def run_sim(dates, value, fname="ECLIPSE_CASE"):
     summary.fwrite()
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_duplicate_summary_time_steps_does_not_fail(
     ert_config,
     storage,
@@ -218,6 +222,7 @@ def test_that_duplicate_summary_time_steps_does_not_fail(
 
 
 @pytest.mark.flaky(reruns=5)
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_mismatched_responses_gives_nan_measured_data(ert_config, prior_ensemble):
     sample_prior(prior_ensemble, range(prior_ensemble.ensemble_size), 123)
 
@@ -246,6 +251,7 @@ def test_that_mismatched_responses_gives_nan_measured_data(ert_config, prior_ens
     assert pd.isna(fopr_1.loc[2].iloc[0])
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_reading_past_2263_is_ok(ert_config, storage, prior_ensemble):
     sample_prior(prior_ensemble, range(prior_ensemble.ensemble_size), 123)
 

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -1089,6 +1089,7 @@ def test_keyword_type_checks_missing_key(snake_oil_default_storage):
 
 
 @pytest.mark.filterwarnings("ignore:.*Use load_responses.*:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_data_fetching_missing_key(snake_oil_case):
     with open_storage(snake_oil_case.ens_path, mode="w") as storage:
         experiment = storage.create_experiment()

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -116,6 +116,7 @@ def test_load_forward_model(snake_oil_default_storage):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_load_forward_model_summary(
     summary_configuration, storage, expected, caplog, run_paths, run_args
 ):
@@ -270,6 +271,7 @@ def test_loading_gen_data_without_restart(storage, run_paths, run_args):
 
 @pytest.mark.usefixtures("copy_snake_oil_case_storage")
 @pytest.mark.integration_test
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_the_states_are_set_correctly():
     """
     When creating a new ensemble and loading results manually (load_from_forward_model)

--- a/tests/ert/unit_tests/test_summary_response.py
+++ b/tests/ert/unit_tests/test_summary_response.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
+import pytest
 from packaging import version
 
 from ert.config import ErtConfig
@@ -10,6 +11,7 @@ from ert.run_models._create_run_path import create_run_path
 from ert.storage.local_ensemble import load_parameters_and_responses_from_runpath
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_load_summary_response_restart_not_zero(
     tmpdir, snapshot, request, storage, run_paths, run_args
 ):


### PR DESCRIPTION
**Issue**
Resolves 55 (identical) warnings

**Approach**



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
