### PR TITLE
Add documentation and rename tests related to redefines

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -132,6 +132,19 @@ The last key defined above (KEY) will be replaced with VALUE1 VALUE2
 VALUE3 VALUE4 - i.e. the extra spaces will be discarded.
 
 
+Note that redefining a key to a different value takes effect for the rest of the file:
+
+::
+
+        DEFINE <X> 3
+        SETENV VAR <X>
+        DEFINE <X> 4
+        SETENV VAR2 <X>
+
+In the above example, the environment variable VAR is set to 3 while the environment variable
+VAR2 is set to 4.
+
+
 DATA_FILE
 ---------
 .. _data_file:

--- a/tests/ert/unit_tests/config/parsing/test_lark_parser.py
+++ b/tests/ert/unit_tests/config/parsing/test_lark_parser.py
@@ -68,7 +68,7 @@ def test_that_new_line_can_be_escaped():
     "ignore:.*Using DEFINE with substitution strings that are not of "
     "the form '<KEY>'.*:ert.config.ConfigWarning"
 )
-def test_that_redefines_overwrite_existing_defines():
+def test_that_redefine_overwrites_existing_defines_in_subsequent_lines():
     config_dict = parse_contents(
         """
         NUM_REALIZATIONS  1

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1420,7 +1420,7 @@ def test_that_multiple_errors_are_shown_for_forward_model():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_redefines_work_with_setenv():
+def test_that_redefine_behavior_is_consistent_with_setting_environment_variables():
     ert_config = ErtConfig.from_file_contents(
         dedent(
             """

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -94,7 +94,7 @@ def test_that_multiple_workflow_jobs_are_ordered_correctly(order):
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_multiple_workflow_jobs_with_redefines_are_ordered_correctly():
+def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
     with open("workflow", "w", encoding="utf-8") as f:
         f.write(
             "\n".join(


### PR DESCRIPTION
**Issue**
Resolves #10191


**Approach**
Adds documentation of redefining to the DEFINE keyword. Also renames the test related to this behavior.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
