### PR TITLE
Resolve job py warnings

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -524,7 +524,8 @@ async def test_long_warning_from_forward_model_is_truncated(
             stdout_file="foo.stdout",
         )
     ]
-    await log_warnings_from_forward_model(realization, start_time - 1)
+    with pytest.warns(PostSimulationWarning):
+        await log_warnings_from_forward_model(realization, start_time - 1)
     for line in caplog.text.splitlines():
         if "Realization 0 step foo.0 warned" in line:
             assert len(line) <= 2048 + 91
@@ -550,7 +551,8 @@ async def test_deduplication_of_repeated_warnings_from_forward_model(
             stdout_file="foo.stdout",
         )
     ]
-    await log_warnings_from_forward_model(realization, start_time - 1)
+    with pytest.warns(PostSimulationWarning):
+        await log_warnings_from_forward_model(realization, start_time - 1)
     assert (
         f"Realization 0 step foo.0 warned 3 time(s) in stdout: {emitted_warning_str}"
         in caplog.text

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -139,6 +139,7 @@ async def test_job_run_sends_expected_events(
         "read_stdout_and_stderr_files",
         lambda *args: "",
     )
+    scheduler.driver._job_error_message_by_iens = {}
 
     job = Job(scheduler, realization)
     job._verify_checksum = partial(job._verify_checksum, timeout=0)


### PR DESCRIPTION
**Issue**
Resolves warnings running test_job.py

```
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[0-1-load_result2-FAILED]
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[1-1-load_result3-FAILED]
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[1-2-load_result5-FAILED]
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[0-2-load_result6-FAILED]
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[1-2-load_result7-FAILED]
tests/ert/unit_tests/scheduler/test_job.py::test_job_run_sends_expected_events[1-1-load_result1-FAILED]
  /tmp/f_scout_ci/actions-runner-02/_temp/test-kenv/root/lib64/python3.11/site-packages/ert/scheduler/job.py:398: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    await self._handle_failure()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
tests/ert/unit_tests/scheduler/test_job.py::test_long_warning_from_forward_model_is_truncated
  /tmp/f_scout_ci/actions-runner-02/_temp/test-kenv/root/lib64/python3.11/site-packages/ert/scheduler/job.py:522: PostSimulationWarning: Realization 0 step foo.0 warned 3 time(s) in stdout: FutureWarning: Feature XYZ is deprecated foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar f
    await log_warnings_from_file(
tests/ert/unit_tests/scheduler/test_job.py::test_deduplication_of_repeated_warnings_from_forward_model
  /tmp/f_scout_ci/actions-runner-02/_temp/test-kenv/root/lib64/python3.11/site-packages/ert/scheduler/job.py:522: PostSimulationWarning: Realization 0 step foo.0 warned 3 time(s) in stdout: FutureWarning: Feature XYZ is deprecated
    await log_warnings_from_file(
```

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
