### PR TITLE
Make ContextString=FileContextToken

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1307,7 +1307,7 @@ class ErtConfig(BaseModel):
                     message="When using SUMMARY keyword, "
                     "the config must also specify ECLBASE",
                     filename=config_file,
-                ).set_context_keyword(config_dict[ConfigKeys.SUMMARY][0][0])
+                ).set_context(config_dict[ConfigKeys.SUMMARY][0])
             )
         return errors
 

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -108,7 +108,7 @@ class GenDataConfig(ResponseConfig):
                         message="RESULT_FILES using %d must have REPORT_STEPS:xxxx"
                         " defined. Several report steps separated with ',' "
                         "and ranges with '-' can be listed",
-                    ).set_context_keyword(gen_data)
+                    ).set_context(gen_data)
                 )
 
             if report_steps_ is not None and "%d" not in res_file:
@@ -116,7 +116,7 @@ class GenDataConfig(ResponseConfig):
                     ErrorInfo(
                         message=f"When configuring REPORT_STEPS:{report_steps_} "
                         "RESULT_FILES must be configured using %d"
-                    ).set_context_keyword(name)
+                    ).set_context(gen_data)
                 )
 
             keys.append(name)

--- a/src/ert/config/parsing/config_errors.py
+++ b/src/ert/config/parsing/config_errors.py
@@ -19,8 +19,6 @@ class ConfigWarning(UserWarning):
     @classmethod
     def deprecation_warn(cls, message: str, context: Any = "") -> None:
         warning = cls.with_context(message, context)
