### PR TITLE
Fix data_for_response matches substrings

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -86,14 +86,8 @@ response_to_pandas_x_axis_fns: dict[str, Callable[[tuple[Any, ...]], Any]] = {
 def _extract_response_type_and_key(
     key: str, response_key_to_response_type: dict[str, str]
 ) -> tuple[str, str] | tuple[None, None]:
-    # Check for exact match first. For example if key is "FOPRH"
-    # it may stop at "FOPR", which would be incorrect
-    response_key = next((k for k in response_key_to_response_type if k == key), None)
-    if response_key is None:
-        response_key = next(
-            (k for k in response_key_to_response_type if k in key and key != f"{k}H"),
-            None,
-        )
+    # Only allow exact matches.
+    response_key = key if key in response_key_to_response_type else None
 
     if response_key is None:
         return None, None


### PR DESCRIPTION
**Issue**
Resolves #11564

**Approach**
Introduced the test from the issue and verified that is was failing. 
Solved the bug to make all tests pass. 
Verified that *H responses are still working in the plotter by running Snake Oil.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
