### PR TITLE
Use personal access token to run update lockfile workflow

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -4,24 +4,16 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 8 * * 1"
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
+
 jobs:
   lock:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
     steps:
       - uses: actions/checkout@v5
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.SCOUT_TEAM_APP_ID }}
-          private-key: ${{ secrets.SCOUT_TEAM_APP_PRIVATE_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -41,12 +33,14 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.LOCKFILE_UPDATE_TOKEN }}
           commit-message: Update uv lockfile
           title: Update uv lockfile
           body-path: uv_output.md
           branch: update-uv-lockfile
           base: main
-          labels: release-notes:dependency
+          labels: dependency_workflow
           delete-branch: true
           add-paths: uv.lock
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
Since proper dependabot support still seems far away.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
