### PR TITLE
Add a check for duplicate keys in observations

### DIFF
--- a/tests/ert/unit_tests/config/observations_generator.py
+++ b/tests/ert/unit_tests/config/observations_generator.py
@@ -266,6 +266,7 @@ def observations(draw, ensemble_keys, summary_keys, std_cutoff, start_date):
                             ),
                         ),
                         max_size=2,
+                        unique_by=lambda s: s.name,
                     ),
                     name=unique_summary_names,
                 ),

--- a/tests/ert/unit_tests/config/parsing/test_observations_parser.py
+++ b/tests/ert/unit_tests/config/parsing/test_observations_parser.py
@@ -537,3 +537,23 @@ def test_that_multiple_segments_are_collected():
     )
 
     assert len(observations[0][1].segment) == 2
+
+
+@pytest.mark.parametrize("observation_type", ["HISTORY", "GENERAL", "SUMMARY"])
+def test_that_duplicate_keys_results_in_error_message_with_location(observation_type):
+    with pytest.raises(
+        ObservationConfigError,
+        match=r"Line 7 \(Column 16-25\): Observation contains duplicate key ERROR_MIN",
+    ):
+        parse_observations(
+            f"""
+            {observation_type}_OBSERVATION GWIR:FIELD
+            {{
+               ERROR       = 0.20;
+               ERROR_MODE  = RELMIN;
+               ERROR_MIN   = 100;
+               ERROR_MIN   = 50;
+            }};
+            """,
+            "",
+        )


### PR DESCRIPTION
Raises an error if there are duplicate fields in the observations.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
