### PR TITLE
backport Log missing communication from fm_dispatch event reporter

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import traceback
+from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from enum import Enum
 from typing import Any, get_args
@@ -35,6 +36,8 @@ from _ert.forward_model_runner.client import (
     HEARTBEAT_TIMEOUT,
 )
 from ert.ensemble_evaluator import identifiers as ids
+from ert.ensemble_evaluator import state
+from ert.shared.net_utils import get_machine_name
 
 from ..config import QueueSystem
 from ._ensemble import FMStepSnapshot
@@ -436,6 +439,46 @@ class EnsembleEvaluator:
             f"Traceback: {exc_traceback}"
         )
 
+    def _log_forward_model_steps_with_missing_status_updates(self) -> None:
+        """There might be some communication issues between the nodes running
+        the forward models and the EnsembleEvaluator. In those situations,
+        we want to be aware of the failing nodes.\n
+        These communication issues does not affect the final result of the realizations,
+        but makes it impossible to see the status of the individual forward model steps.
+        """
+        hosts_with_missing_connection_to_realization_id: dict[str, list[str]] = (
+            defaultdict(list)
+        )
+        for real_id, real_data in (
+            self.ensemble.snapshot.data().get("reals", {}).items()
+        ):
+            if all(
+                fm_step_data["status"] == state.FORWARD_MODEL_STATE_INIT
+                for fm_step_data in real_data.get("fm_steps", {}).values()
+            ):
+                host_name = real_data.get("exec_hosts")
+                if host_name == "-":
+                    host_name = "localhost"
+                if (
+                    host_name
+                    and real_id
+                    not in hosts_with_missing_connection_to_realization_id.get(
+                        host_name, []
+                    )
+                ):
+                    hosts_with_missing_connection_to_realization_id[host_name].append(
+                        real_id
+                    )
+
+        if hosts_with_missing_connection_to_realization_id:
+            logger.warning(
+                "Ensemble finished, but there were missing ForwardModelStep "
+                f"status updates for some realization(s) from some host(s) "
+                f"({dict(hosts_with_missing_connection_to_realization_id)}). "
+                "There could be connectivity issues to evaluator running on port "
+                f"{self._config.router_port} on host {get_machine_name()}"
+            )
+
     async def run_and_get_successful_realizations(self) -> list[int]:
         await self._start_running()
 
@@ -455,6 +498,7 @@ class EnsembleEvaluator:
                 ):
                     logger.error(str(result))
                     raise RuntimeError(result) from result
+        self._log_forward_model_steps_with_missing_status_updates()
         logger.debug("Evaluator is done")
         return self._ensemble.get_successful_realizations()
 

--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import socket
-import traceback
 from functools import lru_cache
 
 from dns import exception, resolver, reversename
@@ -45,7 +44,6 @@ def get_machine_name() -> str:
         # to socket fqdn which are using /etc/hosts to retrieve this name
         return socket.getfqdn()
     except (socket.gaierror, exception.DNSException):
-        logging.getLogger(__name__).debug(traceback.format_exc())
         return "localhost"
 
 

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 from functools import partial
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import zmq.asyncio
@@ -18,7 +18,9 @@ from _ert.events import (
     EnsembleSucceeded,
     ForwardModelStepFailure,
     ForwardModelStepRunning,
+    ForwardModelStepStart,
     ForwardModelStepSuccess,
+    RealizationFailed,
     RealizationResubmit,
     RealizationSuccess,
     event_to_json,
@@ -30,6 +32,7 @@ from _ert.forward_model_runner.client import (
     HEARTBEAT_MSG,
     Client,
 )
+from ert.config.ert_config import ErtConfig
 from ert.ensemble_evaluator import (
     EnsembleEvaluator,
     EnsembleSnapshot,
@@ -750,3 +753,68 @@ async def test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_t
                 break
 
         assert was_completed
+
+
+async def test_log_forward_model_steps_with_missing_status_updates(
+    monkeypatch, tmpdir, caplog, make_ensemble
+):
+    mocked_config = MagicMock(spec=ErtConfig)
+    num_reals = 11
+    num_fm_steps = 3
+    ensemble: LegacyEnsemble = make_ensemble(
+        monkeypatch, tmpdir, num_reals, num_fm_steps
+    )
+    router_port = 111111
+    mocked_config.router_port = router_port
+    working_machine_name = "working_cluster_machine"
+    evaluator_host = "foo_evaluator_host"
+    evaluator = EnsembleEvaluator(ensemble, mocked_config)
+    monkeypatch.setattr(
+        "ert.ensemble_evaluator.evaluator.get_machine_name",
+        lambda *args: evaluator_host,
+    )
+    # One realization passed with no connection problems and reports successfully
+    fm_events = []
+    for fm_step_id in range(num_fm_steps):
+        fm_events.extend(
+            [
+                ForwardModelStepStart(
+                    ensemble=ensemble.id_, real="10", fm_step=str(fm_step_id)
+                ),
+                ForwardModelStepRunning(
+                    ensemble=ensemble.id_, real="10", fm_step=str(fm_step_id)
+                ),
+                ForwardModelStepSuccess(
+                    ensemble=ensemble.id_, real="10", fm_step=str(fm_step_id)
+                ),
+            ]
+        )
+    evaluator._ensemble.update_snapshot(fm_events)
+    driver_events = [
+        RealizationSuccess(
+            real="10", ensemble=ensemble.id_, exec_hosts=working_machine_name
+        )
+    ]
+    for i in range(10):
+        driver_events.append(
+            RealizationFailed(
+                real=str(i),
+                ensemble=ensemble.id_,
+                exec_hosts="foo_cluster_machine"
+                if i % 2 == 0
+                else "bar_cluster_machine",
+            )
+        )
+
+    evaluator._ensemble.update_snapshot(driver_events)
+    evaluator._log_forward_model_steps_with_missing_status_updates()
+
+    assert "working_cluster_machine" not in caplog.text
+    assert "'10'" not in caplog.text  # The realization that passed with no problems
+    assert (
+        "Ensemble finished, but there were missing ForwardModelStep status updates "
+        "for some realization(s) from some host(s) ({'foo_cluster_machine': ['0', "
+        "'2', '4', '6', '8'], 'bar_cluster_machine': ['1', '3', '5', '7', '9']}). "
+        f"There could be connectivity issues to evaluator running on port "
+        f"{router_port} on host {evaluator_host}"
+    ) in caplog.text


### PR DESCRIPTION
This commit makes the EnsembleEvaluator log a warning if the ensemble finishes, but no ForwardModelStep status updates were reported. This would be caused by the ZMQ client in event reporter not being able to connect to EnsembleEvaluator.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
