### PR TITLE
Fix progressbar failing on post simulation warnings

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -471,17 +471,14 @@ class RunDialog(QFrame):
         )
         self._notifier.set_is_simulation_running(False)
         self.flag_simulation_done = True
-        if failed or self.post_simulation_warnings:
-            if self.post_simulation_warnings:
-                logger.info(
-                    f"Simulation finished with "
-                    f"{len(self.post_simulation_warnings)} PostSimulationWarnings"
-                )
 
+        if failed:
             self.update_total_progress(1.0, "Failed")
-
             self._progress_widget.set_all_failed()
+        else:
+            self.update_total_progress(1.0, "Experiment completed.")
 
+        if failed or self.post_simulation_warnings:
             self.fail_msg_box = Suggestor(
                 errors=[ErrorInfo(msg)] if failed else [],
                 warnings=[WarningInfo(msg) for msg in self.post_simulation_warnings],
@@ -496,8 +493,12 @@ class RunDialog(QFrame):
                 parent=self,
             )
             self.fail_msg_box.show()
-        else:
-            self.update_total_progress(1.0, "Experiment completed.")
+
+        if self.post_simulation_warnings:
+            logger.info(
+                f"Simulation finished with "
+                f"{len(self.post_simulation_warnings)} PostSimulationWarnings"
+            )
 
     @Slot()
     def _on_ticker(self) -> None:

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -940,6 +940,13 @@ warnings.warn('Foobar')"""
     for expected_message in expected_messages:
         assert expected_message in messages
 
+    # Regression test for total progress bar being green given
+    # PostSimulationWarning and no failures
+    assert (
+        run_dialog._total_progress_label.text()
+        == "Total progress 100% — Experiment completed."
+    )
+
 
 def test_denied_run_path_warning_dialog_releases_storage_lock(
     qtbot, opened_main_window_poly, use_tmpdir, monkeypatch


### PR DESCRIPTION
To resolve this issue, the logic regarding progressbar, Suggestor window and logging is separated into own blocks.

**Issue**
Resolves #11632 
Before:

https://github.com/user-attachments/assets/7e2b3a46-faf4-4693-8c55-8ec172708211


After:

https://github.com/user-attachments/assets/4664bbbc-f300-4a59-bebc-94163616ac71


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
