### PR TITLE
Remove perturbation_magnitude from eightcells example

### DIFF
--- a/test-data/everest/eightcells/everest/model/config.yml
+++ b/test-data/everest/eightcells/everest/model/config.yml
@@ -9,7 +9,6 @@ controls:
   -
     name: well_rate
     type: generic_control
-    perturbation_magnitude: 150
     variables:
       -
         name: OP1


### PR DESCRIPTION
Documentation says that this should normally not be touched, and removing it does not make a significant impact to optimization results from eightcells

**Issue**
Resolves irrelevant config

**Approach**
✂️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
