### PR TITLE
Make everest parsing of realization_memory like in ert

### DIFF
--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -117,6 +117,15 @@ class SimulatorConfig(BaseModelWithContextSupport, extra="forbid"):
             return options or LocalQueueOptions(max_running=8)
         return v
 
+    @field_validator("queue_system", mode="before")
+    @classmethod
+    def parse_realization_memory(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            v["realization_memory"] = parse_realization_memory_str(
+                str(v.get("realization_memory", 0))
+            )
+        return v
+
     @field_validator("max_memory")
     @classmethod
     def validate_max_memory(cls, max_memory: int | str | None) -> str | None:

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -545,3 +545,31 @@ def test_that_max_memory_does_not_overwrite_realization_memory(
         }
     )
     assert config.simulator.queue_system.realization_memory == expected
+
+
+@pytest.mark.parametrize(
+    "realization_memory, expected",
+    [
+        ("1Gb", 1073741824),
+        ("2Kb", 2048),
+        (999, 999),
+    ],
+)
+def test_parsing_of_relization_memory(
+    change_to_tmpdir, realization_memory, expected
+) -> None:
+    config = EverestConfig.with_defaults(
+        simulator={
+            "queue_system": {"name": "local", "realization_memory": realization_memory},
+        }
+    )
+    assert config.simulator.queue_system.realization_memory == expected
+
+
+def test_parsing_of_non_existing_relization_memory(change_to_tmpdir) -> None:
+    config = EverestConfig.with_defaults(
+        simulator={
+            "queue_system": {"name": "local"},
+        }
+    )
+    assert config.simulator.queue_system.realization_memory == 0


### PR DESCRIPTION
**Issue**
Resolves #11654 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
