### PR TITLE
Keep observations flag in multi-experiments

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -144,6 +144,11 @@ class PlotApi:
             response = client.get("/experiments", timeout=self._timeout)
             self._check_response(response)
 
+            def update_keydef(plot_key_def: PlotApiKeyDefinition) -> None:
+                # Only replace existing key definition if the new has observations
+                if plot_key_def.key not in key_defs or plot_key_def.observations:
+                    key_defs[plot_key_def.key] = plot_key_def
+
             for experiment in response.json():
                 for response_type, response_metadatas in experiment[
                     "responses"
@@ -162,27 +167,33 @@ class PlotApi:
                             for filter_key, values in metadata["filter_on"].items():
                                 for v in values:
                                     subkey = f"{key}@{v}"
-                                    key_defs[subkey] = PlotApiKeyDefinition(
-                                        key=subkey,
-                                        index_type="VALUE",
-                                        observations=has_obs,
-                                        dimensionality=2,
-                                        metadata={
-                                            "data_origin": response_type,
-                                        },
-                                        filter_on={filter_key: v},
-                                        log_scale=False,
-                                        response_metadata=ResponseMetadata(**metadata),
+                                    update_keydef(
+                                        PlotApiKeyDefinition(
+                                            key=subkey,
+                                            index_type="VALUE",
+                                            observations=has_obs,
+                                            dimensionality=2,
+                                            metadata={
+                                                "data_origin": response_type,
+                                            },
+                                            filter_on={filter_key: v},
+                                            log_scale=False,
+                                            response_metadata=ResponseMetadata(
+                                                **metadata
+                                            ),
+                                        )
                                     )
                         else:
-                            key_defs[key] = PlotApiKeyDefinition(
-                                key=key,
-                                index_type="VALUE",
-                                observations=has_obs,
-                                dimensionality=2,
-                                metadata={"data_origin": response_type},
-                                log_scale=False,
-                                response_metadata=ResponseMetadata(**metadata),
+                            update_keydef(
+                                PlotApiKeyDefinition(
+                                    key=key,
+                                    index_type="VALUE",
+                                    observations=has_obs,
+                                    dimensionality=2,
+                                    metadata={"data_origin": response_type},
+                                    log_scale=False,
+                                    response_metadata=ResponseMetadata(**metadata),
+                                )
                             )
 
         return list(key_defs.values())

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -1,4 +1,5 @@
 import gc
+import unittest
 from datetime import date, datetime
 from textwrap import dedent
 from urllib.parse import quote
@@ -440,3 +441,83 @@ def test_that_data_for_response_is_empty_for_ensembles_without_responses(
     result_df = api.data_for_response(str(ensemble.id), "FOPT")
 
     assert result_df.empty
+
+
+def test_that_response_key_has_observation_when_only_one_experiment_has_observations(
+    api_and_storage,
+):
+    api, storage = api_and_storage
+
+    date = datetime(year=2024, month=10, day=4)
+    experiment_with_observation = storage.create_experiment(
+        parameters=[],
+        responses=[
+            SummaryConfig(
+                name="summary",
+                input_files=["CASE.UNSMRY", "CASE.SMSPEC"],
+                keys=["FOPR"],
+            )
+        ],
+        observations={
+            "summary": pl.DataFrame(
+                {
+                    "response_key": "FOPR",
+                    "observation_key": "sumobs",
+                    "time": pl.Series([date]).dt.cast_time_unit("ms"),
+                    "observations": pl.Series([1.0], dtype=pl.Float32),
+                    "std": pl.Series([1.0], dtype=pl.Float32),
+                }
+            )
+        },
+    )
+
+    experiment_without_observation = storage.create_experiment(
+        parameters=[],
+        responses=[
+            SummaryConfig(
+                name="summary",
+                input_files=["CASE.UNSMRY", "CASE.SMSPEC"],
+                keys=["FOPR"],
+            )
+        ],
+    )
+
+    ensemble_with_observation = experiment_with_observation.create_ensemble(
+        ensemble_size=1, name="ensemble_with_obs"
+    )
+    ensemble_without_observation = experiment_without_observation.create_ensemble(
+        ensemble_size=1, name="ensemble_without_obs"
+    )
+
+    df_summary = pl.DataFrame(
+        {
+            "response_key": ["FOPR"],
+            "time": [pl.Series([date]).dt.cast_time_unit("ms")],
+            "values": [pl.Series([1.0], dtype=pl.Float32)],
+        }
+    )
+
+    ensemble_with_observation.save_response(
+        "summary",
+        df_summary,
+        0,
+    )
+
+    ensemble_without_observation.save_response(
+        "summary",
+        df_summary,
+        0,
+    )
+
+    with unittest.mock.patch(
+        "ert.storage.Storage.experiments", new_callable=unittest.mock.PropertyMock
+    ) as mock_experiments:
+        mock_experiments.return_value = [
+            experiment_with_observation,
+            experiment_without_observation,
+        ]
+        responses_from_api = api.responses_api_key_defs
+
+        assert responses_from_api[0].observations, (
+            "Expected FOPR to have observations, also when only one experiment has it"
+        )


### PR DESCRIPTION
If some experiment don't have observations,
make sure the flag is kept

**Issue**
Resolves #11631 


**Approach**
If storage contains responses where in some experiments they have observations and in others not, we may get the wrong "flag" on the response (has_observation). 

The fix is to flag with has_observation if it has observation in any of the experiments.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
