### PR TITLE
Fix a bug where max_memory was not propagated realization_memory

### DIFF
--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -138,7 +138,11 @@ class SimulatorConfig(BaseModelWithContextSupport, extra="forbid"):
 
     @model_validator(mode="after")
     def update_max_memory(config: "SimulatorConfig") -> "SimulatorConfig":
-        if config.max_memory is not None and config.queue_system is not None:
+        if (
+            config.max_memory is not None
+            and config.queue_system is not None
+            and config.queue_system.realization_memory is (None or 0)
+        ):
             config.queue_system.realization_memory = (
                 parse_realization_memory_str(config.max_memory)
                 if type(config.max_memory) is str

--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -135,3 +135,13 @@ class SimulatorConfig(BaseModelWithContextSupport, extra="forbid"):
         if isinstance(data, dict):
             check_removed_config(data.get("queue_system"))
         return data
+
+    @model_validator(mode="after")
+    def update_max_memory(config: "SimulatorConfig") -> "SimulatorConfig":
+        if config.max_memory is not None and config.queue_system is not None:
+            config.queue_system.realization_memory = (
+                parse_realization_memory_str(config.max_memory)
+                if type(config.max_memory) is str
+                else int(config.max_memory)
+            )
+        return config

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -521,10 +521,27 @@ def test_that_resubmit_limit_is_set(change_to_tmpdir) -> None:
 
 
 @pytest.mark.parametrize(
-    "max_memory, realization_memory", [(None, 0), (999, 999), ("1Gb", 1073741824)]
+    "max_memory, realization_memory",
+    [(None, 0), (999, 999), ("1Gb", 1073741824), (0, 0)],
 )
 def test_that_max_memory_is_passed_to_realization_memory(
     change_to_tmpdir, max_memory, realization_memory
 ) -> None:
     config = EverestConfig.with_defaults(simulator={"max_memory": max_memory})
     assert config.simulator.queue_system.realization_memory == realization_memory
+
+
+@pytest.mark.parametrize(
+    "max_memory, realization_memory, expected",
+    [(None, 0, 0), (0, 0, 0), (111, 999, 999), (55, 0, 55)],
+)
+def test_that_max_memory_does_not_overwrite_realization_memory(
+    change_to_tmpdir, max_memory, realization_memory, expected
+) -> None:
+    config = EverestConfig.with_defaults(
+        simulator={
+            "max_memory": max_memory,
+            "queue_system": {"name": "local", "realization_memory": realization_memory},
+        }
+    )
+    assert config.simulator.queue_system.realization_memory == expected

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -518,3 +518,13 @@ def test_that_resubmit_limit_is_set(change_to_tmpdir) -> None:
     ever_config = EverestConfig.with_defaults(simulator={"resubmit_limit": 0})
     config_dict = everest_to_ert_config_dict(ever_config)
     assert config_dict[ErtConfigKeys.MAX_SUBMIT] == 1
+
+
+@pytest.mark.parametrize(
+    "max_memory, realization_memory", [(None, 0), (999, 999), ("1Gb", 1073741824)]
+)
+def test_that_max_memory_is_passed_to_realization_memory(
+    change_to_tmpdir, max_memory, realization_memory
+) -> None:
+    config = EverestConfig.with_defaults(simulator={"max_memory": max_memory})
+    assert config.simulator.queue_system.realization_memory == realization_memory


### PR DESCRIPTION
**Issue**
Resolves #11575 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
