### PR TITLE
Deprecate legacy_ertscript_workflow in order to make `ErtScriptWorkflowJob` serializable

### DIFF
--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -154,7 +154,7 @@ Workflow job
 
 There are two ways to install workflow jobs in ERT.
 Depending on whether you already have a configuration file or need to include additional documentation,
-you can choose between the ``installable_workflow_jobs`` hook or the ``legacy_ertscript_workflow`` hook.
+you can choose between the ``installable_workflow_jobs`` hook or the ``ertscript_workflow`` hook.
 
 1. **Using the installable_workflow_jobs hook**
 
@@ -199,13 +199,13 @@ Implement the hook specification as follows to register the workflow job ``CSV_E
 
 .. _legacy_ert_workflow_jobs:
 
-2. **Using the legacy_ertscript_workflow hook**
+2. **Using the ertscript_workflow hook**
 
 The second approach does not require creating a workflow job configuration file up-front,
 and allows adding documentation.
 
 .. literalinclude:: ../../../../src/ert/plugins/hook_specifications/jobs.py
-   :pyobject: legacy_ertscript_workflow
+   :pyobject: ertscript_workflow
 
 Minimal example:
 
@@ -218,7 +218,7 @@ Minimal example:
            print("Hello World")
 
    @ert.plugin(name="my_plugin")
-    def legacy_ertscript_workflow(config):
+    def ertscript_workflow(config):
         config.add_workflow(MyJob, "MY_JOB")
 
 
@@ -233,25 +233,22 @@ Full example:
            print("Hello World")
 
    @ert.plugin(name="my_plugin")
-    def legacy_ertscript_workflow(config: ert.WorkflowConfigs):
-        workflow: ert.ErtScriptWorkflow = config.add_workflow(MyJob, "MY_JOB")
-        workflow.parser = my_job_parser  # Optional
-        workflow.description = "My job description"  # Optional
-        workflow.examples = "example of use"  # Optional
+    def ertscript_workflow(config: ert.WorkflowConfigs):
+        config.add_workflow(
+            MyJob,
+            "MY_JOB",
+            parser=my_job_parser,
+            description="My job description", # optional
+            examples="example of use", # optional
+        )
 
 The configuration object and properties are as follows.
 
-.. autofunction:: ert.plugins.hook_specifications.jobs.legacy_ertscript_workflow
+.. autofunction:: ert.plugins.hook_specifications.jobs.ertscript_workflow
 
 .. autoclass:: ert.plugins.workflow_config.WorkflowConfigs
     :members: add_workflow
     :undoc-members:
-
-
-.. autoclass:: ert.plugins.workflow_config.ErtScriptWorkflow
-    :members:
-    :undoc-members:
-    :exclude-members: model_config, validate_types
 
 Logging configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -42,7 +42,7 @@ from .summary_config import SummaryConfig
 from .summary_observation import SummaryObservation
 from .surface_config import SurfaceConfig
 from .workflow import Workflow
