### PR TITLE
Create experiment sorting for plotting window

### DIFF
--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -44,7 +44,6 @@ class EnsembleExperiment(InitialEnsembleRunModel):
 
         self._sample_and_evaluate_ensemble(
             evaluator_server_config,
-            None,
             self.target_ensemble,
             rerun_failed_realizations,
             self._ensemble if rerun_failed_realizations else None,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -37,7 +37,6 @@ class EnsembleSmoother(UpdateRunModel, InitialEnsembleRunModel):
 
         prior = self._sample_and_evaluate_ensemble(
             evaluator_server_config,
-            None,
             self.target_ensemble % 0,
         )
         posterior = self.update(prior, self.target_ensemble % 1)

--- a/src/ert/run_models/initial_ensemble_run_model.py
+++ b/src/ert/run_models/initial_ensemble_run_model.py
@@ -21,6 +21,7 @@ from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_arg import create_run_arguments
 from ert.run_models.run_model import RunModel
 from ert.sample_prior import sample_prior
+from ert.storage import SimulationArguments
 from ert.storage.local_ensemble import LocalEnsemble
 from ert.storage.local_experiment import DictEncodedObservations
 
@@ -51,10 +52,10 @@ class InitialEnsembleRunModel(RunModel, ABC):
     def _sample_and_evaluate_ensemble(
         self,
         evaluator_server_config: EvaluatorServerConfig,
-        simulation_arguments: dict[str, str] | None,
         ensemble_name: str,
         rerun_failed_realizations: bool = False,
         ensemble_storage: LocalEnsemble | None = None,
+        simulation_arguments: SimulationArguments | None = None,
     ) -> LocalEnsemble:
         parameters_config, design_matrix, design_matrix_group = (
             self._merge_parameters_from_design_matrix(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -10,7 +10,7 @@ from pydantic import PrivateAttr
 from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.initial_ensemble_run_model import InitialEnsembleRunModel
 from ert.run_models.update_run_model import UpdateRunModel
-from ert.storage import Ensemble
+from ert.storage import Ensemble, SimulationArguments
 from ert.trace import tracer
 
 from ..analysis import smoother_update
@@ -88,11 +88,10 @@ class MultipleDataAssimilation(UpdateRunModel, InitialEnsembleRunModel):
             self.run_workflows(
                 fixtures=PreExperimentFixtures(random_seed=self.random_seed),
             )
-            sim_args = {"weights": self.weights}
             prior = self._sample_and_evaluate_ensemble(
                 evaluator_server_config,
-                sim_args,
                 self.target_ensemble % 0,
+                simulation_arguments=SimulationArguments(weights=self.weights),
             )
 
         enumerated_weights: list[tuple[int, float]] = list(

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from .local_ensemble import LocalEnsemble, load_realization_parameters_and_responses
-from .local_experiment import LocalExperiment
+from .local_experiment import LocalExperiment, SimulationArguments
 from .local_storage import LocalStorage, local_storage_set_ert_config
 from .mode import Mode, ModeLiteral
 from .realization_storage_state import RealizationStorageState
@@ -48,6 +48,7 @@ __all__ = [
     "Experiment",
     "Mode",
     "RealizationStorageState",
+    "SimulationArguments",
     "Storage",
     "load_realization_parameters_and_responses",
     "local_storage_set_ert_config",

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from types import TracebackType
-from typing import Any, cast
+from typing import cast
 from uuid import UUID, uuid4
 
 import polars as pl
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from ert.config import ErtConfig, ParameterConfig, ResponseConfig
 from ert.shared import __version__
 
+from . import SimulationArguments
 from .local_ensemble import LocalEnsemble
 from .local_experiment import DictEncodedObservations, LocalExperiment
 from .mode import BaseMode, Mode, require_write
@@ -311,7 +312,7 @@ class LocalStorage(BaseMode):
         observations: dict[str, DictEncodedObservations]
         | dict[str, pl.DataFrame]
         | None = None,
-        simulation_arguments: dict[Any, Any] | None = None,
+        simulation_arguments: SimulationArguments | None = None,
         name: str | None = None,
         templates: list[tuple[str, str]] | None = None,
     ) -> LocalExperiment:


### PR DESCRIPTION
The simulation arguments are dumped to 'metadata.json'. However, this feature is currently only used by MultipleDataAssimilation.

For other run_models, they simply pass down "None" for this value. Therefore it makes more sense to make it an optional parameter.

I've also introduced the 'time_generated' to the dataclass such that experiments/ensembles can be sorted by this value.

**Issue**
Resolves #11680 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
