### PR TITLE
Use StorageService.session to set config (url, auth, etc) in everest

### DIFF
--- a/src/ert/dark_storage/client/client.py
+++ b/src/ert/dark_storage/client/client.py
@@ -9,11 +9,15 @@ class Client(httpx.Client):
     """
     Wrapper class for httpx.Client that provides a user-friendly way to
     interact with ERT Storage's API
+
+    Stores 'conn_info' to bridge the gap to the Everest client setup
     """
 
     def __init__(self, conn_info: ConnInfo | None = None) -> None:
         if conn_info is None:
             conn_info = find_conn_info()
+
+        self.conn_info = conn_info
 
         headers = {}
         if conn_info.auth_token is not None:

--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -4,9 +4,11 @@ import argparse
 import signal
 import threading
 from functools import partial
+from pathlib import Path
 
+from ert.services import StorageService
 from everest.config import EverestConfig, ServerConfig
-from everest.detached import ExperimentState, everserver_status, server_is_running
+from everest.detached import ExperimentState, everserver_status
 from everest.everest_storage import EverestStorage
 
 from .utils import (
@@ -69,27 +71,35 @@ def monitor_everest(options: argparse.Namespace) -> None:
     config: EverestConfig = options.config
     status_path = ServerConfig.get_everserver_status_path(config.output_dir)
     server_state = everserver_status(status_path)
-    server_context = ServerConfig.get_server_context(config.output_dir)
-    if server_is_running(*server_context):
+
+    try:
+        client = StorageService.session(
+            Path(ServerConfig.get_session_dir(config.output_dir))
+        )
+        server_context = ServerConfig.get_server_context_from_conn_info(
+            client.conn_info
+        )
         run_detached_monitor(server_context=server_context)
         server_state = everserver_status(status_path)
         if server_state["status"] == ExperimentState.failed:
             raise SystemExit(server_state["message"])
         if server_state["message"] is not None:
             print(server_state["message"])
-    elif server_state["status"] == ExperimentState.never_run:
-        config_file = config.config_file
-        print(
-            "The optimization has not run yet.\n"
-            "To run the optimization use command:\n"
-            f"  `everest run {config_file}`"
-        )
-    else:
-        report_on_previous_run(
-            config_file=config.config_file,
-            everserver_status_path=status_path,
-            optimization_output_dir=config.optimization_output_dir,
-        )
+
+    except TimeoutError:
+        if server_state["status"] == ExperimentState.never_run:
+            config_file = config.config_file
+            print(
+                "The optimization has not run yet.\n"
+                "To run the optimization use command:\n"
+                f"  `everest run {config_file}`"
+            )
+        else:
+            report_on_previous_run(
+                config_file=config.config_file,
+                everserver_status_path=status_path,
+                optimization_output_dir=config.optimization_output_dir,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -12,6 +12,7 @@ import yaml
 from fastapi import FastAPI
 from starlette.responses import Response
 
+from ert.services import StorageService
 from ert.shared import find_available_socket
 from everest.bin.everest_script import everest_entry
 from everest.config import EverestConfig, ServerConfig
@@ -188,15 +189,18 @@ def test_that_multiple_everest_clients_can_connect_to_server(
     )
 
     everest_main_thread.start()
+    client = StorageService.session(
+        Path(ServerConfig.get_session_dir(ever_config.output_dir))
+    )
 
     def everserver_is_running():
         return server_is_running(
-            *ServerConfig.get_server_context(ever_config.output_dir)
+            *ServerConfig.get_server_context_from_conn_info(client.conn_info)
         )
 
     wait_until(everserver_is_running, interval=1, timeout=300)
 
-    server_context = ServerConfig.get_server_context(ever_config.output_dir)
+    server_context = ServerConfig.get_server_context_from_conn_info(client.conn_info)
     url, cert, auth = server_context
 
     ssl_context = ssl.create_default_context()

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,7 +25,8 @@ def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
         assert ensemble_names == set(batches)
 
 
-@patch("everest.bin.everest_script.server_is_running", return_value=False)
+@patch("ert.services.StorageService.session", side_effect=[TimeoutError(), MagicMock()])
+@patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch("everest.bin.everest_script.run_detached_monitor")
 @patch("everest.bin.everest_script.wait_for_server")
 @patch("everest.bin.everest_script.start_server")
@@ -34,7 +35,7 @@ def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
     "everest.bin.everest_script.everserver_status",
     return_value={"status": ExperimentState.never_run, "message": None},
 )
-def test_save_running_config(_, _1, _2, _3, _4, _5, change_to_tmpdir):
+def test_save_running_config(_, _1, _2, _3, _4, _5, _6, change_to_tmpdir):
     """Test everest detached, when an optimization has already run"""
 
     Path("config.yml").touch()

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -15,6 +15,7 @@ import ert
 from ert.dark_storage.app import app
 from ert.ensemble_evaluator import EndEvent
 from ert.scheduler.event import FinishedEvent
+from ert.services import StorageService
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
     ExperimentState,
@@ -63,9 +64,12 @@ async def wait_for_server_to_complete(config):
                 return
 
     driver = await start_server(config, logging.DEBUG)
-    wait_for_server(config.output_dir, 120)
+    client = StorageService.session(
+        Path(ServerConfig.get_session_dir(config.output_dir))
+    )
+    wait_for_server(client, 120)
     start_experiment(
-        server_context=ServerConfig.get_server_context(config.output_dir),
+        server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),
         config=config,
     )
     await server_running()


### PR DESCRIPTION
**Issue**
Fixes #11407 
.. by using ERTs StorageService.session to ensure the correct, functioning url is selected. 


**Approach**
In order to use the correct url (full domain name vs. hostname), use the existing StorageService.session to set up a client. 
Next step is to actually use the session's get/post - separate issue here: https://github.com/equinor/ert/issues/11745

Should be merged together with #11714 to get the full enjoyment needed for the TNO non-fqdn setup to work.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
