### PR TITLE
Typo in minimal example docs

### DIFF
--- a/docs/everest/minimal_example.rst
+++ b/docs/everest/minimal_example.rst
@@ -237,7 +237,7 @@ everest_config.yml::
     install_jobs:
       -
         name: distance3d
-        executable: jobs/distance3.py
+        executable: jobs/distance3d.py
 
     model:
       realizations: [0]


### PR DESCRIPTION
**Issue**
Copying the minimal_example docs resulted in valueError when running pre-checks.
verest: error: Loading config file <everest_config.yml> failed with:
Found 1 validation error:


    * Value error, ["Could not find executable: 'jobs/distance3.py'", 'File not executable: {job.exe
controls:


**Approach**
Turns out there is a typo in the minimal config example under jobs.
- distance3.py -> distance3d.py

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
