### PR TITLE
Implement auto-scaling for input constraints

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -265,6 +265,7 @@ class EverestRunModel(RunModel):
         return get_optimization_domain_transforms(
             self.controls,
             self.objective_functions,
+            self.input_constraints,
             self.output_constraints,
             self.model,
             self.optimization.auto_scale,

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -314,7 +314,11 @@ This will produce an output file with the content:
     def validate_scales(self) -> Self:
         errors = []
         if self.optimization.auto_scale:
-            for key in ("objective_functions", "output_constraints"):
+            for key in (
+                "objective_functions",
+                "input_constraints",
+                "output_constraints",
+            ):
                 if any(item.scale is not None for item in getattr(self, key)):
                     errors.append(
                         "The auto_scale option in the optimization section and the "

--- a/src/everest/config/input_constraint_config.py
+++ b/src/everest/config/input_constraint_config.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, PositiveFloat, field_validator
 
 
 class InputConstraintConfig(BaseModel, extra="forbid"):
@@ -34,7 +34,14 @@ class InputConstraintConfig(BaseModel, extra="forbid"):
     upper_bound: float = Field(
         default=np.inf,
         description="""Only control values that satisfy the following
-         equation will be allowed: sum of (<control> * weight) <= upper_bound`
+        equation will be allowed: sum of (<control> * weight) <= upper_bound`
+        """,
+    )
+    scale: PositiveFloat | None = Field(
+        default=None,
+        description="""Scaling of input constraints (scale).
+        scale is a normalization factor which can be used to scale the input constraint.
+        The bounds or target, and the weights will be scaled with this number.
         """,
     )
 

--- a/src/everest/config/objective_function_config.py
+++ b/src/everest/config/objective_function_config.py
@@ -1,6 +1,12 @@
 from typing import Annotated, Any
 
-from pydantic import AfterValidator, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Field,
+    PositiveFloat,
+    model_validator,
+)
 
 from everest.config.validation_utils import not_in_reserved_word_list
 
@@ -19,7 +25,7 @@ used in the optimization process. Weights may be zero or negative, but should ad
 a positive value.
 """,
     )
-    scale: float | None = Field(
+    scale: PositiveFloat | None = Field(
         default=None,
         description="""
     scale is a division factor defined per objective function.
@@ -44,13 +50,6 @@ preferred to be maximized.
 
 """,
     )
-
-    @field_validator("scale")
-    @classmethod
-    def validate_scale_is_not_zero(cls, scale: float | None) -> float | None:
-        if scale == 0.0:
-            raise ValueError("Scale value cannot be zero")
-        return scale
 
     @model_validator(mode="before")
     @classmethod

--- a/src/everest/config/output_constraint_config.py
+++ b/src/everest/config/output_constraint_config.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PositiveFloat, model_validator
 
 
 class OutputConstraintConfig(BaseModel, extra="forbid"):
@@ -37,7 +37,7 @@ the scale (scale).
 where b is the upper bound, f is a function of the control vector x, and c is
 the scale (scale).""",
     )
-    scale: float | None = Field(
+    scale: PositiveFloat | None = Field(
         default=None,
         description="""Scaling of constraints (scale).
 

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -2,7 +2,7 @@ import pytest
 from ruamel.yaml import YAML
 
 from ert.config import ConfigWarning
-from everest.config import EverestConfig
+from everest.config import EverestConfig, InputConstraintConfig, OptimizationConfig
 
 
 def test_input_constraint_control_references(tmp_path, capsys, caplog, monkeypatch):
@@ -81,3 +81,22 @@ def test_input_constraint_control_references(tmp_path, capsys, caplog, monkeypat
         EverestConfig.load_file("config_warns.yml")
 
     assert not capsys.readouterr().out
+
+
+def test_that_auto_scale_and_input_constraints_scale_are_mutually_exclusive(tmp_path):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The auto_scale option in the optimization section and the scale "
+            "options in the input_constraints section are mutually exclusive"
+        ),
+    ):
+        EverestConfig.with_defaults(
+            optimization=OptimizationConfig(auto_scale=True),
+            input_constraints=[
+                InputConstraintConfig.model_validate(
+                    {"upper_bound": 1.0, "weights": {"a": 1.0, "b": 1.0}, "scale": 2.0}
+                )
+                for i in range(2)
+            ],
+        )

--- a/tests/everest/test_multiobjective.py
+++ b/tests/everest/test_multiobjective.py
@@ -1,5 +1,3 @@
-from contextlib import ExitStack as does_not_raise
-
 import pytest
 
 from everest.config import EverestConfig
@@ -37,17 +35,6 @@ from everest.optimizer.everest2ropt import everest2ropt
                 ValueError,
                 match="The objective weight should be greater than 0",
             ),
-        ),
-        (
-            [{"name": "c1", "scale": 0}],
-            pytest.raises(
-                ValueError,
-                match="Scale value cannot be zero",
-            ),
-        ),
-        (
-            [{"name": "c1", "scale": -125}],
-            does_not_raise(),
         ),
     ],
 )


### PR DESCRIPTION
**Issue**
Resolves #11572
Closes #11342


**Approach**
- Add a `scale` option to the input constraint configuration. These are mutually exclusive with the `auto_scale` option in the `optimization` section.
- Update the control variable transforms to scale the input constraints in one of the two following ways:
  - If `auto_scale` is on in the `optimization` section, scale each   equation by the maximum of its coefficients or right-hand-side.
  - Use the scales, if defined, and `auto_scale` is off.
- Tests are added for auto-scaling and manual scaling.

--

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
