### PR TITLE
Remove remaining blanket type ignores in ert.config

### DIFF
--- a/src/ert/config/parsing/workflow_job_schema.py
+++ b/src/ert/config/parsing/workflow_job_schema.py
@@ -1,5 +1,3 @@
-from typing import no_type_check
-
 from .config_dict import ConfigDict
 from .config_errors import ConfigValidationError
 from .config_schema_item import SchemaItem
@@ -76,10 +74,7 @@ def stop_on_fail_keyword() -> SchemaItem:
 
 
 class WorkflowJobSchemaDict(SchemaItemDict):
-    @no_type_check
     def check_required(self, config_dict: ConfigDict, filename: str) -> None:
-        super().check_required(config_dict, filename)
-
         if "MIN_ARG" in config_dict and "MAX_ARG" in config_dict:
             min_arg: int = config_dict["MIN_ARG"]
             max_arg: int = config_dict["MAX_ARG"]

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal, no_type_check
+from typing import Any, Literal
 
 import polars as pl
 from pydantic import field_validator
@@ -80,7 +80,6 @@ class SummaryConfig(ResponseConfig):
     def primary_key(self) -> list[str]:
         return ["time"]
 
-    @no_type_check
     @classmethod
     def from_config_dict(cls, config_dict: ConfigDict) -> SummaryConfig | None:
         if summary_keys := config_dict.get(ConfigKeys.SUMMARY, []):


### PR DESCRIPTION

**Issue**
Resolves #11668


**Approach**
There are still some no_type_check decorators left, but they have very limited scope and are very sensible use cases.

This involved removed call to WorkflowJobSchemaDict super().check_required which mypy considers unsafe. It in any case would invoke the abstract method of SchemaItemDict so would in the best case do nothing.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