-from .workflow_job import _WorkflowJob
+from .workflow_job import ErtScriptWorkflow, ExecutableWorkflow, WorkflowJob
 
 __all__ = [
     "AnalysisConfig",
@@ -56,8 +56,10 @@ __all__ = [
     "EnsembleConfig",
     "ErrorInfo",
     "ErtConfig",
+    "ErtScriptWorkflow",
     "EverestConstraintsConfig",
     "EverestObjectivesConfig",
+    "ExecutableWorkflow",
     "ExtParamConfig",
     "Field",
     "ForwardModelStep",
@@ -89,7 +91,7 @@ __all__ = [
     "TransformFunction",
     "WarningInfo",
     "Workflow",
-    "_WorkflowJob",
+    "WorkflowJob",
     "capture_validation",
     "field_transform",
     "lint_file",

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -803,7 +803,10 @@ class ErtConfig(BaseModel):
             PREINSTALLED_FORWARD_MODEL_STEPS: ClassVar[
                 dict[str, ForwardModelStepPlugin]
             ] = preinstalled_fm_steps
-            PREINSTALLED_WORKFLOWS = pm.get_ertscript_workflows().get_workflows()
+            PREINSTALLED_WORKFLOWS = (
+                pm.get_ertscript_workflows().get_workflows()
+                | pm.get_legacy_ertscript_workflows().get_workflows()
+            )
             ENV_PR_FM_STEP: ClassVar[dict[str, dict[str, Any]]] = env_pr_fm_step
             ACTIVATE_SCRIPT = pm.activate_script()
 

--- a/src/ert/config/workflow.py
+++ b/src/ert/config/workflow.py
@@ -7,21 +7,21 @@ from typing import Any
 
 from .parsing import ConfigValidationError, ErrorInfo, init_workflow_schema, parse
 from .parsing.types import Defines
-from .workflow_job import _WorkflowJob
+from .workflow_job import WorkflowJob
 
 
 @dataclass
 class Workflow:
     src_file: str
-    cmd_list: list[tuple[_WorkflowJob, Any]]
+    cmd_list: list[tuple[WorkflowJob, Any]]
 
     def __len__(self) -> int:
         return len(self.cmd_list)
 
-    def __getitem__(self, index: int) -> tuple[_WorkflowJob, Any]:
+    def __getitem__(self, index: int) -> tuple[WorkflowJob, Any]:
         return self.cmd_list[index]
 
-    def __iter__(self) -> Iterator[tuple[_WorkflowJob, Any]]:
+    def __iter__(self) -> Iterator[tuple[WorkflowJob, Any]]:
         return iter(self.cmd_list)
 
     @classmethod
@@ -29,8 +29,8 @@ class Workflow:
         cls,
         src_file: str,
         context: Defines,
-        job_dict: dict[str, _WorkflowJob],
-    ) -> list[tuple[_WorkflowJob, Any]]:
+        job_dict: dict[str, WorkflowJob],
+    ) -> list[tuple[WorkflowJob, Any]]:
         schema = init_workflow_schema()
         config_dict = parse(src_file, schema, pre_defines=context)
 
@@ -85,7 +85,7 @@ class Workflow:
         cls,
         src_file: str,
         context: dict[str, str] | None,
-        job_dict: dict[str, _WorkflowJob],
+        job_dict: dict[str, WorkflowJob],
     ) -> Workflow:
         cmd_list = cls._parse_command_list(
             src_file=src_file,

--- a/src/ert/config/workflow_job.py
+++ b/src/ert/config/workflow_job.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import textwrap
-from argparse import ArgumentParser
-from collections.abc import Callable
 from dataclasses import field
 from typing import Self, TypeAlias
 
@@ -141,7 +139,6 @@ class ErtScriptWorkflow(_WorkflowJob):
     ert_script: type[ErtScript] = None  # type: ignore
     description: str = ""
     examples: str | None = None
-    parser: Callable[[], ArgumentParser] | None = None
     category: str = "other"
 
     @model_validator(mode="after")

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -22,8 +22,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from ert.config import ErtConfig
-from ert.config.workflow_job import ErtScriptWorkflow
+from ert.config import ErtConfig, ErtScriptWorkflow
 from ert.gui import is_dark_mode, is_high_contrast_mode
 from ert.gui.about_dialog import AboutDialog
 from ert.gui.ertnotifier import ErtNotifier

--- a/src/ert/gui/tools/export/exporter.py
+++ b/src/ert/gui/tools/export/exporter.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ert.config import ErtConfig, _WorkflowJob
+    from ert.config import ErtConfig, WorkflowJob
 
 from ert.gui.ertnotifier import ErtNotifier
 from ert.workflow_runner import WorkflowJobRunner
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class Exporter:
     def __init__(
         self,
-        export_job: _WorkflowJob | None,
+        export_job: WorkflowJob | None,
         notifier: ErtNotifier,
         config: ErtConfig,
     ) -> None:

--- a/src/ert/gui/tools/plugins/plugin.py
+++ b/src/ert/gui/tools/plugins/plugin.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
-from ert.config.workflow_job import ErtScriptWorkflow
+from ert.config import ErtScriptWorkflow
 from ert.plugins import ErtPlugin, WorkflowFixtures
 
 if TYPE_CHECKING:
     from PyQt6.QtWidgets import QWidget
 
-    from ert.config import _WorkflowJob
+    from ert.config import WorkflowJob
     from ert.gui.ertnotifier import ErtNotifier
     from ert.storage import Ensemble, LocalStorage
 
@@ -65,5 +65,5 @@ class Plugin:
     def ensemble(self) -> Ensemble | None:
         return self.__notifier.current_ensemble
 
-    def getWorkflowJob(self) -> _WorkflowJob:
+    def getWorkflowJob(self) -> WorkflowJob:
         return self.__workflow_job

--- a/src/ert/gui/tools/plugins/plugin_handler.py
+++ b/src/ert/gui/tools/plugins/plugin_handler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from ert.config.workflow_job import ErtScriptWorkflow
+from ert.config import ErtScriptWorkflow
 
 from .plugin import Plugin
 

--- a/src/ert/plugins/hook_implementations/__init__.py
+++ b/src/ert/plugins/hook_implementations/__init__.py
@@ -1,11 +1,11 @@
 from .forward_model_steps import installable_forward_model_steps
 from .help_resources import help_links
 from .jobs import installable_workflow_jobs
-from .workflows import legacy_ertscript_workflow
+from .workflows import ertscript_workflow
 
 __all__ = [
+    "ertscript_workflow",
     "help_links",
     "installable_forward_model_steps",
     "installable_workflow_jobs",
-    "legacy_ertscript_workflow",
 ]

--- a/src/ert/plugins/hook_implementations/workflows/__init__.py
+++ b/src/ert/plugins/hook_implementations/workflows/__init__.py
@@ -16,17 +16,14 @@ if TYPE_CHECKING:
 
 
 @ert.plugin(name="ert")
-def legacy_ertscript_workflow(config: WorkflowConfigs) -> None:
-    workflow = config.add_workflow(ExportMisfitDataJob, "EXPORT_MISFIT_DATA")
-    workflow.category = "observations.correlation"
-
-    workflow = config.add_workflow(ExportRunpathJob, "EXPORT_RUNPATH")
-
-    workflow = config.add_workflow(DisableParametersUpdate, "DISABLE_PARAMETERS")
-
-    workflow = config.add_workflow(MisfitPreprocessor, "MISFIT_PREPROCESSOR")
-    workflow.category = "observations.correlation"
-
-    workflow = config.add_workflow(CSVExportJob, "CSV_EXPORT")
-
-    workflow = config.add_workflow(GenDataRFTCSVExportJob, "GEN_DATA_RFT")
+def ertscript_workflow(config: WorkflowConfigs) -> None:
+    config.add_workflow(
+        ExportMisfitDataJob, "EXPORT_MISFIT_DATA", category="observations.correlation"
+    )
+    config.add_workflow(ExportRunpathJob, "EXPORT_RUNPATH")
+    config.add_workflow(DisableParametersUpdate, "DISABLE_PARAMETERS")
+    config.add_workflow(
+        MisfitPreprocessor, "MISFIT_PREPROCESSOR", category="observations.correlation"
+    )
+    config.add_workflow(CSVExportJob, "CSV_EXPORT")
+    config.add_workflow(GenDataRFTCSVExportJob, "GEN_DATA_RFT")

--- a/src/ert/plugins/hook_specifications/__init__.py
+++ b/src/ert/plugins/hook_specifications/__init__.py
@@ -10,6 +10,7 @@ from .forward_model_steps import (
 )
 from .help_resources import help_links
 from .jobs import (
+    ertscript_workflow,
     installable_jobs,
     installable_workflow_jobs,
     job_documentation,
@@ -24,6 +25,7 @@ __all__ = [
     "add_span_processor",
     "ecl100_config_path",
     "ecl300_config_path",
+    "ertscript_workflow",
     "flow_config_path",
     "forward_model_configuration",
     "help_links",

--- a/src/ert/plugins/hook_specifications/jobs.py
+++ b/src/ert/plugins/hook_specifications/jobs.py
@@ -46,10 +46,16 @@ def installable_workflow_jobs() -> PluginResponse[dict[str, str]]:
 
 @no_type_check
 @hook_specification
-def legacy_ertscript_workflow(config: WorkflowConfigs) -> None:
+def ertscript_workflow(config: WorkflowConfigs) -> None:
     """
     This hook allows the user to register a workflow with the config object. A workflow
     must add the class inheriting from ErtScript and an optional name.
 
     :param config: A handle to the main workflow config.
     """
+
+
+@no_type_check
+@hook_specification
+def legacy_ertscript_workflow(config: WorkflowConfigs) -> None:
+    """Deprecated Variant of the hook ertscript_workflow"""

--- a/src/ert/plugins/workflow_config.py
+++ b/src/ert/plugins/workflow_config.py
@@ -1,13 +1,106 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from argparse import ArgumentParser
 from collections.abc import Callable
+
+from ert.config.parsing import SchemaItemType
 
 from ..config.workflow_job import ErtScriptWorkflow
 from .ert_script import ErtScript
 
 logger = logging.getLogger(__name__)
+
+
+class LegacyErtScriptWorkflow:
+    """This is a wrapper around ErtScriptWorkflow to keep backwards compatability"""
+
+    def __init__(
+        self, actual_workflow: ErtScriptWorkflow, workflow_configs: WorkflowConfigs
+    ) -> None:
+        self._actual_workflow = actual_workflow
+        self._workflow_configs = workflow_configs
+
+    @property
+    def name(self) -> str:
+        return self._actual_workflow.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._actual_workflow.name = value
+
+    @property
+    def min_args(self) -> int | None:
+        return self._actual_workflow.min_args
+
+    @min_args.setter
+    def min_args(self, value: int | None) -> None:
+        self._actual_workflow.min_args = value
+
+    @property
+    def max_args(self) -> int | None:
+        return self._actual_workflow.max_args
+
+    @max_args.setter
+    def max_args(self, value: int | None) -> None:
+        self._actual_workflow.max_args = value
+
+    @property
+    def arg_types(self) -> list[SchemaItemType]:
+        return self._actual_workflow.arg_types
+
+    @arg_types.setter
+    def arg_types(self, value: list[SchemaItemType]) -> None:
+        self._actual_workflow.arg_types = value
+
+    @property
+    def stop_on_fail(self) -> bool:
+        return self._actual_workflow.stop_on_fail
+
+    @stop_on_fail.setter
+    def stop_on_fail(self, value: bool) -> None:
+        self._actual_workflow.stop_on_fail = value
+
+    @property
+    def ert_script(self) -> type[ErtScript]:
+        return self._actual_workflow.ert_script
+
+    @ert_script.setter
+    def ert_script(self, value: type[ErtScript]) -> None:
+        self._actual_workflow.ert_script = value
+
+    @property
+    def description(self) -> str:
+        return self._actual_workflow.description
+
+    @description.setter
+    def description(self, value: str) -> None:
+        self._actual_workflow.description = value
+
+    @property
+    def category(self) -> str:
+        return self._actual_workflow.category
+
+    @category.setter
+    def category(self, value: str) -> None:
+        self._actual_workflow.category = value
+
+    @property
+    def examples(self) -> str | None:
+        return self._actual_workflow.examples
+
+    @examples.setter
+    def examples(self, value: str | None) -> None:
+        self._actual_workflow.examples = value
+
+    @property
+    def parser(self) -> Callable[[], ArgumentParser] | None:
+        return self._workflow_configs.parsers[self.name]
+
+    @parser.setter
+    def parser(self, value: Callable[[], ArgumentParser] | None) -> None:
+        self._workflow_configs.parsers[self.name] = value
 
 
 class WorkflowConfigs:
@@ -17,8 +110,50 @@ class WorkflowConfigs:
 
     def __init__(self) -> None:
         self._workflows: list[ErtScriptWorkflow] = []
+        self.parsers: dict[str, Callable[[], ArgumentParser] | None] = {}
 
     def add_workflow(
+        self,
+        ert_script: type[ErtScript],
+        name: str = "",
+        description: str = "",
+        examples: str | None = None,
+        parser: Callable[[], ArgumentParser] | None = None,
+        category: str = "other",
+    ) -> None:
+        """
+        :param category: dot separated string
+        :param parser: will extract information to use in documentation
+        :param examples: must be valid rst, will be added to documentation
+        :param description: must be valid rst, defaults to __doc__
+        :param ert_script: class which inherits from ErtScript
+        :param name: Optional name for workflow (default is name of class)
+        """
+        workflow = ErtScriptWorkflow(
+            name=name or ert_script.__name__,
+            ert_script=ert_script,
+            description=description,
+            examples=examples,
+            category=category,
+        )
+        self._workflows.append(workflow)
+        self.parsers[workflow.name] = parser
+
+    def get_workflows(self) -> dict[str, ErtScriptWorkflow]:
+        configs = {}
+        for workflow in self._workflows:
+            if workflow.name in configs:
+                logger.info(
+                    f"Duplicate workflow name: {workflow.name}, "
+                    f"skipping {workflow.ert_script}"
+                )
+            else:
+                configs[workflow.name] = workflow
+        return configs
+
+
+class LegacyWorkflowConfigs(WorkflowConfigs):
+    def add_workflow(  # type: ignore
         self,
         ert_script: type[ErtScript],
         name: str = "",
@@ -36,25 +171,19 @@ class WorkflowConfigs:
         :param name: Optional name for workflow (default is name of class)
         :return: Instantiated workflow config.
         """
+        warnings.warn(
+            "Use of legacy_ertscript_workflow is deprecated. "
+            "Please see documentation for how to use ertscript_workflow instead",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         workflow = ErtScriptWorkflow(
             name=name or ert_script.__name__,
             ert_script=ert_script,
             description=description,
             examples=examples,
-            parser=parser,
             category=category,
         )
         self._workflows.append(workflow)
-        return workflow
-
-    def get_workflows(self) -> dict[str, ErtScriptWorkflow]:
-        configs = {}
-        for workflow in self._workflows:
-            if workflow.name in configs:
-                logger.info(
-                    f"Duplicate workflow name: {workflow.name}, "
-                    f"skipping {workflow.ert_script}"
-                )
-            else:
-                configs[workflow.name] = workflow
-        return configs
+        self.parsers[workflow.name] = parser
+        return LegacyErtScriptWorkflow(workflow, self)  # type: ignore

--- a/src/ert/workflow_runner.py
+++ b/src/ert/workflow_runner.py
@@ -5,8 +5,7 @@ from concurrent import futures
 from concurrent.futures import Future
 from typing import Any, Self
 
-from ert.config import Workflow
-from ert.config.workflow_job import ErtScriptWorkflow, _WorkflowJob
+from ert.config import ErtScriptWorkflow, Workflow, WorkflowJob
 from ert.plugins import (
     ErtScript,
     ExternalErtScript,
@@ -15,7 +14,7 @@ from ert.plugins import (
 
 
 class WorkflowJobRunner:
-    def __init__(self, workflow_job: _WorkflowJob) -> None:
+    def __init__(self, workflow_job: WorkflowJob) -> None:
         self.job = workflow_job
         self.__running = False
         self.__script: ErtScript | None = None

--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -10,8 +10,10 @@ import everest
 from ert.config import (
     EnsembleConfig,
     ErtConfig,
+    ExecutableWorkflow,
     ForwardModelStep,
     ModelConfig,
+    WorkflowJob,
 )
 from ert.config.ert_config import (
     _substitutions_from_dict,
@@ -21,7 +23,6 @@ from ert.config.ert_config import (
 )
 from ert.config.parsing import ConfigDict, ConfigWarning, read_file
 from ert.config.parsing import ConfigKeys as ErtConfigKeys
-from ert.config.workflow_job import ExecutableWorkflow, _WorkflowJob
 from ert.plugins import ErtPluginContext
 from ert.plugins.plugin_manager import ErtPluginManager
 from everest.config import EverestConfig
@@ -476,8 +477,8 @@ def get_forward_model_steps(
     return forward_model_steps, env_pr_fm_step
 
 
-def get_workflow_jobs(ever_config: EverestConfig) -> dict[str, _WorkflowJob]:
-    workflow_jobs: dict[str, _WorkflowJob] = {}
+def get_workflow_jobs(ever_config: EverestConfig) -> dict[str, WorkflowJob]:
+    workflow_jobs: dict[str, WorkflowJob] = {}
     for job in ever_config.install_workflow_jobs or []:
         if job.executable is not None:
             if job.name in workflow_jobs:

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack as does_not_raise
 import pytest
 from hypothesis import given, strategies
 
-from ert.config import ConfigValidationError, Workflow, _WorkflowJob
+from ert.config import ConfigValidationError, ExecutableWorkflow, Workflow
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -32,7 +32,8 @@ def test_that_substitution_happens_in_workflow():
     with open("workflow", "w", encoding="utf-8") as f:
         f.write("JOB <A> <B>\n")
 
-    job = _WorkflowJob(
+    job = ExecutableWorkflow(
+        executable="echo",
         name="JOB",
         min_args=None,
         max_args=None,
@@ -50,7 +51,8 @@ def test_that_substitution_happens_in_workflow():
 
 
 def get_workflow_job(name):
-    return _WorkflowJob(
+    return ExecutableWorkflow(
+        executable="echo",
         name=name,
         min_args=None,
         max_args=None,
@@ -183,7 +185,8 @@ def test_args_validation(config, expectation, min_args, max_args):
             src_file="workflow",
             context=None,
             job_dict={
-                "WORKFLOW": _WorkflowJob(
+                "WORKFLOW": ExecutableWorkflow(
+                    executable="echo",
                     name="WORKFLOW",
                     min_args=min_args,
                     max_args=max_args,

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -146,8 +146,6 @@ def optional_file(draw):
 def forward_model_steps(substitutions):
     return st.builds(
         ForwardModelStep,
-        name=st.text(min_size=1, max_size=15),
-        executable=st.text(min_size=1, max_size=30),
         stdin_file=optional_file(),
         stdout_file=optional_file(),
         stderr_file=optional_file(),
@@ -159,8 +157,6 @@ def forward_model_steps(substitutions):
         ),
         min_arg=st.one_of(st.none(), st.integers(min_value=0, max_value=5)),
         max_arg=st.one_of(st.none(), st.integers(min_value=0, max_value=10)),
-        arglist=st.lists(realistic_text()),
-        required_keywords=st.lists(realistic_text()),
         default_mapping=st.dictionaries(
             realistic_text(),
             st.one_of(realistic_text(), st.integers()),
@@ -172,8 +168,6 @@ def forward_model_steps(substitutions):
 
 workflow_jobs = st.builds(
     ExecutableWorkflow,
-    executable=realistic_text(),
-    name=realistic_text(),
     min_args=st.integers(min_value=1, max_value=4),
     max_args=st.integers(min_value=1, max_value=4),
     arg_types=st.lists(st.sampled_from(SchemaItemType)),
@@ -357,14 +351,12 @@ def multidass(_):
 
 transform_function_definitions = st.builds(
     TransformFunctionDefinition,
-    name=realistic_text(),
     param_name=st.just("NORMAL"),
     values=st.just([0, 1]),
 )
 
 gen_kw_configs = st.builds(
     GenKwConfig,
-    name=realistic_text(),
     transform_function_definitions=st.lists(
         transform_function_definitions, unique_by=lambda tdf: tdf.name
     ),
@@ -373,7 +365,6 @@ gen_kw_configs = st.builds(
 
 surface_configs = st.builds(
     SurfaceConfig,
-    name=realistic_text(),
     ncol=st.integers(min_value=1, max_value=1000),
     nrow=st.integers(min_value=1, max_value=1000),
     xori=st.floats(allow_nan=False, allow_infinity=False),
@@ -389,7 +380,6 @@ surface_configs = st.builds(
 
 field_configs = st.builds(
     Field,
-    name=realistic_text(),
     nx=st.integers(min_value=1, max_value=100),
     ny=st.integers(min_value=1, max_value=100),
     nz=st.integers(min_value=1, max_value=100),

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -19,6 +19,7 @@ from pytest import MonkeyPatch, TempPathFactory
 from ert.config import (
     ConfigWarning,
     ErtConfig,
+    ErtScriptWorkflow,
     ESSettings,
     ExecutableWorkflow,
     Field,
@@ -49,6 +50,7 @@ from ert.mode_definitions import (
     EVALUATE_ENSEMBLE_MODE,
     MANUAL_UPDATE_MODE,
 )
+from ert.plugins import ExternalErtScript
 from ert.run_models import (
     EnsembleExperiment,
     EnsembleInformationFilter,
@@ -166,11 +168,20 @@ def forward_model_steps(substitutions):
     )
 
 
-workflow_jobs = st.builds(
-    ExecutableWorkflow,
-    min_args=st.integers(min_value=1, max_value=4),
-    max_args=st.integers(min_value=1, max_value=4),
-    arg_types=st.lists(st.sampled_from(SchemaItemType)),
+workflow_jobs = st.one_of(
+    st.builds(
+        ExecutableWorkflow,
+        min_args=st.integers(min_value=1, max_value=4),
+        max_args=st.integers(min_value=1, max_value=4),
+        arg_types=st.lists(st.sampled_from(SchemaItemType)),
+    ),
+    st.builds(
+        ErtScriptWorkflow,
+        min_args=st.just(1),
+        max_args=st.just(1),
+        arg_types=st.just([SchemaItemType.STRING]),
+        ert_script=st.just(ExternalErtScript),
+    ),
 )
 
 workflows = st.builds(

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -19,6 +19,7 @@ from ert.config import (
     ConfigWarning,
     ErtConfig,
     ESSettings,
+    ExecutableWorkflow,
     Field,
     ForwardModelStep,
     GenDataConfig,
@@ -30,7 +31,6 @@ from ert.config import (
     SummaryConfig,
     SurfaceConfig,
     Workflow,
-    _WorkflowJob,
 )
 from ert.config.gen_kw_config import GenKwConfig, TransformFunctionDefinition
 from ert.config.parsing import SchemaItemType
@@ -250,7 +250,8 @@ def forward_model_step_strategy(draw, substitutions: dict[str, str]):
 def workflow_strategy(draw):
     src_file = draw(realistic_text().map(lambda s: f"{s}.wf.json"))
 
-    job = _WorkflowJob(
+    job = ExecutableWorkflow(
+        executable=draw(realistic_text()),
         name=draw(realistic_text()),
         min_args=draw(st.integers(min_value=1, max_value=4)),
         max_args=draw(st.integers(min_value=1, max_value=4)),


### PR DESCRIPTION
Resolves an issue where workflow jobs were deseralized as _WorkflowJob while ert makes the assumption that workflow jobs are always either `ExecutableWorkflowJob` or `ErtScriptWorkflowJob`. In order to do that, ErtScriptWorkflow needed to not have a callable in its schema. That callable is put there because of the plugin system so it is necessary to deprecate `legacy_ertscript_workflow` in order to do so. However, it is for now backwards compatible.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
