### PR TITLE
Have MockZMQServer in unit tests use ipc

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -23,14 +23,12 @@ from _ert.forward_model_runner.reporting.statemachine import TransitionError
 from tests.ert.utils import MockZMQServer
 
 
-def test_report_with_successful_start_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_with_successful_start_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Start(fmstep1))
         reporter.report(Finish())
@@ -45,16 +43,13 @@ def test_report_with_successful_start_message_argument(unused_tcp_port):
     assert os.path.basename(event.std_err) == "stderr"
 
 
-def test_report_with_failed_start_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
-
+def test_report_with_failed_start_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
 
         msg = Start(fmstep1).with_error("massive_failure")
@@ -68,15 +63,13 @@ def test_report_with_failed_start_message_argument(unused_tcp_port):
     assert event.error_msg == "massive_failure"
 
 
-async def test_report_with_successful_exit_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+async def test_report_with_successful_exit_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Exited(fmstep1, 0))
         reporter.report(Finish().with_error("failed"))
@@ -86,15 +79,13 @@ async def test_report_with_successful_exit_message_argument(unused_tcp_port):
     assert type(event) is ForwardModelStepSuccess
 
 
-def test_report_with_failed_exit_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_with_failed_exit_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Exited(fmstep1, 1).with_error("massive_failure"))
         reporter.report(Finish())
@@ -105,15 +96,13 @@ def test_report_with_failed_exit_message_argument(unused_tcp_port):
     assert event.error_msg == "massive_failure"
 
 
-def test_report_with_running_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_with_running_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=100, rss=10)))
         reporter.report(Finish())
@@ -125,15 +114,13 @@ def test_report_with_running_message_argument(unused_tcp_port):
     assert event.current_memory_usage == 10
 
 
-def test_report_only_job_running_for_successful_run(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_only_job_running_for_successful_run():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=100, rss=10)))
         reporter.report(Finish())
@@ -141,15 +128,13 @@ def test_report_only_job_running_for_successful_run(unused_tcp_port):
     assert len(mock_server.messages) == 1
 
 
-def test_report_with_failed_finish_message_argument(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_with_failed_finish_message_argument():
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
 
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=100, rss=10)))
         reporter.report(Finish().with_error("massive_failure"))
@@ -157,10 +142,8 @@ def test_report_with_failed_finish_message_argument(unused_tcp_port):
     assert len(mock_server.messages) == 1
 
 
-def test_report_inconsistent_events(unused_tcp_port):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    reporter = Event(evaluator_url=url)
+def test_report_inconsistent_events():
+    reporter = Event(evaluator_url="")
 
     with pytest.raises(
         TransitionError, match=r"Illegal transition None -> \(MessageType<Finish>,\)"
@@ -168,7 +151,7 @@ def test_report_inconsistent_events(unused_tcp_port):
         reporter.report(Finish())
 
 
-def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
+def test_report_with_failed_reporter_but_finished_jobs():
     # this is to show when the reporter fails ert won't crash nor
     # staying hanging but instead finishes up the job;
     # see reporter._event_publisher_thread.join()
@@ -176,11 +159,9 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
     # meaning Finish event initiated _timeout and timeout was reached
     # which then sets _timeout_timestamp=None
 
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    with MockZMQServer(unused_tcp_port) as mock_server:
+    with MockZMQServer() as mock_server:
         reporter = Event(
-            evaluator_url=url,
+            evaluator_url=mock_server.uri,
             ack_timeout=0.1,
             max_retries=0,
             finished_event_timeout=0.1,
@@ -202,15 +183,12 @@ def test_report_with_failed_reporter_but_finished_jobs(unused_tcp_port):
 
 
 @pytest.mark.integration_test
-def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
+def test_report_with_reconnected_reporter_but_finished_jobs():
     # this is to show when the reporter fails but reconnects
     # reporter still manages to send events and completes fine
     # see reporter._event_publisher for more details.
-
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
-    with MockZMQServer(unused_tcp_port) as mock_server:
-        reporter = Event(evaluator_url=url, ack_timeout=1, max_retries=1)
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri, ack_timeout=1, max_retries=1)
         fmstep1 = ForwardModelStep(
             {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
         )
@@ -238,15 +216,13 @@ def test_report_with_reconnected_reporter_but_finished_jobs(unused_tcp_port):
     ],
 )
 def test_event_reporter_does_not_hang_after_failed(
-    mocked_server_signal, expected_message, unused_tcp_port, monkeypatch, caplog
+    mocked_server_signal, expected_message, monkeypatch, caplog
 ):
-    host = "localhost"
-    url = f"tcp://{host}:{unused_tcp_port}"
     monkeypatch.setattr(
         "_ert.forward_model_runner.reporting.event.Client.DEFAULT_MAX_RETRIES", 1
     )
-    with MockZMQServer(unused_tcp_port, signal=mocked_server_signal):
-        reporter = Event(evaluator_url=url, ack_timeout=1, max_retries=1)
+    with MockZMQServer(signal=mocked_server_signal) as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri, ack_timeout=1, max_retries=1)
         fmstep1 = ForwardModelStep(
             {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
         )


### PR DESCRIPTION
**Approach**
Have MockZMQServer in unit tests use ipc

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