-        if not hasattr(context, "token"):
-            warning.info.set_context_keyword(context)
         warning.info.is_deprecation = True
         cls._formatted_warn(warning)
 

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -87,16 +87,16 @@ class SchemaItem:
         """
 
         if not len(self.type_map) > index:
-            return ContextString(str(token), token, keyword)
+            return ContextString(str(token), token)
         val_type = self.type_map[index]
         match val_type:
             case None:
-                return ContextString(str(token), token, keyword)
+                return ContextString(str(token), token)
             case SchemaItemType.BOOL:
                 if token.lower() == "true":
-                    return ContextBool(True, token, keyword)
+                    return ContextBool(True, token)
                 elif token.lower() == "false":
-                    return ContextBool(False, token, keyword)
+                    return ContextBool(False, token)
                 else:
                     raise ConfigValidationError.with_context(
                         f"{self.kw!r} must have a boolean "
@@ -113,7 +113,7 @@ class SchemaItem:
                         token,
                     ) from e
                 if val > 0:
-                    return ContextInt(val, token, keyword)
+                    return ContextInt(val, token)
                 else:
                     raise ConfigValidationError.with_context(
                         f"{self.kw!r} must have a positive integer "
@@ -122,7 +122,7 @@ class SchemaItem:
                     )
             case SchemaItemType.INT:
                 try:
-                    return ContextInt(int(token), token, keyword)
+                    return ContextInt(int(token), token)
                 except ValueError as e:
                     raise ConfigValidationError.with_context(
                         f"{self.kw!r} must have an integer "
@@ -131,7 +131,7 @@ class SchemaItem:
                     ) from e
             case SchemaItemType.FLOAT:
                 try:
-                    return ContextFloat(float(token), token, keyword)
+                    return ContextFloat(float(token), token)
                 except ValueError as e:
                     raise ConfigValidationError.with_context(
                         f"{self.kw!r} must have a number as argument {index + 1!r}",
@@ -146,7 +146,7 @@ class SchemaItem:
                         token,
                     ) from e
                 if fval > 0:
-                    return ContextFloat(fval, token, keyword)
+                    return ContextFloat(fval, token)
                 else:
                     raise ConfigValidationError.with_context(
                         f"{self.kw!r} must have a positive float "

--- a/src/ert/config/parsing/context_values.py
+++ b/src/ert/config/parsing/context_values.py
@@ -14,12 +14,9 @@ class ContextBoolEncoder(JSONEncoder):
 
 
 class ContextBool:
-    def __init__(
-        self, val: bool, token: FileContextToken, keyword_token: FileContextToken
-    ) -> None:
+    def __init__(self, val: bool, token: FileContextToken) -> None:
         self.val = val
         self.token = token
-        self.keyword_token = keyword_token
 
     def __bool__(self) -> bool:
         return bool(self.val)
@@ -34,39 +31,33 @@ class ContextBool:
 
     @no_type_check
     def __deepcopy__(self, memo) -> ContextBool:
-        new_instance = ContextBool(bool(self), self.token, self.keyword_token)
+        new_instance = ContextBool(bool(self), self.token)
         memo[id(self)] = new_instance
         return new_instance
 
 
 class ContextInt(int):
-    def __new__(
-        cls, val: int, token: FileContextToken, keyword_token: FileContextToken
-    ) -> ContextInt:
+    def __new__(cls, val: int, token: FileContextToken) -> ContextInt:
         obj = super().__new__(cls, val)
         obj.token = token
-        obj.keyword_token = keyword_token
         return obj
 
     @no_type_check
     def __deepcopy__(self, memo) -> ContextInt:
-        new_instance = ContextInt(int(self), self.token, self.keyword_token)
+        new_instance = ContextInt(int(self), self.token)
         memo[id(self)] = new_instance
         return new_instance
 
 
 class ContextFloat(float):
-    def __new__(
-        cls, val: float, token: FileContextToken, keyword_token: FileContextToken
-    ) -> ContextFloat:
+    def __new__(cls, val: float, token: FileContextToken) -> ContextFloat:
         obj = super().__new__(cls, val)
         obj.token = token
-        obj.keyword_token = keyword_token
         return obj
 
     @no_type_check
     def __deepcopy__(self, memo) -> ContextFloat:
-        new_instance = ContextFloat(float(self), self.token, self.keyword_token)
+        new_instance = ContextFloat(float(self), self.token)
         memo[id(self)] = new_instance
         return new_instance
 
@@ -74,19 +65,16 @@ class ContextFloat(float):
 class ContextString(str):  # noqa: FURB189
     @classmethod
     def from_token(cls, token: FileContextToken) -> ContextString:
-        return cls(val=str(token), token=token, keyword_token=token)
+        return cls(val=str(token), token=token)
 
-    def __new__(
-        cls, val: str, token: FileContextToken, keyword_token: FileContextToken
-    ) -> ContextString:
+    def __new__(cls, val: str, token: FileContextToken) -> ContextString:
         obj = super().__new__(cls, val)
         obj.token = token
-        obj.keyword_token = keyword_token
         return obj
 
     @no_type_check
     def __deepcopy__(self, memo) -> ContextString:
-        new_instance = ContextString(str(self), self.token, self.keyword_token)
+        new_instance = ContextString(str(self), self.token)
         memo[id(self)] = new_instance
         return new_instance
 
@@ -95,11 +83,11 @@ T = TypeVar("T")
 
 
 class ContextList(list[T]):  # noqa: FURB189
-    keyword_token: FileContextToken
+    token: FileContextToken
 
     def __init__(self, token: FileContextToken) -> None:
         super().__init__()
-        self.keyword_token = token
+        self.token = token
 
     @classmethod
     def with_values(

--- a/src/ert/config/parsing/context_values.py
+++ b/src/ert/config/parsing/context_values.py
@@ -62,21 +62,7 @@ class ContextFloat(float):
         return new_instance
 
 
-class ContextString(str):  # noqa: FURB189
-    @classmethod
-    def from_token(cls, token: FileContextToken) -> ContextString:
-        return cls(val=str(token), token=token)
-
-    def __new__(cls, val: str, token: FileContextToken) -> ContextString:
-        obj = super().__new__(cls, val)
-        obj.token = token
-        return obj
-
-    @no_type_check
-    def __deepcopy__(self, memo) -> ContextString:
-        new_instance = ContextString(str(self), self.token)
-        memo[id(self)] = new_instance
-        return new_instance
+ContextString = FileContextToken
 
 
 T = TypeVar("T")

--- a/src/ert/config/parsing/error_info.py
+++ b/src/ert/config/parsing/error_info.py
@@ -26,7 +26,10 @@ class ErrorInfo:
         return None
 
     def set_context(self, context: Any) -> Self:
-        self._attach_to_context(self._take(context, "token"))
+        if isinstance(context, FileContextToken):
+            self._attach_to_context(context)
+        else:
+            self._attach_to_context(self._take(context, "token"))
         return self
 
     def set_context_list(self, context_list: Sequence[Any]) -> Self:

--- a/src/ert/config/parsing/error_info.py
+++ b/src/ert/config/parsing/error_info.py
@@ -29,10 +29,6 @@ class ErrorInfo:
         self._attach_to_context(self._take(context, "token"))
         return self
 
-    def set_context_keyword(self, context: Any) -> Self:
-        self._attach_to_context(self._take(context, "keyword_token"))
-        return self
-
     def set_context_list(self, context_list: Sequence[Any]) -> Self:
         parsed_context_list = []
         for context in context_list:

--- a/src/ert/config/parsing/file_context_token.py
+++ b/src/ert/config/parsing/file_context_token.py
@@ -1,4 +1,6 @@
-from typing import cast
+from __future__ import annotations
+
+from typing import Any, cast
 
 from lark import Token
 
@@ -10,7 +12,7 @@ class FileContextToken(Token):
 
     filename: str
 
-    def __new__(cls, token: Token, filename: str) -> "FileContextToken":
+    def __new__(cls, token: Token, filename: str) -> FileContextToken:
         inst = super().__new__(
             cls,
             token.type,
@@ -44,10 +46,13 @@ class FileContextToken(Token):
     def __hash__(self) -> int:
         return hash(self.value)
 
+    def update(self, value: Any = None) -> FileContextToken:  # type: ignore[override]
+        return FileContextToken(super().update(value=value), self.filename)
+
     @classmethod
     def join_tokens(
-        cls, tokens: list["FileContextToken"], separator: str = " "
-    ) -> "FileContextToken":
+        cls, tokens: list[FileContextToken], separator: str = " "
+    ) -> FileContextToken:
         first = tokens[0]
         min_start_pos = min(x.start_pos for x in tokens if x.start_pos is not None)
         max_end_pos = max(x.end_pos for x in tokens if x.end_pos is not None)
@@ -76,7 +81,7 @@ class FileContextToken(Token):
             filename=first.filename,
         )
 
-    def replace_value(self, old: str, new: str, count: int = -1) -> "FileContextToken":
+    def replace_value(self, old: str, new: str, count: int = -1) -> FileContextToken:
         if old in self.value:
             replaced = self.value.replace(old, new, count)
             return FileContextToken(self.update(value=replaced), filename=self.filename)

--- a/src/ert/config/parsing/schema_dict.py
+++ b/src/ert/config/parsing/schema_dict.py
@@ -84,10 +84,7 @@ class SchemaItemDict(UserDict[str, SchemaItem]):
                             schema_info.deprecation_info,
                             cast(
                                 list[ContextString],
-                                ContextList.with_values(
-                                    token=kw.token,
-                                    values=[v],
-                                ),
+                                ContextList.with_values(token=kw, values=[v]),
                             ),
                         )
                     case [ContextString(), *_]:

--- a/src/ert/config/parsing/schema_dict.py
+++ b/src/ert/config/parsing/schema_dict.py
@@ -85,7 +85,7 @@ class SchemaItemDict(UserDict[str, SchemaItem]):
                             cast(
                                 list[ContextString],
                                 ContextList.with_values(
-                                    token=v.keyword_token,  # type: ignore
+                                    token=kw.token,
                                     values=[v],
                                 ),
                             ),

--- a/src/ert/config/workflow.py
+++ b/src/ert/config/workflow.py
@@ -41,7 +41,7 @@ class Workflow:
 
         for job_name in parsed_workflow_job_names:
             for instructions in config_dict[job_name]:
-                job_name_with_context = instructions.keyword_token
+                job_name_with_context = instructions.token
                 job = job_dict.get(job_name)
                 if job is None:
                     errors.append(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -14,6 +14,7 @@ import polars as pl
 import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
+from lark import Token
 from pydantic import RootModel, TypeAdapter
 
 from ert import ErtScript, ErtScriptWorkflow
@@ -1593,7 +1594,7 @@ def test_that_context_types_are_json_serializable():
     bf = ContextBool(val=False, token=None)
     bt = ContextBool(val=True, token=None)
     i = ContextInt(val=23, token=None)
-    s = ContextString(val="forty_two", token=None)
+    s = ContextString(token=Token("typ", "hello", 1, 2, 3, 4, 5), filename="name")
     fl = ContextFloat(val=4.2, token=None)
     cl = ContextList.with_values(None, values=[bf, bt, i, s, fl])
 

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1590,11 +1590,11 @@ def test_ert_config_parser_fails_gracefully_on_unreadable_config_file(caplog, tm
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_context_types_are_json_serializable():
-    bf = ContextBool(val=False, token=None, keyword_token=None)
-    bt = ContextBool(val=True, token=None, keyword_token=None)
-    i = ContextInt(val=23, token=None, keyword_token=None)
-    s = ContextString(val="forty_two", token=None, keyword_token=None)
-    fl = ContextFloat(val=4.2, token=None, keyword_token=None)
+    bf = ContextBool(val=False, token=None)
+    bt = ContextBool(val=True, token=None)
+    i = ContextInt(val=23, token=None)
+    s = ContextString(val="forty_two", token=None)
+    fl = ContextFloat(val=4.2, token=None)
     cl = ContextList.with_values(None, values=[bf, bt, i, s, fl])
 
     payload = {

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -10,7 +10,6 @@ from pydantic import ValidationError
 
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, GenKwConfig
 from ert.config.gen_kw_config import TransformFunctionDefinition
-from ert.config.parsing import ContextString
 from ert.config.parsing.file_context_token import FileContextToken
 from ert.run_models._create_run_path import create_run_path
 from ert.runpaths import Runpaths
@@ -502,8 +501,8 @@ def test_gen_kw_pred_special_suggested_removal():
     assert any("config.ert: Line 2" in str(w.message) for w in warn_log)
 
 
-def make_context_string(msg: str, filename: str) -> ContextString:
-    return ContextString.from_token(FileContextToken(Token("UNQUOTED", msg), filename))
+def make_context_string(msg: str, filename: str) -> FileContextToken:
+    return FileContextToken(Token("UNQUOTED", msg), filename)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -126,6 +126,7 @@ def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
     )
 
     commands = [(name, args[0]) for (name, args) in wf.cmd_list]
+    print(commands)
 
     assert commands == [(foo, "1"), (bar, "1"), (foo, "3"), (baz, "3")]
 


### PR DESCRIPTION
Towards #11695

Because the output of the observations parser consists of lists, dicts and FileContextToken, it greatly simplifies things to simply have ContextString=FileContextToken. In order to do that, we also need to replace keyword_token/keyword_context concept with just the token of an instruction (which already was the token of the keyword).


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
