### PR TITLE
Make everest parsing of realization_memory like in ert (#11657)

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -48,7 +48,29 @@ class QueueOptions(
     max_running: pydantic.NonNegativeInt = 0
     submit_sleep: pydantic.NonNegativeFloat = 0.0
     num_cpu: pydantic.NonNegativeInt = 1
-    realization_memory: pydantic.NonNegativeInt = 0
+    realization_memory: pydantic.NonNegativeInt = Field(
+        default=0,
+        description="""When set, a job is only allowed to use realization_memory
+        of memory.
+
+        realization_memory may be an integer value, indicating the number of bytes, or a
+        string consisting of a number followed by a unit. The unit indicates the
+        multiplier that is applied, and must start with one of these characters:
+
+        * b, B: bytes
+        * k, K: kilobytes (1024 bytes)
+        * m, M: megabytes (1024**2 bytes)
+        * g, G: gigabytes (1024**3 bytes)
+        * t, T: terabytes (1024**4 bytes)
+        * p, P: petabytes (1024**5 bytes)
+
+        Spaces between the number and the unit are ignored, and so are any
+        characters after the first. For example: 2g, 2G, and 2 GB all resolve
+        to the same value: 2 gigabytes, equaling 2 * 1024**3 bytes.
+
+        If not set, or set to zero, the allowed amount of memory is unlimited.
+        """,
+    )
     job_script: str = shutil.which("fm_dispatch.py") or "fm_dispatch.py"
     project_code: str | None = None
     activate_script: str | None = Field(default=None, validate_default=True)
@@ -64,6 +86,15 @@ class QueueOptions(
         if info.context:
             plugin_script = info.context.get("activate_script")
         return plugin_script or activate_script()  # Return default value
+
+    @field_validator("realization_memory", mode="before")
+    @classmethod
+    def validate_realization_memory(cls, v: Any) -> int:
+        if isinstance(v, int):
+            return v
+        if isinstance(v, str):
+            return parse_string_to_bytes(v)
+        raise ValueError(f"Invalid value for realization_memory: {v}")
 
     @staticmethod
     def create_queue_options(

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -521,3 +521,56 @@ def test_that_resubmit_limit_is_set(change_to_tmpdir) -> None:
     ever_config = EverestConfig.with_defaults(simulator={"resubmit_limit": 0})
     config_dict = everest_to_ert_config_dict(ever_config)
     assert config_dict[ErtConfigKeys.MAX_SUBMIT] == 1
+
+
+@pytest.mark.parametrize(
+    "realization_memory, expected",
+    [
+        ("1Gb", 1073741824),
+        ("2Kb", 2048),
+        (999, 999),
+    ],
+)
+def test_parsing_of_relization_memory(realization_memory, expected) -> None:
+    config = EverestConfig.with_defaults(
+        simulator={
+            "queue_system": {"name": "local", "realization_memory": realization_memory},
+        }
+    )
+    assert config.simulator.queue_system.realization_memory == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_memory_spec, error_message",
+    [
+        ("-1", "Negative memory does not make sense"),
+        ("      -2", "Negative memory does not make sense"),
+        ("-1b", "Negative memory does not make sense in -1b"),
+        ("b", "Invalid memory string"),
+        ("'kljh3 k34f15gg.  asd '", "Invalid memory string"),
+        ("'kljh3 1gb'", "Invalid memory string"),
+        ("' 2gb 3k 1gb'", "Invalid memory string"),
+        ("4ub", "Unknown memory unit"),
+    ],
+)
+def test_parsing_of_invalid_relization_memory(
+    invalid_memory_spec, error_message
+) -> None:
+    with pytest.raises(ValidationError, match=error_message):
+        EverestConfig.with_defaults(
+            simulator={
+                "queue_system": {
+                    "name": "local",
+                    "realization_memory": invalid_memory_spec,
+                },
+            }
+        )
+
+
+def test_parsing_of_non_existing_relization_memory() -> None:
+    config = EverestConfig.with_defaults(
+        simulator={
+            "queue_system": {"name": "local"},
+        }
+    )
+    assert config.simulator.queue_system.realization_memory == 0


### PR DESCRIPTION
* Add realization_memory description for documentation purposes
* Add a test for invalid realization_memory

(cherry picked from commit f7109505c0eb22d328411b37d17cce3a11ca4eaa)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
