### PR TITLE
Remove Everest logging hook; rely on ERT

### DIFF
--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -24,6 +24,7 @@ from ert.ensemble_evaluator import (
     SnapshotUpdateEvent,
 )
 from ert.logging import LOGGING_CONFIG
+from ert.plugins.plugin_manager import ErtPluginManager
 from everest.config import EverestConfig
 from everest.config.server_config import ServerConfig
 from everest.detached import (
@@ -34,7 +35,6 @@ from everest.detached import (
     stop_server,
     wait_for_server_to_stop,
 )
-from everest.plugins.everest_plugin_manager import EverestPluginManager
 from everest.simulator import JOB_FAILURE, JOB_RUNNING, JOB_SUCCESS
 from everest.strings import EVEREST, OPT_PROGRESS_ID, SIM_PROGRESS_ID
 from everest.util import makedirs_if_needed
@@ -83,8 +83,8 @@ def setup_logging(options: argparse.Namespace) -> Generator[None, None, None]:
             handler.setLevel(logging.DEBUG)
             root_logger.addHandler(handler)
 
-        plugin_manager = EverestPluginManager()
-        plugin_manager.add_log_handle_to_root()
+        plugin_manager = ErtPluginManager()
+        plugin_manager.add_logging_handle_to_root(logging.getLogger())
         plugin_manager.add_span_processor_to_trace_provider()
         yield
     finally:

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -25,6 +25,7 @@ from ert.ensemble_evaluator import (
     FullSnapshotEvent,
     SnapshotUpdateEvent,
 )
+from ert.plugins.plugin_manager import ErtPluginManager
 from ert.run_models import StatusEvents
 from ert.run_models.everest_run_model import (
     EverestExitCode,
@@ -39,7 +40,6 @@ from everest.detached import (
     everserver_status,
     update_everserver_status,
 )
-from everest.plugins.everest_plugin_manager import EverestPluginManager
 from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
     EVEREST,
@@ -118,8 +118,8 @@ def _configure_loggers(
             yaml.dump(logging_config, outfile, default_flow_style=False)
     logging.config.dictConfig(logging_config)
 
-    plugin_manager = EverestPluginManager()
-    plugin_manager.add_log_handle_to_root()
+    plugin_manager = ErtPluginManager()
+    plugin_manager.add_logging_handle_to_root(logging.getLogger())
     plugin_manager.add_span_processor_to_trace_provider()
 
 

--- a/src/everest/plugins/everest_plugin_manager.py
+++ b/src/everest/plugins/everest_plugin_manager.py
@@ -1,9 +1,7 @@
-import logging
 from typing import Any
 
 import pluggy
 
-from ert.trace import add_span_processor
 from everest.plugins import hook_impl, hook_specs
 from everest.strings import EVEREST
 
@@ -22,13 +20,3 @@ class EverestPluginManager(pluggy.PluginManager):
     def get_documentation(self) -> dict[str, Any]:
         docs = self.hook.get_forward_model_documentations()
         return {k: v for d in docs for k, v in d.items()} if docs else {}
-
-    def add_log_handle_to_root(self) -> None:
-        root_logger = logging.getLogger()
-        for handler in self.hook.add_log_handle_to_root():
-            root_logger.addHandler(handler)
-
-    def add_span_processor_to_trace_provider(self) -> None:
-        span_processors = self.hook.add_span_processor()
-        for span_processor in span_processors:
-            add_span_processor(span_processor)

--- a/src/everest/plugins/hook_specs.py
+++ b/src/everest/plugins/hook_specs.py
@@ -1,8 +1,6 @@
-import logging
 from collections.abc import Sequence
 from typing import Any
 
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pydantic import BaseModel
 
 from everest.plugins import hookspec
@@ -90,26 +88,6 @@ def installable_workflow_jobs() -> dict[str, Any]:  # type: ignore[empty-body]
     """
     :return: dict with workflow job names as keys and path to config as value
     :rtype: PluginResponse with data as dict[str,str]
-    """
-
-
-@hookspec
-def add_log_handle_to_root() -> logging.Handler:  # type: ignore[empty-body]
-    """
-    Create a log handle which will be added to the root logger
-    in the main entry point.
-    :return: A log handle that will be added to the root logger
-    :rtype: logging.Handler
-    """
-
-
-@hookspec
-def add_span_processor() -> BatchSpanProcessor:  # type: ignore
-    """
-    Create a BatchSpanProcessor which will be added to the trace provider
-    in ert.
-
-    :return: A BatchSpanProcessor that will be added to the trace provider in everest
     """
 
 


### PR DESCRIPTION
**Issue**
Resolves: #11164

**Approach**
Use the logging handle and `add_span_processor_to_trace_provider` from the `ErtPluginManager` instead of the `EverestPluginManager` defined add handle. Also remove the hookspecs for these two hooks.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
