### PR TITLE
Remove the optimization callback

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -8,7 +8,6 @@ import time
 import traceback
 import uuid
 from base64 import b64decode
-from functools import partial
 from queue import SimpleQueue
 
 from fastapi import (
@@ -231,7 +230,6 @@ class ExperimentRunner:
                 everest_config=self._everest_config,
                 experiment_name=f"EnOpt@{datetime.datetime.now().isoformat(timespec='seconds')}",
                 target_ensemble="batch",
-                optimization_callback=partial(_opt_monitor, shared_data=shared_data),
                 status_queue=status_queue,
             )
             shared_data.status = ExperimentStatus(
@@ -314,9 +312,3 @@ class Subscriber:
 
     async def is_done(self) -> None:
         await self._done.wait()
-
-
-def _opt_monitor(shared_data: ExperimentRunnerState) -> str | None:
-    if shared_data.status.status.stopped:
-        return "stop_optimization"
-    return None


### PR DESCRIPTION

**Issue**
Resolves #10971


**Approach**
The callback from `ropt` into the run model was only used to check if the user aborted the optimization. This was superseded by a different mechanism and this callback was in fact never called anymore. Optimization is now simply terminated without informing `ropt`. This has no negative consequences on the optimizer that `ropt` is running, it is simply terminated, hence this approach is sufficient and the callback is not necessary anymore.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
