### PR TITLE
Catch the only possible exception from open_storage

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from ert.dark_storage.exceptions import InternalServerError
-from ert.storage import Storage, open_storage
+from ert.storage import ErtStorageException, Storage, open_storage
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def get_storage() -> Storage:
     if _storage is None:
         try:
             return (_storage := open_storage(os.environ["ERT_STORAGE_ENS_PATH"]))
-        except RuntimeError as err:
+        except ErtStorageException as err:
             raise InternalServerError(f"{err!s}") from err
     _storage.refresh()
     return _storage


### PR DESCRIPTION
The open_storage() call can not throw a RuntimeError since it catches anything and re-raises as an ErtStorageException. This commit thus changes the name of the exception raised in dark_storage from ErtStorageException to InternalServerError, probably as originally intended.

**Issue**
Resolves #11168 


**Approach**
Guess the intended behaviour. Both behaviors are probably accepted, but sticking to InternalServerError adds an error code which some parts might use.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
